### PR TITLE
fix(kasm-void): ExposedPorts e2e format + runtime nav_shim smoke

### DIFF
--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -72,11 +72,21 @@
 					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/discord_startup.sh && echo 'PASS: upstream discord startup preserved'",
 					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -f /home/kasm-user/Desktop/cloakbrowser.desktop && echo 'PASS: cloakbrowser.desktop deployed'",
 					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{.Config.Healthcheck.Test}}' | grep -q '/healthz' && echo 'PASS: HEALTHCHECK targets nav_shim /healthz'",
-					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range $$k, $$v := .Config.ExposedPorts}}{{$$k}} {{end}}' | grep -q '9222/tcp' && echo 'PASS: CDP port 9222 exposed'",
-					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range $$k, $$v := .Config.ExposedPorts}}{{$$k}} {{end}}' | grep -q '9998/tcp' && echo 'PASS: nav-shim port 9998 exposed'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{json .Config.ExposedPorts}}' | grep -q '\"9222/tcp\"' && echo 'PASS: CDP port 9222 exposed'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{json .Config.ExposedPorts}}' | grep -q '\"9998/tcp\"' && echo 'PASS: nav-shim port 9998 exposed'",
 					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{.Config.StopSignal}}' | grep -q '^SIGTERM$' && echo 'PASS: STOPSIGNAL=SIGTERM'",
 					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{index .Config.Labels \"org.opencontainers.image.source\"}}' | grep -q 'github.com/KBVE/kbve' && echo 'PASS: OCI source label set'",
-					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{index .Config.Labels \"org.opencontainers.image.title\"}}' | grep -q '^kasm-void$' && echo 'PASS: OCI title label set'"
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{index .Config.Labels \"org.opencontainers.image.title\"}}' | grep -q '^kasm-void$' && echo 'PASS: OCI title label set'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^CLOAK_HOME=/opt/cloakbrowser$' && echo 'PASS: CLOAK_HOME env set'",
+					"docker inspect ghcr.io/kbve/kasm-void:dev --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -q '^CLOAK_BIN=/opt/cloakbrowser/cloakbrowser$' && echo 'PASS: CLOAK_BIN env set'",
+					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'missing=$(ldd /opt/cloakbrowser/chrome 2>/dev/null | grep \"not found\" || true); [ -z \"$missing\" ] || { echo \"missing libs: $missing\" >&2; exit 1; }' && echo 'PASS: chrome shared lib deps resolve'",
+					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'touch /tmp/probe && rm /tmp/probe' && echo 'PASS: /tmp writable by uid 1000'",
+					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'command -v python3 && command -v pip3' >/dev/null && echo 'PASS: python3 + pip3 on PATH'",
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/maximize_window.sh && echo 'PASS: upstream maximize_window.sh preserved'",
+					"cid=$(docker run -d --rm -e URL_LAUNCHER_TOKEN=test --entrypoint python3 ghcr.io/kbve/kasm-void:dev /dockerstartup/nav_shim.py); for i in $(seq 1 15); do docker exec $cid curl -fsS http://127.0.0.1:9998/healthz >/tmp/healthz.out 2>/dev/null && break; sleep 1; done; docker rm -f $cid >/dev/null 2>&1; grep -q '\"ok\":true' /tmp/healthz.out && echo 'PASS: nav_shim /healthz returns ok'",
+					"cid=$(docker run -d --rm -e URL_LAUNCHER_TOKEN=test --entrypoint python3 ghcr.io/kbve/kasm-void:dev /dockerstartup/nav_shim.py); sleep 3; code=$(docker exec $cid curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:9998/open -H 'Content-Type: application/json' -d '{\"url\":\"https://example.com\"}'); docker rm -f $cid >/dev/null 2>&1; [ \"$code\" = \"401\" ] && echo 'PASS: nav_shim /open rejects missing bearer with 401'",
+					"cid=$(docker run -d --rm -e URL_LAUNCHER_TOKEN=test --entrypoint python3 ghcr.io/kbve/kasm-void:dev /dockerstartup/nav_shim.py); sleep 3; code=$(docker exec $cid curl -s -o /dev/null -w '%{http_code}' -X POST http://127.0.0.1:9998/open -H 'Authorization: Bearer test' -H 'Content-Type: application/json' -d '{\"url\":\"http://127.0.0.1/secret\"}'); docker rm -f $cid >/dev/null 2>&1; [ \"$code\" = \"400\" ] && echo 'PASS: nav_shim rejects loopback URL with 400'",
+					"cid=$(docker run -d --rm -e URL_LAUNCHER_TOKEN=test --entrypoint python3 ghcr.io/kbve/kasm-void:dev /dockerstartup/nav_shim.py); sleep 3; code=$(docker exec $cid curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:9998/does-not-exist); docker rm -f $cid >/dev/null 2>&1; [ \"$code\" = \"404\" ] && echo 'PASS: nav_shim returns 404 for unknown route'"
 				],
 				"parallel": false
 			}


### PR DESCRIPTION
## Summary
Latest \`Validate Dev→Main\` ([run](https://github.com/KBVE/kbve/actions/runs/26861195973)) failed the \`CDP port 9222 exposed\` assertion despite \`EXPOSE 9222 9998\` being present and the image picking it up correctly. Root cause is a Go-template quirk: under buildx \`--load\` the inspected \`Config.ExposedPorts\` materialises as a JSON object whose keys are not enumerated by the \`{{range \$k, \$v := ...}}\` form the assertion was using (it emits the empty string), so the \`grep '9222/tcp'\` returns nothing and the test fails.

Switch the two ExposedPorts checks to \`{{json .Config.ExposedPorts}}\` and grep the raw \`"9222/tcp"\` / \`"9998/tcp"\` keys. Robust against any future buildx encoding changes.

## E2E expansion
While we're touching the test list, add coverage that would have caught past breaks earlier (or fences off the next class):

**Static (fast, no container start)**
- \`CLOAK_HOME\` / \`CLOAK_BIN\` env defaults present
- \`ldd /opt/cloakbrowser/chrome\` reports zero \`not found\` entries — catches the next apt drop that loses a libnss/libgtk/libgbm dep
- \`/tmp\` writable by uid 1000 (matches the PYTHONPYCACHEPREFIX target dir from #11705)
- \`python3\` + \`pip3\` on \`PATH\`
- Upstream \`maximize_window.sh\` preserved (custom_startup.sh depends on it)

**Runtime smoke (nav_shim only — no DISPLAY/VNC needed)**
- Start nav_shim, poll for \`/healthz\` returning \`{"ok":true}\`
- \`POST /open\` without bearer → 401
- \`POST /open\` against a loopback URL with bearer → 400 (\`url_safe\` policy)
- \`GET /unknown\` → 404 (catches accidental wildcard handlers in future edits)

All runtime tests reuse \`docker exec \$cid curl\` instead of host port mapping so concurrent CI jobs cannot collide on host 9998.

## Test plan
- [ ] \`nx run kasm-void:test\` passes all 35 assertions locally
- [ ] CI \`Validate Dev→Main PR\` goes green