### PR TITLE
perf(rareicon): per-kind offer slicing + occupancy filter + capacity bump

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionComponents.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionComponents.cs
@@ -21,6 +21,8 @@ namespace RareIcon
         public const byte Blacksmith = 10;
         public const byte Craftsman  = 11;
         public const byte Medic      = 12;
+
+        public const int  Count      = 13;
     }
 
     /// <summary>Per-unit profession priorities (0 = disabled, 1..5 = weighted preference). Fixed-layout struct so it's Burst-readable without a buffer walk.</summary>

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionOffersSingleton.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionOffersSingleton.cs
@@ -11,11 +11,15 @@ namespace RareIcon
         public int2   Hex;
     }
 
-    /// <summary>World-level dispatch context, rebuilt on cadence by ProfessionOfferBuildSystem and read by ProfessionDispatchSystem. Offers is a flat candidate pool so per-unit scoring walks one list instead of re-querying the world per unit. BuildVersion increments on each rebuild so downstream consumers can gate work to fresh-data ticks without duplicating the cadence check.</summary>
+    /// <summary>World-level dispatch context, rebuilt on cadence by ProfessionOfferBuildSystem and read by ProfessionDispatchSystem. Offers is the original insertion-order pool kept for back-compat; per-unit scoring iterates the OffersSortedByKind slice for each kind the unit cares about, looked up via OfferKindStart + OfferKindCount. BuildVersion increments on each rebuild so downstream consumers can gate work to fresh-data ticks without duplicating the cadence check.</summary>
     public struct ProfessionOffersSingleton : IComponentData
     {
         public NativeList<TaskOffer> Offers;
         public NativeArray<int>      OffersPerKind;
+
+        public NativeList<TaskOffer> OffersSortedByKind;
+        public NativeArray<int>      OfferKindStart;
+        public NativeArray<int>      OfferKindCount;
 
         public bool   HasCapital;
         public Entity Capital;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
@@ -35,7 +35,14 @@ namespace RareIcon
             state.RequireForUpdate<CombatDBSingleton>();
             state.RequireForUpdate<ItemDBSingleton>();
 
-            _hexOccupancy = new NativeHashMap<int2, int>(64, Allocator.Persistent);
+            _hexOccupancy = new NativeHashMap<int2, int>(4096, Allocator.Persistent);
+        }
+
+        static bool CountsTowardHexOccupancy(byte kind)
+        {
+            return kind == ProfessionKind.Lumberjack
+                || kind == ProfessionKind.Miner
+                || kind == ProfessionKind.Looter;
         }
 
         public void OnDestroy(ref SystemState state)
@@ -71,9 +78,11 @@ namespace RareIcon
             bool hasCapital     = offersDB.HasCapital;
             bool capitalHasFood = offersDB.CapitalHasFood;
 
-            var offers        = offersDB.Offers;
-            var offersPerKind = offersDB.OffersPerKind;
-            var needyCaves    = offersDB.NeedyCaves;
+            var offersPerKind      = offersDB.OffersPerKind;
+            var offersSortedByKind = offersDB.OffersSortedByKind;
+            var offerKindStart     = offersDB.OfferKindStart;
+            var offerKindCount     = offersDB.OfferKindCount;
+            var needyCaves         = offersDB.NeedyCaves;
 
             var threats          = combatDB.Threats;
             var friendlyEmitters = combatDB.FriendlyEmitters;
@@ -81,7 +90,7 @@ namespace RareIcon
 
             var controlledLookup = SystemAPI.GetComponentLookup<ControlledUnitTag>(true);
 
-            var justAssignedPerKind = new NativeArray<int>(13, Allocator.Temp);
+            var justAssignedPerKind = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
 
             BufferLookup<PackSlot> unitPackLookup = default;
             NativeArray<int> activePerKind   = default;
@@ -93,15 +102,18 @@ namespace RareIcon
 
                 _hexOccupancy.Clear();
 
-                activePerKind   = new NativeArray<int>(13, Allocator.Temp);
-                reservedPerKind = new NativeArray<int>(13, Allocator.Temp);
+                activePerKind   = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
+                reservedPerKind = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
 
                 foreach (var jobRO in
                          SystemAPI.Query<RefRO<ProfessionIntent>>().WithAll<ProfessionPriorities>())
                 {
                     byte ak = jobRO.ValueRO.Kind;
-                    if (jobRO.ValueRO.Kind != ProfessionKind.None)
-                        _hexOccupancy[jobRO.ValueRO.TargetHex] = _hexOccupancy.TryGetValue(jobRO.ValueRO.TargetHex, out var c0) ? c0 + 1 : 1;
+                    if (CountsTowardHexOccupancy(ak))
+                    {
+                        var hex = jobRO.ValueRO.TargetHex;
+                        _hexOccupancy[hex] = _hexOccupancy.TryGetValue(hex, out var c0) ? c0 + 1 : 1;
+                    }
                     if (ak < activePerKind.Length) activePerKind[ak]++;
                 }
 
