### PR TITLE
fix(kasm-void): detect cloak tar layout, drop hardcoded strip-components

### DIFF
--- a/packages/docker/kasm-void/Dockerfile
+++ b/packages/docker/kasm-void/Dockerfile
@@ -42,12 +42,17 @@ RUN set -eux; \
     curl -fL --retry 5 -o /tmp/cloak.tar.gz "$url"; \
     if [ -n "$CLOAK_SHA256" ]; then echo "$CLOAK_SHA256  /tmp/cloak.tar.gz" | sha256sum -c -; fi; \
     mkdir -p "$CLOAK_HOME"; \
-    tar -C "$CLOAK_HOME" --strip-components=1 -xzf /tmp/cloak.tar.gz; \
+    top_count="$(tar -tzf /tmp/cloak.tar.gz | awk -F/ 'NF>0 {print $1}' | sort -u | wc -l | tr -d ' ')"; \
+    if [ "$top_count" = "1" ]; then strip=1; else strip=0; fi; \
+    tar -C "$CLOAK_HOME" --strip-components="$strip" -xzf /tmp/cloak.tar.gz; \
     rm /tmp/cloak.tar.gz; \
-    if [ ! -x "$CLOAK_BIN" ]; then \
-      candidate="$(find "$CLOAK_HOME" -maxdepth 2 -type f \( -name cloakbrowser -o -name chrome -o -name chromium \) -perm -u+x | head -1)"; \
-      [ -n "$candidate" ] && ln -sf "$candidate" "$CLOAK_BIN"; \
+    candidate="$(find "$CLOAK_HOME" -maxdepth 3 -type f \( -name cloakbrowser -o -name chrome -o -name chromium \) -perm -u+x | head -1)"; \
+    if [ -z "$candidate" ]; then \
+      echo "no browser binary found in $CLOAK_HOME" >&2; \
+      ls -la "$CLOAK_HOME" >&2; \
+      exit 1; \
     fi; \
+    ln -sf "$candidate" "$CLOAK_BIN"; \
     [ -x "$CLOAK_BIN" ]; \
     chown -R 1000:1000 "$CLOAK_HOME"
 

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -61,6 +61,7 @@
 					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^LAUNCH_DISCORD=1$' && echo 'PASS: LAUNCH_DISCORD default on'",
 					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^LAUNCH_NAV_SHIM=1$' && echo 'PASS: LAUNCH_NAV_SHIM default on'",
 					"docker run --rm --entrypoint /opt/cloakbrowser/cloakbrowser ghcr.io/kbve/kasm-void:dev --version && echo 'PASS: cloakbrowser binary runs --version'",
+					"docker run --rm --entrypoint readlink ghcr.io/kbve/kasm-void:dev -e /opt/cloakbrowser/cloakbrowser | grep -q . && echo 'PASS: cloakbrowser symlink resolves to a real file'",
 					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-void:dev -c 'import websocket; assert websocket.__version__ == \"1.8.0\", websocket.__version__' && echo 'PASS: websocket-client 1.8.0 importable'",
 					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-void:dev -m py_compile /dockerstartup/nav_shim.py && echo 'PASS: nav_shim.py compiles'",
 					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/nav_shim.py && echo 'PASS: nav_shim.py executable'",


### PR DESCRIPTION
## Summary
Root cause of #11656 (\`kasm-void:container\` failing on \`main\` since #11647 landed): upstream \`cloakbrowser-linux-x64.tar.gz\` switched to a flat layout. Top-level entries are now the chrome binary itself (\`chrome\`, \`chromedriver\`, \`chrome_crashpad_handler\`, \`locales/\`, etc.) instead of a single wrapping directory.

The Dockerfile was hard-coding \`tar --strip-components=1\`, which silently dropped every root-level file — chrome included — and left only the deep \`locales/*\` content behind. The \`find ... -name chrome\` fallback returned empty, the symlink was never created, and \`[ -x \$CLOAK_BIN ]\` exited 1.

Verified by extracting both \`chromium-v146.0.7680.177.4\` and \`.5\` locally — same flat layout in both.

## Fix
- Detect layout at build time: count unique top-level entries from \`tar -tzf\`. Single entry ⇒ wrapper dir (strip=1); multiple entries ⇒ flat (strip=0).
- Always run the find/symlink branch (not gated on \`! -x \$CLOAK_BIN\`) so \`CLOAK_BIN\` always points at the discovered binary regardless of layout.
- Bump \`-maxdepth\` from 2 → 3 so a re-introduced wrapper dir is still reachable.
- Fail loudly with an \`ls -la \$CLOAK_HOME\` dump when nothing matches, instead of falling through to a misleading \`[ -x ... ]\` error.

## E2E
Added \`readlink -e /opt/cloakbrowser/cloakbrowser\` assertion in \`project.json\` — fails the test target when the symlink is dangling, complementing the existing \`--version\` invocation check.

## Test plan
- [ ] \`nx run kasm-void:container\` builds clean against current upstream tarball
- [ ] All e2e assertions pass under \`nx run kasm-void:test\`, including the new \`readlink -e\` check
- [ ] CI \`Publish Docker / kasm-void\` job on \`dev\` and \`main\` go green

Closes #11656