### PR TITLE
feat(rareicon): quadratic crowding penalty for harvest task scoring

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
@@ -23,6 +23,7 @@ namespace RareIcon
         const int PriorityWeight  = 10000;
         const int HysteresisBonus = 50;
         const int DeficitCap      = 2;
+        const int CrowdingPenalty = 200;
 
         uint _lastSeenBuildVersion;
 
@@ -294,11 +295,17 @@ namespace RareIcon
                     int dist = HexDistance(currentHex, offer.Hex);
                     if (dist > OfferDistanceCap(offer.Kind, offer.Variant)) continue;
 
+                    int crowdOcc = 0;
                     if (IsHarvestVariant(offer.Kind, offer.Variant)
-                        && _hexOccupancy.TryGetValue(offer.Hex, out var occ)
-                        && occ >= HexClusterCap) continue;
+                        && _hexOccupancy.TryGetValue(offer.Hex, out var occ))
+                    {
+                        if (occ >= HexClusterCap) continue;
+                        crowdOcc = occ;
+                    }
 
                     long score = (long)prio * PriorityWeight - (long)dist;
+                    if (crowdOcc > 0)
+                        score -= (long)crowdOcc * crowdOcc * CrowdingPenalty;
                     if (offer.Target != Entity.Null && offer.Target == currentTarget)
                         score += HysteresisBonus;
                     if (offer.Kind < offersPerKind.Length)


### PR DESCRIPTION
## Summary

[ProfessionDispatchSystem.cs:297](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs#L297) already rejected harvest offers past `HexClusterCap = 4`, but every unit below that cap competed for the same tile at full priority. So the first four lumberjacks all ran to the closest forest, and the fifth only found a second forest because the hard cap kicked in. Visible as four-deep clusters before the spillover starts.

Add a soft quadratic penalty within the cap:

```csharp
const int CrowdingPenalty = 200;
// …
if (crowdOcc > 0)
    score -= (long)crowdOcc * crowdOcc * CrowdingPenalty;
```

| Already targeting hex | Score delta |
|---|---|
| 0 | 0 |
| 1 | −200 |
| 2 | −800 |
| 3 | −1800 |

`PriorityWeight` stays 10000, so the penalty nudges *within* a priority band without overriding higher-priority work. With two equal-priority forests in range, the empty one wins. With one forest already heavily targeted, an equivalent forest a few hexes farther becomes preferable. Hard cap at 4 remains for the spillover safety net.

Reads `_hexOccupancy`, which is rebuilt every dispatch tick from current `JobIntent.TargetHex` values, so the penalty reflects committed claims (not just current position) — units re-evaluate routes against fresh occupancy each tick.

Pairs with #11714 (spiral hex-slot packing) — placement no longer wraps to centre, scoring no longer drives the wrap.

## Test plan

- [ ] 6 lumberjacks + 2 equidistant forests → expect ~3/3 split, not 4/2.
- [ ] 10 lumberjacks + 3 forests at varied distances → closest gets first, second-closest fills as first hits ~3, third only used once first two are saturated or distant gain offsets crowding.
- [ ] Higher-priority manual order on a crowded hex still wins (penalty < priority-bump gap).
- [ ] Hard cap at 4 still triggers — once a hex hits 4, units pick alternatives even with no nearby forest (wander fallback should kick in).