### PR TITLE
content(astro-kbve): /github/ tab + section responsive + a11y polish

### DIFF
--- a/apps/kbve/astro-kbve/src/components/github/Activity/AstroGithubActivity.astro
+++ b/apps/kbve/astro-kbve/src/components/github/Activity/AstroGithubActivity.astro
@@ -220,17 +220,27 @@ function ago(iso: string): string {
 
 <style>
 	.github-activity {
-		margin: 3rem 0;
+		margin: 2rem 0;
 		color: var(--sl-color-text, #e6edf3);
+	}
+	@media (min-width: 768px) {
+		.github-activity {
+			margin: 3rem 0;
+		}
 	}
 	.github-activity__header {
 		text-align: center;
 		margin-bottom: 1rem;
 	}
 	.github-activity__header h2 {
-		font-size: 1.75rem;
+		font-size: 1.4rem;
 		font-weight: 700;
 		margin: 0 0 0.25rem;
+	}
+	@media (min-width: 768px) {
+		.github-activity__header h2 {
+			font-size: 1.75rem;
+		}
 	}
 	.github-activity__header p {
 		color: var(--sl-color-gray-2, #8b949e);
@@ -244,13 +254,16 @@ function ago(iso: string): string {
 	.github-activity__list {
 		list-style: none;
 		padding: 0;
-		margin: 0;
-		display: flex;
-		flex-direction: column;
+		margin: 0 auto;
+		display: grid;
+		grid-template-columns: 1fr;
 		gap: 0.5rem;
-		max-width: 720px;
-		margin-left: auto;
-		margin-right: auto;
+		max-width: 1100px;
+	}
+	@media (min-width: 768px) {
+		.github-activity__list {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
 	}
 	.github-activity__item {
 		display: flex;

--- a/apps/kbve/astro-kbve/src/components/github/Contribute/AstroGithubContribute.astro
+++ b/apps/kbve/astro-kbve/src/components/github/Contribute/AstroGithubContribute.astro
@@ -131,18 +131,28 @@ const LINKS = [
 
 <style>
 	.github-contribute {
-		margin: 3rem auto;
+		margin: 2rem auto;
 		max-width: 880px;
 		color: var(--sl-color-text, #e6edf3);
+	}
+	@media (min-width: 768px) {
+		.github-contribute {
+			margin: 3rem auto;
+		}
 	}
 	.github-contribute__header {
 		text-align: center;
 		margin-bottom: 1.5rem;
 	}
 	.github-contribute__header h2 {
-		font-size: 1.75rem;
+		font-size: 1.4rem;
 		font-weight: 700;
 		margin: 0 0 0.25rem;
+	}
+	@media (min-width: 768px) {
+		.github-contribute__header h2 {
+			font-size: 1.75rem;
+		}
 	}
 	.github-contribute__header p {
 		color: var(--sl-color-gray-2, #8b949e);
@@ -160,7 +170,12 @@ const LINKS = [
 		background: var(--sl-color-bg-nav, #111);
 		border: 1px solid var(--sl-color-gray-5, #262626);
 		border-radius: 10px;
-		padding: 1rem 1.25rem;
+		padding: 0.85rem 0.95rem;
+	}
+	@media (min-width: 640px) {
+		.github-contribute__step {
+			padding: 1rem 1.25rem;
+		}
 	}
 	.github-contribute__step-head {
 		display: flex;
@@ -194,12 +209,25 @@ const LINKS = [
 		background: #0b1020;
 		border: 1px solid var(--sl-color-gray-6, #1f2937);
 		border-radius: 8px;
-		padding: 0.65rem 0.85rem;
+		padding: 0.6rem 0.75rem;
 		overflow-x: auto;
-		font-size: 0.78rem;
+		font-size: 0.72rem;
 		line-height: 1.55;
 		color: #cbd5e1;
 		margin: 0;
+		-webkit-overflow-scrolling: touch;
+	}
+	.github-contribute__code code {
+		font-family:
+			ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+			'Liberation Mono', monospace;
+		white-space: pre;
+	}
+	@media (min-width: 640px) {
+		.github-contribute__code {
+			padding: 0.65rem 0.85rem;
+			font-size: 0.78rem;
+		}
 	}
 	.github-contribute__links {
 		margin-top: 2rem;

--- a/apps/kbve/astro-kbve/src/components/github/ProjectBoard/AstroGithubProjectBoard.astro
+++ b/apps/kbve/astro-kbve/src/components/github/ProjectBoard/AstroGithubProjectBoard.astro
@@ -144,17 +144,27 @@ function ago(iso: string): string {
 
 <style>
 	.github-board {
-		margin: 3rem 0;
+		margin: 2rem 0;
 		color: var(--sl-color-text, #e6edf3);
+	}
+	@media (min-width: 768px) {
+		.github-board {
+			margin: 3rem 0;
+		}
 	}
 	.github-board__header {
 		text-align: center;
 		margin-bottom: 1.25rem;
 	}
 	.github-board__header h2 {
-		font-size: 1.75rem;
+		font-size: 1.4rem;
 		font-weight: 700;
 		margin: 0 0 0.25rem;
+	}
+	@media (min-width: 768px) {
+		.github-board__header h2 {
+			font-size: 1.75rem;
+		}
 	}
 	.github-board__header p {
 		color: var(--sl-color-gray-2, #8b949e);
@@ -170,8 +180,19 @@ function ago(iso: string): string {
 		padding: 0;
 		margin: 0;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-		gap: 0.75rem;
+		grid-template-columns: 1fr;
+		gap: 0.6rem;
+	}
+	@media (min-width: 480px) {
+		.github-board__grid {
+			grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+			gap: 0.75rem;
+		}
+	}
+	@media (min-width: 1024px) {
+		.github-board__grid {
+			grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+		}
 	}
 	.github-board__card {
 		background: var(--sl-color-bg-nav, #111);

--- a/apps/kbve/astro-kbve/src/components/github/RepoCatalog/AstroGithubRepoCatalog.astro
+++ b/apps/kbve/astro-kbve/src/components/github/RepoCatalog/AstroGithubRepoCatalog.astro
@@ -235,17 +235,27 @@ function shortDate(iso: string): string {
 
 <style>
 	.github-repo-catalog {
-		margin: 3rem 0;
+		margin: 2rem 0;
 		color: var(--sl-color-text, #e6edf3);
+	}
+	@media (min-width: 768px) {
+		.github-repo-catalog {
+			margin: 3rem 0;
+		}
 	}
 	.github-repo-catalog__header {
 		text-align: center;
-		margin-bottom: 1.5rem;
+		margin-bottom: 1.25rem;
 	}
 	.github-repo-catalog__header h2 {
-		font-size: 1.75rem;
+		font-size: 1.4rem;
 		font-weight: 700;
 		margin: 0 0 0.25rem;
+	}
+	@media (min-width: 768px) {
+		.github-repo-catalog__header h2 {
+			font-size: 1.75rem;
+		}
 	}
 	.github-repo-catalog__header p {
 		color: var(--sl-color-gray-2, #8b949e);
@@ -287,8 +297,19 @@ function shortDate(iso: string): string {
 		padding: 0;
 		margin: 0;
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-		gap: 0.75rem;
+		grid-template-columns: 1fr;
+		gap: 0.6rem;
+	}
+	@media (min-width: 480px) {
+		.github-repo-catalog__grid {
+			grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+			gap: 0.75rem;
+		}
+	}
+	@media (min-width: 1024px) {
+		.github-repo-catalog__grid {
+			grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+		}
 	}
 	.github-repo-catalog__card {
 		background: var(--sl-color-bg-nav, #111);

--- a/apps/kbve/astro-kbve/src/components/github/Tabs/AstroGithubTabs.astro
+++ b/apps/kbve/astro-kbve/src/components/github/Tabs/AstroGithubTabs.astro
@@ -1,8 +1,12 @@
 ---
 /**
- * AstroGithubTabs - Pure-CSS radio-driven tab group for /github/.
- * Zero JS. Uses :has() so panels can sit next to (not after) the radios.
- * Each tab is a named slot: activity, board, repos, contribute.
+ * AstroGithubTabs - Radio-driven tab group with ARIA + arrow-key
+ * keyboard navigation. Visual state runs on `:has()` (no JS needed
+ * for show/hide). The 20-line enhancement script only toggles
+ * `aria-selected` so AT can announce the active tab, and rotates
+ * focus on ArrowLeft / ArrowRight / Home / End.
+ *
+ * Named slots: activity, board, repos, contribute.
  */
 
 interface Props {
@@ -12,43 +16,63 @@ interface Props {
 const { idPrefix = 'github-tabs' } = Astro.props;
 
 const TABS = [
-	{ key: 'activity', label: 'Recent Activity', icon: '🟢' },
-	{ key: 'board', label: 'In Flight', icon: '🎯' },
-	{ key: 'repos', label: 'Repositories', icon: '📦' },
-	{ key: 'contribute', label: 'Contribute', icon: '🚀' },
+	{
+		key: 'activity',
+		label: 'Recent Activity',
+		short: 'Activity',
+		icon: '🟢',
+	},
+	{ key: 'board', label: 'In Flight', short: 'In Flight', icon: '🎯' },
+	{ key: 'repos', label: 'Repositories', short: 'Repos', icon: '📦' },
+	{ key: 'contribute', label: 'Contribute', short: 'Contribute', icon: '🚀' },
 ];
 ---
 
 <section
 	class="github-tabs"
 	aria-label="GitHub ecosystem sections"
+	data-github-tabs
 	data-tab-prefix={idPrefix}>
 	{
 		TABS.map((t, i) => (
 			<input
 				type="radio"
 				name={`${idPrefix}-radio`}
-				id={`${idPrefix}-${t.key}`}
-				class={`github-tabs__radio github-tabs__radio--${t.key}`}
+				id={`${idPrefix}-radio-${t.key}`}
+				data-tab-key={t.key}
+				class={`github-tabs__radio github-tabs__radio--${t.key} sr-only`}
 				checked={i === 0}
-				aria-hidden="true"
+				aria-label={t.label}
 				tabindex="-1"
 			/>
 		))
 	}
 
-	<div class="github-tabs__nav" role="tablist" aria-label="GitHub sections">
+	<div
+		class="github-tabs__nav"
+		role="tablist"
+		aria-label="GitHub sections"
+		aria-orientation="horizontal">
 		{
-			TABS.map((t) => (
+			TABS.map((t, i) => (
 				<label
-					for={`${idPrefix}-${t.key}`}
+					for={`${idPrefix}-radio-${t.key}`}
+					id={`${idPrefix}-tab-${t.key}`}
 					class={`github-tabs__tab github-tabs__tab--${t.key}`}
 					role="tab"
-					tabindex="0">
+					aria-controls={`${idPrefix}-panel-${t.key}`}
+					aria-selected={i === 0 ? 'true' : 'false'}
+					tabindex={i === 0 ? '0' : '-1'}
+					data-tab-key={t.key}>
 					<span class="github-tabs__icon" aria-hidden="true">
 						{t.icon}
 					</span>
-					<span class="github-tabs__label">{t.label}</span>
+					<span class="github-tabs__label github-tabs__label--full">
+						{t.label}
+					</span>
+					<span class="github-tabs__label github-tabs__label--short">
+						{t.short}
+					</span>
 				</label>
 			))
 		}
@@ -56,31 +80,101 @@ const TABS = [
 
 	<div class="github-tabs__panels">
 		<section
+			id={`${idPrefix}-panel-activity`}
 			class="github-tabs__panel github-tabs__panel--activity"
 			role="tabpanel"
-			aria-labelledby={`${idPrefix}-activity`}>
+			aria-labelledby={`${idPrefix}-tab-activity`}
+			tabindex="0">
 			<slot name="activity" />
 		</section>
 		<section
+			id={`${idPrefix}-panel-board`}
 			class="github-tabs__panel github-tabs__panel--board"
 			role="tabpanel"
-			aria-labelledby={`${idPrefix}-board`}>
+			aria-labelledby={`${idPrefix}-tab-board`}
+			tabindex="0">
 			<slot name="board" />
 		</section>
 		<section
+			id={`${idPrefix}-panel-repos`}
 			class="github-tabs__panel github-tabs__panel--repos"
 			role="tabpanel"
-			aria-labelledby={`${idPrefix}-repos`}>
+			aria-labelledby={`${idPrefix}-tab-repos`}
+			tabindex="0">
 			<slot name="repos" />
 		</section>
 		<section
+			id={`${idPrefix}-panel-contribute`}
 			class="github-tabs__panel github-tabs__panel--contribute"
 			role="tabpanel"
-			aria-labelledby={`${idPrefix}-contribute`}>
+			aria-labelledby={`${idPrefix}-tab-contribute`}
+			tabindex="0">
 			<slot name="contribute" />
 		</section>
 	</div>
 </section>
+
+<script is:inline>
+	(() => {
+		const groups = document.querySelectorAll('[data-github-tabs]');
+		for (const group of groups) {
+			const tabs = Array.from(group.querySelectorAll('[role="tab"]'));
+			const radios = Array.from(
+				group.querySelectorAll('input[type="radio"][data-tab-key]'),
+			);
+
+			const syncAria = () => {
+				const checked = radios.find((r) => r.checked);
+				const activeKey = checked?.dataset.tabKey;
+				for (const tab of tabs) {
+					const isActive = tab.dataset.tabKey === activeKey;
+					tab.setAttribute('aria-selected', String(isActive));
+					tab.setAttribute('tabindex', isActive ? '0' : '-1');
+				}
+			};
+
+			for (const radio of radios) {
+				radio.addEventListener('change', syncAria);
+			}
+
+			for (const tab of tabs) {
+				tab.addEventListener('keydown', (ev) => {
+					const key = ev.key;
+					if (
+						key !== 'ArrowLeft' &&
+						key !== 'ArrowRight' &&
+						key !== 'Home' &&
+						key !== 'End'
+					) {
+						return;
+					}
+					ev.preventDefault();
+					const idx = tabs.indexOf(tab);
+					let nextIdx = idx;
+					if (key === 'ArrowLeft')
+						nextIdx = (idx - 1 + tabs.length) % tabs.length;
+					if (key === 'ArrowRight') nextIdx = (idx + 1) % tabs.length;
+					if (key === 'Home') nextIdx = 0;
+					if (key === 'End') nextIdx = tabs.length - 1;
+					const nextTab = tabs[nextIdx];
+					const nextKey = nextTab.dataset.tabKey;
+					const nextRadio = radios.find(
+						(r) => r.dataset.tabKey === nextKey,
+					);
+					if (nextRadio) {
+						nextRadio.checked = true;
+						nextRadio.dispatchEvent(
+							new Event('change', { bubbles: true }),
+						);
+					}
+					nextTab.focus();
+				});
+			}
+
+			syncAria();
+		}
+	})();
+</script>
 
 <style>
 	.github-tabs {
@@ -88,15 +182,18 @@ const TABS = [
 		color: var(--sl-color-text, #e6edf3);
 	}
 
-	.github-tabs__radio {
+	/* Visually-hidden radio (sr-only equivalent without relying on
+	   Starlight global utility class shadowing). */
+	.github-tabs__radio.sr-only {
 		position: absolute;
-		opacity: 0;
-		pointer-events: none;
 		width: 1px;
 		height: 1px;
-		overflow: hidden;
-		clip: rect(0 0 0 0);
+		padding: 0;
 		margin: -1px;
+		overflow: hidden;
+		clip: rect(0, 0, 0, 0);
+		white-space: nowrap;
+		border: 0;
 	}
 
 	.github-tabs__nav {
@@ -146,6 +243,38 @@ const TABS = [
 		line-height: 1;
 	}
 
+	/* Swap full ↔ short label at the wrap-risk breakpoint. */
+	.github-tabs__label--full {
+		display: inline;
+	}
+	.github-tabs__label--short {
+		display: none;
+	}
+
+	@media (max-width: 480px) {
+		.github-tabs__label--full {
+			display: none;
+		}
+		.github-tabs__label--short {
+			display: inline;
+		}
+		.github-tabs__nav {
+			gap: 0.3rem;
+			padding: 0.3rem;
+		}
+		.github-tabs__tab {
+			padding: 0.5rem 0.7rem;
+			font-size: 0.78rem;
+		}
+	}
+
+	@media (max-width: 640px) and (min-width: 481px) {
+		.github-tabs__tab {
+			padding: 0.55rem 0.85rem;
+			font-size: 0.82rem;
+		}
+	}
+
 	.github-tabs__panels {
 		position: relative;
 	}
@@ -153,9 +282,10 @@ const TABS = [
 	.github-tabs__panel {
 		display: none;
 	}
+	.github-tabs__panel:focus {
+		outline: none;
+	}
 
-	/* :has() drives both the active-tab style and the visible panel
-	   without any JS. Modern browsers all support it. */
 	.github-tabs:has(.github-tabs__radio--activity:checked)
 		.github-tabs__panel--activity,
 	.github-tabs:has(.github-tabs__radio--board:checked)
@@ -181,21 +311,6 @@ const TABS = [
 		border-color: var(--sl-color-accent, #06b6d4);
 	}
 
-	.github-tabs:has(.github-tabs__radio--activity:checked)
-		.github-tabs__tab--activity
-		.github-tabs__icon,
-	.github-tabs:has(.github-tabs__radio--board:checked)
-		.github-tabs__tab--board
-		.github-tabs__icon,
-	.github-tabs:has(.github-tabs__radio--repos:checked)
-		.github-tabs__tab--repos
-		.github-tabs__icon,
-	.github-tabs:has(.github-tabs__radio--contribute:checked)
-		.github-tabs__tab--contribute
-		.github-tabs__icon {
-		filter: brightness(0) saturate(100%);
-	}
-
 	@keyframes github-tabs-fade-in {
 		from {
 			opacity: 0;
@@ -207,20 +322,6 @@ const TABS = [
 		}
 	}
 
-	/* Keyboard activation: pressing Enter / Space on a focused tab label
-	   is delegated to its associated radio by the browser, so no JS
-	   needed. Arrow-key roving focus is a future enhancement. */
-	@media (max-width: 640px) {
-		.github-tabs__tab {
-			padding: 0.55rem 0.75rem;
-			font-size: 0.78rem;
-		}
-		.github-tabs__label {
-			font-size: 0.78rem;
-		}
-	}
-
-	/* Reduced-motion: drop the fade. */
 	@media (prefers-reduced-motion: reduce) {
 		.github-tabs__panel {
 			animation: none !important;


### PR DESCRIPTION
Stacked on top of #11697. Audit found responsive + a11y gaps in the tab group and the four section components.

## Tabs (`AstroGithubTabs.astro`)

| Before | After |
|---|---|
| Labels had `role=tab` but no `aria-selected` — AT couldn't announce active tab | `aria-selected` kept in sync with the radio via 30-line inline script |
| Panel `aria-labelledby` pointed at the aria-hidden radio (broken label) | Now points at the label id; label has `aria-controls={panel-id}` |
| No keyboard nav between tabs | ArrowLeft / ArrowRight / Home / End rotate focus + activate; tabindex roving (1 tab is `0`, others `-1`) |
| One label string for every breakpoint | `Recent Activity` ↔ `Activity` etc swap at ≤480px so 4 tabs fit on one row at 360px |
| Custom hidden-radio shim | Standard `sr-only` pattern, radio keeps `aria-label` for AT |

## Section responsiveness

| Component | Change |
|---|---|
| Activity | 1 col → 2 cols at ≥768px, max-width 1100px |
| RepoCatalog grid | 1 col → `minmax(240px,1fr)` at ≥480px → `minmax(280px,1fr)` at ≥1024px |
| ProjectBoard grid | 1 col → `minmax(260px,1fr)` at ≥480px → `minmax(300px,1fr)` at ≥1024px |
| Headings | 1.4rem on phones → 1.75rem at ≥768px |
| Section margins | 2rem on phones → 3rem at ≥768px |
| Contribute step padding | Tighter on phones (0.85rem) → 1rem at ≥640px |
| Contribute code blocks | 0.72rem mono font on phones → 0.78rem at ≥640px, explicit monospace stack, `-webkit-overflow-scrolling: touch` |

## Why no Alpine
`grep -rn 'x-data'` across `apps/kbve/astro-kbve/src/components` returns zero hits. Alpine isn't in deps or `astro.config.mjs` integrations. Adding it for one tab interaction would ship ~12 KB of runtime for no precedent. Vanilla inline `<script is:inline>` does the same work in 30 lines.

## Base
Targets `trunk/github-tabs-and-cls-1780446842` (the open #11697 branch). When that merges to dev, rebase this onto dev.

## Test plan
- [ ] Build green: `./kbve.sh -nx astro-kbve:build` → 7688 pages
- [ ] Inspect rendered `/github/`: 4 `aria-controls`, 1 `aria-selected="true"` + 3 `false`, 4 `role="tabpanel"` (verified)
- [ ] Resize Chrome DevTools to 360px → tabs fit one row with short labels
- [ ] Tab to first tab, press ArrowRight → focus + activation moves to next tab
- [ ] VoiceOver / NVDA: each tab announces "Recent Activity, tab, selected" / "not selected"