### PR TITLE
feat(kbve-mod,kbve-kubectl): v0.0.4 exchange/fleet UX + rotator timeout fix

### DIFF
--- a/apps/agones/factorio/mods-local/kbve/changelog.txt
+++ b/apps/agones/factorio/mods-local/kbve/changelog.txt
@@ -1,6 +1,6 @@
 ---------------------------------------------------------------------------------------------------
-Version: 0.0.4
-Date: 2026-06-02
+Version: 0.0.5
+Date: 2026-06-03
   Changes:
     - KBVE Exchange anchors to the right side of the screen and no longer
       hijacks player.opened, so the vanilla inventory can stay open while

--- a/apps/agones/factorio/mods-local/kbve/changelog.txt
+++ b/apps/agones/factorio/mods-local/kbve/changelog.txt
@@ -1,4 +1,28 @@
 ---------------------------------------------------------------------------------------------------
+Version: 0.0.4
+Date: 2026-06-02
+  Changes:
+    - KBVE Exchange anchors to the right side of the screen and no longer
+      hijacks player.opened, so the vanilla inventory can stay open while
+      transferring items into the personal vault.
+    - Market Buy tab now sorts entries by ascending price and drops the
+      decorative disabled sprite-button on each row.
+    - Buy buttons are disabled for items the player cannot afford; the
+      enabled state refreshes after each purchase without rebuilding the
+      list, so scroll position survives purchases.
+    - Trigger key now toggles the Exchange GUI closed when pressed while
+      already open (was previously open-only).
+    - Server now enforces a 3-tile range to a kbve-exchange entity for
+      every purchase, and a 30-tick proximity sweep auto-closes the
+      Exchange GUI when a player wanders away from the market.
+    - Fleet Commander mirrors the same protection: clicks rejected and
+      GUI closed if the player drifts beyond 3 tiles from a
+      kbve-fleet-commander entity, plus a 30-tick sweep.
+  Features:
+    - Starter kit on first join: 2 spider eggs (when kbve-spider is
+      loaded), 1 pistol, and 100 firearm magazines, granted alongside the
+      existing 250 coin welcome bonus.
+---------------------------------------------------------------------------------------------------
 Version: 0.0.3
 Date: 2026-06-01
   Features:

--- a/apps/agones/factorio/mods-local/kbve/control.lua
+++ b/apps/agones/factorio/mods-local/kbve/control.lua
@@ -78,6 +78,8 @@ script.on_event(defines.events.on_chunk_generated, on_chunk_generated)
 
 local function on_tick(event)
 	FleetMissions.on_tick(event)
+	ExchangeGui.on_tick(event)
+	FleetGui.on_tick(event)
 	if (event.tick % 600) == 0 then
 		local surface = game.surfaces['nauvis'] or game.surfaces[1]
 		if surface then Spawn.guard(surface) end

--- a/apps/agones/factorio/mods-local/kbve/info.json
+++ b/apps/agones/factorio/mods-local/kbve/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "kbve",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"factorio_version": "2.0",
 	"title": "KBVE Fleet Commander",
 	"author": "kbve",

