### PR TITLE
fix(kasm-void): redirect py_compile bytecode cache to /tmp

### DIFF
--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -63,7 +63,7 @@
 					"docker run --rm --entrypoint /opt/cloakbrowser/cloakbrowser ghcr.io/kbve/kasm-void:dev --version && echo 'PASS: cloakbrowser binary runs --version'",
 					"docker run --rm --entrypoint readlink ghcr.io/kbve/kasm-void:dev -e /opt/cloakbrowser/cloakbrowser | grep -q . && echo 'PASS: cloakbrowser symlink resolves to a real file'",
 					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-void:dev -c 'import websocket; assert websocket.__version__ == \"1.8.0\", websocket.__version__' && echo 'PASS: websocket-client 1.8.0 importable'",
-					"docker run --rm --entrypoint python3 ghcr.io/kbve/kasm-void:dev -m py_compile /dockerstartup/nav_shim.py && echo 'PASS: nav_shim.py compiles'",
+					"docker run --rm -e PYTHONPYCACHEPREFIX=/tmp/pycache --entrypoint python3 ghcr.io/kbve/kasm-void:dev -m py_compile /dockerstartup/nav_shim.py && echo 'PASS: nav_shim.py compiles'",
 					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/nav_shim.py && echo 'PASS: nav_shim.py executable'",
 					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/custom_startup.sh && echo 'PASS: custom_startup.sh executable'",
 					"docker run --rm --entrypoint cat ghcr.io/kbve/kasm-void:dev /dockerstartup/custom_startup.sh | grep -q cloak_loop && echo 'PASS: custom_startup.sh has cloak supervisor'",


### PR DESCRIPTION
## Summary
\`Validate Dev→Main PR / Lint and Test\` on PR #11703 ([run](https://github.com/KBVE/kbve/actions/runs/26860780404/job/79213643440)) reached the \`kasm-void:test\` target now that the cloak extraction fix (#11700) lets the image build complete — and surfaced a previously-shadowed problem in the e2e suite:

\`\`\`
[Errno 13] Permission denied: '/dockerstartup/__pycache__'
\`\`\`

\`python3 -m py_compile\` writes \`__pycache__/<mod>.cpython-*.pyc\` next to the source file. \`/dockerstartup\` is owned by root, the container drops to UID 1000 at \`USER 1000\`, so the cache directory creation fails.

## Fix
Set \`PYTHONPYCACHEPREFIX=/tmp/pycache\` on the docker run invocation. \`py_compile\` then mirrors the source tree under \`/tmp/pycache\` (writable by everyone) instead of trying \`/dockerstartup/__pycache__\`. Compilation semantics are unchanged — a syntax error still fails the run.

## Test plan
- [ ] \`nx run kasm-void:test\` passes the nav_shim py_compile assertion locally
- [ ] CI \`Validate Dev→Main PR\` goes green