### PR TITLE
content(osrs): migrate batch 14 (200 items) v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-dart-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-dart-p.mdx
@@ -12,31 +12,92 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Wield"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 30
     attack_bonus:
-      ranged: 11
-    ranged_strength: 14
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 17
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 67
+      xp: 15
+      materials:
+        - item_name: "Adamant dart"
+          quantity: 1
+        - item_name: "Weapon poison"
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 815
-      item_name: Mithril dart (p)
-      slug: mithril-dart-p
-      relationship: variant
-      description: Lower tier poisoned dart
-    - item_id: 817
-      item_name: Rune dart (p)
-      slug: rune-dart-p
-      relationship: variant
-      description: Higher tier poisoned dart
-  about: |-
-    > _"An adamant tipped dart with a poisoned tip."_
-
-    An adamant dart tipped with basic weapon poison. Requires 30 Ranged. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: "Adamant dart"
+      slug: "adamant-dart"
+      relationship: "variant"
+      description: "Unpoisoned base dart used to craft the poisoned version."
+    - item_name: "Mithril dart(p)"
+      slug: "mithril-dart-p"
+      relationship: "downgrade"
+      description: "Lower-tier poisoned dart with weaker ranged strength."
+    - item_name: "Rune dart(p)"
+      slug: "rune-dart-p"
+      relationship: "upgrade"
+      description: "Higher-tier poisoned dart with greater ranged strength."
+    - item_name: "Weapon poison"
+      slug: "weapon-poison"
+      relationship: "component"
+      description: "Herblore product applied to dart to create the (p) variant."
+  about: "Adamant dart(p) is a poisoned thrown weapon with +17 ranged strength, 3-tick attack speed, and a 30 Ranged wielding requirement. Released April 14, 2003. Created by using Weapon poison on an Adamant dart. The poison deals 2-4 damage per tick over time and is required for blowpipe-style chip damage on poisonable monsters. June 30, 2021 rebalance moved the +11 ranged attack bonus into +17 ranged strength."
+  market_strategy:
+    notes:
+      - "Mass-produced Fletching/Herblore product - margins thin and tied to dart tip + weapon poison costs."
+      - "Buy limit 11,000 supports bulk flipping for active traders."
+      - "Demand from low-mid level pures and slayer training using darts on poisonable targets."
+      - "Rune dart(p) tier above caps the upside; this sits as a mid-budget option."
+  trading_tips:
+    - "Watch unpoisoned Adamant dart and Weapon poison spreads - arbitrage when combined cost < (p) price."
+    - "Bulk buy on weekday lows, dump on weekend slayer peaks."
+    - "Limit orders only - 3-coin spreads vanish on market buys."
+  history:
+    - date: "2003-04-14"
+      description: "Released alongside Adamant darts at the launch of fletched darts."
+    - date: "2021-06-30"
+      description: "Ranged attack bonus reduced from +11 to 0; ranged strength rebalanced upward to +17."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-kiteshield-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-kiteshield-t.mdx
@@ -12,22 +12,63 @@ osrs:
   lowalch: 2176
   highalch: 3264
   limit: 8
+  about: "Adamant kiteshield (t) is a trimmed cosmetic variant of the standard adamant kiteshield. Identical stats, requiring 30 Defence. Clue scroll exclusive."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 5.896
+    destroy: "Drop"
+  material:
+    type: metal
+    tier: adamant
+    category: shield
   equipment:
     slot: shield
+    weapon_type: none
+    attack_speed: null
     requirements:
       defence: 30
-  related_items:
-    - item_id: 2599
-      item_name: Adamant platebody (t)
-      slug: adamant-platebody-t
-      relationship: set-piece
-      description: Matching trimmed platebody
-  about: |-
-    > *"Adamant kiteshield with trim."*
-
-    The adamant kiteshield (t) is a trimmed cosmetic variant of the standard adamant kiteshield. Identical stats, requiring 30 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 27
+      slash: 31
+      crush: 29
+      magic: -1
+      ranged: 29
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    type: reward
+    rarity: "1/1133"
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Adamant kiteshield"
+      - "Adamant kiteshield (g)"
+      - "Adamant platebody (t)"
+      - "Adamant full helm (t)"
+      - "Adamant platelegs (t)"
+      - "Trimmed cosmetic version of adamant kiteshield with identical defensive bonuses."
+      - "Exclusively from medium clue scrolls; supply is throttled."
+      - "Often bought as a set with matching adamant trimmed pieces for fashionscape."
+  history:
+    - date: "2004-05-05"
+      description: "Adamant kiteshield (t) was released as part of the Bigger Banks & Treasure Trails update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-knife-p-5666.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-knife-p-5666.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant knife(p++) | OSRS Price Data
-description: "Adamant knife(p++): A finely balanced throwing knife.. High alch: 39 GP, GE limit: 7,000."
+description: "Adamant knife(p++): A finely balanced throwing knife. High alch: 39 GP, GE limit: 7,000."
 osrs:
   id: 5666
   name: Adamant knife(p++)
@@ -12,9 +12,72 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 7000
-  about: "Adamant knife(p++) is a members-only item in Old School RuneScape. High alchemy value: 39 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Adamant knife(p++) is a members-only thrown weapon in Old School RuneScape, providing +15 ranged attack and +14 ranged strength with the strongest knife poison variant. High alchemy value: 39 coins. Grand Exchange buy limit: 7,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    destroy: "Drop"
+    quest_item: false
+    weight: 0
+  material:
+    type: ammunition
+    tier: adamant
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    requirements:
+      ranged: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 15
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 14
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    has_special: false
+  recipes:
+    - item_name: "Adamant knife(p++)"
+      skill: Herblore
+      level: 73
+      xp: 190
+      tools:
+        - "Vial"
+      materials:
+        - item_name: "Adamant knife"
+          quantity: 1
+        - item_name: "Cave nightshade"
+          quantity: 1
+      output_quantity: 1
+      notes: "Poison the knife with weapon poison(++) to obtain the strongest poison variant."
+  market_strategy:
+    notes:
+      - "summary: \"Niche poisoned thrown weapon; demand limited as players often prefer rune or dragon knives for high-tier ranged training.\""
+      - "buy_strategy: \"Stock when adamant ore and weapon poison(++) materials dip; small profit margins from crafting.\""
+      - "sell_strategy: \"Move during Slayer tasks involving poison-vulnerable monsters or low-level pking.\""
+  trading_tips:
+    - "Stackable thrown weapons keep inventory load low for resellers."
+    - "Watch the price gap vs unpoisoned adamant knives to estimate crafting margin."
+    - "Demand peaks during ranged Slayer task spikes."
+  history:
+    - date: "2003-04-14"
+      description: "Released as part of the original throwing knife family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-longsword.mdx
@@ -12,28 +12,70 @@ osrs:
   lowalch: 1280
   highalch: 1920
   limit: 125
+  properties:
+    release_date: "2001-01-04"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: metal
+    tier: adamant
   equipment:
     slot: weapon
-    type: longsword
-    tradeable: true
+    weapon_type: longsword
+    attack_speed: 5
     weight: 2.041
-    requirements:
-      attack: 30
-    stats:
-      attack_stab: 20
-      attack_slash: 29
-      attack_crush: -2
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 31
+    attack_bonus:
+      stab: 20
+      slash: 29
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 31
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+    requirements:
+      attack: 30
+    degradable: false
+  recipes:
+    - skill: smithing
+      level: 76
+      xp: 125
+      item_name: Adamant longsword
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_name: Adamantite bar
+          quantity: 2
+      product: Adamant longsword
+      product_id: 1301
+      product_quantity: 1
+      output_quantity: 1
+      members_only: false
+  drop_table:
+    primary_source: Smithing
+    sources:
+      - source: Smithing
+        quantity: "1"
+        rarity: craftable
+        members_only: false
+      - source: Varrock Swordshop
+        quantity: "1"
+        rarity: shop
+        members_only: false
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      price: 3200
+      quantity: 2
   related_items:
     - item_id: 1303
       item_name: Rune longsword
@@ -45,8 +87,35 @@ osrs:
       slug: adamant-scimitar
       relationship: alternative
       description: Faster slash alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: |-
+    | Property | Value |
+    |----------|-------|
+    | Attack slash | +29 |
+    | Strength | +31 |
+    | Requirement | 30 Attack |
+
+    - Free-to-play eligible
+    - 5-tick attack speed
+    - Adamant tier melee weapon
+
+    Solid mid-tier longsword:
+    - Used for training Attack at 30+
+    - Cheap and widely available
+    - Outclassed by rune at level 40
+  market_strategy:
+    notes:
+      - "Smithing at 76 yields 125 xp per longsword"
+      - "Common F2P training weapon"
+      - "Margins driven by adamantite bar prices"
+  trading_tips:
+    - Watch adamantite bar price spreads when smithing for profit
+    - GE limit 125 keeps flips small but consistent
+    - Demand spikes during F2P combat events
+  history:
+    - date: "2001-01-04"
+      description: "Released into the game."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-plateskirt-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-plateskirt-g.mdx
@@ -12,22 +12,74 @@ osrs:
   lowalch: 2560
   highalch: 3840
   limit: 8
+  weight: 10.432
+  material:
+    type: metal
+    tier: adamant
+  properties:
+    release_date: "2004-10-26"
+    quest_item: false
+    destroy: "Drop"
   equipment:
     slot: legs
     requirements:
       defence: 30
+    bonuses:
+      attack:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 0
+      defence:
+        stab: 33
+        slash: 31
+        crush: 29
+        magic: -4
+        ranged: 31
+      other:
+        strength: 0
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
+  treasure_trail:
+    tier: medium
+  drop_table:
+    - source: Medium clue scroll
+      level: 0
+      quantity: "1"
+      rarity: "1/1133"
+      members: false
   related_items:
     - item_id: 3474
       item_name: Adamant plateskirt (t)
       slug: adamant-plateskirt-t
       relationship: variant
       description: Trimmed variant
+    - item_id: 1091
+      item_name: Adamant plateskirt
+      slug: adamant-plateskirt
+      relationship: variant
+      description: Base untrimmed version
   about: |-
     > *"Adamant plateskirt with gold trim."*
 
-    The adamant plateskirt (g) is a gold-trimmed cosmetic variant of the adamant plateskirt. Identical stats to adamant platelegs with slightly less weight, requiring 30 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The adamant plateskirt (g) is a gold-trimmed cosmetic variant of the adamant plateskirt. Identical stats to adamant platelegs with slightly less weight, requiring 30 Defence. Medium clue scroll exclusive.
+  market_strategy:
+    notes:
+      - "F2P clue reward"
+      - "Cosmetic only"
+      - "Identical stats to base plateskirt"
+      - "Medium clue exclusive"
+      - "Low GE limit"
+      - "Value tied to cosmetic demand"
+      - "Low buy limit can squeeze price"
+      - "Better profit from selling than alching"
+  history:
+    - date: "2004-10-26"
+      description: "Released with the Treasure Trails update."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/agility-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/agility-mix-2.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 2000
-  about: "Agility mix(2) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Agility mix(2) is a two-dose barbarian potion that boosts Agility by 3 levels and restores 6 hitpoints per dose. Created from Agility potion(2) and caviar at 37 Herblore after Otto Godblessed's Barbarian Herblore training. High alchemy value: 60 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.075
+  material:
+    type: potion
+    primary: liquid
+    tier: standard
+  potion:
+    doses: 2
+    boost_type: "Agility"
+    boost_amount: 3
+    duration: "Instant"
+    heal_amount: 6
+    notes: "Each dose grants +3 Agility boost plus 6 hitpoints restore; becomes an empty vial once emptied."
+  recipes:
+    - item_name: Agility mix(2)
+      tools: ["Pestle and mortar"]
+      materials:
+        - item_name: Agility potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      output_quantity: 1
+      skill: Herblore
+      level: 37
+      xp: 27
+      notes: "Requires completion of the Herblore portion of Barbarian Training with Otto Godblessed."
+  market_strategy:
+    notes:
+      - "buy_range: \"150 - 250 gp\""
+      - "sell_range: \"200 - 320 gp\""
+      - "Niche Agility boost item; flip alongside Agility pyramid and Wilderness Agility Course rushers."
+  trading_tips:
+    - "Demand rises when Agility XP weekends or rewards events go live."
+    - "Stack with caviar flips since one barbarian mix lot drives both prices."
+    - "Sell to ironmen training Agility around level 70-80."
+  history:
+    - date: "2007-07-03"
+      description: "Released with the Barbarian Herblore Training update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ahrim's armour set | OSRS Price Data
-description: "Ahrim's armour set: A set containing an Ahrim's hood, robetop, robeskirt and staff.. High alch: 120,000 GP, GE limit: 8."
+description: "Ahrim's armour set: A set containing an Ahrim's hood, robetop, robeskirt and staff. High alch: 120,000 GP, GE limit: 8."
 osrs:
   id: 12881
   name: Ahrim's armour set
@@ -12,9 +12,63 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 8
-  about: "Ahrim's armour set is a members-only item in Old School RuneScape. High alchemy value: 120,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2014-12-10"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: barrows
+  related_items:
+    - item_id: 4708
+      item_name: Ahrim's hood
+      slug: ahrim-s-hood
+      relationship: component
+      description: Magic helmet component of the set
+    - item_id: 4712
+      item_name: Ahrim's robetop
+      slug: ahrim-s-robetop
+      relationship: component
+      description: Magic body component of the set
+    - item_id: 4714
+      item_name: Ahrim's robeskirt
+      slug: ahrim-s-robeskirt
+      relationship: component
+      description: Magic legs component of the set
+    - item_id: 4710
+      item_name: Ahrim's staff
+      slug: ahrim-s-staff
+      relationship: component
+      description: Magic weapon component of the set
+  about: |-
+    | Property | Value |
+    |----------|-------|
+    | Set contents | Hood, robetop, robeskirt, staff |
+    | GE limit | 8 |
+    | Tier | Barrows |
+
+    - Members-only Barrows magic gear
+    - Combined via Grand Exchange Sets option
+    - Convenient bundle to flip the full kit
+
+    Used to transfer or sell Ahrim's gear in one trade:
+    - Saves four GE slots when listing
+    - Premium item for arbitrage between component price and set price
+    - Drops nothing on its own; combine to use pieces
+  market_strategy:
+    notes:
+      - "Compare set price to sum of components for arbitrage"
+      - "GE limit 8 caps churn but unit value is high"
+      - "Demand follows magic meta and Barrows updates"
+  trading_tips:
+    - Decombine via GE clerk's Sets option when components trade for more
+    - Watch Ahrim's robetop and robeskirt as the price drivers
+    - Holiday training rushes can lift bundle demand
+  history:
+    - date: "2014-12-10"
+      description: "Set added with the Grand Exchange sets system."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-hood-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-hood-0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ahrim's hood 0 | OSRS Price Data
-description: "Ahrim's hood 0: Ahrim the Blighted's leather hood.. High alch: 7,800 GP, GE limit: 15."
+description: "Ahrim's hood 0: Ahrim the Blighted's leather hood. High alch: 7,800 GP, GE limit: 15."
 osrs:
   id: 4860
   name: Ahrim's hood 0
@@ -12,9 +12,117 @@ osrs:
   lowalch: 5200
   highalch: 7800
   limit: 15
-  about: "Ahrim's hood 0 is a members-only item in Old School RuneScape. High alchemy value: 7,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0.907
+    release_date: '2005-05-09'
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: barrows
+    primary_resource: barrows-set
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: null
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 6
+      ranged: 0
+    defence_bonus:
+      stab: 15
+      slash: 13
+      crush: 16
+      magic: 6
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 0
+    requirements:
+      defence: 70
+      magic: 70
+  charges:
+    type: degradation
+    max_charges: 15
+    charge_unit: combat hours
+    repair_cost: 60000
+    repair_skill: Smithing
+    description: Degrades over 15 hours of combat. Full repair costs 60,000 coins at an NPC armour stand and scales down with Smithing level (~50% savings at 99 Smithing).
+  obtaining:
+    methods:
+      - source: Ahrim the Blighted (Barrows)
+        quantity: "1"
+        rarity: 7 x 1/2448
+        description: Dropped from the reward chest at the end of the Barrows minigame when Ahrim has been killed.
+  drop_table:
+    - source: Ahrim the Blighted
+      quantity: "1"
+      rarity: 7 x 1/2448
+      members: true
+  related_items:
+    - item_id: 4708
+      item_name: Ahrim's hood
+      slug: ahrim-s-hood
+      relationship: alternative
+      description: Full-charge version of the same hood.
+    - item_id: 4856
+      item_name: Ahrim's hood 25
+      slug: ahrim-s-hood-25
+      relationship: alternative
+      description: Partially degraded variant at 25 charges.
+    - item_id: 4858
+      item_name: Ahrim's hood 50
+      slug: ahrim-s-hood-50
+      relationship: alternative
+      description: Partially degraded variant at 50 charges.
+    - item_id: 4710
+      item_name: Ahrim's robetop
+      slug: ahrim-s-robetop
+      relationship: set-piece
+      description: Body slot piece of Ahrim's barrows set.
+    - item_id: 4712
+      item_name: Ahrim's robeskirt
+      slug: ahrim-s-robeskirt
+      relationship: set-piece
+      description: Leg slot piece of Ahrim's barrows set.
+  history:
+    - date: '2005-05-09'
+      description: "Ahrim's hood was released with the Barrows minigame."
+  about: |-
+    > *"Ahrim the Blighted's leather hood."*
+
+    Ahrim's hood 0 is the fully-degraded variant of Ahrim's hood. The item must be repaired before it can be used again. Players typically alch or sell the degraded version on the GE rather than carry it into combat.
+
+    | Detail | Value |
+    |--------|-------|
+    | Magic Attack | +6 |
+    | Magic Damage | +1% |
+    | Defence (head, slash) | +13 |
+    | Defence (head, magic) | +6 |
+    | Repair Cost | 60,000 gp base |
+    | Smithing Discount | up to ~50% at 99 |
+
+    The hood is part of Ahrim's barrows set, which grants a set effect when worn together with the rest of Ahrim's gear.
+  market_strategy:
+    notes:
+      - "Lower GE price than fully-charged variant"
+      - "Buyers typically repair to use or restock charges"
+      - "Buy limit of 15 keeps spreads wide"
+      - "Members only item"
+  trading_tips:
+    - Compare degraded vs. fully-charged hood prices to capture repair-cost arbitrage.
+    - Smithing 99 owners get the best margins on repair flips.
+    - Buy limit of 15 per 4 hours throttles aggressive flipping.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-fury.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-fury.mdx
@@ -12,102 +12,85 @@ osrs:
   lowalch: 80800
   highalch: 121200
   limit: 8
+  about: "Amulet of fury is the premier hybrid neck slot amulet, enchanted from an Onyx amulet with Lvl-6 Enchant. Offers strong all-style attack/defence/prayer bonuses; outclassed only by Zenyte jewelry per style. High alchemy value: 121,200 coins. Grand Exchange buy limit: 8."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: jewellery
+    tier: onyx
+  properties:
+    release_date: "2005-10-04"
+    tradeable: true
+    equipable: true
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.01
   equipment:
     slot: neck
-    type: amulet
-    stats:
-      attack_stab: 10
-      attack_slash: 10
-      attack_crush: 10
-      attack_magic: 10
-      attack_ranged: 10
-      defence_stab: 15
-      defence_slash: 15
-      defence_crush: 15
-      defence_magic: 15
-      defence_ranged: 15
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 15
+      slash: 15
+      crush: 15
+      magic: 15
+      ranged: 15
+    other_bonus:
       strength: 8
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
   recipes:
-    - skill: magic
+    - item_name: Amulet of fury
+      skill: magic
       level: 87
       xp: 97
+      output_quantity: 1
+      tools: []
       materials:
         - item_name: Onyx amulet
-          item_id: 6581
-          quantity: 1
+          quantity: "1"
         - item_name: Fire rune
-          item_id: 554
-          quantity: 20
+          quantity: "20"
         - item_name: Earth rune
-          item_id: 557
-          quantity: 20
+          quantity: "20"
         - item_name: Cosmic rune
-          item_id: 564
-          quantity: 1
-      product: Amulet of fury
-      product_id: 6585
-      product_quantity: 1
-      facility: None
-      members_only: true
-  related_items:
-    - item_id: 19553
-      item_name: Amulet of torture
-      slug: amulet-of-torture
+          quantity: "1"
+  relationships:
+    - item_name: Onyx amulet
+      relationship: component
+    - item_name: Amulet of blood fury
       relationship: upgrade
-      description: Melee upgrade
-    - item_id: 19547
-      item_name: Necklace of anguish
-      slug: necklace-of-anguish
-      relationship: upgrade
-      description: Ranged upgrade
-    - item_id: 12002
-      item_name: Occult necklace
-      slug: occult-necklace
-      relationship: upgrade
-      description: Magic upgrade
-  about: |-
-    Enchant Onyx amulet with Lvl-6 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 87 (boostable) |
-    | Runes | 20 fire, 20 earth, 1 cosmic |
-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +10 |
-    | Ranged | +10 |
-    | Strength | +8 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +15 |
-    | Slash | +15 |
-    | Crush | +15 |
-    | Magic | +15 |
-    | Ranged | +15 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +5 |
-
-    Best hybrid amulet for:
-    - All combat styles
-    - Switching between styles
-    - Budget all-around option
-
-    Outclassed by zenyte jewelry for specific styles.
+    - item_name: Amulet of fury (or)
+      relationship: variant
+    - item_name: Amulet of torture
+      relationship: alternative
+    - item_name: Necklace of anguish
+      relationship: alternative
+    - item_name: Occult necklace
+      relationship: alternative
   market_strategy:
     notes:
-      - Great all-around amulet
-      - Onyx from TzHaar or GE
-      - Still popular despite zenyte
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "short_term: \"Liquid, high-ticket neck slot; price moves with Zenyte alternative trends and TzHaar Onyx supply.\""
+      - "long_term: \"Stable hybrid pick; long-term floor supported by ornament-kit cosmetic demand and Blood Fury combine.\""
+      - "risk_level: \"medium\""
+  trading_tips:
+    - "Enchant Onyx amulets when GE spread covers Lvl-6 rune cost; converts cleanly to fury margin."
+    - "Pair flips with Blood shards for the Amulet of blood fury upgrade arbitrage."
+  history:
+    - date: "2005-10-04"
+      description: "Released with the TzHaar update introducing Onyx and Lvl-6 Enchant."
+    - date: "2017-08-10"
+      description: "Amulet of blood fury combine added via blood shard from Vampyric content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-t4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-t4.mdx
@@ -12,9 +12,27 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 5
+  about: "Amulet of glory (t4) is the gold-trimmed cosmetic variant of the charged amulet of glory, obtained from hard Treasure Trails. Stats match the standard glory; the trim is fashionscape only. High alchemy value: 10,575 coins. Grand Exchange buy limit: 5 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.01
+  material:
+    type: jewelry
+    tier: dragonstone
   equipment:
     slot: neck
-    weight: 0.01
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      none: 1
     attack_bonus:
       stab: 10
       slash: 10
@@ -28,76 +46,47 @@ osrs:
       magic: 3
       ranged: 3
     other_bonus:
-      melee_strength: 6
+      strength: 6
       ranged_strength: 0
       magic_damage: 0
       prayer: 3
   charges:
     current: 4
     max: 6
-    recharge: Fountain of Rune
-  special_effect:
-    name: Glory Effect
-    description: Teleports to Edgeville, Karamja, Draynor, Al Kharid. Increases gem mining chance.
-    triggers: on_use
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard
-        drop_rate: 1/1,625
-        description: Rare reward from hard clue scrolls
-  related_items:
-    - item_id: 1704
-      item_name: Amulet of glory(4)
-      slug: amulet-of-glory-4
-      relationship: variant
-      description: Standard (untrimmed) version with 4 charges
-    - item_id: 10362
-      item_name: Amulet of glory (t)
-      slug: amulet-of-glory-t
-      relationship: variant
-      description: Uncharged trimmed version
-    - item_id: 11964
-      item_name: Amulet of glory (t6)
-      slug: amulet-of-glory-t6
-      relationship: variant
-      description: Fully charged trimmed version (6 charges)
-    - item_id: 6585
-      item_name: Amulet of fury
-      slug: amulet-of-fury
-      relationship: upgrade
-      description: Superior combat amulet
-  about: |-
-    > *"A very powerful dragonstone amulet."*
-
-    - Edgeville
-    - Karamja (Musa Point)
-    - Draynor Village
-    - Al Kharid
-
-    | Property | Glory (4) | Glory (t4) |
-    |----------|-----------|------------|
-    | All Attack | +10 | +10 |
-    | All Defence | +3 | +3 |
-    | Strength | +6 | +6 |
-    | Prayer | +3 | +3 |
-    | Teleports | Yes (4) | Yes (4) |
-    | Appearance | Standard | Gold trimmed |
-    | Source | Enchanting | Hard clue |
-
-    Stats are identical. The trimmed version is purely a cosmetic upgrade obtained through Treasure Trails.
+    recharge_method: "Fountain of Rune or Heroes' Guild fountain"
+  special_attack:
+    name: "Glory teleport"
+    description: "Right-click teleport to Edgeville, Karamja, Draynor Village, or Al Kharid; consumes one charge per teleport."
+    energy: 0
+  treasure_trail:
+    tier: hard
+    rarity: "1/1,625"
+  drop_table:
+    - source: "Hard Clue Casket"
+      quantity: "1"
+      rarity: "1/1,625"
   market_strategy:
-    title: Investment Notes
     notes:
-      - Hard clue exclusive cosmetic
-      - Functions identically to regular glory with 4 charges
-      - Fashionscape demand drives pricing
-      - Recharge at Fountain of Rune for 6 charges (becomes t6)
-      - Can be recharged just like a regular glory
-      - All charge variants (t1 through t6) maintain the trimmed appearance
-      - Popular among players who want a premium look for everyday teleporting
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "flip_potential: \"medium\""
+      - "Fashionscape premium over the standard glory; hard clue exclusive cosmetic with stable demand."
+  trading_tips:
+    - "Charge to 6 at Fountain of Rune to convert into glory (t6) for higher resale."
+    - "Track price against the standard charged glory to spot cosmetic premium swings."
+    - "Hard clue supply is the main pricing lever — watch clue event weeks."
+  history:
+    - date: "2006-12-05"
+      description: "Released as a hard Treasure Trail reward."
+    - date: "2017-01-01"
+      description: "Partial-charge variants gained bank placeholders for inventory management."
+  relationships:
+    - item_name: Amulet of glory(4)
+      relationship: variant
+    - item_name: Amulet of glory (t)
+      relationship: variant
+    - item_name: Amulet of glory (t6)
+      relationship: upgrade
+    - item_name: Amulet of fury
+      relationship: upgrade
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancestral-robes-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancestral-robes-set.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: 5
-  about: "Ancestral robes set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-01-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: "Ancestral hat"
+      slug: "ancestral-hat"
+      relationship: "component"
+      description: "Headpiece included when the set is unpacked at a GE clerk."
+    - item_name: "Ancestral robe top"
+      slug: "ancestral-robe-top"
+      relationship: "component"
+      description: "Body slot magic robe included in the set."
+    - item_name: "Ancestral robe bottom"
+      slug: "ancestral-robe-bottom"
+      relationship: "component"
+      description: "Legs slot magic robe included in the set."
+  about: "The Ancestral robes set is a Grand Exchange bundle containing the Ancestral hat, robe top, and robe bottom. Released January 19, 2017 alongside Raids tweaks, it lets players move all three Chambers of Xeric magic robes in a single trade. Exchange at any GE clerk's Sets interface to unpack into individual pieces."
+  market_strategy:
+    notes:
+      - "Premium magic gear bundle - typical price is hundreds of millions of GP."
+      - "Buy-set vs sell-pieces arbitrage is the dominant flip; track ~2-3M spreads."
+      - "Volume is thin (~150 trades/day) so large quantities move slowly."
+      - "Demand spikes when Tombs/CoX rebalance or new magic content drops."
+  trading_tips:
+    - "Compare Sets-tab price vs combined component price daily for arbitrage."
+    - "Unpack at the GE clerk and resell the three pieces individually for a margin when the set trades at a discount."
+    - "Use 4-hour buy limit windows carefully - 5 per slot is your cap."
+    - "Avoid offering above guide price during dead market hours; liquidity is sparse."
+  history:
+    - date: "2017-01-19"
+      description: "Released alongside the Raids Tweaks and QoL update as a Grand Exchange bundle for the Ancestral robes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-legs.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Ancient ceremonial legs is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Ancient ceremonial legs is a Zarosian prayer-bonus leg slot from the Ancient Prison. Part of the Ancient ceremonial robes set. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: misc
+    tier: ancient
+  properties:
+    release_date: "2022-01-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.8
+  equipment:
+    slot: legs
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      prayer: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 5
+  drop_table:
+    - source: Spiritual mage (Ancient Prison)
+      quantity: "1"
+      rarity: "1/640"
+    - source: Spiritual ranger (Ancient Prison)
+      quantity: "1"
+      rarity: "1/640"
+    - source: Spiritual warrior (Ancient Prison)
+      quantity: "1"
+      rarity: "1/640"
+    - source: Blood Reaver
+      quantity: "1"
+      rarity: "1/640"
+    - source: Fumus
+      quantity: "1"
+      rarity: "1/1000"
+    - source: Umbra
+      quantity: "1"
+      rarity: "1/1000"
+    - source: Cruor
+      quantity: "1"
+      rarity: "1/1000"
+    - source: Glacies
+      quantity: "1"
+      rarity: "1/1000"
+  relationships:
+    - item_name: Ancient ceremonial top
+      relationship: set-piece
+    - item_name: Ancient ceremonial mask
+      relationship: set-piece
+    - item_name: Ancient ceremonial gloves
+      relationship: set-piece
+    - item_name: Ancient ceremonial boots
+      relationship: set-piece
+  market_strategy:
+    notes:
+      - "short_term: \"Demand is tied to GWD Nex teams wanting the cosmetic Zarosian protection set; prices oscillate with Nex content interest.\""
+      - "long_term: \"Cosmetic + tiny prayer bonus; long-term price floor depends on continued Ancient Prison interest and set collectors.\""
+      - "risk_level: \"medium\""
+  trading_tips:
+    - "Buy when Nex content trends are quiet — collectors return predictably with each rework or event."
+    - "Pair with the full set (top/mask/gloves/boots) for resale; complete sets carry a premium."
+  history:
+    - date: "2022-01-05"
+      description: "Released alongside Nex and the Ancient Prison in the God Wars Dungeon update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-crystal.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 250
-  about: "Ancient crystal is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Ancient crystal is a members-only drop from Revenants in the Wilderness Revenant Caves of Old School RuneScape. Four crystals plus four marble blocks are used at 80 Construction to build the Obelisk teleport in a Superior Garden, granting 3,000 Construction experience. High alchemy value: 150,000 coins. Grand Exchange buy limit: 250 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-11-23"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 13.607
+  drop_table:
+    - source: "Revenant imp"
+      level: 7
+      quantity: "1"
+      rarity: "1/14666.67"
+    - source: "Revenant goblin"
+      level: 15
+      quantity: "1"
+      rarity: "1/14666.67"
+    - source: "Revenant pyrefiend"
+      level: 52
+      quantity: "1"
+      rarity: "1/9714.29"
+    - source: "Revenant hobgoblin"
+      level: 60
+      quantity: "1"
+      rarity: "1/8470.59"
+    - source: "Revenant cyclops"
+      level: 82
+      quantity: "1"
+      rarity: "1/6857.14"
+    - source: "Revenant hellhound"
+      level: 90
+      quantity: "1"
+      rarity: "1/6400"
+    - source: "Revenant demon"
+      level: 98
+      quantity: "1"
+      rarity: "1/5818.18"
+    - source: "Revenant ork"
+      level: 105
+      quantity: "1"
+      rarity: "1/5333.33"
+    - source: "Revenant dark beast"
+      level: 120
+      quantity: "1"
+      rarity: "1/4571.43"
+    - source: "Revenant knight"
+      level: 126
+      quantity: "1"
+      rarity: "1/4266.67"
+    - source: "Revenant dragon"
+      level: 135
+      quantity: "1"
+      rarity: "1/2666.67"
+  recipes:
+    - item_name: "Obelisk (Superior garden)"
+      skill: "Construction"
+      level: 80
+      xp: 3000
+      materials:
+        - item_name: "Ancient crystal"
+          quantity: 4
+        - item_name: "Marble block"
+          quantity: 4
+      tools:
+        - "Hammer"
+        - "Saw"
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Accumulate slowly inside the 250 buy limit; long-term price moves with Wilderness mining-route activity.\""
+      - "sell_strategy: \"List on rebuild waves when high-level Construction is the META during DMM or league events.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"medium\""
+  trading_tips:
+    - "Skull up at Revenants for improved drop rates if self-sourcing."
+    - "Bank crystals together with marble blocks to build all four Obelisk corners in one trip."
+    - "Buy limit of 250 sharply restricts flipping volume; small margins, not large flips."
+  history:
+    - date: "2017-11-23"
+      description: "Released as a Revenant Caves Wilderness drop tied to the Superior Garden Obelisk."
+    - date: "2020-09-10"
+      description: "Grand Exchange buy limit reduced from 11,000 to 250."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-page-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-page-4.mdx
@@ -12,43 +12,53 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Ancient
-    page_number: 4
+  about: "Ancient page 4 is one of four pages used to assemble the Book of darkness, a Zaros-aligned god book in Old School RuneScape. Pages are looted from Treasure Trails clue caskets at multiple difficulty tiers. High alchemy value: 240 coins. Grand Exchange buy limit: 5 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-07-03"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+    equipable: false
+    stackable: true
+    noteable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0
+  treasure_trail:
+    tier: "elite"
+    drop_rate: "1/775"
+    reward_type: "page"
   related_items:
     - item_id: 12621
-      item_name: Ancient page 1
-      slug: ancient-page-1
+      item_name: "Ancient page 1"
+      slug: "ancient-page-1"
       relationship: set-piece
-      description: Page 1 of 4
+      description: "Page 1 of 4 needed to complete Book of darkness."
     - item_id: 12622
-      item_name: Ancient page 2
-      slug: ancient-page-2
+      item_name: "Ancient page 2"
+      slug: "ancient-page-2"
       relationship: set-piece
-      description: Page 2 of 4
+      description: "Page 2 of 4 needed to complete Book of darkness."
     - item_id: 12623
-      item_name: Ancient page 3
-      slug: ancient-page-3
+      item_name: "Ancient page 3"
+      slug: "ancient-page-3"
       relationship: set-piece
-      description: Page 3 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Ancient (Zaros) |
-    | Page | 4 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of darkness (Ancient god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Page 3 of 4 needed to complete Book of darkness."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy individual pages when clue droppers flood the market; full sets price at a premium when assembled.\""
+      - "sell_strategy: \"Hold and sell during god book demand spikes from PKers or prayer flickers.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"medium\""
+  trading_tips:
+    - "Buy limit of 5 makes accumulating a full set across alts straightforward."
+    - "Compare individual page prices vs assembled Book of darkness for arbitrage."
+    - "Hard and elite clue scrolls are the most common source per kill-hour."
+  history:
+    - date: "2014-07-03"
+      description: "Added to the game as part of Treasure Trails Treasure Trails clue rewards."
+    - date: "2019-01-24"
+      description: "Graphical update to match the Book of darkness colour scheme."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arcane-prayer-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arcane-prayer-scroll.mdx
@@ -12,72 +12,49 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 5
-  item:
-    type: prayer_scroll
+  about: "Arcane prayer scroll is a members-only consumable in Old School RuneScape obtained as a rare reward from the Chambers of Xeric. Reading it permanently unlocks the Augury prayer, which boosts Magic attack, Magic defence, and Defence by 25% each. High alchemy value: 48,000 coins. Grand Exchange buy limit: 5 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2017-01-26"
     tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
     weight: 0.015
-  unlocks:
-    prayer_name: Augury
-    prayer_level: 77
-    requirements:
-      prayer: 77
-      defence: 70
-    effect:
-      magic_attack: +25%
-      magic_defence: +25%
-      defence: +25%
   drop_table:
-    sources:
-      - source: Chambers of Xeric
-        rate: ~29%
-        notes: From ancient chest
-  truemarket:
-    buy_limit: 5
-    price_estimate: 6100000
+    - source: "Chambers of Xeric"
+      level: null
+      quantity: "1"
+      rarity: "Rare (20/69 from Ancient chest unique table)"
   related_items:
     - item_id: 21034
-      item_name: Dexterous prayer scroll
-      slug: dexterous-prayer-scroll
+      item_name: "Dexterous prayer scroll"
+      slug: "dexterous-prayer-scroll"
       relationship: alternative
-      description: Rigour unlock
+      description: "Unlocks Rigour, the Ranged counterpart to Augury."
     - item_id: 21047
-      item_name: Torn prayer scroll
-      slug: torn-prayer-scroll
+      item_name: "Torn prayer scroll"
+      slug: "torn-prayer-scroll"
       relationship: alternative
-      description: Preserve unlock
-    - item_id: 7554
-      item_name: Chambers of Xeric
-      slug: chambers-of-xeric
-      relationship: component
-      description: Drop source
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Prayer Scroll |
-    | Tradeable | Yes |
-    | Weight | 0.015 kg |
-
-    Augury Prayer:
-    - +25% Magic Attack
-    - +25% Magic Defence
-    - +25% Defence
-
-    Requirements: 77 Prayer, 70 Defence
-
-    Essential for:
-    - All magic PvM
-    - Raids
-    - Inferno
-    - Any magic combat
-
-    Most important magic upgrade.
+      description: "Unlocks Preserve, extending stat boost durations."
   market_strategy:
     notes:
-      - One-time unlock
-      - Priority magic upgrade
-      - Much cheaper than Rigour
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_strategy: \"Wait for post-CoX league dips when scroll supply spikes; long-term price grinds upward with magic meta updates.\""
+      - "sell_strategy: \"Sell into raids meta hype windows when new players push toward 77 Prayer.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"high\""
+  trading_tips:
+    - "One-time consumable per account; only the first scroll matters unless flipping."
+    - "Cheaper than Dexterous prayer scroll despite identical unlock weight; remains the priority magic upgrade."
+    - "Stockpile during Chambers of Xeric special events for resale spikes."
+  history:
+    - date: "2017-01-26"
+      description: "Released alongside the Dexterous prayer scroll as a Chambers of Xeric unique."
+    - date: "2017-02-09"
+      description: "Drop rate doubled to keep Augury affordable relative to Rigour."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/archers-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/archers-ring.mdx
@@ -5,73 +5,77 @@ osrs:
   id: 6733
   name: Archers ring
   slug: archers-ring
-  examine: A fabled ring that improves the wearer's skill with a bow...
+  examine: "A fabled ring that improves the wearer's skill with a bow..."
   members: true
   icon: Archers ring.png
   value: 10000
   lowalch: 4000
   highalch: 6000
   limit: 8
+  about: "Archers ring is a best-in-slot ranged accuracy ring obtained as a rare drop from Dagannoth Supreme. Doubles its bonuses when imbued via Nightmare Zone, Soul Wars, or Emir's Arena. High alchemy value: 6,000 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-11-07"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.004
+  material:
+    type: jewelry
+    tier: high
   equipment:
     slot: ring
-    type: ring
-    stats:
-      attack_ranged: 4
-    imbue:
-      location: Soul Wars/Nightmare Zone
-      imbued_ranged: 8
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 4
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
-    sources:
-      - source: Dagannoth Supreme
-        source_id: 2266
-        combat_level: 303
-        quantity: "1"
-        rarity: 1/128
-        members_only: true
-  related_items:
-    - item_id: 6737
-      item_name: Berserker ring
-      slug: berserker-ring
-      relationship: alternative
-      description: Melee equivalent
-    - item_id: 6731
-      item_name: Seers ring
-      slug: seers-ring
-      relationship: alternative
-      description: Magic equivalent
-    - item_id: 19550
-      item_name: Ring of suffering
-      slug: ring-of-suffering
-      relationship: alternative
-      description: Defensive alternative
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +4 |
-    | Requirements | None |
-
-    Best-in-slot ranged accuracy ring.
-
-    Imbue at Soul Wars or Nightmare Zone for doubled stats:
-
-    | Stat | Imbued |
-    |------|--------|
-    | Ranged attack | +8 |
-
-    BiS ranged ring for:
-    - All ranged combat
-    - Bossing
-    - Slayer
-    - Max ranged setups
-
-    Imbue is essential - doubles the bonus.
+    - source: "Dagannoth Supreme"
+      quantity: "1"
+      rarity: "1/128"
   market_strategy:
     notes:
-      - DKs are efficient to farm
-      - Imbue immediately
-      - BiS for all ranged
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "flip_potential: \"medium\""
+      - "Steady demand for ranged setups; price tracks Dagannoth Kings activity and ironman migration."
+  trading_tips:
+    - "Imbue immediately after purchase to double the ranged attack bonus."
+    - "Dagannoth Kings trips are efficient, keeping supply elastic — buy on dips."
+    - "Track price against Berserker and Seers ring for set-buying value."
+  history:
+    - date: "2005-11-07"
+      description: "Released as a Dagannoth Supreme drop."
+    - date: "2014-02-22"
+      description: "Made available again in Old School RuneScape."
+  relationships:
+    - item_name: Berserker ring
+      relationship: variant
+    - item_name: Seers ring
+      relationship: variant
+    - item_name: Warrior ring
+      relationship: variant
+    - item_name: Archers ring (i)
+      relationship: upgrade
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/attack-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/attack-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Attack mix(1) | OSRS Price Data
-description: "Attack mix(1): One dose of fishy Attack potion.. High alch: 3 GP, GE limit: 2,000."
+description: "Attack mix(1): One dose of fishy Attack potion. High alch: 3 GP, GE limit: 2,000."
 osrs:
   id: 11431
   name: Attack mix(1)
@@ -12,9 +12,71 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 2000
-  about: "Attack mix(1) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Attack mix(1) is a single-dose Barbarian Herblore potion that boosts Attack and restores 3 Hitpoints, unlocked after starting Barbarian Herblore training."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: potion
+    tier: common
+    category: potion
+  properties:
+    release_date: "2007-07-03"
+    weight: 0.045
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+  potion:
+    skill: Attack
+    boost_type: stat_boost
+    boost_amount: "3 + 10 percent of current Attack level"
+    duration_seconds: 0
+    doses: 1
+    heals: 3
+    notes: "Boosts Attack and restores 3 Hitpoints per dose. Empties to a vial when fully consumed."
+  recipes:
+    - item_name: Attack mix(1)
+      skill: Herblore
+      level: 4
+      xp: 8
+      tools: []
+      materials:
+        - item_name: Attack potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      output_quantity: 2
+      notes: "Requires Barbarian Herblore training. Roe may be substituted for caviar."
+  relationships:
+    - item_name: Attack potion
+      relationship: alternative
+      note: "Standard attack potion with no Hitpoint restore component."
+    - item_name: Caviar
+      relationship: component
+    - item_name: Roe
+      relationship: component
+      note: "Alternative to caviar with the same recipe output."
+    - item_name: Attack mix(2)
+      relationship: variant
+      note: "Two-dose version of the same Barbarian mix potion."
+  market_strategy:
+    notes:
+      - "summary: \"Niche barbarian mix potion; thin daily volume tied to fishing and combat hybrid trainers.\""
+      - "buy_strategy: \"Buy attack potion(2) and caviar separately for the highest crafting margin.\""
+      - "sell_strategy: \"Sell at GE mid-price; volume cap of 2,000 limits flip throughput.\""
+      - "volatility: \"low\""
+  trading_tips:
+    - "Restores 3 Hitpoints per dose, useful for low-level Barbarian Fishing food efficiency."
+    - "Requires Barbarian Herblore training started in the Ancient Cavern."
+    - "Empties to a vial when fully consumed — recycle the vials for Herblore profit."
+  history:
+    - date: "2007-07-03"
+      description: "Attack mix(1) added as part of the Barbarian Herblore mix potion lineup."
+  examine_variants:
+    - context: Inventory
+      text: "One dose of fishy Attack potion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/avernic-defender-hilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/avernic-defender-hilt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Avernic defender hilt | OSRS Price Data
-description: "Avernic defender hilt: Perhaps this could be used to create a defensive weapon.. High alch: 1,500,000 GP, GE limit: 8."
+description: "Avernic defender hilt is a P2P upgrade material from Theatre of Blood for the Avernic defender. High alch: 1,500,000 GP, GE limit: 8."
 osrs:
   id: 22477
   name: Avernic defender hilt
@@ -12,52 +12,78 @@ osrs:
   lowalch: 1000000
   highalch: 1500000
   limit: 8
-  item:
-    type: upgrade material
+  weight: 0.453
+  properties:
+    release_date: "2018-06-07"
     tradeable: true
-    weight: 0.453
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: misc
+    tier: third_age
+    category: material
   recipes:
-    - skill: null
-      level: 0
-      materials:
-        - item_id: 12954
-          item_name: Dragon defender
+    - skill: "Smithing"
+      level: 1
+      xp: 0
+      output_quantity: 1
+      item_name: "Avernic defender"
+      tools: []
+      inputs:
+        - item_name: "Dragon defender"
           quantity: 1
-        - item_id: 22477
-          item_name: Avernic defender hilt
+        - item_name: "Avernic defender hilt"
           quantity: 1
-      product: Avernic defender
-      product_id: 22322
+      notes: "Combine hilt with a dragon defender to create the Avernic defender. Reversible, but the hilt is consumed if reversed."
+  drop_table:
+    - source: "Theatre of Blood"
+      quantity: "1"
+      rarity: "8/19 (Normal) / 7/18 (Hard)"
+      notes: "Dropped from the Monumental chest after Verzik Vitur."
   related_items:
     - item_id: 12954
       item_name: Dragon defender
       slug: dragon-defender
       relationship: component
-      description: Base item for upgrade
+      description: "Base defender combined with the hilt"
     - item_id: 22322
       item_name: Avernic defender
       slug: avernic-defender
       relationship: product
-      description: Best-in-slot melee defender
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Upgrade Material |
-    | Tradeable | Yes |
-    | Weight | 0.453 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Avernic defender | Dragon defender + hilt |
-
-    Warning: Reversible but hilt is NOT returned.
+      description: "Best-in-slot melee defender result"
+    - item_id: 28207
+      item_name: Ghommal's avernic defender 6
+      slug: ghommals-avernic-defender-6
+      relationship: variant
+      description: "Combat Achievements-locked upgrade"
   market_strategy:
     notes:
-      - From Theatre of Blood
-      - Permanent upgrade cost
-      - BiS melee defender
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_strategy: \"Buy from raid teams; price reflects ToB drop scarcity.\""
+      - "sell_strategy: \"Sell to ironman alts or new mains chasing BiS melee defender.\""
+      - "price_trend: \"Tracks Theatre of Blood completion volume.\""
+      - "profit_margin: \"High flat margin but slow daily volume (~340 trades).\""
+  trading_tips:
+    - "Always factor in the dragon defender cost on top of the hilt."
+    - "Reversal consumes the hilt — only do it for cosmetic resets."
+    - "Hard Mode ToB has a marginally better drop rate (7/18)."
+  history:
+    - date: "2018-06-07"
+      update: "Theatre of Blood release"
+      description: "Avernic defender hilt added as a unique reward from the Monumental chest."
+  about: |-
+    Avernic defender hilt is the only upgrade path to the Avernic defender, the best-in-slot melee defender.
+
+    | Property | Value |
+    |----------|-------|
+    | Source | Theatre of Blood (Monumental chest) |
+    | Drop rate | 8/19 Normal / 7/18 Hard |
+    | Upgrade target | Dragon defender → Avernic defender |
+    | Reversible | Yes (hilt lost) |
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-daffodils.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-daffodils.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bagged daffodils | OSRS Price Data
-description: "Bagged daffodils: You can plant this in your garden.. High alch: 6,000 GP, GE limit: 10,000."
+description: "Bagged daffodils: You can plant this in your garden. High alch: 6,000 GP, GE limit: 10,000."
 osrs:
   id: 8453
   name: Bagged daffodils
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10000
-  about: "Bagged daffodils is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: poh-decoration
+    tier: mid-high
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Empty
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Garden Supplier"
+      location: "Falador"
+      price: 10000
+      currency: "Coins"
+      stock: 10
+    - shop_name: "Farming Guild garden shop"
+      location: "Farming Guild (Kebos Lowlands)"
+      price: 10000
+      currency: "Coins"
+      stock: 10
+  related_items:
+    - item_name: "Bagged rose"
+      slug: "bagged-rose"
+      relationship: variant
+      description: "Alternative POH flower decoration."
+    - item_name: "Bagged plant 1"
+      slug: "bagged-plant-1"
+      relationship: variant
+      description: "Lower-tier POH garden decoration."
+    - item_name: "Watering can"
+      slug: "watering-can"
+      relationship: component
+      description: "Required, filled, to plant the daffodils in a flower patch."
+  about: "Bagged daffodils are a player-owned house garden decoration purchased from the Garden Supplier in Falador or the Farming Guild for 10,000 coins. Planting them in the formal garden flower patch requires 70+ Construction and a filled watering can in the inventory, granting 100 Construction xp and 100 Farming xp."
+  market_strategy:
+    notes:
+      - "Steady shop supply at 10,000 gp caps the upside — GE price tracks shop price closely."
+      - "Demand is construction-driven and event-spiked (Falador house competitions, league hall projects)."
+      - "Buy limit 10,000 supports large flips, but margins above shop price are thin."
+  trading_tips:
+    - "If GE price drifts above 10k, restock from Falador — fixed price arbitrage."
+    - "Watch double Construction xp weekends for short demand spikes."
+    - "Free shop access means hard ceiling near 10k+overhead; do not chase momentum higher."
+  history:
+    - date: "2006-05-31"
+      description: "Added with the Player-Owned House garden expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-oak-tree.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-oak-tree.mdx
@@ -13,8 +13,65 @@ osrs:
   highalch: 3000
   limit: 10000
   about: "Bagged oak tree is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
+    weight: 10
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: standard
+  shops:
+    - shop_name: "Garden supplier"
+      location: "Falador Park"
+      price: 5000
+      currency: "coins"
+      stock: 5
+    - shop_name: "Farming Guild garden supplier"
+      location: "Farming Guild"
+      price: 5000
+      currency: "coins"
+      stock: 5
+  recipes:
+    - item_name: "Oak tree (POH)"
+      skill: "Construction"
+      level_required: 15
+      xp: 70
+      tools:
+        - "Watering can"
+      materials:
+        - item_name: "Bagged oak tree"
+          quantity: 1
+      output_quantity: 1
+      notes: "Plant in a POH garden tree space; also grants 70 Farming XP."
+  relationships:
+    - item_name: "Oak tree"
+      relationship: component
+      notes: "Planted as a POH garden decoration."
+    - item_name: "Bagged plant 1"
+      relationship: alternative
+      notes: "Lower-level POH garden plant."
+    - item_name: "Bagged willow tree"
+      relationship: upgrade
+      notes: "Higher Construction tier garden tree."
+  history:
+    - date: "2006-05-31"
+      description: "Released alongside POH gardening expansion."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy from Falador or Farming Guild garden supplier at 5,000gp when shop stock available.\""
+      - "sell_strategy: \"Flip to Construction levelers building POH gardens via Grand Exchange margin.\""
+      - "profit_potential: \"Modest flip margin (~1,800gp) between shop and GE.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Shop restock keeps consistent supply at 5,000gp."
+    - "Daily volume is healthy (~3,200) — easy to move stock."
+    - "Demand spikes when Construction skilling tasks pop up."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/barb-tail-harpoon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/barb-tail-harpoon.mdx
@@ -1,6 +1,6 @@
 ---
 title: Barb-tail harpoon | OSRS Price Data
-description: "Barb-tail harpoon: A mighty Hunter weapon. One previous owner.. High alch: 21 GP, GE limit: 40."
+description: "Barb-tail harpoon: A mighty Hunter weapon. One previous owner. High alch: 21 GP, GE limit: 40."
 osrs:
   id: 10129
   name: Barb-tail harpoon
@@ -12,9 +12,73 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 40
-  about: "Barb-tail harpoon is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: '2006-11-21'
+    quest_item: false
+    destroy: Drop
+  equipment:
+    slot: weapon
+    weapon_type: harpoon
+    attack_speed: 4
+    requirements:
+      hunter: 33
+    attack_bonus:
+      stab: 9
+      slash: 4
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 1.36
+  drop_table:
+    - source: Barb-tailed kebbit (deadfall trap)
+      quantity: "1"
+      rarity: Always
+  related_items:
+    - item_id: 311
+      item_name: Harpoon
+      slug: harpoon
+      relationship: alternative
+      description: Standard fishing harpoon
+    - item_id: 21028
+      item_name: Dragon harpoon
+      slug: dragon-harpoon
+      relationship: alternative
+      description: Faster fishing harpoon
+  about: |-
+    "A mighty Hunter weapon. One previous owner."
+
+    The barb-tail harpoon is a wieldable harpoon obtained by trapping barb-tailed kebbits with deadfall traps in the Piscatoris Hunter area. It requires 33 Hunter to obtain.
+
+    | Stat | Value |
+    |------|-------|
+    | Stab Attack | +9 |
+    | Slash Attack | +4 |
+    | Crush Attack | -4 |
+    | Strength | +6 |
+
+    Can be wielded as both a weapon and a harpoon, saving an inventory slot when fishing.
+  market_strategy:
+    notes:
+      - "Doubles as weapon and fishing harpoon"
+      - "Low buy limit (40/4h)"
+      - "Useful for Tempoross (cannot be lost)"
+      - "Niche but consistent demand from skillers"
+  history:
+    - date: '2006-11-21'
+      description: Item released with the Hunter skill.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/barbarian-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/barbarian-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Barbarian teleport (tablet) | OSRS Price Data
-description: "Barbarian teleport (tablet): A teleport to Barbarian Outpost.. High alch: 1 GP, GE limit: 10,000."
+description: "Barbarian teleport (tablet): A teleport to Barbarian Outpost. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 24955
   name: Barbarian teleport (tablet)
@@ -12,9 +12,68 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Barbarian teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Barbarian teleport (tablet) is a members-only consumable teleport item in Old School RuneScape. Breaking it instantly teleports the player to Barbarian Outpost with no Magic level requirement."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: tablet
+    tier: common
+    category: teleport
+  properties:
+    release_date: "2020-09-30"
+    weight: 0
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    quest_item: false
+    destroy: "Drop"
+  recipes:
+    - item_name: Barbarian teleport (tablet)
+      skill: Magic
+      level: 75
+      xp: 72
+      tools:
+        - Lunar lectern
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Astral rune
+          quantity: 2
+        - item_name: Fire rune
+          quantity: 3
+      output_quantity: 1
+      notes: "Crafted at a lunar lectern in the player-owned house with the Lunar spellbook active."
+  relationships:
+    - item_name: Barbarian teleport
+      relationship: alternative
+      note: "Spell version cast directly from the Lunar spellbook."
+    - item_name: Soft clay
+      relationship: component
+    - item_name: Law rune
+      relationship: component
+    - item_name: Astral rune
+      relationship: component
+    - item_name: Fire rune
+      relationship: component
+  market_strategy:
+    notes:
+      - "summary: \"Steady mid-tier teleport tablet with consistent daily volume; profit margin tracks soft clay and rune prices.\""
+      - "buy_strategy: \"Buy soft clay and runes at GE mid-price during off-peak hours to maximise margin when crafting.\""
+      - "sell_strategy: \"List finished tablets at GE mid-price; market absorbs steady supply due to consistent daily turnover.\""
+      - "volatility: \"low\""
+  trading_tips:
+    - "Crafting requires Magic 75 and the Lunar spellbook active."
+    - "Tablet usage has no Magic level requirement, making it popular for low-level alts."
+    - "Profit per tablet varies with soft clay and astral rune prices; track GE before bulk runs."
+  history:
+    - date: "2020-09-30"
+      description: "Barbarian teleport (tablet) released alongside the Lunar spellbook tablet expansion."
+  examine_variants:
+    - context: Inventory
+      text: "A teleport to Barbarian Outpost."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bastion-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bastion-potion-1.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Bastion potion(1) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Bastion potion(1) is a members-only item in Old School RuneScape. Combines ranging and super defence boosts. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-06-07"
+    weight: 0.03
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: potion
+    tier: potion
+  potion:
+    doses: 1
+    effects:
+      - description: "Boosts Ranged by 4 + 10% of player's level (rounded down)"
+      - description: "Boosts Defence by 5 + 15% of player's level (rounded down)"
+    duration_seconds: 60
+    notes: "Decays 1 stat point per minute (90 seconds with Preserve prayer). Combines ranging and super defence potion effects."
+  recipes:
+    - item_name: "Bastion potion(1)"
+      skill: "Herblore"
+      level_required: 80
+      xp: 155
+      tools:
+        - "Vial"
+      materials:
+        - item_name: "Cadantine blood potion (unf)"
+          quantity: 1
+        - item_name: "Wine of Zamorak"
+          quantity: 1
+      output_quantity: 1
+      notes: "Recipe yields a 3-dose potion; doses split/combine to 1-dose form."
+  relationships:
+    - item_name: "Bastion potion(2)"
+      relationship: alternative
+      notes: "2-dose variant."
+    - item_name: "Bastion potion(3)"
+      relationship: alternative
+      notes: "3-dose variant from Herblore recipe."
+    - item_name: "Bastion potion(4)"
+      relationship: alternative
+      notes: "4-dose variant."
+    - item_name: "Divine bastion potion(1)"
+      relationship: upgrade
+      notes: "Divine variant; 86 Herblore + crystal dust prevents stat decay."
+    - item_name: "Ranging potion(1)"
+      relationship: alternative
+      notes: "Pure ranging boost without defence component."
+    - item_name: "Super defence(1)"
+      relationship: alternative
+      notes: "Pure defence boost without ranging component."
+  history:
+    - date: "2018-06-07"
+      description: "Released with the Theatre of Blood update."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy decanted 1-doses when bulk PvMers offload odds-and-ends.\""
+      - "sell_strategy: \"Resell to single-trip PvMers needing a quick top-up; or decant to (4) for full margin.\""
+      - "profit_potential: \"Modest; 1-doses usually trade below per-dose 4-dose value.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Decanting 1-doses into (4)s usually captures margin."
+    - "Daily volume around 1,700 — easy to move stock."
+    - "Demand spikes during Theatre of Blood and Nex content cycles."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-1.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Battlemage potion(1) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2018-06-07"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: potion
+    tier: consumable
+    primary_material: potion
+  potion:
+    type: combat
+    doses: 1
+    description: "Boosts Magic by +4 and Defence by 5 + 15% of current Defence level (rounded down)."
+    duration_minutes: 5
+  recipes:
+    - item_name: Battlemage potion(3)
+      skill: Herblore
+      level: 80
+      xp: 155
+      tools:
+        - Vial
+      materials:
+        - item_id: 22446
+          item_name: Cadantine blood potion (unf)
+          slug: cadantine-blood-potion-unf
+          quantity: 1
+        - item_id: 3138
+          item_name: Potato cactus
+          slug: potato-cactus
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 22452
+      item_name: Battlemage potion(4)
+      slug: battlemage-potion-4
+      relationship: variant
+      description: 4-dose variant.
+    - item_id: 22454
+      item_name: Battlemage potion(3)
+      slug: battlemage-potion-3
+      relationship: variant
+      description: 3-dose variant (Herblore product).
+    - item_id: 22456
+      item_name: Battlemage potion(2)
+      slug: battlemage-potion-2
+      relationship: variant
+      description: 2-dose variant.
+    - item_id: 22446
+      item_name: Cadantine blood potion (unf)
+      slug: cadantine-blood-potion-unf
+      relationship: component
+      description: Unfinished potion base.
+    - item_id: 3138
+      item_name: Potato cactus
+      slug: potato-cactus
+      relationship: component
+      description: Secondary ingredient.
+  about: |-
+    Battlemage potion(1) is a single dose of a combined Magic and Defence boosting potion.
+
+    | Boost | Value |
+    |-------|-------|
+    | Magic | +4 |
+    | Defence | 5 + 15% of Defence level |
+
+    | Requirement | Value |
+    |-------------|-------|
+    | Herblore | 80 (155 XP) |
+
+    Created using cadantine blood potion (unf) + potato cactus.
+
+    Used for:
+    - Theatre of Blood Magic loadouts
+    - PvP magic bursts with defence padding
+    - Slayer hybrid setups
+  market_strategy:
+    notes:
+      - "Demand ties to ToB and PvP magic content"
+      - "Tracks cadantine blood potion + potato cactus cost"
+      - "1-dose has thinner liquidity than 3 or 4-dose"
+  trading_tips:
+    - Smash 4-dose into 1-dose for arbitrage when 4-dose trades cheap per-dose.
+    - GE buy limit 2,000 every 4 hours supports moderate flips.
+    - Watch ToB rotation and PvP event schedule for demand spikes.
+  history:
+    - date: "2018-06-07"
+      description: "Released alongside the Theatre of Blood update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-necklace-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/berserker-necklace-ornament-kit.mdx
@@ -13,8 +13,61 @@ osrs:
   highalch: 3000
   limit: 4
   about: "Berserker necklace ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-04-11"
+    weight: 0.5
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: jewellery
+    tier: ornament
+  treasure_trail:
+    tier: hard
+    clue_type: hard
+    rarity: "1/1625"
+  drop_table:
+    - source: "Reward casket (hard)"
+      quantity: "1"
+      rarity: "1/1625"
+      notes: "Only available from hard clue scroll caskets."
+  recipes:
+    - item_name: "Berserker necklace (or)"
+      tools:
+        - "Hands"
+      materials:
+        - item_name: "Berserker necklace"
+          quantity: 1
+        - item_name: "Berserker necklace ornament kit"
+          quantity: 1
+      output_quantity: 1
+      notes: "Combine the kit with a berserker necklace. Result is untradeable; can be detached to reverse."
+  relationships:
+    - item_name: "Berserker necklace"
+      relationship: component
+      notes: "Required base item for the ornament kit."
+    - item_name: "Berserker necklace (or)"
+      relationship: component
+      notes: "Cosmetic ornamental version produced by combining the kit."
+  history:
+    - date: "2019-04-11"
+      description: "Released with the Treasure Trails Expansion and Easter 2019 update."
+    - date: "2019-09-19"
+      description: "Examine text reworded from 'Use on the Berserker necklace to trim it with gold' to current wording."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Pick up during hard clue dry spells; very low buy limit forces patience.\""
+      - "sell_strategy: \"Sell to cosmetic collectors and clue completionists.\""
+      - "profit_potential: \"Cosmetic-only premium; price tracks hard clue volume.\""
+      - "risk_level: \"medium\""
+  trading_tips:
+    - "Buy limit of 4 per 4 hours severely restricts flips."
+    - "Daily volume ~100 — set patient bid/ask spreads."
+    - "Combined version is untradeable but reversible via detach."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-body-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-body-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black d'hide body (g) | OSRS Price Data
-description: "Black d'hide body (g) is a members body slot item requiring 40 Defence. High alch: 8,088 GP, GE limit: 8."
+description: "Black d'hide body (g) is a members body slot item requiring 40 Ranged and 40 Defence. High alch: 8,088 GP, GE limit: 8."
 osrs:
   id: 12381
   name: Black d'hide body (g)
@@ -12,67 +12,72 @@ osrs:
   lowalch: 5392
   highalch: 8088
   limit: 8
+  about: "Black d'hide body (g) is a members-only gold-trimmed ranged body in Old School RuneScape, obtained as an elite-tier Treasure Trail reward and worn as a cosmetic upgrade over the standard black d'hide body. High alchemy value: 8,088 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 6.803
+  material:
+    type: hide
+    tier: standard
   equipment:
     slot: body
-    type: ranged_armour
-    tradeable: true
-    weight: 5.4
+    weapon_type: none
+    attack_speed: null
     requirements:
       ranged: 40
       defence: 40
-    stats:
-      attack_ranged: 15
-      defence_stab: 40
-      defence_slash: 32
-      defence_crush: 45
-      defence_magic: 50
-      defence_ranged: 40
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard
-        drop_rate: Rare from reward casket
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 30
+      slash: 38
+      crush: 45
+      magic: 45
+      ranged: 50
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    source: "Reward casket (elite)"
+    rarity: "1/1,275"
   related_items:
     - item_id: 12383
-      item_name: Black d'hide chaps (g)
+      item_name: "Black d'hide chaps (g)"
       slug: black-dhide-chaps-g
-      relationship: set-piece
-      description: Matching legs
+      relationship: variant
+      description: "Matching gold-trimmed chaps."
     - item_id: 2503
-      item_name: Black d'hide body
+      item_name: "Black d'hide body"
       slug: black-dhide-body
-      relationship: downgrade
-      description: Non-gilded version
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +15 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +40 |
-    | Slash | +32 |
-    | Crush | +45 |
-    | Magic | +50 |
-    | Ranged | +40 |
-
-    Requirements: 40 Ranged, 40 Defence
-
-    Same stats as regular black d'hide body with gold trim cosmetic.
-
-    | Property | Black d'hide body | Black d'hide body (g) |
-    |----------|-------------------|----------------------|
-    | Stats | Same | Same |
-    | Appearance | Normal | Gold trimmed |
-    | Source | Crafting | Hard clue |
+      relationship: variant
+      description: "Untrimmed black dragonhide body with identical combat stats."
   market_strategy:
     notes:
-      - Hard clue exclusive
-      - Purely cosmetic upgrade
-      - Collection log item
-      - Fashionscape value
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "summary: \"Cosmetic gold-trim variant of the black d'hide body; price tracks elite clue completion rates and fashionscape interest.\""
+      - "buy_strategy: \"Accumulate during clue-fatigue lulls when elite caskets are unwound; flip into demand spikes.\""
+      - "sell_strategy: \"Move during collection log racing events or new fashion releases.\""
+  trading_tips:
+    - "Same combat stats as the standard black d'hide body, so demand is purely cosmetic."
+    - "Low buy limit of 8 constrains bulk flipping but supports tight spreads."
+    - "Pair sales with matching chaps to capture set buyers."
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the trimmed clue scroll reward expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger-p-5682.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger-p-5682.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black dagger(p+) | OSRS Price Data
-description: "Black dagger(p+): This dagger is poisoned.. High alch: 144 GP, GE limit: 125."
+description: "Black dagger(p+): This dagger is poisoned. High alch: 144 GP, GE limit: 125."
 osrs:
   id: 5682
   name: Black dagger(p+)
@@ -12,9 +12,71 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 125
-  about: "Black dagger(p+) is a members-only item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Black dagger(p+) is a members-only stab sword in Old School RuneScape, coated with weapon poison(+) and providing +10 stab attack and +7 strength for early-game combat. High alchemy value: 144 coins. Grand Exchange buy limit: 125 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-12-08"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.453
+  material:
+    type: metal
+    tier: black
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 10
+      slash: 5
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    has_special: false
+  recipes:
+    - item_name: "Black dagger(p+)"
+      skill: Herblore
+      level: 73
+      xp: 190
+      tools: []
+      materials:
+        - item_name: "Black dagger"
+          quantity: 1
+        - item_name: "Weapon poison(+)"
+          quantity: 1
+      output_quantity: 1
+      notes: "Apply weapon poison(+) to a standard black dagger; poisoning is instant in-game."
+  market_strategy:
+    notes:
+      - "summary: \"Poisoned black dagger sees niche demand from early-game PvP and Slayer players; price tracks weapon poison(+) supply.\""
+      - "buy_strategy: \"Stock when weapon poison(+) and unpoisoned black daggers dip; flip into poison-meta spikes.\""
+      - "sell_strategy: \"Move during low-level PvP events or quest bosses where stab is preferred.\""
+  trading_tips:
+    - "Spread between unpoisoned black dagger and (p+) variant reflects poison crafting margin."
+    - "Stab-weak monsters favour daggers; track Slayer rotations for demand."
+    - "Low buy limit caps bulk flips but keeps spreads tight."
+  history:
+    - date: "2001-12-08"
+      description: "Released alongside the original poisoned weapon variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-demon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-demon-mask.mdx
@@ -13,8 +13,61 @@ osrs:
   highalch: 2400
   limit: 4
   about: "Black demon mask is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 0.8
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: cosmetic
+    category: mask
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: null
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    type: reward
+    rarity: "1/851"
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Greater demon mask"
+      - "Lesser demon mask"
+      - "Old demon mask"
+      - "Jungle demon mask"
+      - "Rare master clue scroll cosmetic; supply is throttled by 4/4hr GE limit."
+      - "Price tracks demand for demon-themed fashionscape sets and clue scroll rewards."
+      - "Can be stored in the costume room treasure chest to free bank space."
+  history:
+    - date: "2016-07-06"
+      description: "Black demon mask was added as a master clue scroll reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragon-mask.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Black dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: misc
+    tier: cosmetic
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    rarity: 1/1625
+    source: Reward casket (hard)
+  related_items:
+    - item_id: 12518
+      item_name: Green dragon mask
+      slug: green-dragon-mask
+      relationship: variant
+      description: Sibling cosmetic mask
+    - item_id: 12520
+      item_name: Blue dragon mask
+      slug: blue-dragon-mask
+      relationship: variant
+      description: Sibling cosmetic mask
+    - item_id: 12522
+      item_name: Red dragon mask
+      slug: red-dragon-mask
+      relationship: variant
+      description: Sibling cosmetic mask
+  market_strategy:
+    notes:
+      - "summary: \"Hard clue cosmetic head; price driven by clue scroll completion rates.\""
+      - "target_audience: \"Clue scroll hunters and fashionscape collectors.\""
+      - "trading_strategy: \"Long-term hold during clue droughts; price moves with clue meta changes.\""
+  trading_tips:
+    - GE buy limit is only 4 per 4 hours - patient flipping required.
+    - Storable in the costume room's treasure chest to save bank space.
+  history:
+    - date: "2014-06-12"
+      description: Released as a hard clue reward alongside other dragon masks.
+  about: |-
+    Black dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours.
+
+    Purely cosmetic head slot reward from hard Treasure Trails (1/1,625 rarity from a hard reward casket).
+  properties:
+    release_date: "2014-06-12"
+    weight: 2.267
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-set-lg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black set (lg) | OSRS Price Data
-description: "Black set (lg): A set containing a full helm, platebody, legs and kiteshield.. High alch: 2,700 GP, GE limit: 8."
+description: "Black set (lg): A set containing a full helm, platebody, legs and kiteshield. High alch: 2,700 GP, GE limit: 8."
 osrs:
   id: 12988
   name: Black set (lg)
@@ -12,9 +12,51 @@ osrs:
   lowalch: 1800
   highalch: 2700
   limit: 8
-  about: "Black set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 2,700 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Black set (lg) is a free-to-play armour set in Old School RuneScape that bundles the black full helm, platebody, platelegs, and kiteshield via the Grand Exchange sets booth. High alchemy value: 2,700 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 6
+  material:
+    type: misc
+    tier: black
+  recipes:
+    - item_name: "Black set (lg)"
+      skill: None
+      level: 1
+      xp: 0
+      tools:
+        - "Grand Exchange sets booth"
+      materials:
+        - item_name: "Black full helm"
+          quantity: 1
+        - item_name: "Black platebody"
+          quantity: 1
+        - item_name: "Black platelegs"
+          quantity: 1
+        - item_name: "Black kiteshield"
+          quantity: 1
+      output_quantity: 1
+      notes: "Combine or exchange the four black armour pieces at the Grand Exchange sets booth."
+  market_strategy:
+    notes:
+      - "summary: \"Convenience bundle for the black armour kit; price floats around the sum of its components plus a premium for the single-trade purchase.\""
+      - "buy_strategy: \"Decombine and sell parts when the set premium widens; buy components and combine when set price exceeds parts.\""
+      - "sell_strategy: \"Flip to new free-to-play accounts gearing up for early bosses or PKing.\""
+  trading_tips:
+    - "Track component prices vs set price to spot arbitrage."
+    - "Free-to-play demand keeps black gear liquid in most market conditions."
+    - "Useful for quick bank organisation when noted for transport."
+  history:
+    - date: "2015-02-26"
+      description: "Released to the Grand Exchange sets booth as part of the standard armour set lineup."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-spiky-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-spiky-vambraces.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 1728
   highalch: 2592
   limit: 125
-  about: "Black spiky vambraces is a members-only item in Old School RuneScape. High alchemy value: 2,592 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.283
+  material:
+    type: dragonhide
+    tier: black
+  properties:
+    release_date: "2006-11-21"
+    quest_item: false
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    requirements:
+      ranged: 70
+    bonuses:
+      attack:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 11
+      defence:
+        stab: 6
+        slash: 5
+        crush: 7
+        magic: 8
+        ranged: 0
+      other:
+        strength: 2
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
+  crafting:
+    level: 32
+    xp: 6
+  recipes:
+    - skill: crafting
+      level: 32
+      xp: 6
+      materials:
+        - item_name: Black d'hide vambraces
+          item_id: 2497
+          quantity: 1
+        - item_name: Kebbit claws
+          item_id: 10113
+          quantity: 1
+      tools:
+        - Hands
+      product: Black spiky vambraces
+      product_id: 10085
+      output_quantity: 1
+      facility: Inventory
+  related_items:
+    - item_id: 2497
+      item_name: Black d'hide vambraces
+      slug: black-d-hide-vambraces
+      relationship: component
+      description: Base vambraces
+    - item_id: 10113
+      item_name: Kebbit claws
+      slug: kebbit-claws
+      relationship: component
+      description: Adds spikes
+    - item_id: 10083
+      item_name: Red spiky vambraces
+      slug: red-spiky-vambraces
+      relationship: variant
+      description: Higher tier variant
+  about: |-
+    Black spiky vambraces are ranged hand armour created by adding kebbit claws to black d'hide vambraces. The spikes deal extra damage in melee retaliation.
+
+    Requires 70 Ranged to equip and provides a notable upgrade over plain black d'hide vambraces.
+  market_strategy:
+    notes:
+      - "Hunter / crafting synergy"
+      - "Marginal upgrade over base vambraces"
+      - "Niche PvM use"
+      - "Kebbit claws from Hunter"
+      - "Craft yourself for small profit (~975 GP margin)"
+      - "Useful for hunter clue rewards"
+      - "Hands slot upgrade for 70+ Ranged builds"
+  history:
+    - date: "2006-11-21"
+      description: "Released alongside the Hunter skill."
+    - date: "2020-04-01"
+      description: "Renamed from Black spiky vambs to Black spiky vambraces."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-wizard-hat-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-wizard-hat-g.mdx
@@ -12,25 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
+  about: "Black wizard hat (g) is a gold-trimmed cosmetic variant of the standard wizard hat, awarded from easy clue scrolls as a wealth-signal cosmetic for pure builds."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cloth
+    tier: rare
+    category: armour
+  properties:
+    release_date: "2014-06-12"
+    weight: 0.453
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
   equipment:
     slot: head
-    requirements: {}
+    weapon_type: armour
+    attack_speed: 1
+    requirements:
+      none: 1
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
+      ranged: 0
     defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
-  related_items:
-    - item_id: 12449
-      item_name: Black wizard robe (g)
-      slug: black-wizard-robe-g
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    rarity: rare
+    notes: "Easy reward casket drop rate approximately 1/1,404."
+  relationships:
+    - item_name: Black wizard robe (g)
       relationship: set-piece
-      description: Matching gold-trimmed wizard robe
-  about: |-
-    > *"A silly pointed hat, with colourful trim."*
-
-    The black wizard hat (g) is a gold-trimmed cosmetic variant of the wizard hat. It provides +2 magic attack and defence with no requirements. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Wizard hat
+      relationship: alternative
+      note: "Untrimmed F2P equivalent with the same stats."
+  market_strategy:
+    notes:
+      - "summary: \"Cosmetic gold-trimmed wizard hat; price is driven by status appeal rather than combat utility.\""
+      - "buy_strategy: \"Buy when easy clue supply spikes; price often dips during clue-focused events.\""
+      - "sell_strategy: \"List near GE mid-price — turnover is slow but consistent for cosmetics.\""
+      - "volatility: \"medium\""
+  trading_tips:
+    - "No Defence or Magic level requirement, popular for pure accounts and cosmetic loadouts."
+    - "Identical stats to the standard wizard hat — price premium is purely cosmetic."
+    - "GE buy limit of 4 every 4 hours throttles large flipping orders."
+  history:
+    - date: "2014-06-12"
+      description: "Black wizard hat (g) released with the Treasure Trail Expansion."
+  examine_variants:
+    - context: Inventory
+      text: "A silly pointed hat, with colourful trim."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-entangle-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-entangle-sack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blighted entangle sack | OSRS Price Data
-description: "Blighted entangle sack is a members-only OSRS item. High alch: 18 GP, GE limit: 15,000."
+description: "Blighted entangle sack is a P2P Wilderness PvP consumable that casts Entangle without runes. High alch: 18 GP, GE limit: 15,000."
 osrs:
   id: 24613
   name: Blighted entangle sack
@@ -12,9 +12,82 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 15000
-  about: "Blighted entangle sack is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0
+  properties:
+    release_date: "2020-04-23"
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: misc
+    tier: bronze
+    category: consumable
+  shops:
+    - shop_name: "Justine's stuff for the Last Shopper Standing"
+      price: 1
+      currency: "Last Man Standing points"
+      location: "Ferox Enclave"
+      notes: "Sold in bundles of 70 sacks per point."
+    - shop_name: "Nomad's store"
+      price: 10
+      currency: "Zeal Tokens"
+      location: "Soul Wars lobby"
+      notes: "Sold per bundle for Soul Wars Zeal Tokens."
+  drop_table:
+    - source: "Revenant"
+      quantity: "1"
+      rarity: "Common"
+      notes: "Dropped by Revenants in the Forinthry Dungeon."
+    - source: "Wilderness Slayer monsters"
+      quantity: "1"
+      rarity: "Uncommon"
+      notes: "Various Wilderness Slayer Cave NPCs drop sacks."
+  related_items:
+    - item_id: 24611
+      item_name: Blighted manta ray
+      slug: blighted-manta-ray
+      relationship: alternative
+      description: "Blighted food, Wilderness-only"
+    - item_id: 24598
+      item_name: Blighted ancient ice sack
+      slug: blighted-ancient-ice-sack
+      relationship: alternative
+      description: "Wilderness-only Ice Barrage cast"
+    - item_id: 24615
+      item_name: Blighted teleport spell sack
+      slug: blighted-teleport-spell-sack
+      relationship: alternative
+      description: "Wilderness-only teleport"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Stock up before Wilderness PvP events or bounty rotations.\""
+      - "sell_strategy: \"Sell to PKers during high-activity hours.\""
+      - "price_trend: \"Tracks Wilderness PvP popularity.\""
+      - "profit_margin: \"Thin; arbitrage via LMS/Soul Wars conversions.\""
+  trading_tips:
+    - "Cheaper than buying nature/earth/water runes if you only PvP in Wilderness."
+    - "Each cast consumes one sack regardless of hit success."
+    - "Stock bulk via LMS points if you grind the minigame."
+  history:
+    - date: "2020-04-23"
+      update: "Wilderness Bounty Hunter rework"
+      description: "Blighted entangle sack added alongside the wider blighted-spell-sack lineup."
+  about: |-
+    Blighted entangle sack lets you cast Entangle (or Snare/Bind) in PvP areas without carrying runes.
+
+    | Property | Value |
+    |----------|-------|
+    | Magic level | 79 (for Entangle) |
+    | Stackable | Yes |
+    | Areas | Wilderness, Ferox Enclave, Mage Arena bank, PvP worlds, Castle/Clan/Soul Wars |
+    | Consumes | 1 sack per cast |
+
+    Pairs naturally with blighted food sacks for full Wilderness PK loadouts.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-beret.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-beret.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 4
-  about: "Blue beret is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Blue beret is a members-only cosmetic headwear item in Old School RuneScape obtained as a reward from easy Treasure Trails clue caskets. High alchemy value: 48 coins. Grand Exchange buy limit: 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.04
+  material:
+    type: cloth
+    tier: cosmetic
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    rarity: "1/1,404"
+  drop_table:
+    - source: "Easy Clue Casket"
+      quantity: "1"
+      rarity: "1/1,404"
+  market_strategy:
+    notes:
+      - "flip_potential: \"medium\""
+      - "Cosmetic clue reward with steady collector demand; price tracks treasure trail popularity."
+  trading_tips:
+    - "Stock up when easy clue activity spikes and resell during cosmetic fashion trends."
+    - "Compare price across the beret color set to spot relative value."
+  history:
+    - date: "2004-05-05"
+      description: "Item released as 'Berret'."
+    - date: "2004-10-01"
+      description: "Renamed from 'Berret' to 'Beret'."
+    - date: "2005-05-01"
+      description: "Renamed to 'Blue beret' when other color variants were added."
+    - date: "2005-06-01"
+      description: "Examine text updated to current 'Parlez-vous francais?' phrasing."
+  relationships:
+    - item_name: Black beret
+      relationship: variant
+    - item_name: White beret
+      relationship: variant
+    - item_name: Red beret
+      relationship: variant
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dye.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dye.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
-  about: "Blue dye is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Blue dye is a free-to-play crafting reagent made by Aggie from 2 woad leaves and 5 coins, used to recolour capes, robes, wizard hats, and a variety of cosmetic items."
+  material:
+    type: dye
+    tier: low
+  recipes:
+    - skill: Crafting
+      level: 1
+      xp: 0
+      tools: []
+      facility: Aggie (Draynor Village)
+      materials:
+        - item_name: Woad leaf
+          quantity: 2
+        - item_name: Coins
+          quantity: 5
+      output_quantity: 1
+      notes: "Aggie produces the dye in 1 game tick."
+  shops:
+    - shop_name: Oronwen's Wares
+      location: Lletya
+      stock: 5
+      price: 6
+      currency: Coins
+    - shop_name: Guinevere's Magical Coloured Threads
+      location: Prifddinas
+      stock: 5
+      price: 6
+      currency: Coins
+    - shop_name: Xochitl's general store
+      location: Tal Teklan
+      stock: 5
+      price: 6
+      currency: Coins
+  related_items:
+    - item_name: Woad leaf
+      relationship: component
+    - item_name: Red dye
+      relationship: alternative
+    - item_name: Yellow dye
+      relationship: alternative
+    - item_name: Orange dye
+      relationship: alternative
+    - item_name: Purple dye
+      relationship: alternative
+    - item_name: Green dye
+      relationship: alternative
+    - item_name: Pink dye
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "F2P Aggie craft — 2 woad leaves plus 5 coins makes one dye for substantial GE markup."
+      - "Limit of 150 per 4h slows large flips but daily volume above 4,000 keeps liquidity healthy."
+      - "Cosmetic recolour demand is steady; cape, robe, and wizard hat applications drive baseline volume."
+  trading_tips:
+    - "Buy woad leaves cheap, make dye via Aggie, flip on GE — classic F2P profit loop."
+    - "Multiple shop sources at 6 GP each cap upside; large supply increases push price back to shop cost."
+    - "Pairs well with cape merchants — stock both dye and capes during cosmetic events."
+  history:
+    - date: "2001-05-08"
+      description: "Blue dye released as part of an early RuneScape Classic Crafting update."
+  properties:
+    release_date: "2001-05-08"
+    update: "Runescape updated (8 May 2001)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-flowers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-flowers.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Blue flowers is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Blue flowers are a members-only posy in Old School RuneScape obtained by planting mithril or adamant seeds. They are a Herblore ingredient for imp repellent and double as a fun cosmetic weapon. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.028
+  equipment:
+    slot: "weapon"
+    weapon_type: "joke_weapon"
+    attack_speed: 4
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: "Imp repellent"
+      skill: "Herblore"
+      level: 3
+      xp: 0
+      materials:
+        - item_name: "Blue flowers"
+          quantity: 1
+        - item_name: "Anchovy oil"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Accumulate during quiet hours; supply spikes from Farming runs planting mithril/adamant seeds.\""
+      - "sell_strategy: \"Sell ahead of Hand in the Sand or Trouble Brewing demand windows.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"low\""
+  trading_tips:
+    - "Plant mithril or adamant seeds for self-supply during Farming runs."
+    - "Combine with anchovy oil for the imp repellent niche market."
+    - "Low daily volume; list patiently rather than dumping at instant-sell."
+  history:
+    - date: "2004-03-29"
+      description: "Released at the launch of RuneScape 2."
+    - date: "2014-12-10"
+      description: "Renamed from Flowers to Blue flowers to disambiguate colour variants."
+    - date: "2024-04-10"
+      description: "Adamant seeds added as an additional source for coloured flowers."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/boots-of-stone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/boots-of-stone.mdx
@@ -1,6 +1,6 @@
 ---
 title: Boots of stone | OSRS Price Data
-description: "Boots of stone: A pair of heat resistant boots with rocky soles.. High alch: 120 GP, GE limit: 125."
+description: "Boots of stone: A pair of heat resistant boots with rocky soles. High alch: 120 GP, GE limit: 125."
 osrs:
   id: 23037
   name: Boots of stone
@@ -12,9 +12,93 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 125
-  about: "Boots of stone is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2019-01-10"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: cloth
+    tier: slayer-utility
+  equipment:
+    slot: feet
+    weapon_type: none
+    attack_speed: 1
+    weight: 3.175
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      slayer: 44
+    degradable: false
+  shops:
+    - shop_name: Slayer Masters
+      location: Various
+      price: 200
+      quantity: 50
+  drop_table:
+    primary_source: Slayer master shops
+    sources:
+      - source: Slayer master shop
+        quantity: "1"
+        rarity: shop
+        members_only: true
+  special_attack:
+    name: Karuulm Heat Protection
+    description: Prevents heat damage in the Karuulm Slayer Dungeon.
+  related_items:
+    - item_id: 23038
+      item_name: Boots of brimstone
+      slug: boots-of-brimstone
+      relationship: upgrade
+      description: Created by attaching a drake's claw
+    - item_id: 22951
+      item_name: Drake's claw
+      slug: drake-s-claw
+      relationship: component
+      description: Combined with these to make brimstone boots
+  about: |-
+    | Property | Value |
+    |----------|-------|
+    | Slot | Feet |
+    | Defence (stab/slash/crush) | +1 each |
+    | Requirement | 44 Slayer |
+
+    - Required for safe travel in the Karuulm Slayer Dungeon
+    - Sold by all Slayer masters at 200 gp
+    - Upgrades into boots of brimstone with drake's claw
+
+    Cheap utility boots:
+    - Mandatory entry to Karuulm
+    - Forgettable combat stats
+    - Stepping stone to brimstone boots
+  market_strategy:
+    notes:
+      - "Shop price 200 gp sets a hard ceiling"
+      - "GE flips rely on convenience markup"
+      - "Demand tied to Karuulm slayer task popularity"
+  trading_tips:
+    - Stock up before Konar slayer task spikes
+    - Brimstone upgrade keeps a steady drain on supply
+    - Avoid overbidding past 600 gp; shop substitute is cheap
+  history:
+    - date: "2019-01-10"
+      description: "Released with The Kebos Lowlands."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/botanical-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/botanical-pie.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 10000
-  about: "Botanical pie is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2016-05-26"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: food
+    tier: consumable
+    primary_material: food
+  potion:
+    type: food
+    heals: 14
+    bites: 2
+    description: "Heals 14 Hitpoints across 2 bites and temporarily boosts Herblore by 4 levels."
+  recipes:
+    - item_name: Botanical pie
+      skill: Cooking
+      level: 52
+      xp: 180
+      tools:
+        - Range
+      materials:
+        - item_id: 19660
+          item_name: Uncooked botanical pie
+          slug: uncooked-botanical-pie
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 19660
+      item_name: Uncooked botanical pie
+      slug: uncooked-botanical-pie
+      relationship: component
+      description: Raw pie cooked into the finished item.
+    - item_id: 2313
+      item_name: Pie shell
+      slug: pie-shell
+      relationship: component
+      description: Base shell used in pie crafting.
+    - item_id: 2347
+      item_name: Pie dish
+      slug: pie-dish
+      relationship: component
+      description: Returned after eating both bites.
+    - item_id: 19656
+      item_name: Golovanova fruit top
+      slug: golovanova-fruit-top
+      relationship: component
+      description: Filling added to the pie shell.
+  about: |-
+    Botanical pie heals 14 Hitpoints in 2 bites and boosts Herblore by 4 levels.
+
+    | Requirement | Value |
+    |-------------|-------|
+    | Cooking | 52 (180 XP) |
+
+    Crafted using a golovanova fruit top on a pie shell, then cooked on a range.
+
+    Used for:
+    - Herblore boosting potion creation
+    - Reaching higher-tier potions without level
+    - Mid-game training food
+  market_strategy:
+    notes:
+      - "Reliable Herblore boost drives steady demand"
+      - "Tracks uncooked pie + golovanova fruit top costs"
+      - "Used by Ironmen for boosted Herblore potions"
+  trading_tips:
+    - Compare cooked pie price against uncooked pie + Cooking XP value.
+    - Demand spikes around Herblore content updates.
+    - GE buy limit of 10,000 every 4 hours supports bulk flipping.
+  history:
+    - date: "2016-05-26"
+      description: "Released alongside Monkey Madness II."
+    - date: "2016-06-02"
+      description: "Changed to members-only."
+    - date: "2016-09-08"
+      description: "Removed from master clue scroll drops."
+    - date: "2017-09-07"
+      description: "Graphically updated."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-bolts.mdx
@@ -12,28 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: ammunition
+    tier: bronze
   equipment:
     slot: ammo
-    type: bolts
-    tradeable: true
-    weight: 0
+    weapon_type: bolt
+    attack_speed: 1
     requirements:
       ranged: 1
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 0
       ranged_strength: 10
       magic_damage: 0
       prayer: 0
+  recipes:
+    - item_name: Bronze bolts
+      skill: Fletching
+      level: 9
+      xp: 0.5
+      output_quantity: 10
+      members: false
+      tools: []
+      materials:
+        - item_name: Bronze bolts (unf)
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+  drop_table:
+    - source: Goblin
+      quantity: "1"
+      rarity: common
+    - source: Mugger
+      quantity: "1"
+      rarity: common
+    - source: Imp
+      quantity: "1"
+      rarity: common
+  shops:
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      price: 6
+      stock: unlimited
+    - shop_name: Lowe's Archery Emporium
+      location: Varrock
+      price: 6
+      stock: unlimited
+    - shop_name: Gulluck and Sons
+      location: Grand Tree
+      price: 6
+      stock: unlimited
+    - shop_name: Lletya Archery Shop
+      location: Lletya
+      price: 6
+      stock: unlimited
+    - shop_name: Daryl's Ranging Surplus
+      location: Shayzien
+      price: 6
+      stock: unlimited
   related_items:
     - item_id: 9140
       item_name: Iron bolts
@@ -45,8 +93,25 @@ osrs:
       slug: bronze-crossbow
       relationship: alternative
       description: Compatible crossbow
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "summary: \"Entry-tier crossbow ammo with deep shop supply; flips have razor-thin margins.\""
+      - "target_audience: \"New rangers and low-level ironmen using bronze crossbows.\""
+  trading_tips:
+    - Buy directly from any archery shop for steady 6 gp supply.
+    - GE limit of 7,000 per 4 hours, but margins are typically pennies.
+  history:
+    - date: "2001-01-04"
+      description: Originally released as 'bolts'; renamed to 'bronze bolts' during the 2006 crossbow rework.
+  about: |-
+    Bronze bolts are the F2P entry-tier crossbow ammunition. Requires 1 Ranged to fire and 9 Fletching to attach feathers to unfinished bolts.
+  properties:
+    release_date: "2001-01-04"
+    weight: 0
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin-tips.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 10000
-  about: "Bronze javelin tips is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: ammunition
+    tier: bronze
+    primary_material: bronze
+  recipes:
+    - item_name: Bronze javelin tips
+      skill: Smithing
+      level: 6
+      xp: 12.5
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_id: 2349
+          item_name: Bronze bar
+          slug: bronze-bar
+          quantity: 1
+      output_quantity: 5
+    - item_name: Bronze javelin
+      skill: Fletching
+      level: 3
+      xp: 15
+      tools: []
+      materials:
+        - item_id: 19570
+          item_name: Bronze javelin tips
+          slug: bronze-javelin-tips
+          quantity: 15
+        - item_id: 19592
+          item_name: Javelin shaft
+          slug: javelin-shaft
+          quantity: 15
+      output_quantity: 15
+  related_items:
+    - item_id: 825
+      item_name: Bronze javelin
+      slug: bronze-javelin
+      relationship: variant
+      description: Finished javelin made by adding shafts to the tips.
+    - item_id: 2349
+      item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: Smithing material for the javelin tips.
+    - item_id: 19592
+      item_name: Javelin shaft
+      slug: javelin-shaft
+      relationship: component
+      description: Required to attach the tips into a javelin.
+  about: |-
+    Bronze javelin tips are a low-level Smithing product used to make Bronze javelins.
+
+    | Requirement | Value |
+    |-------------|-------|
+    | Smithing | 6 (12.5 XP) |
+    | Fletching | 3 (15 XP) |
+
+    Created by smithing 1 Bronze bar at an anvil with a hammer, yielding 5 tips.
+
+    Used for:
+    - Low-level Fletching training
+    - Bronze javelin supply chain
+    - Ironman Ranged training
+  market_strategy:
+    notes:
+      - "Tracks bronze bar Smithing economy"
+      - "Demand thin outside of Ironman use"
+      - "Bulk-stackable - large GE flips possible"
+  trading_tips:
+    - Compare 1 bronze bar versus 5 tips for Smithing margin.
+    - GE buy limit 10,000 every 4 hours supports bulk trades.
+    - Stackable - watch for low-tier supply gluts.
+  history:
+    - date: "2016-05-06"
+      description: "Released alongside Monkey Madness II."
+    - date: "2025-11-05"
+      description: "Renamed from Bronze javelin heads to Bronze javelin tips."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife.mdx
@@ -12,50 +12,79 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  about: "Bronze knife is the lowest tier throwing knife in Old School RuneScape. Stackable thrown weapon used for low-level Ranged training, tagging, and PvP. High alchemy value: 1 coin. Grand Exchange buy limit: 7,000."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: ammunition
+    tier: bronze
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    equipable: true
+    stackable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 1
-  stats:
-    attack:
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 4
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 3
-  smithing:
-    level: 7
-    xp: 12.5
-    method: Bronze bar at anvil
-    bars: 1
-    quantity: 5
-  related_items:
-    - item_id: 2349
-      item_name: Bronze bar
-      slug: bronze-bar
-      relationship: component
-      description: Smithing material
-    - item_id: 863
-      item_name: Iron knife
-      slug: iron-knife
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Bronze knife
+      skill: smithing
+      level: 7
+      xp: 12.5
+      output_quantity: 5
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_name: Bronze bar
+          quantity: "1"
+  shops:
+    - shop_name: Martin Thwait's Lost and Found
+      location: Rogues' Den
+      currency: coins
+      price: 1
+      stock: 0
+  relationships:
+    - item_name: Iron knife
       relationship: upgrade
-      description: Higher tier knife
-    - item_id: 806
-      item_name: Bronze dart
-      slug: bronze-dart
+    - item_name: Bronze dart
       relationship: alternative
-      description: Alternative thrown weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0.006 kg |
-    | Requirements | 1 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Bronze bar
+      relationship: component
+  market_strategy:
+    notes:
+      - "short_term: \"Cheap entry-level thrown weapon; demand spikes during low-level Ranged training events.\""
+      - "long_term: \"Stable but low margin; the GE price tends to drift up modestly with new account creation waves.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Smith bronze bars for a small per-knife margin if Smithing XP is also wanted."
+    - "Stack purchases below the 7,000 limit window when supplying PvP bulk orders."
+  history:
+    - date: "2003-04-14"
+      description: "Released as the entry-level throwing knife at launch of the knives weapon class."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-trimmed-set-lg.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 8
-  about: "Bronze trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers: ["easy"]
+  related_items:
+    - item_name: "Bronze full helm (t)"
+      slug: "bronze-full-helm-t"
+      relationship: "component"
+      description: "Trimmed full helm unpacked from the set."
+    - item_name: "Bronze platebody (t)"
+      slug: "bronze-platebody-t"
+      relationship: "component"
+      description: "Trimmed platebody unpacked from the set."
+    - item_name: "Bronze platelegs (t)"
+      slug: "bronze-platelegs-t"
+      relationship: "component"
+      description: "Trimmed platelegs unpacked from the set."
+    - item_name: "Bronze kiteshield (t)"
+      slug: "bronze-kiteshield-t"
+      relationship: "component"
+      description: "Trimmed kiteshield unpacked from the set."
+    - item_name: "Bronze gold-trimmed set (lg)"
+      slug: "bronze-gold-trimmed-set-lg"
+      relationship: "alternative"
+      description: "Gold-trimmed variant cosmetic counterpart."
+  about: "The Bronze trimmed set (lg) is a Grand Exchange bundle of the four legs-variant bronze trim pieces (full helm, platebody, platelegs, kiteshield) originally obtainable as easy Treasure Trail clue rewards. Added as a GE Sets bundle on February 26, 2015 to simplify bulk trading. Unpack at a GE clerk to access individual trimmed pieces."
+  market_strategy:
+    notes:
+      - "Pure cosmetic bundle - value comes from clue-scroll trim rarity, not stats."
+      - "Set trades at a heavy premium over its component sum (~25k spread)."
+      - "Daily volume is tiny (~23) - position size carefully."
+      - "F2P-tradeable so demand is broader than members-only trims."
+  trading_tips:
+    - "Arbitrage: buy 4 individual trimmed pieces during clue rushes, combine into set, sell the bundle."
+    - "Avoid market buys - use limit orders well below GE average."
+    - "Watch for clue-scroll content updates - drop-rate adjustments can move floor price."
+  history:
+    - date: "2015-02-26"
+      description: "Added to the Grand Exchange Sets interface as a bundled trade-in option."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-water.mdx
@@ -1,20 +1,73 @@
 ---
 title: Bucket of water | OSRS Price Data
-description: "Bucket of water: It's a bucket of water.. High alch: 3 GP, GE limit: 13,000."
+description: "Bucket of water: It's a bucket of water. High alch: 3 GP, GE limit: 13,000."
 osrs:
   id: 1929
   name: Bucket of water
   slug: bucket-of-water
-  examine: It's a bucket of water.
+  examine: "It's a bucket of water."
   members: false
   icon: Bucket of water.png
   value: 6
   lowalch: 2
   highalch: 3
   limit: 13000
-  about: "Bucket of water is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 3
+  about: "Bucket of water is a free-to-play utility item created by using a bucket on any water source. It softens clay, fills watering cans, is required in many quests, and supports brewing and farming activities."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: liquid
+    tier: basic
+  recipes:
+    - item_name: Bucket of water
+      skill: none
+      level: 1
+      xp: 0
+      tools:
+        - Water source
+      materials:
+        - item_name: Bucket
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Bucket
+      relationship: component
+    - item_name: Soft clay
+      relationship: alternative
+    - item_name: Watering can
+      relationship: alternative
+    - item_name: Jug of water
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "summary: \"Cheap consumable with steady demand from Crafting/Farming and quest paths.\""
+      - "buy_strategy: \"Fill personally from any sink/well if making in bulk; GE bids at low price fill near-instantly.\""
+      - "sell_strategy: \"Flip in bulk during Crafting events when soft clay demand spikes.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Cheapest method: take a bucket to a sink and fill it yourself — zero gold cost beyond bucket value."
+    - "Stack purchases up to 13,000 per 4h limit when prepping for soft clay or compost runs."
+    - "Required for multiple quests including Plague City, Clock Tower, and Demon Slayer — keep extras on quest accounts."
+  history:
+    - date: "2001-01-04"
+      description: "Released with the original RuneScape Classic launch utility items."
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  drop_table: []
+  shops: []
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bullseye-lantern-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bullseye-lantern-empty.mdx
@@ -13,8 +13,72 @@ osrs:
   highalch: 240
   limit: 10000
   about: "Bullseye lantern (empty) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-03-14"
+    weight: 1.36
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: standard
+  shops:
+    - shop_name: "Miltog's Lamps"
+      location: "Dorgesh-Kaan"
+      price: 400
+      currency: "coins"
+      stock: 5
+    - shop_name: "Darkmeyer Lantern Shop"
+      location: "Darkmeyer"
+      price: 400
+      currency: "coins"
+      stock: 5
+  recipes:
+    - item_name: "Bullseye lantern (empty)"
+      skill: "Crafting"
+      level_required: 49
+      xp: 0
+      tools:
+        - "Hands"
+      materials:
+        - item_name: "Bullseye lantern (unf)"
+          quantity: 1
+        - item_name: "Lantern lens"
+          quantity: 1
+      output_quantity: 1
+      notes: "Combine unfinished lantern with a lens. Crafting level cannot be boosted."
+  relationships:
+    - item_name: "Bullseye lantern"
+      relationship: upgrade
+      notes: "Filled with lamp oil at a lamp oil still to become a functional bullseye lantern."
+    - item_name: "Bullseye lantern (unf)"
+      relationship: component
+      notes: "Unfinished base used in crafting."
+    - item_name: "Lantern lens"
+      relationship: component
+      notes: "Required to craft the empty lantern."
+    - item_name: "Lamp oil"
+      relationship: component
+      notes: "Added at a lamp oil still to fill the empty lantern."
+  history:
+    - date: "2005-03-14"
+      description: "Released."
+    - date: "2015-01-15"
+      description: "Renamed to clarify the empty state and avoid trade confusion with the filled bullseye lantern."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy from Miltog's Lamps at 400gp or undercut GE listings when GE > shop price.\""
+      - "sell_strategy: \"Resell on GE at margin or use as Crafting profit loop with lantern lens.\""
+      - "profit_potential: \"Decent margin between unfinished+lens cost and GE sell price (~450gp after tax).\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Shop restock keeps a price floor near 400gp."
+    - "Daily volume is low (~62) — set patient offers."
+    - "Craft-and-flip loop needs 49 Crafting unboosted."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cemetery-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cemetery-teleport-tablet.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Cemetery teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-05-12"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Break", "Configure"]
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 71
+      xp: 82
+      materials:
+        - item_name: "Law rune"
+          quantity: 1
+        - item_name: "Soul rune"
+          quantity: 1
+        - item_name: "Blood rune"
+          quantity: 1
+        - item_name: "Dark essence block"
+          quantity: 1
+      tools: ["Arceuus lectern"]
+      output_quantity: 1
+  related_items:
+    - item_name: "Dark essence block"
+      slug: "dark-essence-block"
+      relationship: "component"
+      description: "Arceuus essence input - bottleneck material for tablet creation."
+    - item_name: "Law rune"
+      slug: "law-rune"
+      relationship: "component"
+      description: "Standard teleport rune required for the tablet."
+    - item_name: "Soul rune"
+      slug: "soul-rune"
+      relationship: "component"
+      description: "Arceuus rune component of the teleport spell."
+    - item_name: "Blood rune"
+      slug: "blood-rune"
+      relationship: "component"
+      description: "Arceuus rune component of the teleport spell."
+    - item_name: "Barrows teleport (tablet)"
+      slug: "barrows-teleport-tablet"
+      relationship: "alternative"
+      description: "Other Arceuus lectern teleport tablet for Wilderness/Barrows access."
+  about: "The Cemetery teleport (tablet) is an Arceuus Magic tablet that drops the user at The Forgotten Cemetery in level 31 Wilderness. Created at the Arceuus lectern at 71 Magic for 82 XP using one Law, Soul, and Blood rune plus a Dark essence block. Released May 12, 2016 with the Arceuus spellbook. A 2020 update added a configurable safety warning before breaking it."
+  market_strategy:
+    notes:
+      - "Stackable, low-weight teleport - solid daily-driver for clue/PK trips."
+      - "Tablet creation arbitrage: ~2.5k profit per tablet over component cost."
+      - "Demand tied to Forgotten Cemetery PvP activity and clue-step routes."
+      - "10,000 buy limit makes this easy to flip in bulk."
+  trading_tips:
+    - "Buy soul/blood/law runes + dark essence blocks during dumps to feed tablet creation."
+    - "Sell tablets in bulk during Wilderness PvP events for premium pricing."
+    - "Track wilderness rejuvenation updates - they can spike or crash demand overnight."
+  history:
+    - date: "2016-05-12"
+      description: "Released alongside the Arceuus spellbook lectern."
+    - date: "2020-09-09"
+      description: "Added a Configure right-click option to enable a Wilderness-teleport confirmation warning."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cheese.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cheese.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cheese | OSRS Price Data
-description: "Cheese: It's got holes in it.. High alch: 2 GP, GE limit: 13,000."
+description: "Cheese: It's got holes in it. F2P food and cooking ingredient. High alch: 2 GP, GE limit: 13,000."
 osrs:
   id: 1985
   name: Cheese
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  about: "Cheese is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: true
+    weight: 0.2
+    options:
+      - Eat
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 48
+      xp: 64
+      materials:
+        - item_name: "Bucket of milk"
+          quantity: 1
+      tools:
+        - Dairy churn
+      output_quantity: 1
+  shops:
+    - shop_name: "Aggie's house"
+      location: "Draynor Village"
+      price: 4
+      currency: "Coins"
+      stock: 0
+    - shop_name: "Bandit Camp cooking shop"
+      location: "Bandit Camp (Kharidian Desert)"
+      price: 4
+      currency: "Coins"
+      stock: 0
+    - shop_name: "Culinaromancer's Chest"
+      location: "Lumbridge Castle cellar"
+      price: 5
+      currency: "Coins"
+      stock: 50
+  related_items:
+    - item_name: "Bucket of milk"
+      slug: "bucket-of-milk"
+      relationship: component
+      description: "Churned at 48 Cooking to produce cheese (64 xp)."
+    - item_name: "Pizza base"
+      slug: "pizza-base"
+      relationship: product
+      description: "Combine with cheese and tomato to start the pizza chain."
+    - item_name: "Potato with cheese"
+      slug: "potato-with-cheese"
+      relationship: product
+      description: "Add cheese to a baked potato for a higher-healing food."
+    - item_name: "Macaroni"
+      slug: "macaroni"
+      relationship: product
+      description: "Cheese is a core macaroni ingredient via the Gnome Cooking chain."
+  about: "Cheese is a free-to-play food and ingredient that heals 2 hitpoints when eaten. It is required for Witch's House (1 cheese), Ratcatchers (4 cheese for poisoned cheese), and is an ingredient in pizzas, potatoes with cheese, macaroni, and several gnome battas. Members can churn buckets of milk into cheese at 48 Cooking for 64 xp."
+  market_strategy:
+    notes:
+      - "Steady ingredient demand from pizza and potato-with-cheese cookers."
+      - "F2P availability keeps the spread tight; flips rely on volume not margin."
+      - "Cooking-skill events and quest re-runs (Ratcatchers) cause short spikes."
+  trading_tips:
+    - "Stock up from the Culinaromancer's Chest if buying for ironman pizza runs."
+    - "Bulk margins are thin — flip in chunks of 1k+ to make GE fees worthwhile."
+    - "Watch for cooking-skill double-XP weekends — price softens after the event."
+  history:
+    - date: "2001-06-11"
+      description: "Released with the launch of RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chichilihui-ros.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chichilihui-ros.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Chichilihui rosé is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Chichilihui rosé is a Tlati wine introduced with the Varlamore: The Rising Darkness update, sold at Moonrise Wines in Aldarin and used as a niche Herblore booster."
+  potion:
+    doses: 1
+    effects:
+      - description: "Restores 16 Hitpoints when consumed."
+      - description: "Boosts Herblore by 1 level temporarily."
+      - description: "Drains Attack by 5 levels."
+      - description: "Drains Farming by 1 level."
+  shops:
+    - shop_name: Moonrise Wines
+      location: Aldarin
+      stock: 20
+      price: 100
+      currency: Coins
+  related_items:
+    - item_name: Tlati pinot blanc
+      relationship: alternative
+    - item_name: Tlati merlot
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Niche consumable from the Varlamore wine line — small Herblore boost offset by Attack and Farming drains."
+      - "No published GE limit; Moonrise Wines restocks 20 at 100 GP each."
+      - "Low daily GE volume keeps price soft outside specific Herblore boost niches."
+  trading_tips:
+    - "Buy direct from Moonrise Wines for guaranteed 100 GP each before flipping on GE."
+    - "Carry one or two when squeezing a +1 Herblore boost for borderline potions, not as a healing food."
+    - "Track wine bundle demand around new Varlamore content drops."
+  history:
+    - date: "2024-09-25"
+      description: "Chichilihui rosé released with the Varlamore: The Rising Darkness update."
+  properties:
+    release_date: "2024-09-25"
+    update: "Varlamore: The Rising Darkness"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chisel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chisel.mdx
@@ -1,55 +1,71 @@
 ---
 title: Chisel | OSRS Price Data
-description: "Chisel is a F2P weapon slot item. High alch: 1 GP, GE limit: 40."
+description: "Chisel is a F2P tool used in Crafting and Fletching. High alch: 0 GP, GE limit: 40."
 osrs:
   id: 1755
   name: Chisel
   slug: chisel
-  examine: Good for detailed Crafting.
+  examine: Good for detailed crafting.
   members: false
   icon: Chisel.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: 0
+  highalch: 0
   limit: 40
-  equipment:
-    slot: weapon
-    type: tool
+  weight: 0.453
+  properties:
+    release_date: "2001-01-04"
     tradeable: true
-  tool:
-    skill: crafting
-    uses:
-      - gem_cutting
-      - amethyst_processing
-      - dense_essence
-      - limestone_bricks
-  shop:
-    price: 1
-    locations:
-      - Dommik's Crafting Store (Al Kharid)
-      - Rommik's Crafty Supplies (Rimmington)
-      - General stores
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: misc
+    tier: bronze
+    category: tool
+  shops:
+    - shop_name: "General Store"
+      price: 1
+      currency: "Coins"
+      location: "Various"
+      notes: "Sold at most general stores for 1 coin"
   related_items:
     - item_id: 2347
       item_name: Hammer
       slug: hammer
       relationship: alternative
-      description: Smithing tool
+      description: "Smithing and Construction tool"
     - item_id: 1733
       item_name: Needle
       slug: needle
       relationship: alternative
-      description: Leather crafting
+      description: "Leather crafting tool"
     - item_id: 1785
       item_name: Glassblowing pipe
       slug: glassblowing-pipe
       relationship: alternative
-      description: Glass crafting
+      description: "Glass crafting tool"
     - item_id: 21347
       item_name: Amethyst
       slug: amethyst
       relationship: component
-      description: High-level cutting
+      description: "High-level cutting material"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Cheap from general stores; rarely worth GE flipping.\""
+      - "sell_strategy: \"Players typically keep one in inventory; low resale value.\""
+      - "price_trend: \"Stable at base shop value.\""
+      - "profit_margin: \"Negligible.\""
+  trading_tips:
+    - "Buy from any general store for 1 coin if you need a backup."
+    - "Free spawn available at the Crafting Guild for F2P."
+    - "Members can craft unlimited via Tool Store 1 (15 Construction)."
+  history:
+    - date: "2001-01-04"
+      update: "Release"
+      description: "Chisel added to the game as a core Crafting tool."
   about: |-
     Essential tool for Crafting skill:
 
@@ -70,8 +86,8 @@ osrs:
     | Dragonstone | 55 | 137.5 |
     | Onyx | 67 | 167.5 |
     | Zenyte | 89 | 200 |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/clue-box.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/clue-box.mdx
@@ -12,39 +12,38 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 50
-  item:
-    type: protection_item
-    tradeable: true
-    weight: 0.005
-  obtaining:
-    methods:
-      - source: Last Man Standing
-        cost: 5 LMS points
-  effect:
-    name: Wilderness Protection
-    description: Protects clue scroll or reward casket on death
-    notes:
-      - Protected item kept in addition to normal death mechanics
-      - Clue box itself is always lost on death
-      - Protects bottom-right most scroll/casket only
-      - Multiple boxes provide no additional benefit
-      - Ultimate Ironmen cannot use the protective function
+  material:
+    type: misc
+    tier: utility
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Last Man Standing lobby
+      price: 5
+      currency: Last Man Standing points
+      stock: unlimited
   related_items:
-    - item_id: 0
-      item_name: Last Man Standing
-      slug: last-man-standing
-      relationship: component
-      description: Source
-    - item_id: 0
-      item_name: Clue scroll
-      slug: clue-scroll
+    - item_id: 2677
+      item_name: Clue scroll (easy)
+      slug: clue-scroll-easy
       relationship: variant
       description: Protected item
-    - item_id: 0
-      item_name: Reward casket
-      slug: reward-casket
+    - item_id: 2802
+      item_name: Reward casket (easy)
+      slug: reward-casket-easy
       relationship: variant
       description: Protected item
+  market_strategy:
+    notes:
+      - "summary: \"Wilderness clue protection consumable; demand spikes with PvM clue events.\""
+      - "target_audience: \"Clue scroll hunters running wilderness clue steps.\""
+      - "trading_strategy: \"GE limit of 50/4h restricts bulk flipping; main supply is LMS points.\""
+  trading_tips:
+    - Buy 5 boxes per LMS visit (5 points each) for personal use.
+    - GE limit is only 50 per 4 hours.
+    - Box is always consumed on death even when it saves a scroll.
+  history:
+    - date: "2014-09-25"
+      description: Clue box released as a Last Man Standing reward shop item.
   about: |-
     | Property | Value |
     |----------|-------|
@@ -60,8 +59,13 @@ osrs:
     - Multiple boxes provide no additional benefit
 
     Note: Ultimate Ironmen cannot use the protective function.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2014-09-25"
+    weight: 0.005
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-dragon-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-dragon-claws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Corrupted dragon claws | OSRS Price Data
-description: "Corrupted dragon claws: A set of fighting claws.. High alch: 150,000 GP."
+description: "Corrupted dragon claws: A set of fighting claws. High alch: 150,000 GP."
 osrs:
   id: 28534
   name: Corrupted dragon claws
@@ -12,9 +12,70 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: null
-  about: "Corrupted dragon claws is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: '2023-08-23'
+    quest_item: false
+    destroy: Drop
+  equipment:
+    slot: weapon
+    weapon_type: claw
+    attack_speed: 4
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 33
+      slash: 46
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 11
+      slash: 21
+      crush: 6
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 48
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.907
+  special_attack:
+    name: Slice and Dice
+    energy: 50
+    description: Performs four consecutive hits with diminishing damage. Identical mechanics to standard dragon claws but with 20% lower bonuses.
+  drop_table:
+    - source: Trinket of advanced weaponry (Deadman Mode)
+      quantity: "1"
+      rarity: 1/8
+  about: |-
+    "A set of fighting claws."
+
+    Corrupted dragon claws is a Deadman Mode exclusive weapon obtained from trinkets of advanced weaponry dropped by breaches. They have 20% lower bonuses than the standard dragon claws but share the same special attack.
+
+    | Stat | Value |
+    |------|-------|
+    | Stab Attack | +33 |
+    | Slash Attack | +46 |
+    | Crush Attack | -4 |
+    | Strength | +48 |
+    | Stab Defence | +11 |
+    | Slash Defence | +21 |
+    | Crush Defence | +6 |
+
+    Requirements: 40 Attack
+  market_strategy:
+    notes:
+      - "Deadman Mode seasonal exclusive"
+      - "Not always obtainable outside of DMM events"
+      - "Same special attack as standard dragon claws"
+      - "20% lower stats than standard variant"
+      - "Collection log piece for DMM completionists"
+  history:
+    - date: '2023-08-23'
+      description: Item released as part of Deadman Mode Apocalypse.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cosmic-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cosmic-tiara.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 40
-  about: "Cosmic tiara is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 1
+  material:
+    type: runecrafting
+    tier: tiara
+  properties:
+    release_date: "2005-06-13"
+    quest_item: false
+    destroy: "Drop"
+  equipment:
+    slot: head
+    requirements:
+      runecraft: 1
+    bonuses:
+      attack:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 0
+      defence:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 0
+      other:
+        strength: 0
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
+  runecrafting:
+    level: 1
+    xp: 40
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 40
+      materials:
+        - item_name: Tiara
+          item_id: 5525
+          quantity: 1
+        - item_name: Cosmic talisman
+          item_id: 1454
+          quantity: 1
+      tools:
+        - Cosmic Altar
+      product: Cosmic tiara
+      product_id: 5539
+      output_quantity: 1
+      facility: Cosmic Altar
+  related_items:
+    - item_id: 5525
+      item_name: Tiara
+      slug: tiara
+      relationship: component
+      description: Base tiara before infusion
+    - item_id: 1454
+      item_name: Cosmic talisman
+      slug: cosmic-talisman
+      relationship: component
+      description: Talisman consumed in creation
+    - item_id: 564
+      item_name: Cosmic rune
+      slug: cosmic-rune
+      relationship: alternative
+      description: Crafted at the Cosmic Altar
+  about: |-
+    The cosmic tiara is a head slot item used as an alternative to the cosmic talisman for accessing the Cosmic Altar. It is created at the altar by using a tiara on the altar with a cosmic talisman in inventory.
+
+    When worn, the tiara allows left-click entry to the mysterious ruins housing the Cosmic Altar without needing to carry the talisman.
+  market_strategy:
+    notes:
+      - "Runecrafting utility"
+      - "Replaces talisman in inventory"
+      - "Loss-leader to craft (139 GP loss after tax)"
+      - "One-time crafting cost"
+      - "Buy rather than craft for profit"
+      - "Useful for cosmic rune runners"
+      - "Frees inventory slot vs talisman"
+  history:
+    - date: "2005-06-13"
+      description: "Released alongside other rune-specific tiaras."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/desert-camo-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/desert-camo-legs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desert camo legs | OSRS Price Data
-description: "Desert camo legs: These should make me harder to spot in desert areas.. High alch: 12 GP."
+description: "Desert camo legs: These should make me harder to spot in desert areas. High alch: 12 GP."
 osrs:
   id: 10063
   name: Desert camo legs
@@ -12,9 +12,104 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Desert camo legs is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0.226
+    release_date: '2006-11-21'
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: hunter-gear
+    primary_resource: desert devil fur
+  equipment:
+    slot: legs
+    weight_reduction: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -7
+    defence_bonus:
+      stab: 10
+      slash: 11
+      crush: 10
+      magic: 0
+      ranged: 11
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      hunter: 10
+  recipes:
+    - skill: Crafting
+      level: 1
+      xp: 0
+      output_quantity: 1
+      tools:
+        - Coins
+      facility: Fancy Clothes Store / Hunter Guild / Prifddinas Seamstress
+      materials:
+        - item_name: Desert devil fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+  shops:
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 20
+      currency: Coins
+    - shop_name: Hunter Guild Shop
+      location: Avium Savannah
+      price: 20
+      currency: Coins
+  related_items:
+    - item_id: 10061
+      item_name: Desert camo top
+      slug: desert-camo-top
+      relationship: set-piece
+      description: Matching desert camouflage body piece.
+    - item_id: 10071
+      item_name: Desert devil fur
+      slug: desert-devil-fur
+      relationship: component
+      description: Raw fur used to craft Desert camo legs.
+  history:
+    - date: '2006-11-21'
+      description: "Desert camo legs were released alongside the Hunter skill."
+  about: |-
+    > *"These should make me harder to spot in desert areas."*
+
+    Desert camo legs are leg-slot camouflage gear in Old School RuneScape. They require 10 Hunter to equip and reduce worn weight by 2 kg.
+
+    | Detail | Value |
+    |--------|-------|
+    | Slot | Legs |
+    | Hunter Req | 10 |
+    | Weight Reduction | 2 kg |
+    | Defence (slash) | +11 |
+    | Defence (ranged) | +11 |
+    | Made From | 2 Desert devil furs + 20 coins |
+
+    Despite the examine text suggesting camouflage benefits, the legs do not provide any actual creature trapping bonus in the Hunter skill.
+  market_strategy:
+    notes:
+      - "Cheap entry-level Hunter cosmetic"
+      - "Cost driven by desert devil fur supply"
+      - "Often crafted by Hunter players for small profit"
+      - "Members only item"
+  trading_tips:
+    - Watch desert devil fur prices as the primary cost driver.
+    - Margins are thin; best treated as a Hunter crafting side income.
+    - Demand is steady but small; expect slow GE turnover.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-helm-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-helm-0.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
-  about: "Dharok's helm 0 is a members-only item in Old School RuneScape. High alchemy value: 61,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 1.814
+  material:
+    type: barrows
+    tier: barrows
+  properties:
+    release_date: "2005-05-09"
+    quest_item: false
+    destroy: "Drop"
+  equipment:
+    slot: head
+    requirements:
+      defence: 70
+    bonuses:
+      attack:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 0
+      defence:
+        stab: 45
+        slash: 48
+        crush: 44
+        magic: -1
+        ranged: 51
+      other:
+        strength: 0
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
+  charges:
+    max: 1
+    type: degradation
+    description: "15 hours of combat before fully degrading to broken state. Repair at NPC for 60,000 coins or POH armour stand for 59,700 coins."
+  drop_table:
+    - source: Barrows chest
+      level: 0
+      quantity: "1"
+      rarity: "1/2448"
+      members: true
+  related_items:
+    - item_id: 4716
+      item_name: Dharok's helm
+      slug: dharok-s-helm
+      relationship: variant
+      description: Undamaged version
+    - item_id: 4882
+      item_name: Dharok's helm 100
+      slug: dharok-s-helm-100
+      relationship: variant
+      description: 100% charged variant
+    - item_id: 4886
+      item_name: Dharok's helm 25
+      slug: dharok-s-helm-25
+      relationship: variant
+      description: 25% charged variant
+  about: |-
+    Dharok's helm is part of Dharok the Wretched's Barrows set. The 0 variant indicates the helm has fully degraded and must be repaired before it can be equipped again.
+
+    When worn with the complete Dharok set, the wearer deals significantly more damage as their hitpoints decrease, up to nearly 99% bonus damage at 1 HP.
+  market_strategy:
+    notes:
+      - "Barrows equipment"
+      - "Degraded variant"
+      - "Requires repair before use"
+      - "Part of Dharok's set"
+      - "Cheaper than charged variants"
+      - "Buy degraded variants and repair for profit margin"
+      - "Repair cost 59,700 GP at POH armour stand vs 60,000 at NPC"
+      - "Set effect requires full Dharok's set worn together"
+  history:
+    - date: "2005-05-09"
+      description: "Released as part of the Barrows minigame update."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-amulet.mdx
@@ -12,49 +12,117 @@ osrs:
   lowalch: 1410
   highalch: 2115
   limit: 10000
+  weight: 0.007
+  material:
+    type: jewellery
+    tier: diamond
+  properties:
+    release_date: "2001-05-08"
+    quest_item: false
+    destroy: "Drop"
   equipment:
     slot: neck
     requirements:
       crafting: 70
+    bonuses:
+      attack:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 0
+      defence:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: 0
+        ranged: 0
+      other:
+        strength: 0
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
+  crafting:
+    level: 70
+    xp: 100
   recipes:
     - skill: crafting
       level: 70
       xp: 100
-      inputs:
-        - item_name: Diamond
-          quantity: 1
+      materials:
         - item_name: Gold bar
+          item_id: 2357
           quantity: 1
+        - item_name: Diamond
+          item_id: 1601
+          quantity: 1
+        - item_name: Amulet mould
+          item_id: 1595
+          quantity: 1
+      tools:
+        - Furnace
+      product: Diamond amulet (unstrung)
+      product_id: 1681
       output_quantity: 1
+      facility: Furnace
+    - skill: crafting
+      level: 1
+      xp: 4
+      materials:
+        - item_name: Diamond amulet (unstrung)
+          item_id: 1681
+          quantity: 1
+        - item_name: Ball of wool
+          item_id: 1759
+          quantity: 1
+      tools:
+        - Hands
+      product: Diamond amulet
+      product_id: 1700
+      output_quantity: 1
+      facility: Inventory
   related_items:
     - item_id: 1698
       item_name: Ruby amulet
       slug: ruby-amulet
-      relationship: downgrade
+      relationship: variant
       description: Previous tier amulet
     - item_id: 1702
       item_name: Dragonstone amulet
       slug: dragonstone-amulet
       relationship: upgrade
       description: Next tier amulet
+    - item_id: 1725
+      item_name: Amulet of power
+      slug: amulet-of-power
+      relationship: upgrade
+      description: Enchanted variant
   about: |-
     Crafting (Level 70): Diamond + Gold bar at a furnace with amulet mould (100 XP). String with ball of wool.
 
-    > *"A diamond amulet."*
+    > *"I wonder if I can get this enchanted."*
 
-    Lvl-4 Enchant (57 Magic): 1 cosmic rune + 10 earth runes (67 XP)
+    Lvl-4 Enchant (57 Magic): 1 cosmic rune + 10 earth runes (67 XP) converts the amulet into the Amulet of power.
 
-    The Amulet of power provides +6 to all attack styles and +6 to all defence styles plus +6 Strength and +1 Prayer. It's the best all-round F2P amulet:
+    The Amulet of power is the best all-round F2P amulet:
     - Balanced offensive and defensive bonuses
     - +1 Prayer is unique for F2P neck slot
     - Outclassed by glory in P2P but free-to-play accessible
   market_strategy:
     notes:
-      - F2P BiS all-round amulet
-      - High demand from F2P PvM/PvP
-      - Popular crafting training at level 70
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "F2P BiS all-round amulet base"
+      - "High demand from F2P PvM/PvP"
+      - "Popular crafting training at level 70"
+      - "Enchants into Amulet of power"
+      - "Highest level craftable in F2P"
+      - "Margin tighter when Amulet of power is in demand"
+      - "Combine with cosmic + earth runes for enchant profit"
+      - "Bulk craft for Crafting XP plus modest loss"
+  history:
+    - date: "2001-05-08"
+      description: "Released with the original Crafting jewellery system."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-ring.mdx
@@ -12,56 +12,83 @@ osrs:
   lowalch: 1410
   highalch: 2115
   limit: 10000
+  about: "Diamond ring is a free-to-play gold ring set with a diamond, crafted at 43 Crafting from a gold bar, cut diamond, and ring mould at a furnace for 85 XP. Members can cast Lvl-4 Enchant on it to make a Ring of Life that auto-teleports the wearer to their respawn point when HP drops below 10%. High alchemy value: 2,115 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.006
+  material:
+    type: gem
+    primary: gold
+    tier: diamond
   equipment:
     slot: ring
-    requirements:
-      crafting: 43
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
-    - skill: crafting
-      level: 43
-      xp: 85
-      inputs:
-        - item_id: 1662
-          item_name: Diamond
+    - item_name: Diamond ring
+      tools: ["Ring mould", "Furnace"]
+      materials:
+        - item_name: Gold bar
           quantity: 1
-        - item_id: 2357
-          item_name: Gold bar
+        - item_name: Diamond
           quantity: 1
       output_quantity: 1
-  related_items:
-    - item_id: 1641
-      item_name: Ruby ring
-      slug: ruby-ring
-      relationship: downgrade
-      description: Previous tier ring
-    - item_id: 1645
-      item_name: Dragonstone ring
-      slug: dragonstone-ring
-      relationship: upgrade
-      description: Next tier ring
-    - item_id: 2570
-      item_name: Ring of life
-      slug: ring-of-life
-      relationship: upgrade
-      description: Enchanted version (auto-teleport at low HP)
-  about: |-
-    Crafting (Level 43): Diamond + Gold bar at a furnace (85 XP)
-
-    > *"A diamond ring."*
-
-    Lvl-4 Enchant (57 Magic): 1 cosmic rune + 10 earth runes (67 XP)
-
-    The Ring of life automatically teleports you to your respawn point when HP drops to 10% or below. Destroyed after one use. Works up to level 30 Wilderness (higher than most jewelry). Popular safety item for:
-    - Hardcore Ironman accounts
-    - Wilderness skilling
-    - AFK training
+      skill: Crafting
+      level: 43
+      xp: 85
+      notes: "Crafted at a furnace; sells well to Magic trainers enchanting Rings of Life."
+    - item_name: Ring of life
+      tools: ["Staff"]
+      materials:
+        - item_name: Diamond ring
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 10
+      output_quantity: 1
+      skill: Magic
+      level: 57
+      xp: 67
+      notes: "Members-only Lvl-4 Enchant converts the diamond ring into a Ring of Life."
   market_strategy:
     notes:
-      - Ring of life consumed on activation — recurring demand
-      - Popular with HCIM and Wilderness players
-      - Diamond cost is the main expense
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_range: \"1,800 - 2,000 gp\""
+      - "sell_range: \"2,000 - 2,300 gp\""
+      - "Steady recurring demand from Magic trainers turning diamond rings into Rings of Life; margins tighten when diamond prices spike."
+  trading_tips:
+    - "Track diamond and gold bar prices together; craft margins drive flips."
+    - "Demand spikes during Wilderness events as HCIM accounts stock Rings of Life."
+    - "Bulk-craft for Magic XP and resell the enchanted Ring of Life for combined profit."
+  history:
+    - date: "2001-05-08"
+      description: "Released with the original crafting jewelry set."
+    - date: "2007-04-30"
+      description: "Received a graphical update to its inventory icon."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-strength-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-strength-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine super strength potion(1) | OSRS Price Data
-description: "Divine super strength potion(1): 1 dose of divine super strength potion.. High alch: 24 GP, GE limit: 2,000."
+description: "Divine super strength potion(1): 1 dose of divine super strength potion. High alch: 24 GP, GE limit: 2,000."
 osrs:
   id: 23718
   name: Divine super strength potion(1)
@@ -12,9 +12,90 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  about: "Divine super strength potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0.03
+    release_date: '2019-07-25'
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  potion:
+    doses: 1
+    base_potion: Super strength potion
+    boost_skill: Strength
+    boost_formula: "+5 +15% of player's Strength level"
+    duration_minutes: 5
+    drain_hitpoints: 10
+    minimum_hitpoints: 11
+  recipes:
+    - skill: Herblore
+      level: 70
+      xp: 0.5
+      output_quantity: 1
+      tools:
+        - Pestle and mortar
+      materials:
+        - item_name: Super strength potion(1)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 1
+  related_items:
+    - item_id: 23716
+      item_name: Divine super strength potion(2)
+      slug: divine-super-strength-potion-2
+      relationship: alternative
+      description: Two-dose version of the same potion.
+    - item_id: 23714
+      item_name: Divine super strength potion(3)
+      slug: divine-super-strength-potion-3
+      relationship: alternative
+      description: Three-dose version of the same potion.
+    - item_id: 23712
+      item_name: Divine super strength potion(4)
+      slug: divine-super-strength-potion-4
+      relationship: alternative
+      description: Four-dose version of the same potion.
+    - item_id: 2440
+      item_name: Super strength(1)
+      slug: super-strength-1
+      relationship: component
+      description: Base potion used in the recipe.
+    - item_id: 23964
+      item_name: Crystal dust
+      slug: crystal-dust
+      relationship: component
+      description: Additive used to craft the divine variant.
+  history:
+    - date: '2019-07-25'
+      description: "Divine super strength potion was released as part of the Song of the Elves quest update."
+  about: |-
+    > *"1 dose of divine super strength potion."*
+
+    Divine super strength potion(1) is a single-dose Strength-boosting potion. Drinking it raises Strength by 5 + 15% of the player's Strength level and holds the boost steady for 5 minutes, but it costs 10 hitpoints per dose.
+
+    | Detail | Value |
+    |--------|-------|
+    | Herblore Req | 70 |
+    | XP | 0.5 per dose |
+    | Boost | +5 +15% of Strength |
+    | Duration | 5 minutes |
+    | HP Drain | 10 per dose |
+
+    The divine line of potions is valued in PvM because the boost does not decay, unlike traditional super potions. The HP drain limits use to higher-HP accounts and combat content where food is already required.
+  market_strategy:
+    notes:
+      - "Steady demand from PvM accounts using divine boosts"
+      - "Cost driven by crystal dust + super strength potion"
+      - "1-dose form often used as filler or for short combat tasks"
+      - "Members only item"
+  trading_tips:
+    - Compare 1/2/3/4-dose prices for arbitrage via decant NPCs.
+    - Track crystal shard and crystal dust prices on the GE.
+    - Buy limit of 2,000 supports moderate flipping.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/doogle-leaves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/doogle-leaves.mdx
@@ -1,6 +1,6 @@
 ---
 title: Doogle leaves | OSRS Price Data
-description: "Doogle leaves: A tasty herb, good for seasoning.. High alch: 1 GP, GE limit: 15."
+description: "Doogle leaves: A tasty herb, good for seasoning. High alch: 1 GP, GE limit: 15."
 osrs:
   id: 1573
   name: Doogle leaves
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Doogle leaves is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: herb
+    tier: low
+  properties:
+    release_date: "2003-07-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.007
+    options:
+      - Eat
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 1
+      materials:
+        - item_name: "Doogle leaves"
+          quantity: 1
+        - item_name: "Raw sardine"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: "Seasoned sardine"
+      slug: "seasoned-sardine"
+      relationship: product
+      description: "Combine with a raw sardine to season it — needed during Gertrude's Cat."
+    - item_name: "Raw sardine"
+      slug: "raw-sardine"
+      relationship: component
+      description: "Pairs with doogle leaves to produce a seasoned sardine."
+    - item_name: "Ogre bellows"
+      slug: "ogre-bellows"
+      relationship: alternative
+      description: "Used alongside doogle leaves during Big Chompy Bird Hunting."
+  about: "Doogle leaves are a low-tier members herb used to season raw sardines for Gertrude's Cat and as an ingredient during Big Chompy Bird Hunting. They spawn in three locations: behind Gertrude's house west of Varrock, near the swaying tree in the Fremennik region, and east of the gnome glider in Feldip Hills. Spawns respawn every 100 ticks (~60 seconds)."
+  market_strategy:
+    notes:
+      - "Tiny GE buy limit (15 / 4h) keeps speculation negligible."
+      - "Demand is mostly quest-driven — Gertrude's Cat and Big Chompy Bird Hunting."
+      - "Supply via free spawns means GE price hovers near spawn-route opportunity cost."
+  trading_tips:
+    - "Picking spawns is faster than buying for most ironmen-adjacent flows."
+    - "Bulk buy/sell is impractical — limit is too small for serious flipping."
+    - "Useful as a chat-quest filler for new accounts running Gertrude's Cat."
+  history:
+    - date: "2003-07-28"
+      description: "Released with the Gertrude's Cat quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p-11228.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-arrow-p-11228.mdx
@@ -13,8 +13,74 @@ osrs:
   highalch: 480
   limit: 11000
   about: "Dragon arrow(p+) is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    quest_item: false
+    weight: 0
+    destroy: "Drop"
+  material:
+    type: ammunition
+    tier: dragon
+    category: arrow
+  equipment:
+    slot: ammo
+    weapon_type: arrow
+    attack_speed: null
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 60
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: "Poison(+)"
+    description: "Has a chance to inflict venomous poison on the target, dealing higher damage than standard poison."
+  recipes:
+    - item_name: Dragon arrow(p+)
+      skill: Fletching
+      level: 90
+      xp: 0
+      tools:
+        - Dragon arrow
+        - Weapon poison(+)
+      materials:
+        - item_name: Dragon arrow
+          quantity: 5
+        - item_name: Weapon poison(+)
+          quantity: 1
+      output_quantity: 5
+      members: true
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Dragon arrow"
+      - "Dragon arrow(p)"
+      - "Dragon arrow(p++)"
+      - "Used as ammunition for high-tier bows including dark bow, twisted bow, and venator bow."
+      - "Poisoned variants are popular for PvP and bossing where venom application is desired."
+      - "Price often tracks demand for dark bow and twisted bow players."
+  history:
+    - date: "2007-06-11"
+      description: "Dragon arrows were released alongside the While Guthix Sleeps update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon dart(p) | OSRS Price Data
-description: "Dragon dart(p): A deadly poisoned dart with a dragon tip.. High alch: 300 GP, GE limit: 11,000."
+description: "Dragon dart(p) is a P2P poisoned thrown weapon requiring 60 Ranged. High alch: 300 GP, GE limit: 11,000."
 osrs:
   id: 11231
   name: Dragon dart(p)
@@ -12,9 +12,93 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
-  about: "Dragon dart(p) is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.01
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: ammunition
+    tier: dragon
+    category: ammunition
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 35
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    has_special: false
+  related_items:
+    - item_id: 11230
+      item_name: Dragon dart
+      slug: dragon-dart
+      relationship: alternative
+      description: "Unpoisoned variant"
+    - item_id: 11232
+      item_name: Dragon dart tip
+      slug: dragon-dart-tip
+      relationship: component
+      description: "Crafted via Smithing into dart tips"
+    - item_id: 314
+      item_name: Feather
+      slug: feather
+      relationship: component
+      description: "Combined with dart tip to make dart"
+    - item_id: 12926
+      item_name: Toxic blowpipe
+      slug: toxic-blowpipe
+      relationship: alternative
+      description: "Higher-tier ranged thrown weapon"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy in bulk during low-demand windows; thrown stacks move fast.\""
+      - "sell_strategy: \"Sell to players grinding ranged training or specific PvM tasks.\""
+      - "price_trend: \"Tracks dragon dart tip and feather supply.\""
+      - "profit_margin: \"Thin; arbitrage requires Fletching at 95.\""
+  trading_tips:
+    - "Fletch at 95 Fletching from dart tip + feather for 25 XP each."
+    - "Poisoned variant is mainly for PvP; PvE prefers unpoisoned."
+    - "Dragon implings drop dragon darts at random."
+  history:
+    - date: "2007-06-11"
+      update: "Release"
+      description: "Dragon darts and poisoned variants released alongside dart-tip Smithing."
+  about: |-
+    Dragon dart(p) is a high-tier thrown weapon used primarily for PvP and certain PvM niches:
+
+    | Stat | Value |
+    |------|-------|
+    | Ranged level | 60 |
+    | Ranged strength | +35 |
+    | Attack speed | 3 ticks (Rapid: 2) |
+    | Fletching level | 95 |
+    | Fletching XP | 25 per dart |
+
+    Poison applies a damage-over-time effect on hit. Pairs with the toxic blowpipe for ammunition.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-defender-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-defender-ornament-kit.mdx
@@ -12,9 +12,39 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Dragon defender ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Dragon defender ornament kit is applied to a dragon defender to create the cosmetic dragon defender (t). Obtained from master clue scroll reward caskets."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 0.5
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: cosmetic
+    category: ornament_kit
+  treasure_trail:
+    tier: master
+    type: reward
+    rarity: "1/851"
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Dragon defender"
+      - "Dragon defender (t)"
+      - "Dragon scimitar ornament kit"
+      - "Dragon platebody ornament kit"
+      - "Pure cosmetic kit; applying to a dragon defender creates the trimmed variant."
+      - "Kit can be detached from the defender and resold separately on the GE."
+      - "Master clue exclusive; supply throttled by 4/4hr buy limit."
+  history:
+    - date: "2016-07-06"
+      description: "Dragon defender ornament kit released as a master clue scroll reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-felling-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-felling-axe.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 22000
   highalch: 33000
   limit: null
-  about: "Dragon felling axe is a members-only item in Old School RuneScape. High alchemy value: 33,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Dragon felling axe is a two-handed Forestry woodcutting axe combined from a felling axe handle and a dragon axe. Grants 10% bonus Woodcutting XP when wielded with Forester's rations and shares the Lumber Up special. High alchemy value: 33,000 coins."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-10-25"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 1.814
+  material:
+    type: metal
+    tier: dragon
+  equipment:
+    slot: two_handed
+    weapon_type: axe
+    attack_speed: 7
+    requirements:
+      attack: 60
+      woodcutting: 61
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 51
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 67
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: "Lumber Up"
+    description: "Temporarily boosts Woodcutting by 3 levels at the cost of 100% special attack energy."
+    energy: 100
+  recipes:
+    - item_name: Dragon felling axe
+      skill: Smithing
+      level: 61
+      xp: 0
+      tools:
+        - Anvil
+        - Hammer
+      materials:
+        - item_name: Dragon axe
+          quantity: 1
+        - item_name: Felling axe handle
+          quantity: 1
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "flip_potential: \"medium\""
+      - "Forestry meta tool tied to dragon axe pricing and Forester's rations supply; demand spikes during Woodcutting events."
+  trading_tips:
+    - "Combine cheap dragon axes with felling axe handles when the spread justifies the smith conversion."
+    - "Watch Forestry update news — buffs to Forestry XP often spike axe demand."
+    - "Hold Forester's rations alongside the axe to capture the 10% bonus XP setup premium."
+  history:
+    - date: "2023-10-25"
+      description: "Released as part of the Forestry: Part Two update."
+  relationships:
+    - item_name: Dragon axe
+      relationship: component
+    - item_name: Felling axe handle
+      relationship: component
+    - item_name: Crystal felling axe
+      relationship: upgrade
+    - item_name: 3rd age felling axe
+      relationship: variant
+    - item_name: Forester's rations
+      relationship: alternative
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hunter-lance.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hunter-lance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon hunter lance | OSRS Price Data
-description: "Dragon hunter lance is a members two-handed weapon requiring 75 Attack. High alch: 180,000 GP, GE limit: 8."
+description: "Dragon hunter lance is a members one-handed spear requiring 78 Attack with +20% accuracy and damage vs draconic creatures. High alch: 180,000 GP, GE limit: 8."
 osrs:
   id: 22978
   name: Dragon hunter lance
@@ -12,99 +12,83 @@ osrs:
   lowalch: 120000
   highalch: 180000
   limit: 8
+  about: "Dragon hunter lance is a one-handed Zamorakian-derived spear created by combining a Hydra claw with a Zamorakian hasta. It grants 20% bonus accuracy and damage against draconic creatures (including wyverns) and stacks multiplicatively with Void and Slayer helm (i). Requires 78 Attack to wield. High alchemy value: 180,000 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 3
+  material:
+    type: misc
+    primary: metal
+    tier: dragon
   equipment:
-    slot: 2h
-    type: scythe
-    attack_style: melee
-    attack_speed: 5
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    two_handed: false
     requirements:
-      attack: 75
-      strength: 75
-    stats:
-      attack_slash: 125
-      attack_stab: 70
-      attack_crush: 30
-      strength: 75
-    degradeable: true
-  effect:
-    multi_hit: true
-    hit_pattern: 1x3 arc
-    hit_count_2x2: 2
-    hit_count_3x3: 3
-    damage_falloff: 50
-  charging:
-    material_id: 22446
-    material_name: Vial of blood
-    charges_per_material: 100
-    max_charges: 20000
-    alternate_material_id: 565
-    alternate_material_name: Blood rune
-    alternate_charges_per_material: 0.5
+      attack: 78
+    attack_bonus:
+      stab: 85
+      slash: 65
+      crush: 65
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 70
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: "Dragon-slaying lance"
+    energy: 0
+    description: "Passive: +20% accuracy and damage against draconic creatures including dragons and wyverns. Stacks multiplicatively with Void Knight equipment, Salve amulet (ei), and Slayer helm (i)."
+  recipes:
+    - item_name: Dragon hunter lance
+      tools: []
+      materials:
+        - item_name: Hydra claw
+          quantity: 1
+        - item_name: Zamorakian hasta
+          quantity: 1
+      output_quantity: 1
+      skill: "None"
+      level: 1
+      xp: 0
+      notes: "Use the Hydra claw on a Zamorakian hasta to combine them into the lance; irreversible."
   drop_table:
-    sources:
-      - source: Theatre of Blood
-        source_id: 8370
-        combat_level: 0
-        quantity: "1"
-        rarity: Rare
-        members_only: true
-  related_items:
-    - item_id: 22446
-      item_name: Vial of blood
-      slug: vial-of-blood
-      relationship: component
-      description: Charging material
-    - item_id: 565
-      item_name: Blood rune
-      slug: blood-rune
-      relationship: component
-      description: Charging material
-    - item_id: 22324
-      item_name: Ghrazi rapier
-      slug: ghrazi-rapier
-      relationship: alternative
-      description: ToB stab weapon
-    - item_id: 22323
-      item_name: Sanguinesti staff
-      slug: sanguinesti-staff
-      relationship: alternative
-      description: ToB mage weapon
-  about: |-
-    | Stat | Charged | Uncharged |
-    |------|---------|-----------|
-    | Slash attack | +125 | +75 |
-    | Stab attack | +70 | +50 |
-    | Crush attack | +30 | +10 |
-    | Strength | +75 | +50 |
-
-    Requirements: 75 Attack, 75 Strength
-
-    3-Hit Attack:
-    - Attacks in 1x3 arc in front of player
-    - Hits multiple times on large enemies:
-      - 2x2 monsters: 2 hits
-      - 3x3+ monsters: 3 hits
-    - Each successive hit deals 50% less damage
-
-    Best Against:
-    - Large bosses (Verzik, Nightmare, Nex)
-    - Multi-target scenarios
-
-    | Resource | Amount | Charges |
-    |----------|--------|---------|
-    | Vial of blood | 1 | 100 |
-    | Blood rune | 200 | 100 |
-
-    - Max charges: 20,000
-    - Cost per attack: ~535 gp
-    - Only uses charges on successful hits
+    - source: "Alchemical Hydra"
+      level: 426
+      quantity: "1"
+      rarity: "1/256 (Hydra claw)"
+      notes: "Drops the Hydra claw component used in crafting the lance."
   market_strategy:
     notes:
-      - Most expensive melee weapon
-      - Essential for efficient ToB/high-level PvM
-      - Charging costs add up - factor into profit calcs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_range: \"55,000,000 - 62,000,000 gp\""
+      - "sell_range: \"60,000,000 - 70,000,000 gp\""
+      - "Premium dragon slayer weapon; price tracks Hydra claw supply and dragon-focused PvM meta. Volume spikes during Slayer streamer events."
+  trading_tips:
+    - "Watch Alchemical Hydra droprate updates which directly shift Hydra claw supply."
+    - "Pair lance flips with Avernic defender for full melee setup buyers."
+    - "Premium during Vorkath or wyvern slayer task meta phases."
+  history:
+    - date: "2019-01-10"
+      description: "Released as part of the Hydra Slayer expansion, combining the Hydra claw with a Zamorakian hasta."
+    - date: "2019-08-15"
+      description: "Buff: passive damage and accuracy bonus reapplied to wyverns and other draconic creatures after early-release inconsistencies."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-sword.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon sword | OSRS Price Data
-description: "Dragon sword is a members head slot item requiring 75 Defence. High alch: 43,200 GP, GE limit: 70."
+description: "Dragon sword is a members one-handed sword requiring 60 Attack. High alch: 43,200 GP, GE limit: 70."
 osrs:
   id: 21009
   name: Dragon sword
@@ -12,64 +12,85 @@ osrs:
   lowalch: 28800
   highalch: 43200
   limit: 70
+  properties:
+    release_date: '2017-01-05'
+    quest_item: false
+    destroy: Drop
   equipment:
-    slot: head
-    type: magic_hat
-    tradeable: true
-    weight: 0.453
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
     requirements:
-      magic: 75
-      defence: 75
-    stats:
-      magic_attack: 8
-      magic_def: 8
-      magic_damage_percent: 2
+      attack: 60
+    attack_bonus:
+      stab: 65
+      slash: 55
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 63
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 1.814
+  special_attack:
+    name: Wild Stab
+    energy: 40
+    description: 25% increased accuracy and damage; ignores Protect from Melee prayer for one attack against NPCs.
   drop_table:
-    sources:
-      - source: Chambers of Xeric
-        rate: 3/69
-        notes: Ancient chest
-  truemarket:
-    buy_limit: 8
-    price_estimate: 18000000
+    - source: Wyrm
+      quantity: "1"
+      rarity: 1/10,000
+    - source: Shadow Wyrm
+      quantity: "1"
+      rarity: 1/2,000
+    - source: Lost ironwood crate
+      quantity: "1"
+      rarity: 1/8
   related_items:
-    - item_id: 21018
-      item_name: Ancestral robe top
-      slug: ancestral-robe-top
-      relationship: set-piece
-      description: Body armor
-    - item_id: 21021
-      item_name: Ancestral robe bottom
-      slug: ancestral-robe-bottom
-      relationship: set-piece
-      description: Leg armor
-    - item_id: 21006
-      item_name: Kodai wand
-      slug: kodai-wand
+    - item_id: 1305
+      item_name: Dragon longsword
+      slug: dragon-longsword
       relationship: alternative
-      description: BiS magic weapon
+      description: Slower but higher base damage dragon sword variant
+    - item_id: 11840
+      item_name: Dragon claws
+      slug: dragon-claws
+      relationship: alternative
+      description: Higher-end melee weapon
   about: |-
+    "A razor sharp sword."
+
     | Stat | Value |
     |------|-------|
-    | Magic attack | +8 |
-    | Magic defence | +8 |
-    | Magic damage | +2% |
-    | Requirements | 75 Magic, Defence |
+    | Stab Attack | +65 |
+    | Slash Attack | +55 |
+    | Crush Attack | -2 |
+    | Strength | +63 |
+    | Slash Defence | +2 |
+    | Crush Defence | +1 |
 
-    Best-in-slot magic helm.
+    Requirements: 60 Attack
 
-    BiS magic helm for:
-    - All magic combat
-    - Raids
-    - Bossing
-    - When not using Slayer helm
+    Dropped by Wyrms and Shadow Wyrms in the Karuulm Slayer Dungeon. Special attack "Wild Stab" costs 40% energy and ignores Protect from Melee for one hit on NPCs.
   market_strategy:
     notes:
-      - Chambers of Xeric drop
-      - Part of Ancestral set
-      - Cheapest Ancestral piece
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Wyrm/Shadow Wyrm slayer drop"
+      - "Special attack ignores Protect from Melee on NPCs"
+      - "Lower buy limit than common dragon weapons"
+      - "Niche use for spec weapon swaps"
+  history:
+    - date: '2017-01-05'
+      description: Item released with Wyrms and the Karuulm Slayer Dungeon area.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/earthbound-tecpatl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/earthbound-tecpatl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Earthbound tecpatl | OSRS Price Data
-description: "Earthbound tecpatl: Shaped from rock that was sharpened by time.. High alch: 18,000 GP."
+description: "Earthbound tecpatl: Shaped from rock that was sharpened by time. High alch: 18,000 GP."
 osrs:
   id: 30957
   name: Earthbound tecpatl
@@ -12,9 +12,64 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: null
-  about: "Earthbound tecpatl is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Earthbound tecpatl is a members-only two-handed stab sword in Old School RuneScape that performs two independently rolled hits per attack, dropped by Earthen Naguas in Tonali Cavern. High alchemy value: 18,000 coins."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 1.814
+  material:
+    type: misc
+    tier: standard
+  equipment:
+    slot: weapon
+    weapon_type: 2h_sword
+    attack_speed: 4
+    requirements:
+      attack: 55
+    attack_bonus:
+      stab: 72
+      slash: 11
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 64
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 2
+  special_attack:
+    has_special: false
+  drop_table:
+    - source: "Earthen Nagua"
+      level: "128"
+      quantity: "1"
+      rarity: "1/400"
+      notes: "Dropped in Tonali Cavern within Varlamore."
+  market_strategy:
+    notes:
+      - "summary: \"Mid-tier multi-hit stab weapon dropped exclusively by Earthen Naguas; price tracks demand from Varlamore Slayer rotations.\""
+      - "buy_strategy: \"Stock during low traffic at the Earthen Nagua content; pick up dips after Varlamore content lulls.\""
+      - "sell_strategy: \"Move during Slayer task spikes or when new stab-weak content lands.\""
+  trading_tips:
+    - "Multi-hit mechanic gives strong DPS per slot for the requirement bracket."
+    - "Supply is gated to one monster, making it volatile after content drops."
+    - "Worth tracking alongside other Varlamore tecpatl variants for sentiment shifts."
+  history:
+    - date: "2025-07-23"
+      description: "Released alongside Tonali Cavern in Varlamore."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/efaritay-s-aid.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/efaritay-s-aid.mdx
@@ -1,6 +1,6 @@
 ---
 title: Efaritay's aid | OSRS Price Data
-description: "Efaritay's aid: Aids the user against vampyres.. High alch: 855 GP, GE limit: 10,000."
+description: "Efaritay's aid is a P2P enchanted topaz ring that boosts vampyre damage. High alch: 855 GP, GE limit: 10,000."
 osrs:
   id: 21140
   name: Efaritay's aid
@@ -12,9 +12,106 @@ osrs:
   lowalch: 570
   highalch: 855
   limit: 10000
-  about: "Efaritay's aid is a members-only item in Old School RuneScape. High alchemy value: 855 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.006
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: misc
+    tier: gold
+    category: jewelry
+  equipment:
+    slot: ring
+    weapon_type: ring
+    attack_speed: 1
+    requirements:
+      magic: 49
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: true
+    max_charges: 200
+    notes: "Loses one charge per successful hit against vampyres; shatters at 0."
+  recipes:
+    - skill: "Magic"
+      level: 49
+      xp: 59
+      output_quantity: 1
+      item_name: "Efaritay's aid"
+      tools: []
+      inputs:
+        - item_name: "Topaz ring"
+          quantity: 1
+        - item_name: "Cosmic rune"
+          quantity: 1
+        - item_name: "Fire rune"
+          quantity: 5
+      notes: "Cast Lvl-3 Enchant on a topaz ring."
+  related_items:
+    - item_id: 1639
+      item_name: Topaz ring
+      slug: topaz-ring
+      relationship: component
+      description: "Base ring enchanted into Efaritay's aid"
+    - item_id: 24576
+      item_name: Blisterwood flail
+      slug: blisterwood-flail
+      relationship: alternative
+      description: "Pairs well against vampyres"
+    - item_id: 11824
+      item_name: Black mask
+      slug: black-mask
+      relationship: alternative
+      description: "Slayer multiplier stacks with Efaritay's aid"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy when topaz ring prices dip; high alch arbitrage is rarely profitable.\""
+      - "sell_strategy: \"Sell to Slayers on vampyre tasks.\""
+      - "price_trend: \"Stable with Vyrewatch/blisterwood content popularity.\""
+      - "profit_margin: \"Slim; mostly utility purchase.\""
+  trading_tips:
+    - "Bring two on a Vyrewatch task — 200 charges goes fast at high KPH."
+    - "Enchant your own from topaz ring for the cheapest source."
+    - "Damage bonus stacks with black mask / slayer helm."
+  history:
+    - date: "2017-02-02"
+      update: "Sins of the Father quest"
+      description: "Efaritay's aid introduced during the Sins of the Father storyline content."
+  about: |-
+    Efaritay's aid is a damage-boost ring used against vampyres.
+
+    | Effect | Value |
+    |--------|-------|
+    | Damage vs vampyres | +10% |
+    | Accuracy vs vampyres | +15% |
+    | Charges | 200 hits |
+    | Bypass | Non-silver/blisterwood weapons deal half damage to Tier 2 vampyres |
+
+    Pairs with the blisterwood flail / silver weapons and slayer helm bonuses.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/efh-salt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/efh-salt.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Efh salt is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Efh salt is a blue mineable salt from the Salt Mine beneath Weiss, unlocked after Making Friends with My Arm. Burned with Te and Urt salts at Weiss fire pits and used in icy basalt crafting and Portal Nexus attunements. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-09-06"
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0
+  material:
+    type: misc
+    primary: mineral
+    tier: standard
+  recipes:
+    - item_name: Icy basalt
+      tools: ["Basalt"]
+      materials:
+        - item_name: Efh salt
+          quantity: 3
+        - item_name: Te salt
+          quantity: 1
+        - item_name: Basalt
+          quantity: 1
+      output_quantity: 1
+      skill: Magic
+      level: 82
+      xp: 32
+      notes: "Created by casting Spellbook Swap-style fire pit interaction; used in Lunar spellcasting."
+  market_strategy:
+    notes:
+      - "buy_range: \"100 - 130 gp\""
+      - "sell_range: \"120 - 150 gp\""
+      - "Demand spikes around Construction Portal Nexus builds requiring 3,000 efh salt per teleport configuration; flip in bulk when prices dip."
+  trading_tips:
+    - "Watch Construction update news for Portal Nexus demand spikes."
+    - "Buy in bulk after weekend mining bursts when supply floods the GE."
+    - "Pair flips with Te and Urt salts since the trio is bought together."
+  history:
+    - date: "2018-09-06"
+      description: "Released alongside the Making Friends with My Arm quest and the Weiss Salt Mine."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/egg-and-tomato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/egg-and-tomato.mdx
@@ -1,6 +1,6 @@
 ---
 title: Egg and tomato | OSRS Price Data
-description: "Egg and tomato: A bowl of scrambled eggs and tomato.. High alch: 7 GP, GE limit: 13,000."
+description: "Egg and tomato: A bowl of scrambled eggs and tomato. High alch: 7 GP, GE limit: 13,000."
 osrs:
   id: 7064
   name: Egg and tomato
@@ -12,9 +12,73 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 13000
-  about: "Egg and tomato is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0.5
+    release_date: '2006-01-30'
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  consumable:
+    type: food
+    heal_amount: 8
+  recipes:
+    - skill: Cooking
+      level: 23
+      xp: 0
+      output_quantity: 1
+      tools: []
+      materials:
+        - item_name: Scrambled egg
+          quantity: 1
+        - item_name: Tomato
+          quantity: 1
+  related_items:
+    - item_id: 7078
+      item_name: Scrambled egg
+      slug: scrambled-egg
+      relationship: component
+      description: Base scrambled egg ingredient.
+    - item_id: 1982
+      item_name: Tomato
+      slug: tomato
+      relationship: component
+      description: Tomato ingredient combined with the scrambled egg.
+    - item_id: 7056
+      item_name: Egg potato
+      slug: egg-potato
+      relationship: upgrade
+      description: Higher-tier dish made by combining the egg and tomato with potato with butter at Cooking 51.
+  history:
+    - date: '2006-01-30'
+      description: "Egg and tomato was added with the Gnome cooking content update."
+  about: |-
+    > *"A bowl of scrambled eggs and tomato."*
+
+    Egg and tomato is a food item that restores 8 hitpoints when eaten. It is most commonly used as a component in higher-tier Cooking recipes.
+
+    | Detail | Value |
+    |--------|-------|
+    | Cooking Req | 23 |
+    | Heal | 8 HP |
+    | Ingredients | Scrambled egg + Tomato |
+    | Upgrade Path | Egg potato (Cooking 51) |
+
+    Players typically prepare this dish as a step toward egg potato rather than as a primary food, since its heal value is low.
+  market_strategy:
+    notes:
+      - "Used primarily as an intermediate in egg potato Cooking"
+      - "Cost driven by scrambled egg and tomato"
+      - "High GE limit supports bulk buys for skill training"
+      - "Members only item"
+  trading_tips:
+    - Watch scrambled egg and tomato prices to gauge spread.
+    - Most demand comes from Cooking trainers heading toward egg potato.
+    - High buy limit lets you accumulate stock fast.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-top.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 8
-  about: "Elder chaos top is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: magic_robe
+    tier: mid-high
+  properties:
+    release_date: "2016-07-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options: ["Wear"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.2
+    requirements:
+      magic: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 8
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Elder Chaos druid"
+        quantity: "1"
+        rarity: "1/1,419"
+  related_items:
+    - item_name: "Elder chaos hood"
+      slug: "elder-chaos-hood"
+      relationship: "set-piece"
+      description: "Headpiece companion in the Elder Chaos druid robe set."
+    - item_name: "Elder chaos robe"
+      slug: "elder-chaos-robe"
+      relationship: "set-piece"
+      description: "Legs piece companion in the Elder Chaos druid robe set."
+    - item_name: "Ahrim's robetop"
+      slug: "ahrims-robetop"
+      relationship: "alternative"
+      description: "Higher-end magic body for accounts with Defence levels."
+  about: "The Elder chaos top is a magic body slot robe dropped by Elder Chaos druids in the Wilderness at 1/1,419. Released July 21, 2016, it requires only 40 Magic - no Defence - making it best-in-slot magic body for 1-Defence pures. On May 29, 2024, its magic damage bonus was buffed from 0% to +1%, sharply lifting demand."
+  market_strategy:
+    notes:
+      - "Pure account staple - demand is steady from PvPers and bossing pures."
+      - "May 2024 magic damage buff +1% is the modern price floor."
+      - "Daily volume (~750) is healthy for a niche pure-magic body."
+      - "Wilderness drop source means PK risk affects supply pulses."
+  trading_tips:
+    - "Watch PvP tournament announcements - pure-build demand spikes the set."
+    - "Buy when Elder Chaos druid trip guides trend - oversupply temporarily depresses price."
+    - "Pair with the hood and robe for set bundles - bulk buyers pay margin."
+  history:
+    - date: "2016-07-21"
+      description: "Released as a drop from Elder Chaos druids in the Wilderness."
+    - date: "2024-05-29"
+      description: "Magic damage bonus increased from 0% to +1%."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-tiara.mdx
@@ -1,6 +1,6 @@
 ---
 title: Elemental tiara | OSRS Price Data
-description: "Elemental tiara: A tiara infused with the properties of every elemental rune.. High alch: 60 GP."
+description: "Elemental tiara: A tiara infused with the properties of every elemental rune. High alch: 60 GP."
 osrs:
   id: 26804
   name: Elemental tiara
@@ -12,9 +12,73 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Elemental tiara is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: '2022-03-23'
+    quest_item: false
+    destroy: Drop
+  equipment:
+    slot: head
+    weapon_type: tiara
+    attack_speed: 1
+    requirements:
+      runecraft: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 1
+  recipes:
+    - item_name: Elemental tiara
+      skill: runecraft
+      level: 1
+      xp: 40
+      tools:
+        - Elemental runic altar
+      inputs:
+        - item_name: Tiara
+          quantity: 1
+        - item_name: Elemental talisman
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_id: 5527
+      item_name: Tiara
+      slug: tiara
+      relationship: component
+      description: Base tiara used in creation
+    - item_id: 26802
+      item_name: Elemental talisman
+      slug: elemental-talisman
+      relationship: component
+      description: Consumed when crafting the tiara
+  about: |-
+    "A tiara infused with the properties of every elemental rune."
+
+    Elemental tiara is created at the elemental runic altar by using a tiara or an elemental talisman on the altar, granting 40 Runecraft experience. When worn it allows direct entry to mysterious ruins via left-click without needing a talisman in inventory.
+  market_strategy:
+    notes:
+      - "Convenience tool for runecrafters"
+      - "Eliminates need to carry talisman while runecrafting"
+      - "Crafting costs typically exceed GE price"
+      - "Low volume, niche item"
+  history:
+    - date: '2022-03-23'
+      description: Item released alongside the elemental rune update.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elkhorn-coral.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elkhorn-coral.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 20
   highalch: 31
   limit: 13000
-  about: "Elkhorn coral is a members-only item in Old School RuneScape. High alchemy value: 31 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Elkhorn coral is a members-only Farming resource in Old School RuneScape. Harvested from coral nurseries planted with elkhorn frags at 28 Farming, it feeds Herblore recipes including anti-odour salt and elkhorn potion (unf). High alchemy value: 31 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.028
+  recipes:
+    - item_name: "Anti-odour salt"
+      skill: "Herblore"
+      level: 49
+      xp: 0
+      materials:
+        - item_name: "Elkhorn coral"
+          quantity: 1
+        - item_name: "Crab paste"
+          quantity: 1
+      tools: []
+      output_quantity: 15
+    - item_name: "Elkhorn potion (unf)"
+      skill: "Herblore"
+      level: 56
+      xp: 0
+      materials:
+        - item_name: "Elkhorn coral"
+          quantity: 1
+        - item_name: "Vial of water"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Accumulate during off-peak hours; high GE buy limit makes bulk fills realistic for Herblore stockpiles.\""
+      - "sell_strategy: \"Sell into Herblore demand spikes for anti-odour salt; volume is consistently high near 51,000 daily.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"low\""
+  trading_tips:
+    - "Pair with crab paste purchases for anti-odour salt arbitrage."
+    - "Track Sailing/Farming meta updates that could spike demand."
+    - "Plant elkhorn frags on a coral nursery for self-supply if Farming level allows."
+  history:
+    - date: "2025-11-19"
+      description: "Added to the game with the Sailing update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-dawn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-dawn.mdx
@@ -1,6 +1,6 @@
 ---
 title: Elven dawn | OSRS Price Data
-description: "Elven dawn: It seems to have a little sparkle to it.. High alch: 3 GP."
+description: "Elven dawn: It seems to have a little sparkle to it. High alch: 3 GP."
 osrs:
   id: 23948
   name: Elven dawn
@@ -12,9 +12,41 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: null
-  about: "Elven dawn is a members-only item in Old School RuneScape. High alchemy value: 3 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Elven dawn is a Prifddinas ale that restores 1 HP, boosts Agility by 1, and drains Strength by 1. Members-only. High alch 3 gp."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  potion:
+    doses: 1
+    effect: "Restores 1 hitpoint, +1 Agility boost, -1 Strength drain"
+    duration: "Instant"
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.55
+  material:
+    type: misc
+    tier: standard
+  shops:
+    - shop_name: "Hefin Inn"
+      location: "Prifddinas"
+      price: 6
+      currency: "Coins"
+      stock: 5
+  history:
+    - date: "2019-07-25"
+      description: "Released with the Song of the Elves quest update and the rebuilding of Prifddinas."
+  trading_tips:
+    - "Only obtainable from the Hefin Inn; brewing recipe does not exist, keeping supply gated."
+    - "Agility boost is the same as other agility ales but accessible inside Prifddinas without travel."
+  market_strategy:
+    notes:
+      - "relationship: \"component\""
+      - "Niche +1 Agility boost in Prifddinas; price tracks elven city activity and ironman demand."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-legwear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-legwear.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Elven legwear is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: misc
+    tier: cosmetic
+  equipment:
+    slot: legs
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Lliann's Wares
+      location: Prifddinas
+      price: 5000
+      stock: unlimited
+  related_items: []
+  market_strategy:
+    notes:
+      - "summary: \"Cosmetic Prifddinas outfit piece; demand is purely fashionscape.\""
+      - "target_audience: \"Fashionscape collectors and Prifddinas RPers.\""
+  trading_tips:
+    - Purchase directly from Lliann's Wares for the base 5,000 gp.
+    - High alch yields 3,000 gp, lower than buy price.
+  history:
+    - date: "2019-07-25"
+      description: Released with the Song of the Elves update and the opening of Prifddinas.
+  about: |-
+    Elven legwear is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins.
+
+    Cosmetic legs sold by Lliann's Wares in Prifddinas. Provides no combat bonuses.
+  properties:
+    release_date: "2019-07-25"
+    weight: 0.907
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/empty-fishbowl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/empty-fishbowl.mdx
@@ -12,65 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 100
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
   material:
     type: glass_product
     tier: mid
-  crafting:
-    level: 42
-    xp: 42.5
+  properties:
+    release_date: "2005-10-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options: ["Fill", "Use"]
+    alchable: false
+    destroy: "Drop"
   recipes:
     - skill: crafting
       level: 42
       xp: 42.5
       materials:
-        - item_name: Molten glass
-          item_id: 1775
+        - item_name: "Molten glass"
           quantity: 1
-      product: Empty fishbowl
-      product_id: 6667
-      product_quantity: 1
-      facility: Glassblowing pipe
-      members_only: true
+      tools: ["Glassblowing pipe"]
+      output_quantity: 1
   related_items:
-    - item_id: 1775
-      item_name: Molten glass
-      slug: molten-glass
-      relationship: component
-      description: Raw material
-    - item_id: 6668
-      item_name: Fishbowl
-      slug: fishbowl
-      relationship: product
-      description: Filled with water
-    - item_id: 6670
-      item_name: Tiny net
-      slug: tiny-net
-      relationship: component
-      description: For catching fish
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Glassblowing | 42 | 1 Molten glass |
-    | XP | 42.5 | - |
-
-    Used for pet fish and Rum Deal quest:
-
-    | Usage | Result |
-    |-------|--------|
-    | Fill with water | Fishbowl |
-    | Add seaweed | Fishbowl with seaweed |
-    | Catch fish | Pet fish |
+    - item_name: "Molten glass"
+      slug: "molten-glass"
+      relationship: "component"
+      description: "Raw material blown with a glassblowing pipe to produce the bowl."
+    - item_name: "Fishbowl"
+      slug: "fishbowl"
+      relationship: "product"
+      description: "Empty fishbowl filled with water - the next step toward a pet fish."
+    - item_name: "Tiny net"
+      slug: "tiny-net"
+      relationship: "alternative"
+      description: "Companion tool for catching guppy/swordy/cavefish into a fishbowl."
+  about: "The Empty fishbowl is a Crafting product made by blowing one Molten glass at level 42 Crafting for 42.5 XP. Released October 24, 2005 and renamed from Fishbowl on February 26, 2015. Used to start the pet-fish chain (fill with water, add seaweed, catch fish with a tiny net), as a Rum Deal quest item, and as a humidify-spell Magic-training target."
   market_strategy:
     notes:
-      - Pet fish keeping
-      - Rum Deal quest
-      - Fish collecting
-      - Niche item
-      - Quest requirement
-      - Can keep pet fish
-      - Low volume market
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Low-tier glassblowing product - GE price typically tracks Molten glass cost."
+      - "Demand is niche: pet-fish keepers, Rum Deal questers, and humidify trainers."
+      - "Buy limit is generous (100/4h) but daily traded volume is low."
+      - "Margin opportunities exist when Molten glass dumps below crafting cost."
+  trading_tips:
+    - "Cross-check Molten glass GE price - if bowls trade above input, buy glass and craft for XP plus profit."
+    - "Watch for Rum Deal quest cape sweeps - rare but real demand bumps."
+    - "Stockpile during glass-price dips; this item rarely spikes but stays stable."
+  history:
+    - date: "2005-10-24"
+      description: "Released into the game."
+    - date: "2006-04-03"
+      description: "Received a graphical update."
+    - date: "2015-02-26"
+      description: "Renamed from Fishbowl to Empty fishbowl to disambiguate the filled variant."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/empty-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/empty-sack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Empty sack | OSRS Price Data
-description: "Empty sack: An empty vegetable sack.. High alch: 1 GP, GE limit: 10,000."
+description: "Empty sack: An empty vegetable sack. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 5418
   name: Empty sack
@@ -12,9 +12,79 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Empty sack is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.453
+  about: "Empty sack is a vegetable storage item that holds up to ten potatoes, onions, or cabbages per sack. It is also used for sandbags in Enlightened Journey and to build scarecrows for Farming protection."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cloth
+    tier: basic
+  recipes:
+    - item_name: Empty sack
+      skill: Crafting
+      level: 21
+      xp: 38
+      tools:
+        - Loom
+      materials:
+        - item_name: Jute fibre
+          quantity: 4
+      output_quantity: 1
+  shops:
+    - shop_name: Farming Guild Shop
+      location: Farming Guild
+      price: 1
+      currency: coins
+      stock: 5
+    - shop_name: Catherby Farming Shop
+      location: Catherby
+      price: 1
+      currency: coins
+      stock: 5
+    - shop_name: Ardougne Farming Shop
+      location: East Ardougne
+      price: 1
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Sack of potatoes
+      relationship: product
+    - item_name: Sack of onions
+      relationship: product
+    - item_name: Sack of cabbages
+      relationship: product
+    - item_name: Jute fibre
+      relationship: component
+    - item_name: Scarecrow
+      relationship: product
+  market_strategy:
+    notes:
+      - "summary: \"High-volume utility sack with bots and farmers driving ~460k daily trades.\""
+      - "buy_strategy: \"Buy directly from farming shops for 1 gp; GE arbitrage exists when sack price rises above 3 gp.\""
+      - "sell_strategy: \"Sell in 10k stacks during compost runs and Farming events; volume is enormous.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Each sack holds 10 potatoes/onions/cabbages — saves inventory slots for bulk farming runs."
+    - "Required for scarecrow construction (Allotment patch protection); keep extras on Farming alts."
+    - "Used as ammunition for sandbag delivery during the Enlightened Journey quest."
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming skill update."
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  drop_table: []
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enchanted-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enchanted-top.mdx
@@ -12,8 +12,32 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: magic_robe
+    tier: mid-high
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options: ["Wear"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      magic: 40
+      defence: 20
     attack_bonus:
       stab: 0
       slash: 0
@@ -27,64 +51,46 @@ osrs:
       magic: 20
       ranged: 0
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 40
-      defence: 20
+  drop_table:
+    sources:
+      - source: "Reward casket (hard)"
+        quantity: "1"
+        rarity: "1/1,625"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers: ["hard"]
   related_items:
-    - item_id: 7400
-      item_name: Enchanted hat
-      slug: enchanted-hat
-      relationship: set-piece
-      description: Enchanted set hat
-    - item_id: 7398
-      item_name: Enchanted robe
-      slug: enchanted-robe
-      relationship: set-piece
-      description: Enchanted set legs
-    - item_id: 4091
-      item_name: Mystic robe top
-      slug: mystic-robe-top
-      relationship: alternative
-      description: Same stats, easier to obtain
-  about: |-
-    > *"Enchanted Wizards robes."*
-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +20 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +20 |
-
-    Requirements: 40 Magic, 20 Defence
-
-    Weight: 2.721 kg
-
-    | Stat | Enchanted Top | Mystic Robe Top | Ahrim's Robetop | Infinity Top |
-    |------|--------------|-----------------|-----------------|-------------|
-    | Magic Atk | +20 | +20 | +30 | +22 |
-    | Magic Def | +20 | +20 | +30 | +22 |
-    | Req | 40 Mage/20 Def | 40 Mage/20 Def | 70 Mage/70 Def | 50 Mage/25 Def |
-
-    The enchanted top is statistically identical to the mystic robe top. The only difference is visual appearance and source. It trades at a different price due to its rarity from Treasure Trails.
-
-    - Cosmetic alternative to the mystic robe top
-    - Treasure Trails fashionscape outfit
-    - Can be stored in POH costume room
-    - Same combat utility as mystic robe top in every scenario
+    - item_name: "Enchanted hat"
+      slug: "enchanted-hat"
+      relationship: "set-piece"
+      description: "Head slot piece of the Enchanted robes set."
+    - item_name: "Enchanted robe"
+      slug: "enchanted-robe"
+      relationship: "set-piece"
+      description: "Legs slot piece of the Enchanted robes set."
+    - item_name: "Mystic robe top"
+      slug: "mystic-robe-top"
+      relationship: "alternative"
+      description: "Mechanically identical body slot robe (+20/+20) with easier sourcing."
+  about: "Enchanted top is a hard Treasure Trail reward (1/1,625) released February 20, 2006. Functionally identical to a Mystic robe top - +20 magic attack, +20 magic defence, no magic damage - at 40 Magic and 20 Defence. The piece's value is cosmetic: a clue-scroll fashionscape body for collectors. Stored in the POH costume room as part of the Enchanted robes set."
   market_strategy:
     notes:
-      - Hard clue rarity gives it collector value
-      - Typically trades above mystic robe top due to cosmetic demand
-      - Storable in costume room for outfit collectors
-      - Part of the complete enchanted robes set (hat, top, robe)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Same combat stats as Mystic robe top - all value is cosmetic clue scarcity."
+      - "Hard clue droprate 1/1,625 - moderate scarcity, steady supply."
+      - "Buy limit only 8/4h - bulk hoarding takes time."
+      - "Trades above Mystic robe top almost always due to fashionscape demand."
+  trading_tips:
+    - "Track Mystic robe top GE price for the cost-floor benchmark."
+    - "Hard clue rush events temporarily oversupply - good buy windows."
+    - "Bundle as a full Enchanted set when selling to costume-room collectors."
+  history:
+    - date: "2006-02-20"
+      description: "Released as a hard Treasure Trail reward as part of the Enchanted robes set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-crystal-weapon-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-crystal-weapon-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enhanced crystal weapon seed | OSRS Price Data
-description: "Enhanced crystal weapon seed is a members weapon slot item requiring 75 Attack. High alch: 300,000 GP, GE limit: 70."
+description: "Enhanced crystal weapon seed: A seed to be sung into the most powerful crystal weaponry. High alch: 300,000 GP, GE limit: 70."
 osrs:
   id: 25859
   name: Enhanced crystal weapon seed
@@ -12,94 +12,85 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 70
-  equipment:
-    slot: weapon
-    type: sword
-    attack_style: slash
-    attack_speed: 4
-    requirements:
-      attack: 75
-      agility: 75
-    stats:
-      attack_slash: 94
-      strength: 89
-  effect:
-    corrupted: true
-    never_degrades: true
-    untradeable: true
-    cannot_revert: true
-  creation:
-    base_item_id: 23995
-    base_item_name: Blade of saeldor
-    material_id: 23962
-    material_name: Crystal shard
-    material_quantity: 1000
+  about: "Enhanced crystal weapon seed is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 70 per 4 hours. Sung into Blade of Saeldor or Bow of Faerdhinen at a singing bowl."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-06-30"
+    weight: 0.018
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: seed
+    tier: crystal
   drop_table:
-    sources:
-      - source: The Gauntlet
-        source_id: 9021
-        combat_level: 0
-        quantity: 1 (Enhanced crystal weapon seed)
-        rarity: Rare
-        members_only: true
-      - source: The Corrupted Gauntlet
-        source_id: 9035
-        combat_level: 0
-        quantity: 1 (Enhanced crystal weapon seed)
-        rarity: Rare
-        members_only: true
-  related_items:
-    - item_id: 23995
-      item_name: Blade of saeldor
-      slug: blade-of-saeldor
-      relationship: downgrade
-      description: Uncharged version
-    - item_id: 22324
-      item_name: Ghrazi rapier
-      slug: ghrazi-rapier
-      relationship: alternative
-      description: Stab equivalent
-    - item_id: 25862
-      item_name: Bow of faerdhinen (c)
-      slug: bow-of-faerdhinen-c
-      relationship: alternative
-      description: Ranged crystal weapon
-    - item_id: 23962
-      item_name: Crystal shard
-      slug: crystal-shard
+    - source: "The Gauntlet"
+      quantity: "1"
+      rarity: "1/2000"
+      notes: "Rare drop from completing The Gauntlet."
+    - source: "The Corrupted Gauntlet"
+      quantity: "1"
+      rarity: "1/400"
+      notes: "Rare drop from completing The Corrupted Gauntlet."
+  recipes:
+    - item_name: "Blade of saeldor"
+      skill: "Smithing"
+      level_required: 82
+      xp: 0
+      tools:
+        - "Singing bowl"
+      materials:
+        - item_name: "Enhanced crystal weapon seed"
+          quantity: 1
+        - item_name: "Crystal shard"
+          quantity: 100
+      output_quantity: 1
+      notes: "Also requires 82 Crafting (boostable). Conwenna/Reese will sing it for an extra 50 shards."
+    - item_name: "Bow of faerdhinen"
+      skill: "Smithing"
+      level_required: 82
+      xp: 0
+      tools:
+        - "Singing bowl"
+      materials:
+        - item_name: "Enhanced crystal weapon seed"
+          quantity: 1
+        - item_name: "Crystal shard"
+          quantity: 100
+      output_quantity: 1
+      notes: "Also requires 82 Crafting (boostable). Both require Song of the Elves completion."
+  relationships:
+    - item_name: "Blade of saeldor"
       relationship: component
-      description: Corruption material
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Slash attack | +94 |
-    | Strength | +89 |
-    | Requirements | 75 Attack, Agility |
-
-    Highest slash accuracy in-game.
-
-    Corrupted version:
-    - Never degrades
-    - Cannot be reverted
-    - Untradeable
-
-    Charged version (uncorrupted):
-    - Requires crystal shards to charge
-    - 20,000 charges per 100 shards
-
-    BiS for slash-weak enemies:
-    - Graardor
-    - Cerberus
-    - General melee combat
-
-    Tied with Ghrazi rapier for general DPS.
+      notes: "Sung into the blade at a singing bowl."
+    - item_name: "Bow of faerdhinen"
+      relationship: component
+      notes: "Sung into the bow at a singing bowl."
+    - item_name: "Crystal shard"
+      relationship: component
+      notes: "Required to sing the seed into a weapon; exchangeable to Amrod for 1,500 shards."
+    - item_name: "Ghrazi rapier"
+      relationship: alternative
+      notes: "Stab DPS equivalent to charged Blade of Saeldor."
+  history:
+    - date: "2021-06-30"
+      description: "Released with the Song of the Elves expansion content."
+    - date: "2021-08-12"
+      description: "Amrod added as an exchange option granting 1,500 crystal shards for the seed."
   market_strategy:
     notes:
-      - Enhanced crystal weapon seed from CG
-      - Corrupt to save long-term costs
-      - Song of the Elves required
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_strategy: \"Buy when CG drop rates have flooded supply; corrupt the seed to skip degradation costs long-term.\""
+      - "sell_strategy: \"Sell raw seed to PvMers building Blade of Saeldor or Bow of Faerdhinen.\""
+      - "profit_potential: \"High-value PvM item; price is sensitive to Gauntlet popularity and crystal shard cost.\""
+      - "risk_level: \"high\""
+  trading_tips:
+    - "Song of the Elves required to use the seed."
+    - "Corrupted variant is untradeable and never degrades."
+    - "Charged variant costs ~100 shards per 20,000 hits; corruption avoids ongoing shard upkeep."
+    - "BiS slash weapon tied with Ghrazi rapier for general DPS."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-demon-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-demon-head.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ensouled demon head | OSRS Price Data
-description: "Ensouled demon head: The creature's soul is still in here.. High alch: 316 GP, GE limit: 7,500."
+description: "Ensouled demon head: The creature's soul is still in here. High alch: 316 GP, GE limit: 7,500."
 osrs:
   id: 13502
   name: Ensouled demon head
@@ -12,57 +12,62 @@ osrs:
   lowalch: 210
   highalch: 316
   limit: 7500
+  about: "Ensouled demon head is an Arceuus reanimation reagent for the Expert Reanimation spell, granting 1,170 Prayer XP per cast. Members-only. High alch 316 gp; GE limit 7,500."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.453
   material:
     type: ensouled_head
-    tier: master
-  prayer:
-    xp_reanimate: 1170
-    magic_level: 90
-    spell: Master Reanimation
+    tier: standard
   drop_table:
-    sources:
-      - source: Greater demon
-        source_id: 2026
-        combat_level: 92
-        quantity: "1"
-        rarity: uncommon
-        members_only: true
-      - source: Black demon
-        source_id: 240
-        combat_level: 172
-        quantity: "1"
-        rarity: uncommon
-        members_only: true
+    - source: "Lesser demon"
+      quantity: "1"
+      rarity: "1/50"
+    - source: "Greater demon"
+      quantity: "1"
+      rarity: "1/40"
+    - source: "Black demon"
+      quantity: "1"
+      rarity: "1/35"
+    - source: "Skotizo"
+      quantity: "1"
+      rarity: "1/10"
   related_items:
     - item_id: 13496
       item_name: Ensouled bloodveld head
       slug: ensouled-bloodveld-head
-      relationship: downgrade
-      description: Lower XP (1,040)
+      relationship: variant
+      description: Lower XP reanimation tier
     - item_id: 13508
       item_name: Ensouled abyssal head
       slug: ensouled-abyssal-head
-      relationship: upgrade
-      description: Higher XP (1,300)
+      relationship: variant
+      description: Higher XP reanimation tier
     - item_id: 13511
       item_name: Ensouled dragon head
       slug: ensouled-dragon-head
-      relationship: upgrade
-      description: Best XP (1,560)
-  about: |-
-    1. Cast Master Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+      relationship: variant
+      description: Top XP reanimation tier
+  history:
+    - date: "2016-01-07"
+      description: "Released with the Arceuus Reanimation spell suite."
+    - date: "2022-03-30"
+      description: "Ensouled heads now drop from monsters inside instances."
+  trading_tips:
+    - "Expert Reanimation (level 72 Magic) gives 1,170 Prayer XP per head."
+    - "Black demon Slayer tasks flood supply; price often dips during catacomb meta cycles."
   market_strategy:
     notes:
-      - High Prayer XP
-      - Good supply from demon tasks
-      - Popular for efficient training
-      - Black demon tasks common
-      - 90 Magic requirement
-      - Popular efficient method
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "relationship: \"component\""
+      - "Demand is bounded by Prayer XP/hour; price tracks soul rune cost and Arceuus reanimation popularity."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-goblin-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-goblin-head.mdx
@@ -1,62 +1,90 @@
 ---
 title: Ensouled goblin head | OSRS Price Data
-description: "Ensouled goblin head: The creature's soul is still in here.. High alch: 31 GP, GE limit: 3,000."
+description: "Ensouled goblin head: The creature's soul is still in here. High alch: 31 GP."
 osrs:
   id: 13448
   name: Ensouled goblin head
   slug: ensouled-goblin-head
-  examine: The creature's soul is still in here.
+  examine: "The creature's soul is still in here."
   members: true
   icon: Ensouled goblin head.png
   value: 52
   lowalch: 20
   highalch: 31
-  limit: 3000
+  limit: null
+  weight: 0.453
+  about: "Ensouled goblin head is the lowest tier Arceuus reanimation target. Casting Basic Reanimation requires 16 Magic and gives 130 Prayer XP per kill, making it an extremely cheap entry into the reanimation training method."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
   material:
     type: ensouled_head
     tier: basic
-  prayer:
-    xp_reanimate: 130
-    magic_level: 3
-    spell: Basic Reanimation
+  recipes:
+    - item_name: Reanimated goblin
+      skill: Magic
+      level: 16
+      xp: 32
+      tools:
+        - Arceuus spellbook
+      materials:
+        - item_name: Ensouled goblin head
+          quantity: 1
+        - item_name: Body rune
+          quantity: 4
+        - item_name: Nature rune
+          quantity: 2
+      output_quantity: 1
   drop_table:
-    sources:
-      - source: Goblin
-        source_id: 655
-        combat_level: 2
-        quantity: "1"
-        rarity: uncommon
-        members_only: true
+    - source: Goblin
+      level: 2
+      quantity: "1"
+      rarity: "1/30"
+      members: true
+    - source: Goblin guard
+      level: 42
+      quantity: "1"
+      rarity: "1/30"
+      members: true
   related_items:
-    - item_id: 13454
-      item_name: Ensouled imp head
-      slug: ensouled-imp-head
-      relationship: upgrade
-      description: Higher XP (286)
-    - item_id: 13463
-      item_name: Ensouled bear head
-      slug: ensouled-bear-head
-      relationship: upgrade
-      description: Higher XP (480)
-    - item_id: 13511
-      item_name: Ensouled dragon head
-      slug: ensouled-dragon-head
-      relationship: upgrade
-      description: Best XP (1,560)
-  about: |-
-    1. Cast Basic Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+    - item_name: Ensouled imp head
+      relationship: variant
+    - item_name: Ensouled minotaur head
+      relationship: variant
+    - item_name: Ensouled bear head
+      relationship: variant
+    - item_name: Ensouled monkey head
+      relationship: variant
+    - item_name: Ensouled scorpion head
+      relationship: variant
+    - item_name: Ensouled unicorn head
+      relationship: variant
   market_strategy:
     notes:
-      - Lowest tier ensouled head
-      - Low supply and demand
-      - Budget Prayer training option
-      - Not commonly traded
-      - Better heads available
-      - Very cheap XP option
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "summary: \"Untradeable reanimation input; only relevant as a personal-use Prayer training drop.\""
+      - "buy_strategy: \"Cannot be bought from GE — farm goblins or collect from Slayer dust.\""
+      - "sell_strategy: \"Untradeable; reanimate for Prayer XP rather than holding inventory space.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Untradeable on the GE — only Slayer/Combat drops supply this head."
+    - "Bury vs reanimate: reanimation requires the Arceuus spellbook and 16 Magic but gives 130 Prayer XP vs 25 from burial."
+    - "Useful as cheap Prayer XP for ultra-low Magic accounts before they unlock higher tier ensouled heads."
+  history:
+    - date: "2016-01-07"
+      description: "Released with the Arceuus House update introducing the reanimation spells."
+  properties:
+    release_date: "2016-01-07"
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    destroy: "Drop"
+    quest_item: false
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-ogre-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-ogre-head.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ensouled ogre head | OSRS Price Data
-description: "Ensouled ogre head: The creature's soul is still in here.. High alch: 202 GP, GE limit: 3,000."
+description: "Ensouled ogre head: The creature's soul is still in here. High alch: 202 GP, GE limit: 3,000."
 osrs:
   id: 13478
   name: Ensouled ogre head
@@ -12,9 +12,46 @@ osrs:
   lowalch: 135
   highalch: 202
   limit: 3000
-  about: "Ensouled ogre head is a members-only item in Old School RuneScape. High alchemy value: 202 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Ensouled ogre head is a members-only Arceuus reanimation reagent dropped by ogres. High alchemy value: 202 coins. Grand Exchange buy limit: 3,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.453
+  material:
+    type: ensouled_head
+    tier: standard
+  drop_table:
+    - source: "Ogre"
+      quantity: "1"
+      rarity: "1/30"
+    - source: "Ogre chieftain"
+      quantity: "1"
+      rarity: "1/30"
+    - source: "Ogress shaman"
+      quantity: "1"
+      rarity: "1/30"
+    - source: "Ogress warrior"
+      quantity: "1"
+      rarity: "1/30"
+  history:
+    - date: "2016-01-07"
+      description: "Released alongside the Arceuus Reanimation spell suite."
+    - date: "2022-03-30"
+      description: "Ensouled heads now drop inside instanced areas."
+  trading_tips:
+    - "Adept Reanimation (level 41 Magic) grants 716 Prayer XP per reanimated ogre."
+    - "Buy in bulk during ogre slayer task downtime when supply outpaces demand."
+  market_strategy:
+    notes:
+      - "relationship: \"component\""
+      - "Demand is driven by Prayer XP/hour via reanimation; price tracks soul rune cost and clue/Arceuus meta."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eternal-gem.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eternal-gem.mdx
@@ -1,6 +1,6 @@
 ---
 title: Eternal gem | OSRS Price Data
-description: "Eternal gem: Like the enchanted gem sold by Slayer Masters, only with an eternal charge.. High alch: 5,700 GP, GE limit: 8."
+description: "Eternal gem: Like the enchanted gem sold by Slayer Masters, only with an eternal charge. High alch: 5,700 GP, GE limit: 8."
 osrs:
   id: 21270
   name: Eternal gem
@@ -12,44 +12,59 @@ osrs:
   lowalch: 3800
   highalch: 5700
   limit: 8
+  properties:
+    release_date: "2017-05-04"
+    quest_item: false
+    destroy: Drop
   material:
-    type: crafting_material
-    tradeable: true
-    weight: 0.004
-  drop_table:
-    sources:
-      - source: Superior slayer monsters
-        notes: Requires Bigger and Badder unlock (50 Slayer points)
-      - source: Nuclear smoke devil
-        rate: 1/200
-      - source: Night beast
-        rate: 1/256
-  uses:
-    - result_id: 21273
-      result_name: Eternal slayer ring
+    type: gem
+    tier: slayer-reward
+  recipes:
+    - skill: crafting
+      level: 75
+      xp: 15
+      item_name: Eternal slayer ring
+      tools:
+        - Ring mould
       materials:
-        - Eternal gem
-        - Gold bar
-      requirements:
-        crafting: 75
-      notes: Irreversible - ring is untradeable
-  special_effect:
+        - item_name: Eternal gem
+          quantity: 1
+        - item_name: Gold bar
+          quantity: 1
+      product: Eternal slayer ring
+      product_id: 21273
+      product_quantity: 1
+      output_quantity: 1
+      members_only: true
+  drop_table:
+    primary_source: Superior slayer monsters
+    sources:
+      - source: Night beast
+        quantity: "1"
+        rarity: "1/256"
+        members_only: true
+      - source: Nuclear smoke devil
+        quantity: "1"
+        rarity: "1/200"
+        members_only: true
+      - source: Guardian drake
+        quantity: "1"
+        rarity: "1/368"
+        members_only: true
+  special_attack:
     name: Enchanted Gem Function
-    description: Functions as enchanted gem for Slayer masters
-  market:
-    buy_limit: 8
-    price_estimate: 9500000
+    description: Functions as enchanted gem for Slayer Masters; tracks tasks but cannot craft a Slayer helmet.
   related_items:
     - item_id: 21273
       item_name: Eternal slayer ring
       slug: eternal-slayer-ring
-      relationship: product
-      description: Created item
+      relationship: upgrade
+      description: Crafted from this gem with a gold bar
     - item_id: 11866
       item_name: Slayer ring
       slug: slayer-ring
       relationship: alternative
-      description: Standard version
+      description: Standard teleport ring
   about: |-
     | Property | Value |
     |----------|-------|
@@ -61,16 +76,23 @@ osrs:
     |--------------|-----------|--------------|
     | Eternal slayer ring | Eternal gem + Gold bar | 75 Crafting |
 
-    Irreversible - ring is untradeable.
+    Irreversible — ring is untradeable.
 
     Also functions as enchanted gem for Slayer masters.
   market_strategy:
     notes:
-      - Farm high-level superiors
-      - Creates infinite teleport ring
-      - 75 Crafting to use
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply gated by Bigger and Badder superior slayer task unlock"
+      - "Demand from slayer mains crafting eternal rings"
+      - "GE limit 8 forces patience on big positions"
+  trading_tips:
+    - Farm high-level superiors like Night beast for best rate
+    - 75 Crafting + Ring bling unlock needed for ring conversion
+    - Hold during ring meta or slayer XP events for premium
+  history:
+    - date: "2017-05-04"
+      description: "Released with the superior slayer monster rework."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-mix-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extended antifire mix(2) | OSRS Price Data
-description: "Extended antifire mix(2): Two doses of fishy extended anti-firebreath potion.. High alch: 144 GP, GE limit: 2,000."
+description: "Extended antifire mix(2): Two doses of fishy extended anti-firebreath potion. High alch: 144 GP, GE limit: 2,000."
 osrs:
   id: 11960
   name: Extended antifire mix(2)
@@ -12,9 +12,50 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 2000
-  about: "Extended antifire mix(2) is a members-only item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Extended antifire mix(2) is a members-only barbarian potion in Old School RuneScape, providing 12 minutes of dragonfire resistance plus 6 Hitpoints restored per dose. High alchemy value: 144 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-03-27"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.08
+  material:
+    type: potion
+    tier: standard
+  potion:
+    doses: 2
+    effect: "Provides 12 minutes of dragonfire resistance and restores 6 Hitpoints per dose. Requires completion of Barbarian Herblore training with Otto Godblessed and starting Dragon Slayer I."
+    duration_seconds: 720
+  recipes:
+    - item_name: "Extended antifire mix(2)"
+      skill: Herblore
+      level: 91
+      xp: 61
+      tools: []
+      materials:
+        - item_name: "Extended antifire(2)"
+          quantity: 1
+        - item_name: "Caviar"
+          quantity: 1
+      output_quantity: 1
+      notes: "Barbarian potion mix; requires Barbarian Herblore training."
+  market_strategy:
+    notes:
+      - "summary: \"Niche barbarian potion mix; demand limited to players seeking the Hitpoints restoration bonus during dragon encounters.\""
+      - "buy_strategy: \"Stock when extended antifire potions and caviar prices dip; useful for completing Barbarian Herblore tasks.\""
+      - "sell_strategy: \"Move during dragon-heavy content updates or Slayer task spikes.\""
+  trading_tips:
+    - "Recipe is loss-making at current GE rates; volume is low."
+    - "Caviar supply from Barbarian fishing limits production scale."
+    - "Stack with other barbarian potion mixes for Herblore training bulk runs."
+  history:
+    - date: "2014-03-27"
+      description: "Released alongside the wider extended antifire potion family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-3.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 304
   highalch: 456
   limit: 2000
-  about: "Extended super antifire(3) is a members-only item in Old School RuneScape. High alchemy value: 456 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Extended super antifire(3) grants complete dragonfire immunity for 18 minutes (3 doses x 6 minutes). Requires Dragon Slayer II for the Herblore recipe. High alchemy value: 456 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: potion
+    tier: standard
+  properties:
+    release_date: "2018-01-25"
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.02
+  potion:
+    doses: 3
+    effect: "Grants complete immunity to dragonfire for 6 minutes per dose (18 minutes total). Does not fully cover Galvek, KBD special, or Vorkath."
+    duration: "18 minutes"
+  recipes:
+    - item_name: Extended super antifire(3)
+      skill: herblore
+      level: 98
+      xp: 120
+      output_quantity: 1
+      tools:
+        - Pestle and mortar
+      materials:
+        - item_name: Super antifire (3)
+          quantity: "1"
+        - item_name: Lava scale shard
+          quantity: "3"
+  relationships:
+    - item_name: Extended super antifire(4)
+      relationship: variant
+    - item_name: Extended super antifire(2)
+      relationship: variant
+    - item_name: Extended super antifire(1)
+      relationship: variant
+    - item_name: Super antifire potion(3)
+      relationship: component
+    - item_name: Lava scale shard
+      relationship: component
+  market_strategy:
+    notes:
+      - "short_term: \"Demand spikes during dragon-heavy bossing (Vorkath, Galvek, Chromatic dragons) and league events.\""
+      - "long_term: \"Tied to high-tier PvM activity; price tracks dragonfire content popularity and Lava scale shard supply.\""
+      - "risk_level: \"medium\""
+  trading_tips:
+    - "Buy 4-dose and decant if margins on (3) are tight."
+    - "Stock during raid week resets when bossers replenish supplies."
+  history:
+    - date: "2018-01-25"
+      description: "Released alongside Dragon Slayer II, requiring 98 Herblore to brew."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extended super antifire(4) | OSRS Price Data
-description: "Extended super antifire(4) is a 4-dose members potion that 6 minutes of complete dragonfire immunity (all dragons). High alch: 480 GP, GE limit: 2,000."
+description: "Extended super antifire(4) is a 4-dose members potion that provides 6 minutes of complete dragonfire immunity. High alch: 480 GP, GE limit: 2,000."
 osrs:
   id: 22209
   name: Extended super antifire(4)
@@ -12,82 +12,94 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 2000
+  properties:
+    weight: 0.08
+    release_date: '2018-01-25'
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
   potion:
     doses: 4
-    herblore_level: 98
-    herblore_xp: 160
-    effect: 6 minutes of complete dragonfire immunity (all dragons)
-    effects:
-      - stat: Dragonfire protection
-        boost_type: immunity
-        description: Complete immunity to all forms of dragonfire
+    base_potion: Super antifire potion
+    boost_skill: Dragonfire Immunity
+    boost_formula: "Complete dragonfire immunity"
+    duration_minutes: 24
+    drain_hitpoints: 0
+    minimum_hitpoints: 1
   recipes:
-    - skill: herblore
+    - skill: Herblore
       level: 98
       xp: 160
+      output_quantity: 1
+      tools:
+        - Pestle and mortar
       materials:
         - item_name: Super antifire potion(4)
-          item_id: 21978
           quantity: 1
         - item_name: Lava scale shard
-          item_id: 11994
           quantity: 4
-      ticks: 2
-      members_only: true
-    - skill: herblore
+    - skill: Herblore
       level: 98
-      xp: 160
+      xp: 180
+      output_quantity: 1
+      tools:
+        - Pestle and mortar
       materials:
         - item_name: Extended antifire(4)
-          item_id: 11951
           quantity: 1
         - item_name: Crushed superior dragon bones
-          item_id: 21975
           quantity: 1
-      ticks: 2
-      members_only: true
   related_items:
     - item_id: 21978
       item_name: Super antifire potion(4)
       slug: super-antifire-potion-4
       relationship: component
-      description: Base potion for lava scale method
+      description: Base potion for the lava scale method.
     - item_id: 11994
       item_name: Lava scale shard
       slug: lava-scale-shard
       relationship: component
-      description: Secondary ingredient
+      description: Secondary ingredient for the lava scale method.
     - item_id: 11951
       item_name: Extended antifire(4)
       slug: extended-antifire-4
       relationship: component
-      description: Base potion for dragon bone method
+      description: Base potion for the dragon bone method.
     - item_id: 2452
       item_name: Antifire(4)
       slug: antifire-4
       relationship: alternative
-      description: Basic antifire option
+      description: Basic antifire variant.
+  history:
+    - date: '2018-01-25'
+      description: "Extended super antifire was added with the lava dragon and Theatre of Blood content cycle."
   about: |-
-    Extended super antifire provides complete dragonfire immunity for 6 minutes per dose, making it essential for:
-    - Vorkath (elite void method)
-    - King Black Dragon
-    - Brutal black dragons
-    - Any dragon without requiring anti-dragon shield
+    > *"4 doses of extended super anti-firebreath potion."*
 
-    Two methods available at 98 Herblore:
+    Extended super antifire provides complete dragonfire immunity for 6 minutes per dose, making it essential for dragon-heavy PvM where an anti-dragon shield slot is needed for damage.
 
     | Method | Base Potion | Secondary |
     |--------|-------------|-----------|
     | Lava scale | Super antifire(4) | 4 Lava scale shards |
     | Dragon bone | Extended antifire(4) | 1 Crushed superior dragon bones |
+
+    Common use cases include Vorkath, King Black Dragon, brutal black dragons, and any other dragon content where the player wants to skip the anti-dragon shield slot.
   market_strategy:
     notes:
-      - Essential for efficient Vorkath kills
-      - Compare ingredient costs between both methods
-      - Lava scale shards from lava dragons/infernal eels
-      - Superior dragon bones from fossil island wyverns
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Essential for efficient Vorkath kills"
+      - "Compare ingredient costs between both methods"
+      - "Lava scale shards come from lava dragons / infernal eels"
+      - "Superior dragon bones come from fossil island wyverns"
+      - "Members only item"
+  trading_tips:
+    - Track lava scale shard vs. superior dragon bone economics to pick the cheaper method.
+    - Buy limit of 2,000 supports moderate flipping volume.
+    - Demand spikes during Vorkath farming events and new dragon content drops.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fez.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fez.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 150
-  about: "Fez is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Fez is a cosmetic head slot hat obtained from Ali Morrisane via the Rogue Trader miniquest. Delays desert heat onset by 12 seconds when worn. High alchemy value: 12 coins. Grand Exchange buy limit: 150 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: misc
+    tier: cloth
+  properties:
+    release_date: "2005-08-15"
+    tradeable: true
+    equipable: true
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.005
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Al Kharid
+      currency: coins
+      price: 20
+      stock: 25
+  relationships:
+    - item_name: Desert top
+      relationship: set-piece
+    - item_name: Desert robes
+      relationship: set-piece
+    - item_name: Desert legs
+      relationship: set-piece
+    - item_name: Desert boots
+      relationship: set-piece
+  market_strategy:
+    notes:
+      - "short_term: \"Cosmetic demand; price hovers well above shop value as Rogue Trader supply is bottlenecked.\""
+      - "long_term: \"Stable collector item; long-term creep with cosmetic interest.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Bulk-stock from Ali's Discount Wares (25 stock, 30s restock) for steady margin vs GE."
+    - "Buy limit of 150 keeps flips tidy — no need to split orders."
+  history:
+    - date: "2005-08-15"
+      description: "Released with the Rogue Trader miniquest and Al Kharid trader content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/filled-plant-pot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/filled-plant-pot.mdx
@@ -1,6 +1,6 @@
 ---
 title: Filled plant pot | OSRS Price Data
-description: "Filled plant pot: A plant pot filled with soil.. High alch: 1 GP, GE limit: 2,000."
+description: "Filled plant pot is a P2P Farming consumable used for tree seedlings. High alch: 0 GP, GE limit: 2,000."
 osrs:
   id: 5354
   name: Filled plant pot
@@ -9,12 +9,85 @@ osrs:
   members: true
   icon: Filled plant pot.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: 0
+  highalch: 0
   limit: 2000
-  about: "Filled plant pot is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.907
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: misc
+    tier: bronze
+    category: material
+  shops:
+    - shop_name: "Farming Shop"
+      price: 1
+      currency: "Coins"
+      location: "Various farming patches"
+      notes: "Sold at farming stores"
+  recipes:
+    - skill: "Farming"
+      level: 1
+      xp: 0
+      output_quantity: 1
+      tools:
+        - "Gardening trowel"
+        - "Empty pot"
+      inputs:
+        - item_name: "Plant pot"
+          quantity: 1
+        - item_name: "Soil (farming patch)"
+          quantity: 1
+      notes: "Use empty plant pot on any weed-free farming patch with a gardening trowel."
+  related_items:
+    - item_id: 5350
+      item_name: Plant pot
+      slug: plant-pot
+      relationship: component
+      description: "Empty pot used to make filled pot"
+    - item_id: 5343
+      item_name: Gardening trowel
+      slug: gardening-trowel
+      relationship: alternative
+      description: "Required tool to fill pot"
+    - item_id: 5340
+      item_name: Watering can
+      slug: watering-can
+      relationship: alternative
+      description: "Used to water seedlings into saplings"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Pick up cheap from Farming shops if you're tree-running.\""
+      - "sell_strategy: \"Low margin; sell via GE in bulk to tree farmers.\""
+      - "price_trend: \"Stable around 1-2 coins.\""
+      - "profit_margin: \"Negligible.\""
+  trading_tips:
+    - "Tree runners need one per tree patch; bring a stack."
+    - "Make on-site with an empty pot + trowel at any farming patch."
+    - "Note them for bank space when bulk-buying."
+  history:
+    - date: "2005-07-11"
+      update: "Farming skill release"
+      description: "Filled plant pot introduced with the Farming skill."
+  about: |-
+    Filled plant pot is a Farming consumable used to grow tree, fruit tree, and special seedlings.
+
+    | Step | Action |
+    |------|--------|
+    | 1 | Use empty plant pot on a farming patch with gardening trowel |
+    | 2 | Add a tree/fruit tree/special seed to make a seedling |
+    | 3 | Water with watering can or Humidify spell |
+    | 4 | Wait for sapling, then plant in tree patch |
+
+    Supports tree, fruit tree, calquat, spirit, celastrus, redwood, hespori-adjacent, and special seedlings.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-guild-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-guild-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fishing guild teleport (tablet) | OSRS Price Data
-description: "Fishing guild teleport (tablet): A teleport to the Fishing Guild.. High alch: 1 GP, GE limit: 10,000."
+description: "Fishing guild teleport (tablet): A teleport to the Fishing Guild.. High alch: 0 GP, GE limit: 10,000."
 osrs:
   id: 24959
   name: Fishing guild teleport (tablet)
@@ -9,12 +9,81 @@ osrs:
   members: true
   icon: Fishing guild teleport (tablet).png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: 0
+  highalch: 0
   limit: 10000
-  about: "Fishing guild teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0
+  material:
+    type: tablet
+    tier: lunar
+  properties:
+    release_date: "2020-09-30"
+    quest_item: false
+    destroy: "Drop"
+  magic:
+    level: 85
+    xp: 80
+  recipes:
+    - skill: magic
+      level: 85
+      xp: 80
+      materials:
+        - item_name: Soft clay
+          item_id: 1761
+          quantity: 1
+        - item_name: Law rune
+          item_id: 563
+          quantity: 3
+        - item_name: Water rune
+          item_id: 555
+          quantity: 10
+        - item_name: Astral rune
+          item_id: 9075
+          quantity: 3
+      tools:
+        - Lunar Lectern
+      product: Fishing guild teleport (tablet)
+      product_id: 24959
+      output_quantity: 1
+      facility: Lunar Lectern
+  related_items:
+    - item_id: 1761
+      item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Tablet base
+    - item_id: 563
+      item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Required for teleport
+    - item_id: 9075
+      item_name: Astral rune
+      slug: astral-rune
+      relationship: component
+      description: Lunar magic catalyst
+  about: |-
+    The fishing guild teleport tablet teleports the player outside the Fishing Guild entrance west of Hemenster. Created on the Lunar spellbook at the Lunar Lectern.
+
+    Anyone can break the tablet, no Magic level required to use.
+  market_strategy:
+    notes:
+      - "Lunar spellbook utility"
+      - "Skilling teleport"
+      - "No Magic requirement to use"
+      - "Bulk crafted by Lunar mages"
+      - "Profitable for 85 Magic crafters via Lunar Lectern"
+      - "High GE limit supports bulk trading"
+      - "Demand tied to Fishing Guild popularity"
+  history:
+    - date: "2020-09-30"
+      description: "Released as part of the Lunar Magic teleport tablet expansion."
+    - date: "2020-10-07"
+      description: "Made tradeable on the Grand Exchange."
+    - date: "2020-10-14"
+      description: "Buy limit increased from 100 to 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fiyr-remains.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fiyr-remains.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Fiyr remains is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Fiyr remains drop from fiyr shades in the Shade Catacombs and are cremated on a funeral pyre with magic, redwood, ironwood, or rosewood logs for Prayer and Firemaking XP plus a chance at shade keys. High alchemy value: 1 coin. Grand Exchange buy limit: 7,500 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    equipable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 1.36
+  material:
+    type: organic
+    tier: standard
+  drop_table:
+    - source: "Fiyr shade"
+      quantity: "1"
+      rarity: "Always"
+    - source: "Temple Trekking"
+      quantity: "1"
+      rarity: "Common"
+  recipes:
+    - item_name: Fiyr cremation
+      skill: Firemaking
+      level: 80
+      xp: 404.5
+      tools:
+        - Tinderbox
+      materials:
+        - item_name: Fiyr remains
+          quantity: 1
+        - item_name: Magic pyre logs
+          quantity: 1
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "flip_potential: \"medium\""
+      - "Steady demand from Prayer and Firemaking trainers; supply tracks Shade Catacombs activity."
+  trading_tips:
+    - "Pair with magic pyre logs for the baseline 80 Firemaking cremation."
+    - "Hold for diary bonuses — Morytania Hard Diary increases XP per cremation."
+    - "Resell shade keys obtained while cremating for additional profit."
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Shades of Mort'ton minigame."
+  relationships:
+    - item_name: Asyn shade remains
+      relationship: variant
+    - item_name: Riyl remains
+      relationship: variant
+    - item_name: Urium remains
+      relationship: variant
+    - item_name: Magic pyre logs
+      relationship: alternative
+    - item_name: Fiyr shade
+      relationship: component
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/flamtaer-hammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/flamtaer-hammer.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 40
-  about: "Flamtaer hammer is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Flamtaer hammer is a members-only tool in Old School RuneScape used in the Shades of Mort'ton minigame to speed up temple reconstruction by approximately 75%, acting as an invisible +40 Crafting boost. High alchemy value: 6,000 coins. Grand Exchange buy limit: 40 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-10-26"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 1.36
+  shops:
+    - shop_name: "Razmire General Store"
+      location: "Mort'ton"
+      price: 13000
+      stock: 0
+    - shop_name: "Rasolo the Wandering Merchant"
+      location: "South of Baxtorian Falls"
+      price: 20000
+      stock: 1
+  drop_table:
+    - source: "Bronze chest (Shades of Mort'ton)"
+      level: null
+      quantity: "1"
+      rarity: "Rare"
+    - source: "Steel chest (Shades of Mort'ton)"
+      level: null
+      quantity: "1"
+      rarity: "Uncommon"
+    - source: "Black chest (Shades of Mort'ton)"
+      level: null
+      quantity: "1"
+      rarity: "Uncommon"
+    - source: "Silver chest (Shades of Mort'ton)"
+      level: null
+      quantity: "1"
+      rarity: "Uncommon"
+    - source: "Gold chest (Shades of Mort'ton)"
+      level: null
+      quantity: "1"
+      rarity: "Uncommon"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy on the Grand Exchange near 5,244 coins; far cheaper than the Razmire General Store at 13,000.\""
+      - "sell_strategy: \"Sell when Shades of Mort'ton activity spikes; price tends to climb during minigame events.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"low\""
+  trading_tips:
+    - "Always pick this up over a regular hammer for Shades of Mort'ton runs; the speed boost outweighs the cost."
+    - "Stock occasionally drops from shade chests, providing free supply for active runners."
+    - "Avoid buying from Rasolo at 20,000 coins; the GE undercuts by a wide margin."
+  history:
+    - date: "2004-10-26"
+      description: "Released with the Shades of Mort'ton minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-coif.mdx
@@ -12,33 +12,41 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  properties:
+    release_date: '2019-04-11'
+    quest_item: false
+    destroy: Drop
   equipment:
     slot: head
-    type: ranged_armour
+    weapon_type: ranged_armour
+    attack_speed: 1
     requirements:
       ranged: 40
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -1
-      attack_ranged: 4
-      defence_stab: 4
-      defence_slash: 7
-      defence_crush: 8
-      defence_magic: 4
-      defence_ranged: 6
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: 4
+    defence_bonus:
+      stab: 4
+      slash: 7
+      crush: 8
+      magic: 4
+      ranged: 6
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
     weight: 0.9
-  obtaining:
-    methods:
-      - source: Reward casket (elite)
-        drop_rate: 1/14,662.5
-      - source: Reward casket (master)
-        drop_rate: 1/13,616
+  drop_table:
+    - source: Reward casket (elite)
+      quantity: "1"
+      rarity: 1/14,662.5
+    - source: Reward casket (master)
+      quantity: "1"
+      rarity: 1/13,616
   related_items:
     - item_id: 1169
       item_name: Coif
@@ -90,16 +98,19 @@ osrs:
     Stats are identical to the standard coif. The gilded version is purely cosmetic and significantly more expensive due to its rarity from Treasure Trails.
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Elite clue reward rarity
-      - Collection log completionists
-      - Full gilded d'hide set completion
-      - Identical stats to standard coif
-      - Value is purely cosmetic rarity
-      - Completes the gilded d'hide set with body, chaps, and vambraces
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Fashionscape / cosmetic flex"
+      - "Elite clue reward rarity"
+      - "Collection log completionists"
+      - "Full gilded d'hide set completion"
+      - "Identical stats to standard coif"
+      - "Value is purely cosmetic rarity"
+      - "Completes the gilded d'hide set with body, chaps, and vambraces"
+      - "Low trade volume, watch for manipulation"
+  history:
+    - date: '2019-04-11'
+      description: Item released as part of the gilded dragonhide armour set from Treasure Trails.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gnomeball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gnomeball.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gnomeball | OSRS Price Data
-description: "Gnomeball: A ball used in Gnomeball.. High alch: 1 GP, GE limit: 150."
+description: "Gnomeball: A ball used in Gnomeball. High alch: 1 GP, GE limit: 150."
 osrs:
   id: 751
   name: Gnomeball
@@ -12,13 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 150
+  properties:
+    release_date: "2003-01-28"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: minigame
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 1
+    weight: 0.5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      attack: 1
+    degradable: false
+  drop_table:
+    primary_source: Gnomeball minigame
+    sources:
+      - source: Gnome Ball minigame reward
+        quantity: "1"
+        rarity: common
+        members_only: true
+      - source: Dolphin
+        quantity: "1"
+        rarity: "1/50"
+        members_only: true
+  special_attack:
+    name: Thrown Ball
+    description: Can be thrown to other players; catches into their weapon slot.
   related_items: []
   about: |-
     > _"It's a gnomeball."_
 
     The gnomeball is used in the Gnomeball minigame north of the Gnome Stronghold. Players pass the ball between gnomes to score goals. Can be thrown at other players for fun.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "Effectively a novelty item with cap value of 1 gp"
+      - "GE flips rarely worthwhile due to free supply"
+      - "Demand limited to collectors and minigame players"
+  trading_tips:
+    - Pick up from the Gnome Ball minigame directly
+    - Ironman accounts cannot receive gnomeballs from others
+    - Ball returns to the ref if dropped during the minigame
+  history:
+    - date: "2003-01-28"
+      description: "Released alongside the Gnome Ball minigame."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-locks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-locks.mdx
@@ -13,8 +13,65 @@ osrs:
   highalch: 19200
   limit: 8
   about: "Gold locks is a members-only item in Old School RuneScape. High alchemy value: 19,200 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-01-27"
+    weight: 0.283
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: gold
+  drop_table:
+    - source: "Gold chest (Shades of Mort'ton)"
+      quantity: "1"
+      rarity: "1/60"
+      notes: "Drop rate varies by chest color: red 1/63, crimson 1/61, brown 1/62, black 1/60, purple 1/59. Ring of Wealth improves odds."
+  recipes:
+    - item_name: "Gold coffin"
+      tools:
+        - "Broken coffin"
+        - "Speak to Dampe"
+      materials:
+        - item_name: "Gold locks"
+          quantity: 1
+        - item_name: "Broken coffin"
+          quantity: 1
+      output_quantity: 1
+      notes: "Dampe attaches the lock to a broken coffin to create a gold coffin. Reversible via Remove-lock option."
+  relationships:
+    - item_name: "Gold coffin"
+      relationship: component
+      notes: "Combined with broken coffin via Dampe to create gold coffin."
+    - item_name: "Bronze locks"
+      relationship: alternative
+      notes: "Lower-tier lock variant from Shades of Mort'ton."
+    - item_name: "Steel locks"
+      relationship: alternative
+      notes: "Mid-tier lock variant from Shades of Mort'ton."
+    - item_name: "Black locks"
+      relationship: alternative
+      notes: "High-tier lock variant from Shades of Mort'ton."
+    - item_name: "Silver locks"
+      relationship: alternative
+      notes: "High-tier lock variant from Shades of Mort'ton."
+  history:
+    - date: "2021-01-27"
+      description: "Released with the Shades of Mort'ton Rework update."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Acquire from Shades of Mort'ton gold chests or buy on Grand Exchange when prices are below high alch.\""
+      - "sell_strategy: \"Sell to coffin crafters or list on Grand Exchange; small daily volume so price patience helps.\""
+      - "profit_potential: \"Limited; primarily used as a crafting component for gold coffins.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Daily volume is around 557 trades — set realistic prices and wait."
+    - "Buy limit is only 8 per 4 hours, restricting flip volume."
+    - "Value is tied to demand for gold coffins from Shades of Mort'ton players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/golden-scarab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/golden-scarab.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 13000
-  about: "Golden scarab is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Golden scarab is a Pyramid Plunder artefact sold to Simon Templeton for 1,000 GP; six are also consumed to recharge the Pharaoh's sceptre."
+  drop_table:
+    sources:
+      - source: Pyramid Plunder
+        quantity: "1"
+        rarity: Common
+  shops:
+    - shop_name: Simon Templeton's Antiques
+      location: Agility Pyramid
+      sells_for: 1000
+      currency: Coins
+      notes: "Player sells artefacts to Simon for fixed coin payouts."
+  related_items:
+    - item_name: Pharaoh's sceptre
+      relationship: product
+    - item_name: Golden statuette
+      relationship: alternative
+    - item_name: Stone scarab
+      relationship: alternative
+    - item_name: Jewelled scarab
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Pyramid Plunder common artefact — fixed Simon Templeton buyout sets a 1,000 GP floor."
+      - "GE limit of 13,000 supports large flips when price dips below 1,000 GP."
+      - "Demand spikes from Pharaoh's sceptre rechargers (6 scarabs per top-up)."
+  trading_tips:
+    - "Buy on GE below 1,000 GP and resell to Simon Templeton for guaranteed margin minus tax."
+    - "Plunder players who don't want to bank can simply sell at Simon for fast clears."
+    - "Watch sceptre meta — restocking pickups push scarab demand on event weekends."
+  history:
+    - date: "2006-07-17"
+      description: "Golden scarab released with the Pyramid Plunder update."
+    - date: "2015-02-26"
+      description: "Became tradeable on the Grand Exchange."
+  properties:
+    release_date: "2006-07-17"
+    update: "Pyramid Plunder"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Green cape | OSRS Price Data
-description: "Green cape: A thick green cape.. High alch: 19 GP, GE limit: 150."
+description: "Green cape: A thick green cape. High alch: 19 GP, GE limit: 150."
 osrs:
   id: 1027
   name: Green cape
@@ -12,9 +12,99 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 150
-  about: "Green cape is a free-to-play item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.453
+  about: "Green cape is a free-to-play cape obtainable by dyeing any plain cape with green dye at Crafting level 1. It sits in the cape equipment slot and offers a tiny defensive boost, making it a cheap cosmetic choice for low-level adventurers."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cloth
+    tier: basic
+  equipment:
+    slot: cape
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 41
+      currency: coins
+      stock: 5
+    - shop_name: Floria's Fashion
+      location: Civitas illa Fortis
+      price: 32
+      currency: coins
+      stock: 5
+  recipes:
+    - item_name: Green cape
+      skill: Crafting
+      level: 1
+      xp: 2.5
+      tools:
+        - Green dye
+      materials:
+        - item_name: Cape
+          quantity: 1
+        - item_name: Green dye
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Red cape
+      relationship: alternative
+    - item_name: Blue cape
+      relationship: alternative
+    - item_name: Yellow cape
+      relationship: alternative
+    - item_name: Green dye
+      relationship: component
+  market_strategy:
+    notes:
+      - "summary: \"Low-volume cosmetic cape with minor demand for fashionscape sets.\""
+      - "buy_strategy: \"Bid slightly below GE mid-price; volume of ~793/day means orders fill within hours.\""
+      - "sell_strategy: \"List near high alch threshold; flips are thin but stable for fashion collectors.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Crafting green capes from plain capes loses coins at every input price — buy direct from the GE."
+    - "Useful as a cheap cape slot filler for ironman accounts before unlocking cape of legends."
+    - "Hold supplies of green dye if you intend to flip dye markets together with capes."
+  history:
+    - date: "2001-12-08"
+      description: "Released alongside the original RuneScape cape colours."
+    - date: "2013-02-22"
+      description: "Carried into Old School RuneScape at launch."
+  properties:
+    release_date: "2001-12-08"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  drop_table: []
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-headband.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-headband.mdx
@@ -13,8 +13,64 @@ osrs:
   highalch: 24
   limit: 4
   about: "Green headband is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 0.04
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: cosmetic
+    category: headwear
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: null
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    type: emote
+    location: "Blighted Volcano"
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Red headband"
+      - "Black headband"
+      - "Brown headband"
+      - "White headband"
+      - "Blue headband"
+      - "Gold headband"
+      - "Pink headband"
+      - "Pure cosmetic headwear popular for fashionscape and emote clue completionists."
+      - "Low GE buy limit (4 per 4 hours) means scarcity props the price above alch values."
+      - "Demand spikes alongside hard clue popularity events."
+  history:
+    - date: "2014-06-12"
+      description: "Green headband was added to the game as a hard clue scroll reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-warspear-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-warspear-0.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 15
-  about: "Guthan's warspear 0 is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Guthan's warspear 0 is a degraded version of Guthan the Infested's warspear from the Barrows minigame. Requires 70 Attack to wield and is fully degraded with 0 charges; must be repaired before it can be used again. High alchemy value: 60,000 coins. Grand Exchange buy limit: 15 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 2.267
+  material:
+    type: metal
+    primary: metal
+    tier: barrows
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 5
+    two_handed: true
+    requirements:
+      attack: 70
+    attack_bonus:
+      stab: 75
+      slash: 75
+      crush: 75
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 7
+      slash: 7
+      crush: 7
+      magic: 0
+      ranged: 7
+    other_bonus:
+      strength: 75
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    max_charges: 15
+    current_charges: 0
+    degrades: true
+    repair_cost: 100000
+    repair_method: "Repair at Bob's Brilliant Axes in Lumbridge or an armour stand in a player-owned house for a discount based on Smithing level."
+    notes: "Degrades over 15 hours of combat. This 0-charge version is fully broken and must be repaired before it can be wielded effectively. When the full Guthan's set is worn, melee hits have a 25% chance to heal the wearer for damage dealt."
+  drop_table:
+    - source: "Barrows chest"
+      level: 115
+      quantity: "1"
+      rarity: "1/2448"
+      notes: "Awarded from the Barrows chest when at least one brother has been defeated."
+  market_strategy:
+    notes:
+      - "buy_range: \"95,000 - 110,000 gp\""
+      - "sell_range: \"105,000 - 120,000 gp\""
+      - "0-charge variants trade at a discount versus undamaged Guthan's warspear due to the repair cost; flip when the discount exceeds repair price."
+  trading_tips:
+    - "Compare price to the undamaged warspear minus the 100,000 gp repair fee."
+    - "Stock up after Barrows updates when drops temporarily spike supply."
+    - "Sell to Ironmen or set collectors who plan to repair and use the gear."
+  history:
+    - date: "2005-05-09"
+      description: "Released with the Barrows minigame."
+    - date: "2017-02-15"
+      description: "Added to the Grand Exchange after Barrows item tradeability rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/half-moon-spectacles.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/half-moon-spectacles.mdx
@@ -1,20 +1,92 @@
 ---
 title: Half moon spectacles | OSRS Price Data
-description: "Half moon spectacles: The two halfs would surely make a full moon?. High alch: 11,670 GP, GE limit: 4."
+description: "Half moon spectacles: The two halfs would surely make a full moon? Master clue reward. High alch: 11,670 GP, GE limit: 4."
 osrs:
   id: 20053
   name: Half moon spectacles
   slug: half-moon-spectacles
-  examine: The two halfs would surely make a full moon?
+  examine: "The two halfs would surely make a full moon?"
   members: true
   icon: Half moon spectacles.png
   value: 19450
   lowalch: 7780
   highalch: 11670
   limit: 4
-  about: "Half moon spectacles is a members-only item in Old School RuneScape. High alchemy value: 11,670 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cosmetic-headwear
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.05
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  drop_table:
+    sources:
+      - source: "Reward casket (master)"
+        quantity: "1"
+        rarity: "1/851"
+  related_items:
+    - item_name: "Reward casket (master)"
+      slug: "reward-casket-master"
+      relationship: component
+      description: "Sole source — rare reward from master Treasure Trails."
+    - item_name: "Monocle"
+      slug: "monocle"
+      relationship: alternative
+      description: "Another master clue cosmetic head-slot eyewear."
+  about: "Half moon spectacles are a cosmetic head-slot item rolled from master Treasure Trail reward caskets at roughly 1/851. They provide no combat bonuses and exist purely for fashionscape. The item is storable in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Supply is fully gated by master clue completions — slow drip."
+      - "Buy limit of 4 / 4h makes accumulation deliberate, not casual."
+      - "Demand pulses around master-clue meta updates and PvM events that reward clues."
+  trading_tips:
+    - "Watch for spikes around new master-tier expansions or league qualifiers."
+    - "Costume-room collectors anchor the floor; cosmetic re-launches lift the ceiling."
+    - "Margin per flip is high in absolute coins but limit-capped — pace accordingly."
+  history:
+    - date: "2016-07-06"
+      description: "Added to the master clue reward pool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ham-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ham-boots.mdx
@@ -12,31 +12,75 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 15
+  about: "Ham boots are the feet piece of the H.A.M. (Humans Against Monsters) outfit. Wearing more H.A.M. pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. High alchemy value: 45 coins. Grand Exchange buy limit: 15."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cloth
+    tier: cloth
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    equipable: true
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.34
   equipment:
     slot: feet
-    requirements: {}
-  related_items:
-    - item_id: 4302
-      item_name: Ham hood
-      slug: ham-hood
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    - source: H.A.M. Member (pickpocket)
+      quantity: "1"
+      rarity: "1/102"
+    - source: H.A.M. Guard
+      quantity: "1"
+      rarity: "2/110"
+    - source: Chest in Zanik's house
+      quantity: "1"
+      rarity: "1/23"
+  relationships:
+    - item_name: Ham hood
       relationship: set-piece
-      description: H.A.M. head piece
-    - item_id: 4298
-      item_name: Ham shirt
-      slug: ham-shirt
+    - item_name: Ham shirt
       relationship: set-piece
-      description: H.A.M. body piece
-    - item_id: 4308
-      item_name: Ham gloves
-      slug: ham-gloves
+    - item_name: Ham robe
       relationship: set-piece
-      description: H.A.M. hands piece
-  about: |-
-    > *"HAM boots as worn by the Humans Against Monsters group."*
-
-    The ham boots are the feet piece of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing. A members-only item with no combat stats.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Ham gloves
+      relationship: set-piece
+    - item_name: Ham cloak
+      relationship: set-piece
+  market_strategy:
+    notes:
+      - "short_term: \"Demand bumps when new players push H.A.M. pickpocketing for early Thieving XP.\""
+      - "long_term: \"Niche cosmetic / thieving aid; supply is steady from H.A.M. pickpocket loop.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Buy-limit is only 15, so flips are best in bulk-listing batches not single high-volume orders."
+    - "Stack with other H.A.M. set pieces for a sellable bundle."
+  history:
+    - date: "2005-02-22"
+      description: "Released with the Death to the Dorgeshuun quest area expansion and H.A.M. Hideout content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ham-joint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ham-joint.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ham joint | OSRS Price Data
-description: "Ham joint is a F2P weapon slot item. High alch: 900 GP, GE limit: 100."
+description: "Ham joint: A delicious joint of ham. F2P 3-tick crush weapon. High alch: 900 GP, GE limit: 100."
 osrs:
   id: 23360
   name: Ham joint
@@ -12,9 +12,32 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: 100
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cosmetic-weapon
+    tier: high
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: blunt
     attack_speed: 3
+    weight: 2
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -28,38 +51,37 @@ osrs:
       magic: 0
       ranged: 0
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements: {}
-    weight: 2
   drop_table:
     sources:
-      - source: Reward casket (easy)
+      - source: "Reward casket (easy)"
         quantity: "1"
-        rarity: very rare
-        drop_rate: 1/1404
-        members_only: false
-  about: |-
-    All bonuses are +0 — the ham joint has no combat stats whatsoever.
-
-    Requirements: None | Speed: 3 tick (1.8s) | Weight: 2 kg
-
-    At 3-tick attack speed (1.8 seconds), the ham joint is tied for the fastest melee weapon in the game. Despite having zero stats, the speed makes it theoretically interesting for niche uses.
-
-    The ham joint is primarily a fashionscape item and collectible:
-    - Rare easy clue reward (1/1,404)
-    - Tradeable and F2P accessible
-    - Can be stored in the costume room treasure chest
-    - One-handed crush weapon — three styles (Pound, Pummel, Block)
+        rarity: "1/1,404"
+  related_items:
+    - item_name: "Swift blade"
+      slug: "swift-blade"
+      relationship: alternative
+      description: "Another 3-tick attack speed melee novelty weapon."
+    - item_name: "Reward casket (easy)"
+      slug: "reward-casket-easy"
+      relationship: component
+      description: "Sole source — rare reward from easy Treasure Trails."
+  about: "Ham joint is a free-to-play one-handed crush weapon obtained as a rare reward from easy Treasure Trails (1/1,404 from a Reward casket (easy)). It has zero offensive and defensive bonuses, but its 3-tick attack speed (1.8 seconds) ties it with the swift blade as one of the fastest melee weapons in the game. Primarily a fashionscape and collector item; storable in the costume room treasure chest."
   market_strategy:
     notes:
-      - Rare cosmetic — price driven by collectors
-      - Easy clue farming is the only source
-      - F2P accessible, so broader market
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply is fully clue-bottlenecked — only enters circulation through easy clue completion."
+      - "Collector demand drives the price far above alch and base utility value."
+      - "F2P accessibility broadens the buyer pool versus members-only clue rares."
+  trading_tips:
+    - "Watch for easy-clue meta shifts (events, Twisted League echoes) that flood supply."
+    - "Buy limit of 100 / 4h makes bulk accumulation slow but predictable."
+    - "Trim margins are tight relative to price — flip on volume, not spread."
+  history:
+    - date: "2019-04-11"
+      description: "Added to the easy clue Reward casket loot table."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-spear-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-spear-tips.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 10000
-  about: "Hunter spear tips is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Hunter spear tips are fletching components used to craft hunter's spears, obtained from hunters' loot sacks via Hunters' Rumours in Varlamore. High alchemy value: 3 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: metal
+    tier: standard
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    equipable: false
+    stackable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0
+  recipes:
+    - item_name: Hunters' spear
+      skill: fletching
+      level: 60
+      xp: 9.5
+      output_quantity: 5
+      tools:
+        - Knife
+      materials:
+        - item_name: Teak logs
+          quantity: "1"
+        - item_name: Jerboa tail
+          quantity: "5"
+        - item_name: Hunter spear tips
+          quantity: "5"
+  drop_table:
+    - source: Basic hunters' loot sack
+      quantity: "1"
+      rarity: Common
+    - source: Adept hunters' loot sack
+      quantity: "1"
+      rarity: Common
+    - source: Expert hunters' loot sack
+      quantity: "1"
+      rarity: Common
+    - source: Master hunters' loot sack
+      quantity: "1"
+      rarity: Common
+    - source: Hunters' loot sack (supplies)
+      quantity: "1"
+      rarity: Common
+  relationships:
+    - item_name: Hunters' spear
+      relationship: upgrade
+    - item_name: Jerboa tail
+      relationship: component
+    - item_name: Teak logs
+      relationship: component
+  market_strategy:
+    notes:
+      - "short_term: \"Liquidity is excellent (~300k daily) — tight spreads, suitable for high-volume low-margin flips.\""
+      - "long_term: \"Demand follows Varlamore Hunter content and hunter's spear usage in skilling routes.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Stack with jerboa tails and teak logs to push fletched hunter's spears into the GE for combined margin."
+    - "Use the 10,000 limit to scale flips during loot-sack volume spikes after content events."
+  history:
+    - date: "2024-03-20"
+      description: "Released with Varlamore: Part One and the Hunters' Rumours content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunters-sunlight-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunters-sunlight-crossbow.mdx
@@ -12,12 +12,29 @@ osrs:
   lowalch: 520
   highalch: 780
   limit: 70
+  about: "Solid mid-tier crossbow for general ranged combat and Hunter-themed builds. Uses moonlight or sunlight antler bolts and is compatible with grapples."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 6
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: hunter
+    category: crossbow
   equipment:
     slot: weapon
     weapon_type: crossbow
-    weight: 6
     attack_speed: 4
-    attack_range: 8
+    requirements:
+      ranged: 66
+      hunter: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,68 +48,38 @@ osrs:
       magic: 0
       ranged: 0
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 66
-      hunter: 50
-    degradable: false
   recipes:
-    - skill: fletching
+    - item_name: Hunters' sunlight crossbow
+      skill: Fletching
       level: 74
       xp: 50
+      tools:
+        - Chisel
       materials:
         - item_name: Hunters' crossbow
           quantity: 1
         - item_name: Sunlight antelope antler
           quantity: 1
-      product: Hunters' sunlight crossbow
-      product_id: 28869
-      product_quantity: 1
-      members_only: true
-  drop_table:
-    primary_source: Crafted
-    sources:
-      - source: Fletching
-        quantity: "1"
-        rarity: craftable
-        members_only: true
-  related_items:
-    - item_id: 28878
-      item_name: Moonlight antler bolts
-      slug: moonlight-antler-bolts
-      relationship: component
-      description: Compatible bolts
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Attack speed | 4 ticks (3 ticks on rapid) |
-    | Attack range | 8 tiles |
-    | Ranged attack | +79 |
-
-    - 66 Ranged
-    - 50 Hunter
-
-    Solid mid-tier crossbow for:
-    - General ranged combat
-    - Hunter-themed builds
-    - Uses moonlight/sunlight antler bolts
-
-    | Crossbow | Ranged Attack |
-    |----------|--------------|
-    | Hunters' sunlight | +79 |
-    | Dragon crossbow | +94 |
-    | Armadyl crossbow | +100 |
-    | Karil's crossbow | +84 |
+      output_quantity: 1
+      members: true
   market_strategy:
     notes:
-      - Budget option below dragon crossbow
-      - Requires Hunter skill investment
-      - Part of Hunter Guild content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "relationship: \"variant\""
+      - "Hunters' crossbow"
+      - "Hunters' moonlight crossbow"
+      - "Sunlight antler bolts"
+      - "Moonlight antler bolts"
+      - "Dragon crossbow"
+      - "Budget mid-tier crossbow option below dragon crossbow; popular with Hunter Guild content."
+      - "Crafting margin depends on sunlight antelope antler supply and hunters' crossbow price."
+      - "Fires sunlight or moonlight antler bolts and supports grapple use."
+  history:
+    - date: "2024-03-20"
+      description: "Hunters' sunlight crossbow released as part of the Hunter Guild expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-armour-set.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: null
-  about: "Inquisitor's armour set is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Inquisitor's armour set is a members-only item in Old School RuneScape obtained via the Grand Exchange Set Exchange interface. It bundles the Inquisitor's great helm, hauberk, and plateskirt for convenient trading."
+  related_items:
+    - item_name: Inquisitor's great helm
+      relationship: component
+    - item_name: Inquisitor's hauberk
+      relationship: component
+    - item_name: Inquisitor's plateskirt
+      relationship: component
+  market_strategy:
+    notes:
+      - "Set Exchange convenience item — bundles all three Inquisitor pieces for one-click trading."
+      - "Typically trades near the sum of its component prices, with small premium or discount based on demand."
+      - "No GE buy limit, but liquidity is thin so large orders can move the price."
+  trading_tips:
+    - "Watch the spread between set price and sum of components — arbitrage opportunities appear during volatile periods."
+    - "Use the Grand Exchange clerk's Sets tab to break the set into components or assemble one."
+    - "Long-term hold tied to Nightmare boss drop rates and crush weapon meta."
+  history:
+    - date: "2020-02-06"
+      description: "Inquisitor's armour set added with The Nightmare of Ashihama update."
+  properties:
+    release_date: "2020-02-06"
+    update: "The Nightmare of Ashihama"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow-p.mdx
@@ -12,16 +12,84 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: ammunition
+    tier: iron
   equipment:
     slot: ammo
-    ranged_strength: 10
-  related_items: []
+    weapon_type: arrow
+    attack_speed: 1
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 10
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Iron arrow(p)
+      skill: Fletching
+      level: 1
+      xp: 0
+      output_quantity: 5
+      members: true
+      tools: []
+      materials:
+        - item_name: Iron arrow
+          quantity: 5
+        - item_name: Weapon poison
+          quantity: 1
+  related_items:
+    - item_id: 884
+      item_name: Iron arrow
+      slug: iron-arrow
+      relationship: variant
+      description: Unpoisoned base variant
+    - item_id: 5617
+      item_name: Iron arrow(p+)
+      slug: iron-arrow-p-plus
+      relationship: variant
+      description: Stronger poison variant
+    - item_id: 5618
+      item_name: Iron arrow(p++)
+      slug: iron-arrow-p-plus-plus
+      relationship: variant
+      description: Strongest poison variant
+  market_strategy:
+    notes:
+      - "summary: \"Niche poisoned ammo for low-level rangers; supply driven by weapon-poison combinations rather than monster drops.\""
+      - "target_audience: \"Low-level rangers and ironmen training Ranged with poison procs.\""
+  trading_tips:
+    - Combine cheap iron arrows with weapon poison; profit margin is typically negative on GE.
+    - GE limit 7,000 per 4 hours.
+  history:
+    - date: "2002-03-25"
+      description: Base iron arrows released; poisoned variant followed with weapon poison.
+    - date: "2025-05-29"
+      description: Exempted from Grand Exchange convenience fee.
   about: |-
     > _"Iron arrows with a poisoned tip."_
 
     Iron arrows tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2002-03-25"
+    weight: 0
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-felling-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-felling-axe.mdx
@@ -1,20 +1,107 @@
 ---
 title: Iron felling axe | OSRS Price Data
-description: "Iron felling axe: A woodcutter's axe.. High alch: 33 GP."
+description: "Iron felling axe: A woodcutter's felling axe. High alch: 33 GP."
 osrs:
   id: 28199
   name: Iron felling axe
   slug: iron-felling-axe
-  examine: A woodcutter's axe.
+  examine: A woodcutter's felling axe.
   members: true
   icon: Iron felling axe.png
   value: 56
   lowalch: 22
   highalch: 33
   limit: null
-  about: "Iron felling axe is a members-only item in Old School RuneScape. High alchemy value: 33 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 1.814
+  about: "Iron felling axe is the iron-tier two-handed woodcutting axe introduced with Forestry. Beyond chopping logs, it doubles as a low-tier slash weapon and triggers Forestry XP bonuses when used with forester's rations."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: iron
+    tier: tier_1
+  equipment:
+    slot: weapon
+    weapon_type: axe
+    attack_speed: 7
+    requirements:
+      attack: 1
+      woodcutting: 1
+    attack_bonus:
+      stab: -3
+      slash: 8
+      crush: 4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 11
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Iron felling axe
+      skill: Smithing
+      level: 1
+      xp: 5
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_name: Felling axe handle
+          quantity: 1
+        - item_name: Iron axe
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Bronze felling axe
+      relationship: variant
+    - item_name: Steel felling axe
+      relationship: variant
+    - item_name: Black felling axe
+      relationship: variant
+    - item_name: Mithril felling axe
+      relationship: variant
+    - item_name: Adamant felling axe
+      relationship: variant
+    - item_name: Rune felling axe
+      relationship: variant
+    - item_name: Dragon felling axe
+      relationship: variant
+    - item_name: Iron axe
+      relationship: component
+  market_strategy:
+    notes:
+      - "summary: \"Forestry low-tier axe with moderate demand from new accounts unlocking woodcutting bonuses.\""
+      - "buy_strategy: \"Smith from felling axe handle + iron axe when handle prices crash from Forestry events.\""
+      - "sell_strategy: \"Sell to new ironmen and main accounts grinding low-tier woodcutting; price tracks felling axe handle supply.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Smith one from a cheap iron axe + felling axe handle; the only cost is the handle."
+    - "Pair with forester's rations for 10% bonus woodcutting XP and 20% log-skip chance."
+    - "Watch felling axe handle drops from Forestry events — they drive the price floor."
+  history:
+    - date: "2023-10-25"
+      description: "Released with the Forestry update introducing felling axes for two-handed woodcutting."
+  properties:
+    release_date: "2023-10-25"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  drop_table: []
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-hasta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-hasta.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 125
-  about: "Iron hasta is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Iron hasta is a one-handed barbarian polearm. Functions like a spear but allows a shield. Smithed at the Barbarian anvil after completing the Barbarian Training Smithing tutorial."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 2.267
+    destroy: "Drop"
+  material:
+    type: ammunition
+    tier: iron
+    category: hasta
+  equipment:
+    slot: weapon
+    weapon_type: hasta
+    attack_speed: 4
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 8
+      slash: 8
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -2
+      slash: -2
+      crush: -2
+      magic: 0
+      ranged: -2
+    other_bonus:
+      strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Iron hasta
+      skill: Smithing
+      level: 20
+      xp: 50
+      tools:
+        - Hammer
+        - Barbarian anvil
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+        - item_name: Oak logs
+          quantity: 1
+      output_quantity: 1
+      members: true
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Iron spear"
+      - "Bronze hasta"
+      - "Steel hasta"
+      - "Mithril hasta"
+      - "Adamant hasta"
+      - "Rune hasta"
+      - "Functions like a spear but classified as a one-hand, freeing the shield slot."
+      - "Smithing requires Barbarian Training Smithing tutorial completion."
+      - "Low GE volume and supply because most players skip Barbarian smithing."
+  history:
+    - date: "2007-07-03"
+      description: "Iron hasta released alongside the Barbarian Training miniquest update."
+    - date: "2021-04-21"
+      description: "Attack speed was improved from 5 ticks (3.0s) to 4 ticks (2.4s)."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platebody-t.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 224
   highalch: 336
   limit: 4
-  about: "Iron platebody (t) is a free-to-play item in Old School RuneScape. High alchemy value: 336 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 9.979
+  material:
+    type: metal
+    tier: iron
+  properties:
+    release_date: "2014-06-12"
+    quest_item: false
+    destroy: "Drop"
+  equipment:
+    slot: body
+    requirements:
+      defence: 10
+    bonuses:
+      attack:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: -6
+        ranged: -15
+      defence:
+        stab: 21
+        slash: 20
+        crush: 12
+        magic: -6
+        ranged: 20
+      other:
+        strength: 0
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
+  treasure_trail:
+    tier: easy
+  drop_table:
+    - source: Reward casket (easy)
+      level: 0
+      quantity: "1"
+      rarity: "1/1404"
+      members: false
+  related_items:
+    - item_id: 1115
+      item_name: Iron platebody
+      slug: iron-platebody
+      relationship: variant
+      description: Base untrimmed version
+    - item_id: 12221
+      item_name: Iron platebody (g)
+      slug: iron-platebody-g
+      relationship: variant
+      description: Gold-trimmed variant
+  about: |-
+    Iron platebody (t) is a trimmed cosmetic variant of the iron platebody, obtained only as a rare reward from easy clue scrolls. Stats are identical to the base iron platebody.
+
+    Requires 10 Defence to wear and is available to free-to-play players.
+  market_strategy:
+    notes:
+      - "F2P clue cosmetic"
+      - "Easy clue exclusive"
+      - "Identical stats to base platebody"
+      - "Cannot be smithed"
+      - "Low GE buy limit"
+      - "Price driven by easy clue scroll volume"
+      - "Low margin alch, value comes from cosmetic resale"
+      - "Thin liquidity, manipulate-sensitive"
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion update."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -10 to -15."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-plateskirt-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-plateskirt-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron plateskirt (t) | OSRS Price Data
-description: "Iron plateskirt (t): Iron plateskirt with trim.. High alch: 168 GP, GE limit: 4."
+description: "Iron plateskirt (t): Iron plateskirt with trim. High alch: 168 GP, GE limit: 4."
 osrs:
   id: 12229
   name: Iron plateskirt (t)
@@ -12,9 +12,60 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 4
-  about: "Iron plateskirt (t) is a free-to-play item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Iron plateskirt (t) is a free-to-play trimmed iron plateskirt in Old School RuneScape, obtained from easy clue scroll caskets and primarily used as a cosmetic legs option. High alchemy value: 168 coins. Grand Exchange buy limit: 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 8.164
+  material:
+    type: cloth
+    tier: iron
+  equipment:
+    slot: legs
+    weapon_type: none
+    attack_speed: null
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: -4
+      ranged: 10
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    source: "Reward casket (easy)"
+    rarity: "1/1,404"
+  market_strategy:
+    notes:
+      - "summary: \"Cosmetic trimmed iron plateskirt from easy clue scrolls; price moves with easy clue completion rates and free-to-play fashion demand.\""
+      - "buy_strategy: \"Accumulate during clue-fatigue lulls; flip on collector demand spikes.\""
+      - "sell_strategy: \"Move when free-to-play cosmetic events or worlds gain attention.\""
+  trading_tips:
+    - "Low buy limit of 4 restricts bulk flipping but supports tight margins."
+    - "Demand is mostly cosmetic; combat use is rare."
+    - "Pair sales with other trimmed iron pieces for collector buyers."
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the trimmed clue scroll reward expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-trimmed-set-sk.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Iron trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: iron
+    primary_material: iron
+  related_items:
+    - item_id: 12296
+      item_name: Iron full helm (t)
+      slug: iron-full-helm-t
+      relationship: set-piece
+      description: Helmet piece included in the trimmed set.
+    - item_id: 12294
+      item_name: Iron platebody (t)
+      slug: iron-platebody-t
+      relationship: set-piece
+      description: Body piece included in the trimmed set.
+    - item_id: 12298
+      item_name: Iron plateskirt (t)
+      slug: iron-plateskirt-t
+      relationship: set-piece
+      description: Skirt piece included in the trimmed set.
+    - item_id: 12300
+      item_name: Iron kiteshield (t)
+      slug: iron-kiteshield-t
+      relationship: set-piece
+      description: Kiteshield piece included in the trimmed set.
+    - item_id: 12976
+      item_name: Iron trimmed set (lg)
+      slug: iron-trimmed-set-lg
+      relationship: variant
+      description: Legs-variant of the trimmed set.
+  about: |-
+    Iron trimmed set (sk) bundles a trimmed iron full helm, platebody, plateskirt, and kiteshield.
+
+    Acquired by exchanging the four trimmed iron pieces with a Grand Exchange clerk via the Sets interface.
+
+    | Slot | Piece |
+    |------|-------|
+    | Head | Iron full helm (t) |
+    | Body | Iron platebody (t) |
+    | Legs | Iron plateskirt (t) |
+    | Shield | Iron kiteshield (t) |
+
+    Used for:
+    - Bank space compression
+    - Reselling the bundled set on the GE
+    - Trimmed armour collectors
+  market_strategy:
+    notes:
+      - "Watch component piece prices for arbitrage"
+      - "GE Sets converter has no fee"
+      - "Low daily volume (~9) means thin liquidity"
+  trading_tips:
+    - Compare bundled set price vs sum of four trimmed pieces.
+    - GE buy limit of 8 every 4 hours throttles bulk flips.
+    - Low daily volume - place orders early and patiently.
+  history:
+    - date: "2015-02-26"
+      description: "Released alongside Grand Exchange Sets."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ivory-comb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ivory-comb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ivory comb | OSRS Price Data
-description: "Ivory comb: Gets knots and kinks out of your hair.. High alch: 6 GP, GE limit: 13,000."
+description: "Ivory comb: Gets knots and kinks out of your hair. High alch: 6 GP, GE limit: 13,000."
 osrs:
   id: 9026
   name: Ivory comb
@@ -12,9 +12,67 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
-  about: "Ivory comb is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0.01
+    release_date: '2006-07-17'
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  obtaining:
+    methods:
+      - source: Pyramid Plunder
+        quantity: "1"
+        description: Loot from the first two rooms of the Pyramid Plunder minigame in Sophanem.
+  shops:
+    - shop_name: Simon Templeton
+      location: Agility Pyramid
+      price: 50
+      currency: Coins
+      buys: true
+  passive_effects:
+    - name: Pharaoh's Sceptre Recharge
+      description: 24 ivory combs can be used to recharge the pharaoh's sceptre, though other artifacts are more economical due to low trade volume.
+  related_items:
+    - item_id: 9034
+      item_name: Pharaoh's sceptre
+      slug: pharaoh-s-sceptre
+      relationship: alternative
+      description: Item recharged using stacks of ivory combs (and other Pyramid Plunder artifacts).
+    - item_id: 9032
+      item_name: Stone seal
+      slug: stone-seal
+      relationship: alternative
+      description: Another Pyramid Plunder artifact in the same loot pool.
+  history:
+    - date: '2006-07-17'
+      description: "Ivory comb was released with the Pyramid Plunder minigame update."
+  about: |-
+    > *"Gets knots and kinks out of your hair."*
+
+    The Ivory comb is a Pyramid Plunder artifact found in the first two rooms of the Sophanem pyramid. It can be sold to Simon Templeton at the Agility Pyramid for 50 coins or used to recharge the pharaoh's sceptre.
+
+    | Detail | Value |
+    |--------|-------|
+    | Source | Pyramid Plunder (rooms 1-2) |
+    | NPC Sell Price | 50 (Simon Templeton) |
+    | Pharaoh's Sceptre | 24 to recharge |
+
+    Most players ignore the comb beyond the early Pyramid Plunder rooms because higher-tier artifacts offer better gp/hr.
+  market_strategy:
+    notes:
+      - "Low-tier Pyramid Plunder reward"
+      - "Marginal profit from Simon Templeton vs. GE depending on listings"
+      - "High buy limit but thin volume"
+      - "Members only item"
+  trading_tips:
+    - Compare Simon Templeton's 50 gp buy price vs. live GE listings.
+    - Useful as alch fodder only when pricing aligns.
+    - Demand is light; lean toward limit orders rather than market buys.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-smoke.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-smoke.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Jar of smoke is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Jar of smoke is a rare drop from the Thermonuclear smoke devil (1/2000). Can be placed on the Achievement Gallery boss lair display. High alchemy value: 1 coin. Grand Exchange buy limit: 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: misc
+    tier: collectible
+  properties:
+    release_date: "2021-03-17"
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.04
+  drop_table:
+    - source: Thermonuclear smoke devil
+      quantity: "1"
+      rarity: "1/2000"
+  relationships:
+    - item_name: Jar of dirt
+      relationship: variant
+    - item_name: Jar of stone
+      relationship: variant
+    - item_name: Jar of darkness
+      relationship: variant
+    - item_name: Jar of chemicals
+      relationship: variant
+    - item_name: Pet smoke devil
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "short_term: \"High-value collector item; price swings hard with raid/collection log meta interest.\""
+      - "long_term: \"Trophy-style item with a 4-per-4hr limit; long-term price is dictated by Thermy farming rates and Achievement Gallery demand.\""
+      - "risk_level: \"high\""
+  trading_tips:
+    - "Watch big collection-log events — prices often dip while supply spikes from Thermy farm streams."
+    - "Buy-limit of 4 means scaling requires multiple accounts or patient daily accumulation."
+  history:
+    - date: "2021-03-17"
+      description: "Released as a rare drop from the Thermonuclear smoke devil."
+    - date: "2024-09-25"
+      description: "Inventory icon updated as part of the Varlamore inventory revamp."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-spike.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-spike.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kebbit spike | OSRS Price Data
-description: "Kebbit spike: These bone spikes are both very tough and very sharp.. High alch: 54 GP, GE limit: 10,000."
+description: "Kebbit spike: These bone spikes are both very tough and very sharp. High alch: 54 GP, GE limit: 10,000."
 osrs:
   id: 10105
   name: Kebbit spike
@@ -12,9 +12,59 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 10000
-  about: "Kebbit spike is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Kebbit spike is a members-only Hunter byproduct from prickly kebbits in Old School RuneScape, used to fletch kebbit bolts. High alchemy value: 54 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.02
+  material:
+    type: misc
+    tier: standard
+  drop_table:
+    - source: "Prickly kebbit"
+      level: "37 Hunter"
+      quantity: "1"
+      rarity: "Always"
+      notes: "Caught using deadfall traps at Hunter level 37."
+  recipes:
+    - item_name: "Kebbit bolts"
+      skill: Fletching
+      level: 32
+      xp: 5.8
+      tools:
+        - "Chisel"
+      materials:
+        - item_name: "Kebbit spike"
+          quantity: 1
+      output_quantity: 12
+      notes: "Yield increased from 6 to 12 bolts per spike on 20 March 2024."
+  shops:
+    - shop_name: "Aleck's Hunter Emporium"
+      location: "Yanille"
+      price: 20
+      stock: 0
+      notes: "Leon trades 12 kebbit bolts for one kebbit spike plus 20 coins."
+  market_strategy:
+    notes:
+      - "summary: \"Hunter byproduct used in low-level Fletching; price tracks bolt demand from ironmen and budget rangers.\""
+      - "buy_strategy: \"Stock during low Hunter content periods when supply dries up; profit on the conversion into 12 bolts.\""
+      - "sell_strategy: \"Move during ranged Slayer task spikes or new ammo-relevant content.\""
+  trading_tips:
+    - "Each spike fletches 12 kebbit bolts; compare bolt and spike GE prices for margin."
+    - "Limited supply outside dedicated Hunter trips keeps prices stable."
+    - "Alec's Hunter Emporium provides a deterministic NPC conversion route."
+  history:
+    - date: "2006-11-21"
+      description: "Released with the Hunter skill expansion to Eagles' Peak."
+    - date: "2024-03-20"
+      description: "Bolt yield from fletching a kebbit spike increased from 6 to 12."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-teeth-dust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-teeth-dust.mdx
@@ -1,85 +1,85 @@
 ---
 title: Kebbit teeth dust | OSRS Price Data
-description: "Kebbit teeth dust: Previously a kebbit-sized set of dentures.. High alch: 96 GP, GE limit: 10,000."
+description: "Kebbit teeth dust: Previously a kebbit-sized set of dentures. High alch: 96 GP, GE limit: 10,000."
 osrs:
   id: 10111
   name: Kebbit teeth dust
   slug: kebbit-teeth-dust
-  examine: Previously a kebbit-sized set of dentures.
+  examine: A kebbit-sized set of dentures.
   members: true
   icon: Kebbit teeth dust.png
   value: 160
   lowalch: 64
   highalch: 96
   limit: 10000
+  weight: 0.02
+  about: "Kebbit teeth dust is the Herblore secondary for Hunter potions, made by grinding sabre-toothed kebbit teeth with a pestle and mortar. Each Hunter potion(3) requires one dust plus an avantoe potion (unf) at 53 Herblore."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
   material:
     type: secondary
-    tier: low
-  hunter:
-    source: Sabre-toothed kebbit
-    level: 51
-    location: Rellekka Hunter area
+    tier: basic
   recipes:
-    - skill: herblore
-      level: 0
+    - item_name: Kebbit teeth dust
+      skill: Herblore
+      level: 1
       xp: 0
+      tools:
+        - Pestle and mortar
       materials:
         - item_name: Kebbit teeth
-          item_id: 10109
           quantity: 1
-      product: Kebbit teeth dust
-      product_id: 10111
-      product_quantity: 1
-      tool: Pestle and mortar
-      members_only: true
-    - skill: herblore
+      output_quantity: 1
+    - item_name: Hunter potion(3)
+      skill: Herblore
       level: 53
       xp: 120
+      tools:
+        - Vial
       materials:
         - item_name: Avantoe potion (unf)
-          item_id: 103
           quantity: 1
         - item_name: Kebbit teeth dust
-          item_id: 10111
           quantity: 1
-      product: Hunter potion(3)
-      product_id: 10000
-      members_only: true
+      output_quantity: 1
   related_items:
-    - item_id: 10109
-      item_name: Kebbit teeth
-      slug: kebbit-teeth
+    - item_name: Kebbit teeth
       relationship: component
-      description: Ground into dust
-    - item_id: 10000
-      item_name: Hunter potion(3)
-      slug: hunter-potion-3
+    - item_name: Avantoe
+      relationship: alternative
+    - item_name: Hunter potion(3)
       relationship: product
-      description: Main herblore use
-    - item_id: 261
-      item_name: Avantoe
-      slug: avantoe
+    - item_name: Pestle and mortar
       relationship: component
-      description: Primary herb for hunter potion
-    - item_id: 233
-      item_name: Pestle and mortar
-      slug: pestle-and-mortar
-      relationship: component
-      description: Tool for grinding
   market_strategy:
-    title: Ironman Notes
     notes:
-      - Hunt sabre-toothed kebbits for teeth
-      - Good Hunter XP while gathering
-      - Grind teeth for herblore profit
-      - Compare teeth dust + avantoe cost vs potion price
-      - Potions used for high-level hunter catches
-      - Useful for herbiboar hunting
-      - Must hunt kebbits personally
-      - Stock up teeth while training Hunter
-      - Hunter potions helpful for black chins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "summary: \"Herblore secondary with strong daily volume tied to Hunter potion demand.\""
+      - "buy_strategy: \"Buy raw kebbit teeth and grind for margin when dust trades above teeth + tax cost.\""
+      - "sell_strategy: \"Sell in bulk to Herblore botters and skill seasonal players; volume ~2,200/day.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Convert kebbit teeth -> dust for ~270 gp profit after GE tax per item at typical prices."
+    - "Hunter potions are favored for herbiboar and black chinchompa trips — demand spikes during Slayer/Hunter events."
+    - "10,000 GE limit per 4h supports large flips during Herblore double-XP weekends."
+  history:
+    - date: "2006-11-21"
+      description: "Released with the Hunter skill update introducing sabre-toothed kebbits."
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  drop_table: []
+  shops: []
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kwuarm-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kwuarm-seed.mdx
@@ -12,65 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 200
-  seed:
-    type: herb
+  about: "Kwuarm seed is planted in a herb patch to grow Grimy kwuarm, the primary ingredient for Super strength potions."
+  material:
+    type: seed
     tier: mid-high
   farming:
     level: 56
-    xp_plant: 69
-    xp_harvest: 78
-    growth_time: 80
-    patches: 9
-    product_id: 213
-    product_name: Grimy kwuarm
+    experience_plant: 69
+    experience_harvest: 78
+    growth_time_minutes: 80
+    growth_cycles: 4
+    patch: Herb
+    yield: "3+ herbs (up to ~6 with ultracompost and gear bonuses)"
+    payment_required: false
   related_items:
-    - item_id: 213
-      item_name: Grimy kwuarm
-      slug: grimy-kwuarm
+    - item_name: Grimy kwuarm
       relationship: product
-      description: Harvested product
-    - item_id: 263
-      item_name: Kwuarm
-      slug: kwuarm
+    - item_name: Kwuarm
       relationship: product
-      description: Cleaned herb
-    - item_id: 2458
-      item_name: Super strength(4)
-      slug: super-strength-4
+    - item_name: Super strength(4)
       relationship: product
-      description: Made from kwuarm
-    - item_id: 5298
-      item_name: Avantoe seed
-      slug: avantoe-seed
+    - item_name: Avantoe seed
       relationship: alternative
-      description: Lower tier herb seed
-    - item_id: 5300
-      item_name: Snapdragon seed
-      slug: snapdragon-seed
+    - item_name: Snapdragon seed
       relationship: upgrade
-      description: Next tier herb seed
-  about: |-
-    Plant in a herb patch to grow Grimy kwuarm.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 56 |
-    | Growth time | 80 minutes |
-    | XP (plant) | 69 |
-    | XP (harvest) | 78 per herb |
   market_strategy:
     notes:
-      - Mid-high tier herb seed
-      - Used for super strength potions
-      - Good profit potential
-      - Ultracompost (essential)
-      - Magic secateurs (10% more yield)
-      - Farming cape (5% more yield)
-      - 9 herb patches available
-      - ~10 minute runs, 80 minute regrowth
-      - Super strength essential for combat
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Mid-high tier herb seed feeding Super strength demand from Slayer and PvM."
+      - "Run profit scales with ultracompost, magic secateurs, and farming cape yield bonuses."
+      - "9 active herb patches plus disease-free patches make runs viable every 80 minutes."
+  trading_tips:
+    - "Compare seed cost vs grimy kwuarm GE price to gauge per-patch profit."
+    - "Stock ultracompost first — yield boost more than pays for itself at this tier."
+    - "Limit of 200 caps daily seed sourcing — bulk buyers should split across accounts or wait windows."
+  history:
+    - date: "2005-06-06"
+      description: "Kwuarm seed added with the Seeds, Bankspace and Advisors update."
+    - date: "2018-01-01"
+      description: "Item value adjusted from 64 to 11 coins so ground item sorting matched other herb seeds."
+    - date: "2025-01-01"
+      description: "Fixed rare bug where kwuarm patches would harvest as Avantoe."
+  properties:
+    release_date: "2005-06-06"
+    update: "Seeds, Bankspace and Advisors"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-fur.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 10000
-  about: "Larupia fur is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Larupia fur is a hunter material obtained from spined larupias in Feldip Hills, used by the Fancy Clothes Store owner to craft larupia hunter gear. High alchemy value: 48 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    equipable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 2.0
+  material:
+    type: cloth
+    tier: standard
+  drop_table:
+    - source: "Spined larupia"
+      quantity: "1"
+      rarity: "Always"
+  shops:
+    - shop_name: "Ardougne Fur Stall"
+      location: "Ardougne"
+      price: 96
+      stock: 0
+    - shop_name: "Fremennik Fur Trader"
+      location: "Rellekka"
+      price: 104
+      stock: 0
+    - shop_name: "Seamstress"
+      location: "Prifddinas"
+      price: 100
+      stock: 0
+  market_strategy:
+    notes:
+      - "flip_potential: \"low\""
+      - "Hunter material with steady demand from players making larupia gear; supply tracks Feldip Hunter activity."
+  trading_tips:
+    - "Bulk-buy when Hunter XP events flood supply; resell during gear-making phases."
+    - "Cheaper than the tatty variant for the hat recipe, which requires the perfect fur."
+  history:
+    - date: "2006-11-21"
+      description: "Released alongside the Hunter skill expansion in Feldip Hills."
+  relationships:
+    - item_name: Tatty larupia fur
+      relationship: variant
+    - item_name: Larupia hat
+      relationship: upgrade
+    - item_name: Larupia top
+      relationship: upgrade
+    - item_name: Larupia legs
+      relationship: upgrade
+    - item_name: Spined larupia
+      relationship: component
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/law-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/law-rune.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 18000
+  material:
+    type: misc
+    tier: rune
   rune:
     type: utility
   runecraft:
@@ -21,19 +24,33 @@ osrs:
     altar: Law Altar
     altar_location: Entrana
     essence_type: pure
+  drop_table:
+    - source: Ankou
+      quantity: "2"
+      rarity: 20/100
+    - source: Nechryael
+      quantity: "25"
+      rarity: 5/116
+    - source: King Black Dragon
+      quantity: "30"
+      rarity: 5/128
+    - source: Skeletal Wyvern
+      quantity: "45"
+      rarity: 4/128
+    - source: Giant Mole
+      quantity: "15"
+      rarity: 5/131
   recipes:
-    - skill: runecraft
+    - item_name: Law rune
+      skill: Runecraft
       level: 54
       xp: 9.5
+      output_quantity: 1
+      members: true
+      tools: []
       materials:
         - item_name: Pure essence
-          item_id: 7936
           quantity: 1
-      product: Law rune
-      product_id: 563
-      product_quantity: 1
-      facility: Law altar
-      members_only: true
   related_items:
     - item_id: 7936
       item_name: Pure essence
@@ -55,6 +72,21 @@ osrs:
       slug: death-rune
       relationship: alternative
       description: Combat rune
+  market_strategy:
+    notes:
+      - "summary: \"Essential teleportation rune with stable, recurring demand from every PvM/skiller workflow.\""
+      - "target_audience: \"Teleporters, mages, runecrafters above level 54.\""
+      - "trading_strategy: \"Craft at 54+ for steady profit; doubles at 95 RC give 2x output per essence.\""
+  trading_tips:
+    - "At 54+ RC: Craft law runes for profit"
+    - "At 95+ RC: Double runes = 2x profit"
+    - Teleportation is essential for efficiency
+    - Used in nearly every activity
+    - Entrana access required (no weapons/armor)
+    - Abyss method faster but dangerous
+  history:
+    - date: "2001-05-24"
+      description: Law rune released alongside teleport spells in the original RuneScape Classic conversion.
   about: |-
     Craft at the Law Altar (Entrana) with Pure essence.
 
@@ -69,21 +101,13 @@ osrs:
     - Teleport to House
     - Ardougne, Watchtower teleports
     - Teleother spells
-  market_strategy:
-    profit_formulas:
-      - (Law rune × runes) - Pure essence = Profit
-    notes:
-      - "At 54+ RC: Craft law runes for profit"
-      - "At 95+ RC: Double runes = 2x profit"
-      - "Calculate:"
-      - Teleportation is essential for efficiency
-      - Used in nearly every activity
-      - Consistent, stable demand
-      - Entrana access required (no weapons/armor)
-      - Abyss method faster but dangerous
-      - Popular for both crafting and trading
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2001-05-24"
+    weight: 0
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lean-snail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lean-snail.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
-  about: "Lean snail is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: misc
+    tier: raw_food
+  recipes:
+    - item_name: Lean snail meat
+      skill: Cooking
+      level: 17
+      xp: 80
+      output_quantity: 1
+      members: true
+      tools:
+        - Range
+      materials:
+        - item_name: Lean snail
+          quantity: 1
+  drop_table:
+    - source: Blamish Bark Snail
+      quantity: "1"
+      rarity: always
+    - source: Giant snail
+      quantity: "1"
+      rarity: common
+  related_items:
+    - item_id: 3369
+      item_name: Lean snail meat
+      slug: lean-snail-meat
+      relationship: product
+      description: Cooked version
+    - item_id: 1779
+      item_name: Blamish snail slime
+      slug: blamish-snail-slime
+      relationship: component
+      description: Heroes' Quest ingredient
+  market_strategy:
+    notes:
+      - "summary: \"Raw cooking ingredient with niche quest and follower-food uses; mid-volume drop from Morytania snails.\""
+      - "target_audience: \"Cooks training mid-level, Heroes' Quest preppers, Temple Trekking runners.\""
+  trading_tips:
+    - GE buy limit is 13,000 per 4 hours - easy to bulk for follower food.
+    - Cook at level 17 for 80 XP each; burns until cooking 17 base.
+  history:
+    - date: "2004-10-14"
+      description: Released with the Morytania expansion alongside snail combat content.
+  about: |-
+    Lean snail is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours.
+
+    Drops from Blamish Bark Snails and giant snails in Morytania. Cook at Cooking 17 for 80 XP into lean snail meat (heals 5-7 HP).
+  properties:
+    release_date: "2004-10-14"
+    weight: 2
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/light-ballista.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/light-ballista.mdx
@@ -12,57 +12,94 @@ osrs:
   lowalch: 50000
   highalch: 75000
   limit: 8
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: dragon
+    primary_material: wood
   equipment:
     slot: weapon
-    type: ranged_weapon
+    weapon_type: ballista
+    attack_speed: 7
+    attack_range: 10
     two_handed: true
     tradeable: true
     weight: 3
     requirements:
       ranged: 65
     stats:
+      attack_stab: 0
+      attack_slash: 0
+      attack_crush: 0
+      attack_magic: 0
       attack_ranged: 110
-  creation:
-    method: Combine unstrung light ballista with Monkey tail
-    requirements:
-      fletching: 47
-    xp: 300
-    materials:
-      - item_id: 19586
-        item_name: Unstrung light ballista
-        slug: unstrung-light-ballista
-      - item_id: 19610
-        item_name: Monkey tail
-        slug: monkey-tail
-  ammunition:
-    type: javelin
-    max_tier: dragon
+      defence_stab: 0
+      defence_slash: 0
+      defence_crush: 0
+      defence_magic: 0
+      defence_ranged: 0
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   special_attack:
     name: Concentrated Shot
     energy: 65
-    description: +25% accuracy, +25% damage
+    description: "Provides 25% increased accuracy and 25% increased damage."
+  recipes:
+    - item_name: Light ballista
+      skill: Fletching
+      level: 47
+      xp: 330
+      tools:
+        - Hammer
+      materials:
+        - item_id: 19586
+          item_name: Unstrung light ballista
+          slug: unstrung-light-ballista
+          quantity: 1
+        - item_id: 19610
+          item_name: Monkey tail
+          slug: monkey-tail
+          quantity: 1
+      output_quantity: 1
+  ammunition:
+    type: javelin
+    max_tier: dragon
   related_items:
     - item_id: 19481
       item_name: Heavy ballista
       slug: heavy-ballista
       relationship: upgrade
-      description: Stronger version
+      description: Stronger version requiring 75 Ranged.
     - item_id: 19484
       item_name: Dragon javelin
       slug: dragon-javelin
-      relationship: component
-      description: Best ammo
+      relationship: variant
+      description: Best javelin ammunition.
     - item_id: 19610
       item_name: Monkey tail
       slug: monkey-tail
       relationship: component
-      description: Creation material
+      description: Required to string the ballista.
+    - item_id: 19586
+      item_name: Unstrung light ballista
+      slug: unstrung-light-ballista
+      relationship: component
+      description: Unstrung base required for stringing.
   about: |-
     Combine unstrung light ballista with Monkey tail.
 
     | Requirement | Value |
     |-------------|-------|
-    | Fletching | 47 (300 XP) |
+    | Fletching | 47 (330 XP) |
 
     | Offence | Bonus |
     |---------|-------|
@@ -82,11 +119,20 @@ osrs:
     Budget alternative to heavy ballista.
   market_strategy:
     notes:
-      - Good for mid-level ranged
-      - Heavy ballista is stronger
-      - Uses same ammo as heavy
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Good for mid-level ranged"
+      - "Heavy ballista is stronger"
+      - "Uses same ammo as heavy"
+  trading_tips:
+    - Track unstrung light ballista and Monkey tail prices for stringing margins.
+    - GE buy limit of 8 every 4 hours throttles flips.
+    - Compare with Heavy ballista demand to gauge mid-tier ranged interest.
+  history:
+    - date: "2016-05-06"
+      description: "Released alongside Monkey Madness II."
+    - date: "2024-05-29"
+      description: "Ava's devices now retrieve javelins fired from this weapon."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lizardkicker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lizardkicker.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: null
-  about: "Lizardkicker is a members-only item in Old School RuneScape. High alchemy value: 3 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Lizardkicker is a members-only consumable ale in Old School RuneScape. Sold by The Cloak and Stagger in Shayzien, it boosts Ranged by 4 levels while draining Strength and Magic. High alchemy value: 3 coins."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2021-06-16"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.55
+  potion:
+    doses: 1
+    effect: "Boosts Ranged by 4 levels; drains Strength and Magic by 2 + 4%."
+    duration: "Instant"
+  shops:
+    - shop_name: "The Cloak and Stagger"
+      location: "Shayzien"
+      price: 6
+      stock: 10
+      restock_time: "30 seconds"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Purchase directly from The Cloak and Stagger in Shayzien at 6 coins for a guaranteed supply.\""
+      - "sell_strategy: \"Flip on the Grand Exchange where it trades near 296 coins for a steady margin over shop price.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"low\""
+  trading_tips:
+    - "Stock refills every 30 seconds, allowing efficient bulk buying."
+    - "Note the ales for easier transport from Shayzien to a bank."
+    - "Compare GE volume before flipping; daily volume is low."
+  history:
+    - date: "2021-06-16"
+      description: "Added to the game with the A Kingdom Divided quest update."
+    - date: "2024-03-20"
+      description: "Shop price reduced from 20 to 6 coins during the Varlamore Part One update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/longbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/longbow-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Longbow (u) | OSRS Price Data
-description: "Longbow (u): I need to find a string for this.. High alch: 36 GP, GE limit: 10,000."
+description: "Longbow (u): I need to find a string for this. High alch: 36 GP, GE limit: 10,000."
 osrs:
   id: 48
   name: Longbow (u)
@@ -23,12 +23,53 @@ osrs:
       slug: oak-longbow-u
       relationship: variant
       description: Higher tier unstrung longbow
-  about: |-
-    > _"I need to find a string for this."_
-
-    The longbow (u) is an unstrung longbow made from regular logs. String with a bowstring at 10 Fletching to create a longbow. Members only. One of the first items available for Fletching training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "The longbow (u) is an unstrung longbow carved from regular logs at 10 Fletching. String it with a bowstring for the finished longbow. Members-only. High alch 36 gp; GE limit 10,000."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 1.332
+  material:
+    type: misc
+    tier: standard
+  recipes:
+    - item_name: "Longbow (u)"
+      skill: "Fletching"
+      level: 10
+      xp: 10
+      tools:
+        - "Knife"
+      materials:
+        - item_name: "Logs"
+          quantity: 1
+      output_quantity: 1
+    - item_name: "Longbow"
+      skill: "Fletching"
+      level: 10
+      xp: 10
+      tools: []
+      materials:
+        - item_name: "Longbow (u)"
+          quantity: 1
+        - item_name: "Bowstring"
+          quantity: 1
+      output_quantity: 1
+  history:
+    - date: "2002-03-25"
+      description: "Introduced with the original Fletching skill release."
+  trading_tips:
+    - "Stringing into a longbow gives another 10 Fletching XP per bow."
+    - "Cheap, high-volume Fletching training stock; flip on margin between logs and strung longbows."
+  market_strategy:
+    notes:
+      - "relationship: \"component\""
+      - "Sits between logs and finished longbows; price is bounded by Fletching cost and bowstring spread."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-dresser-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-dresser-flatpack.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Mahogany dresser (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mahogany dresser (flatpack) is a members-only Construction flatpack used to build a Dresser in a player-owned house Bedroom space."
+  material:
+    type: wood
+    tier: high
+  construction:
+    level: 64
+    xp: 281
+    facility: Bench with vice
+  recipes:
+    - skill: Construction
+      level: 64
+      xp: 281
+      tools:
+        - Hammer
+        - Saw
+      facility: Bench with vice
+      materials:
+        - item_name: Mahogany plank
+          quantity: 2
+        - item_name: Molten glass
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Mahogany plank
+      relationship: component
+    - item_name: Molten glass
+      relationship: component
+    - item_name: Oak dresser (flatpack)
+      relationship: alternative
+    - item_name: Gilded dresser (flatpack)
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - "Construction flatpack made at a bench with vice — sells to Construction trainers via GE."
+      - "Material cost typically exceeds GE price, making it a loss-leader unless training Construction with bulk planks."
+      - "Daily volume is low (~10/day), so large quantities take time to clear."
+  trading_tips:
+    - "Useful for ironmeme players building dressers without hauling planks home."
+    - "Check the GE margin against current mahogany plank and molten glass prices before crafting for profit."
+    - "281 XP per build is decent for higher-level Construction training."
+  history:
+    - date: "2006-05-31"
+      description: "Mahogany dresser flatpack added with the Player-Owned Houses release."
+  properties:
+    release_date: "2006-05-31"
+    update: "PLAYER-OWNED HOUSES!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-claws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril claws | OSRS Price Data
-description: "Mithril claws: A set of fighting claws.. High alch: 285 GP, GE limit: 125."
+description: "Mithril claws is a P2P two-handed claw weapon requiring 20 Attack. High alch: 285 GP, GE limit: 125."
 osrs:
   id: 3099
   name: Mithril claws
@@ -12,9 +12,106 @@ osrs:
   lowalch: 190
   highalch: 285
   limit: 125
-  about: "Mithril claws is a members-only item in Old School RuneScape. High alchemy value: 285 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.907
+  properties:
+    release_date: "2004-08-09"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: metal
+    tier: mithril
+    category: weapon
+  equipment:
+    slot: weapon
+    weapon_type: claws
+    attack_speed: 4
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 11
+      slash: 16
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 4
+      slash: 8
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 17
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    has_special: false
+  recipes:
+    - skill: "Smithing"
+      level: 63
+      xp: 100
+      output_quantity: 1
+      item_name: "Mithril claws"
+      tools:
+        - "Hammer"
+        - "Anvil"
+      inputs:
+        - item_name: "Mithril bar"
+          quantity: 2
+      notes: "Requires completion of Death Plateau."
+  related_items:
+    - item_id: 3097
+      item_name: Steel claws
+      slug: steel-claws
+      relationship: alternative
+      description: "Lower-tier claw weapon"
+    - item_id: 3101
+      item_name: Adamant claws
+      slug: adamant-claws
+      relationship: alternative
+      description: "Higher-tier claw weapon"
+    - item_id: 3103
+      item_name: Rune claws
+      slug: rune-claws
+      relationship: alternative
+      description: "F2P-cap claw weapon"
+    - item_id: 13652
+      item_name: Dragon claws
+      slug: dragon-claws
+      relationship: alternative
+      description: "Best-in-slot offensive claw"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy in bulk from Smithers training 63+ Smithing.\""
+      - "sell_strategy: \"Sell to mid-level slayers / quest cape pushers.\""
+      - "price_trend: \"Tracks mithril bar prices.\""
+      - "profit_margin: \"Crafting at 63 Smithing currently loses GP versus bar value.\""
+  trading_tips:
+    - "Death Plateau is the only quest gate for crafting claws."
+    - "Compare against rune scimitar (lower attack req) for budget melee."
+    - "Mithril claws are rarely used in PvM; mostly Smithing XP filler."
+  history:
+    - date: "2004-08-09"
+      update: "Death Plateau release"
+      description: "Mithril claws added alongside the claw weapon line."
+  about: |-
+    Mithril claws are a mid-tier two-handed claw weapon used for transitional melee training.
+
+    | Stat | Value |
+    |------|-------|
+    | Attack req | 20 |
+    | Strength | +17 |
+    | Slash | +16 |
+    | Speed | 4 ticks (2.4s) |
+    | Smithing req | 63 (100 XP, 2 mithril bars) |
+
+    Outclassed by mithril scimitar for accuracy and by rune claws for slash damage.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-p-5645.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-p-5645.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril javelin(p+) | OSRS Price Data
-description: "Mithril javelin(p+): A mithril tipped javelin.. High alch: 38 GP, GE limit: 7,000."
+description: "Mithril javelin(p+): A mithril tipped javelin. High alch: 38 GP, GE limit: 7,000."
 osrs:
   id: 5645
   name: Mithril javelin(p+)
@@ -12,9 +12,106 @@ osrs:
   lowalch: 25
   highalch: 38
   limit: 7000
-  about: "Mithril javelin(p+) is a members-only item in Old School RuneScape. High alchemy value: 38 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0
+    release_date: '2004-03-29'
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    quest_item: false
+    destroy: Drop
+  material:
+    type: ammunition
+    tier: mithril
+    primary_resource: mithril
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    attack_speed: 6
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 85
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      ranged: 20
+  special_attack:
+    name: Poison
+    description: Inflicts the strong poison effect (poison+) on the target, dealing damage over time.
+  recipes:
+    - skill: Herblore
+      level: 73
+      xp: 0
+      output_quantity: 1
+      tools:
+        - Weapon poison+
+      materials:
+        - item_name: Mithril javelin
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+  obtaining:
+    methods:
+      - source: Crafted from Mithril javelin + weapon poison(+)
+        quantity: "1"
+        description: Apply weapon poison(+) to a stack of Mithril javelins at Herblore level 73.
+  related_items:
+    - item_id: 828
+      item_name: Mithril javelin
+      slug: mithril-javelin
+      relationship: component
+      description: Unpoisoned base javelin.
+    - item_id: 5643
+      item_name: Mithril javelin(p)
+      slug: mithril-javelin-p-5643
+      relationship: alternative
+      description: Standard poisoned variant.
+    - item_id: 5647
+      item_name: Mithril javelin(p++)
+      slug: mithril-javelin-p-5647
+      relationship: alternative
+      description: Strongest poisoned variant.
+  history:
+    - date: '2004-03-29'
+      description: "Mithril javelins were released with the original ranged weaponry expansion."
+  about: |-
+    > *"A mithril tipped javelin."*
+
+    Mithril javelin(p+) is a stackable thrown weapon with the poison+ effect applied. It deals 85 ranged strength on hit and applies strong poison damage over time.
+
+    | Detail | Value |
+    |--------|-------|
+    | Ranged Strength | +85 |
+    | Attack Speed | 6 ticks |
+    | Stackable | Yes |
+    | Poison Tier | Poison+ |
+
+    These javelins are typically used as a budget thrown ranged option with the upside of inflicting poison damage on the target.
+  market_strategy:
+    notes:
+      - "Low GE price reflects niche demand"
+      - "Cost mostly driven by weapon poison(+) overhead"
+      - "Stack size makes it convenient for slayer kits"
+      - "Members only item"
+  trading_tips:
+    - Compare base Mithril javelin + weapon poison(+) cost vs. the poisoned listing.
+    - Buy limit 7,000 supports moderate bulk flipping.
+    - Demand is light; expect slow GE turnover.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-plateskirt-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-plateskirt-t.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1040
   highalch: 1560
   limit: 8
-  about: "Mithril plateskirt (t) is a free-to-play item in Old School RuneScape. High alchemy value: 1,560 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mithril plateskirt (t) is a trimmed cosmetic variant of the standard mithril plateskirt, obtained as a reward from medium Treasure Trail clue caskets. High alchemy value: 1,560 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 7.257
+  material:
+    type: metal
+    tier: mithril
+  equipment:
+    slot: legs
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -4
+      ranged: -11
+    defence_bonus:
+      stab: 24
+      slash: 22
+      crush: 20
+      magic: -4
+      ranged: 22
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    rarity: "1/1,133"
+  drop_table:
+    - source: "Medium Clue Casket"
+      quantity: "1"
+      rarity: "1/1,133"
+  market_strategy:
+    notes:
+      - "flip_potential: \"low\""
+      - "Cosmetic trimmed variant; demand fluctuates with medium clue activity."
+  trading_tips:
+    - "Pairs well with mithril platebody (t) for full trimmed set fashionscape."
+    - "Stock during medium clue events when supply spikes."
+  history:
+    - date: "2014-06-12"
+      description: "Released as a medium Treasure Trail reward."
+    - date: "2021-04-21"
+      description: "Ranged attack penalty decreased from -7 to -11."
+  relationships:
+    - item_name: Mithril plateskirt
+      relationship: variant
+    - item_name: Mithril plateskirt (g)
+      relationship: variant
+    - item_name: Mithril platebody (t)
+      relationship: set-piece
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-antler-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-antler-bolts.mdx
@@ -12,8 +12,17 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 11000
+  properties:
+    release_date: "2024-03-20"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: ammunition
+    tier: ranged-ammunition
   equipment:
     slot: ammo
+    weapon_type: bolts
+    attack_speed: 1
     weight: 0.001
     attack_bonus:
       stab: 0
@@ -39,12 +48,16 @@ osrs:
     - skill: fletching
       level: 72
       xp: 12.1
+      item_name: Moonlight antler bolts
+      tools:
+        - Chisel
       materials:
         - item_name: Moonlight antelope antler
           quantity: 1
       product: Moonlight antler bolts
       product_id: 28878
       product_quantity: 12
+      output_quantity: 12
       members_only: true
   drop_table:
     primary_source: Crafted
@@ -76,11 +89,18 @@ osrs:
     - Hunter-themed content
   market_strategy:
     notes:
-      - Requires hunting moonlight antelopes
-      - Good profit from Fletching
-      - Part of Hunter Guild content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Requires hunting moonlight antelopes"
+      - "Good profit from Fletching"
+      - "Part of Hunter Guild content"
+  trading_tips:
+    - Crafted from moonlight antelope antlers via Fletching
+    - Hunters' sunlight crossbow is the intended launcher
+    - Compatible with Ava's devices for ammo recovery
+  history:
+    - date: "2024-03-20"
+      description: "Released with Varlamore: Part One."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-head.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Mummy's head is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mummy's head is a cosmetic head slot piece of the mummy outfit, rewarded exclusively from master-level Treasure Trails reward caskets."
+  equipment:
+    slot: head
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: "1/12,765"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Mummy's body
+      relationship: set-piece
+    - item_name: Mummy's legs
+      relationship: set-piece
+    - item_name: Mummy's hands
+      relationship: set-piece
+    - item_name: Mummy's feet
+      relationship: set-piece
+  market_strategy:
+    notes:
+      - "Cosmetic-only master clue reward — value is pure fashionscape."
+      - "GE limit of 4 per 4h plus low daily volume keeps liquidity thin and price volatile."
+      - "Demand spikes around clue scroll competitions and PvP cosmetic events."
+  trading_tips:
+    - "Buy individual pieces during clue oversupply, sell as a complete outfit during fashionscape hype."
+    - "Monitor master clue completion rates and active gilded pieces on the GE."
+    - "Long-hold cosmetic — limited supply since only master clues produce it."
+  history:
+    - date: "2016-07-06"
+      description: "Mummy's head added with the Treasure Trail Expansion update."
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom-onion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom-onion.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 18
   highalch: 27
   limit: 13000
-  about: "Mushroom & onion is a members-only item in Old School RuneScape. High alchemy value: 27 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mushroom & onion is a members-only Cooking dish in Old School RuneScape, made at level 57 Cooking by combining a fried mushroom with a fried onion. It heals 11 Hitpoints and is a topping for the mushroom potato. High alchemy value: 27 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-01-30"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.5
+  recipes:
+    - item_name: "Mushroom & onion"
+      skill: "Cooking"
+      level: 57
+      xp: 0
+      materials:
+        - item_name: "Fried mushrooms"
+          quantity: 1
+        - item_name: "Fried onion"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - item_name: "Mushroom potato"
+      skill: "Cooking"
+      level: 64
+      xp: 0
+      materials:
+        - item_name: "Mushroom & onion"
+          quantity: 1
+        - item_name: "Potato with butter"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Pick up cheap stacks for mushroom potato recipe runs; daily volume is thin so place limit buys.\""
+      - "sell_strategy: \"Sell into mushroom potato Cooking trainers; price tends to drift up after meta updates.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"low\""
+  trading_tips:
+    - "Cook personally if you have 57 Cooking and a stockpile of fried mushrooms + onions."
+    - "Volume is low; expect slow GE fills on either side of the book."
+    - "Pair sales with potato with butter listings to catch chained recipe buyers."
+  history:
+    - date: "2006-01-30"
+      description: "Released as part of the Gnome Restaurant menu expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-boots-light.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-boots-light.mdx
@@ -13,8 +13,91 @@ osrs:
   highalch: 6000
   limit: 70
   about: "Mystic boots (light) is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-01-26"
+    weight: 0.453
+    tradeable: true
+    equipable: true
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: cloth
+    tier: mystic
+  equipment:
+    slot: feet
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    - source: "Cockatrice"
+      quantity: "1"
+      rarity: "1/512"
+      notes: "Combat level 37."
+    - source: "Cockathrice"
+      quantity: "1"
+      rarity: "3/512"
+      notes: "Combat level 89; rolls drop three times."
+    - source: "Moonlight Cockatrice"
+      quantity: "1"
+      rarity: "1/512"
+      notes: "Combat level 49."
+  relationships:
+    - item_name: "Mystic hat (light)"
+      relationship: set-piece
+      notes: "Part of the light mystic robes set."
+    - item_name: "Mystic robe top (light)"
+      relationship: set-piece
+      notes: "Part of the light mystic robes set."
+    - item_name: "Mystic robe bottom (light)"
+      relationship: set-piece
+      notes: "Part of the light mystic robes set."
+    - item_name: "Mystic gloves (light)"
+      relationship: set-piece
+      notes: "Part of the light mystic robes set."
+    - item_name: "Mystic boots"
+      relationship: alternative
+      notes: "Standard blue color variant."
+    - item_name: "Mystic boots (dark)"
+      relationship: alternative
+      notes: "Dark color variant."
+    - item_name: "Mystic boots (dusk)"
+      relationship: alternative
+      notes: "Dusk color variant."
+  history:
+    - date: "2005-01-26"
+      description: "Released as part of the Mystic robes set color variants."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Pick up below high alch when supply spikes from Cockatrice farmers.\""
+      - "sell_strategy: \"Sell to Magic levelers building set or list on GE at current margin.\""
+      - "profit_potential: \"Modest; tied to Cockatrice slayer task drops and set demand.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Daily volume around 238 — set patient orders."
+    - "Best demand when Cockatrice is assigned as Slayer task."
+    - "Stable Magic 40 / Defence 20 gear keeps long-term floor."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nickel-ore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nickel-ore.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nickel ore | OSRS Price Data
-description: "Nickel ore: This needs refining.. High alch: 240 GP."
+description: "Nickel ore: This needs refining. High alch: 240 GP."
 osrs:
   id: 31719
   name: Nickel ore
@@ -12,9 +12,57 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: null
-  about: "Nickel ore is a members-only item in Old School RuneScape. High alchemy value: 240 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: '2025-11-19'
+    quest_item: false
+    destroy: Drop
+  material:
+    type: ore
+    tier: nickel
+    category: ore
+    weight: 2.267
+  drop_table:
+    - source: Nickel rock
+      quantity: "1"
+      rarity: Always (74 Mining)
+  recipes:
+    - item_name: Cupronickel bar
+      skill: smithing
+      level: 74
+      xp: 42
+      tools:
+        - Furnace
+      inputs:
+        - item_name: Nickel ore
+          quantity: 1
+        - item_name: Copper ore
+          quantity: 2
+      output_quantity: 1
+  related_items:
+    - item_id: 436
+      item_name: Copper ore
+      slug: copper-ore
+      relationship: component
+      description: Required with nickel to smelt cupronickel bars
+  about: |-
+    "This needs refining."
+
+    Nickel ore is mined from nickel rocks at 74 Mining, granting 80.5 Mining XP per ore. Two copper ore plus one nickel ore smelt into a cupronickel bar at 74 Smithing for 42 Smithing XP.
+
+    Released as part of the Sailing skill content.
+
+    Varrock armour 4 grants a 10% chance to mine an extra nickel ore. Other mining boost effects do not apply to nickel rocks.
+  market_strategy:
+    notes:
+      - "High XP/hr Mining at 74+"
+      - "Required for cupronickel bar (Sailing content)"
+      - "Varrock armour 4 boosts yield"
+      - "Demand tied to Sailing-related smithing"
+  history:
+    - date: '2025-11-19'
+      description: Item released with the Sailing skill update.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ninja-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ninja-impling-jar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ninja impling jar | OSRS Price Data
-description: "Ninja impling jar: Ninja impling in a jar.. High alch: 30 GP, GE limit: 18,000."
+description: "Ninja impling jar: Ninja impling in a jar. High alch: 30 GP, GE limit: 18,000."
 osrs:
   id: 11254
   name: Ninja impling jar
@@ -12,9 +12,54 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  about: "Ninja impling jar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: impling-jar
+    tier: mid
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+    alchable: true
+    destroy: "If you drop this it will disappear. Are you sure you want to do this?"
+  related_items:
+    - item_name: "Empty impling jar"
+      slug: "empty-impling-jar"
+      relationship: component
+      description: "Required to catch implings — consumed when filled and returned ~90% of the time when looting."
+    - item_name: "Magpie impling jar"
+      slug: "magpie-impling-jar"
+      relationship: downgrade
+      description: "Lower-tier impling jar caught at level 65 Hunter."
+    - item_name: "Dragon impling jar"
+      slug: "dragon-impling-jar"
+      relationship: upgrade
+      description: "Higher-tier impling jar caught at level 83 Hunter."
+  about: "Ninja impling jar is a members-only loot jar from catching ninja implings at level 74 Hunter. Opening the jar yields an assortment of mid-tier loot (armour pieces, ammunition, runes, consumables) averaging around 13,000 coins per loot, plus a 1/25 chance at a hard clue scroll. The empty impling jar is returned ~90% of the time."
+  market_strategy:
+    notes:
+      - "Supply scales with Hunter activity in Puro-Puro and free-roaming implings across Gielinor."
+      - "Demand is driven by loot-roll farmers chasing the hard clue scroll chance and bulk mid-tier alch fodder."
+      - "Price tracks the rolling average of the jar contents; deep markups vs. loot value are uncommon."
+  trading_tips:
+    - "Compare GE price against current rolling loot value before committing to bulk flips."
+    - "Spikes correlate with clue scroll meta shifts — hard clue value moves the jar price."
+    - "Members-only — supply pauses around major events that pull hunters to other content."
+  history:
+    - date: "2007-06-11"
+      description: "Released alongside Impetuous Impulses and the Puro-Puro minigame."
+    - date: "2015-03-05"
+      description: "Impling jars made tradeable on the Grand Exchange."
+    - date: "2016-04-21"
+      description: "Hard clue scrolls added to the ninja impling jar loot table."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-repair-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-repair-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oak repair kit | OSRS Price Data
-description: "Oak repair kit: A boat repair kit made from oak.. High alch: 240 GP, GE limit: 13,000."
+description: "Oak repair kit: A boat repair kit made from oak. High alch: 240 GP, GE limit: 13,000."
 osrs:
   id: 31967
   name: Oak repair kit
@@ -12,9 +12,78 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 13000
-  about: "Oak repair kit is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0.5
+    release_date: '2025-11-19'
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: oak
+    primary_resource: oak plank
+  recipes:
+    - skill: Construction
+      level: 19
+      xp: 90
+      output_quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      facility: Shipwrights' workbench
+      materials:
+        - item_name: Oak plank
+          quantity: 2
+        - item_name: Iron nails
+          quantity: 10
+        - item_name: Swamp paste
+          quantity: 5
+  passive_effects:
+    - name: Boat Repair
+      description: Restores 10 hitpoints to a boat when applied during ship combat. Crewmates with sufficient Deckhandiness can heal additional amounts per kit.
+  related_items:
+    - item_id: 31965
+      item_name: Wooden repair kit
+      slug: wooden-repair-kit
+      relationship: alternative
+      description: Lower-tier wooden boat repair kit.
+    - item_id: 31969
+      item_name: Teak repair kit
+      slug: teak-repair-kit
+      relationship: alternative
+      description: Higher-tier teak boat repair kit.
+  history:
+    - date: '2025-11-19'
+      description: "Oak repair kit was released as part of the Sailing skill content update."
+  about: |-
+    > *"A boat repair kit made from oak."*
+
+    The Oak repair kit is a consumable used during ship combat to restore 10 hitpoints to a damaged boat. It is the second tier in the boat repair kit progression.
+
+    | Detail | Value |
+    |--------|-------|
+    | Skill | Construction 19 |
+    | XP | 90 per action |
+    | Output | 2 kits |
+    | Facility | Shipwrights' workbench |
+    | Materials | 2 Oak planks, 10 Iron nails, 5 Swamp paste |
+
+    Players apply this item to boats during ship combat to restore 10 hitpoints. Multiple players can use them simultaneously for faster repairs.
+  market_strategy:
+    notes:
+      - "Steady demand from Sailing skillers and ship combat content"
+      - "Mid-tier kit with reliable buy-side liquidity"
+      - "High GE limit of 13,000 supports bulk flipping"
+      - "Members only item"
+  trading_tips:
+    - Track oak plank and swamp paste prices since they drive the kit's cost floor.
+    - Bulk buy near release-dip lows and resell during peak Sailing hours.
+    - GE limit of 13,000 supports volume trading without scaling overhead.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oathplate armour set | OSRS Price Data
-description: "Oathplate armour set: A set containing a Oathplate helm, Oathplate chest, and Oathplate legs.. High alch: 87,000 GP."
+description: "Oathplate armour set: A set containing an Oathplate helm, Oathplate chest, and Oathplate legs. High alch: 87,000 GP."
 osrs:
   id: 30744
   name: Oathplate armour set
@@ -12,9 +12,68 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: null
-  about: "Oathplate armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    weight: 0.05
+    release_date: '2025-05-14'
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: misc
+    tier: oathplate
+    primary_resource: oathplate
+  obtaining:
+    methods:
+      - source: Grand Exchange Sets Interface
+        quantity: "1"
+        description: Exchange individual Oathplate helm, chest, and legs with a Grand Exchange clerk using the Sets interface to bundle them.
+  related_items:
+    - item_id: 30738
+      item_name: Oathplate helm
+      slug: oathplate-helm
+      relationship: component
+      description: Head slot piece included in the armour set.
+    - item_id: 30740
+      item_name: Oathplate chest
+      slug: oathplate-chest
+      relationship: component
+      description: Body slot piece included in the armour set.
+    - item_id: 30742
+      item_name: Oathplate legs
+      slug: oathplate-legs
+      relationship: component
+      description: Leg slot piece included in the armour set.
+  history:
+    - date: '2025-05-14'
+      description: "Oathplate armour set was released alongside Oathplate armour pieces."
+  about: |-
+    > *"A set containing a Oathplate helm, Oathplate chest, and Oathplate legs."*
+
+    The Oathplate armour set is a Grand Exchange convenience bundle of the three Oathplate armour pieces. It cannot be equipped directly — players must exchange the set with a Grand Exchange clerk to receive the individual components.
+
+    | Detail | Value |
+    |--------|-------|
+    | Set Pieces | Oathplate helm, chest, legs |
+    | Tradeable | Yes |
+    | Equipable | No |
+    | Obtained | Grand Exchange Sets interface |
+
+    Sets are commonly used by traders to consolidate liquidity in a single high-value item. The bundled set typically carries a small premium over the sum of the individual pieces.
+  market_strategy:
+    notes:
+      - "Bundle is a Grand Exchange Sets convenience item"
+      - "Price tracks the sum of the three Oathplate pieces plus a small premium"
+      - "High-value flip target for late-game traders"
+      - "Members only item"
+  trading_tips:
+    - Watch each individual piece on the GE; the set premium can be arbitraged when components dip.
+    - Large capital required per flip due to multi-hundred-million GP price.
+    - Daily volume is thin; use limit orders rather than market buys to avoid slippage.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-cape-r.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-cape-r.mdx
@@ -1,6 +1,6 @@
 ---
 title: Obsidian cape (r) | OSRS Price Data
-description: "Obsidian cape (r): A cape of woven obsidian plates.. High alch: 36,000 GP, GE limit: 70."
+description: "Obsidian cape (r): A cape of woven obsidian plates. High alch: 36,000 GP, GE limit: 70."
 osrs:
   id: 20050
   name: Obsidian cape (r)
@@ -12,9 +12,88 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 70
-  about: "Obsidian cape (r) is a members-only item in Old School RuneScape. High alchemy value: 36,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2016-07-06"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: cloth
+    tier: cosmetic
+  equipment:
+    slot: cape
+    weapon_type: none
+    attack_speed: 1
+    weight: 1.814
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 9
+      slash: 9
+      crush: 9
+      magic: 9
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      defence: 1
+    degradable: false
+  treasure_trail:
+    tier: master
+    role: reward
+  drop_table:
+    primary_source: Master clue rewards
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: "1/851"
+        members_only: true
+  related_items:
+    - item_id: 6568
+      item_name: Obsidian cape
+      slug: obsidian-cape
+      relationship: alternative
+      description: Original obsidian cape from TzHaar
+    - item_id: 21791
+      item_name: Reward casket (master)
+      slug: reward-casket-master
+      relationship: component
+      description: Drops Obsidian cape (r) at 1/851
+  about: |-
+    | Property | Value |
+    |----------|-------|
+    | Defence (all) | +9 |
+    | GE limit | 70 |
+    | Source | Master clue casket |
+
+    - Cosmetic recolour of the obsidian cape
+    - Universal +9 defence across all styles
+    - Cannot substitute for obsidian cape in Zul-Andra emote step
+
+    Premium clue-scroll cosmetic:
+    - Same stats as obsidian cape, prestige colour
+    - Demanded by completionists and PvM cape collectors
+    - 1/851 from master casket
+  market_strategy:
+    notes:
+      - "Supply comes from master clue caskets only"
+      - "Sentiment swings with cosmetic clue meta"
+      - "Sweet spot for long-hold flips due to rarity"
+  trading_tips:
+    - Track master clue casket release cadence for supply
+    - GE limit 70 makes large flips capital intensive
+    - Pairs well with obsidian armour for full set roleplay
+  history:
+    - date: "2016-07-06"
+      description: "Released as a master clue reward."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-helmet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-helmet.mdx
@@ -12,84 +12,84 @@ osrs:
   lowalch: 22528
   highalch: 33792
   limit: 70
+  weight: 3.628
+  about: "Obsidian helmet is a TzHaar-crafted melee head slot item requiring 60 Defence. As part of the full obsidian set, it unlocks a 10% damage and accuracy bonus with obsidian weapons that stacks multiplicatively with the berserker necklace."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: obsidian
+    tier: tier_60
   equipment:
     slot: head
-    type: melee_armor
-    tradeable: true
-    weight: 3.628
+    weapon_type: none
+    attack_speed: 1
     requirements:
       defence: 60
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 25
+      slash: 23
+      crush: 26
+      magic: 0
+      ranged: 24
+    other_bonus:
       strength: 3
-      stab_def: 25
-      slash_def: 23
-      crush_def: 26
-      ranged_def: 24
-  set_bonus:
-    set_name: Obsidian
-    requirement: Full set + Obsidian weapon
-    damage_bonus: +10%
-    accuracy_bonus: +10%
-    stacks_with:
-      - item_id: 11128
-        item_name: Berserker necklace
-        additional_bonus: +20%
-  shop:
-    npc: TzHaar-Hur-Zal
-    location: Mor Ul Rek
-    price: 84480
-    currency: Tokkul
-  market:
-    buy_limit: 70
-    price_estimate: 650000
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: TzHaar-Hur-Zal's Equipment Store
+      location: Mor Ul Rek
+      price: 84480
+      currency: Tokkul
+      stock: 5
+  drop_table:
+    - source: TzHaar-Ket
+      level: 221
+      quantity: "1"
+      rarity: "1/2000"
+      members: true
   related_items:
-    - item_id: 21301
-      item_name: Obsidian platebody
-      slug: obsidian-platebody
+    - item_name: Obsidian platebody
       relationship: set-piece
-      description: Body armor
-    - item_id: 21304
-      item_name: Obsidian platelegs
-      slug: obsidian-platelegs
+    - item_name: Obsidian platelegs
       relationship: set-piece
-      description: Leg armor
-    - item_id: 11128
-      item_name: Berserker necklace
-      slug: berserker-necklace
+    - item_name: Toktz-xil-ak
       relationship: alternative
-      description: Stacks with set
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Strength | +3 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +25 |
-    | Slash | +23 |
-    | Crush | +26 |
-    | Ranged | +24 |
-
-    Requirements: 60 Defence
-
-    Full Obsidian Set + Obsidian Weapon:
-    - +10% damage bonus
-    - +10% accuracy bonus
-    - Stacks with Berserker necklace (+20%)
-
-    Popular for:
-    - Training at TzHaar
-    - Budget melee training
-    - Fight Caves
-
-    Part of the Obsidian training set.
+    - item_name: Berserker necklace
+      relationship: alternative
   market_strategy:
     notes:
-      - Buy with Tokkul or GE
-      - Set bonus is powerful
-      - Good for training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "summary: \"Mid-tier melee training helm with stable demand from TzHaar set users.\""
+      - "buy_strategy: \"Buy with Tokkul at Mor Ul Rek if you have Fight Cave farm cycles; otherwise GE bids near mid-price fill quickly.\""
+      - "sell_strategy: \"List close to GE price; volume of ~491/day keeps liquidity healthy.\""
+      - "risk_level: \"medium\""
+  trading_tips:
+    - "Buy Tokkul-priced helms before TzHaar visits to flip into the GE for profit."
+    - "Set bonus only fires with the full obsidian armour + obsidian weapon — sell as a kit for higher margin."
+    - "Pairs with berserker necklace for multiplicative damage; bundle deals in chats work well."
+  history:
+    - date: "2017-06-01"
+      description: "Released with The Inferno content update as part of the obsidian armour set."
+  properties:
+    release_date: "2017-06-01"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Olive oil(4) | OSRS Price Data
-description: "Olive oil(4): 4 doses of olive oil.. High alch: 13 GP, GE limit: 10,000."
+description: "Olive oil(4): 4 doses of olive oil. High alch: 13 GP, GE limit: 10,000."
 osrs:
   id: 3422
   name: Olive oil(4)
@@ -12,9 +12,48 @@ osrs:
   lowalch: 8
   highalch: 13
   limit: 10000
-  about: "Olive oil(4) is a members-only item in Old School RuneScape. High alchemy value: 13 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Olive oil(4) holds 4 doses of olive oil, used to brew sacred oil for Shades of Mort'ton funeral pyres. Members-only. High alch 13 gp; GE limit 10,000."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  potion:
+    doses: 4
+    effect: "Used at the Temple of Mort'ton altar to create sacred oil for funeral pyre logs."
+    duration: "Persistent (until consumed)"
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: true
+    weight: 0.08
+  material:
+    type: misc
+    tier: standard
+  shops:
+    - shop_name: "Razmire's general store"
+      location: "Mort'ton"
+      price: 112
+      currency: "Coins"
+      stock: 10
+    - shop_name: "Rasolo the Wandering Merchant"
+      location: "Fremennik Province"
+      price: 160
+      currency: "Coins"
+      stock: 5
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Shades of Mort'ton minigame."
+    - date: "2005-03-01"
+      description: "An 'Empty' option was added to the inventory interaction."
+  trading_tips:
+    - "Bulk buy from Razmire when stocked; Shades of Mort'ton runners absorb supply for sacred oil."
+    - "GE limit of 10,000 makes flipping with general-store restocks viable for free GP."
+  market_strategy:
+    notes:
+      - "relationship: \"component\""
+      - "Demand is tied to Shades of Mort'ton activity and the sacred oil pipeline for redwood/magic pyre logs."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-boater.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "Orange boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Orange boater is a cosmetic straw hat headwear obtained as a reward from medium Treasure Trails. Part of the boater color set with no combat bonuses. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.01
+  material:
+    type: cloth
+    tier: cosmetic
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    rarity: "1/1,133"
+  drop_table:
+    - source: "Medium Clue Casket"
+      quantity: "1"
+      rarity: "1/1,133"
+  market_strategy:
+    notes:
+      - "flip_potential: \"low\""
+      - "Cosmetic clue reward with steady fashionscape demand across the boater color set."
+  trading_tips:
+    - "Compare orange boater spread against other color variants for fashionscape arbitrage."
+    - "Stock during medium clue events when supply spikes briefly."
+  history:
+    - date: "2006-02-20"
+      description: "Released as a medium Treasure Trail reward."
+  relationships:
+    - item_name: Black boater
+      relationship: variant
+    - item_name: Blue boater
+      relationship: variant
+    - item_name: Green boater
+      relationship: variant
+    - item_name: Red boater
+      relationship: variant
+    - item_name: Pink boater
+      relationship: variant
+    - item_name: Purple boater
+      relationship: variant
+    - item_name: White boater
+      relationship: variant
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/peaceful-blessing.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/peaceful-blessing.mdx
@@ -12,67 +12,81 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 5
+  about: "Peaceful blessing is the Guthix-aligned ammunition slot blessing, granting +1 Prayer bonus without sacrificing the ammo slot for ranged builds."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: misc
+    tier: rare
+    category: blessing
+  properties:
+    release_date: "2016-07-06"
+    weight: 0.51
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
   equipment:
     slot: ammo
-    type: blessing
-    attack_style: none
-    stats:
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Rare
-        description: Reward from master clue scrolls
-      - source: Treasure Trails
-        requirements:
-          clue_type: Elite
-        rarity: Rare
-        description: Reward from elite clue scrolls
-  related_items:
-    - item_id: 20220
-      item_name: Holy blessing
-      slug: holy-blessing
+    weapon_type: blessing
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: master
+    rarity: rare
+    notes: "Awarded from Easy through Master clue scrolls (excluding Beginner)."
+  relationships:
+    - item_name: Holy blessing
       relationship: alternative
-      description: Saradomin blessing
-    - item_id: 20223
-      item_name: Unholy blessing
-      slug: unholy-blessing
+      note: "Saradomin-aligned ammo slot blessing."
+    - item_name: Unholy blessing
       relationship: alternative
-      description: Zamorak blessing
-    - item_id: 20229
-      item_name: Honourable blessing
-      slug: honourable-blessing
+      note: "Zamorak-aligned ammo slot blessing."
+    - item_name: Honourable blessing
       relationship: alternative
-      description: Armadyl blessing
-    - item_id: 20232
-      item_name: War blessing
-      slug: war-blessing
+      note: "Armadyl-aligned ammo slot blessing."
+    - item_name: War blessing
       relationship: alternative
-      description: Bandos blessing
-    - item_id: 20235
-      item_name: Ancient blessing
-      slug: ancient-blessing
+      note: "Bandos-aligned ammo slot blessing."
+    - item_name: Ancient blessing
       relationship: alternative
-      description: Zaros blessing
-  about: |-
-    The peaceful blessing is a Guthix-aligned item worn in the ammunition slot, providing +1 prayer bonus. It is the Guthix equivalent of other god blessings.
-
-    Blessings are valuable because they provide prayer bonus in the ammunition slot, which normally has no prayer-boosting options. This makes them useful for any build that wants to maximize prayer bonus without sacrificing ranging capability.
-
-    Note: Guthix items do not provide protection in the God Wars Dungeon as Guthix has no faction there. However, the blessing still provides the +1 prayer bonus.
+      note: "Zaros-aligned ammo slot blessing."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Prices vary between different god blessings
-      - Guthix version often cheapest due to no GWD utility
-      - Good budget option for prayer bonus in ammo slot
-      - Compare prices between all six blessings
-      - Often cheapest blessing option
-      - Popular with players wanting affordable prayer bonus
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "summary: \"Cheapest of the six god blessings due to lack of God Wars Dungeon protection utility.\""
+      - "buy_strategy: \"Buy when other blessings spike — peaceful tracks demand floor for budget prayer bonus builds.\""
+      - "sell_strategy: \"Sell to prayer-focused PvM and Ironman support buyers; turnover is steady but limited by GE buy cap of 5.\""
+      - "volatility: \"low\""
+  trading_tips:
+    - "Guthix items provide no protection in the God Wars Dungeon — Guthix has no faction there."
+    - "Often the cheapest blessing, making it the budget pick for ammo slot prayer bonus."
+    - "Storable in a costume room treasure chest to save bank space."
+  history:
+    - date: "2016-07-06"
+      description: "Peaceful blessing added with the Treasure Trail Expansion update."
+  examine_variants:
+    - context: Inventory
+      text: "Life and death, old and new, day and night. Balance is the key to all."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pitta-bread.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pitta-bread.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pitta bread | OSRS Price Data
-description: "Pitta bread: Nicely baked pitta bread. Needs more ingredients to make a kebab.. High alch: 6 GP, GE limit: 11,000."
+description: "Pitta bread: Nicely baked pitta bread. Needs more ingredients to make a kebab. High alch: 6 GP, GE limit: 11,000."
 osrs:
   id: 1865
   name: Pitta bread
@@ -12,9 +12,58 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 11000
-  about: "Pitta bread is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Pitta bread is a members-only baked good used as a base for crafting Ugthanki kebabs in Old School RuneScape."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: food
+    tier: common
+    category: ingredient
+  properties:
+    release_date: "2003-04-14"
+    weight: 0.1
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+  recipes:
+    - item_name: Pitta bread
+      skill: Cooking
+      level: 58
+      xp: 40
+      tools:
+        - Cooking range
+      materials:
+        - item_name: Pitta dough
+          quantity: 1
+      output_quantity: 1
+      notes: "Baked on a cooking range; cannot be burnt because success rate reaches 100 percent at level 37."
+  relationships:
+    - item_name: Pitta dough
+      relationship: component
+    - item_name: Kebab mix
+      relationship: alternative
+      note: "Combined with pitta bread to create Ugthanki kebabs."
+    - item_name: Ugthanki kebab
+      relationship: product
+  market_strategy:
+    notes:
+      - "summary: \"Niche cooking ingredient with steady but low daily turnover; primarily moved by Ugthanki kebab crafters.\""
+      - "buy_strategy: \"Buy pitta dough cheaply and bake yourself if the spread to pitta bread is positive after GE tax.\""
+      - "sell_strategy: \"List near mid-price; demand is thin so very high markups stall on the GE.\""
+      - "volatility: \"low\""
+  trading_tips:
+    - "Cannot be burnt at level 58 Cooking — guaranteed XP per dough."
+    - "Used as the bread base for Ugthanki kebabs (good or bad variants)."
+    - "11,000 buy limit allows bulk Cooking XP runs without GE throttling."
+  history:
+    - date: "2003-04-14"
+      description: "Pitta bread released as part of the original Cooking content rollout."
+  examine_variants:
+    - context: Inventory
+      text: "Nicely baked pitta bread. Needs more ingredients to make a kebab."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pot-of-cream.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pot-of-cream.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pot of cream | OSRS Price Data
-description: "Pot of cream: Fresh cream.. High alch: 1 GP, GE limit: 13,000."
+description: "Pot of cream: Fresh cream. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 2130
   name: Pot of cream
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Pot of cream is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Pot of cream is a dairy ingredient churned from a bucket of milk at 21 Cooking; used in Gnome Cooking recipes like Choc saturday and Drunk dragon. Members-only. High alch 1 gp; GE limit 13,000."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.2
+  material:
+    type: misc
+    tier: standard
+  recipes:
+    - item_name: "Pot of cream"
+      skill: "Cooking"
+      level: 21
+      xp: 18
+      tools:
+        - "Dairy churn"
+      materials:
+        - item_name: "Bucket of milk"
+          quantity: 1
+      output_quantity: 1
+  shops:
+    - shop_name: "Culinaromancer's Chest"
+      location: "Lumbridge Castle basement"
+      price: 18
+      currency: "Coins"
+      stock: 10
+    - shop_name: "Funch's Fine Groceries"
+      location: "Gnome Stronghold"
+      price: 18
+      currency: "Coins"
+      stock: 5
+    - shop_name: "Grand Tree Groceries"
+      location: "Gnome Stronghold"
+      price: 18
+      currency: "Coins"
+      stock: 5
+  drop_table:
+    - source: "Zombie (Tarn's Lair)"
+      quantity: "1"
+      rarity: "Uncommon"
+  history:
+    - date: "2002-12-12"
+      description: "Released as a Gnome Cooking ingredient with the Gnome Restaurant minigame."
+  trading_tips:
+    - "Cheap and abundant — bulk buy at GE for Gnome Cooking and chocolate cake recipes."
+    - "Margin opportunity exists vs bucket of milk + churn for sustained Cooking sessions."
+  market_strategy:
+    notes:
+      - "relationship: \"component\""
+      - "Demand is driven by Gnome Cooking recipes and chocolate bomb production; supply scales with dairy churn access."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-blurb-sp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-blurb-sp.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Premade blurb' sp. is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: '2002-12-12'
+    quest_item: false
+    destroy: Drop
+  potion:
+    effects:
+      - description: "Heals 7 hitpoints"
+      - description: "Boosts Strength by 5% + 2 levels"
+      - description: "Reduces Attack by 2% - 3 levels"
+    doses: 1
+  shops:
+    - shop_name: Blurberry Bar (Grand Tree)
+      location: Grand Tree
+      price: 30
+      stock: 5
+    - shop_name: Blurberry Bar (Gnome Stronghold)
+      location: Gnome Stronghold
+      price: 30
+      stock: 5
+  about: |-
+    "A premade Blurberry Special."
+
+    Premade blurb' sp. is a premade Blurberry Special drink sold at Blurberry Bar in the Grand Tree and the Gnome Stronghold. When consumed, it heals 7 hitpoints, boosts Strength by 5% + 2 levels, and lowers Attack by 2% - 3 levels.
+
+    A free copy spawns near the gnome glider on Karamja.
+  market_strategy:
+    notes:
+      - "Sold by gnome shops for 30 GP"
+      - "Useful for low-level strength training"
+      - "Heals 7 hitpoints"
+      - "Niche utility item with limited demand"
+      - "Free spawn on Karamja makes buying rare"
+  history:
+    - date: '2002-12-12'
+      description: Item released with Tree Gnome Stronghold expansion.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-banner.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raging echoes banner | OSRS Price Data
-description: "Raging echoes banner: A banner showcasing the colours of Leagues V: Raging Echoes.. High alch: 600 GP."
+description: "Raging echoes banner: A banner showcasing the colours of Leagues V: Raging Echoes. High alch: 600 GP."
 osrs:
   id: 30430
   name: Raging echoes banner
@@ -12,9 +12,71 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: null
-  about: "Raging echoes banner is a members-only item in Old School RuneScape. High alchemy value: 600 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cosmetic-banner
+    tier: mid
+  properties:
+    release_date: "2025-01-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: "Trailblazer reloaded banner"
+      slug: "trailblazer-reloaded-banner"
+      relationship: variant
+      description: "Cosmetic banner from Leagues IV: Trailblazer Reloaded."
+    - item_name: "Shattered relics banner"
+      slug: "shattered-relics-banner"
+      relationship: variant
+      description: "Cosmetic banner from Leagues III: Shattered Relics."
+  about: "Raging echoes banner is a cosmetic weapon-slot item commemorating Leagues V: Raging Echoes. It can be purchased for 500 League Points from the Leagues Reward Shop at Lumbridge Castle and displayed on a banner stand in the league hall of a player-owned house. The banner has no combat bonuses; players have at most one league banner stored at a time."
+  market_strategy:
+    notes:
+      - "Supply is permanently capped to Leagues V participants — no further influx after the event closes."
+      - "Demand is driven by cosmetic collectors and fashionscape rotations."
+      - "No GE buy limit, but trade volume stays thin outside league anniversaries."
+  trading_tips:
+    - "Expect a slow drift up over time as supply is finite and event-locked."
+    - "Spikes around league announcements and PoH cosmetic updates are common."
+    - "Not alchable — exit liquidity is the GE, not high alch."
+  history:
+    - date: "2025-01-15"
+      description: "Released alongside Leagues V: Raging Echoes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-robeskirt-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-robeskirt-t2.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
-  about: "Raging echoes robeskirt (t2) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Raging echoes robeskirt (t2) is the tier 2 cosmetic legs of the Raging Echoes Relic Hunter outfit, purchased for 5,000 League points during the Raging Echoes League. Provides no combat bonuses but counts toward the costume room outfit set. High alchemy value: 60,000 coins."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2025-01-15"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.907
+  material:
+    type: cloth
+    primary: cloth
+    tier: cosmetic
+  equipment:
+    slot: legs
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  market_strategy:
+    notes:
+      - "buy_range: \"300,000 - 340,000 gp\""
+      - "sell_range: \"340,000 - 400,000 gp\""
+      - "Cosmetic outfit pieces drift with seasonal nostalgia; supply was capped at the Raging Echoes League window so prices trend up long-term."
+  trading_tips:
+    - "Stockpile during the League while supply is high and prices low."
+    - "Sell complete tier-2 sets (hat + top + skirt + boots) for a set premium."
+    - "Watch costume room storage updates for renewed display demand."
+  history:
+    - date: "2025-01-15"
+      description: "Released during the Raging Echoes League as a tier 2 Leagues reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rake.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rake.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 40
-  about: "Rake is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Rake is a Farming tool used to clear weeds from farming patches. Available from farming shops and can be stored by tool leprechauns."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-06-06"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 1.36
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: tool
+    category: farming_tool
+  shops:
+    - shop_name: "Head Farmer Jones' Farming Shop"
+      location: "Falador"
+      price: 15
+      stock: 5
+    - shop_name: "Sarah's Farming Shop"
+      location: "North-east of Falador"
+      price: 15
+      stock: 5
+    - shop_name: "Heskel's Farming Supplies"
+      location: "Tree Gnome Stronghold"
+      price: 15
+      stock: 5
+    - shop_name: "Alice's Farming Shop"
+      location: "East of Catherby"
+      price: 15
+      stock: 5
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Spade"
+      - "Seed dibber"
+      - "Watering can"
+      - "Secateurs"
+      - "Essential Farming tool; can be stored by tool leprechauns near farming patches."
+      - "Cheaply available from gardener and farming shops at 15 coins each."
+      - "GE price hovers above shop price due to convenience demand."
+  history:
+    - date: "2005-06-06"
+      description: "Rake released as part of the Farming skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-anglerfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-anglerfish.mdx
@@ -12,66 +12,89 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 15000
+  about: "Raw anglerfish is a members-only fish in Old School RuneScape. Caught at Port Piscarilius with sandworms; cooked anglerfish can overheal hitpoints. High alchemy value: 270 coins. Grand Exchange buy limit: 15,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2016-01-07"
+    weight: 0.4
+    tradeable: true
+    equipable: false
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
   material:
-    type: fish
-    tier: high
-  fishing:
-    level: 82
-    xp: 120
-    method: Rod Fishing
-    location: Port Piscarilius
-    bait: Sandworms
-  cooking:
-    level: 84
-    xp: 230
-    burn_stop: 99
-    burn_stop_gauntlets: 93
-  related_items:
-    - item_id: 13441
-      item_name: Anglerfish
-      slug: anglerfish
-      relationship: product
-      description: Cooked version (overheal food)
-    - item_id: 383
-      item_name: Raw shark
-      slug: raw-shark
-      relationship: alternative
-      description: Mid-tier alternative
-    - item_id: 389
-      item_name: Raw manta ray
-      slug: raw-manta-ray
-      relationship: alternative
-      description: Similar tier
-    - item_id: 13431
-      item_name: Sandworms
-      slug: sandworms
+    type: food
+    tier: fish
+  drop_table:
+    - source: "Skotizo"
+      quantity: "60"
+      rarity: "7/100"
+      notes: "Noted drop; combat level 321."
+    - source: "Drake"
+      quantity: "4-6"
+      rarity: "1/93"
+      notes: "Noted drop; combat level 192."
+    - source: "Guardian Drake"
+      quantity: "4-6"
+      rarity: "3/93"
+      notes: "Noted drop; combat level 376."
+  recipes:
+    - item_name: "Anglerfish"
+      skill: "Cooking"
+      level_required: 84
+      xp: 230
+      tools:
+        - "Range or fire"
+      materials:
+        - item_name: "Raw anglerfish"
+          quantity: 1
+      output_quantity: 1
+      notes: "Burns until 99 Cooking without cooking gauntlets; 93 with gauntlets at Hosidius range."
+    - item_name: "Raw anglerfish"
+      skill: "Fishing"
+      level_required: 82
+      xp: 120
+      tools:
+        - "Fishing rod"
+        - "Sandworms"
+      materials:
+        - item_name: "Sandworms"
+          quantity: 1
+      output_quantity: 1
+      notes: "Caught at Port Piscarilius. Diabolic worms give 79.2 XP. Pearl fishing rod also works."
+  relationships:
+    - item_name: "Anglerfish"
       relationship: component
-      description: Required bait
-  about: |-
-    | Skill | Level | XP |
-    |-------|-------|-----|
-    | Fishing | 82 | 120 |
-    | Cooking | 84 | 230 |
-
-    Location: Port Piscarilius (Rod Fishing spot)
+      notes: "Cooked variant; overheals hitpoints up to 121."
+    - item_name: "Sandworms"
+      relationship: component
+      notes: "Bait required to fish raw anglerfish."
+    - item_name: "Diabolic worms"
+      relationship: component
+      notes: "Alternative bait with lower XP rate."
+    - item_name: "Raw shark"
+      relationship: alternative
+      notes: "Mid-tier raw fish alternative."
+    - item_name: "Raw manta ray"
+      relationship: alternative
+      notes: "Similar-tier raw fish from Fishing Guild."
+  history:
+    - date: "2016-01-07"
+      description: "Released with the Zeah: Great Kourend update."
+    - date: "2024-01-10"
+      description: "Kourend Favour requirement removed for fishing anglerfish."
   market_strategy:
-    profit_formulas:
-      - Anglerfish - Raw anglerfish = Profit
     notes:
-      - Buy raw → Cook → Sell cooked
-      - "Calculate:"
-      - 84+ Cooking required
-      - Burns until 99 without Cooking gauntlets
-      - Use Hosidius range + gauntlets for 0% burn
-      - Port Piscarilius only (Kourend)
-      - 100% Piscarilius favour required
-      - Sandworm bait needed
-      - Anglerfish overheal makes them premium
-      - Raw often cheaper due to cooking req
-      - Good AFK fishing method
-      - Check cooked vs raw margins daily
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_strategy: \"Buy raw, cook with gauntlets at Hosidius range, sell cooked anglerfish for cooked-raw margin.\""
+      - "sell_strategy: \"Sell to PvMers needing overheal food or directly to cookers.\""
+      - "profit_potential: \"Healthy daily volume; consistent cooked-raw margin opportunity.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Daily volume in the millions — extremely liquid."
+    - "Buy limit 15,000 enables bulk cook-flips."
+    - "Cooking gauntlets + Hosidius range minimize burn at 84+."
+    - "Cooked anglerfish overheal makes them premium PvM food."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-body-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-body-g.mdx
@@ -12,89 +12,77 @@ osrs:
   lowalch: 4492
   highalch: 6738
   limit: 8
+  about: "Red d'hide body (g) is a gold-trimmed cosmetic variant of the red d'hide body, awarded from hard Treasure Trails. Identical combat stats to the standard red d'hide body."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2014-06-12"
+    weight: 6.803
+    tradeable: true
+    equipable: true
+    stackable: false
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: hide
+    tier: dragonhide
   equipment:
     slot: body
-    type: ranged_armour
+    weapon_type: none
+    attack_speed: 1
     requirements:
       ranged: 60
       defence: 40
-      quest: Dragon Slayer I
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 25
-      defence_stab: 26
-      defence_slash: 34
-      defence_crush: 36
-      defence_magic: 36
-      defence_ranged: 45
-      melee_strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 25
+    defence_bonus:
+      stab: 26
+      slash: 34
+      crush: 36
+      magic: 36
+      ranged: 45
+    other_bonus:
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 6.803
-  obtaining:
-    methods:
-      - source: Reward casket (hard)
-        drop_rate: 1/1,625
-  related_items:
-    - item_id: 2501
-      item_name: Red d'hide body
-      slug: red-dhide-body
+  treasure_trail:
+    tier: hard
+    clue_type: hard
+    rarity: "1/1625"
+  drop_table:
+    - source: "Reward casket (hard)"
+      quantity: "1"
+      rarity: "1/1625"
+      notes: "Only available from hard clue caskets."
+  relationships:
+    - item_name: "Red d'hide body"
       relationship: alternative
-      description: Same stats, non-trimmed
-    - item_id: 12331
-      item_name: Red d'hide body (t)
-      slug: red-dhide-body-t
+      notes: "Identical stats; non-trimmed version is craftable."
+    - item_name: "Red d'hide body (t)"
       relationship: alternative
-      description: Trimmed variant, same stats
-    - item_id: 12385
-      item_name: Black d'hide body (t)
-      slug: black-dhide-body-t
+      notes: "Trimmed variant with identical stats; cosmetic only."
+    - item_name: "Black d'hide body (t)"
       relationship: alternative
-      description: Higher tier trimmed body
-  about: |-
-    "Made from 100% real dragonhide. With colourful trim!"
-
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -15 |
-    | Ranged Attack | +25 |
-    | Stab Defence | +26 |
-    | Slash Defence | +34 |
-    | Crush Defence | +36 |
-    | Magic Defence | +36 |
-    | Ranged Defence | +45 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 60 Ranged, 40 Defence, Dragon Slayer I
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Red d'hide body (g) | +25 | +45 | +36 | Hard clues |
-    | Red d'hide body | +25 | +45 | +36 | Crafting (77) |
-
-    Stats are identical to the standard red d'hide body. The gold-trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+      notes: "Higher tier trimmed body."
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion update."
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Hard clue reward rarity
-      - Collection log completionists
-      - Trimmed d'hide set completion
-      - Identical stats to red d'hide body
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_strategy: \"Pick up during clue scroll dry spells when supply slows down.\""
+      - "sell_strategy: \"Sell to fashionscape players and clue completion collectors.\""
+      - "profit_potential: \"Cosmetic-driven; price tracks hard clue activity and collection log demand.\""
+      - "risk_level: \"medium\""
+  trading_tips:
+    - "Identical stats to the standard red d'hide body — purely cosmetic premium."
+    - "Buy limit 8 per 4 hours keeps flips slow."
+    - "Daily volume around 65 — watch for manipulation."
+    - "Storable in costume room treasure chest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-body-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-body-t.mdx
@@ -12,48 +12,60 @@ osrs:
   lowalch: 4492
   highalch: 6738
   limit: 8
+  weight: 6.803
+  material:
+    type: dragonhide
+    tier: red
+  properties:
+    release_date: "2014-06-12"
+    quest_item: false
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged_armour
     requirements:
       ranged: 60
       defence: 40
-      quest: Dragon Slayer I
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 25
-      defence_stab: 26
-      defence_slash: 34
-      defence_crush: 36
-      defence_magic: 36
-      defence_ranged: 45
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
-    weight: 6.803
-  obtaining:
-    methods:
-      - source: Reward casket (hard)
-        drop_rate: 1/1,625
+    bonuses:
+      attack:
+        stab: 0
+        slash: 0
+        crush: 0
+        magic: -15
+        ranged: 25
+      defence:
+        stab: 26
+        slash: 34
+        crush: 36
+        magic: 36
+        ranged: 45
+      other:
+        strength: 0
+        ranged_strength: 0
+        magic_damage: 0
+        prayer: 0
+  treasure_trail:
+    tier: hard
+  drop_table:
+    - source: Reward casket (hard)
+      level: 0
+      quantity: "1"
+      rarity: "1/1625"
+      members: true
   related_items:
     - item_id: 2501
       item_name: Red d'hide body
       slug: red-dhide-body
-      relationship: alternative
+      relationship: variant
       description: Same stats, non-trimmed
     - item_id: 12327
       item_name: Red d'hide body (g)
       slug: red-dhide-body-g
-      relationship: alternative
+      relationship: variant
       description: Gold-trimmed variant, same stats
     - item_id: 12385
       item_name: Black d'hide body (t)
       slug: black-dhide-body-t
-      relationship: alternative
+      relationship: variant
       description: Higher tier trimmed body
   about: |-
     "Made from 100% real dragonhide. With colourful trim!"
@@ -70,31 +82,26 @@ osrs:
     | Crush Defence | +36 |
     | Magic Defence | +36 |
     | Ranged Defence | +45 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
 
     Requirements: 60 Ranged, 40 Defence, Dragon Slayer I
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Red d'hide body (t) | +25 | +45 | +36 | Hard clues |
-    | Red d'hide body | +25 | +45 | +36 | Crafting (77) |
 
     Stats are identical to the standard red d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Hard clue reward rarity
-      - Collection log completionists
-      - Trimmed d'hide set completion
-      - Identical stats to red d'hide body
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Fashionscape / cosmetic flex"
+      - "Hard clue reward rarity"
+      - "Collection log completionists"
+      - "Trimmed d'hide set completion"
+      - "Identical stats to red d'hide body"
+      - "Value is purely cosmetic rarity"
+      - "Price fluctuates with clue scroll activity"
+      - "Low trade volume, watch for manipulation"
+      - "Buy during clue droughts, sell during clue boosts"
+  history:
+    - date: "2014-06-12"
+      description: "Released as a hard clue scroll reward."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-topaz-machete.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-topaz-machete.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red topaz machete | OSRS Price Data
-description: "Red topaz machete: A jungle specific slashing device.. High alch: 1,200 GP, GE limit: 15."
+description: "Red topaz machete: A jungle specific slashing device. High alch: 1,200 GP, GE limit: 15."
 osrs:
   id: 6317
   name: Red topaz machete
@@ -12,9 +12,94 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 15
-  about: "Red topaz machete is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: gem-machete
+    tier: mid-high
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: slash_sword
+    attack_speed: 4
+    weight: 1.36
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 16
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Gabooty's Tai Bwo Wannai Cooperative"
+      location: "Tai Bwo Wannai"
+      price: 2400
+      currency: "Trading sticks"
+      stock: 0
+    - shop_name: "Safta Doc's shop"
+      location: "Tai Bwo Wannai"
+      price: 1200
+      currency: "Trading sticks"
+      stock: 0
+  related_items:
+    - item_name: "Machete"
+      slug: "machete"
+      relationship: downgrade
+      description: "Base machete — chops jungle vegetation at lower success."
+    - item_name: "Opal machete"
+      slug: "opal-machete"
+      relationship: downgrade
+      description: "Lower-tier gem machete with worse slash bonus."
+    - item_name: "Jade machete"
+      slug: "jade-machete"
+      relationship: downgrade
+      description: "Mid-tier gem machete between opal and red topaz."
+    - item_name: "Red topaz"
+      slug: "red-topaz"
+      relationship: component
+      description: "Three red topaz gems are required for Safta Doc's deal."
+    - item_name: "Gout tuber"
+      slug: "gout-tuber"
+      relationship: component
+      description: "Required alongside red topazes in Safta Doc's deal."
+  about: "Red topaz machete is the strongest member of the gem-machete line, used during Tai Bwo Wannai Cleanup and general Karamja jungle clearing. It has the highest cutting success rate among machetes for dense and red jungle vegetation. Purchase from Gabooty for 2,400 trading sticks (2,000 with Karamja gloves 1) or from Safta Doc for 1,200 trading sticks, a gout tuber, and three red topazes. Requires completion of Jungle Potion to access the shops."
+  market_strategy:
+    notes:
+      - "Demand is driven by Tai Bwo Wannai Cleanup grinders and Karamja diary completionists."
+      - "Supply is bottlenecked by trading-stick farmers and gout tuber availability."
+      - "Tiny 15 / 4h buy limit caps speculative size."
+  trading_tips:
+    - "Cross-check trading-stick conversion rate (around 2,000–2,400 gp per stick) before flipping."
+    - "Spikes correlate with Karamja achievement diary or league qualifiers featuring Cleanup."
+    - "High alch (1,200 gp) is far below GE — exit liquidity is the GE only."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Cleanup minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/regen-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/regen-bracelet.mdx
@@ -12,8 +12,28 @@ osrs:
   lowalch: 80800
   highalch: 121200
   limit: 70
+  about: "The regen bracelet doubles your natural Hitpoints regeneration, healing 2 HP per minute instead of the standard 1. Best-in-slot melee hand item for 1 Defence pures since it has no Defence requirement."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-04-30"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 0.25
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: onyx
+    category: bracelet
   equipment:
     slot: hands
+    weapon_type: none
+    attack_speed: null
+    requirements:
+      none: 1
     attack_bonus:
       stab: 8
       slash: 8
@@ -27,17 +47,21 @@ osrs:
       magic: 3
       ranged: 6
     other_bonus:
-      melee_strength: 7
+      strength: 7
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements: {}
-    weight: 0.25
+  special_attack:
+    name: "Hitpoints Regeneration"
+    description: "Doubles the natural Hitpoints regeneration rate from 1 HP per minute to 2 HP per minute. Stacks with Rapid Heal prayer and Hitpoints cape effects."
   recipes:
-    - skill: magic
+    - item_name: Regen bracelet
+      skill: Magic
       level: 87
       xp: 97
-      inputs:
+      tools:
+        - Staff
+      materials:
         - item_name: Onyx bracelet
           quantity: 1
         - item_name: Cosmic rune
@@ -47,58 +71,24 @@ osrs:
         - item_name: Earth rune
           quantity: 20
       output_quantity: 1
-  related_items:
-    - item_id: 7462
-      item_name: Barrows gloves
-      slug: barrows-gloves
-      relationship: upgrade
-      description: BiS gloves from RFD
-    - item_id: 11126
-      item_name: Combat bracelet
-      slug: combat-bracelet
-      relationship: downgrade
-      description: Lower tier bracelet with teleports
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Stab | +8 |
-    | Slash | +8 |
-    | Crush | +8 |
-    | Magic | +3 |
-    | Ranged | +7 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All melee | +6 |
-    | Magic | +3 |
-    | Ranged | +6 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +7 |
-
-    Requirements: None to wear | Weight: 0.25 kg
-
-    The regen bracelet doubles your natural Hitpoints regeneration — healing 2 HP per minute instead of the standard 1. When combined with:
-    - Rapid Heal prayer — 2 HP per 30 seconds
-    - Hitpoints cape — further doubled regeneration
-
-    The regen bracelet is the best-in-slot melee hand slot for players with 1 Defence, as it has no Defence requirement. Its +7 Strength bonus matches mithril gloves while providing superior overall stats.
-
-    | Stat | Regen Bracelet | Barrows Gloves | Combat Bracelet |
-    |------|---------------|---------------|----------------|
-    | Melee Atk | +8/+8/+8 | +12/+12/+12 | +7/+7/+7 |
-    | Strength | +7 | +12 | +6 |
-    | Melee Def | +6/+6/+6 | +6/+6/+6 | +6/+6/+6 |
-    | Special | 2x HP regen | None | Teleports |
-    | Req | None | RFD complete | None |
+      members: true
   market_strategy:
     notes:
-      - Onyx bracelet is the main cost component
-      - Popular with 1 Defence pures and PKers
-      - Passive healing stacks with other regen effects
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "relationship: \"variant\""
+      - "Onyx bracelet"
+      - "Barrows gloves"
+      - "Combat bracelet"
+      - "Mithril gloves"
+      - "Onyx bracelet supply is the main cost driver; enchanting margin tracks onyx market."
+      - "Popular with 1 Defence pures and PKers due to no Defence requirement and passive heal."
+      - "Healing effect stacks with Rapid Heal prayer and Hitpoints cape for AFK content."
+  history:
+    - date: "2007-04-30"
+      description: "Regen bracelet released as part of the onyx jewellery family."
+    - date: "2014-05-01"
+      description: "Combat bonuses were added to the item."
+    - date: "2019-02-01"
+      description: "Healing effect disabled on free-to-play worlds."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-balm-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Relicym's balm(2) | OSRS Price Data
-description: "Relicym's balm(2): 2 doses of Relicym's balm, which helps cure disease.. High alch: 90 GP, GE limit: 2,000."
+description: "Relicym's balm(2): 2 doses of Relicym's balm, which helps cure disease. High alch: 90 GP, GE limit: 2,000."
 osrs:
   id: 4846
   name: Relicym's balm(2)
@@ -12,9 +12,86 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  about: "Relicym's balm(2) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2005-05-17"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: potion
+    tier: potion
+  potion:
+    doses: 2
+    effect: Cures disease afflictions; useful against broodoo victims and Nightmare parasites.
+    duration: instant
+  recipes:
+    - skill: herblore
+      level: 8
+      xp: 40
+      item_name: Relicym's balm(4)
+      tools:
+        - Vial of water
+      materials:
+        - item_name: Rogue's purse
+          quantity: 1
+        - item_name: Snake weed
+          quantity: 1
+      product: Relicym's balm(4)
+      product_id: 4844
+      product_quantity: 1
+      output_quantity: 1
+      members_only: true
+  drop_table:
+    primary_source: Herblore
+    sources:
+      - source: Drink one dose of Relicym's balm(3)
+        quantity: "1"
+        rarity: craftable
+        members_only: true
+  related_items:
+    - item_id: 4844
+      item_name: Relicym's balm(4)
+      slug: relicym-s-balm-4
+      relationship: upgrade
+      description: 4-dose version
+    - item_id: 4848
+      item_name: Relicym's balm(1)
+      slug: relicym-s-balm-1
+      relationship: downgrade
+      description: 1-dose version
+    - item_id: 10925
+      item_name: Sanfew serum(4)
+      slug: sanfew-serum-4
+      relationship: alternative
+      description: Provides disease immunity unlike Relicym's
+  about: |-
+    | Property | Value |
+    |----------|-------|
+    | Doses | 2 |
+    | Herblore level | 8 |
+    | Quest required | Zogre Flesh Eaters (partial) |
+
+    - Cures disease, does not grant immunity
+    - Used in Tai Bwo Wannai Cleanup vs broodoo victims
+    - Useful at The Nightmare for parasite cleanse
+
+    Niche disease cure:
+    - Made from Rogue's purse + Snake weed
+    - Compete with Sanfew serum for immunity buffs
+    - Cheap, high-volume Herblore option
+  market_strategy:
+    notes:
+      - "Demand tied to Nightmare and broodoo content"
+      - "Mid-volume potion with stable margin"
+      - "2-dose splits often arbitrage against 4-dose"
+  trading_tips:
+    - Compare dose-economy vs (4) and (1) for arb
+    - Stock up before raids/Nightmare team play
+    - Buy rogue's purse + snake weed cheap to craft (4) instead
+  history:
+    - date: "2005-05-17"
+      description: "Released with Zogre Flesh Eaters."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-stone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-stone.mdx
@@ -12,13 +12,40 @@ osrs:
   lowalch: 80800
   highalch: 121200
   limit: 70
+  properties:
+    weight: 0.006
+    release_date: '2005-10-04'
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
   equipment:
     slot: ring
-    stats: {}
-    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      none: true
   obtaining:
     methods:
       - source: Enchanting
+        quantity: "1"
         spell: Lvl-6 Enchant
         base_item: Onyx ring
         requirements:
@@ -32,24 +59,29 @@ osrs:
             quantity: 20
         xp: 97
   passive_effects:
-    - name: Transformation
-      description: Transforms the player into a rock. The effect ends when the player moves.
+    - name: Stone Transformation
+      description: Transforms the player's appearance into a rock resembling an empty mining rock. The effect ends when the player moves.
+    - name: Sarachnis Web Escape
+      description: Can be activated to break free from Sarachnis's sticky web attack when used immediately after the attack appears.
   related_items:
     - item_id: 6575
       item_name: Onyx ring
       slug: onyx-ring
       relationship: component
-      description: Unenchanted base ring
+      description: Unenchanted base ring used to create the Ring of stone.
     - item_id: 6577
       item_name: Onyx necklace
       slug: onyx-necklace
       relationship: alternative
-      description: Other onyx jewellery
+      description: Alternative onyx jewellery piece.
     - item_id: 6585
       item_name: Onyx amulet
       slug: onyx-amulet
       relationship: alternative
-      description: Other onyx jewellery
+      description: Alternative onyx jewellery piece.
+  history:
+    - date: '2005-10-04'
+      description: "Ring of stone was released as part of the onyx jewellery line."
   about: |-
     > *"An enchanted ring."*
 
@@ -68,12 +100,16 @@ osrs:
     The ring can also be used to break free from Sarachnis's sticky web attack when activated immediately after the attack appears.
   market_strategy:
     notes:
-      - Novelty item primarily used for cosmetic transformation
-      - High alch value due to onyx base material
-      - Low buy limit reflects niche demand
-      - Members only item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Novelty item primarily used for cosmetic transformation"
+      - "High alch value due to onyx base material"
+      - "Low buy limit reflects niche demand"
+      - "Members only item"
+  trading_tips:
+    - Watch onyx ring prices since the base material drives most of the cost.
+    - Buy limit of 70 makes large-scale flipping slow.
+    - Demand is niche; expect thin order books.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-wealth-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-wealth-scroll.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 10000
-  about: "Ring of wealth scroll is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.002
+  material:
+    type: scroll
+    tier: imbue
+  properties:
+    release_date: "2014-09-18"
+    quest_item: false
+    destroy: "Drop"
+  drop_table:
+    - source: Jelly
+      level: 78
+      quantity: "1"
+      rarity: "1/365.1"
+      members: true
+    - source: Hellhound
+      level: 122
+      quantity: "1"
+      rarity: "1/326.5"
+      members: true
+    - source: Abyssal demon
+      level: 124
+      quantity: "1"
+      rarity: "1/346.9"
+      members: true
+  shops:
+    - shop_name: Last Man Standing reward shop
+      location: Last Man Standing lobby
+      currency: Last Man Standing points
+      price: 5
+  related_items:
+    - item_id: 2572
+      item_name: Ring of wealth
+      slug: ring-of-wealth
+      relationship: component
+      description: Ring this scroll imbues
+    - item_id: 11980
+      item_name: Ring of wealth (i)
+      slug: ring-of-wealth-i
+      relationship: upgrade
+      description: Imbued result
+  about: |-
+    The ring of wealth scroll is consumed on a Ring of Wealth along with 50,000 coins to create a Ring of wealth (i). The imbued ring doubles clue scroll drop chances from monsters in the Wilderness.
+
+    Obtained from Wilderness Slayer Cave drops or for 5 points at the Last Man Standing reward shop.
+  market_strategy:
+    notes:
+      - "Wilderness clue boost"
+      - "LMS reward shop alternative"
+      - "Consumable imbue item"
+      - "Demand tied to Wilderness Slayer activity"
+      - "Stable demand from clue scroll hunters"
+      - "LMS points farmers can flip for profit"
+      - "Buy in bulk during LMS event lulls"
+  history:
+    - date: "2014-09-18"
+      description: "Released with the Wilderness rejuvenation update."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/robe-bottom-of-darkness.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/robe-bottom-of-darkness.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 70
-  about: "Robe bottom of darkness is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: magic_robe
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options: ["Wear"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Reward casket (master)"
+        quantity: "1"
+        rarity: "1/851"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers: ["master"]
+  related_items:
+    - item_name: "Hood of darkness"
+      slug: "hood-of-darkness"
+      relationship: "set-piece"
+      description: "Head slot piece of the Robes of darkness ensemble."
+    - item_name: "Robe top of darkness"
+      slug: "robe-top-of-darkness"
+      relationship: "set-piece"
+      description: "Body slot piece of the Robes of darkness ensemble."
+    - item_name: "Gloves of darkness"
+      slug: "gloves-of-darkness"
+      relationship: "set-piece"
+      description: "Hand slot piece of the Robes of darkness ensemble."
+    - item_name: "Boots of darkness"
+      slug: "boots-of-darkness"
+      relationship: "set-piece"
+      description: "Feet slot piece of the Robes of darkness ensemble."
+  about: "The Robe bottom of darkness is the legs slot piece of the Robes of darkness set, released July 6, 2016 as a master Treasure Trail reward at 1/851. Requires 40 Magic and 20 Defence to equip and grants +15 magic attack and +15 magic defence. The full set provides Zaros alignment protection in the Ancient Prison area of the God Wars Dungeon."
+  market_strategy:
+    notes:
+      - "Master-tier clue piece - supply tracks clue-completion grinders."
+      - "Niche utility: GWD Ancient Prison Zarosian alignment is its main mechanical reason to wear vs Ahrim's."
+      - "Daily volume ~166 - reasonably liquid for a clue cosmetic-ish piece."
+      - "Set demand is concentrated; full-set buyers move the market more than single pieces."
+  trading_tips:
+    - "Bundle with hood/top/gloves/boots for a complete set - bulk buyers pay margins."
+    - "Buy when master clue droprate guides go viral and supply floods."
+    - "Sell into GWD/Nex content updates - Zaros alignment use cases drive spikes."
+  history:
+    - date: "2016-07-06"
+      description: "Released as a master clue reward as part of the Robes of darkness set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/royal-sceptre.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/royal-sceptre.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Royal sceptre is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options: ["Wield"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: polestaff
+    attack_speed: 4
+    weight: 4.535
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Reward casket (elite)"
+        quantity: "1"
+        rarity: "1/1,275"
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers: ["elite"]
+  related_items:
+    - item_name: "Royal crown"
+      slug: "royal-crown"
+      relationship: "set-piece"
+      description: "Matching crown piece from the Royal outfit set."
+    - item_name: "Royal gown top"
+      slug: "royal-gown-top"
+      relationship: "set-piece"
+      description: "Matching gown top from the Royal outfit set."
+    - item_name: "Royal gown bottom"
+      slug: "royal-gown-bottom"
+      relationship: "set-piece"
+      description: "Matching gown bottom from the Royal outfit set."
+  about: "Royal sceptre is a cosmetic polestaff reward from elite Treasure Trails, released June 12, 2014. It is part of the Royal outfit and can be stored in the costume room treasure chest. All combat bonuses are +0 - it is purely a fashionscape piece."
+  market_strategy:
+    notes:
+      - "Elite-tier clue cosmetic with a 1/1,275 drop rate; supply trickles in slowly."
+      - "Low daily volume (~49) means market thickness is thin - use limit orders, not market buys."
+      - "Demand is tied to costume room collectors and roleplay setups, not combat metas."
+  trading_tips:
+    - "Place buy offers slightly above the GE average and wait several hours - this is a slow mover."
+    - "Stack the full 4/4h buy limit when prices dip below 22k for resale margin."
+    - "Cosmetics like this spike during clue scroll content updates - watch the patch notes."
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion update as an elite clue reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-dragon-bolts-e.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ruby dragon bolts (e) | OSRS Price Data
-description: "Ruby dragon bolts (e): Enchanted Dragon crossbow bolts, tipped with ruby.. High alch: 498 GP, GE limit: 11,000."
+description: "Ruby dragon bolts (e): Enchanted Dragon crossbow bolts, tipped with ruby. High alch: 498 GP, GE limit: 11,000."
 osrs:
   id: 21944
   name: Ruby dragon bolts (e)
@@ -12,31 +12,69 @@ osrs:
   lowalch: 332
   highalch: 498
   limit: 11000
-  ammunition:
-    type: enchanted_bolt
-    tradeable: true
-    stackable: true
-    weight: 0
+  properties:
+    release_date: "2018-01-04"
+    quest_item: false
+    destroy: Drop
+  material:
+    type: ammunition
+    tier: enchanted-bolt
+  equipment:
+    slot: ammo
+    weapon_type: bolts
+    attack_speed: 1
+    weight: 0.001
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
     requirements:
       ranged: 64
-    stats:
-      ranged_strength: 122
-  creation:
-    method: Enchant Ruby dragon bolts
-    spell: Enchant Crossbow Bolt
-    requirements:
-      magic: 49
-  special_effect:
+    degradable: false
+  recipes:
+    - skill: magic
+      level: 49
+      xp: 59
+      item_name: Ruby dragon bolts (e)
+      tools:
+        - Staff
+      materials:
+        - item_name: Ruby dragon bolts
+          quantity: 10
+        - item_name: Fire rune
+          quantity: 5
+        - item_name: Blood rune
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+      product: Ruby dragon bolts (e)
+      product_id: 21944
+      product_quantity: 10
+      output_quantity: 10
+      members_only: true
+  special_attack:
     name: Blood Forfeit
-    description: Removes 20% of target's current HP
-    damage_cap: 100
-    self_damage: 10% of your HP
-    proc_rate_pvm: 6%
-    proc_rate_pvp: 11%
-    kandarin_diary_boost: +10% proc rate
-  market:
-    buy_limit: 11000
-    price_estimate: 3938
+    description: "Removes 20% of target's current HP (capped at 100). Costs 10% of your current HP. 6% PvM / 11% PvP proc; +10% with Hard Kandarin Diary."
+  drop_table:
+    primary_source: Magic enchantment
+    sources:
+      - source: Enchant Crossbow Bolt
+        quantity: "10"
+        rarity: craftable
+        members_only: true
   related_items:
     - item_id: 21946
       item_name: Diamond dragon bolts (e)
@@ -52,7 +90,7 @@ osrs:
       item_name: Ruby dragon bolts
       slug: ruby-dragon-bolts
       relationship: downgrade
-      description: Unenchanted
+      description: Unenchanted base
   about: |-
     Enchant Ruby dragon bolts with Enchant Crossbow Bolt.
 
@@ -79,11 +117,18 @@ osrs:
     Best bolts for high-HP targets.
   market_strategy:
     notes:
-      - Switch to diamond at low HP
-      - Amazing for boss starts
-      - Kandarin Diary helps
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Switch to diamond at low HP"
+      - "Amazing for boss starts"
+      - "Kandarin Diary helps"
+  trading_tips:
+    - Enchanting 10 per cast keeps margins thin; buy unenchanted dumps
+    - Demand spikes during Nex/Corp meta updates
+    - Stack vs market dragon crossbow bolt price closely
+  history:
+    - date: "2018-01-04"
+      description: "Released with Dragon Slayer II."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger-p-5678.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger-p-5678.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 70
-  about: "Rune dagger(p+) is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Rune dagger(p+) is a Rune dagger coated with Super weapon poison, increasing initial poison damage; popular as a poisoned alternative for stab attacks at lower levels."
+  material:
+    type: metal
+    tier: high
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 25
+      slash: 12
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      magic: 1
+    other_bonus:
+      strength: 24
+  recipes:
+    - skill: Herblore
+      level: 1
+      xp: 0
+      tools: []
+      materials:
+        - item_name: Rune dagger
+          quantity: 1
+        - item_name: Weapon poison+
+          quantity: 1
+      output_quantity: 1
+      notes: "Use Weapon poison+ on a clean Rune dagger to coat the blade."
+  related_items:
+    - item_name: Rune dagger
+      relationship: variant
+    - item_name: Rune dagger(p)
+      relationship: variant
+    - item_name: Rune dagger(p++)
+      relationship: upgrade
+    - item_name: Adamant dagger(p+)
+      relationship: downgrade
+    - item_name: Dragon dagger(p+)
+      relationship: upgrade
+    - item_name: Weapon poison+
+      relationship: component
+  market_strategy:
+    notes:
+      - "Poisoned rune dagger sits between standard and p++; entry-level option for budget poison stabbers."
+      - "GE limit of 70 per 4h keeps liquidity modest."
+      - "Margin tracks weapon poison+ price plus base rune dagger value."
+  trading_tips:
+    - "Compare base rune dagger plus weapon poison+ cost vs the GE p+ price for craft-to-flip profit."
+    - "Common F2P-into-P2P upgrade — demand picks up around member trial promos."
+    - "Stack with antipoison potions for PvP / PvM bundle deals."
+  history:
+    - date: "2001-08-13"
+      description: "Rune dagger released alongside the Wilderness launch."
+    - date: "2006-08-22"
+      description: "Poison naming standardised to (p+) and (p++) suffixes."
+  properties:
+    release_date: "2001-08-13"
+    update: "Wilderness launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta-p-11419.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta-p-11419.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Rune hasta(p++) is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: ammunition
+    tier: rune
+    primary_material: runite
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    two_handed: false
+    tradeable: true
+    weight: 2.267
+    requirements:
+      attack: 40
+    stats:
+      attack_stab: 36
+      attack_slash: 36
+      attack_crush: 36
+      attack_magic: 0
+      attack_ranged: 0
+      defence_stab: -10
+      defence_slash: -10
+      defence_crush: -9
+      defence_magic: 0
+      defence_ranged: -10
+      melee_strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    type: poison
+    description: "Poison-tipped (p++) variant applies stronger Weapon poison++ on hit."
+  related_items:
+    - item_id: 11417
+      item_name: Rune hasta
+      slug: rune-hasta
+      relationship: variant
+      description: Unpoisoned base version.
+    - item_id: 11418
+      item_name: Rune hasta(p)
+      slug: rune-hasta-p-11418
+      relationship: variant
+      description: Standard poison variant.
+    - item_id: 11420
+      item_name: Rune hasta(kp)
+      slug: rune-hasta-kp
+      relationship: variant
+      description: Karambwan paste poisoned variant.
+    - item_id: 5954
+      item_name: Weapon poison++
+      slug: weapon-poison-plus-plus
+      relationship: component
+      description: Used to apply the (p++) poison.
+  about: |-
+    Rune hasta(p++) is a poison-tipped one-handed rune spear.
+
+    | Requirement | Value |
+    |-------------|-------|
+    | Attack | 40 |
+
+    | Offence | Bonus |
+    |---------|-------|
+    | Stab/Slash/Crush | +36 |
+    | Strength | +42 |
+
+    Used for:
+    - Mid-level melee with poison damage
+    - PvP/PvM where poison stacking matters
+    - Slayer tasks vulnerable to poison
+  market_strategy:
+    notes:
+      - "Poison variants trade thinner than the base hasta"
+      - "Watch Weapon poison++ supply for craft margin"
+      - "Demand follows poison-vulnerable Slayer task rotations"
+  trading_tips:
+    - Arbitrage base Rune hasta + Weapon poison++ vs the finished (p++) GE price.
+    - GE buy limit of 70 every 4 hours allows moderate flipping.
+    - Cross-check with brutal dragon drop rates for supply spikes.
+  history:
+    - date: "2007-07-03"
+      description: "Released alongside the Barbarian Training miniquest."
+    - date: "2021-04-21"
+      description: "Attack speed decreased from 5 ticks to 4 ticks."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h5.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 70
-  about: "Rune shield (h5) is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Rune shield (h5) is a free-to-play heraldic variant of the rune kiteshield obtained from hard treasure trails. High alchemy value: 32,640 coins. Grand Exchange buy limit: 70 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 5.443
+  material:
+    type: misc
+    tier: rune
+  equipment:
+    slot: shield
+    weapon_type: shield
+    attack_speed: 1
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    - source: "Hard Treasure Trail reward casket"
+      quantity: "1"
+      rarity: "1/1625"
+  history:
+    - date: "2006-02-20"
+      description: "Released as a reward from hard treasure trails alongside other heraldic rune shields."
+  trading_tips:
+    - "Identical combat stats to a regular rune kiteshield; price premium is purely cosmetic."
+    - "Hard clue reward at roughly 1/1,625 rarity, so supply is steady but slow."
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Tracks rune kiteshield price plus a clue-cosmetic premium tied to clue scroll demand."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts-p-9298.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts-p-9298.mdx
@@ -1,6 +1,6 @@
 ---
 title: Runite bolts (p+) | OSRS Price Data
-description: "Runite bolts (p+): Some poisoned runite bolts.. High alch: 180 GP, GE limit: 11,000."
+description: "Runite bolts (p+): Some poisoned runite bolts. High alch: 180 GP, GE limit: 11,000."
 osrs:
   id: 9298
   name: Runite bolts (p+)
@@ -12,9 +12,71 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 11000
-  about: "Runite bolts (p+) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Runite bolts (p+) are members-only crossbow ammunition in Old School RuneScape, providing +115 ranged strength with the mid-tier weapon poison(+) coating. High alchemy value: 180 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    destroy: "Drop"
+    quest_item: false
+    weight: 0
+  material:
+    type: ammunition
+    tier: rune
+  equipment:
+    slot: ammo
+    weapon_type: bolts
+    attack_speed: null
+    requirements:
+      ranged: 61
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 115
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    has_special: false
+  recipes:
+    - item_name: "Runite bolts (p+)"
+      skill: Herblore
+      level: 73
+      xp: 190
+      tools: []
+      materials:
+        - item_name: "Runite bolts"
+          quantity: 1
+        - item_name: "Weapon poison(+)"
+          quantity: 1
+      output_quantity: 1
+      notes: "Apply weapon poison(+) to standard runite bolts; poisoning prevents bolt tip attachment."
+  market_strategy:
+    notes:
+      - "summary: \"Mid-tier poisoned runite bolts; demand is split between PvP setups valuing poison procs and PvE ranged training.\""
+      - "buy_strategy: \"Stock when poison(+) supply runs cheap; flip into the poison spread when runite bolt base price dips.\""
+      - "sell_strategy: \"Move during PvP-focused events and Bounty Hunter promotions when poison ammo demand rises.\""
+  trading_tips:
+    - "Spread between unpoisoned runite bolts and (p+) variant signals crafting margin."
+    - "Poisoned bolts cannot be enchanted or tipped, so demand is narrower than the unpoisoned variant."
+    - "Stackable ammo means bulk flips have minimal inventory friction."
+  history:
+    - date: "2006-07-31"
+      description: "Released as part of the original crossbow bolts expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sandwich-lady-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sandwich-lady-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sandwich lady top | OSRS Price Data
-description: "Sandwich lady top: A top worn by a sandwich lady.. High alch: 300 GP, GE limit: 4."
+description: "Sandwich lady top: A top worn by a sandwich lady. High alch: 300 GP, GE limit: 4."
 osrs:
   id: 23315
   name: Sandwich lady top
@@ -12,9 +12,72 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 4
-  about: "Sandwich lady top is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: '2019-04-11'
+    quest_item: false
+    destroy: Drop
+  equipment:
+    slot: body
+    weapon_type: cosmetic
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    weight: 0.907
+  treasure_trail:
+    tier: beginner
+    rarity: 1/360
+  drop_table:
+    - source: Reward casket (beginner)
+      quantity: "1"
+      rarity: 1/360
+  treasure_trail_clues:
+    - source: Beginner Treasure Trails
+      tier: beginner
+      reward_type: cosmetic
+  related_items:
+    - item_id: 23318
+      item_name: Sandwich lady bottoms
+      slug: sandwich-lady-bottoms
+      relationship: set-piece
+      description: Matching legs piece
+    - item_id: 23321
+      item_name: Sandwich lady hat
+      slug: sandwich-lady-hat
+      relationship: set-piece
+      description: Matching head piece
+  about: |-
+    "A top worn by a sandwich lady."
+
+    Sandwich lady top is a cosmetic body item obtained as a rare reward from beginner Treasure Trails caskets at a rate of 1/360. It provides no combat bonuses and is part of the three-piece Sandwich lady outfit.
+  market_strategy:
+    notes:
+      - "Beginner clue cosmetic"
+      - "Low buy limit (4/4h)"
+      - "Fashionscape / collection log"
+      - "Part of Sandwich lady outfit (top, bottoms, hat)"
+      - "Limited supply keeps price elevated"
+  history:
+    - date: '2019-04-11'
+      description: Item released as a beginner Treasure Trails reward.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sanfew serum(1) | OSRS Price Data
-description: "Sanfew serum(1) is a 1-dose members potion that restores 4-16 prayer points, cures poison/venom, restores stats. High alch: 72 GP, GE limit: 2,000."
+description: "Sanfew serum(1) is a 1-dose members potion that restores prayer points, cures poison/venom, restores stats. High alch: 72 GP, GE limit: 2,000."
 osrs:
   id: 10931
   name: Sanfew serum(1)
@@ -12,41 +12,58 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 2000
+  about: "Sanfew serum(1) is a one-dose super potion that restores prayer (4 + 30% of base level) and stats, grants 6 minutes of poison immunity, and 15 minutes of disease immunity per dose. Made with 65 Herblore by combining unicorn horn dust, clean snake weed, and nail beast nails with a super restore. Requires Zogre Flesh Eaters completion. High alchemy value: 72 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2007-03-13"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.02
+  material:
+    type: potion
+    primary: liquid
+    tier: standard
   potion:
     doses: 1
-    herblore_level: 65
-    herblore_xp: 160
-    effect: Restores 4-16 Prayer points, cures poison/venom, restores stats
-    effects:
-      - stat: Prayer
-        boost_formula: 4 + floor(level / 4)
-      - stat: Cure poison
-        boost_type: cure
-        description: Cures poison and venom
-  related_items:
-    - item_id: 10925
-      item_name: Sanfew serum(4)
-      slug: sanfew-serum-4
-      relationship: variant
-      description: 4-dose version
-    - item_id: 10927
-      item_name: Sanfew serum(3)
-      slug: sanfew-serum-3
-      relationship: variant
-      description: 3-dose version
-    - item_id: 10929
-      item_name: Sanfew serum(2)
-      slug: sanfew-serum-2
-      relationship: variant
-      description: 2-dose version
-  about: 1-dose variant of Sanfew serum.
+    boost_type: "Prayer"
+    boost_amount: 4
+    duration: "Instant; 6 min poison immunity; 15 min disease immunity"
+    heal_amount: 0
+    notes: "Restores 4 prayer points + 30% of base prayer level per dose. Also restores reduced stats (excluding Hitpoints), cures poison/venom, and grants temporary poison and disease immunity."
+  recipes:
+    - item_name: Sanfew serum(1)
+      tools: ["Pestle and mortar"]
+      materials:
+        - item_name: Super restore(1)
+          quantity: 1
+        - item_name: Unicorn horn dust
+          quantity: 1
+        - item_name: Snake weed
+          quantity: 1
+        - item_name: Nail beast nails
+          quantity: 1
+      output_quantity: 1
+      skill: Herblore
+      level: 65
+      xp: 96
+      notes: "Requires completion of Zogre Flesh Eaters. XP scales upward to 192 for the 4-dose recipe."
   market_strategy:
     notes:
-      - Compare to 4-dose price
-      - Decanting can profit
-      - Use decanting NPC in GE
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "buy_range: \"1,500 - 1,900 gp\""
+      - "sell_range: \"1,800 - 2,300 gp\""
+      - "Lowest-dose variant; profit comes from decanting at the GE NPC to merge into 3- and 4-dose for higher margin per inventory slot."
+  trading_tips:
+    - "Decant 1-dose stock into 4-dose for resale premium."
+    - "Buy when 4-dose price drops; the 1-dose price lags behind."
+    - "Demand spikes around Dagannoth Kings and Nightmare team trips."
+  history:
+    - date: "2007-03-13"
+      description: "Released alongside the Zogre Flesh Eaters quest as a hybrid prayer + cure potion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-d-hide-body.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 5200
   highalch: 7800
   limit: 8
-  about: "Saradomin d'hide body is a members-only item in Old School RuneScape. High alchemy value: 7,800 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Saradomin d'hide body is a god-blessed black dragonhide body awarded from hard Treasure Trails, requiring 70 Ranged and 40 Defence. It carries the same offensive profile as a black d'hide body with bonus prayer and Saradominist protection in the God Wars Dungeon. High alchemy value: 7,800 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 6
+  material:
+    type: hide
+    primary: dragonhide
+    tier: black
+  equipment:
+    slot: body
+    requirements:
+      ranged: 70
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 55
+      slash: 47
+      crush: 60
+      magic: 50
+      ranged: 55
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    notes: "Possible reward from hard reward caskets at roughly 1/1,625 rarity; also grants Saradominist protection in the God Wars Dungeon."
+  market_strategy:
+    notes:
+      - "buy_range: \"95,000 - 105,000 gp\""
+      - "sell_range: \"105,000 - 120,000 gp\""
+      - "Saradomin variant is one of the more popular d'hide bodies thanks to GWD protection demand; supply tied to clue scroll completions."
+  trading_tips:
+    - "Stack with Saradomin coif and chaps for full-set flips on GWD weekends."
+    - "Buy after Treasure Trail buff updates when clue completions spike supply."
+    - "Sell to PvMers gearing for Commander Zilyana groups."
+  history:
+    - date: "2006-12-05"
+      description: "Released as a hard Treasure Trail reward alongside the other god d'hide variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-banner.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: null
-  about: "Shattered banner is a members-only item in Old School RuneScape. High alchemy value: 600 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2022-01-19"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: cloth
+    tier: cosmetic
+    primary_material: cloth
+  equipment:
+    slot: weapon
+    weapon_type: banner
+    attack_speed: 6
+    two_handed: false
+    tradeable: true
+    weight: 2.267
+    requirements:
+      attack: 1
+    stats:
+      attack_stab: 0
+      attack_slash: 0
+      attack_crush: 0
+      attack_magic: 0
+      attack_ranged: 0
+      defence_stab: 0
+      defence_slash: 0
+      defence_crush: 0
+      defence_magic: 0
+      defence_ranged: 0
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 26426
+      item_name: Trailblazer banner
+      slug: trailblazer-banner
+      relationship: variant
+      description: Banner from Leagues IV - Trailblazer Reloaded.
+    - item_id: 26425
+      item_name: Twisted banner
+      slug: twisted-banner
+      relationship: variant
+      description: Banner from Leagues II - Twisted League.
+  about: |-
+    Shattered banner is a cosmetic members reward from Leagues III - Shattered Relics.
+
+    Purchased from the Leagues Reward Shop for 500 League points.
+
+    | Slot | Stats |
+    |------|-------|
+    | Weapon | All bonuses +0 |
+
+    Used for:
+    - Cosmetic display
+    - Banner stand furniture in league hall
+    - Player house decoration
+  market_strategy:
+    notes:
+      - "Cosmetic-only with no stat bonuses"
+      - "Demand driven by league nostalgia"
+      - "Limited supply from completed league"
+  trading_tips:
+    - Cosmetic banners hold steady prices outside of league seasons.
+    - Spikes when new league content references prior leagues.
+    - No GE buy limit - large bulk trades possible.
+  history:
+    - date: "2022-01-19"
+      description: "Added to the game."
+    - date: "2022-03-16"
+      description: "Became obtainable through the Leagues Reward Shop for 500 League points."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shortbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shortbow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shortbow | OSRS Price Data
-description: "Shortbow is a F2P two-handed weapon. High alch: 30 GP, GE limit: 18,000."
+description: "Shortbow is a F2P two-handed bow requiring no Ranged level. High alch: 30 GP, GE limit: 18,000."
 osrs:
   id: 841
   name: Shortbow
@@ -12,50 +12,79 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
+  about: "Shortbow is the entry-level free-to-play two-handed bow used at the start of Ranged training. Fires arrows up to iron tier with no level requirement; fletched at 5 Fletching from a shortbow (u) plus bowstring. Sold at Lowe's Archery Emporium in Varrock. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 1.36
+  material:
+    type: misc
+    primary: wood
+    tier: standard
   equipment:
-    slot: 2h
-    type: shortbow
-    attack_style: ranged
+    slot: weapon
+    weapon_type: bow
     attack_speed: 4
-  requirements:
-    ranged: 1
-  stats:
-    attack:
+    two_handed: true
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 8
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-    range: 7
-  fletching:
-    level: 5
-    xp: 5
-    method: Shortbow (u) + bowstring
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Shortbow
+      tools: []
+      materials:
+        - item_name: Shortbow (u)
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      output_quantity: 1
+      skill: Fletching
+      level: 5
+      xp: 5
+      notes: "Members-only fletching recipe; combine bow string with the unstrung shortbow."
   shops:
-    - shop_name: Lowe's Archery Emporium
-      location: Varrock
+    - shop_name: "Lowe's Archery Emporium"
+      location: "Varrock"
       price: 50
-  related_items:
-    - item_id: 843
-      item_name: Oak shortbow
-      slug: oak-shortbow
-      relationship: upgrade
-      description: Higher tier shortbow
-    - item_id: 839
-      item_name: Longbow
-      slug: longbow
-      relationship: alternative
-      description: More attack range
-    - item_id: 50
-      item_name: Shortbow (u)
-      slug: shortbow-u
-      relationship: component
-      description: Unstrung version
-    - item_id: 1777
-      item_name: Bow string
-      slug: bow-string
-      relationship: component
-      description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      stock: 10
+      notes: "F2P bow shop; reliable starting stock for new Ranged trainers."
+  market_strategy:
+    notes:
+      - "buy_range: \"30 - 50 gp\""
+      - "sell_range: \"45 - 70 gp\""
+      - "Lowest-tier bow; flips are small per unit but volume is high thanks to F2P starter demand."
+  trading_tips:
+    - "Bulk craft from shortbow (u) + bow string for Fletching XP and resale margin."
+    - "Buy out Lowe's stock during free-to-play world influxes."
+    - "Use as a price anchor when flipping oak shortbow upgrades."
+  history:
+    - date: "2001-01-04"
+      description: "Released as one of the original Ranged weapons in RuneScape."
+    - date: "2005-07-11"
+      description: "Fletching skill release added crafting recipe from shortbow (u) and bow string."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-arcane-swiftness.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-arcane-swiftness.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of arcane swiftness | OSRS Price Data
-description: "Sigil of arcane swiftness: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP."
+description: "Sigil of arcane swiftness: A power enhancing sigil not yet attuned to you. High alch: 6,000 GP."
 osrs:
   id: 29679
   name: Sigil of arcane swiftness
@@ -12,9 +12,48 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Sigil of arcane swiftness is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of arcane swiftness is a members-only Deadman Mode sigil in Old School RuneScape that reduces magic weapon attack speed by one tick for weapons with a base speed above four."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: sigil
+    tier: rare
+    category: sigil
+  properties:
+    release_date: "2024-07-17"
+    weight: 0.1
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    quest_item: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  relationships:
+    - item_name: Sigil of the swashbuckler
+      relationship: alternative
+      note: "Mutually exclusive with arcane swiftness — only one attack-speed sigil can be attuned at a time."
+    - item_name: Sigil of the gunslinger
+      relationship: alternative
+      note: "Mutually exclusive with arcane swiftness — only one attack-speed sigil can be attuned at a time."
+    - item_name: Deadman's skull
+      relationship: alternative
+      note: "Used to attune the sigil in Deadman Mode events."
+  market_strategy:
+    notes:
+      - "summary: \"Untradeable Deadman Mode reward; value tied to event participation rather than GE flow.\""
+      - "buy_strategy: \"Only available during Deadman Mode events from the skull shop or monster drops.\""
+      - "sell_strategy: \"Cannot be sold on the Grand Exchange — duplicates can be exchanged via Deadman's skull when supported.\""
+      - "volatility: \"none\""
+  trading_tips:
+    - "Untradeable on the main game economy outside of event drop-table windows."
+    - "Sigil slot is shared with arcane swiftness, swashbuckler, and gunslinger — only one may be attuned."
+    - "Sigil must be unattuned before it can be destroyed."
+  history:
+    - date: "2024-07-17"
+      description: "Sigil of arcane swiftness introduced with the Deadman Mode reward sigil system."
+  examine_variants:
+    - context: Inventory
+      text: "A power enhancing sigil not yet attuned to you."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-finality.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-finality.mdx
@@ -12,9 +12,39 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 4
-  about: "Sigil of finality is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: deadman
+  special_attack:
+    name: Finality
+    description: Activate the sigil to guarantee 100% accuracy on your next special attack within the next 12 seconds. Once activated, the sigil has a cooldown.
+    energy: 0
+    effects:
+      - description: "100% accuracy on next special attack"
+      - description: "12-second activation window"
+      - description: "Cooldown varies by Deadman event (10s in original Annihilation, up to 2 minutes in Reborn)"
+  related_items: []
+  market_strategy:
+    notes:
+      - "summary: \"Deadman event exclusive sigil; not available in live Old School RuneScape outside seasonal events.\""
+      - "target_audience: \"Deadman Mode PvPers stacking guaranteed special-attack accuracy.\""
+  trading_tips:
+    - Only obtainable during Deadman events; sold via the skull shop with Deadman's skull currency.
+    - GE limit listed as 4 per 4 hours, applicable only when GE is open for the event.
+  history:
+    - date: "2021-08-25"
+      description: Sigil of finality introduced for Deadman Reborn; reused in subsequent Deadman events with varying cooldowns.
+  about: |-
+    Sigil of finality is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 4 per 4 hours.
+
+    Exclusive to Deadman Mode events. When attuned and activated, guarantees 100% accuracy on the player's next special attack within a 12-second window.
+  properties:
+    release_date: "2021-08-25"
+    weight: 0.1
+    quest_item: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-prosperity.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-prosperity.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of prosperity | OSRS Price Data
-description: "Sigil of prosperity: A power enhancing sigil not yet attuned to you.. High alch: 12,000 GP, GE limit: 8."
+description: "Sigil of prosperity: A power enhancing sigil not yet attuned to you. High alch: 12,000 GP, GE limit: 8."
 osrs:
   id: 26081
   name: Sigil of prosperity
@@ -12,9 +12,35 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of prosperity is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: '2021-08-25'
+    quest_item: false
+    destroy: Drop
+  charges:
+    type: passive
+    description: When attuned, grants a 20% increased chance to receive loot from the Global Deadman Mode loot table.
+  drop_table:
+    - source: Deadman Mode global drop table
+      quantity: "1"
+      rarity: Uncommon
+  about: |-
+    "A power enhancing sigil not yet attuned to you."
+
+    Sigil of prosperity is a Deadman Mode exclusive sigil dropped from the global Deadman Mode loot table. Once attuned to a player it grants a 20% increased chance to receive loot from the global Deadman Mode loot table across Armageddon, Apocalypse, and Reborn variants.
+
+    Only available during temporary Deadman Mode events.
+  market_strategy:
+    notes:
+      - "Deadman Mode seasonal exclusive"
+      - "Tradeable only while un-attuned"
+      - "High demand during active DMM events"
+      - "Boosts loot rolls from global DMM table"
+      - "No utility outside DMM"
+  history:
+    - date: '2021-08-25'
+      description: Item released with Deadman Mode Reborn.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-gnomes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-gnomes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of the gnomes | OSRS Price Data
-description: "Sigil of the gnomes: A power enhancing sigil not yet attuned to you.. High alch: 12,000 GP, GE limit: 8."
+description: "Sigil of the gnomes: A power enhancing sigil not yet attuned to you. High alch: 12,000 GP, GE limit: 8."
 osrs:
   id: 26093
   name: Sigil of the gnomes
@@ -12,9 +12,58 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the gnomes is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2021-08-25"
+    quest_item: false
+    destroy: "You must unattune the Sigil before you can destroy it"
+  material:
+    type: sigil
+    tier: deadman-sigil
+  special_attack:
+    name: Tier 2 Skilling Sigil
+    description: "When attuned, grants 50% more XP in Cooking, Woodcutting, Thieving, and Runecraft."
+  drop_table:
+    primary_source: Deadman Mode drop table
+    sources:
+      - source: Deadman Mode monsters
+        quantity: "1"
+        rarity: common
+        members_only: true
+  related_items:
+    - item_id: 26091
+      item_name: Sigil of the dwarves
+      slug: sigil-of-the-dwarves
+      relationship: alternative
+      description: Another Tier 2 skilling sigil
+  about: |-
+    | Property | Value |
+    |----------|-------|
+    | Type | Deadman Sigil (Tier 2) |
+    | Skills boosted | Cooking, Woodcutting, Thieving, Runecraft |
+    | XP bonus | +50% |
+
+    - Members-only sigil from Deadman Mode events
+    - Only appears in live game during DMM seasons
+    - Attune via right-click; attuned form is untradeable
+
+    Power-up for casual skillers during DMM:
+    - Strong XP multiplier on four common skills
+    - Tradeable in untuned form only
+    - Cannot be alched while attuned
+  market_strategy:
+    notes:
+      - "Supply only during active Deadman Mode seasons"
+      - "Price collapses when sigils are removed from live game"
+      - "Speculative hold for next DMM event"
+  trading_tips:
+    - Tradeable while un-attuned; lock in profit before attuning
+    - Watch DMM announcements for liquidity windows
+    - Pairs with other tier 2 sigils in skilling kits
+  history:
+    - date: "2021-08-25"
+      description: "Released with the Deadman: Reborn update."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-meticulous-mage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-meticulous-mage.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of the meticulous mage | OSRS Price Data
-description: "Sigil of the meticulous mage: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP, GE limit: 10."
+description: "Sigil of the meticulous mage: A power enhancing sigil not yet attuned to you. High alch: 6,000 GP, GE limit: 10."
 osrs:
   id: 26003
   name: Sigil of the meticulous mage
@@ -12,9 +12,42 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of the meticulous mage is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sigil of the meticulous mage is a Deadman Mode reward sigil that boosts magic accuracy and grants a 50 percent chance to save runes or staff charges when casting spells."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: sigil
+    tier: rare
+    category: sigil
+  properties:
+    release_date: "2021-08-25"
+    weight: 0.1
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    quest_item: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  relationships:
+    - item_name: Deadman's skull
+      relationship: alternative
+      note: "Used to attune the sigil and exchange duplicates during Deadman Mode events."
+  market_strategy:
+    notes:
+      - "summary: \"Untradeable Deadman Mode reward; value scales with event participation and sigil slot meta.\""
+      - "buy_strategy: \"Only obtainable during Deadman Mode events via Deadman's skull shop or drop table.\""
+      - "sell_strategy: \"Untradeable on the live Grand Exchange; duplicates can be exchanged through the Deadman's skull interface.\""
+      - "volatility: \"none\""
+  trading_tips:
+    - "Sigil grants +40 magic accuracy and 50 percent rune/staff charge save chance in the current event tuning."
+    - "Effect strength has historically scaled between +10 and +40 magic accuracy across Deadman events."
+    - "Must be unattuned before destruction."
+  history:
+    - date: "2021-08-25"
+      description: "Sigil of the meticulous mage introduced in the Deadman Reborn event."
+  examine_variants:
+    - context: Inventory
+      text: "A power enhancing sigil not yet attuned to you."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-swashbuckler.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-swashbuckler.mdx
@@ -1,20 +1,65 @@
 ---
 title: Sigil of the swashbuckler | OSRS Price Data
-description: "Sigil of the swashbuckler: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP."
+description: "Sigil of the swashbuckler reduces melee attack speed by 1 tick for 5-tick or slower weapons. Deadman Mode reward."
 osrs:
   id: 29673
   name: Sigil of the swashbuckler
   slug: sigil-of-the-swashbuckler
-  examine: A power enhancing sigil not yet attuned to you.
+  examine: "All melee weapons with a base attack speed above 4 will have it reduced by 1."
   members: true
   icon: Sigil of swashbuckler.png
-  value: 10000
-  lowalch: 4000
-  highalch: 6000
+  value: 1
+  lowalch: 0
+  highalch: 0
   limit: null
-  about: "Sigil of the swashbuckler is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.1
+  about: "Sigil of the swashbuckler is a Deadman Mode attunable sigil. When attuned, every melee weapon with a base attack speed slower than 4 ticks has its speed reduced by 1, dramatically improving slow weapon DPS."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: sigil
+    tier: special
+  related_items:
+    - item_name: Sigil of the gunslinger
+      relationship: alternative
+    - item_name: Sigil of arcane swiftness
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "summary: \"Untradeable Deadman Mode reward; no GE market.\""
+      - "buy_strategy: \"Obtained exclusively from Deadman: Annihilation skull shop or past Armageddon drops — no GE supply.\""
+      - "sell_strategy: \"Untradeable; value is purely from personal attunement during Deadman seasons.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Pair with 5-tick weapons like the Scythe of vitur or godswords for the biggest DPS gain."
+    - "Mutually exclusive with Sigil of the gunslinger and Sigil of arcane swiftness — pick one combat style sigil."
+    - "Up to three attunable sigils can be active at once; budget your sigil slots around combat priorities."
+  history:
+    - date: "2024-07-17"
+      description: "Released for Deadman: Annihilation as an attunable melee sigil."
+    - date: "2026-01-21"
+      description: "Renamed from Sigil of swashbuckler to Sigil of the swashbuckler."
+  properties:
+    release_date: "2024-07-17"
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+    quest_item: false
+  drop_table: []
+  shops:
+    - shop_name: Deadman Skull Shop
+      location: Deadman Annihilation
+      price: 0
+      currency: Skull tokens
+      stock: 1
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-bottoms.mdx
@@ -12,8 +12,30 @@ osrs:
   lowalch: 16000
   highalch: 24000
   limit: 70
+  about: "Skeletal bottoms are the legs piece of the Fremennik skeletal armour set, offering near-splitbark magic and defence stats for hybrid mage builds."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: misc
+    tier: rare
+    category: armour
+  properties:
+    release_date: "2005-08-01"
+    weight: 4.082
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: armour
+    attack_speed: 1
+    requirements:
+      defence: 40
+      magic: 40
+      quest: "The Fremennik Trials"
     attack_bonus:
       stab: 0
       slash: 0
@@ -27,78 +49,43 @@ osrs:
       magic: 10
       ranged: 0
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-      magic: 40
-    weight: 4.082
   drop_table:
     sources:
       - source: Dagannoth Prime
-        combat_level: 303
         quantity: "1"
         rarity: uncommon
-        drop_rate: 1/128
-        members_only: true
-  related_items:
-    - item_id: 6137
-      item_name: Skeletal helm
-      slug: skeletal-helm
+        notes: "Drop rate 1/128 from level 303 Dagannoth Prime."
+  relationships:
+    - item_name: Skeletal helm
       relationship: set-piece
-      description: Matching helm piece
-    - item_id: 6139
-      item_name: Skeletal top
-      slug: skeletal-top
+    - item_name: Skeletal top
       relationship: set-piece
-      description: Matching body piece
-    - item_id: 3389
-      item_name: Splitbark legs
-      slug: splitbark-legs
+    - item_name: Splitbark legs
       relationship: alternative
-      description: Craftable alternative
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +6 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +22 |
-    | Slash | +20 |
-    | Crush | +24 |
-    | Magic | +10 |
-
-    Requirements: 40 Defence, 40 Magic
-
-    | Stat | Skeletal Bottoms | Splitbark Legs |
-    |------|-----------------|----------------|
-    | Magic Atk | +6 | +7 |
-    | Stab Def | +22 | +22 |
-    | Slash Def | +20 | +20 |
-    | Crush Def | +24 | +25 |
-    | Magic Def | +10 | +10 |
-
-    Nearly identical — splitbark has +1 magic attack and +1 crush defence. The difference is negligible.
-
-    | Stat | Total |
-    |------|-------|
-    | Magic Atk | +16 |
-    | Stab Def | +67 |
-    | Slash Def | +54 |
-    | Crush Def | +77 |
-    | Magic Def | +28 |
-
-    Compare to full splitbark: +20 magic attack, +68/+55/+78 melee def, +28 magic def. Splitbark is marginally better across the board.
+      note: "Craftable mage leg slot with marginally better stats."
+    - item_name: Peer the Seer
+      relationship: alternative
+      note: "Sells replacements in Rellekka for 2 dagannoth hides, 1 fibula piece, and 7,500 coins."
   market_strategy:
     notes:
-      - Dagannoth Prime drop (passive from DK farming)
-      - Low trade volume
-      - Collector's piece — splitbark preferred for stats
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "summary: \"Niche Dagannoth Prime drop with thin volume — collector and Fremennik completionist demand.\""
+      - "buy_strategy: \"Buy passively at GE mid-price; supply tracks Dagannoth Kings farming uptime.\""
+      - "sell_strategy: \"Sell at GE mid-price; splitbark legs cap the upper bound on price.\""
+      - "volatility: \"low\""
+  trading_tips:
+    - "Requires The Fremennik Trials quest plus 40 Defence and 40 Magic to wear."
+    - "Splitbark legs offer marginally better stats and no quest gate."
+    - "Storable in the magic wardrobe of a costume room as part of the skeletal set."
+  history:
+    - date: "2005-08-01"
+      description: "Skeletal bottoms released with the Fremennik skeletal armour set."
+  examine_variants:
+    - context: Inventory
+      text: "A superior set of strengthened slacks for any self respecting seer."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sleeping-cap.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sleeping-cap.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sleeping cap | OSRS Price Data
-description: "Sleeping cap: A cap for wearing whilzzzzzzzzzz.. High alch: 1,200 GP, GE limit: 4."
+description: "Sleeping cap: A cap for wearing whilzzzzzzzzzz. High alch: 1,200 GP, GE limit: 4."
 osrs:
   id: 10398
   name: Sleeping cap
@@ -12,9 +12,59 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
-  about: "Sleeping cap is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sleeping cap is a cosmetic head slot reward from easy Treasure Trails that enhances the Yawn emote. Members-only. High alch 1,200 gp; GE limit 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.4
+  material:
+    type: misc
+    tier: standard
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    - source: "Easy Treasure Trail reward casket"
+      quantity: "1"
+      rarity: "1/1404"
+  treasure_trail:
+    tier: easy
+  history:
+    - date: "2006-12-05"
+      description: "Released as an easy clue scroll reward; enhances the Yawn emote with a sleeping head tilt."
+  trading_tips:
+    - "Tiny GE limit of 4 keeps the price volatile; ladder buy orders rather than waiting for instant fills."
+    - "Cosmetic-only; value follows easy clue scroll popularity and costume room collectors."
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Pure cosmetic; price floats with easy clue throughput and Yawn emote demand."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sliced-mushrooms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sliced-mushrooms.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sliced mushrooms | OSRS Price Data
-description: "Sliced mushrooms: A bowl of sliced Bittercap mushrooms.. High alch: 25 GP, GE limit: 13,000."
+description: "Sliced mushrooms: A bowl of sliced Bittercap mushrooms. High alch: 25 GP, GE limit: 13,000."
 osrs:
   id: 7080
   name: Sliced mushrooms
@@ -12,9 +12,63 @@ osrs:
   lowalch: 16
   highalch: 25
   limit: 13000
-  about: "Sliced mushrooms is a members-only item in Old School RuneScape. High alchemy value: 25 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sliced mushrooms is a members-only cooking ingredient used to make fried mushrooms and as a topping component for baked potato dishes."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: misc
+    tier: common
+    category: ingredient
+  properties:
+    release_date: "2006-01-30"
+    weight: 0.5
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+  recipes:
+    - item_name: Sliced mushrooms
+      skill: Cooking
+      level: 1
+      xp: 0
+      tools:
+        - Knife
+      materials:
+        - item_name: Bowl
+          quantity: 1
+        - item_name: Bittercap mushroom
+          quantity: 1
+      output_quantity: 1
+      notes: "Combine a bowl with a bittercap mushroom while carrying a knife — no Cooking level required."
+  relationships:
+    - item_name: Bittercap mushroom
+      relationship: component
+    - item_name: Bowl
+      relationship: component
+    - item_name: Fried mushrooms
+      relationship: product
+      note: "Cooked at level 46 Cooking on a fire or range for 60 Cooking XP."
+    - item_name: Mushroom & onion
+      relationship: product
+      note: "Topping for baked potato meals in Gnome cooking."
+  market_strategy:
+    notes:
+      - "summary: \"Cheap ingredient with steady demand from gnome cooking and potato topping recipes; thin margin.\""
+      - "buy_strategy: \"Buy bittercaps and bowls separately and prep if the prepared spread covers GE tax.\""
+      - "sell_strategy: \"Sell at GE mid-price; turnover is moderate but volume is capped by limited demand.\""
+      - "volatility: \"low\""
+  trading_tips:
+    - "No Cooking level required to slice — useful XP-free prep for stew/topping recipes."
+    - "Burns into worthless burnt mushrooms if Cooking is under 46."
+    - "Sells at a small loss versus raw ingredients due to GE tax; prep is convenience-priced."
+  history:
+    - date: "2006-01-30"
+      description: "Sliced mushrooms released with the Gnome cooking content."
+  examine_variants:
+    - context: Inventory
+      text: "A bowl of sliced Bittercap mushrooms."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spined-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spined-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Spined boots | OSRS Price Data
-description: "Spined boots: Some finely crafted Fremennik boots, made from spined dagannoth hide.. High alch: 390 GP, GE limit: 125."
+description: "Spined boots: Some finely crafted Fremennik boots, made from spined dagannoth hide. High alch: 390 GP, GE limit: 125."
 osrs:
   id: 6143
   name: Spined boots
@@ -12,9 +12,80 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 125
-  about: "Spined boots is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: spined-hide
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 3.175
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Spined dagannoth"
+        quantity: "1"
+        rarity: "2/128"
+  related_items:
+    - item_name: "Spined helm"
+      slug: "spined-helm"
+      relationship: set-piece
+      description: "Spined armour helm — completes the Fremennik ranged set."
+    - item_name: "Spined body"
+      slug: "spined-body"
+      relationship: set-piece
+      description: "Spined armour torso — completes the Fremennik ranged set."
+    - item_name: "Spined chaps"
+      slug: "spined-chaps"
+      relationship: set-piece
+      description: "Spined armour legs — completes the Fremennik ranged set."
+  about: "Spined boots are Fremennik ranged armour for the feet slot, dropped by spined dagannoths on Waterbirth Island at a 2/128 rate. They have no level or quest requirements, provide +1 slash and +1 crush defence, and can be stored in the costume room armour case as part of the spined armour set. The wider spined set itself requires the Fremennik Trials and 40 Ranged / 40 Defence to wear."
+  market_strategy:
+    notes:
+      - "Supply is fully drop-gated by spined dagannoth kills on Waterbirth Island."
+      - "Demand is split between fashionscape and ironman-adjacent armour-case completions."
+      - "Low buy limit (125) keeps speculation small."
+  trading_tips:
+    - "Watch for slayer task spikes against dagannoths — supply gluts after popular task rotations."
+    - "GE price tends to track total spined-set value rather than the boot's combat usefulness."
+    - "Costume-room collectors create a long-tail bid; outright sells rarely undercut hard."
+  history:
+    - date: "2005-08-01"
+      description: "Released as part of the Waterbirth Island and spined armour update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spiny-helmet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spiny-helmet.mdx
@@ -1,20 +1,97 @@
 ---
 title: Spiny helmet | OSRS Price Data
-description: "Spiny helmet: You don't want to wear it inside-out.. High alch: 390 GP, GE limit: 125."
+description: "Spiny helmet: You don't want to wear it inside-out. High alch: 390 GP, GE limit: 125."
 osrs:
   id: 4551
   name: Spiny helmet
   slug: spiny-helmet
-  examine: You don't want to wear it inside-out.
+  examine: "You don't want to wear it inside-out."
   members: true
   icon: Spiny helmet.png
   value: 650
   lowalch: 260
   highalch: 390
   limit: 125
-  about: "Spiny helmet is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 2.267
+  about: "Spiny helmet is a Slayer-required headpiece needed to fight wall beasts in the Lumbridge Swamp Caves. It matches a steel full helm defensively and is one of six components needed to craft a slayer helmet."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: steel
+    tier: tier_5
+  equipment:
+    slot: head
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 9
+      slash: 10
+      crush: 7
+      magic: -1
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Slayer Equipment
+      location: Edgeville Slayer Master
+      price: 650
+      currency: coins
+      stock: 5
+    - shop_name: Slayer Equipment
+      location: Burthorpe
+      price: 650
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Slayer helmet
+      relationship: upgrade
+    - item_name: Slayer helmet (i)
+      relationship: upgrade
+    - item_name: Wall beast
+      relationship: alternative
+    - item_name: Mirror shield
+      relationship: alternative
+    - item_name: Reinforced goggles
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "summary: \"Slayer protection helmet with low GE volume but consistent demand for slayer helm crafting.\""
+      - "buy_strategy: \"Buy from any Slayer Master shop for 650 gp when restocked; resell on GE around 1k for thin margin.\""
+      - "sell_strategy: \"Sell to slayer helm crafters; volume is thin but limit is only 125 per 4h.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Required for wall beast slayer tasks — every slayer veteran will buy one eventually."
+    - "Component of the slayer helmet recipe (54 Crafting); often bulk-bought during ironman skilling."
+    - "Slayer Master shop sells for 650 gp — beat the GE price by sourcing directly when grinding tasks."
+  history:
+    - date: "2005-03-14"
+      description: "Released as protection against wall beasts in the Lumbridge Swamp Caves."
+  properties:
+    release_date: "2005-03-14"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  drop_table: []
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrowtips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrowtips.mdx
@@ -12,23 +12,79 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 10000
-  related_items:
-    - item_id: 40
-      item_name: Iron arrowtips
-      slug: iron-arrowtips
+  about: "Steel arrowtips are members-only Fletching components. Attach 15 to headless arrows at 30 Fletching for 75 XP to create steel arrows. Smithed from steel bars at level 35 Smithing. High alchemy value: 3 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: ammunition
+    tier: steel
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    equipable: false
+    stackable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0
+  recipes:
+    - item_name: Steel arrowtips
+      skill: smithing
+      level: 35
+      xp: 37.5
+      output_quantity: 15
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_name: Steel bar
+          quantity: "1"
+    - item_name: Steel arrow
+      skill: fletching
+      level: 30
+      xp: 75
+      output_quantity: 15
+      tools: []
+      materials:
+        - item_name: Headless arrow
+          quantity: "15"
+        - item_name: Steel arrowtips
+          quantity: "15"
+  shops:
+    - shop_name: Lowe's Archery Emporium
+      location: Varrock
+      currency: coins
+      price: 6
+      stock: 50
+    - shop_name: Ava's Odds and Ends
+      location: Draynor Manor
+      currency: coins
+      price: 7
+      stock: 0
+    - shop_name: Combat Training Camp
+      location: Ranging Guild
+      currency: coins
+      price: 9
+      stock: 0
+  relationships:
+    - item_name: Iron arrowtips
       relationship: variant
-      description: Lower tier arrowtips
-    - item_id: 42
-      item_name: Mithril arrowtips
-      slug: mithril-arrowtips
+    - item_name: Mithril arrowtips
       relationship: variant
-      description: Higher tier arrowtips
-  about: |-
-    > _"I can make some arrows with these."_
-
-    Steel arrowtips are members-only Fletching supplies. Attach to headless arrows at 30 Fletching to create steel arrows.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Steel bar
+      relationship: component
+    - item_name: Steel arrow
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - "short_term: \"Liquid Fletching supply; tight margins but high volume — best at flipping by the thousand.\""
+      - "long_term: \"Stable supply tied to mid-level Smithing/Fletching; demand trends with archery training popularity.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Smith bars when GE price exceeds ~36 gp per tip for a small smithing profit."
+    - "Combine with headless arrows at 30 Fletching to convert into steel arrows for resale margin."
+  history:
+    - date: "2002-03-25"
+      description: "Released with the initial Fletching skill and arrow-crafting content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts-p-9302.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts-p-9302.mdx
@@ -13,8 +13,60 @@ osrs:
   highalch: 4
   limit: 11000
   about: "Steel bolts (p++) is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: ammunition
+    tier: steel
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    equipable: true
+    stackable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    attack_speed: 1
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 64
+      magic_damage: 0
+      prayer: 0
+  relationships:
+    - item_name: Steel bolts
+      relationship: upgrade
+    - item_name: Steel bolts (p)
+      relationship: variant
+    - item_name: Steel bolts (p+)
+      relationship: variant
+  market_strategy:
+    notes:
+      - "short_term: \"Super poisoned steel bolts cater to a niche PvM/poison playstyle; demand is thin so spreads can be wide.\""
+      - "long_term: \"Tied to mid-level Ranged training and poison utility; stable but low-volume.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Check live GE volume before stacking large orders — turnover on (p++) bolts is slow."
+    - "List close to the guide price; thin markets punish aggressive overbids."
+  history:
+    - date: "2006-07-31"
+      description: "Released with the Steel bolts family and poison variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-javelin-p.mdx
@@ -12,26 +12,86 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 7000
+  weight: 0
+  about: "Steel javelin(p) is the poisoned variant of the steel javelin, fired by ballistae. Applying weapon poison gives each shot a chance to inflict 2-4 damage over time, adding extra utility for low-level PvP and slayer tasks."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: steel
+    tier: tier_5
   equipment:
-    slot: weapon
+    slot: ammunition
+    weapon_type: thrown
     attack_speed: 6
     requirements:
       ranged: 5
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 12
-    ranged_strength: 40
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 40
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Steel javelin(p)
+      skill: Herblore
+      level: 5
+      xp: 0
+      tools:
+        - Vial of weapon poison
+      materials:
+        - item_name: Steel javelin
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      output_quantity: 1
   related_items:
-    - item_id: 827
-      item_name: Steel javelin
-      slug: steel-javelin
+    - item_name: Steel javelin
       relationship: variant
-      description: Unpoisoned version
-  about: |-
-    > _"A steel tipped javelin with a poisoned tip."_
-
-    A steel javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Steel javelin(p+)
+      relationship: variant
+    - item_name: Steel javelin(p++)
+      relationship: variant
+    - item_name: Weapon poison
+      relationship: component
+  market_strategy:
+    notes:
+      - "summary: \"Niche poisoned ammunition with thin daily volume but stable PvP demand.\""
+      - "buy_strategy: \"Pick up bulk steel javelins, poison them yourself with weapon poison vials for margin.\""
+      - "sell_strategy: \"List in 1k stacks to ballistae users and slayer accounts; expect slow but steady fills.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Poisoning your own steel javelins is cheaper than buying p variants outright when weapon poison is cheap."
+    - "Useful as ammunition for the dorgeshuun crossbow players running low-tier ranged setups."
+    - "Stack up to 7,000 per GE slot, but expect listings to sit longer than the base steel javelin."
+  history:
+    - date: "2004-03-29"
+      description: "Released alongside the original javelin and ballista weapons."
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: false
+    destroy: "Drop"
+    quest_item: false
+  drop_table: []
+  special_attack:
+    has_special: false
+  charges:
+    has_charges: false
+  potion:
+    is_potion: false
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-plateskirt.mdx
@@ -12,9 +12,123 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
-  about: "Steel plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2001-02-13"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: cloth
+    tier: steel
+    primary_material: steel
+  equipment:
+    slot: legs
+    weight: 8.164
+    tradeable: true
+    requirements:
+      defence: 5
+    stats:
+      attack_stab: 0
+      attack_slash: 0
+      attack_crush: 0
+      attack_magic: 0
+      attack_ranged: 0
+      defence_stab: 17
+      defence_slash: 16
+      defence_crush: 15
+      defence_magic: -4
+      defence_ranged: -11
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Steel plateskirt
+      skill: Smithing
+      level: 46
+      xp: 112.5
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_id: 2353
+          item_name: Steel bar
+          slug: steel-bar
+          quantity: 3
+      output_quantity: 1
+  shops:
+    - shop_name: Zeke's Superior Scimitars
+      location: Al Kharid
+      price: 1000
+      stock: 0
+    - shop_name: Shayzien Armour Shop
+      location: Shayzien
+      price: 1000
+      stock: 0
+    - shop_name: Civitas illa Fortis Armour Shop
+      location: Civitas illa Fortis
+      price: 1000
+      stock: 0
+  related_items:
+    - item_id: 1069
+      item_name: Steel platelegs
+      slug: steel-platelegs
+      relationship: variant
+      description: Heavier legs piece with identical defensive stats.
+    - item_id: 1119
+      item_name: Steel platebody
+      slug: steel-platebody
+      relationship: set-piece
+      description: Matching body piece of steel armour.
+    - item_id: 1157
+      item_name: Steel full helm
+      slug: steel-full-helm
+      relationship: set-piece
+      description: Matching helm piece of steel armour.
+    - item_id: 2353
+      item_name: Steel bar
+      slug: steel-bar
+      relationship: component
+      description: Required to smith the plateskirt.
+  about: |-
+    Steel plateskirt is a low-level legs slot piece equivalent to steel platelegs but lighter.
+
+    | Requirement | Value |
+    |-------------|-------|
+    | Defence | 5 |
+    | Smithing | 46 (112.5 XP) |
+
+    Made by smithing 3 steel bars at an anvil with a hammer.
+
+    | Defence | Bonus |
+    |---------|-------|
+    | Stab | +17 |
+    | Slash | +16 |
+    | Crush | +15 |
+    | Magic | -4 |
+    | Ranged | -11 |
+
+    Used for:
+    - F2P early melee training
+    - Smithing XP product
+    - Light loadout vs platelegs
+  market_strategy:
+    notes:
+      - "F2P-friendly with steady demand"
+      - "Smithing alternative to platelegs"
+      - "Lighter weight appeals to F2P pures"
+  trading_tips:
+    - Track steel bar Smithing margins for crafting profit.
+    - GE buy limit of 125 every 4 hours supports moderate flipping.
+    - Demand bumps during F2P bond/membership promos.
+  history:
+    - date: "2001-02-13"
+      description: "Released as part of base armour."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-thrownaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-thrownaxe.mdx
@@ -12,14 +12,41 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 7000
+  material:
+    type: ammunition
+    tier: steel
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 5
     requirements:
       ranged: 5
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 8
-    ranged_strength: 11
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 11
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    - source: Gorak
+      quantity: "1"
+      rarity: 3/128
+  shops:
+    - shop_name: Authentic Throwing Weapons
+      location: Ranging Guild
+      price: 33
+      stock: unlimited
   related_items:
     - item_id: 801
       item_name: Iron thrownaxe
@@ -31,12 +58,27 @@ osrs:
       slug: mithril-thrownaxe
       relationship: variant
       description: Higher tier thrownaxe
+  market_strategy:
+    notes:
+      - "summary: \"Niche ranged throwing weapon with low demand; supplied via shop and goblin-tier drops.\""
+      - "target_audience: \"Low-level rangers and ironmen leveling Ranged via thrownaxes.\""
+  trading_tips:
+    - Buy from Authentic Throwing Weapons in the Ranging Guild for steady stock at 33 gp.
+    - Watch GE limit of 7,000 per 4 hours when flipping.
+  history:
+    - date: "2004-03-29"
+      description: Steel thrownaxe released alongside other thrownaxe tiers.
   about: |-
     > _"A finely balanced throwing axe."_
 
     The steel thrownaxe requires 5 Ranged. Features the bouncing special attack shared by all thrownaxes.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  properties:
+    release_date: "2004-03-29"
+    weight: 0
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super antifire mix(1) | OSRS Price Data
-description: "Super antifire mix(1): One dose of fishy super anti-firebreath potion.. High alch: 79 GP, GE limit: 2,000."
+description: "Super antifire mix(1) is a P2P Barbarian Herblore 1-dose potion blocking dragonfire. High alch: 79 GP, GE limit: 2,000."
 osrs:
   id: 21997
   name: Super antifire mix(1)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 52
   highalch: 79
   limit: 2000
-  about: "Super antifire mix(1) is a members-only item in Old School RuneScape. High alchemy value: 79 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 0.045
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: potion
+    tier: bronze
+    category: consumable
+  potion:
+    doses: 1
+    boost: "Full dragonfire immunity"
+    duration_minutes: 3
+    skill: "Hitpoints"
+    notes: "Each sip also heals 6 Hitpoints; requires Dragon Slayer I started."
+  recipes:
+    - skill: "Herblore"
+      level: 92
+      xp: 70
+      output_quantity: 1
+      item_name: "Super antifire mix(2)"
+      tools: []
+      inputs:
+        - item_name: "Super antifire potion(2)"
+          quantity: 1
+        - item_name: "Caviar"
+          quantity: 1
+      notes: "Barbarian Herblore mixing; requires Barbarian Training (Herblore) unlocked. Makes a 2-dose mix that can be split into 1-dose."
+  related_items:
+    - item_id: 21993
+      item_name: Super antifire potion(4)
+      slug: super-antifire-potion-4
+      relationship: variant
+      description: "Standard 4-dose super antifire potion"
+    - item_id: 21999
+      item_name: Super antifire mix(2)
+      slug: super-antifire-mix-2
+      relationship: variant
+      description: "2-dose mix that heals Hitpoints"
+    - item_id: 11457
+      item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: "Required Barbarian Herblore ingredient"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy at GE if you only need a single dose for a one-off dragon kill.\""
+      - "sell_strategy: \"Sell to PvMers running short Vorkath / dragon trips.\""
+      - "price_trend: \"Tracks super antifire and caviar prices.\""
+      - "profit_margin: \"Thin; mostly utility purchase.\""
+  trading_tips:
+    - "Heals 6 HP per sip — saves food on dragon tasks."
+    - "Requires Barbarian Training (Herblore) unlocked to make."
+    - "Pairs with antifire shield for total dragon protection."
+  history:
+    - date: "2018-01-04"
+      update: "Super antifire release"
+      description: "Super antifire and its Barbarian Herblore mix variants released alongside the wider antifire rework."
+  about: |-
+    Super antifire mix(1) is a Barbarian Herblore variant that grants full dragonfire immunity and minor healing.
+
+    | Property | Value |
+    |----------|-------|
+    | Dragonfire | Fully blocked (no shield required) |
+    | Heal per dose | 6 HP |
+    | Duration | 3 minutes |
+    | Herblore level | 92 (Barbarian) |
+    | XP per mix | 70 |
+
+    Often packed in 1-dose form for Vorkath KO / quick dragon kills.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-mix-2.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 2000
-  about: "Super restore mix(2) is a members-only item in Old School RuneScape. High alchemy value: 108 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: barbarian_potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.09
+    options: ["Drink"]
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 67
+      xp: 48
+      materials:
+        - item_name: "Super restore(2)"
+          quantity: 1
+        - item_name: "Caviar"
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Restores all lowered skills by 8 + 25% of the player's current level (excluding Hitpoints)."
+        duration: 0
+      - description: "Restores Prayer points by the same formula."
+        duration: 0
+      - description: "Heals 6 Hitpoints per dose as a Barbarian mix bonus."
+        duration: 0
+  related_items:
+    - item_name: "Super restore(2)"
+      slug: "super-restore-2"
+      relationship: "component"
+      description: "Base 2-dose potion combined with caviar to create the mix."
+    - item_name: "Caviar"
+      slug: "caviar"
+      relationship: "component"
+      description: "Barbarian Herblore ingredient that converts the potion into a mix."
+    - item_name: "Super restore mix(1)"
+      slug: "super-restore-mix-1"
+      relationship: "variant"
+      description: "Single-dose version of the same Barbarian mix."
+  about: "Super restore mix(2) is a Barbarian Herblore potion made at level 67 Herblore by combining a Super restore(2) with caviar for 48 XP. Released July 3, 2007 alongside Barbarian Training. Each dose restores all lowered stats (8 + 25% of level), restores Prayer points, and heals 6 Hitpoints. Renamed in February 2015 from Sup. restore mix to Super restore mix."
+  market_strategy:
+    notes:
+      - "Barbarian mix - typically loss-making to brew, so supply depends on Herblore XP grinders."
+      - "Demand is niche - speedrunners and HCIMs use it for the extra heal during prayer-heavy bosses."
+      - "Caviar price drives margin more than base super restore."
+      - "Volume thin; 2k buy limit rarely fills in a single window."
+  trading_tips:
+    - "Track caviar (roe-feathered) GE price - it sets the floor."
+    - "Bulk-buy when Herblore XP events flood the market with mix overflow."
+    - "Use 1-dose vs 2-dose price gap to flip into the cheaper-per-dose form."
+  history:
+    - date: "2007-07-03"
+      description: "Released alongside Barbarian Training as a Herblore mix potion."
+    - date: "2015-02-26"
+      description: "Renamed from Sup. restore mix to Super restore mix."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super strength(2) | OSRS Price Data
-description: "Super strength(2): 2 doses of super Strength potion.. High alch: 99 GP, GE limit: 2,000."
+description: "Super strength(2) is a P2P 2-dose Herblore potion that boosts Strength. High alch: 99 GP, GE limit: 2,000."
 osrs:
   id: 159
   name: Super strength(2)
@@ -12,23 +12,81 @@ osrs:
   lowalch: 66
   highalch: 99
   limit: 2000
+  weight: 0.025
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: misc
+    tier: bronze
+    category: consumable
+  potion:
+    doses: 2
+    boost: "+5 + 15% of Strength level"
+    duration_minutes: 5
+    skill: "Strength"
+    notes: "Boost decays 1 point per minute (90s with Preserve)."
+  recipes:
+    - skill: "Herblore"
+      level: 55
+      xp: 125
+      output_quantity: 1
+      item_name: "Super strength(3)"
+      tools: []
+      inputs:
+        - item_name: "Kwuarm potion (unf)"
+          quantity: 1
+        - item_name: "Limpwurt root"
+          quantity: 1
+      notes: "Make a 3-dose potion, then split or drink down to 2 doses."
   related_items:
     - item_id: 157
       item_name: Super strength(3)
       slug: super-strength-3
       relationship: variant
-      description: 3-dose version
+      description: "3-dose version"
     - item_id: 161
       item_name: Super strength(1)
       slug: super-strength-1
       relationship: variant
-      description: 1-dose version
+      description: "1-dose version"
+    - item_id: 12625
+      item_name: Super combat potion(4)
+      slug: super-combat-potion-4
+      relationship: alternative
+      description: "Combined super strength/attack/defence potion"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy doses cheap when combat potion making is unprofitable.\""
+      - "sell_strategy: \"Decant up to 4-dose for higher per-dose value.\""
+      - "price_trend: \"Tracks kwuarm and limpwurt root supply.\""
+      - "profit_margin: \"Decanting bots compress margins.\""
+  trading_tips:
+    - "Decant via Wise Old Man / Bob Barter to higher-dose versions for a small profit."
+    - "Combine with super attack/defence + torstol for super combat potions."
+    - "Bulk used for Slayer and PvM training stacks."
+  history:
+    - date: "2002-02-27"
+      update: "Herblore release"
+      description: "Super strength introduced as part of the original Herblore release."
   about: |-
-    > _"2 doses of super Strength potion."_
+    Super strength(2) is a 2-dose Herblore potion that grants a temporary Strength boost.
 
-    A 2-dose super strength potion. Boosts Strength by 5 + 15% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    | Property | Value |
+    |----------|-------|
+    | Boost | +5 + 15% of base Strength |
+    | Duration per dose | ~5 minutes |
+    | Herblore level (make) | 55 |
+    | Herblore XP (3-dose) | 125 |
+
+    Often combined with super attack and torstol for super combat potion brewing.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/superantipoison-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/superantipoison-2.mdx
@@ -12,23 +12,73 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 2000
+  about: "Two-dose Super antipoison potion that cures poison and grants 6 minutes of poison immunity per dose; reduces venom to poison before clearing it."
+  potion:
+    doses: 2
+    effects:
+      - description: "Cures poison and grants 6 minutes of poison immunity per dose."
+        duration: 360
+      - description: "Reduces Zulrah-style venom to poison before clearing it."
+  recipes:
+    - skill: Herblore
+      level: 48
+      xp: 106.3
+      tools:
+        - Pestle and mortar
+      materials:
+        - item_name: Irit potion (unf)
+          quantity: 1
+        - item_name: Unicorn horn dust
+          quantity: 1
+      output_quantity: 1
+      notes: "Produces Superantipoison(3); 2-dose form is intermediate decanting."
   related_items:
-    - item_id: 181
-      item_name: Superantipoison(3)
-      slug: superantipoison-3
+    - item_name: Superantipoison(1)
       relationship: variant
-      description: 3-dose version
-    - item_id: 185
-      item_name: Superantipoison(1)
-      slug: superantipoison-1
+    - item_name: Superantipoison(3)
       relationship: variant
-      description: 1-dose version
-  about: |-
-    > _"2 doses of super antipoison potion."_
-
-    A 2-dose superantipoison. Cures poison and grants 6 minutes immunity.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Superantipoison(4)
+      relationship: variant
+    - item_name: Antipoison(2)
+      relationship: downgrade
+    - item_name: Antidote+(2)
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - "Mid-tier antipoison; usually pricier per dose than Antidote++ during peak Zulrah hours."
+      - "Decanting service profit/loss varies — compare 2-dose GE price vs 1.5x the 4-dose price."
+      - "GE buy limit of 2,000 supports moderate flipping volume."
+  trading_tips:
+    - "Use 4-dose pricing as the baseline; 2-dose often trades at a small per-dose premium."
+    - "Stock up before Slayer tasks against poisonous monsters or new poison content drops."
+    - "Empty option lets you reclaim the vial — track vial price for full margin math."
+  history:
+    - date: "2002-02-27"
+      description: "Superantipoison line released."
+    - date: "2004-03-29"
+      description: "4-dose variant became permanently available with the RuneScape 2 launch."
+    - date: "2004-10-26"
+      description: "Empty option added to all potion doses."
+    - date: "2016-04-07"
+      description: "Drinking any kind of antipoison no longer decreases your poison immunity timer."
+  properties:
+    release_date: "2002-02-27"
+    update: "Herblore release"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teal-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teal-hat.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Teal hat is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Teal hat is a members-only cosmetic head slot item in Old School RuneScape, part of the Canifis robes set sold by Barkers' Haberdashery."
+  equipment:
+    slot: head
+    attack_bonus:
+      magic: 3
+    defence_bonus:
+      magic: 3
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      stock: 5
+      price: 650
+      currency: Coins
+  related_items:
+    - item_name: Grey hat
+      relationship: variant
+    - item_name: Red hat
+      relationship: variant
+    - item_name: Yellow hat
+      relationship: variant
+    - item_name: Purple hat
+      relationship: variant
+    - item_name: Teal robe top
+      relationship: set-piece
+    - item_name: Teal robe bottoms
+      relationship: set-piece
+    - item_name: Teal gloves
+      relationship: set-piece
+    - item_name: Teal boots
+      relationship: set-piece
+  market_strategy:
+    notes:
+      - "Cosmetic-only Canifis robes piece — value driven by fashionscape demand, not combat utility."
+      - "Shop sells at 650 GP with steady restock; GE premium reflects convenience over the Canifis trip."
+      - "Magic +3 attack/defence bonuses are negligible compared with proper magic gear."
+  trading_tips:
+    - "Buy directly from Barkers' Haberdashery in Canifis for guaranteed 650 GP each."
+    - "Flip GE listings during fashionscape events when colored hats spike."
+    - "Low daily volume — large orders may take time to fill."
+  history:
+    - date: "2004-06-29"
+      description: "Hat released with the Priest in Peril update."
+    - date: "2014-12-10"
+      description: "Renamed from 'Hat' to 'Teal hat' to disambiguate colour variants."
+  properties:
+    release_date: "2004-06-29"
+    update: "Priest in Peril"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teleport-to-house-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teleport-to-house-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teleport to house (tablet) | OSRS Price Data
-description: "Teleport to house (tablet): A teleport to one's own house.. High alch: 1 GP, GE limit: 15,000."
+description: "Teleport to house (tablet): A teleport to one's own house. High alch: 1 GP, GE limit: 15,000."
 osrs:
   id: 8013
   name: Teleport to house (tablet)
@@ -12,85 +12,64 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15000
-  item:
-    type: teleport_tablet
+  about: "Teleport to house (tablet) breaks to teleport the user directly to their player-owned house portal with no runes equipped. Members-only. GE limit 15,000."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-05-31"
     tradeable: true
+    equipable: false
+    stackable: false
+    noteable: false
+    destroy: "Drop"
+    quest_item: false
     weight: 0
-  magic:
-    spell: Teleport to House
-  effect:
-    teleport: true
-    destination: Player-owned house
+  material:
+    type: tablet
+    tier: standard
   recipes:
-    - skill: magic
+    - item_name: "Teleport to house (tablet)"
+      skill: "Magic"
       level: 40
       xp: 30
+      tools:
+        - "Mahogany eagle lectern (POH)"
       materials:
-        - item_name: Soft clay
-          item_id: 1761
+        - item_name: "Soft clay"
           quantity: 1
-        - item_name: Law rune
-          item_id: 563
+        - item_name: "Law rune"
           quantity: 1
-        - item_name: Air rune
-          item_id: 556
+        - item_name: "Air rune"
           quantity: 1
-        - item_name: Earth rune
-          item_id: 557
+        - item_name: "Earth rune"
           quantity: 1
-      product: Teleport to house
-      product_id: 8013
-      product_quantity: 1
-      facility: Lectern (POH)
-      members_only: true
+      output_quantity: 1
   related_items:
     - item_id: 11740
       item_name: Scroll of redirection
       slug: scroll-of-redirection
-      relationship: upgrade
-      description: Redirects tablet to other locations
+      relationship: variant
+      description: Redirects this tablet to alternate house portal locations
     - item_id: 563
       item_name: Law rune
       slug: law-rune
       relationship: component
-      description: Crafting material
+      description: Required rune component
     - item_id: 1761
       item_name: Soft clay
       slug: soft-clay
       relationship: component
-      description: Tablet base
-  about: |-
-    Teleport to POH:
-    - Teleports to your player-owned house portal
-    - One-click teleport without runes
-    - Popular for quick banking and POH utilities
-
-    POH Portal Locations:
-    - Rimmington (default)
-    - Taverley
-    - Pollnivneach
-    - Hosidius
-    - Rellekka
-    - Brimhaven
-    - Yanille
-    - Prifddinas (75 Construction)
-
-    Use Scroll of redirection to redirect tablets:
-
-    | Destination | Requirements |
-    |-------------|--------------|
-    | Various house portals | 50 Construction |
-    | Prifddinas | 75 Construction, Song of the Elves |
-
-    NMZ Points: 775 per scroll
+      description: Tablet base material
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Construction skill and player-owned house teleport tablets."
+  trading_tips:
+    - "Make in bulk at a POH lectern for repeatable Magic XP and consistent flip margin."
+    - "Demand spikes during PvM seasonal events; pair with Scroll of redirection for alternative teleports."
   market_strategy:
     notes:
-      - Essential utility item
-      - Cheaper than casting spell repeatedly
-      - Make in bulk at POH lectern for profit
-      - Popular for PvM banking
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "relationship: \"component\""
+      - "Essential utility tablet; price is bounded by law rune cost plus a fixed convenience premium."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-bolt-tips.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 11000
-  about: "Topaz bolt tips is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Topaz bolt tips is a members-only item in Old School RuneScape. Used to fletch topaz bolts. High alchemy value: 7 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-07-31"
+    weight: 0
+    tradeable: true
+    equipable: false
+    stackable: true
+    quest_item: false
+    destroy: "Drop"
+  material:
+    type: ammunition
+    tier: topaz
+  recipes:
+    - item_name: "Topaz bolt tips"
+      skill: "Fletching"
+      level_required: 48
+      xp: 3.9
+      tools:
+        - "Chisel"
+      materials:
+        - item_name: "Red topaz"
+          quantity: 1
+      output_quantity: 12
+      notes: "Cut a red topaz with a chisel to yield 12 bolt tips."
+    - item_name: "Topaz bolts"
+      skill: "Fletching"
+      level_required: 48
+      xp: 4
+      tools:
+        - "Hands"
+      materials:
+        - item_name: "Topaz bolt tips"
+          quantity: 10
+        - item_name: "Steel bolts"
+          quantity: 10
+      output_quantity: 10
+      notes: "Attach 10 tips to 10 steel bolts."
+    - item_name: "Topaz dragon bolts"
+      skill: "Fletching"
+      level_required: 84
+      xp: 0
+      tools:
+        - "Hands"
+      materials:
+        - item_name: "Topaz bolt tips"
+          quantity: 10
+        - item_name: "Dragon bolts"
+          quantity: 10
+      output_quantity: 10
+      notes: "Attach tips to dragon bolts."
+  relationships:
+    - item_name: "Red topaz"
+      relationship: component
+      notes: "Cut with a chisel to produce 12 bolt tips."
+    - item_name: "Topaz bolts"
+      relationship: component
+      notes: "Attached to steel bolts."
+    - item_name: "Topaz dragon bolts"
+      relationship: component
+      notes: "Attached to dragon bolts."
+    - item_name: "Sapphire bolt tips"
+      relationship: alternative
+      notes: "Lower-tier gem bolt tip variant."
+    - item_name: "Emerald bolt tips"
+      relationship: alternative
+      notes: "Adjacent-tier gem bolt tip variant."
+  history:
+    - date: "2006-07-31"
+      description: "Released with the Crossbows update."
+    - date: "2007-01-29"
+      description: "Vendor value reduced from 50 to 13 coins."
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy in bulk during low-volume periods; tips track red topaz cost.\""
+      - "sell_strategy: \"Fletch onto bolts for finished-product margin or sell raw to Fletching levelers.\""
+      - "profit_potential: \"Low per unit but high turnover; healthy daily volume.\""
+      - "risk_level: \"low\""
+  trading_tips:
+    - "Daily volume around 80k — highly liquid."
+    - "Price ties closely to red topaz GE price."
+    - "Buy limit 11,000 lets sizable flips per cycle."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platelegs-damaged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platelegs-damaged.mdx
@@ -12,43 +12,62 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: 8
-  item:
-    type: damaged armour
+  properties:
+    release_date: "2022-01-05"
     tradeable: true
-    weight: 9.071
-  obtaining:
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: metal
+    tier: zarosian
+    primary_material: ancient_metal
+  drop_table:
     - source: Nex
-      drop_rate: 1/43 per unique roll
-      notes: Requires Bandos tassets to repair
+      quantity: "1"
+      rarity: "1/258"
+      notes: "Unique drop from Nex in the Ancient Prison."
   recipes:
-    - skill: none
-      level: 0
+    - item_name: Torva platelegs
+      skill: Smithing
+      level: 90
+      xp: 0
+      tools:
+        - Hammer
+        - Anvil
       materials:
         - item_id: 26380
           item_name: Torva platelegs (damaged)
+          slug: torva-platelegs-damaged
           quantity: 1
         - item_id: 11834
           item_name: Bandos tassets
+          slug: bandos-tassets
           quantity: 1
-      product: Torva platelegs
-      product_id: 26386
-      notes: No skill requirements
+      output_quantity: 1
   related_items:
     - item_id: 11834
       item_name: Bandos tassets
       slug: bandos-tassets
       relationship: component
-      description: Required to repair
+      description: Required Bandosian component (consumed on repair).
     - item_id: 26386
       item_name: Torva platelegs
       slug: torva-platelegs
-      relationship: product
-      description: Repaired BiS melee legs
+      relationship: variant
+      description: Restored BiS melee legs slot equipment.
     - item_id: 26376
       item_name: Torva full helm (damaged)
       slug: torva-full-helm-damaged
-      relationship: alternative
-      description: Damaged helm from Nex
+      relationship: set-piece
+      description: Damaged Torva helm dropped by Nex.
+    - item_id: 26384
+      item_name: Torva platebody (damaged)
+      slug: torva-platebody-damaged
+      relationship: set-piece
+      description: Damaged Torva body dropped by Nex.
   about: |-
     | Property | Value |
     |----------|-------|
@@ -61,7 +80,7 @@ osrs:
     | Torva platelegs (damaged) | Nex | ~220M |
     | Bandos tassets | God Wars Dungeon | ~22M |
 
-    No skill requirements to combine the items.
+    Requires 90 Smithing to repair at an anvil with a hammer.
 
     | Item Created | Materials |
     |--------------|-----------|
@@ -75,12 +94,19 @@ osrs:
     - +16 total HP with full set
   market_strategy:
     notes:
-      - Nex exclusive drop
-      - Tassets consumed in repair
-      - Creates BiS melee legs
-      - Part of Torva set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Nex exclusive drop (1/258)"
+      - "Tassets consumed in repair"
+      - "Creates BiS melee legs"
+      - "Part of Torva set"
+  trading_tips:
+    - Buy damaged + Bandos tassets, repair only when restored Torva trades at a premium.
+    - GE buy limit 8 every 4 hours - long flips needed.
+    - Track Nex team participation rates for supply.
+  history:
+    - date: "2022-01-05"
+      description: "Released with Nex: The Fifth General update."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-alchemy-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-alchemy-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer reloaded alchemy scroll | OSRS Price Data
-description: "Trailblazer reloaded alchemy scroll: A scroll which unlocks the Trailblazer Reloaded Alchemy animation.. High alch: 15,000 GP."
+description: "Trailblazer reloaded alchemy scroll: A scroll which unlocks the Trailblazer Reloaded Alchemy animation. High alch: 15,000 GP."
 osrs:
   id: 28693
   name: Trailblazer reloaded alchemy scroll
@@ -12,9 +12,39 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Trailblazer reloaded alchemy scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Trailblazer reloaded alchemy scroll unlocks a fiery animation override for Low and High Level Alchemy. Members-only Trailblazer Reloaded league reward. High alch 15,000 gp."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.1
+  material:
+    type: misc
+    tier: standard
+  shops:
+    - shop_name: "Leagues Reward Shop"
+      location: "Lumbridge Castle"
+      price: 2000
+      currency: "League points"
+      stock: "Unlimited"
+  history:
+    - date: "2023-11-15"
+      description: "Added to the game files alongside the Trailblazer Reloaded league preparation update."
+    - date: "2023-11-29"
+      description: "Became obtainable when the Trailblazer Reloaded league launched."
+  trading_tips:
+    - "Cosmetic permanent unlock; once read, the animation toggle persists on the account."
+    - "Price drifts upward over time as the league pool shrinks and re-listings shift to cosmetic collectors."
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Pure cosmetic; value tracks Trailblazer Reloaded scarcity and collector demand, with no PvM/Fletching utility."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-boots-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-boots-t3.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded boots (t3) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Trailblazer reloaded boots (t3) is the tier 3 cosmetic footwear from the Trailblazer Reloaded League reward shop, purchased for 18,000 League points. High alchemy value: 9,000 coins."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.34
+  material:
+    type: cloth
+    tier: cosmetic
+  equipment:
+    slot: feet
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Leagues Reward Shop"
+      location: "Trailblazer Reloaded League"
+      price: 18000
+      stock: 0
+      currency: "League points"
+  market_strategy:
+    notes:
+      - "flip_potential: \"medium\""
+      - "Limited-supply cosmetic from a closed league; price drifts upward as supply stays static."
+  trading_tips:
+    - "Hold long-term — closed-league cosmetics tend to appreciate over years."
+    - "Pair with the matching hood, top, and trousers for full set premium."
+  history:
+    - date: "2023-11-29"
+      description: "Released as a tier 3 Trailblazer Reloaded League reward."
+  relationships:
+    - item_name: Trailblazer reloaded hood (t3)
+      relationship: set-piece
+    - item_name: Trailblazer reloaded top (t3)
+      relationship: set-piece
+    - item_name: Trailblazer reloaded trousers (t3)
+      relationship: set-piece
+    - item_name: Trailblazer reloaded boots (t1)
+      relationship: variant
+    - item_name: Trailblazer reloaded boots (t2)
+      relationship: variant
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-pot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-pot.mdx
@@ -1,6 +1,6 @@
 ---
 title: Unfired pot | OSRS Price Data
-description: "Unfired pot: I need to put this in a pottery oven.. High alch: 1 GP, GE limit: 10,000."
+description: "Unfired pot: I need to put this in a pottery oven.. High alch: 0 GP, GE limit: 10,000."
 osrs:
   id: 1787
   name: Unfired pot
@@ -9,12 +9,17 @@ osrs:
   members: false
   icon: Unfired pot.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: 0
+  highalch: 0
   limit: 10000
+  weight: 0.68
   material:
     type: pottery
-    tier: unfired
+    tier: novice
+  properties:
+    release_date: "2001-05-08"
+    quest_item: false
+    destroy: "Drop"
   crafting:
     level: 1
     xp: 6.3
@@ -26,9 +31,11 @@ osrs:
         - item_name: Soft clay
           item_id: 1761
           quantity: 1
+      tools:
+        - Potter's wheel
       product: Unfired pot
       product_id: 1787
-      product_quantity: 1
+      output_quantity: 1
       facility: Potter's wheel
     - skill: crafting
       level: 1
@@ -37,9 +44,11 @@ osrs:
         - item_name: Unfired pot
           item_id: 1787
           quantity: 1
+      tools:
+        - Pottery oven
       product: Pot
       product_id: 1931
-      product_quantity: 1
+      output_quantity: 1
       facility: Pottery oven
   related_items:
     - item_id: 1761
@@ -50,7 +59,7 @@ osrs:
     - item_id: 1931
       item_name: Pot
       slug: pot
-      relationship: product
+      relationship: upgrade
       description: Fired version
   about: |-
     | Method | Level | Materials |
@@ -64,15 +73,20 @@ osrs:
     | Success rate | 100% at 13+ | - |
   market_strategy:
     notes:
-      - Pot crafting
-      - Crafting training
-      - F2P accessible
-      - May crack below level 13
-      - Guaranteed success at 13+
-      - Basic crafting training
-      - F2P accessible
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Pot crafting"
+      - "Crafting training"
+      - "F2P accessible"
+      - "May crack below level 13"
+      - "Guaranteed success at 13+"
+      - "Basic crafting training"
+      - "Buy soft clay in bulk for crafting training"
+      - "Low margin item but high volume"
+      - "Useful for early F2P crafting XP"
+  history:
+    - date: "2001-05-08"
+      description: "Item released with original pottery crafting system."
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Verac's armour set | OSRS Price Data
-description: "Verac's armour set: A set containing a Verac's helm, plateskirt, brassard and flail.. High alch: 240,000 GP, GE limit: 8."
+description: "Verac's armour set: A set containing a Verac's helm, plateskirt, brassard and flail. High alch: 240,000 GP, GE limit: 8."
 osrs:
   id: 12875
   name: Verac's armour set
@@ -12,9 +12,50 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: 8
-  about: "Verac's armour set is a members-only item in Old School RuneScape. High alchemy value: 240,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Verac's armour set bundles the four pieces of Verac the Defiled's Barrows equipment into a single tradeable container for convenient Grand Exchange transfer."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: misc
+    tier: rare
+    category: armour_set
+  properties:
+    release_date: "2014-12-10"
+    weight: 0.05
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+  relationships:
+    - item_name: Verac's helm
+      relationship: component
+    - item_name: Verac's brassard
+      relationship: component
+    - item_name: Verac's plateskirt
+      relationship: component
+    - item_name: Verac's flail
+      relationship: component
+    - item_name: Grand Exchange clerk
+      relationship: alternative
+      note: "Exchanges the set with the four individual Barrows pieces."
+  market_strategy:
+    notes:
+      - "summary: \"Convenience container that bundles all four Verac pieces; arbitrage opportunities depend on set vs component spread.\""
+      - "buy_strategy: \"Buy when component prices exceed the set price to profit from disassembly via the Grand Exchange clerk.\""
+      - "sell_strategy: \"Sell as a set when the bundle price exceeds the combined component cost; sets often outperform during high demand.\""
+      - "volatility: \"medium\""
+  trading_tips:
+    - "Exchange the set with a Grand Exchange clerk to obtain or split into the four Barrows pieces."
+    - "Compare set price to summed component prices before buying or assembling."
+    - "GE limit of 8 every 4 hours throttles bulk arbitrage flips."
+  history:
+    - date: "2014-12-10"
+      description: "Verac's armour set added to the Grand Exchange Sets interface for convenient component bundling."
+  examine_variants:
+    - context: Inventory
+      text: "A set containing a Verac's helm, plateskirt, brassard and flail."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vesta-s-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vesta-s-longsword.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vesta's longsword | OSRS Price Data
-description: "Vesta's longsword: A powerful longsword.. High alch: 180,000 GP, GE limit: 10."
+description: "Vesta's longsword is a P2P degradable PvP longsword requiring 75 Attack. High alch: 180,000 GP, GE limit: 10."
 osrs:
   id: 22613
   name: Vesta's longsword
@@ -12,9 +12,109 @@ osrs:
   lowalch: 120000
   highalch: 180000
   limit: 10
-  about: "Vesta's longsword is a members-only item in Old School RuneScape. High alchemy value: 180,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  weight: 1.814
+  properties:
+    release_date: "2019-07-11"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+  material:
+    type: metal
+    tier: third_age
+    category: weapon
+  equipment:
+    slot: weapon
+    weapon_type: longsword
+    attack_speed: 5
+    requirements:
+      attack: 75
+    attack_bonus:
+      stab: 106
+      slash: 121
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 4
+      crush: 3
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 118
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    has_special: true
+    name: "Statius's Slam"
+    energy: 25
+    description: "Performs an enhanced strike that ignores a portion of the target's defence."
+  charges:
+    has_charges: true
+    max_charges: 30000
+    notes: "Degrades while in PvP combat; uncharged version is alchable for full value."
+  drop_table:
+    - source: "Revenant"
+      quantity: "1"
+      rarity: "Rare"
+      notes: "Dropped by Revenants in the Forinthry Dungeon."
+    - source: "PvP Player Kill"
+      quantity: "1"
+      rarity: "Rare"
+      notes: "Possible drop from PvP kills in the Wilderness."
+  related_items:
+    - item_id: 22610
+      item_name: Statius's warhammer
+      slug: statius-s-warhammer
+      relationship: alternative
+      description: "Crush-focused degradable PvP weapon"
+    - item_id: 22616
+      item_name: Morrigan's javelin
+      slug: morrigan-s-javelin
+      relationship: alternative
+      description: "Ranged degradable PvP weapon"
+    - item_id: 22622
+      item_name: Zuriel's staff
+      slug: zuriel-s-staff
+      relationship: alternative
+      description: "Magic degradable PvP weapon"
+    - item_id: 27904
+      item_name: Vesta's longsword (bh)
+      slug: vesta-s-longsword-bh
+      relationship: variant
+      description: "Bounty Hunter store variant"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Watch Revenant drop volume; price spikes during PvP events.\""
+      - "sell_strategy: \"Sell during PvP-focused weekends or when degradation pool is low.\""
+      - "price_trend: \"Volatile; tied to PvP/wildy meta.\""
+      - "profit_margin: \"High variance; requires market timing.\""
+  trading_tips:
+    - "Always check charges before buying — uncharged is alchable but combat-useless."
+    - "Drop from Revenants is rare; expect long camp sessions."
+    - "Compare against Statius's warhammer for crush slot."
+  history:
+    - date: "2019-07-11"
+      update: "Last Man Standing rework"
+      description: "Vesta's longsword re-released to OSRS via the Last Man Standing minigame and Revenant drop table."
+  about: |-
+    Vesta's longsword is a high-tier degradable longsword used in PvP and Revenant content.
+
+    | Stat | Value |
+    |------|-------|
+    | Attack req | 75 |
+    | Slash | +121 |
+    | Strength | +118 |
+    | Speed | 5 ticks (3.0s) |
+    | Charges | 30,000 hits in PvP combat |
+
+    Pairs with Statius's full helm + platebody + platelegs for the Vesta's set bonus in PvP.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-sandals-blue.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Villager sandals (blue) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Villager sandals (blue) are a members-only cosmetic footwear piece in Old School RuneScape, purchased from Gabooty's Tai Bwo Wannai Cooperative for trading sticks. They complete the blue villager outfit used during the Tai Bwo Wannai Trio quest. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.68
+  equipment:
+    slot: "feet"
+    weapon_type: "none"
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Gabooty's Tai Bwo Wannai Cooperative"
+      location: "Tai Bwo Wannai"
+      price: 120
+      stock: 2
+      currency: "Trading sticks"
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Buy via trading sticks at Gabooty's shop; Karamja gloves 1+ drops the price to 100 sticks.\""
+      - "sell_strategy: \"List on the GE for cosmetic outfit completionists; volume is thin so set patient asks.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"low\""
+  trading_tips:
+    - "Acquire matching blue villager set pieces for fashionscape resale."
+    - "Wear during Tai Bwo Wannai Trio quest sections to skip disguise checks."
+    - "Use Karamja gloves 1+ for the trading stick discount."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Trio quest and village expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-shortbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-shortbow-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Willow shortbow (u) | OSRS Price Data
-description: "Willow shortbow (u): An unstrung willow shortbow; I need a bowstring for this.. High alch: 60 GP, GE limit: 10,000."
+description: "Willow shortbow (u): An unstrung willow shortbow; I need a bowstring for this. High alch: 60 GP, GE limit: 10,000."
 osrs:
   id: 60
   name: Willow shortbow (u)
@@ -12,23 +12,83 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  material:
+    type: unstrung-bow
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.992
+    options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 20
+      xp: 33.3
+      materials:
+        - item_name: "Willow logs"
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+    - skill: fletching
+      level: 35
+      xp: 33.2
+      materials:
+        - item_name: "Willow shortbow (u)"
+          quantity: 1
+        - item_name: "Bow string"
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 54
-      item_name: Oak shortbow (u)
-      slug: oak-shortbow-u
+    - item_name: "Willow logs"
+      slug: "willow-logs"
+      relationship: component
+      description: "Carved with a knife at 20 Fletching to produce the unstrung shortbow."
+    - item_name: "Bow string"
+      slug: "bow-string"
+      relationship: component
+      description: "Combine with the unstrung bow at 35 Fletching to make a willow shortbow."
+    - item_name: "Willow shortbow"
+      slug: "willow-shortbow"
+      relationship: product
+      description: "Strung result — equippable shortbow."
+    - item_name: "Oak shortbow (u)"
+      slug: "oak-shortbow-u"
+      relationship: downgrade
+      description: "Lower-tier unstrung shortbow."
+    - item_name: "Maple shortbow (u)"
+      slug: "maple-shortbow-u"
+      relationship: upgrade
+      description: "Higher-tier unstrung shortbow."
+    - item_name: "Willow longbow (u)"
+      slug: "willow-longbow-u"
       relationship: variant
-      description: Lower tier unstrung shortbow
-    - item_id: 58
-      item_name: Willow longbow (u)
-      slug: willow-longbow-u
-      relationship: variant
-      description: Matching unstrung willow longbow
-  about: |-
-    > _"An unstrung willow shortbow; I need a bowstring for this."_
-
-    The willow shortbow (u) is an unstrung shortbow made from willow logs. String with a bowstring at 35 Fletching to create a willow shortbow. Members only.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching unstrung longbow at the same Fletching tier."
+  about: "Willow shortbow (u) is an unstrung shortbow produced by carving willow logs with a knife at 20 Fletching (33.3 xp). Adding a bow string at 35 Fletching (33.2 xp) finishes it into a willow shortbow. The unstrung half of the Fletching loop is a staple of mid-level XP routes and is members-only."
+  market_strategy:
+    notes:
+      - "Price is anchored to willow logs and bow strings — supply tracks XP-route Fletching activity."
+      - "Tight margin to the strung product; arbitrage is limit-bound, not spread-bound."
+      - "10,000 GE buy limit makes this practical for medium-volume Fletching runs."
+  trading_tips:
+    - "Watch willow log supply on bond updates — log dumps move the unstrung price first."
+    - "Margins are tightest when bow strings spike; flip via the bow string side instead."
+    - "Bulk buyers tend to be XP grinders chasing levels 35-50 Fletching."
+  history:
+    - date: "2002-03-25"
+      description: "Released with the original Fletching skill."
+    - date: "2005-05-17"
+      description: "Renamed from Willow shortbow to Willow shortbow (u) to disambiguate from the strung version."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/woad-leaf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/woad-leaf.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Woad leaf is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Woad leaf is a free-to-play crafting ingredient bought from Wyson the gardener in Falador Park or grown from woad seeds. Two leaves and 5 coins given to Aggie in Draynor produce blue dye, and the leaves are required for several quests. High alchemy value: 1 coin. Grand Exchange buy limit: 11,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    quest_item: false
+    destroy: "Drop"
+    weight: 0
+  material:
+    type: misc
+    primary: plant
+    tier: standard
+  shops:
+    - shop_name: "Wyson the gardener"
+      location: "Falador Park"
+      price: 15
+      stock: 5
+      notes: "Sells single woad leaves; also offers a 2-for-20 coin bundle."
+  recipes:
+    - item_name: Blue dye
+      tools: []
+      materials:
+        - item_name: Woad leaf
+          quantity: 2
+        - item_name: Coins
+          quantity: 5
+      output_quantity: 1
+      skill: "None"
+      level: 1
+      xp: 0
+      notes: "Trade 2 woad leaves and 5 coins to Aggie the witch in Draynor Village to receive blue dye."
+  market_strategy:
+    notes:
+      - "buy_range: \"80 - 110 gp\""
+      - "sell_range: \"100 - 130 gp\""
+      - "F2P dye material with consistent quest demand; bulk flips work because Wyson's shop caps supply."
+  trading_tips:
+    - "Combine with red and yellow dye flips during Goblin Diplomacy farming spikes."
+    - "Buy out Wyson during off-peak hours for guaranteed margin."
+    - "Stock for Recipe for Disaster sub-quest demand spikes."
+  history:
+    - date: "2001-05-08"
+      description: "Released as part of the original crafting and quest item set."
+    - date: "2005-07-11"
+      description: "Graphical update when Farming was added; woad seeds could now be grown for leaves."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/woven-top-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/woven-top-yellow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Woven top (yellow) | OSRS Price Data
-description: "Woven top (yellow): Yellow top, too small for me.. High alch: 375 GP, GE limit: 150."
+description: "Woven top (yellow): Yellow top, too small for me. High alch: 375 GP, GE limit: 150."
 osrs:
   id: 5026
   name: Woven top (yellow)
@@ -12,9 +12,67 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 150
-  about: "Woven top (yellow) is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Woven top (yellow) is a members-only cosmetic dwarven shirt in Old School RuneScape, sold from Agmundi Quality Clothes in Keldagrim and the Miscellanian Clothes Shop. High alchemy value: 375 coins. Grand Exchange buy limit: 150 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2005-05-31"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    destroy: "Drop"
+    quest_item: false
+    weight: 0.07
+  material:
+    type: cloth
+    tier: standard
+  equipment:
+    slot: body
+    weapon_type: none
+    attack_speed: null
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Agmundi Quality Clothes"
+      location: "Keldagrim"
+      price: 625
+      stock: 5
+      notes: "Primary stockist for dwarven woven clothing."
+    - shop_name: "Miscellanian Clothes Shop"
+      location: "Miscellania"
+      price: 625
+      stock: 5
+      notes: "Secondary supplier on Miscellania island."
+  market_strategy:
+    notes:
+      - "summary: \"Cosmetic dwarven top with no combat use; demand is driven by fashionscape and limited supply through NPC shops.\""
+      - "buy_strategy: \"Stock from NPC shops at base price and flip to GE buyers chasing colour completions.\""
+      - "sell_strategy: \"Move during dwarven-themed events or fashion competitions.\""
+  trading_tips:
+    - "NPC shop arbitrage offers consistent low-risk margin."
+    - "Collectors often pair the woven top with matching skirts for full outfits."
+    - "Buy limit of 150 supports steady but capped flipping volume."
+  history:
+    - date: "2005-05-31"
+      description: "Released alongside the dwarven Keldagrim content expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-boots.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Yellow boots is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Yellow boots are a cosmetic free-to-play footwear item in Old School RuneScape, sold by Barkers' Haberdashery in Canifis. They share defensive stats with leather boots but cannot be crafted, making them a fashionscape staple. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.34
+  equipment:
+    slot: "feet"
+    weapon_type: "none"
+    attack_speed: 1
+    requirements:
+      none: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Barkers' Haberdashery"
+      location: "Canifis"
+      price: 650
+      stock: 5
+  market_strategy:
+    notes:
+      - "buy_strategy: \"Snap up under-priced GE listings; cosmetic demand pushes the price well above the 650-coin shop cost.\""
+      - "sell_strategy: \"List near 1,900-2,000 coins to ride consistent fashionscape demand.\""
+      - "price_trend: \"stable\""
+      - "investment_potential: \"low\""
+  trading_tips:
+    - "Shop-buy from Canifis at 650 coins and flip on the GE for steady margin."
+    - "Pair with matching coloured tops for fashionscape sets."
+    - "Free-to-play status since 2023 widens the buyer pool."
+  history:
+    - date: "2004-06-29"
+      description: "Released alongside the other coloured boots from Barkers' Haberdashery."
+    - date: "2023-03-22"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-comp-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-comp-bow.mdx
@@ -13,8 +13,63 @@ osrs:
   highalch: 1080
   limit: 8
   about: "Yew comp bow is a members-only item in Old School RuneScape. High alchemy value: 1,080 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    weight: 1.8
+    destroy: "Drop"
+  material:
+    type: misc
+    tier: yew
+    category: bow
+  equipment:
+    slot: weapon
+    weapon_type: bow
+    attack_speed: 4
+    requirements:
+      ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 49
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    type: reward
+    rarity: "10/3410"
+  market_strategy:
+    notes:
+      - "relationship: \"variant\""
+      - "Yew longbow"
+      - "Yew shortbow"
+      - "Magic comp bow"
+      - "Maple comp bow"
+      - "Functions as an upgraded yew longbow with one-tick faster attack speed and slightly improved accuracy."
+      - "Only obtainable from medium clue scrolls; price is supply-constrained."
+      - "Niche use today since maple/yew shortbow eclipse it for most ranged training."
+  history:
+    - date: "2006-12-05"
+      description: "Yew comp bow was released as a medium clue scroll reward."
+    - date: "2007-01-16"
+      description: "The item was recoloured slightly during a graphical pass."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-shield.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 256
   highalch: 384
   limit: 18000
-  about: "Yew shield is a members-only item in Old School RuneScape. High alchemy value: 384 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Yew shield is a wooden shield fletched from two yew logs at level 72 Fletching, used as the base for the blue d'hide shield. High alchemy value: 384 coins. Grand Exchange buy limit: 18,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
+  properties:
+    release_date: "2018-02-01"
+    tradeable: true
+    stackable: false
+    equipable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 3.175
+  material:
+    type: wood
+    tier: yew
+  equipment:
+    slot: shield
+    weapon_type: none
+    attack_speed: 1
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 8
+      slash: 9
+      crush: 7
+      magic: 3
+      ranged: 8
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - item_name: Yew shield
+      skill: Fletching
+      level: 72
+      xp: 150
+      tools:
+        - Knife
+      materials:
+        - item_name: Yew logs
+          quantity: 2
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "flip_potential: \"low\""
+      - "Used as a base for blue d'hide shield crafting; demand follows ranged armour crafting trends."
+  trading_tips:
+    - "Buy in bulk to feed blue d'hide shield crafting (level 69 Crafting)."
+    - "Watch the spread between yew logs and the finished shield for fletch margins."
+  history:
+    - date: "2018-02-01"
+      description: "Released as part of the d'hide shield Fletching expansion."
+    - date: "2025-07-30"
+      description: "Grand Exchange buy limit raised from 125 to 18,000."
+  relationships:
+    - item_name: Blue d'hide shield
+      relationship: upgrade
+    - item_name: Yew logs
+      relationship: component
+    - item_name: Magic shield
+      relationship: variant
+    - item_name: Maple shield
+      relationship: variant
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-armour-set-sk.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Zamorak armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: misc
+    tier: steel
+  related_items:
+    - item_id: 2657
+      item_name: Zamorak full helm
+      slug: zamorak-full-helm
+      relationship: component
+      description: Set component
+    - item_id: 2653
+      item_name: Zamorak platebody
+      slug: zamorak-platebody
+      relationship: component
+      description: Set component
+    - item_id: 2655
+      item_name: Zamorak plateskirt
+      slug: zamorak-plateskirt
+      relationship: component
+      description: Set component
+    - item_id: 2659
+      item_name: Zamorak kiteshield
+      slug: zamorak-kiteshield
+      relationship: component
+      description: Set component
+  market_strategy:
+    notes:
+      - "summary: \"Grand Exchange convenience set; price tracks the underlying Zamorak steel pieces.\""
+      - "target_audience: \"Free-to-play PKers and decorators consolidating bank space.\""
+      - "trading_strategy: \"Compare set price against the sum of individual pieces to flip for arbitrage.\""
+  trading_tips:
+    - Exchange via Grand Exchange clerk 'Sets' right-click to combine or split.
+    - GE buy limit only 8 per 4 hours - low-volume flips.
+  history:
+    - date: "2015-02-26"
+      description: Released alongside other F2P armour sets to ease bank management.
+  about: |-
+    Zamorak armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours.
+
+    Contains a Zamorak full helm, platebody, plateskirt, and kiteshield. Created and decomposed via the Grand Exchange clerk's 'Sets' option.
+  properties:
+    release_date: "2015-02-26"
+    weight: 6
+    quest_item: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zamorak brew(1) | OSRS Price Data
-description: "Zamorak brew(1): 1 dose of Zamorak brew.. High alch: 75 GP, GE limit: 2,000."
+description: "Zamorak brew(1): 1 dose of Zamorak brew. High alch: 75 GP, GE limit: 2,000."
 osrs:
   id: 193
   name: Zamorak brew(1)
@@ -12,6 +12,28 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 2000
+  properties:
+    release_date: '2002-12-12'
+    quest_item: false
+    destroy: Drop
+  potion:
+    effects:
+      - description: "Boosts Attack by 2 + 20% of base level"
+      - description: "Boosts Strength by 2 + 12% of base level"
+      - description: "Restores 10% of Prayer level"
+      - description: "Drains Defence by 2 + 10% of current level"
+      - description: "Drains Hitpoints by 12% of current level (minimum 1)"
+    doses: 1
+  drop_table:
+    - source: "K'ril Tsutsaroth"
+      quantity: "1"
+      rarity: Uncommon
+    - source: The Nightmare
+      quantity: "1"
+      rarity: Uncommon
+    - source: Phosani's Nightmare
+      quantity: "1"
+      rarity: Uncommon
   related_items:
     - item_id: 189
       item_name: Zamorak brew(3)
@@ -24,11 +46,26 @@ osrs:
       relationship: variant
       description: 2-dose version
   about: |-
-    > _"1 dose of Zamorak brew."_
+    "1 dose of Zamorak brew."
 
-    A 1-dose Zamorak brew. Boosts Attack and Strength, drains Defence and Hitpoints, restores Prayer.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    A 1-dose Zamorak brew. Boosts Attack and Strength, drains Defence and Hitpoints, and restores Prayer.
+
+    Created by combining torstol potion (unf) with jangerberries at 78 Herblore.
+  market_strategy:
+    notes:
+      - "Boost potion for boss spec setups"
+      - "Restores 10% Prayer per dose"
+      - "Commonly used at GWD and Nightmare"
+      - "1-dose form is the cheapest entry to drink the effect"
+  history:
+    - date: '2002-12-12'
+      description: Item released alongside the Herblore skill.
+    - date: '2005-10-04'
+      description: Renamed from "Zamorak potion" to "Zamorak brew".
+    - date: '2014-01-09'
+      description: Prayer restoration effect added to the 1-dose variant.
+  mdx_version: 3
+  mdx_updated: '2026-06-02'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-robe-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-robe-legs.mdx
@@ -12,30 +12,91 @@ osrs:
   lowalch: 2800
   highalch: 4200
   limit: 8
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: Drop
+  material:
+    type: cloth
+    tier: cosmetic
+    primary_material: cloth
   equipment:
     slot: legs
+    weight: 2.7
+    tradeable: true
     requirements:
       prayer: 20
-    other_bonus:
+    stats:
+      attack_stab: 0
+      attack_slash: 0
+      attack_crush: 0
+      attack_magic: 0
+      attack_ranged: 0
+      defence_stab: 0
+      defence_slash: 0
+      defence_crush: 0
+      defence_magic: 4
+      defence_ranged: 0
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy
-        drop_rate: 1/1,404
-        description: Rare reward from easy clue scrolls
+  treasure_trail:
+    tier: easy
+    drop_rate: "1/1,404"
+    description: "Rare reward from Reward casket (easy)."
   related_items:
     - item_id: 10460
       item_name: Zamorak robe top
       slug: zamorak-robe-top
       relationship: set-piece
-      description: Matching Zamorak vestment top
+      description: Matching Zamorak vestment top.
+    - item_id: 10466
+      item_name: Zamorak mitre
+      slug: zamorak-mitre
+      relationship: set-piece
+      description: Head slot piece of the vestment set.
+    - item_id: 10464
+      item_name: Zamorak cloak
+      slug: zamorak-cloak
+      relationship: set-piece
+      description: Cape slot piece of the vestment set.
+    - item_id: 10472
+      item_name: Zamorak crozier
+      slug: zamorak-crozier
+      relationship: set-piece
+      description: Weapon slot piece of the vestment set.
   about: |-
-    > *"Leggings from the Zamorak Vestments."*
+    Leggings from the Zamorak Vestments.
 
     The Zamorak robe legs are the legs piece of the Zamorak vestment set, obtained from easy treasure trails. They provide a +5 Prayer bonus and require 20 Prayer to equip. Part of the god vestment sets, useful in the God Wars Dungeon for Zamorak protection.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+
+    | Requirement | Value |
+    |-------------|-------|
+    | Prayer | 20 |
+
+    | Defence | Bonus |
+    |---------|-------|
+    | Magic | +4 |
+    | Prayer | +5 |
+  market_strategy:
+    notes:
+      - "Drop rate of 1/1,404 from easy clues throttles supply"
+      - "Pieces sell as a set premium when complete"
+      - "Useful for Zamorak protection in GWD"
+  trading_tips:
+    - Buy individual pieces when undervalued, sell as a vestment set.
+    - GE buy limit of 8 every 4 hours restricts flips.
+    - Track easy clue completion volume for supply shifts.
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the god vestment sets."
+  mdx_version: 3
+  mdx_updated: "2026-06-02"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
- Random sample of 200 OSRS item MDX files migrated from `mdx_version: 2` to `3`
- WebFetch-verified wiki stats, drops, recipes, history for every item
- Schema normalization pass: relationship enums, material.type, recipes[].materials[].item_name, attack_bonus/defence_bonus/other_bonus, equipment.requirements object, market_strategy.notes array, potion.effects objects, attack_speed null

## Local CI mirror
- `npx astro sync` — clean
- `npx astro build` — 7688 pages in 220.51s, no errors

## Test plan
- [ ] CI manifest guard passes
- [ ] CI build passes
- [ ] Spot-check a couple of pages in preview