--- a/apps/agones/factorio/mods-local/kbve/info.json
+++ b/apps/agones/factorio/mods-local/kbve/info.json
@@ -1,6 +1,6 @@
 {
 	"name": "kbve",
-	"version": "0.0.3",
+	"version": "0.0.4",
 	"factorio_version": "2.0",
 	"title": "KBVE Fleet Commander",
 	"author": "kbve",

--- a/apps/agones/factorio/mods-local/kbve/modules/coins.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/coins.lua
@@ -74,6 +74,20 @@ function Coins.spend(player_index, amount, reason)
 	return removed == amount
 end
 
+local STARTER_KIT = {
+	{ name = 'kbve-spider-egg', count = 2 },
+	{ name = 'pistol', count = 1 },
+	{ name = 'firearm-magazine', count = 100 },
+}
+
+local function grant_starter_kit(player)
+	for _, gift in ipairs(STARTER_KIT) do
+		if prototypes.item[gift.name] then
+			player.insert({ name = gift.name, count = gift.count })
+		end
+	end
+end
+
 function Coins.handle_player_joined(event)
 	Coins.init_state()
 	local player = game.get_player(event.player_index)
@@ -82,6 +96,7 @@ function Coins.handle_player_joined(event)
 	if not storage.kbve.seen_players[name] then
 		storage.kbve.seen_players[name] = true
 		Coins.grant(event.player_index, WELCOME_BONUS, 'welcome')
+		grant_starter_kit(player)
 		player.print({ 'kbve.coin_welcome', name, WELCOME_BONUS })
 	end
 end

--- a/apps/agones/factorio/mods-local/kbve/modules/exchange_gui.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/exchange_gui.lua
@@ -11,7 +11,10 @@ local GUI_NAME = 'kbve_exchange'
 local TABBED_NAME = 'kbve_tabbed'
 local BUY_TAB_CONTENT = 'kbve_buy_content'
 local VAULT_TAB_CONTENT = 'kbve_vault_content'
+local BUY_BALANCE_NAME = 'kbve_buy_balance'
+local BUY_SCROLL_NAME = 'kbve_buy_scroll'
 local BUY_PREFIX = 'kbve_buy_'
+local EXCHANGE_RADIUS = 3
 local SLOT_PREFIX = 'kbve_vault_slot_'
 local CLOSE_NAME = 'kbve_close'
 local DEPOSIT_ALL = 'kbve_deposit_all'
@@ -29,13 +32,31 @@ local function destroy(player)
 	end
 end
 
+local function is_near_exchange(player)
+	if not (player and player.valid and player.character) then return false end
+	local surface = player.surface
+	if not surface then return false end
+	local nearby = surface.find_entities_filtered({
+		position = player.position,
+		radius = EXCHANGE_RADIUS,
+		name = 'kbve-exchange',
+	})
+	return #nearby > 0
+end
+
 local function render_buy(content, player)
 	content.clear()
+	local balance = Coins.get_balance(player.index)
 	content.add({
 		type = 'label',
-		caption = { '', 'Balance: [item=coin] ', Coins.get_balance(player.index) },
+		name = BUY_BALANCE_NAME,
+		caption = { '', 'Balance: [item=coin] ', balance },
 	})
-	local scroll = content.add({ type = 'scroll-pane', direction = 'vertical' })
+	local scroll = content.add({
+		type = 'scroll-pane',
+		name = BUY_SCROLL_NAME,
+		direction = 'vertical',
+	})
 	scroll.style.maximal_height = 480
 	scroll.style.minimal_width = 480
 	for i, entry in ipairs(Market.ITEMS) do
@@ -43,9 +64,8 @@ local function render_buy(content, player)
 		if proto then
 			local row = scroll.add({ type = 'flow', direction = 'horizontal' })
 			row.add({
-				type = 'sprite-button',
+				type = 'sprite',
 				sprite = 'item/' .. entry.item,
-				enabled = false,
 				tooltip = proto.localised_name,
 			})
 			row.add({
@@ -57,7 +77,35 @@ local function render_buy(content, player)
 				type = 'button',
 				name = BUY_PREFIX .. i,
 				caption = { '', 'Buy ', entry.price, ' [item=coin]' },
+				enabled = balance >= entry.price,
 			})
+		end
+	end
+end
+
+local function refresh_balance_state(player)
+	local frame = player.gui.screen[GUI_NAME]
+	if not frame then return end
+	local body = frame[BODY_NAME]
+	local tabbed = body and body[TABBED_NAME]
+	local content = tabbed and tabbed[BUY_TAB_CONTENT]
+	if not content then return end
+	local balance = Coins.get_balance(player.index)
+	local label = content[BUY_BALANCE_NAME]
+	if label then
+		label.caption = { '', 'Balance: [item=coin] ', balance }
+	end
+	local scroll = content[BUY_SCROLL_NAME]
+	if not scroll then return end
+	for _, row in ipairs(scroll.children) do
+		for _, child in ipairs(row.children) do
+			if child.type == 'button' and child.name:sub(1, #BUY_PREFIX) == BUY_PREFIX then
+				local i = tonumber(child.name:sub(#BUY_PREFIX + 1))
+				local entry = i and Market.ITEMS[i]
+				if entry then
+					child.enabled = balance >= entry.price
+				end
+			end
 		end
 	end
 end
@@ -99,7 +147,12 @@ function ExchangeGui.show(player)
 		direction = 'vertical',
 		caption = 'KBVE Exchange',
 	})
-	frame.auto_center = true
+	local res = player.display_resolution
+	local scale = player.display_scale or 1
+	local frame_width_est = 760 * scale
+	local x = math.max(20, res.width - frame_width_est - 20)
+	local y = 80 * scale
+	frame.location = { x, y }
 
 	local close_flow = frame.add({ type = 'flow', direction = 'horizontal' })
 	close_flow.add({ type = 'empty-widget' }).style.horizontally_stretchable = true
@@ -133,8 +186,6 @@ function ExchangeGui.show(player)
 	})
 	tabbed.add_tab(vault_tab, vault_content)
 	render_vault(vault_content, player)
-
-	player.opened = frame
 end
 
 function ExchangeGui.on_gui_closed(event)
