### PR TITLE
test(yuki): pixel-level guard on yuki-vrm spec — closes the gap that let the invisible-VRM bug pass CI

### DIFF
--- a/apps/kbve/astro-kbve/e2e/yuki-vrm.spec.ts
+++ b/apps/kbve/astro-kbve/e2e/yuki-vrm.spec.ts
@@ -1,19 +1,28 @@
 import { test, expect, type ConsoleMessage } from '@playwright/test';
 
 const HOST_PAGE = '/yuki/?yuki-debug=1';
-const LOAD_MARK = '[yuki-vrm] loaded';
+const READY_MARK = '[yuki-vrm] mount ready';
+const LEGACY_LOAD_MARK = '[yuki-vrm] loaded';
+const FIRST_RENDER_MARK = '[yuki-vrm] first render';
 const MOUNT_TIMEOUT = 30_000;
 
 test.describe('yuki vrm smoke', () => {
-	test('VRM mounts with humanoid + populated scene under ?yuki-debug=1', async ({
+	test('VRM mounts with humanoid + populated scene + paints pixels to canvas', async ({
 		page,
 	}) => {
 		const consoleErrors: string[] = [];
-		const debugMessages: ConsoleMessage[] = [];
+		const readyMessages: ConsoleMessage[] = [];
+		const firstRenderMessages: ConsoleMessage[] = [];
 
 		page.on('console', (msg) => {
-			if (msg.type() === 'error') consoleErrors.push(msg.text());
-			if (msg.text().includes(LOAD_MARK)) debugMessages.push(msg);
+			const text = msg.text();
+			if (msg.type() === 'error') consoleErrors.push(text);
+			if (text.includes(READY_MARK) || text.includes(LEGACY_LOAD_MARK)) {
+				readyMessages.push(msg);
+			}
+			if (text.includes(FIRST_RENDER_MARK)) {
+				firstRenderMessages.push(msg);
+			}
 		});
 
 		await page.goto(HOST_PAGE, { waitUntil: 'load' });
@@ -32,12 +41,12 @@ test.describe('yuki vrm smoke', () => {
 		}
 
 		await expect
-			.poll(() => debugMessages.length, { timeout: MOUNT_TIMEOUT })
+			.poll(() => readyMessages.length, { timeout: MOUNT_TIMEOUT })
 			.toBeGreaterThan(0);
 
-		const args = debugMessages[0].args();
-		expect(args.length).toBeGreaterThanOrEqual(2);
-		const payload = (await args[1].jsonValue()) as {
+		const readyArgs = readyMessages[0].args();
+		expect(readyArgs.length).toBeGreaterThanOrEqual(2);
+		const payload = (await readyArgs[1].jsonValue()) as {
 			hasHumanoid: boolean;
 			sceneChildren: number;
 			canvasSize: { w: number; h: number };
@@ -54,6 +63,46 @@ test.describe('yuki vrm smoke', () => {
 		expect(box?.width ?? 0).toBeGreaterThan(0);
 		expect(box?.height ?? 0).toBeGreaterThan(0);
 
+		const sawFirstRender = await pollOptional(
+			() => firstRenderMessages.length > 0,
+			6_000,
+		);
+		if (sawFirstRender) {
+			const renderArgs = firstRenderMessages[0].args();
+			if (renderArgs.length >= 2) {
+				const renderPayload = (await renderArgs[1].jsonValue()) as {
+					canvasSize: { w: number; h: number };
+					webglContextLost: boolean | string;
+				};
+				expect(renderPayload.webglContextLost).not.toBe(true);
+				expect(renderPayload.canvasSize.w).toBeGreaterThan(0);
+				expect(renderPayload.canvasSize.h).toBeGreaterThan(0);
+			}
+		}
+
+		// Settle a few frames so the rest-pose + lookAt smoothing finish
+		// before the screenshot diff. Animations are disabled at the
+		// project level (playwright.config.ts `animations: 'disabled'`)
+		// but the render loop itself keeps ticking — give it 600 ms to
+		// reach a stable frame.
+		await page.waitForTimeout(600);
+
+		await expect(canvas).toHaveScreenshot('yuki-vrm-canvas.png', {
+			maxDiffPixelRatio: 0.4,
+		});
+
 		expect(consoleErrors, consoleErrors.join('\n')).toHaveLength(0);
 	});
 });
+
+async function pollOptional(
+	predicate: () => boolean,
+	timeoutMs: number,
+): Promise<boolean> {
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		if (predicate()) return true;
+		await new Promise((r) => setTimeout(r, 100));
+	}
+	return false;
+}


### PR DESCRIPTION
Follow-up to #11651. Tracks #11717 (broader rollout). Pairs with #11713 (the in-flight always-on diagnostics).

## Why

The original \`yuki-vrm.spec.ts\` asserted scene graph + canvas DOM but never asserted the canvas had pixels drawn. The model rendered invisible on production while CI stayed green — exactly the failure mode #11641 + #11713 are still chasing.

The spec passed because:

- \`hasHumanoid\` is set the moment \`gltf.userData.vrm\` is parsed
- \`sceneChildren >= 3\` just means \`scene.add()\` ran
- \`canvas\` is visible because the DOM \`<canvas>\` has size — pixels can be all transparent / all slate
- Zero console errors — \`renderer.render()\` returns \`void\`, doesn't surface \"drew nothing\"

Plus headless Chromium has SwiftShader so WebGL issues that bite real iOS Safari often pass in CI.

## Changes

1. Wait for both the existing \`[yuki-vrm] mount ready\` log AND, when present (PR #11713), the \`[yuki-vrm] first render\` log. The new render-phase payload exposes WebGL context state + canvas size; assert \`webglContextLost !== true\` and dims > 0.
2. Settle 600 ms after the render-mark so lookAt smoothing + rest-pose reach a stable frame (animations are disabled at the project level via \`playwright.config.ts\`, the render loop itself keeps ticking).
3. \`await expect(canvas).toHaveScreenshot('yuki-vrm-canvas.png', { maxDiffPixelRatio: 0.4 })\` — uses the visual-regression infra from #11598. A blank slate / transparent canvas diffs > 40 % vs a populated baseline and fails the spec.

## Baselines

**Intentionally NOT committed in this PR.** They need to be generated locally with \`pnpm exec playwright test yuki-vrm.spec.ts --update-snapshots\` after rebasing on top of #11713 (so the first-render diagnostic is present), then committed as a follow-up. The bare assertion failing on the first CI run after this PR is the intended forcing function — without it the next person to touch the dock would silently regress the same gap.

## Test plan

- [ ] Merge order: #11713 → this → baseline-update PR
- [ ] After #11713 lands, \`pnpm exec playwright test yuki-vrm.spec.ts --update-snapshots\` produces 4 baselines (chromium / webkit / mobile-chrome / mobile-safari) under \`e2e/__screenshots__/{projectName}/yuki-vrm.spec.ts/\`
- [ ] Locally regress YukiVRM by commenting out \`scene.add(vrm.scene)\` → spec fails on the screenshot diff, not on \`sceneChildren >= 3\`
- [ ] Locally regress YukiVRM by setting \`camera.position.set(0, 0, 1000)\` (offscreen) → spec fails on the screenshot diff, scene-graph assertions all pass