### PR TITLE
fix(astro-kbve): scale + wrap footer socials on mobile

### DIFF
--- a/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
+++ b/apps/kbve/astro-kbve/src/components/footer/AstroFooter.astro
@@ -288,6 +288,8 @@ const currentYear = new Date().getFullYear();
 	.kf-social {
 		display: flex;
 		align-items: center;
+		flex-wrap: wrap;
+		justify-content: flex-end;
 		gap: 1.5rem;
 	}
 
@@ -301,6 +303,20 @@ const currentYear = new Date().getFullYear();
 		.kf-brand {
 			grid-column: 1 / -1;
 		}
+
+		/* Tablet: tighter spacing, allow wrap. SocialTooltip ships a
+		   fixed 56px trigger from packages/npm/astro — override via
+		   :global() since the child markup is unscoped. */
+		.kf-social {
+			gap: 1rem;
+			justify-content: center;
+			width: 100%;
+		}
+		.kf-social :global(.stt__trigger),
+		.kf-social :global(.stt__trigger .stt__layer) {
+			width: 48px;
+			height: 48px;
+		}
 	}
 
 	@media (max-width: 480px) {
@@ -313,6 +329,28 @@ const currentYear = new Date().getFullYear();
 			flex-direction: column;
 			gap: 1rem;
 			text-align: center;
+		}
+
+		/* Phone: 10 socials wrap to 2 rows. Five per row at 40px +
+		   0.6rem gap fits a 360px viewport without horizontal
+		   scroll. */
+		.kf-social {
+			gap: 0.6rem;
+			row-gap: 0.75rem;
+			justify-content: center;
+		}
+		.kf-social :global(.stt__trigger),
+		.kf-social :global(.stt__trigger .stt__layer) {
+			width: 40px;
+			height: 40px;
+		}
+		.kf-social :global(.stt__icon) {
+			width: 40px;
+			height: 40px;
+		}
+		.kf-social :global(.kf-social-glyph svg) {
+			width: 18px;
+			height: 18px;
 		}
 	}
 </style>


### PR DESCRIPTION
The footer ships 10 social tooltips, each a fixed 56×56 px ring with 1.5rem gap. ~728px wide. Below 768px the row blows past the viewport and the bottom bar horizontal-scrolls; on a 360px phone none of the ten fit.

## Fix
Two responsive tiers in `AstroFooter.astro`, both scoped to `.kf-social`:

| Breakpoint | gap | trigger | icon glyph | layout |
|---|---|---|---|---|
| ≤768px (tablet) | 1rem | 48px | 20px | center, full-width row, wrap |
| ≤480px (phone) | 0.6rem (col), 0.75rem (row) | 40px | 18px | 2 rows of 5, centered |
| desktop | 1.5rem | 56px | 20px | unchanged |

`SocialTooltip` lives in `packages/npm/astro` so its `.stt__trigger` / `.stt__layer` / `.stt__icon` classes aren't reachable through Astro's scoped style. Override via `.kf-social :global(.stt__*)` — keeps the API of the shared component intact, only this footer instance scales.

`.kf-social` also adds `flex-wrap: wrap` so the row degrades cleanly on every viewport (not only at the 480px breakpoint). Pre-existing 480px rule already stacks the bottom bar vertically; the socials now sit as a tidy 2×5 grid beneath the copyright.

No SocialTooltip API change. No JS.

## Test plan
- [ ] Build green: `./kbve.sh -nx astro-kbve:build` (7688 pages, verified)
- [ ] Chrome DevTools 360px viewport → 10 icons wrap to 2 rows of 5, no horizontal scroll
- [ ] 768px viewport → icons center below copyright at 48px each
- [ ] Desktop ≥769px → unchanged 56px row