### PR TITLE
fix(yuki): always-on lifecycle diagnostics so the next "VRM invisible" report self-diagnoses

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -114,11 +114,31 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	key.position.set(1, 2, 1.5);
 	scene.add(key);
 
+	console.warn('[yuki-vrm] mount start', {
+		vrmUrl,
+		hostSize: { w: host.clientWidth, h: host.clientHeight },
+		transparent,
+	});
+
 	const loader = new GLTFLoader();
 	loader.register((parser) => new VRMLoaderPlugin(parser));
-	const gltf = await loader.loadAsync(vrmUrl);
+	let gltf;
+	try {
+		gltf = await loader.loadAsync(vrmUrl);
+	} catch (err) {
+		console.error('[yuki-vrm] loadAsync failed', vrmUrl, err);
+		throw err;
+	}
 	const vrm: VRM | undefined = gltf.userData.vrm;
-	if (!vrm) throw new Error('VRM payload missing on loaded GLTF');
+	if (!vrm) {
+		console.error('[yuki-vrm] gltf has no userData.vrm', gltf);
+		throw new Error('VRM payload missing on loaded GLTF');
+	}
+	console.warn('[yuki-vrm] gltf loaded', {
+		hasVrm: !!vrm,
+		hasHumanoid: !!vrm.humanoid,
+		sceneChildrenBeforeAdd: scene.children.length,
+	});
 
 	try {
 		(
@@ -136,18 +156,15 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	scene.add(vrm.scene);
 	applyRestPose(vrm);
 
-	if (
-		typeof window !== 'undefined' &&
-		/[?&]yuki-debug=1/.test(window.location.search)
-	) {
-		console.warn('[yuki-vrm] loaded', {
-			hasHumanoid: !!vrm.humanoid,
-			sceneChildren: scene.children.length,
-			canvasSize: { w: canvas.width, h: canvas.height },
-			hostSize: { w: host.clientWidth, h: host.clientHeight },
-			vrmUrl,
-		});
-	}
+	const gl = renderer.getContext();
+	console.warn('[yuki-vrm] mount ready', {
+		hasHumanoid: !!vrm.humanoid,
+		sceneChildren: scene.children.length,
+		canvasSize: { w: canvas.width, h: canvas.height },
+		hostSize: { w: host.clientWidth, h: host.clientHeight },
+		webglContextLost: gl ? gl.isContextLost() : 'no-context',
+		vrmUrl,
+	});
 
 	const humanoid = vrm.humanoid;
 	const spineBone = humanoid?.getNormalizedBoneNode(VRMHumanBoneName.Spine);
@@ -268,6 +285,7 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	let rafId = 0;
 	let disposed = false;
 	let active = true;
+	let firstRenderLogged = false;
 
 	const tick = (now: number) => {
 		if (disposed) return;
@@ -339,7 +357,30 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		}
 
 		vrm.update(delta);
-		renderer.render(scene, camera);
+		try {
+			renderer.render(scene, camera);
+		} catch (err) {
+			if (!firstRenderLogged) {
+				console.error('[yuki-vrm] renderer.render threw', err);
+				firstRenderLogged = true;
+			}
+			return;
+		}
+		if (!firstRenderLogged) {
+			firstRenderLogged = true;
+			const ctx = renderer.getContext();
+			console.warn('[yuki-vrm] first render', {
+				canvasSize: { w: canvas.width, h: canvas.height },
+				canvasClientSize: {
+					w: canvas.clientWidth,
+					h: canvas.clientHeight,
+				},
+				hostSize: { w: host.clientWidth, h: host.clientHeight },
+				visibility: document.visibilityState,
+				webglContextLost: ctx ? ctx.isContextLost() : 'no-context',
+				vrmSceneVisible: vrm.scene.visible,
+			});
+		}
 	};
 	rafId = requestAnimationFrame(tick);
 


### PR DESCRIPTION
## Why

User reports that even after #11641 the Yuki model still doesn't render in production while the chat stream works. The \`?yuki-debug=1\` diagnostic added there is opt-in and only fires after \`scene.add(vrm.scene)\`. We can't distinguish between:

- 404 / CORS on \`/assets/vt/witch-mimiko-meadow.vrm\`
- GLTF loads but \`gltf.userData.vrm\` is missing (loader plugin not picked up)
- WebGL context is lost (GPU driver, headless mode quirk)
- Canvas mounted with zero dimensions (host hidden at mount, ResizeObserver never fires)
- \`renderer.render\` throws silently
- Tick loop never starts

## What

Promote the diagnostics to always-on at four phases. One \`console.warn\` each — cheap, single-mount, no per-frame noise:

1. **\`mount start\`** — \`vrmUrl\` + host element dimensions + transparent flag, before the GLTFLoader runs
2. **\`gltf loaded\`** — VRM payload presence after \`loader.loadAsync\`, with explicit \`console.error\` paths when \`loadAsync\` rejects or \`gltf.userData.vrm\` is missing
3. **\`mount ready\`** — humanoid + scene children + canvas + host dims + WebGL context-lost state, after \`scene.add(vrm.scene)\`
4. **\`first render\`** — one-shot log when \`renderer.render(scene, camera)\` completes its first frame; surfaces canvas vs host size, document visibility, WebGL context loss, and \`vrm.scene.visible\`. If the render call throws, log the error once instead of spamming.

The first-frame log is the key new signal:

- \`canvas.width == 0\` → ResizeObserver never fired against a real host
- \`webglContextLost: true\` → GPU driver / headless context drop
- \`hostSize: { w: 0, h: 0 }\` → mounted into a \`display:none\` panel
- Log missing entirely → \`renderer.render\` is throwing or the tick loop never started

Built clean — 7688 pages.

## Test plan

- [ ] Open any page with the dock + open DevTools console + expand dock + toggle \"Show 3D Yuki\" on
- [ ] Console shows \`[yuki-vrm] mount start\` → \`gltf loaded\` → \`mount ready\` → \`first render\` in order
- [ ] If the model is visible: every payload is sane, no \`console.error\`
- [ ] If the model is invisible: at least one of the four payloads is anomalous and tells us exactly which phase failed