@@ -173,6 +224,11 @@ local function refresh_vault(player)
 end
 
 local function handle_buy(player, index)
+	if not is_near_exchange(player) then
+		player.print('Too far from the KBVE Exchange.')
+		destroy(player)
+		return
+	end
 	local entry = Market.ITEMS[index]
 	if not entry then return end
 	local balance = Coins.get_balance(player.index)
@@ -244,14 +300,22 @@ end
 function ExchangeGui.on_custom_input(event)
 	local player = game.get_player(event.player_index)
 	if not player or not player.character then return end
-	if player.gui.screen[GUI_NAME] then return end
-	local nearby = player.surface.find_entities_filtered({
-		position = player.position,
-		radius = 3,
-		name = 'kbve-exchange',
-	})
-	if #nearby == 0 then return end
+	if player.gui.screen[GUI_NAME] then
+		destroy(player)
+		return
+	end
+	if not is_near_exchange(player) then return end
 	ExchangeGui.show(player)
+end
+
+function ExchangeGui.on_tick(event)
+	if (event.tick % 30) ~= 0 then return end
+	for _, player in pairs(game.connected_players) do
+		if player.gui.screen[GUI_NAME] and not is_near_exchange(player) then
+			destroy(player)
+			player.print('Too far from the KBVE Exchange — closing.')
+		end
+	end
 end
 
 function ExchangeGui.on_gui_click(event)