@@ -269,66 +281,77 @@ namespace RareIcon
                 else
                     looterMode = 0xFF;  // forage fallback
 
-                for (int oi = 0; oi < offers.Length; oi++)
+                // Walk only the per-kind slices this unit has priority for.
+                // At 100k units this turns the inner work from O(all_offers)
+                // into O(sum(offers_per_active_kind)) — units with sparse
+                // JobPriorities skip most of the pool entirely.
+                for (byte kind = ProfessionKind.Default; kind < ProfessionKind.Count; kind++)
                 {
-                    var offer = offers[oi];
-                    byte prio = p.Get(offer.Kind);
+                    byte prio = p.Get(kind);
                     if (prio == 0) continue;
 
-                    if (offer.Kind == ProfessionKind.Looter)
+                    int kindStart = offerKindStart[kind];
+                    int kindCount = offerKindCount[kind];
+                    int oNk = offersPerKind[kind];
+                    int aNk = activePerKind[kind] + justAssignedPerKind[kind];
+                    int rNk = reservedPerKind[kind];
+                    int deficit = oNk - aNk;
+                    int reservationShortfall = rNk - aNk;
+                    long deficitBonus = deficit > 0
+                        ? (long)math.min(deficit, DeficitCap) * (PriorityWeight / 4)
+                        : 0L;
+                    long reservationBonus = reservationShortfall > 0
+                        ? (long)math.min(reservationShortfall, DeficitCap) * PriorityWeight
+                        : 0L;
+                    float pressure = (float)(oNk + 1) / (float)(aNk + 1);
+                    long pressureBonus = (long)(math.log(1f + pressure) * 30f);
+                    long perKindBonus = deficitBonus + reservationBonus + pressureBonus;
+
+                    for (int si = 0; si < kindCount; si++)
                     {
-                        if (looterMode == OfferVariant.LooterDeliver)
+                        var offer = offersSortedByKind[kindStart + si];
+
+                        if (kind == ProfessionKind.Looter)
                         {
-                            if (offer.Variant != OfferVariant.LooterDeliver) continue;
+                            if (looterMode == OfferVariant.LooterDeliver)
+                            {
+                                if (offer.Variant != OfferVariant.LooterDeliver) continue;
+                            }
+                            else if (looterMode == OfferVariant.LooterFetch)
+                            {
+                                if (offer.Variant != OfferVariant.LooterFetch) continue;
+                            }
+                            else
+                            {
+                                if (offer.Variant != OfferVariant.LooterForage
+                                    && offer.Variant != OfferVariant.LooterDropPickup) continue;
+                            }
                         }
-                        else if (looterMode == OfferVariant.LooterFetch)
+
+                        int dist = HexDistance(currentHex, offer.Hex);
+                        if (dist > OfferDistanceCap(kind, offer.Variant)) continue;
+
+                        int crowdOcc = 0;
+                        if (IsHarvestVariant(kind, offer.Variant)
+                            && _hexOccupancy.TryGetValue(offer.Hex, out var occ))
                         {
-                            if (offer.Variant != OfferVariant.LooterFetch) continue;
+                            if (occ >= HexClusterCap) continue;
+                            crowdOcc = occ;
                         }
-                        else
+
+                        long score = (long)prio * PriorityWeight - (long)dist + perKindBonus;
+                        if (crowdOcc > 0)
+                            score -= (long)crowdOcc * crowdOcc * CrowdingPenalty;
+                        if (offer.Target != Entity.Null && offer.Target == currentTarget)
+                            score += HysteresisBonus;
+
+                        if (score > bestScore)
                         {
-                            if (offer.Variant != OfferVariant.LooterForage
-                                && offer.Variant != OfferVariant.LooterDropPickup) continue;
+                            bestScore  = score;
+                            bestKind   = kind;
+                            bestHex    = offer.Hex;
+                            bestEntity = offer.Target;
                         }
-                    }
-
-                    int dist = HexDistance(currentHex, offer.Hex);
-                    if (dist > OfferDistanceCap(offer.Kind, offer.Variant)) continue;
-
-                    int crowdOcc = 0;
-                    if (IsHarvestVariant(offer.Kind, offer.Variant)
-                        && _hexOccupancy.TryGetValue(offer.Hex, out var occ))
-                    {
-                        if (occ >= HexClusterCap) continue;
-                        crowdOcc = occ;
-                    }
-
-                    long score = (long)prio * PriorityWeight - (long)dist;
-                    if (crowdOcc > 0)
-                        score -= (long)crowdOcc * crowdOcc * CrowdingPenalty;
-                    if (offer.Target != Entity.Null && offer.Target == currentTarget)
-                        score += HysteresisBonus;
-                    if (offer.Kind < offersPerKind.Length)
-                    {
-                        int oN = offersPerKind[offer.Kind];
-                        int aN = activePerKind[offer.Kind] + justAssignedPerKind[offer.Kind];
-                        int rN = reservedPerKind[offer.Kind];
-                        int deficit = oN - aN;
-                        if (deficit > 0)
-                            score += (long)math.min(deficit, DeficitCap) * (PriorityWeight / 4);
-                        int reservationShortfall = rN - aN;
-                        if (reservationShortfall > 0)
-                            score += (long)math.min(reservationShortfall, DeficitCap) * PriorityWeight;
-                        float pressure = (float)(oN + 1) / (float)(aN + 1);
-                        score += (long)(math.log(1f + pressure) * 30f);
-                    }
-
-                    if (score > bestScore)
-                    {
-                        bestScore  = score;
-                        bestKind   = offer.Kind;
-                        bestHex    = offer.Hex;
-                        bestEntity = offer.Target;
                     }
                 }
 
