### PR TITLE
fix(ci-steam-promote): accept EResult=1 as success, not just "OK"

### DIFF
--- a/.github/workflows/ci-steam-promote.yml
+++ b/.github/workflows/ci-steam-promote.yml
@@ -146,10 +146,18 @@ jobs:
                     exit 1
                   fi
 
+                  # Steam Partner API returns response.result as a numeric
+                  # EResult code (1 = OK, 2 = Fail, …). Older docs / some
+                  # endpoints emit the string "OK" instead, so accept both.
                   RESULT=$(jq -r '.response.result // empty' "$HTTP_BODY" 2>/dev/null || echo "")
-                  if [ "$RESULT" != "OK" ] && [ -n "$RESULT" ]; then
-                    echo "::error::Steam API result=$RESULT — promotion failed"
+                  MESSAGE=$(jq -r '.response.message // ""' "$HTTP_BODY" 2>/dev/null || echo "")
+                  if [ -z "$RESULT" ]; then
+                    echo "::error::Steam API returned no response.result field"
+                    exit 1
+                  fi
+                  if [ "$RESULT" != "1" ] && [ "$RESULT" != "OK" ]; then
+                    echo "::error::Steam API result=$RESULT (${MESSAGE:-no message}) — promotion failed"
                     exit 1
                   fi
 
-                  echo "::notice::Promotion succeeded — $APP_ID build $BUILD_ID is now live on $TO_BRANCH"
+                  echo "::notice::Promotion succeeded — $APP_ID build $BUILD_ID is now live on ${BETAKEY:-<default/public>}"


### PR DESCRIPTION
## Summary

ci-steam-promote.yml run [#26861099894](https://github.com/KBVE/kbve/actions/runs/26861099894) — Steam **succeeded**, but the workflow flagged it as failure:

```
HTTP 200
{"response":{"result":1,"message":""}}
##[error]Steam API result=1 — promotion failed
```

Steam Partner Web API returns `response.result` as a numeric [EResult](https://partner.steamgames.com/doc/api/steam_api#EResult) code (1 = `EResult::OK`, 2 = `EResult::Fail`, 3 = `EResult::NoConnection`, …). The success check at [ci-steam-promote.yml:150](.github/workflows/ci-steam-promote.yml#L150) compared against the literal string `"OK"` — false negative every time SetAppBuildLive succeeds.

The demo's `default` branch IS now live on buildid 23522599 — verify in [Steamworks dashboard](https://partner.steamgames.com/apps/builds/3791950). Just our workflow was lying.

## Fix

Accept either `1` (numeric EResult) or `"OK"` (string, used by some older endpoints) as success. Add a guard for missing `response.result` and surface `response.message` on failure for diagnostic clarity.

Also fix the success notice to print `${BETAKEY:-<default/public>}` rather than the raw `TO_BRANCH` — matches the dispatch notice earlier in the same step.

## Test plan

- [ ] Re-dispatch the same promotion: `gh workflow run ci-steam-promote.yml -f app_id=3791950 -f build_id=23522599 -f to_branch=default -f app_label=demo`
- [ ] Approve `steam-prod` gate, expect green run with `Promotion succeeded — 3791950 build 23522599 is now live on <default/public>`
- [ ] Confirm Steamworks dashboard still shows buildid 23522599 on `default` (this PR doesn't alter Steam state, only the success check)