@@ -277,7 +341,7 @@ function ExchangeGui.on_gui_click(event)
 		local i = tonumber(name:sub(#BUY_PREFIX + 1))
 		if i then
 			handle_buy(player, i)
-			refresh_buy(player)
+			refresh_balance_state(player)
 		end
 		return
 	end

--- a/apps/agones/factorio/mods-local/kbve/modules/fleet_gui.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/fleet_gui.lua
@@ -93,6 +93,20 @@ local function known_vehicle_names()
 	return out
 end
 
+local FLEET_RADIUS = 3
+
+local function is_near_fleet(player)
+	if not (player and player.valid and player.character) then return false end
+	local surface = player.surface
+	if not surface then return false end
+	local nearby = surface.find_entities_filtered({
+		position = player.position,
+		radius = FLEET_RADIUS,
+		name = 'kbve-fleet-commander',
+	})
+	return #nearby > 0
+end
+
 local function destroy(player)
 	if player.gui.screen[GUI_NAME] then
 		player.gui.screen[GUI_NAME].destroy()
@@ -960,14 +974,22 @@ end
 function FleetGui.on_custom_input(event)
 	local player = game.get_player(event.player_index)
 	if not player or not player.character then return end
-	if player.gui.screen[GUI_NAME] then return end
-	local nearby = player.surface.find_entities_filtered({
-		position = player.position,
-		radius = 3,
-		name = 'kbve-fleet-commander',
-	})
-	if #nearby == 0 then return end
+	if player.gui.screen[GUI_NAME] then
+		destroy(player)
+		return
+	end
+	if not is_near_fleet(player) then return end
 	FleetGui.show(player)
+end
+
+function FleetGui.on_tick(event)
+	if (event.tick % 30) ~= 0 then return end
+	for _, player in pairs(game.connected_players) do
+		if player.gui.screen[GUI_NAME] and not is_near_fleet(player) then
+			destroy(player)
+			player.print('Too far from the Fleet Commander — closing.')
+		end
+	end
 end
 
 local function mining_dispatch(player)
@@ -1095,6 +1117,12 @@ function FleetGui.on_gui_click(event)
 	if not player then return end
 
 	if name == CLOSE_NAME then
+		destroy(player)
+		return
+	end
+
+	if not is_near_fleet(player) then
+		player.print('Too far from the Fleet Commander.')
 		destroy(player)
 		return
 	end

--- a/apps/agones/factorio/mods-local/kbve/modules/market.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/market.lua
@@ -1,6 +1,6 @@
 local Market = {}
 
-Market.ITEMS = {
+local RAW_ITEMS = {
 	{ item = 'repair-pack', price = 3, count = 5 },
 	{ item = 'iron-gear-wheel', price = 4, count = 25 },
 	{ item = 'steel-plate', price = 5, count = 10 },
@@ -37,5 +37,12 @@ Market.ITEMS = {
 	{ item = 'power-armor-mk2', price = 5000, count = 1 },
 	{ item = 'fusion-reactor-equipment', price = 6000, count = 1 },
 }
+
+table.sort(RAW_ITEMS, function(a, b)
+	if a.price ~= b.price then return a.price < b.price end
+	return a.item < b.item
+end)
+
+Market.ITEMS = RAW_ITEMS
 
 return Market

--- a/apps/vm/kubectl/src/main.rs
+++ b/apps/vm/kubectl/src/main.rs
@@ -114,8 +114,12 @@ struct GuestExecStatusReturn {
 
 #[inline]
 async fn kubectl_output(args: &[&str]) -> Result<String, String> {
+    kubectl_output_with_timeout(args, DEFAULT_TIMEOUT).await
+}
+
+async fn kubectl_output_with_timeout(args: &[&str], timeout: Duration) -> Result<String, String> {
     let output = tokio::time::timeout(
-        DEFAULT_TIMEOUT,
+        timeout,
         tokio::process::Command::new("kubectl").args(args).output(),
     )
     .await
@@ -449,14 +453,18 @@ async fn cmd_rotate_gameserver(
     tracing::info!("image drift detected: {running} -> {desired}; rotating");
 
     let timeout_arg = format!("--timeout={delete_timeout}s");
-    match kubectl_output(&[
-        "-n",
-        namespace,
-        "delete",
-        &gs_ref,
-        &timeout_arg,
-        "--ignore-not-found",
-    ])
+    let wrapper_timeout = Duration::from_secs(delete_timeout.saturating_add(30));
+    match kubectl_output_with_timeout(
+        &[
+            "-n",
+            namespace,
+            "delete",
+            &gs_ref,
+            &timeout_arg,
+            "--ignore-not-found",
+        ],
+        wrapper_timeout,
+    )
     .await
     {
         Ok(_) => {


### PR DESCRIPTION
## Summary

### kbve mod v0.0.4 (Exchange + Fleet UX hardening)

- **Inventory + market coexist** — Exchange GUI anchors to the right side of the screen and no longer sets \`player.opened\`, so the vanilla inventory keeps its center slot. Players can drag items between inventory and vault without the market hijacking focus.
- **Sorted, affordability-gated Buy tab** — \`Market.ITEMS\` is sorted at module load by ascending price. Each Buy button starts enabled iff \`balance >= entry.price\`. After a purchase, only the balance label + per-row enabled state refresh (no full rebuild), so the scroll position survives.
- **Trigger keys toggle both GUIs** — pressing \`kbve-open-exchange\` / \`kbve-open-fleet\` while the corresponding GUI is open now closes it (previously open-only).
- **3-tile range gates** — both \`handle_buy\` (Exchange) and \`on_gui_click\` (Fleet) reject the action and destroy the GUI when the player is >3 tiles from the matching entity (\`kbve-exchange\` / \`kbve-fleet-commander\`). A 30-tick proximity sweep additionally closes the GUI when the player wanders away mid-session. Belt-and-suspenders against the bug where players could move off the market tile but keep clicking Buy.
- **Starter kit on first join** — alongside the existing 250 coin welcome bonus, new players now receive 2 spider eggs (when \`kbve-spider\` is loaded), 1 pistol, and 100 firearm-magazines. Gated on the same \`seen_players[name]\` flag so re-joiners don't double-dip.

### kbve-kubectl rotator timeout fix

The rotator was logging \`ERROR delete failed: kubectl timed out\` every tick that drift was present, even though the delete itself was always submitted and Agones tore down the GameServer as expected. Root cause: \`kubectl_output\` wrapped every call in \`DEFAULT_TIMEOUT = 30s\`, but \`rotate-gameserver\` invoked \`kubectl delete gs/factorio --timeout=180s\` — the wrapper killed kubectl at 30s while it was still watching for the resource to disappear.

- Introduce \`kubectl_output_with_timeout(args, Duration)\`; \`kubectl_output\` keeps the 30s default.
- \`rotate-gameserver\` delete now uses \`delete_timeout + 30s\` slack as the wrapper timeout, so the long delete completes naturally before the wrapper fires.

## Test plan

- [x] \`luac -p\` clean on all modified Lua files
- [x] \`cargo check\` + \`cargo clippy -- -D warnings\` clean on \`apps/vm/kubectl\`
- [x] Local Factorio: opened Exchange + inventory simultaneously, transferred items into vault
- [x] Local Factorio: Buy tab sorted ascending; Buy buttons disabled for unaffordable items; bought item mid-list, scroll position held
- [x] Local Factorio: walked away from Exchange / Fleet — GUI auto-closes within 0.5s
- [ ] CI publishes mod v0.0.4 to the Factorio mod portal
- [ ] CI publishes \`kbve-kubectl\` v0.1.4 → rotation-cronjob.yaml image pin auto-bumps via \`deployment_yamls\` → next drift cycle no longer reports \"kubectl timed out\"