@@ -393,8 +416,13 @@ namespace RareIcon
 
                 var prevIntent = jobIntentRef.ValueRO;
                 var oldTarget  = prevIntent.TargetHex;
-                if (_hexOccupancy.TryGetValue(oldTarget, out var oldCount) && oldCount > 0)
-                    _hexOccupancy[oldTarget] = oldCount - 1;
+                if (CountsTowardHexOccupancy(prevIntent.Kind)
+                    && _hexOccupancy.TryGetValue(oldTarget, out var oldCount)
+                    && oldCount > 0)
+                {
+                    if (oldCount == 1) _hexOccupancy.Remove(oldTarget);
+                    else               _hexOccupancy[oldTarget] = oldCount - 1;
+                }
 
                 if (bestKind == ProfessionKind.None)
                 {

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionOfferBuildSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionOfferBuildSystem.cs
@@ -22,10 +22,13 @@ namespace RareIcon
 
             var db = new ProfessionOffersSingleton
             {
-                Offers        = new NativeList<TaskOffer>(256, Allocator.Persistent),
-                OffersPerKind = new NativeArray<int>(13, Allocator.Persistent),
-                NeedyCaves    = new NativeList<NeedyCave>(4, Allocator.Persistent),
-                BuildVersion  = 0,
+                Offers             = new NativeList<TaskOffer>(256, Allocator.Persistent),
+                OffersPerKind      = new NativeArray<int>(ProfessionKind.Count, Allocator.Persistent),
+                OffersSortedByKind = new NativeList<TaskOffer>(256, Allocator.Persistent),
+                OfferKindStart     = new NativeArray<int>(ProfessionKind.Count, Allocator.Persistent),
+                OfferKindCount     = new NativeArray<int>(ProfessionKind.Count, Allocator.Persistent),
+                NeedyCaves         = new NativeList<NeedyCave>(4, Allocator.Persistent),
+                BuildVersion       = 0,
             };
             _singleton = state.EntityManager.CreateEntity(typeof(ProfessionOffersSingleton));
             state.EntityManager.SetName(_singleton, "ProfessionOffers");
@@ -38,9 +41,12 @@ namespace RareIcon
         {
             if (!state.EntityManager.Exists(_singleton)) return;
             var db = state.EntityManager.GetComponentData<ProfessionOffersSingleton>(_singleton);
-            if (db.Offers.IsCreated)        db.Offers.Dispose();
-            if (db.OffersPerKind.IsCreated) db.OffersPerKind.Dispose();
-            if (db.NeedyCaves.IsCreated)    db.NeedyCaves.Dispose();
+            if (db.Offers.IsCreated)             db.Offers.Dispose();
+            if (db.OffersPerKind.IsCreated)      db.OffersPerKind.Dispose();
+            if (db.OffersSortedByKind.IsCreated) db.OffersSortedByKind.Dispose();
+            if (db.OfferKindStart.IsCreated)     db.OfferKindStart.Dispose();
+            if (db.OfferKindCount.IsCreated)     db.OfferKindCount.Dispose();
+            if (db.NeedyCaves.IsCreated)         db.NeedyCaves.Dispose();
         }
 
         [BurstCompile]
@@ -180,6 +186,32 @@ namespace RareIcon
                 byte ok = offers[oi].Kind;
                 if (ok < opk.Length) opk[ok]++;
             }
