### PR TITLE
feat(rareicon): spiral hex-slot packing — unit decluster stops wrapping at 20+

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/HexSlotAssignSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/HexSlotAssignSystem.cs
@@ -5,7 +5,7 @@ using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Decluster pass: assigns every unit a unique intra-hex slot so two units targeting the same hex don't stack on the same pixel. Build-bucket job partitions units by TargetHex into a NativeParallelMultiHashMap, then the assign job walks each unit's bucket and ranks by Entity.Index so the N-th smallest-index unit on a hex lands at slot N. Slot offset comes from a 19-point table (1 centre + 6-point ring at r=0.06 + 12-point ring at r=0.12) — keeps everyone inside the 0.25 hex radius. Missing HexSlotOffset components are added via ECB on first sight so spawn code doesn't have to remember to seed it. Runs in MovementSystemGroup before UnitMovementSystem so the target used for locomotion already carries the slot offset.</summary>
+    /// <summary>Decluster pass: assigns every unit a unique intra-hex slot so two units targeting the same hex don't stack on the same pixel. Build-bucket job partitions units by TargetHex into a NativeParallelMultiHashMap, then the assign job walks each unit's bucket and ranks by Entity.Index so the N-th smallest-index unit on a hex lands at slot N. Slot offset uses Vogel's phyllotaxis (golden-angle spiral): radius = c·sqrt(rank), angle = rank·goldenAngle. Every rank lands at a distinct (x, y) so 20+ units on one hex no longer wrap back onto the centre, and density stays roughly uniform across the disc. Capped at the hex inner radius so units stay inside the tile. Missing HexSlotOffset components are added via ECB on first sight so spawn code doesn't have to remember to seed it. Runs in MovementSystemGroup before UnitMovementSystem so the target used for locomotion already carries the slot offset.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(MovementSystemGroup))]
     [UpdateBefore(typeof(UnitMovementSystem))]
@@ -100,18 +100,16 @@ namespace RareIcon
             offset.Value = SlotOffset(rank);
         }
 
+        const float GoldenAngle    = 2.39996323f;
+        const float SpiralScale    = 0.07f;
+        const float HexInnerRadius = 0.22f;
+
         static float2 SlotOffset(int rank)
         {
-            int slot = rank % 19;
-            if (slot == 0) return float2.zero;
-            if (slot <= 6)
-            {
-                float a = (slot - 1) * (math.PI / 3f);
-                return new float2(math.cos(a), math.sin(a)) * 0.08f;
-            }
-            int outerIdx = slot - 7;
-            float ao = outerIdx * (math.PI / 6f);
-            return new float2(math.cos(ao), math.sin(ao)) * 0.16f;
+            if (rank <= 0) return float2.zero;
+            float r = math.min(SpiralScale * math.sqrt(rank), HexInnerRadius);
+            float a = rank * GoldenAngle;
+            return new float2(math.cos(a), math.sin(a)) * r;
         }
     }
 }


### PR DESCRIPTION
## Summary

[HexSlotAssignSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/HexSlotAssignSystem.cs) used a 19-point lookup table (1 centre + 6-pt ring at r=0.08 + 12-pt ring at r=0.16) and cycled via `rank % 19`. So the 20th unit on a hex landed back at the centre and stacked the 21st on the inner ring, etc. Visible as creature pile-ups whenever combat or harvest converged on a tile.

Replace with Vogel phyllotaxis (golden-angle spiral):

```csharp
const float GoldenAngle    = 2.39996323f; // π · (3 − √5)
const float SpiralScale    = 0.07f;
const float HexInnerRadius = 0.22f;

float r = math.min(SpiralScale * math.sqrt(rank), HexInnerRadius);
float a = rank * GoldenAngle;
offset.Value = new float2(math.cos(a), math.sin(a)) * r;
```

Properties:

- **Every rank → distinct (x, y)** within the hex. No `% N` wrap-around.
- **Density stays roughly uniform** across the disc (sunflower seed-head distribution).
- **High-rank units that hit the clamp** still advance by golden angle around the perimeter — they ring the edge instead of overlapping.
- **Spacing**: c=0.07 keeps low-rank distance from centre in the same ballpark as the old inner ring (r=0.07 vs 0.08). Bulk-spiral nearest-neighbour ≈ 0.124, vs the old inner ring's 0.08 — units feel more spread without leaving the hex.
- **Stays inside the prior 0.25-hex safety margin** (clamp at 0.22).
- Both Burst jobs still compile — `math.sqrt` / `math.cos` / `math.sin` only.

## Test plan

- [ ] Stress test: 50+ units harvest the same forest tile — visually distinct positions, no centre pile.
- [ ] Combat scrum on one hex — units ring the perimeter at higher ranks, no overlap with low ranks.
- [ ] Confirm Burst still compiles HexSlotAssignSystem clean (no BC1xxx errors).
- [ ] Frame-time delta sanity check (math.sqrt + one trig pair per unit ≤ the old branch + multiply).

## Follow-up

Shader detail iteration ([HexUnit.shader](apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexUnit.shader)) parked — revisit after seeing this in-game. Soft boids separation force in [JobMovementExecutor](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/JobMovementExecutor.cs) also parked; only worth the lift if static-rank spiral still feels too rigid in motion.