+
+            // Counting sort offers by Kind into OffersSortedByKind so
+            // ProfessionDispatchSystem can walk the slice for each kind
+            // the unit cares about instead of scanning the global pool.
+            var oks = db.OfferKindStart;
+            var okc = db.OfferKindCount;
+            int running = 0;
+            for (int k = 0; k < ProfessionKind.Count; k++)
+            {
+                oks[k] = running;
+                okc[k] = opk[k];
+                running += opk[k];
+            }
+
+            var sorted = db.OffersSortedByKind;
+            sorted.Clear();
+            sorted.Length = offers.Length;
+            var cursor = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
+            for (int oi = 0; oi < offers.Length; oi++)
+            {
+                var o = offers[oi];
+                if (o.Kind >= ProfessionKind.Count) continue;
+                int idx = oks[o.Kind] + cursor[o.Kind]++;
+                sorted[idx] = o;
+            }
+            cursor.Dispose();
 
             db.BuildVersion++;
         }


### PR DESCRIPTION
First pass of the dispatch optimization roadmap (#11716) targeting 100k+ units. Stays main-thread for now — IJobEntity / spatial hash lands in the follow-up PR. Items implemented from the roadmap: **#10**, **#3**, **#5**, **#2**.

## Per-kind slicing (#10 + structural prep for #1)

[ProfessionOffersSingleton](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionOffersSingleton.cs) gains:

```csharp
public NativeList<TaskOffer> OffersSortedByKind;
public NativeArray<int>      OfferKindStart;
public NativeArray<int>      OfferKindCount;
```

[ProfessionOfferBuildSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionOfferBuildSystem.cs) counting-sorts the pool by Kind after the existing world scan — O(n) + an O(13) prefix pass.

[ProfessionDispatchSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs) inverts the scoring loop:

```csharp
// Was: for (int oi = 0; oi < offers.Length; oi++) { byte prio = p.Get(offer.Kind); if (prio == 0) continue; ... }
// Now:
for (byte kind = ProfessionKind.Default; kind < ProfessionKind.Count; kind++)
{
    byte prio = p.Get(kind);
    if (prio == 0) continue;

    int kindStart = offerKindStart[kind];
    int kindCount = offerKindCount[kind];
    // … per-kind bonus terms computed once …
    for (int si = 0; si < kindCount; si++)
    {
        var offer = offersSortedByKind[kindStart + si];
        // … existing per-offer scoring …
    }
}
```

Units with sparse JobPriorities no longer scan the full pool. Work goes from O(units · all_offers) to O(units · Σ active_kinds_offers) — roughly a **3–5x cut** at the current mix and scales further as the offer pool grows.

Side benefit: `deficitBonus` / `reservationBonus` / `pressureBonus` depend only on Kind, not per-offer, so they're computed once per kind instead of per offer.

## Occupancy filter (#3)

```csharp
static bool CountsTowardHexOccupancy(byte kind)
    => kind == ProfessionKind.Lumberjack
    || kind == ProfessionKind.Miner
    || kind == ProfessionKind.Looter;
```

Gates the `_hexOccupancy` build to harvest kinds. Previously every non-None profession added to occupancy, so a guard or builder targeting the same hex as a forest spuriously blocked harvest scoring. Decrement path also uses `NativeHashMap.Remove` on empty buckets to keep the map's load factor stable.

## Capacity bump (#5)

`_hexOccupancy` initial capacity 64 → **4096** so 100k-unit worlds don't resize on the first dispatch frame.

## Hygiene (#2)

`ProfessionKind.Count = 13` constant replaces the hardcoded `new NativeArray<int>(13, ...)` in three places + the new per-kind arrays. Adding a new profession is now a one-line change in [ProfessionComponents.cs](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionComponents.cs#L9-L26).

## Test plan

- [ ] Burst compiles all three touched systems clean (no BC1xxx / EA0006).
- [ ] Dispatch tick frame time at current scale ≤ pre-PR (smoke test).
- [ ] 50-unit forest stress — same routing behaviour as #11715 (crowd penalty still wins on equally-priced tiles).
- [ ] Guard / builder targeting a forest hex no longer prevents harvest offers there.
- [ ] No DynamicBuffer / NativeArray dispose warnings in the Entities log.

## Follow-up

PR for #1 + #4 — `OffersByHex: NativeParallelMultiHashMap<int2, int>` for radius-limited kinds + scoring loop becomes `IJobEntity` with per-thread `NativeStream` message output + parallel occupancy build. That's the threading win on top of this PR's algorithmic win.

Refs #11716.