### PR TITLE
content(osrs): migrate batch 16 (200 items) v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/abyssal-whip.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/abyssal-whip.mdx
@@ -12,12 +12,32 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: abyssal
+    tier: high
+  properties:
+    release_date: "2005-02-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
   equipment:
     slot: weapon
     weapon_type: whip
-    weight: 0.453
     attack_speed: 4
-    attack_range: 1
+    weight: 0.453
+    requirements:
+      attack: 70
     attack_bonus:
       stab: 0
       slash: 82
@@ -35,72 +55,48 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 70
-    degradable: false
   special_attack:
     name: Energy Drain
+    description: Consumes 50% special attack energy, increases accuracy by 25%, and transfers 10% of the target's run energy to the wielder in PvP.
     energy: 50
-    description: Hits with 25% increased accuracy and transfers 10% of the opponent's run energy to you
-    accuracy_modifier: 1.25
   drop_table:
-    primary_source: Abyssal demon
-    best_drop_rate: 1/512
     sources:
       - source: Abyssal demon
-        source_id: 415
-        combat_level: 124
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/512
-        members_only: true
-      - source: Abyssal Sire
-        source_id: 5886
-        combat_level: 350
+        rarity: 1/512
+      - source: Greater abyssal demon
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/100
-        members_only: true
+        rarity: 3/512
+      - source: Unsired (Abyssal Sire)
+        quantity: "1"
+        rarity: 12/128
   related_items:
-    - item_id: 12773
-      item_name: Abyssal tentacle
+    - item_name: Abyssal tentacle
       slug: abyssal-tentacle
       relationship: upgrade
-      description: Upgraded version with +8 attack/str, degrades
-    - item_id: 12774
-      item_name: Kraken tentacle
+      description: Whip combined with a kraken tentacle; +8 attack and strength, degrades
+    - item_name: Kraken tentacle
       slug: kraken-tentacle
       relationship: component
-      description: Required to create Abyssal tentacle
-    - item_id: 4178
-      item_name: Volcanic abyssal whip
+      description: Required to upgrade an abyssal whip into an abyssal tentacle
+    - item_name: Volcanic abyssal whip
       slug: volcanic-abyssal-whip
       relationship: variant
-      description: Red cosmetic recolor (untradeable)
-    - item_id: 4179
-      item_name: Frozen abyssal whip
+      description: Red cosmetic recolour applied with a volcanic whip mix (untradeable)
+    - item_name: Frozen abyssal whip
       slug: frozen-abyssal-whip
       relationship: variant
-      description: Blue cosmetic recolor (untradeable)
-    - item_id: 13265
-      item_name: Abyssal dagger
+      description: Blue cosmetic recolour applied with a frozen whip mix (untradeable)
+    - item_name: Abyssal dagger
       slug: abyssal-dagger
       relationship: alternative
-      description: Alternative Abyssal weapon for Strength training
-  about: |-
-    Best-in-slot for:
-    - 70 Attack training
-    - Slayer tasks
-    - Budget melee setup
-
-    Note: Cannot train Strength (controlled only gives shared XP)
+      description: Alternative abyssal weapon focused on strength training via spec
+  about: "The abyssal whip is a one-handed slash weapon dropped by abyssal demons and the Abyssal Sire. Requiring 70 Attack, it has +82 slash and +82 strength, attacks every 4 ticks, and has long been the go-to weapon for 70 Attack training and Slayer tasks. Although surpassed by the Ghrazi rapier and abyssal tentacle, the whip remains widely used due to its low price and non-degradable nature."
   market_strategy:
     notes:
-      - High volume item
-      - Steady demand from Slayer
-      - Tentacle upgrade consumes whip
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "High volume item with steady Slayer-driven demand"
+      - "Tentacle upgrade permanently consumes whips, creating a constant supply sink"
+      - "Price floored close to alch by mass dropouts; spikes track Slayer popularity"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h1.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 6656
   highalch: 9984
   limit: 8
-  about: "Adamant platebody (h1) is a free-to-play item in Old School RuneScape. High alchemy value: 9,984 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 11.339
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weight: 11.339
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 65
+      slash: 63
+      crush: 55
+      magic: -6
+      ranged: 63
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Adamant platebody
+      slug: adamant-platebody
+      relationship: variant
+      description: Standard adamant platebody without heraldic design
+    - item_name: Adamant platebody (h2)
+      slug: adamant-platebody-h2
+      relationship: variant
+      description: Alternate heraldic design
+    - item_name: Adamant platebody (h3)
+      slug: adamant-platebody-h3
+      relationship: variant
+      description: Alternate heraldic design
+  about: "Adamant platebody (h1) is a heraldic variant of the standard adamant platebody, obtained exclusively as a reward from medium Treasure Trails with a 1/1,133 drop rate from a Reward casket (medium). Functionally identical to the regular adamant platebody but features a unique heraldic design. Available to free-to-play players and stores in a costume room's treasure chest."
+  market_strategy:
+    notes:
+      - "Exclusive to medium clue scroll rewards"
+      - "Low buy limit reflects limited supply"
+      - "Cosmetic value drives demand"
+  trading_tips:
+    - Identical stats to standard adamant platebody — cosmetic-only premium
+    - Low volume can mean slow buy/sell at margin
+  history:
+    - date: "2019-04-11"
+      description: Released as part of the Treasure Trails Expansion update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-4.mdx
@@ -12,118 +12,108 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonstone
+    tier: mid-high
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Rub
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: amulet
-    stats:
-      attack_stab: 10
-      attack_slash: 10
-      attack_crush: 10
-      attack_magic: 10
-      attack_ranged: 10
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
       strength: 6
-      defence_all: 3
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
-  effect:
-    teleports:
-      - destination: Edgeville
-      - destination: Karamja
-      - destination: Draynor Village
-      - destination: Al Kharid
-    charges: 4
-    recharge: Fountain of Heroes (4), Fountain of Rune (6)
   recipes:
     - skill: magic
       level: 68
       xp: 78
       materials:
-        - item_id: 1702
-          item_name: Dragonstone amulet
+        - item_name: Dragonstone amulet
           quantity: 1
-        - item_id: 555
-          item_name: Water rune
+        - item_name: Water rune
           quantity: 15
-        - item_id: 557
-          item_name: Earth rune
+        - item_name: Earth rune
           quantity: 15
-        - item_id: 564
-          item_name: Cosmic rune
+        - item_name: Cosmic rune
           quantity: 1
-      product: Amulet of glory(4)
-      product_id: 1712
-      facility: N/A
+      tools: []
+      output_quantity: 1
+  charges:
+    type: teleport
+    description: "Holds four teleport charges to Edgeville, Karamja, Draynor Village, or Al Kharid. Recharge at the Fountain of Heroes (4 charges) after Heroes' Quest or at the Fountain of Rune (6 charges) for a full inventory of glories."
   related_items:
-    - item_id: 6585
-      item_name: Amulet of fury
-      slug: amulet-of-fury
+    - item_name: Amulet of glory(6)
+      slug: amulet-of-glory-6
       relationship: upgrade
-      description: Combat upgrade
-    - item_id: 19707
-      item_name: Amulet of eternal glory
+      description: Six-charge variant obtained from the Fountain of Rune.
+    - item_name: Amulet of glory
+      slug: amulet-of-glory
+      relationship: variant
+      description: Uncharged amulet, enchant to recharge it.
+    - item_name: Amulet of eternal glory
       slug: amulet-of-eternal-glory
       relationship: upgrade
-      description: Unlimited charges
-    - item_id: 11105
-      item_name: Skills necklace
+      description: Rare 1/25,000 transformation with unlimited teleports.
+    - item_name: Amulet of fury
+      slug: amulet-of-fury
+      relationship: upgrade
+      description: End-game neck slot upgrade for combat bonuses.
+    - item_name: Skills necklace
       slug: skills-necklace
       relationship: alternative
-      description: Different teleports
-  about: |-
-    Enchant Dragonstone amulet with Lvl-5 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 68 (boostable) |
-    | Runes | 15 water, 15 earth, 1 cosmic |
-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +10 |
-    | Ranged | +10 |
-    | Strength | +6 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +3 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    | Destination | Charges |
-    |-------------|---------|
-    | Edgeville | 1 |
-    | Karamja | 1 |
-    | Draynor Village | 1 |
-    | Al Kharid | 1 |
-
-    Recharge: Fountain of Heroes (4), Fountain of Rune (6)
-
-    Popular for:
-    - Early-mid game teleports
-    - Gem mining (dragonstone chance)
-    - Budget combat amulet
-
-    Required for upgrade:
-    - 8x Amulet of glory(4)
-    - 8x Ring of wealth (5)
-    - 2x Gold leaf
-    - 91 Construction
-
-    Provides unlimited teleports to all glory destinations from POH.
+      description: Alternative dragonstone jewellery offering skill teleports.
+  about: "Amulet of glory(4) is the most common charged form of the amulet of glory, released alongside Old School RuneScape's dragonstone jewellery in February 2002. Enchanting a dragonstone amulet with Lvl-5 Enchant at Magic 68 produces the four-charge version. Each rub teleports the wearer to Edgeville, Karamja, Draynor Village, or Al Kharid, while the +10 attack and +6 strength bonuses make it a workhorse mid-game neck slot piece."
   market_strategy:
     notes:
-      - Very affordable
-      - Buy 8 for ornate jewellery box
-      - Upgrade to fury for combat later
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand spikes around Construction goals that require eight glories for an ornate jewellery box."
+      - "Recharging at the Fountain of Rune trades player time for an extra two charges per glory."
+  trading_tips:
+    - Buying in bulk near the 10,000 limit suits Construction grinders.
+    - Watch dragonstone amulet prices; the (4) version flips alongside enchant material costs.
+  history:
+    - date: "2002-02-27"
+      description: Released with the original dragonstone jewellery batch.
+    - date: "2015-04-23"
+      description: Partial charges were made untradeable to combat exploit chains.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amulet of glory (t) | OSRS Price Data
-description: "Amulet of glory (t): A very powerful dragonstone amulet.. High alch: 10,575 GP, GE limit: 5."
+description: "Amulet of glory (t): A very powerful dragonstone amulet. High alch: 10,575 GP, GE limit: 5."
 osrs:
   id: 10362
   name: Amulet of glory (t)
@@ -12,12 +12,81 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 5
-  about: "Amulet of glory (t) is a members-only item in Old School RuneScape. High alchemy value: 10,575 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragonstone
+    tier: high
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options: ["Wear", "Rub", "Drop"]
+    worn_options: ["Rub"]
+    alchable: true
+  equipment:
+    slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
+      strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+  drop_table:
+    sources:
+      - source: Hard clue casket
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers: ["hard"]
+  related_items:
+    - item_name: Amulet of glory
+      slug: amulet-of-glory
+      relationship: variant
+      description: Standard untrimmed version with identical stats and teleports
+    - item_name: Amulet of glory (4)
+      slug: amulet-of-glory-4
+      relationship: alternative
+      description: Charged glory used for teleports
+  about: "The Amulet of glory (t) is the trimmed cosmetic version of the Amulet of glory, awarded from hard Treasure Trails at roughly 1/1,625 per reward slot. It carries the same dragonstone amulet bonuses and supports up to six teleports to Edgeville, Karamja, Draynor Village, and Al Kharid. Unlike the regular glory, the trimmed variant cannot be mounted in a Player-Owned House Quest Hall, and Ironmen cannot use it to satisfy clue requirements - they must obtain an uncharged regular glory separately."
+  market_strategy:
+    notes:
+      - "Cosmetic prestige item - thin clue-hunter demand"
+      - "GE buy limit of 5 keeps order books shallow"
+      - "Members-only neck slot with strong all-round bonuses"
+      - "High alch value sits well below market - not an alch target"
+  trading_tips:
+    - Watch for clue scroll spotlights to time buy windows
+    - Decant from rare drop tables can flood supply briefly
+  history:
+    - date: "2006-12-05"
+      description: Added to the trimmed Treasure Trail reward pool.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-kiteshield.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 8
-  about: "Ancient kiteshield is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: alternative
+      description: Standard variant, identical stats
+    - item_name: Ancient full helm
+      slug: ancient-full-helm
+      relationship: set-piece
+      description: Matching Ancient set helm
+    - item_name: Ancient platebody
+      slug: ancient-platebody
+      relationship: set-piece
+      description: Matching Ancient set body
+    - item_name: Ancient platelegs
+      slug: ancient-platelegs
+      relationship: set-piece
+      description: Matching Ancient set legs
+  about: |-
+    "Rune kiteshield in the colours of a long-forgotten god."
+
+    Ancient kiteshield is a cosmetic free-to-play variant of the rune kiteshield, exclusively rewarded from hard Treasure Trails reward caskets at 1/1,625. Stats match the standard rune kiteshield (+44 Stab Defence, +48 Slash Defence, +46 Crush Defence, +46 Ranged Defence, +1 Prayer) and require 40 Defence. Part of the Ancient armour set with full helm, platebody, and platelegs, storable in costume room treasure chests.
+  market_strategy:
+    notes:
+      - "F2P cosmetic rune variant"
+      - "Hard clue reward rarity"
+      - "Collection log completion driver"
+      - "Ancient armour set premium"
+      - "Identical stats to rune kiteshield"
+      - "Buy limit 8 thins the book"
+      - "Price tracks clue scroll events"
+  trading_tips:
+    - Pair set pieces for collector premium
+    - Watch F2P trade volumes
+    - Low liquidity, ladder bids
+  history:
+    - date: "2014-06-12"
+      description: Released with Ancient armour set update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-mitre.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-mitre.mdx
@@ -12,25 +12,83 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: vestment
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.3
     requirements:
       prayer: 40
       magic: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
   related_items:
-    - item_id: 12193
-      item_name: Ancient robe top
+    - item_name: Ancient robe top
       slug: ancient-robe-top
       relationship: set-piece
       description: Ancient vestment body
-  about: |-
-    > *"An Ancient mitre."*
-
-    The Ancient mitre is a head slot item from the Ancient vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Offers the second-highest prayer bonus for head slot items. Counts as a Zarosian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Ancient robe legs
+      slug: ancient-robe-legs
+      relationship: set-piece
+      description: Ancient vestment legs
+    - item_name: Ancient stole
+      slug: ancient-stole
+      relationship: set-piece
+      description: Ancient vestment stole
+    - item_name: Ancient crozier
+      slug: ancient-crozier
+      relationship: set-piece
+      description: Ancient vestment crozier
+    - item_name: Ancient cloak
+      slug: ancient-cloak
+      relationship: set-piece
+      description: Ancient vestment cloak
+  about: "Ancient mitre is a head slot vestment from elite Treasure Trails, obtained via the Cheer emote clue by the Shadow Dungeon ladder while wearing a Ring of visibility. Provides +5 Prayer (second-highest head slot prayer bonus) plus +4 Magic attack and defence, matching mystic hats for magic stats. Requires 40 Prayer and 40 Magic to equip and counts as a Zarosian item in the God Wars Dungeon."
+  market_strategy:
+    notes:
+      - "Elite clue exclusive supply"
+      - "Prayer bonus competes with Mitre and 3a hats"
+      - "Costume room storage maintains long-term demand"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-rune-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-rune-armour-set-sk.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Ancient rune armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: set
+    tier: mid-high
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Grand Exchange
+      location: Varrock
+      price: 186410
+      currency: Coins
+      stock: 0
+  related_items:
+    - item_name: Ancient full helm
+      slug: ancient-full-helm
+      relationship: set-piece
+      description: Head slot piece in the set
+    - item_name: Ancient platebody
+      slug: ancient-platebody
+      relationship: set-piece
+      description: Body slot piece in the set
+    - item_name: Ancient plateskirt
+      slug: ancient-plateskirt
+      relationship: set-piece
+      description: Legs slot piece in the set
+    - item_name: Ancient kiteshield
+      slug: ancient-kiteshield
+      relationship: set-piece
+      description: Shield slot piece in the set
+    - item_name: Ancient rune armour set (lg)
+      slug: ancient-rune-armour-set-lg
+      relationship: variant
+      description: Legs variant set with platelegs instead of plateskirt
+  about: "Ancient rune armour set (sk) is a Grand Exchange equipment set containing an ancient full helm, platebody, plateskirt, and kiteshield. The set is constructed by exchanging individual components using the Sets interface with a Grand Exchange clerk. The complete set provides +207 stab, +209 slash, and +192 crush defence with minor magic (-65) and ranged (-31) penalties. Free-to-play accessible since 14 April 2016."
+  market_strategy:
+    notes:
+      - "Set premium over component total"
+      - "F2P accessible since April 2016"
+      - "Cosmetic appeal of ancient-themed armour"
+  trading_tips:
+    - Compare set price vs unpacked component total to spot arbitrage
+    - Skirt variant historically trades at slight premium vs (lg) version
+  history:
+    - date: "2015-02-26"
+      description: Released as a Grand Exchange equipment set.
+    - date: "2016-04-14"
+      description: Made accessible to free-to-play players.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-1.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 4000
-  about: "Antidote+(1) is a members-only item in Old School RuneScape. High alchemy value: 86 coins. Grand Exchange buy limit: 4,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: Cures poison and grants immunity to poison for 9 minutes; two doses convert venom to poison, then cure it entirely.
+        duration: 540
+  recipes:
+    - skill: herblore
+      level: 68
+      xp: 38.75
+      materials:
+        - item_name: Antidote+ (unf)
+          quantity: 1
+        - item_name: Yew roots
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Antidote+(2)
+      slug: antidote-2
+      relationship: variant
+      description: Two-dose vial of the same potion
+    - item_name: Antidote+(3)
+      slug: antidote-3
+      relationship: variant
+      description: Three-dose vial of the same potion
+    - item_name: Antidote+(4)
+      slug: antidote-4
+      relationship: variant
+      description: Four-dose vial of the same potion
+    - item_name: Antidote++(4)
+      slug: antidote-4-1
+      relationship: upgrade
+      description: Stronger antipoison variant lasting 12 minutes
+  about: "Antidote+(1) is a single dose of an extra strong antipoison potion that cures existing poison and grants 9 minutes of poison immunity, three minutes longer than super antipoison. Two doses are required to cure venom by converting it to poison first. It is brewed at 68 Herblore from antidote+ (unf) and yew roots, with the four-dose batch awarding 155 experience."
+  market_strategy:
+    notes:
+      - "Single-dose stocks lag higher-dose siblings on price per dose"
+      - "Demand spikes during venomous boss content like Zulrah and Vorkath"
+  history:
+    - date: "2005-07-11"
+      description: Antidote+ added with the Tai Bwo Wannai Trio cleanup content.
+    - date: "2007-07-03"
+      description: Potion store values increased across antidote+ doses.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arrow-shaft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arrow-shaft.mdx
@@ -12,100 +12,118 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: fletching
-    tier: basic
-  fletching:
-    level: 1
-    xp: 0.33
-    method: Knife on logs
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Drop", "Examine"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
   recipes:
     - skill: fletching
       level: 1
       xp: 5
       materials:
         - item_name: Logs
-          item_id: 1511
           quantity: 1
-      product: Arrow shaft
-      product_id: 52
-      product_quantity: 15
-      tool: Knife
+      tools: ["Knife"]
+      output_quantity: 15
     - skill: fletching
       level: 15
       xp: 10
       materials:
         - item_name: Oak logs
-          item_id: 1521
           quantity: 1
-      product: Arrow shaft
-      product_id: 52
-      product_quantity: 30
-      tool: Knife
+      tools: ["Knife"]
+      output_quantity: 30
     - skill: fletching
       level: 30
       xp: 15
       materials:
         - item_name: Willow logs
-          item_id: 1519
           quantity: 1
-      product: Arrow shaft
-      product_id: 52
-      product_quantity: 45
-      tool: Knife
+      tools: ["Knife"]
+      output_quantity: 45
+    - skill: fletching
+      level: 45
+      xp: 20
+      materials:
+        - item_name: Maple logs
+          quantity: 1
+      tools: ["Knife"]
+      output_quantity: 60
+    - skill: fletching
+      level: 60
+      xp: 25
+      materials:
+        - item_name: Yew logs
+          quantity: 1
+      tools: ["Knife"]
+      output_quantity: 75
+    - skill: fletching
+      level: 75
+      xp: 30
+      materials:
+        - item_name: Magic logs
+          quantity: 1
+      tools: ["Knife"]
+      output_quantity: 90
+    - skill: fletching
+      level: 90
+      xp: 35
+      materials:
+        - item_name: Redwood logs
+          quantity: 1
+      tools: ["Knife"]
+      output_quantity: 105
   related_items:
-    - item_id: 1511
-      item_name: Logs
+    - item_name: Logs
       slug: logs
       relationship: component
-      description: Basic source (15 shafts)
-    - item_id: 314
-      item_name: Feather
+      description: Basic source (15 shafts per log).
+    - item_name: Feather
       slug: feather
       relationship: component
-      description: For headless arrows
-    - item_id: 53
-      item_name: Headless arrow
+      description: Combined with shaft to make headless arrows.
+    - item_name: Headless arrow
       slug: headless-arrow
       relationship: product
-      description: Next step
-    - item_id: 39
-      item_name: Bronze arrowtips
+      description: Shaft + feather; next step toward finished arrows.
+    - item_name: Bronze arrowtips
       slug: bronze-arrowtips
       relationship: component
-      description: Basic tips
-    - item_id: 40
-      item_name: Iron arrowtips
+      description: Basic arrowtips for finishing arrows.
+    - item_name: Iron arrowtips
       slug: iron-arrowtips
       relationship: component
-      description: Common tips
-  about: |-
-    Use a Knife on any logs to create Arrow shafts.
-
-    | Log Type | Shafts per Log | Fletching Level |
-    |----------|----------------|-----------------|
-    | Logs | 15 | 1 |
-    | Oak logs | 30 | 15 |
-    | Willow logs | 45 | 30 |
-    | Maple logs | 60 | 45 |
-    | Yew logs | 75 | 60 |
-    | Magic logs | 90 | 75 |
-
-    Add feathers and arrowtips to create arrows:
-
-    1. Arrow shaft + Feather = Headless arrow
-    2. Headless arrow + Arrowtips = Finished arrows
+      description: Common arrowtips for finishing arrows.
+  about: "Arrow shafts are produced by using a Knife on any log type. Higher-tier logs yield more shafts at higher Fletching levels (15 from regular logs up to 105 from redwood logs). Combine with feathers for headless arrows, then attach arrowtips to finish."
   market_strategy:
-    title: Bulk Processing
     notes:
-      - High volume, low margin item
-      - "Compare:  vs"
-      - Best margins often with regular Logs
-      - Buy Arrow shafts + Feathers
-      - Fletch into Headless arrows
-      - Sell to fletchers making finished arrows
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "High-volume, thin-margin item; bulk only."
+      - "Best margins are usually regular logs into shafts at low Fletching levels."
+      - "Pair with feathers + arrowtips for end-to-end arrow production."
+  trading_tips:
+    - Buy in stacks of thousands within the 7,000 GE limit window.
+    - Note via banker for fast bank transfers while fletching.
+  history:
+    - date: "2002-03-25"
+      description: Released.
+    - date: "2005-08-15"
+      description: Inventory icon now reflects quantity held.
+    - date: "2016-08-25"
+      description: Higher-tier logs yield more arrow shafts per cut.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/astral-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/astral-rune.mdx
@@ -12,82 +12,66 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 25000
-  rune:
-    type: catalytic
-    element: astral
-  runecraft:
-    level: 40
-    xp: 8.7
-    multiple_at: 82
-    altar: Astral Altar
-    altar_location: Lunar Isle
-    essence_type: pure
-    quest_required: Lunar Diplomacy
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid
+  properties:
+    release_date: "2006-07-24"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: runecraft
       level: 40
       xp: 8.7
       materials:
         - item_name: Pure essence
-          item_id: 7936
           quantity: 1
-      product: Astral rune
-      product_id: 9075
-      product_quantity: 1
-      facility: Astral altar
-      members_only: true
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Baba Yaga's Magic Shop
+      location: Lunar Isle
+      price: 50
+      currency: Coins
+      stock: 250
   related_items:
-    - item_id: 561
-      item_name: Nature rune
+    - item_name: Nature rune
       slug: nature-rune
       relationship: component
-      description: Lunar spell combo
-    - item_id: 557
-      item_name: Earth rune
+      description: Combined with astrals for Plank Make
+    - item_name: Earth rune
       slug: earth-rune
       relationship: component
-      description: Plank Make combo
-    - item_id: 560
-      item_name: Death rune
+      description: Lunar Plank Make ingredient
+    - item_name: Death rune
       slug: death-rune
       relationship: component
-      description: Vengeance combo
-    - item_id: 563
-      item_name: Law rune
+      description: Used alongside astrals for Vengeance
+    - item_name: Law rune
       slug: law-rune
       relationship: component
-      description: Teleport spells
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 40 |
-    | XP per rune | 8.7 |
-    | Quest | Lunar Diplomacy |
-    | Altar location | Lunar Isle |
-
-    | Spell | Astral Runes | Magic Level |
-    |-------|--------------|-------------|
-    | Plank Make | 2 | 86 |
-    | Vengeance | 4 | 94 |
-    | String Jewellery | 2 | 80 |
-    | Superglass Make | 2 | 77 |
-    | Tan Leather | 2 | 78 |
-    | Fertile Soil | 3 | 83 |
-    | NPC Contact | 1 | 67 |
+      description: Required by Lunar teleport spells
+  about: "Astral runes are the catalytic runes of the Lunar spellbook, crafted at the Astral Altar on Lunar Isle after completing Lunar Diplomacy. Required for every Lunar spell, with Plank Make and Vengeance driving the bulk of consumption. At 82 Runecraft, players receive two astral runes per pure essence."
   market_strategy:
     notes:
-      - All Lunar spells use astral
-      - Plank Make drives demand
-      - Vengeance for PvP
-      - Plank Make (Construction)
-      - Vengeance (PvP/PvM)
-      - String Jewellery (Crafting)
-      - Tan Leather (Crafting)
-      - Lunar Diplomacy required to craft
-      - Plank Make most common use
-      - Vengeance always in demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Plank Make absorbs astrals during Construction grinds"
+      - "Vengeance keeps a steady PvP-driven floor"
+      - "Crafting profit is decent at 40+ Runecraft"
+  history:
+    - date: "2006-07-24"
+      description: "Released with the Lunar Diplomacy quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/atlatl-dart-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/atlatl-dart-tips.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 98
   highalch: 147
   limit: 10000
-  about: "Atlatl dart tips is a members-only item in Old School RuneScape. High alchemy value: 147 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bone
+    tier: mid
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: fletching
+      level: 74
+      xp: 10
+      materials:
+        - item_name: Broken antler
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 100
+  related_items:
+    - item_name: Broken antler
+      slug: broken-antler
+      relationship: component
+      description: Source material chiseled into dart tips
+    - item_name: Atlatl dart
+      slug: atlatl-dart
+      relationship: product
+      description: Finished dart fletched from tip and shaft
+    - item_name: Headless atlatl dart
+      slug: headless-atlatl-dart
+      relationship: component
+      description: Shaft combined with tip to form atlatl dart
+  about: "Atlatl dart tips are crafted by chiseling broken antlers (dropped by Custodian stalkers) at 74 Fletching for 10 XP each, yielding 100 tips per antler. Combine 20 tips with 20 headless atlatl darts to fletch 20 finished atlatl darts and 190 Fletching XP."
+  market_strategy:
+    notes:
+      - "Supply tied to Custodian stalker drops"
+      - "High buy limit supports bulk fletching flips"
+      - "Profitability moves with broken antler and dart prices"
+  history:
+    - date: "2025-07-23"
+      description: Released alongside the atlatl weapon and Custodian stalker content.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-plant-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-plant-2.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 10000
-  about: "Bagged plant 2 is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: garden-supply
+    tier: mid
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: construction
+      level: 6
+      xp: 70
+      materials:
+        - item_name: Bagged plant 2
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Garden Centre
+      location: Falador Park
+      price: 5000
+      currency: coins
+      stock: 10
+  related_items:
+    - item_name: Bagged plant 1
+      slug: bagged-plant-1
+      relationship: variant
+      description: Smaller bagged garden plant variant
+    - item_name: Bagged plant 3
+      slug: bagged-plant-3
+      relationship: variant
+      description: Larger bagged garden plant variant
+  about: "Bagged plant 2 is a decorative garden item used in player-owned houses. When planted with a filled watering can, it grows into one of four plant variants (bush, large leaf bush, small fern, or thistle) requiring 6 Construction and 1 Farming for 70 XP in each skill. Purchased from the Garden Centre in Falador Park or the Farming Guild for 5,000 coins."
+  market_strategy:
+    notes:
+      - "Stable demand from house decorators"
+      - "Garden Centre cap controls price floor"
+      - "All variant plants are visually distinct but share the same item"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-sunflower.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-sunflower.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 10000
-  about: "Bagged sunflower is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gardening
+    tier: mid
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 66
+      xp: 70
+      materials:
+        - item_name: Bagged sunflower
+          quantity: 1
+        - item_name: Watering can
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Sunflower
+      slug: sunflower
+      relationship: product
+      description: Planted decoration result
+    - item_name: Marigolds
+      slug: marigolds
+      relationship: alternative
+      description: Alternative formal garden decoration
+  about: "Bagged sunflower is a decorative gardening item purchased from Garden Suppliers in Falador or the Farming Guild for 5,000 coins. Players plant it in formal gardens of player-owned houses, requiring 66 Construction and granting 70 XP in both Construction and Farming. The result is a Sunflower decoration with no functional purpose beyond aesthetics."
+  market_strategy:
+    notes:
+      - "Niche POH decoration demand"
+      - "Construction training adjacent"
+      - "Players prefer GE over shop purchase"
+      - "Stable mid-tier value"
+      - "Buy limit 10,000 supports flips"
+  trading_tips:
+    - Margins driven by POH building activity
+    - Cheaper than shop value, decent flip
+    - Track Construction event spikes
+  history:
+    - date: "2006-05-31"
+      description: Bagged sunflower released alongside formal garden updates.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-blue.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Bandana eyepatch (blue) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+  equipment:
+    slot: head
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: false
+    reward_tiers:
+      - elite
+  related_items:
+    - item_name: Bandana eyepatch (red)
+      slug: bandana-eyepatch-red
+      relationship: variant
+      description: Red colour variant of the same pirate headwear
+    - item_name: Bandana eyepatch (white)
+      slug: bandana-eyepatch-white
+      relationship: variant
+      description: White colour variant of the same pirate headwear
+    - item_name: Blue bandana
+      slug: blue-bandana
+      relationship: component
+      description: Bandana combined with a right eyepatch by Patchy on Mos Le'Harmless
+    - item_name: Right eyepatch
+      slug: right-eyepatch
+      relationship: component
+      description: Eyepatch combined with a blue bandana by Patchy on Mos Le'Harmless
+  about: "The blue bandana eyepatch is a cosmetic pirate headwear assembled by Patchy on Mos Le'Harmless for 500 coins, requiring a blue bandana, a right eyepatch, and completion of Cabin Fever. It has no combat bonuses but is needed for an elite Treasure Trail emote clue, sustaining low but steady GE demand at a price well above its alch value."
+  market_strategy:
+    notes:
+      - "Elite clue emote requirement keeps a baseline demand"
+      - "No combat use — purely cosmetic and clue-driven flow"
+      - "Cheap to assemble vs GE price; supply often comes from clue rewards"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-brown.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Bandana eyepatch (brown) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Bandana eyepatch (blue)
+      slug: bandana-eyepatch-blue
+      relationship: variant
+      description: Blue colour variant
+    - item_name: Bandana eyepatch (red)
+      slug: bandana-eyepatch-red
+      relationship: variant
+      description: Red colour variant
+    - item_name: Bandana eyepatch (white)
+      slug: bandana-eyepatch-white
+      relationship: variant
+      description: White colour variant
+    - item_name: Pirate bandana (brown)
+      slug: pirate-bandana-brown
+      relationship: component
+      description: Base bandana combined with an eyepatch
+  about: "Bandana eyepatch (brown) is a cosmetic pirate headwear item created after Cabin Fever by combining a brown pirate bandana and right eye patch with Patchy on Mos Le'Harmless for 500 coins. It carries no combat bonuses but is accepted for elite clue scroll tasks requiring a bandana."
+  market_strategy:
+    notes:
+      - "Cosmetic-only demand from clue scroll completionists"
+      - "Crafted supply keeps margins thin near the 735 coin material cost"
+  history:
+    - date: "2006-07-04"
+      description: Bandana eyepatches released with the Cabin Fever quest.
+    - date: "2025-09-24"
+      description: Accepted as the bandana for elite clue scroll tasks.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-red.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-red.mdx
@@ -12,9 +12,110 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Bandana eyepatch (red) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Red pirate bandana
+          quantity: 1
+        - item_name: Eye patch
+          quantity: 1
+        - item_name: Coins
+          quantity: 500
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Zombie pirate (Harmony Island)
+        quantity: "1"
+        rarity: "5/128"
+      - source: Sorebones
+        quantity: "1"
+        rarity: "5/128"
+  treasure_trail:
+    tier: elite
+    is_reward: false
+    reward_tiers:
+      - elite
+  related_items:
+    - item_name: Bandana eyepatch (blue)
+      slug: bandana-eyepatch-blue
+      relationship: variant
+      description: "Blue colour variant of the bandana eyepatch."
+    - item_name: Bandana eyepatch (brown)
+      slug: bandana-eyepatch-brown
+      relationship: variant
+      description: "Brown colour variant of the bandana eyepatch."
+    - item_name: Bandana eyepatch (white)
+      slug: bandana-eyepatch-white
+      relationship: variant
+      description: "White colour variant of the bandana eyepatch."
+    - item_name: Red pirate bandana
+      slug: red-pirate-bandana
+      relationship: component
+      description: "Bandana combined with an eye patch and 500 coins by Patchy to create this item."
+    - item_name: Eye patch
+      slug: eye-patch
+      relationship: component
+      description: "Eye patch combined with a coloured bandana by Patchy to create this item."
+  about: "Bandana eyepatch (red) is a members-only cosmetic head slot item released on 4 July 2006 with the Trouble Brewing update. After completing Cabin Fever, players can combine a red pirate bandana, an eye patch and 500 coins at Patchy on Mos Le'Harmless to assemble the item. It provides no combat bonuses and is purely fashionscape, but is required to perform the 'Headbang' emote step on certain elite Treasure Trail clues at the Fight Arena Bar. It also drops at 5/128 from Zombie pirates on Harmony Island and from Sorebones. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - "Crafting cost (689 coins) sits above the GE price, so direct creation is loss-making - buy from the GE instead."
+      - "Demand spikes whenever elite clue 'Headbang' emote requirements trend on guides."
+      - "Buy limit of 150 supports modest flipping volume."
+  trading_tips:
+    - "Stockpile before elite clue meta updates and resell on emote-step demand."
+    - "Bundle with eyepatch variants and pirate-themed cosmetics for set sales."
+    - "Avoid crafting from components - GE pricing is well below assembly cost."
+  history:
+    - date: "2006-07-04"
+      description: "Released with the Trouble Brewing minigame update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-cloak.mdx
@@ -12,24 +12,90 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.4
     requirements:
       prayer: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 12265
-      item_name: Bandos robe top
+    - item_name: Bandos robe top
       slug: bandos-robe-top
       relationship: set-piece
-      description: Bandos vestment body
-  about: |-
-    > *"A Bandos cloak."*
-
-    The Bandos cloak is the cape piece of the Bandos vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Bandosian item in the God Wars Dungeon. Required for certain master clue steps.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Body slot piece of the Bandos vestment set
+    - item_name: Bandos robe legs
+      slug: bandos-robe-legs
+      relationship: set-piece
+      description: Legs slot piece of the Bandos vestment set
+    - item_name: Bandos mitre
+      slug: bandos-mitre
+      relationship: set-piece
+      description: Head slot piece of the Bandos vestment set
+    - item_name: Bandos stole
+      slug: bandos-stole
+      relationship: set-piece
+      description: Neck slot piece of the Bandos vestment set
+  about: "The Bandos cloak is the cape component of the Bandos vestment set, obtained as a rare reward from medium Treasure Trails at a 1/1,133 rate. Requiring 40 Prayer to wear, it offers a +3 Prayer bonus, light defensive stats and counts as a Bandosian item in the God Wars Dungeon. It is also required for certain master clue scroll steps and is a popular cosmetic for Bandos-themed setups."
+  market_strategy:
+    notes:
+      - "Supply is gated by medium clue completions"
+      - "Demand spikes during master clue step popularity"
+      - "Tiny 8 buy limit makes large flips slow"
+  trading_tips:
+    - Watch medium clue boost events for short-term supply increases
+    - Stack multiple buy limits across the day if accumulating a set
+    - Cross-check pricing against the rest of the Bandos vestment set
+  history:
+    - date: "2014-06-12"
+      description: "Added to the game as part of the God Wars vestment sets update."
+    - date: "2014-08-14"
+      description: "Added to medium clue scroll rewards after being initially omitted."
+    - date: "2015-08-13"
+      description: "Graphical fix applied to the cloak's appearance."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-stole.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-stole.mdx
@@ -12,24 +12,88 @@ osrs:
   lowalch: 1000
   highalch: 1500
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: neck
+    weight: 0.01
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 10
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 12275
-      item_name: Bandos crozier
+    - item_name: Bandos crozier
       slug: bandos-crozier
       relationship: set-piece
       description: Bandos vestment weapon
-  about: |-
-    > *"A Bandos stole."*
-
-    The Bandos stole is a neck slot item from the Bandos vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. One of the highest prayer bonus items available in the neck slot. Counts as a Bandosian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Bandos mitre
+      slug: bandos-mitre
+      relationship: set-piece
+      description: Bandos vestment head piece
+    - item_name: Bandos cloak
+      slug: bandos-cloak
+      relationship: set-piece
+      description: Bandos vestment cape
+    - item_name: Bandos robe top
+      slug: bandos-robe-top
+      relationship: set-piece
+      description: Bandos vestment torso
+    - item_name: Bandos robe legs
+      slug: bandos-robe-legs
+      relationship: set-piece
+      description: Bandos vestment legs
+  about: "Bandos stole is a neck slot piece from the Bandos vestment set, awarded from medium Treasure Trails. It grants +10 Prayer, the highest neck prayer bonus available, and requires 60 Prayer to wear. Counts as a Bandosian item in the God Wars Dungeon and can be stored in a costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Medium clue supply caps the price floor"
+      - "Niche but steady demand from prayer-focused PvMers"
+      - "8 buy limit keeps flipping volumes low"
+  history:
+    - date: "2014-06-12"
+      description: Released as part of the god vestment Treasure Trail rewards.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/battlemage-potion-2.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 2000
-  about: "Battlemage potion(2) is a members-only item in Old School RuneScape. High alchemy value: 108 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2018-06-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Magic by 4 (flat) and Defence by 5 + 15% of current Defence level."
+        duration: null
+  recipes:
+    - skill: herblore
+      level: 80
+      xp: 155
+      materials:
+        - item_name: Cadantine blood potion (unf)
+          quantity: 1
+        - item_name: Potato cactus
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Battlemage potion(1)
+      slug: battlemage-potion-1
+      relationship: variant
+      description: 1-dose version
+    - item_name: Battlemage potion(3)
+      slug: battlemage-potion-3
+      relationship: variant
+      description: 3-dose version
+    - item_name: Battlemage potion(4)
+      slug: battlemage-potion-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Cadantine blood potion (unf)
+      slug: cadantine-blood-potion-unf
+      relationship: component
+      description: Unfinished base used in the Herblore recipe
+    - item_name: Potato cactus
+      slug: potato-cactus
+      relationship: component
+      description: Secondary ingredient
+    - item_name: Divine battlemage potion(2)
+      slug: divine-battlemage-potion-2
+      relationship: upgrade
+      description: Crystal-dust enhanced version at 86 Herblore
+  about: "Battlemage potion(2) is a 2-dose Magic + Defence combo that boosts Magic by a flat 4 and Defence by 5 + 15% of current level. Brewed at 80 Herblore by mixing a Cadantine blood potion (unf) with Potato cactus for 155 experience, it is a budget alternative to imbued heart effects for tank-mage setups across Tombs of Amascut, Theatre of Blood, and the wilderness mage robes meta."
+  market_strategy:
+    notes:
+      - "Cadantine blood vial cost dominates margin"
+      - "Demand spikes around tank-mage PvM weeks"
+      - "2-dose form preferred for clue-step inventories"
+  history:
+    - date: "2018-06-07"
+      description: Released alongside the Theatre of Blood combat-potion expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-cane.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-cane.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 4
-  about: "Black cane is a members-only item in Old School RuneScape. High alchemy value: 360 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: cane
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 8
+      slash: -2
+      crush: 16
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 13
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 2
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Black elegant shirt
+      slug: black-elegant-shirt
+      relationship: set-piece
+      description: Pairs with the cane for the iconic black elegant outfit
+    - item_name: Black elegant legs
+      slug: black-elegant-legs
+      relationship: set-piece
+      description: Pairs with the cane for the iconic black elegant outfit
+    - item_name: Black mace
+      slug: black-mace
+      relationship: alternative
+      description: Same combat stats but faster attack speed; functional alternative
+    - item_name: White cane
+      slug: white-cane
+      relationship: variant
+      description: White colour variant of the cane
+  about: "The black cane is a ruby-topped one-handed crush weapon obtained as a master clue reward. It needs 10 Attack to wield and has the same stats as a black mace plus a +2 prayer bonus, but swings at attack speed 5 instead of 4. It is overwhelmingly used as a cosmetic accessory with black elegant clothing rather than as a combat weapon."
+  market_strategy:
+    notes:
+      - "Master clue reward — supply driven by clue completion rate"
+      - "Buy limit of 4 forces patient flipping rather than mass dumps"
+      - "Cosmetic pairing with black elegant outfit holds price above alch"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger-p-5700.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dagger-p-5700.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 125
-  about: "Black dagger(p++) is a members-only item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2001-12-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 10
+      slash: 5
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 7
+      prayer: 0
+  related_items:
+    - item_name: Black dagger
+      slug: black-dagger
+      relationship: variant
+      description: Unpoisoned base dagger.
+    - item_name: Black dagger(p)
+      slug: black-dagger-p
+      relationship: variant
+      description: Weakly poisoned variant.
+    - item_name: Black dagger(p+)
+      slug: black-dagger-p
+      relationship: variant
+      description: Moderately poisoned variant.
+  about: "The Black dagger(p++) is the strongest-poison variant of the black dagger, requiring 10 Attack to wield. Used by ironmen and low-level PvP for the +7 strength bonus combined with extra-strength poison; functionally identical to the base dagger in combat stats."
+  market_strategy:
+    notes:
+      - "Cheap niche weapon; expect thin margins around alch value."
+      - "Demand tied to budget PKers and ironman bridging."
+  history:
+    - date: "2001-12-08"
+      description: Black dagger released.
+    - date: "2002-02-25"
+      description: Poisoned dagger variants introduced.
+    - date: "2006-08-29"
+      description: Poisoned variants renamed from (+)/(s) to (p+)/(p++).
+    - date: "2021-07-21"
+      description: Female-character weapon positioning corrected.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-desert-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-desert-robe.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 15
-  about: "Black desert robe is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-11-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: legs
+    weight: 0.907
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Desert robe
+          quantity: 1
+        - item_name: Black dye
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Desert robe
+      slug: desert-robe
+      relationship: component
+      description: Base robe dyed black
+    - item_name: Black dye
+      slug: black-dye
+      relationship: component
+      description: Dye applied to colour the robe
+    - item_name: Black desert shirt
+      slug: black-desert-shirt
+      relationship: set-piece
+      description: Matching torso piece for the evil look
+  about: "Black desert robe is a leg slot quest item used in Shadow of the Storm, where the player must wear three black garments to look evil. Made by applying black dye to a standard desert robe. Offers no protection from desert heat despite its appearance."
+  market_strategy:
+    notes:
+      - "Quest item — demand spikes around Shadow of the Storm"
+      - "GE limit of 15 prevents large flipping operations"
+      - "Cheap craft from desert robe plus black dye"
+  history:
+    - date: "2005-11-14"
+      description: Released for the Shadow of the Storm quest.
+    - date: "2022-02-09"
+      description: Examine text changed from "stained black with mushroom ink" to current wording.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-red-shell-round.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-red-shell-round.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 13000
-  about: "Blamish red shell (round) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: snail-shell
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    alchable: true
+  drop_table:
+    sources:
+      - source: Blood Blamish Snail (round)
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish red shell (round)
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_name: Blood'n'tar snelm (round)
+      slug: bloodntar-snelm-round
+      relationship: product
+      description: Crafted from this shell at level 15 Crafting.
+    - item_name: Blamish red shell (pointed)
+      slug: blamish-red-shell-pointed
+      relationship: variant
+      description: Pointed variant from the same snail family.
+  about: "Blamish red shell (round) drops from Blood Blamish Snails in the Mort Myre Swamp. Members with 15 Crafting can use a chisel on the shell to fashion a Blood'n'tar snelm (round), a low-level helmet that requires the Priest in Peril quest. Released 14 October 2004."
+  market_strategy:
+    notes:
+      - "Snelm crafting demand keeps a steady but thin floor on shell prices."
+      - "GE limit of 13,000 supports bulk flips when craft margins widen."
+  history:
+    - date: "2004-10-14"
+      description: Added to the game alongside the Mort Myre snail family.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-karambwan.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-karambwan.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 10000
-  about: "Blighted karambwan is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2020-04-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.65
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+  shops:
+    - shop_name: "Justine's stuff for the Last Shopper Standing"
+      location: Last Man Standing lobby
+      price: 1
+      currency: Last Man Standing points
+      stock: 1000
+    - shop_name: Bounty Hunter Store
+      location: Daimon's Crater
+      price: 2
+      currency: Bounty Hunter points
+      stock: 1000
+    - shop_name: Soul Wars Reward Shop
+      location: Isle of Souls
+      price: 10
+      currency: Zeal Tokens
+      stock: 1000
+  related_items:
+    - item_name: Cooked karambwan
+      slug: cooked-karambwan
+      relationship: alternative
+      description: Non-Wilderness combo-eating equivalent
+    - item_name: Blighted anglerfish
+      slug: blighted-anglerfish
+      relationship: alternative
+      description: Higher-healing Wilderness blighted food option
+    - item_name: Blighted manta ray
+      slug: blighted-manta-ray
+      relationship: alternative
+      description: Mid-tier blighted food alternative
+  about: "Blighted karambwan is the Wilderness-restricted version of the cooked karambwan, restoring 18 Hitpoints and retaining the karambwan combo-eat property that lets it be consumed almost immediately after another food. It is purchased with Last Man Standing, Bounty Hunter, or Soul Wars currencies and can only be eaten in PvP-enabled areas such as the Wilderness, Ferox Enclave, Mage Arena bank, PvP worlds, Castle Wars lobby, and Clan Wars."
+  market_strategy:
+    notes:
+      - "Pricing tracks Last Man Standing and Bounty Hunter point payouts"
+      - "Demand spikes around PvP tournament weekends and Wilderness events"
+  trading_tips:
+    - Stack with Blighted anglerfish for high-tier Wilderness combo eating
+    - Watch for arbitrage between LMS-point cost and GE price
+  history:
+    - date: "2020-04-23"
+      description: Introduced as part of the Last Man Standing rework, adding blighted Wilderness foods.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-armour-set.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: 2
-  about: "Blood moon armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 2 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour_set
+    tier: high
+  properties:
+    release_date: "2025-08-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  shops:
+    - shop_name: Grand Exchange (item sets)
+      location: Grand Exchange
+      price: 145000
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Blood moon helm
+      slug: blood-moon-helm
+      relationship: set-piece
+      description: Head slot piece of the Blood moon set
+    - item_name: Blood moon chestplate
+      slug: blood-moon-chestplate
+      relationship: set-piece
+      description: Body slot piece of the Blood moon set
+    - item_name: Blood moon tassets
+      slug: blood-moon-tassets
+      relationship: set-piece
+      description: Legs slot piece of the Blood moon set
+    - item_name: Dual macuahuitl
+      slug: dual-macuahuitl
+      relationship: set-piece
+      description: Weapon paired with the Blood moon armour
+  about: "Blood moon armour set is a Grand Exchange item bundle containing the Blood moon helm, chestplate, tassets, and Dual macuahuitl. Players use the Grand Exchange clerk's item sets interface to consolidate the four pieces into one tradeable item or split it back into components."
+  market_strategy:
+    notes:
+      - "Set price tracks combined component cost closely"
+      - "Use sets to flip when individual pieces are cheaper than bundle"
+      - "Convert via GE clerk to capture arbitrage spread"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-armour-set.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: 2
-  about: "Bloodbark armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 2 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bloodbark
+    tier: high
+  properties:
+    release_date: "2025-08-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  related_items:
+    - item_name: Bloodbark helm
+      slug: bloodbark-helm
+      relationship: set-piece
+      description: Head slot piece
+    - item_name: Bloodbark body
+      slug: bloodbark-body
+      relationship: set-piece
+      description: Torso slot piece
+    - item_name: Bloodbark legs
+      slug: bloodbark-legs
+      relationship: set-piece
+      description: Legs slot piece
+    - item_name: Bloodbark gauntlets
+      slug: bloodbark-gauntlets
+      relationship: set-piece
+      description: Hands slot piece
+    - item_name: Bloodbark boots
+      slug: bloodbark-boots
+      relationship: set-piece
+      description: Feet slot piece
+  about: "The Bloodbark armour set is a Grand Exchange convenience bundle containing the Bloodbark helm, body, legs, gauntlets and boots. The full set provides +50 Magic attack, +112 Stab defence, +92 Slash defence, +131 Crush defence, +57 Magic defence, and a 3% magic damage boost. The set is available to members for purchase or sale as a single unit on the GE."
+  market_strategy:
+    notes:
+      - "Buying the set vs individual pieces can offer arbitrage opportunities"
+      - "Set premium fluctuates around ~44k coins"
+      - "Buy limit of 2 per 4 hours restricts flipping volume"
+  history:
+    - date: "2025-08-20"
+      description: Added to the game.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-body-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-body-t.mdx
@@ -12,89 +12,95 @@ osrs:
   lowalch: 3744
   highalch: 5616
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: mid-high
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
     requirements:
       ranged: 50
       defence: 40
-      quest: Dragon Slayer I
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 20
-      defence_stab: 23
-      defence_slash: 30
-      defence_crush: 30
-      defence_magic: 28
-      defence_ranged: 40
-      melee_strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 20
+    defence_bonus:
+      stab: 23
+      slash: 30
+      crush: 30
+      magic: 28
+      ranged: 40
+    other_bonus:
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 6.803
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: Reward casket (hard)
-        drop_rate: 1/1,625
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 2499
-      item_name: Blue d'hide body
+    - item_name: Blue d'hide body
       slug: blue-dhide-body
       relationship: alternative
-      description: Same stats, non-trimmed
-    - item_id: 7374
-      item_name: Blue d'hide body (g)
+      description: Untrimmed variant, identical stats
+    - item_name: Blue d'hide body (g)
       slug: blue-dhide-body-g
       relationship: alternative
-      description: Gold-trimmed variant, same stats
-    - item_id: 7372
-      item_name: Green d'hide body (t)
+      description: Gold-trimmed cosmetic variant
+    - item_name: Green d'hide body (t)
       slug: green-dhide-body-t
-      relationship: alternative
-      description: Lower tier trimmed body
+      relationship: downgrade
+      description: Lower-tier trimmed dragonhide body
   about: |-
     "Made from 100% real dragonhide. With colourful trim!"
 
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -15 |
-    | Ranged Attack | +20 |
-    | Stab Defence | +23 |
-    | Slash Defence | +30 |
-    | Crush Defence | +30 |
-    | Magic Defence | +28 |
-    | Ranged Defence | +40 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 50 Ranged, 40 Defence, Dragon Slayer I
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Blue d'hide body (t) | +20 | +40 | +28 | Hard clues |
-    | Blue d'hide body | +20 | +40 | +28 | Crafting (71) |
-
-    Stats are identical to the standard blue d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+    Blue d'hide body (t) is a cosmetic trimmed variant of the standard blue dragonhide body, exclusively rewarded from hard Treasure Trails reward caskets at 1/1,625. Stats are identical to the untrimmed version (+20 Ranged Attack, +40 Ranged Defence, +28 Magic Defence) and requirements remain 50 Ranged plus 40 Defence. Value is purely cosmetic rarity.
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Hard clue reward rarity
-      - Collection log completionists
-      - Trimmed d'hide set completion
-      - Identical stats to blue d'hide body
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Fashionscape cosmetic flex"
+      - "Hard clue reward rarity drives price"
+      - "Collection log completionist demand"
+      - "Trimmed d'hide set completion target"
+      - "Identical stats to standard body"
+      - "Price tracks clue activity events"
+      - "Low trade volume risks manipulation"
+  trading_tips:
+    - Watch hard clue events for supply spikes
+    - Pair with chaps (t) for set premium
+    - Thin order book, ladder bids
+  history:
+    - date: "2006-02-20"
+      description: Released with Treasure Trails reward expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-body.mdx
@@ -12,96 +12,102 @@ osrs:
   lowalch: 3744
   highalch: 5616
   limit: 125
+  material:
+    type: dragonhide
+    tier: mid
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options: ["Wear", "Drop"]
+    worn_options: []
+    alchable: true
   equipment:
     slot: body
-    type: ranged_armour
-    ranged_requirement: 50
-    defence_requirement: 40
-  attack_bonuses:
-    ranged: 20
-  defence_bonuses:
-    ranged: 45
-    magic: 30
-  crafting:
-    level: 71
-    xp: 210
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
+    requirements:
+      ranged: 50
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 20
+    defence_bonus:
+      stab: 23
+      slash: 30
+      crush: 30
+      magic: 28
+      ranged: 40
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 71
       xp: 210
       materials:
         - item_name: Blue dragon leather
-          item_id: 2505
           quantity: 3
         - item_name: Thread
-          item_id: 1734
           quantity: 1
-      product: Blue d'hide body
-      product_id: 2499
-      product_quantity: 1
-      facility: Needle and thread
-      members_only: true
+      tools:
+        - Needle
+      output_quantity: 1
   related_items:
-    - item_id: 1751
-      item_name: Blue dragonhide
+    - item_name: Blue dragonhide
       slug: blue-dragonhide
       relationship: component
-      description: Raw material
-    - item_id: 2505
-      item_name: Blue dragon leather
+      description: Raw hide source dropped by blue dragons
+    - item_name: Blue dragon leather
       slug: blue-dragon-leather
       relationship: component
-      description: Tanned hide
-    - item_id: 2493
-      item_name: Blue d'hide chaps
+      description: Tanned hide used to craft the body
+    - item_name: Blue d'hide chaps
       slug: blue-dhide-chaps
-      relationship: alternative
-      description: Matching legs
-    - item_id: 2487
-      item_name: Blue d'hide vambraces
+      relationship: set-piece
+      description: Matching dragonhide legs
+    - item_name: Blue d'hide vambraces
       slug: blue-dhide-vambraces
-      relationship: alternative
-      description: Matching gloves
-    - item_id: 1135
-      item_name: Green d'hide body
+      relationship: set-piece
+      description: Matching dragonhide gloves
+    - item_name: Green d'hide body
       slug: green-dhide-body
-      relationship: alternative
-      description: Lower tier body
-    - item_id: 2501
-      item_name: Red d'hide body
-      slug: red-dhide-body
-      relationship: alternative
-      description: Higher tier body
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Crafting | 71 | 3 Blue dragon leather |
-    | XP | 210 | - |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged requirement | 50 |
-    | Defence requirement | 40 |
-    | Ranged attack | +20 |
-    | Ranged defence | +45 |
-    | Magic defence | +30 |
+      relationship: downgrade
+      description: Lower dragonhide body tier
+    - item_name: Red d'hide body
+      slug: red-d-hide-body
+      relationship: upgrade
+      description: Higher dragonhide body tier
+  about: "Blue d'hide body is the second dragonhide ranged body tier, requiring 50 Ranged and 40 Defence to equip. It is crafted at level 71 Crafting from 3 blue dragon leather and thread for 210 experience and is one of the staples of mid-level ranged training. With strong all-round defensive coverage and only mild magic penalty, it is a popular Wilderness risk piece and crafting XP method."
   market_strategy:
     notes:
-      - Second dragonhide body tier
-      - Members only
-      - Popular crafting item
-      - Crafting training (210 XP)
-      - Mid-level ranged armor
-      - Wilderness risk gear
-      - 3 leather per body
-      - Good XP for level
-      - Popular crafting method
-      - Alch value decent
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "High-throughput crafting commodity (210 XP per body)"
+      - "GE buy limit of 125 enables mid-volume flips"
+      - "Demand tied to Crafting bonus events and mid-level ranged training"
+      - "Margin tracks blue dragon leather supply"
+  trading_tips:
+    - Watch blue dragon leather price for crafting arbitrage
+    - Crafting double-XP weekends spike demand sharply
+  history:
+    - date: "2004-03-29"
+      description: Released with the RuneScape 2 launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-tassets-broken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-tassets-broken.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 115964
   highalch: 173946
   limit: 15
-  about: "Blue moon tassets (broken) is a members-only item in Old School RuneScape. High alchemy value: 173,946 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic armour
+    tier: high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options: ["Repair", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Lunar Chest (Neypotzli)
+        quantity: "1"
+        rarity: "1/224"
+  related_items:
+    - item_name: Blue moon tassets
+      slug: blue-moon-tassets
+      relationship: variant
+      description: Repaired, equippable version.
+    - item_name: Blue moon helm (broken)
+      slug: blue-moon-helm-broken
+      relationship: set-piece
+      description: Head slot piece of the Blue Moon set.
+    - item_name: Blue moon chestplate (broken)
+      slug: blue-moon-chestplate-broken
+      relationship: set-piece
+      description: Body slot piece of the Blue Moon set.
+  about: "The broken Blue Moon tassets are the unrepaired legs from the Lunar Chest in Neypotzli. They must be repaired before wearing: 1,500,000 coins at an armour stand with a Smithing requirement, or roughly 757,500 coins at 99 Smithing for full self-repair discount. Once repaired, the tassets provide a +1 strength bonus and +1% magic damage at 75 Magic / 50 Defence."
+  market_strategy:
+    notes:
+      - "Repair cost arbitrage: buy broken cheap, repair, resell as functional tassets if margin clears."
+      - "Supply tracks Perilous Moons clear rates."
+  history:
+    - date: "2024-03-20"
+      description: Released as part of the Perilous Moons / Neypotzli content.
+    - date: "2024-04-24"
+      description: Weight reduced from 8 kg to 1.36 kg.
+    - date: "2024-05-29"
+      description: Magic damage bonus increased from 0% to 1%.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-hat-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-hat-t.mdx
@@ -12,25 +12,75 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
     requirements: {}
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
+      ranged: 0
     defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 7392
-      item_name: Blue wizard robe (t)
+    - item_name: Blue wizard hat
+      slug: blue-wizard-hat
+      relationship: variant
+      description: Untrimmed standard version
+    - item_name: Blue wizard robe (t)
       slug: blue-wizard-robe-t
       relationship: set-piece
       description: Matching trimmed wizard robe
-  about: |-
-    > *"A silly pointed hat, with colourful trim."*
-
-    The blue wizard hat (t) is a trimmed cosmetic variant of the standard wizard hat. It provides +2 magic attack and defence with no requirements. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Black wizard hat (t)
+      slug: black-wizard-hat-t
+      relationship: variant
+      description: Black-coloured trimmed wizard hat counterpart
+  about: "Blue wizard hat (t) is a free-to-play trimmed cosmetic head-slot variant of the standard blue wizard hat, rewarded from Easy clue caskets at roughly 1/1,404. It grants +2 Magic attack and +2 Magic defence with no requirements, making it a popular fashion or pure-account hat. Unlike the standard blue wizard hat it cannot be dyed black."
+  market_strategy:
+    notes:
+      - "Tight 4-per-4-hour buy limit means modest volume and elevated unit price"
+      - "Pricing tracks Easy clue completion rates and overall trim-set demand"
+  history:
+    - date: "2006-02-20"
+      description: Released with the Treasure Trails rework that introduced trimmed clue rewards.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 70
-  about: "Bone dagger is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bone
+    tier: mid
+  properties:
+    release_date: "2006-06-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 5
+      slash: 3
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 4
+      prayer: 0
+  shops:
+    - shop_name: Nardok's Bone Weapons
+      location: Dorgesh-Kaan
+      price: 2000
+      currency: coins
+      stock: 5
+  special_attack:
+    name: Backstab
+    description: Drains the target's Defence by the damage dealt. Cannot miss if the target has not yet been damaged in the fight.
+    energy: 75
+  related_items:
+    - item_name: Bone dagger(p)
+      slug: bone-dagger-p
+      relationship: variant
+      description: Poisoned variant.
+    - item_name: Bone dagger(p+)
+      slug: bone-dagger-p
+      relationship: variant
+      description: Stronger-poison variant.
+    - item_name: Bone dagger(p++)
+      slug: bone-dagger-p
+      relationship: variant
+      description: Strongest-poison variant.
+    - item_name: Dorgeshuun crossbow
+      slug: dorgeshuun-crossbow
+      relationship: alternative
+      description: Other Dorgeshuun-tier weapon with stat-draining special.
+  about: "The Bone dagger is a Dorgeshuun weapon purchased from Nardok's Bone Weapons in Dorgesh-Kaan (requires the Death to the Dorgeshuun quest). Its Backstab special attack drains the target's Defence and is guaranteed to land on a target that has not been damaged yet in combat, making it useful for opening attacks in PvP."
+  market_strategy:
+    notes:
+      - "Shop price (2,000 gp) caps GE upside; demand driven by PKers and ironmen."
+      - "Buy limit 70 / 4h keeps flips modest."
+  history:
+    - date: "2006-06-21"
+      description: Released with the Death to the Dorgeshuun quest content.
+    - date: "2006-08-29"
+      description: Poisoned variants renamed to (p+)/(p++).
+    - date: "2021-07-21"
+      description: Female-character weapon positioning corrected.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-spear.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 4
-  about: "Bone spear is a members-only item in Old School RuneScape. High alchemy value: 360 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bone
+    tier: low
+  properties:
+    release_date: "2005-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 6
+    weight: 1.36
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 11
+      slash: 11
+      crush: 11
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 13
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Cave goblin guard
+        quantity: "1"
+        rarity: 20/128
+      - source: Master clue scroll (Hard)
+        quantity: "1"
+        rarity: common
+  shops:
+    - shop_name: Nardok's Bone Weapons
+      location: Dorgesh-Kaan mine
+      price: 600
+      currency: coins
+      stock: 5
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Bone dagger
+      slug: bone-dagger
+      relationship: alternative
+      description: Dorgeshuun stab dagger
+    - item_name: Bone club
+      slug: bone-club
+      relationship: alternative
+      description: Dorgeshuun crush club
+    - item_name: Dorgeshuun crossbow
+      slug: dorgeshuun-crossbow
+      relationship: alternative
+      description: Companion ranged Dorgeshuun weapon
+  about: "Bone spear is the only one-handed spear in OSRS, allowing it to pair with a shield or defender. Crafted by the Dorgeshuun and sold by Nardok in the Dorgesh-Kaan mine, it boasts spear-tier stab, slash, and crush bonuses with +13 strength but cannot be poisoned."
+  market_strategy:
+    notes:
+      - "Niche pickup for ironmen lacking better one-handed stab weapons"
+      - "Hard clue reward keeps a small but consistent supply"
+  history:
+    - date: "2005-05-31"
+      description: Bone spear released with The Lost Tribe quest.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bones-to-peaches-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bones-to-peaches-tablet.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Bones to peaches (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: true
+  recipes:
+    - skill: magic
+      level: 60
+      xp: 35.5
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Nature rune
+          quantity: 2
+        - item_name: Earth rune
+          quantity: 4
+        - item_name: Water rune
+          quantity: 4
+      tools:
+        - Mahogany demon lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Bones to peaches
+      slug: bones-to-peaches
+      relationship: alternative
+      description: Standard spellbook version of the spell.
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Required base material for tablet creation.
+    - item_name: Nature rune
+      slug: nature-rune
+      relationship: component
+      description: Two nature runes are consumed per tablet.
+  history:
+    - date: "2024-05-08"
+      description: Tablets were updated to function on bones inside the Mage Training Arena's Creature Graveyard.
+  about: "Bones to peaches (tablet) is a stackable magic tablet that breaks to cast the Bones to peaches spell, converting bones in the inventory into peaches without needing the spellbook or runes. Each tablet is created at a mahogany (or better) demon lectern at 60 Magic, consuming soft clay alongside nature, earth, and water runes for 35.5 Magic experience. Breaking the tablet itself awards no experience but is popular for slayer tasks and Bounty Hunter trips where flexibility matters."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bow-string.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bow-string.mdx
@@ -12,83 +12,81 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: string
-    tier: basic
-  crafting:
-    level: 1
-    xp: 15
-    method: Spin flax on spinning wheel
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.014
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "I need a bow stave to attach this to."
   recipes:
     - skill: crafting
       level: 1
       xp: 15
       materials:
         - item_name: Flax
-          item_id: 1779
           quantity: 1
-      product: Bow string
-      product_id: 1777
-      product_quantity: 1
-      facility: Spinning wheel
+      tools:
+        - Spinning wheel
+      output_quantity: 1
+    - skill: magic
+      level: 76
+      xp: 75
+      materials:
+        - item_name: Flax
+          quantity: 5
+        - item_name: Nature rune
+          quantity: 2
+        - item_name: Astral rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 5
+      tools: []
+      output_quantity: 5
   related_items:
-    - item_id: 1779
-      item_name: Flax
+    - item_name: Flax
       slug: flax
       relationship: component
-      description: Raw material
-    - item_id: 66
-      item_name: Yew longbow (u)
+      description: Raw material spun on a spinning wheel
+    - item_name: Yew longbow (u)
       slug: yew-longbow-u
       relationship: product
       description: Popular stringing target
-    - item_id: 64
-      item_name: Magic longbow (u)
+    - item_name: Magic longbow (u)
       slug: magic-longbow-u
       relationship: product
       description: High value stringing
-    - item_id: 855
-      item_name: Yew longbow
+    - item_name: Yew longbow
       slug: yew-longbow
       relationship: product
       description: Strung yew bow
-    - item_id: 859
-      item_name: Magic longbow
+    - item_name: Magic longbow
       slug: magic-longbow
       relationship: product
       description: Strung magic bow
-  about: |-
-    Spin Flax on a spinning wheel to create Bow string.
-
-    | Action | Crafting Level | XP |
-    |--------|----------------|-----|
-    | Spin flax | 1 | 15 |
-
-    Bow strings are used to string unstrung bows:
-
-    | Bow | Fletching Level |
-    |-----|-----------------|
-    | Shortbow | 5 |
-    | Longbow | 10 |
-    | Oak shortbow | 20 |
-    | Oak longbow | 25 |
-    | Willow shortbow | 35 |
-    | Willow longbow | 40 |
-    | Maple shortbow | 50 |
-    | Maple longbow | 55 |
-    | Yew shortbow | 65 |
-    | Yew longbow | 70 |
-    | Magic shortbow | 80 |
-    | Magic longbow | 85 |
+  about: "Bow string is a core Fletching material produced by spinning flax on a spinning wheel for 15 Crafting experience, or via the 76 Magic Spin Flax Lunar spell for 5 strings per cast. It is used to string every wooden shortbow and longbow in the game, making it a staple money-making material for low-level Crafters."
   market_strategy:
     notes:
-      - Buy Flax → Spin → Sell Bow string
-      - Low effort, decent GP/hr for low levels
-      - Buy unstrung bows + bow strings
-      - String and sell finished bows
-      - Works well with Yew longbow (u)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy flax, spin into bow string, sell finished strings"
+      - "String unstrung yew or magic longbows for stable Fletching margins"
+      - "Lunar Spin Flax scales bow string output for higher-level players"
+  history:
+    - date: "2002-03-25"
+      description: Bow string introduced with the Crafting skill.
+    - date: "2005-01-26"
+      description: Inventory sprite refreshed during the early 2005 art pass.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bowl-of-hot-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bowl-of-hot-water.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
-  about: "Bowl of hot water is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cooking-ingredient
+    tier: low
+  properties:
+    release_date: "2005-02-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Bowl of water
+          quantity: 1
+      tools:
+        - Range or fire
+      output_quantity: 1
+  related_items:
+    - item_name: Bowl of water
+      slug: bowl-of-water
+      relationship: component
+      description: Heated on a range or fire to produce the hot variant
+    - item_name: Cup of hot water
+      slug: cup-of-hot-water
+      relationship: variant
+      description: Smaller cup version created by pouring this bowl into an empty cup
+    - item_name: Guthix rest
+      slug: guthix-rest-4
+      relationship: product
+      description: Used as the base liquid for brewing Guthix rest tea
+  about: "Bowl of hot water is made by heating a bowl of water on a cooking range, stove, or fire. It serves as the base ingredient for Guthix rest tea and can be poured into empty cups to create cups of hot water for further recipes."
+  history:
+    - date: "2005-02-28"
+      description: Released alongside the One Small Favour quest.
+    - date: "2024-08-07"
+      description: Enabled the Make-All menu when pouring bowls of hot water into empty cups.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bowl-of-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bowl-of-water.mdx
@@ -12,9 +12,44 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  about: "Bowl of water is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Empty
+      - Drop
+    alchable: true
+  related_items:
+    - item_name: Bowl
+      slug: bowl
+      relationship: component
+      description: Filled with water at any source (except a well) to produce a bowl of water.
+    - item_name: Jug of water
+      slug: jug-of-water
+      relationship: alternative
+      description: Equivalent water container made with a jug instead of a bowl.
+    - item_name: Bowl of hot water
+      slug: bowl-of-hot-water
+      relationship: product
+      description: Heated form used as a tea-making intermediate.
+    - item_name: Nettle-water
+      slug: nettle-water
+      relationship: product
+      description: Combine with nettles in a bowl of hot water to brew nettle tea.
+  history:
+    - date: "2005-03-21"
+      description: An Empty option was added to the bowl of water.
+    - date: "2006-01-30"
+      description: The bowl of water received a graphical update.
+  about: "Bowl of water is a basic utility item created by using an empty bowl on a water source other than a well, or by casting Humidify on an empty bowl. It is consumed in a wide range of cooking and herblore recipes, including tea brewing, stew preparation, and several quest interactions. The Grand Exchange buy limit of 13,000 per four hours keeps it abundant for free-to-play crafters and cooks."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bowl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bowl.mdx
@@ -12,63 +12,73 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: pottery
-    tier: fired
-  crafting:
-    level: 1
-    xp: 15
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: crafting
       level: 1
       xp: 15
       materials:
         - item_name: Unfired bowl
-          item_id: 1791
           quantity: 1
-      product: Bowl
-      product_id: 1923
-      product_quantity: 1
-      facility: Pottery oven
+      tools:
+        - Pottery oven
+      output_quantity: 1
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge
+      price: 5
+      currency: coins
+      stock: 10
+    - shop_name: Rimmington General Store
+      location: Rimmington
+      price: 5
+      currency: coins
+      stock: 2
+    - shop_name: Trader Stan's Trading Post
+      location: Port Sarim
+      price: 10
+      currency: coins
+      stock: 5
   related_items:
-    - item_id: 1791
-      item_name: Unfired bowl
+    - item_name: Unfired bowl
       slug: unfired-bowl
       relationship: component
-      description: Unfired version
-    - item_id: 1761
-      item_name: Soft clay
+      description: Soft clay shaped on a wheel, hardened in the pottery oven
+    - item_name: Soft clay
       slug: soft-clay
       relationship: component
-      description: Raw material
-    - item_id: 1921
-      item_name: Bowl of water
+      description: Raw material moulded into an unfired bowl
+    - item_name: Bowl of water
       slug: bowl-of-water
       relationship: product
-      description: Filled version
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Pottery oven | 1 | 1 Unfired bowl |
-    | XP | 15 | - |
-
-    | Use | Skill | Result |
-    |-----|-------|--------|
-    | Fill with water | N/A | Bowl of water |
-    | Nettle tea | Cooking | Nettle tea |
-    | Stew | Cooking | Various stews |
-    | Curry | Cooking | Curry |
+      description: Filled at any water source
+  about: "Bowl is a free-to-play Crafting product made from one Unfired bowl on a pottery oven for 15 experience at level 1. It acts as a vessel for cooking inputs (water, stew, curry, kebab mix) and is sold cheap at Culinaromancer's Chest and several general stores, making it the go-to bulk container for low-level cooks."
   market_strategy:
     notes:
-      - Stew making
-      - Curry cooking
-      - Cooking training
-      - Used for stews
-      - F2P accessible
-      - Buy from shops
-      - Low value item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy in bulk from Culinaromancer's Chest at 5 gp"
+      - "Demand driven by stew/curry cooking"
+      - "Margin is tiny, volume is the play"
+  history:
+    - date: "2001-06-11"
+      description: Added with the original RuneScape Classic Cooking skill rollout.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-mould.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bracelet mould | OSRS Price Data
-description: "Bracelet mould: Used to make gold bracelets.. High alch: 3 GP, GE limit: 40."
+description: "Bracelet mould is a members Crafting tool used to make gold and silver bracelets. High alch: 3 GP, GE limit: 40."
 osrs:
   id: 11065
   name: Bracelet mould
@@ -12,9 +12,75 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 40
-  about: "Bracelet mould is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mould
+    tier: low
+  properties:
+    release_date: "2007-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  shops:
+    - shop_name: Dommik's Crafting Store
+      location: Al Kharid
+      price: 8
+      currency: coins
+      stock: 2
+    - shop_name: Rommik's Crafty Supplies
+      location: Rimmington
+      price: 8
+      currency: coins
+      stock: 2
+    - shop_name: Hamab's Crafting Emporium
+      location: Ape Atoll
+      price: 8
+      currency: coins
+      stock: 2
+    - shop_name: Jamila's Craft Stall
+      location: Sophanem
+      price: 8
+      currency: coins
+      stock: 2
+  related_items:
+    - item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Used with the mould at a furnace to craft bracelets
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Alternative metal for silver bracelets
+    - item_name: Ring mould
+      slug: ring-mould
+      relationship: alternative
+      description: Equivalent mould for ring crafting
+    - item_name: Necklace mould
+      slug: necklace-mould
+      relationship: alternative
+      description: Equivalent mould for necklace crafting
+  about: "Bracelet mould is a Crafting tool used at a furnace to shape gold or silver bars into bracelets. Players combine the mould with a bar (and optional gem) to produce the bracelet, used in enchantment recipes and combat or skilling utility jewelry. It is stocked by Crafting shops across the game, including Dommik's in Al Kharid and Rommik's in Rimmington, and is permanent once obtained. Most players buy one and keep it forever; market demand is driven by new accounts and ironmen losing or replacing theirs."
+  market_strategy:
+    notes:
+      - "One-time purchase for most players"
+      - "Limited 40 buy limit caps speculation"
+      - "Supply from shop restocks keeps price near floor"
+      - "Niche premium when crafting bracelet meta updates land"
+  trading_tips:
+    - Buy from shops at 8 GP and resell on GE
+    - Watch for Crafting skill update announcements
+  history:
+    - date: "2007-04-30"
+      description: Released with bracelet crafting expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-p-5628.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-p-5628.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Bronze dart(p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 2
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 1
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Bronze dart
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Bronze dart
+      slug: bronze-dart
+      relationship: variant
+      description: Unpoisoned base dart
+    - item_name: Bronze dart(p)
+      slug: bronze-dart-p-806
+      relationship: variant
+      description: Standard poison variant
+    - item_name: Bronze dart(p++)
+      slug: bronze-dart-p-5635
+      relationship: upgrade
+      description: Extra-strength poison variant
+  about: |-
+    "A deadly poisoned dart with a bronze tip."
+
+    Bronze dart(p+) is the +-poisoned variant of the base bronze dart, made by applying weapon poison(+) to an unpoisoned dart. Acts identically to the base dart in combat (+1 Ranged Strength, 2-tick attack speed) with the added chance to inflict stronger poison. Requires only level 1 Ranged to wield.
+  market_strategy:
+    notes:
+      - "Low-tier PKing dart variant"
+      - "Poison cost rarely justified"
+      - "Bronze base limits damage ceiling"
+      - "Buy limit 7,000 sustains bulk flips"
+      - "Niche demand vs unpoisoned"
+  trading_tips:
+    - Margins minimal due to 1gp alch
+    - Volume tied to PK event spikes
+    - Usually flip the base dart instead
+  history:
+    - date: "2003-04-14"
+      description: Released with throwing weapon expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-felling-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-felling-axe.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: null
-  about: "Bronze felling axe is a members-only item in Old School RuneScape. High alchemy value: 9 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2023-10-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Chop
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: 2h
+    weapon_type: axe
+    attack_speed: 7
+    weight: 1.814
+    requirements:
+      woodcutting: 1
+      attack: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 5
+      materials:
+        - item_name: Felling axe handle
+          quantity: 1
+        - item_name: Bronze axe
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  related_items:
+    - item_name: Iron felling axe
+      slug: iron-felling-axe
+      relationship: upgrade
+      description: Next-tier felling axe
+    - item_name: Bronze axe
+      slug: bronze-axe
+      relationship: component
+      description: Required to craft the felling axe
+    - item_name: Felling axe handle
+      slug: felling-axe-handle
+      relationship: component
+      description: Forestry-specific handle needed for assembly
+  about: "The bronze felling axe is the lowest-tier Forestry felling axe, used in two-handed woodcutting activities alongside other Forestry contributors. Functions as a regular bronze axe unless the player carries forester's rations, which grant a 10% bonus Woodcutting XP and a 20% chance to skip receiving logs. Crafted at level 1 Smithing by combining a felling axe handle and a bronze axe on an anvil."
+  market_strategy:
+    notes:
+      - "Not on the Grand Exchange so liquidity is player-to-player"
+      - "Cheap to assemble for Forestry events"
+      - "Replaced quickly as players unlock higher-tier axes"
+  history:
+    - date: "2023-10-25"
+      description: "Made obtainable with the Forestry: The Way of the Forester update."
+    - date: "2023-11-01"
+      description: "Bug fixes to felling axe behaviour."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bruise-blue-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bruise-blue-snelm.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Bruise blue snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: snail shell
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+  equipment:
+    slot: head
+    attack_speed: null
+    weight: 2
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 6
+      magic: -1
+      ranged: 7
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish blue shell (round)
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  passive_effects:
+    - name: Snail damage reduction
+      description: Reduces damage taken from snails by 8.
+  related_items:
+    - item_name: Bruise blue snelm (pointed)
+      slug: bruise-blue-snelm-pointed
+      relationship: variant
+      description: Pointed-shell variant with the same colour
+    - item_name: Blamish blue shell (round)
+      slug: blamish-blue-shell-round
+      relationship: component
+      description: Round blue shell chiselled into the round bruise blue snelm
+    - item_name: Myre snelm
+      slug: myre-snelm
+      relationship: alternative
+      description: Other snelm colour variants found in Morytania
+  about: "The bruise blue snelm is a head-slot helmet crafted at 15 Crafting by chiselling a blamish blue shell (round). It offers defensive stats roughly equivalent to a steel medium helm with no requirements to wear and reduces snail damage by 8, making it useful while fighting blamish or giant rock snails. Note that snelms do not count for Treasure Trail full helm clue requirements."
+  market_strategy:
+    notes:
+      - "Cheap craftable shell helm — low GE volume"
+      - "Demand mostly from snail-fighting Slayer or low-level DIY accounts"
+      - "Limit of 150 supports occasional bulk dumps of snail loot"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-helm.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 5600
   highalch: 8400
   limit: 4
-  about: "Bucket helm is a members-only item in Old School RuneScape. High alchemy value: 8,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  about: "Bucket helm is a members-only cosmetic head slot item in Old School RuneScape, obtained as a rare reward from elite Treasure Trail caskets at roughly a 1 in 1,275 drop rate. Released on 6 July 2016 with the Treasure Trail Expansion, it provides no combat bonuses and is purely a fashion piece. High alchemy value: 8,400 coins. Grand Exchange buy limit: 4 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is driven by fashionscape collectors rather than combat utility, so price swings track cosmetic trends."
+      - "Buy limit of 4 makes large-scale flipping slow; stagger orders across multiple GE slots."
+      - "Elite clue supply keeps trickle inventory; spikes after clue-related updates are common entry points."
+  trading_tips:
+    - "Watch elite clue completion rates after content updates that boost clue scroll drops."
+    - "List slightly under the average GE price to clear stock against the low daily volume."
+    - "Pair with other bucket-themed cosmetics in fashionscape bundles for resale on Discord markets."
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cabbages-10.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cabbages-10.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  about: "Cabbages(10) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: produce-sack
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Fill
+      - Empty
+      - Drop
+    alchable: false
+  related_items:
+    - item_name: Cabbage
+      slug: cabbage
+      relationship: component
+      description: Individual vegetable stored in this sack.
+    - item_name: Vegetable sack
+      slug: vegetable-sack
+      relationship: variant
+      description: Empty sack used to hold cabbages or other vegetables.
+    - item_name: Tomatoes(10)
+      slug: tomatoes-10
+      relationship: alternative
+      description: Similar Farming payment sack for allotment patches.
+  about: "Cabbages(10) is a full vegetable sack containing ten cabbages. Players fill an empty vegetable sack with cabbages from their inventory and empty them out one at a time when needed. Two full sacks of cabbages can be paid to a farmer to protect a tomato allotment from disease, while three sacks are used as protection payment for Krandorian hops. Cabbages picked from the Draynor Manor patch cannot be stored in the sack. Released 11 July 2005 with the Farming skill expansion."
+  market_strategy:
+    notes:
+      - "Low GE limit of 600 caps bulk arbitrage between individual cabbages and full sacks."
+      - "Demand comes from Farming protection payments rather than direct consumption."
+  trading_tips:
+    - Buying 10 cabbages individually is often cheaper than a full sack at GE.
+  history:
+    - date: "2005-07-11"
+      description: Added as a vegetable sack format with the Farming skill.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/calquat-fruit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/calquat-fruit.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 21
   highalch: 32
   limit: 11000
-  about: "Calquat fruit is a members-only item in Old School RuneScape. High alchemy value: 32 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: fruit
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 72
+      xp: 48.5
+      materials:
+        - item_name: Calquat tree seed
+          quantity: 1
+      tools: []
+      output_quantity: 6
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Calquat fruit
+          quantity: 1
+        - item_name: Knife
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Calquat tree seed
+      slug: calquat-tree-seed
+      relationship: component
+      description: Seed planted to grow the calquat tree
+    - item_name: Calquat keg
+      slug: calquat-keg
+      relationship: product
+      description: Hollowed-out calquat fruit used for brewing
+  about: "Calquat fruit is harvested from fully grown calquat trees at 72 Farming, yielding six fruits per tree and 48.5 Farming experience per pick. The fruit's tough, woody skin and hollow interior make it ideal for hollowing out with a knife into a calquat keg for the Keg of Beer minigame and brewing supplies."
+  market_strategy:
+    notes:
+      - "Supply is gated by 72 Farming and slow 16-hour tree growth"
+      - "Demand fluctuates with Construction butler tip runs and brewing"
+  history:
+    - date: "2005-07-11"
+      description: Calquat fruit released with the Farming skill.
+    - date: "2020-06-18"
+      description: Knife-hollowing updated to process multiple fruits sequentially.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-blowpipe-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-blowpipe-empty.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 880
   highalch: 1320
   limit: 8
-  about: "Camphor blowpipe (empty) is a members-only item in Old School RuneScape. High alchemy value: 1,320 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: camphor wood
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0.3
+    requirements:
+      ranged: 45
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 12
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 2
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 58
+      xp: 140
+      materials:
+        - item_name: Camphor logs
+          quantity: 2
+        - item_name: Squid beak
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Camphor blowpipe
+      slug: camphor-blowpipe
+      relationship: variant
+      description: Loaded camphor blowpipe with darts equipped
+    - item_name: Camphor logs
+      slug: camphor-logs
+      relationship: component
+      description: Required to fletch the blowpipe
+    - item_name: Squid beak
+      slug: squid-beak
+      relationship: component
+      description: Sailing-source mouthpiece for the blowpipe
+    - item_name: Toxic blowpipe
+      slug: toxic-blowpipe
+      relationship: upgrade
+      description: Higher-tier blowpipe with stronger ranged bonuses
+  about: "The camphor blowpipe (empty) is a Sailing-era thrown ranged weapon fletched at 58 Fletching from two camphor logs and a squid beak. It needs 45 Ranged to wield, fires up to mithril darts, and serves as a mid-tier alternative below the toxic blowpipe. The empty state is the tradeable form before darts are loaded."
+  market_strategy:
+    notes:
+      - "Sailing release item — supply driven by squid beak and camphor log throughput"
+      - "GE limit of 8 caps single-account flips"
+      - "Demand from mid-level ranged training and ironman crafting chains"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-hull-parts.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 2500
   highalch: 3750
   limit: 100
-  about: "Camphor hull parts is a members-only item in Old School RuneScape. High alchemy value: 3,750 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: shipwright
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 53
+      xp: 400
+      materials:
+        - item_name: Camphor plank
+          quantity: 5
+      tools:
+        - Saw
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Camphor plank
+      slug: camphor-plank
+      relationship: component
+      description: Source plank for the parts
+    - item_name: Camphor hull
+      slug: camphor-hull
+      relationship: product
+      description: Final boat hull built from parts
+    - item_name: Large camphor hull parts
+      slug: large-camphor-hull-parts
+      relationship: alternative
+      description: Larger variant for sloops
+  about: |-
+    "Parts for creating a camphor hull for a boat."
+
+    Camphor hull parts are crafted at a shipwrights' workbench from 5 camphor planks at level 53 Construction, granting 400 XP per part. Ten parts assemble a camphor hull for a skiff, while sloops use the larger variant. Released November 19, 2025 with the boat-building update.
+  market_strategy:
+    notes:
+      - "New Shipwright Construction loop"
+      - "Plank cost vs GE arbitrage"
+      - "Buy limit 100 caps speculation"
+      - "Crafting yields modest profit"
+      - "Demand tied to boat ownership rate"
+  trading_tips:
+    - Track camphor plank prices
+    - Bulk flipping for skiff builders
+    - Watch sloop large-part premium
+  history:
+    - date: "2025-11-19"
+      description: Released with Shipwright boat construction update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/carved-teak-bench-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/carved-teak-bench-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Carved teak bench (flatpack) | OSRS Price Data
-description: "Carved teak bench (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Carved teak bench (flatpack) is a members Construction flatpack. High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8570
   name: Carved teak bench (flatpack)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Carved teak bench (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teak
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: construction
+      level: 44
+      xp: 360
+      materials:
+        - item_name: Teak plank
+          quantity: 4
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Construction material used to build the flatpack
+    - item_name: Carved teak bench
+      slug: carved-teak-bench
+      relationship: product
+      description: Furniture built from this flatpack in a player-owned house
+    - item_name: Steel framed workbench
+      slug: steel-framed-workbench
+      relationship: component
+      description: Workbench required to assemble the flatpack
+  about: "Carved teak bench (flatpack) is a Construction flatpack made on a steel framed workbench in a player-owned house workshop, requiring 44 Construction and 4 teak planks to produce for 360 XP. It packages a carved teak bench that can be unflatpacked and built inside another player's house, commonly sold to mid-level Construction trainers via the Grand Exchange. Crafting these incurs a loss versus material cost, so they are usually a training byproduct rather than a profit play."
+  market_strategy:
+    notes:
+      - "Training byproduct for Construction levellers"
+      - "Loses GP vs teak plank cost after GE tax"
+      - "Useful supply for house parties and Construction services"
+      - "Buy limit 500 caps speculation"
+  trading_tips:
+    - Buy below teak plank break-even for resale
+    - Stockpile during double XP weekends
+  history:
+    - date: "2006-05-31"
+      description: Released with the Construction skill.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/catherby-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/catherby-teleport-tablet.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Catherby teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tablet
+    tier: mid
+  properties:
+    release_date: "2020-09-30"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 87
+      xp: 89
+      materials:
+        - item_name: Law rune
+          quantity: 3
+        - item_name: Water rune
+          quantity: 10
+        - item_name: Astral rune
+          quantity: 3
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Lunar lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Moonclan teleport (tablet)
+      slug: moonclan-teleport-tablet
+      relationship: variant
+      description: Another Lunar spellbook teleport tablet
+    - item_name: Fishing Guild teleport (tablet)
+      slug: fishing-guild-teleport-tablet
+      relationship: variant
+      description: Sibling Lunar teleport tablet
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Required tablet material
+  about: "The Catherby teleport tablet teleports the player to Catherby bank when broken. Crafted at a Lunar lectern in a player-owned house at 87 Magic with the Lunar spellbook active. The user does not need the Magic level to break it, making it popular for low-level skillers fishing or farming in Catherby."
+  market_strategy:
+    notes:
+      - "Demand tracks Fishing and Farming activity"
+      - "Buy limit raised to 10,000 in 2020 keeps spreads tight"
+      - "Soft clay and astral rune prices drive cost basis"
+  history:
+    - date: "2020-09-30"
+      description: "Released with the Lunar tablets update."
+    - date: "2020-10-14"
+      description: "Buy limit raised from 100 to 10,000."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chaos-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chaos-talisman.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Chaos talisman is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: talisman
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.015
+    options: ["Locate", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Chaos druid
+        quantity: "1"
+        rarity: Common
+      - source: Abyssal leech
+        quantity: "1"
+        rarity: Common
+      - source: Abyssal walker
+        quantity: "1"
+        rarity: Common
+      - source: Abyssal guardian
+        quantity: "1"
+        rarity: Common
+      - source: Rare drop table
+        quantity: "1"
+        rarity: Uncommon
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 42.5
+      materials:
+        - item_name: Tiara
+          quantity: 1
+        - item_name: Chaos talisman
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Chaos tiara
+      slug: chaos-tiara
+      relationship: product
+      description: Wearable headgear crafted from a chaos talisman and a regular tiara.
+    - item_name: Chaos rune
+      slug: chaos-rune
+      relationship: product
+      description: Runecrafting output created at the Chaos Altar using a pure essence.
+    - item_name: Elemental talisman
+      slug: elemental-talisman
+      relationship: alternative
+      description: Other elemental talismans used to enter their respective altars.
+    - item_name: Pure essence
+      slug: pure-essence
+      relationship: component
+      description: Essence required for crafting chaos runes at the altar.
+  about: "The chaos talisman lets a member enter the Chaos Altar in the Wilderness, just north-west of Edgeville, and is one of the talismans used to bind raw essence into chaos runes. Most players quickly convert their first talisman into a chaos tiara so the altar can be entered with a single click and the inventory slot can be freed for essence. The talisman drops commonly from chaos druids and abyssal creatures, making it an early money-maker for chaos rune farmers."
+  market_strategy:
+    notes:
+      - "Volume is driven by ironmen crafting chaos tiaras and by Runecrafters bulk-buying talismans for tiara production."
+      - "Price tends to track chaos rune demand more than talisman supply itself."
+      - "High buy limit of 11,000 makes this a reliable low-margin flip."
+  trading_tips:
+    - "Watch for buy-spike days when chaos rune prices climb - tiara crafting demand follows."
+    - "Convert leftover stock into chaos tiaras and resell when tiara margins exceed talisman flip margin."
+  history:
+    - date: "2004-03-29"
+      description: "Released with Runecraft to allow entry to the Chaos Altar."
+    - date: "2005-04-12"
+      description: "Chaos tiara crafting added, letting players combine the talisman with a tiara for one-click altar entry."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-1.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 50
-  about: "Compost potion(1) is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2005-08-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options: ["Drink", "Empty"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Converts a bucket of regular compost into supercompost; one dose used on a Big Compost Bin upgrades all 30 buckets inside."
+        duration: null
+  related_items:
+    - item_name: Compost potion(2)
+      slug: compost-potion-2
+      relationship: upgrade
+      description: Two-dose version of the same potion.
+    - item_name: Compost potion(3)
+      slug: compost-potion-3
+      relationship: upgrade
+      description: Three-dose version of the same potion.
+    - item_name: Compost potion(4)
+      slug: compost-potion-4
+      relationship: upgrade
+      description: Full four-dose flask of compost potion.
+    - item_name: Vial
+      slug: vial
+      relationship: component
+      description: Empty glass vial left behind once the potion is fully drunk.
+    - item_name: Supercompost
+      slug: supercompost
+      relationship: product
+      description: Upgraded compost produced by pouring this potion onto regular compost.
+  about: "Compost potion(1) is the single-dose remainder of a compost potion flask and is most often used in a Big Compost Bin, where one dose is enough to upgrade all 30 buckets of regular compost into supercompost. Bulk farmers buy 1-dose vials when their price-per-dose is below the 4-dose flask, since each bin only needs one application."
+  recipes:
+    - skill: herblore
+      level: 22
+      xp: 60
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Volcanic ash
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "Big Compost Bins only consume one dose, so the 1-dose flask is a strong-per-dose buy on most days."
+      - "Supply is bottlenecked by volcanic ash and harralander, mirroring the wider compost potion market."
+      - "Buy limit of 50 caps short flips, but daily farming demand is consistent."
+  trading_tips:
+    - "Buy 1-dose flasks whenever their price per dose dips under the (4) flask divided by four."
+    - "Recombine empty vials into batches and flip for steady single-digit profit per vial."
+  history:
+    - date: "2005-08-30"
+      description: "Released as part of the original Herblore potion lineup for compost upgrades."
+    - date: "2013-12-12"
+      description: "Compost potion mixing became repeatable beyond the Garden of Tranquillity reward path."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-2.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 50
-  about: "Compost potion(2) is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2005-08-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options: ["Drink", "Empty"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Converts a bucket of regular compost into supercompost; a single dose used on a Big Compost Bin upgrades all 30 buckets inside."
+        duration: null
+  related_items:
+    - item_name: Compost potion(1)
+      slug: compost-potion-1
+      relationship: downgrade
+      description: One-dose version of the same potion.
+    - item_name: Compost potion(3)
+      slug: compost-potion-3
+      relationship: upgrade
+      description: Three-dose version of the same potion.
+    - item_name: Compost potion(4)
+      slug: compost-potion-4
+      relationship: upgrade
+      description: Full four-dose flask of compost potion.
+    - item_name: Vial
+      slug: vial
+      relationship: component
+      description: Empty glass vial left behind once the potion is fully drunk.
+    - item_name: Supercompost
+      slug: supercompost
+      relationship: product
+      description: Upgraded compost produced by pouring this potion onto regular compost.
+  about: "Compost potion(2) is a two-dose flask that converts regular compost into supercompost when poured into a compost bin. Farmers favour it because a single dose upgrades an entire Big Compost Bin's 30 buckets, dramatically reducing the time and Herblore investment required to mass-produce supercompost for high-tier patches."
+  recipes:
+    - skill: herblore
+      level: 22
+      xp: 60
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Volcanic ash
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  market_strategy:
+    notes:
+      - "Demand follows farming meta - tree, fruit tree, and herb runs all benefit from supercompost."
+      - "Supply is bottlenecked by volcanic ash, so price tracks ash and Fossil Island mining trends."
+      - "Buy limit of 50 caps short-term flips, but stable consumption keeps daily volume healthy."
+  trading_tips:
+    - "Stockpile when volcanic ash dips after combat achievement weeks bring Fossil Island traffic."
+    - "Split into 1-dose vials when single-dose price per dose exceeds the 2-dose price."
+  history:
+    - date: "2005-08-30"
+      description: "Released as part of the original Herblore potion lineup for compost upgrades."
+    - date: "2013-12-12"
+      description: "Compost potion mixing became repeatable beyond the Garden of Tranquillity reward path."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-4.mdx
@@ -12,12 +12,79 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 50
-  about: "Compost potion(4) is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2005-08-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Pour onto a compost bin of regular compost to convert all 15 items into supercompost."
+        duration: null
+  recipes:
+    - skill: herblore
+      level: 22
+      xp: 60
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Volcanic ash
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Compost potion(3)
+      slug: compost-potion-3
+      relationship: variant
+      description: Three-dose version.
+    - item_name: Compost potion(2)
+      slug: compost-potion-2
+      relationship: variant
+      description: Two-dose version.
+    - item_name: Compost potion(1)
+      slug: compost-potion-1
+      relationship: variant
+      description: Single-dose version.
+    - item_name: Supercompost
+      slug: supercompost
+      relationship: product
+      description: Result of pouring the potion onto a compost bin.
+    - item_name: Volcanic ash
+      slug: volcanic-ash
+      relationship: component
+      description: Secondary ingredient for the Herblore recipe.
+  about: "Compost potion(4) is a Herblore potion released 30 August 2005 that upgrades the contents of a regular compost bin into supercompost. The potion is brewed at Herblore 22 by combining a Harralander potion (unf) with volcanic ash for 60 Herblore experience. Each four-dose flask is enough to fully convert one compost bin, making it a low-effort but slightly costly farming utility item."
+  market_strategy:
+    notes:
+      - "Demand follows farming activity; price tracks volcanic ash availability."
+      - "Nightmare Zone rewards keep supply steady at 5,000 points per (4)."
+  trading_tips:
+    - Buy when volcanic ash prices spike to corner farmer demand.
+    - Compare flipping vs. brewing from Harralander potion (unf) for the better margin.
+  history:
+    - date: "2005-08-30"
+      description: Released with the Garden of Tranquillity quest, the original source of the potion.
+    - date: "2013-09-23"
+      description: Added as a Nightmare Zone reward for 5,000 reward points.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-giant-crab-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-giant-crab-meat.mdx
@@ -12,9 +12,47 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 6000
-  about: "Cooked giant crab meat is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cooked-food
+    tier: low
+  properties:
+    release_date: "2006-03-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.907
+    options:
+      - Eat
+      - Drop
+    alchable: true
+  recipes:
+    - skill: cooking
+      level: 21
+      xp: 100
+      materials:
+        - item_name: Raw giant crab meat
+          quantity: 1
+      tools:
+        - Fire
+      output_quantity: 1
+  related_items:
+    - item_name: Raw giant crab meat
+      slug: raw-giant-crab-meat
+      relationship: component
+      description: Uncooked source meat dropped by giant crabs during Recipe for Disaster preparation.
+    - item_name: Burnt giant crab meat
+      slug: burnt-giant-crab-meat
+      relationship: alternative
+      description: Failed cook outcome when handling raw giant crab meat.
+  history:
+    - date: "2025-11-05"
+      description: The item was renamed from "Cooked crab meat" to "Cooked giant crab meat" for clarity.
+  about: "Cooked giant crab meat is prepared by cooking raw giant crab meat at level 21 Cooking for 100 Cooking experience. Each portion provides five bites that heal 2 hitpoints each, for a total of 10 hitpoints, making it suited to precise micro-healing rather than general food use. It is also a quest ingredient in the Freeing Pirate Pete subquest of Recipe for Disaster, and the Grand Exchange limit of 6,000 per four hours keeps a steady supply for both cooks and questers."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cotton-yarn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cotton-yarn.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 13000
-  about: "Cotton yarn is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: textile
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    alchable: true
+  recipes:
+    - skill: crafting
+      level: 73
+      xp: 105
+      materials:
+        - item_name: Cotton boll
+          quantity: 1
+      tools:
+        - Spinning wheel
+      output_quantity: 1
+  related_items:
+    - item_name: Cotton boll
+      slug: cotton-boll
+      relationship: component
+      description: Spun on a spinning wheel to produce cotton yarn.
+    - item_name: Bolt of cotton
+      slug: bolt-of-cotton
+      relationship: product
+      description: Woven from cotton yarn for shipbuilding upgrades.
+    - item_name: Haemostatic dressing
+      slug: haemostatic-dressing
+      relationship: product
+      description: Surgery supply crafted from cotton yarn.
+    - item_name: Cotton trawling net
+      slug: cotton-trawling-net
+      relationship: product
+      description: Fishing trawling net produced from cotton yarn.
+  about: "Cotton yarn is a members-only textile created by spinning cotton bolls on a spinning wheel at Crafting level 73 for 105 experience per spin. The yarn feeds into multiple downstream products including bolts of cotton (used for shipbuilding upgrades), haemostatic dressings (a healing item), and cotton trawling nets. Released 19 November 2025."
+  market_strategy:
+    notes:
+      - "High Crafting level requirement narrows the supply pipeline."
+      - "Demand scales with shipbuilding and trawler content participation."
+  trading_tips:
+    - Track cotton boll vs cotton yarn spread - profit comes from spinning when GE tax-adjusted margin is positive.
+  history:
+    - date: "2025-11-19"
+      description: Released alongside cotton boll farming and downstream textile content.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-2h-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-2h-axe.mdx
@@ -6,15 +6,95 @@ osrs:
   name: Crystal 2h axe
   slug: crystal-2h-axe
   examine: A woodcutter's axe.
-  members: false
+  members: true
   icon: Crystal 2h axe.png
   value: 520000
   lowalch: 208000
   highalch: 312000
   limit: null
-  about: "Crystal 2h axe is a free-to-play item in Old School RuneScape. High alchemy value: 312,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crystal
+    tier: high
+  properties:
+    release_date: "2023-10-25"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Check
+      - Revert
+      - Drop
+    worn_options:
+      - Check
+      - Revert
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: 2h
+    weapon_type: axe
+    attack_speed: 7
+    weight: 1.36
+    requirements:
+      attack: 70
+      agility: 50
+      woodcutting: 71
+    attack_bonus:
+      stab: -3
+      slash: 60
+      crush: 51
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 67
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    type: crystal-shard
+    description: "Starts with 10,000 charges (max 20,000). Each log chopped consumes one charge; recharge by adding crystal shards at 100 charges per shard. With the Elven/Celestial signet equipped there is a 10% chance to not consume charges."
+  special_attack:
+    name: Lumber Up
+    description: "Boosts the player's Woodcutting level by 3 for 3 minutes."
+    energy: 100
+  related_items:
+    - item_name: Crystal tool seed
+      slug: crystal-tool-seed
+      relationship: component
+      description: "Crystal seed used as the core material for crafting the axe at the Singing Bowl."
+    - item_name: Dragon felling axe
+      slug: dragon-felling-axe
+      relationship: downgrade
+      description: "Lower-tier felling axe upgraded into the crystal version."
+    - item_name: Crystal axe
+      slug: crystal-axe
+      relationship: alternative
+      description: "Standard one-handed crystal woodcutting axe without the felling axe special."
+  about: "The Crystal 2h axe (Crystal felling axe) is a members-only two-handed woodcutting weapon released on 25 October 2023 with Forestry: Part Two. Crafted at the Singing Bowl from a Dragon felling axe, a Felling axe handle, a Crystal tool seed and 120 crystal shards, it requires 71 Woodcutting, 70 Attack and 50 Agility to wield and a boostable 76 Smithing and 76 Crafting to create. The axe carries the Lumber Up special attack, which raises Woodcutting by 3 levels for three minutes at the cost of 100% special energy. High alchemy value: 312,000 coins."
+  market_strategy:
+    notes:
+      - "Untradeable, so all value comes from creation cost (Dragon felling axe + crystal shards + tool seed)."
+      - "Treat as a long-term efficiency investment: faster Forestry events and bonus Woodcutting XP from the special attack."
+      - "Stock up on crystal shards before extended Forestry sessions to keep the axe active."
+  trading_tips:
+    - "Buy the Dragon felling axe and Crystal tool seed when prices dip after Forestry meta shifts."
+    - "Keep 100 crystal shards on hand to refresh charges in-place rather than reverting to seed."
+    - "Equip the Elven or Celestial signet to extend charge life by ~10% during long chopping sessions."
+  history:
+    - date: "2023-10-25"
+      description: "Released as part of the Forestry: Part Two update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-bow-tie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-bow-tie.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Dark bow tie is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: neck
+    weight: 0.1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/12750
+  related_items:
+    - item_name: Dark tuxedo jacket
+      slug: dark-tuxedo-jacket
+      relationship: set-piece
+      description: Body piece of the dark tuxedo outfit
+    - item_name: Dark trousers
+      slug: dark-trousers
+      relationship: set-piece
+      description: Leg piece of the dark tuxedo outfit
+    - item_name: Dark tuxedo cuffs
+      slug: dark-tuxedo-cuffs
+      relationship: set-piece
+      description: Hand piece of the dark tuxedo outfit
+    - item_name: Dark tuxedo shoes
+      slug: dark-tuxedo-shoes
+      relationship: set-piece
+      description: Foot piece of the dark tuxedo outfit
+  about: "The dark bow tie is a cosmetic neck item from the dark tuxedo outfit, obtainable as an elite Treasure Trail reward. The examine text references the Eleventh Doctor's catchphrase from Doctor Who. It can be stored in a costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Elite clue reward — low and steady supply"
+      - "Cosmetic-only — demand tied to fashionscape trends"
+      - "4-item buy limit constrains flipping volume"
+  history:
+    - date: "2016-07-06"
+      description: Released as part of the dark tuxedo outfit from elite Treasure Trails.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-magic-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-magic-potion-3.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 2000
-  about: "Divine magic potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: Boosts Magic by 4 levels and prevents the Magic level from draining below the maximum boost for 5 minutes.
+        duration: 300
+      - description: Inflicts 10 Hitpoints of damage on consumption — minimum 11 HP required to drink safely.
+        duration: null
+  recipes:
+    - skill: herblore
+      level: 78
+      xp: 0.5
+      materials:
+        - item_name: Magic potion(3)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Divine super attack potion(3)
+      slug: divine-super-attack-potion-3
+      relationship: variant
+      description: Divine variant for Attack boost
+    - item_name: Divine super strength potion(3)
+      slug: divine-super-strength-potion-3
+      relationship: variant
+      description: Divine variant for Strength boost
+    - item_name: Divine battlemage potion(3)
+      slug: divine-battlemage-potion-3
+      relationship: variant
+      description: Combined Magic + Defence divine potion
+    - item_name: Magic potion(3)
+      slug: magic-potion-3
+      relationship: component
+      description: Base potion before adding crystal dust
+  about: "Divine magic potion is a stat-boosting elixir released with Song of the Elves. It increases Magic by 4 levels for 5 minutes and prevents the player's Magic level from draining below the maximum boost during this window. Drinking it inflicts 10 Hitpoints of damage, so the player needs at least 11 HP to use it safely. Made by combining crystal dust with a magic potion at 78 Herblore."
+  market_strategy:
+    notes:
+      - "Low XP per dose limits Herblore training appeal"
+      - "Niche use in extended Magic boost scenarios"
+      - "Crystal dust supply ties price to Song of the Elves throughput"
+  history:
+    - date: "2019-07-25"
+      description: Released with the Song of the Elves update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-2.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Divine ranging potion(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Ranged level by 4 + 10% of current Ranged level for 5 minutes; while active, Ranged cannot drain below the boosted maximum. Drinking deals 10 damage."
+        duration: 300
+  recipes:
+    - skill: herblore
+      level: 74
+      xp: 1
+      materials:
+        - item_name: Ranging potion(2)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 2
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Divine ranging potion(1)
+      slug: divine-ranging-potion-1
+      relationship: variant
+      description: 1-dose version
+    - item_name: Divine ranging potion(3)
+      slug: divine-ranging-potion-3
+      relationship: variant
+      description: 3-dose version
+    - item_name: Divine ranging potion(4)
+      slug: divine-ranging-potion-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Ranging potion(2)
+      slug: ranging-potion-2
+      relationship: component
+      description: Base ingredient before crystal dust infusion
+    - item_name: Crystal dust
+      slug: crystal-dust
+      relationship: component
+      description: Catalyst for the divine variant
+  about: "Divine ranging potion(2) is a 2-dose Herblore potion that boosts Ranged by 4 + 10% of current level and prevents the boost from draining for 5 minutes, at the cost of 10 hitpoints per dose. Created at 74 Herblore by combining a Ranging potion(2) with 2 Crystal dust for 1 experience."
+  market_strategy:
+    notes:
+      - "Niche dose for tick-perfect brews at content like Inferno"
+      - "Demand peaks alongside Crystal dust supply"
+      - "High alch only 54 gp, value lives in PvM utility"
+  history:
+    - date: "2019-07-25"
+      description: Released alongside the divine potion family rework.
+    - date: "2020-07-02"
+      description: Inventory icon refreshed for the divine potion line.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin.mdx
@@ -12,81 +12,99 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 11000
-  ammunition:
-    type: javelin
-    tier: dragon
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
-    ranged_strength: 150
+    slot: ammo
+    weapon_type: javelin
+    attack_speed: null
+    weight: 0
     requirements:
       ranged: 75
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 150
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: fletching
       level: 92
       xp: 225
       materials:
         - item_name: Javelin shaft
-          item_id: 19582
           quantity: 15
         - item_name: Dragon javelin heads
-          item_id: 19570
           quantity: 15
-      product: Dragon javelin
-      product_id: 19484
-      product_quantity: 15
-      members_only: true
+      tools: []
+      output_quantity: 15
   related_items:
-    - item_id: 19582
-      item_name: Javelin shaft
+    - item_name: Javelin shaft
       slug: javelin-shaft
       relationship: component
-      description: Component
-    - item_id: 19570
-      item_name: Dragon javelin heads
+      description: Crafting component
+    - item_name: Dragon javelin heads
       slug: dragon-javelin-heads
       relationship: component
-      description: Component
-    - item_id: 19478
-      item_name: Rune javelin
+      description: Crafting component (Vorkath drop)
+    - item_name: Rune javelin
       slug: rune-javelin
+      relationship: downgrade
+      description: Lower tier javelin
+    - item_name: Amethyst javelin
+      slug: amethyst-javelin
       relationship: alternative
-      description: Lower tier
-    - item_id: 19481
-      item_name: Heavy ballista
+      description: Alternative javelin
+    - item_name: Heavy ballista
       slug: heavy-ballista
       relationship: alternative
       description: Best launcher
-    - item_id: 21318
-      item_name: Amethyst javelin
-      slug: amethyst-javelin
-      relationship: alternative
-      description: Alternative
-  about: |-
-    Combine 15× Javelin shaft + 15× Dragon javelin tips.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Fletching Level | 92 |
-    | XP gained | 225 (per 15) |
+  about: "The Dragon javelin is the highest-tier standard javelin in Old School RuneScape, requiring 75 Ranged to wield with a light or heavy ballista. Released with Monkey Madness II on 6 May 2016, it provides +150 Ranged Strength. Players can fletch 15 javelins at a time at 92 Fletching from 15 javelin shafts and 15 dragon javelin heads for 225 XP. Heavy ballista with dragon javelins is a popular PvP special attack weapon."
   market_strategy:
-    profit_formulas:
-      - (Dragon javelin × 15) - (Shaft × 15) - (Tips × 15) = Profit
     notes:
-      - "Calculate:"
-      - 92 Fletching required
-      - Check tip vs javelin margins
-      - Dragon javelin tips from Vorkath
-      - Zulrah drops
-      - CoX raids
-      - Heavy ballista primary ammo
-      - PKing spec weapon
-      - CoX raids
-      - Vorkath farmers selling tips
-      - Ballista spec popular in PvP
-      - Tips mainly from Vorkath
-      - Check tip supply vs demand
-      - Good fletching profit margin
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Heavy ballista primary ammunition"
+      - "PKing special attack weapon"
+      - "Dragon javelin heads sourced from Vorkath"
+      - "Check tip vs javelin margins for fletching profit"
+      - "92 Fletching required to craft"
+  trading_tips:
+    - Ballista spec popular in PvP, drives demand
+    - Tips mainly come from Vorkath farmers
+    - Track tip supply vs javelin demand for arbitrage
+  history:
+    - date: "2016-05-06"
+      description: Added to the game with Monkey Madness II.
+    - date: "2016-10-31"
+      description: Ranged Strength bonus decreased from +175 to +150.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-platebody.mdx
@@ -12,8 +12,32 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 11.339
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weight: 11.339
+    requirements:
+      defence: 60
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,48 +55,46 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 60
+  recipes:
+    - skill: smithing
+      level: 90
+      xp: 2000
+      materials:
+        - item_name: Dragon chainbody
+          quantity: 1
+        - item_name: Dragon metal lump
+          quantity: 1
+        - item_name: Dragon metal shard
+          quantity: 1
+      tools:
+        - Dragon Forge
+      output_quantity: 1
   related_items:
-    - item_id: 3140
-      item_name: Dragon chainbody
+    - item_name: Dragon chainbody
       slug: dragon-chainbody
-      relationship: downgrade
-      description: Easier to obtain dragon body
-    - item_id: 11832
-      item_name: Bandos chestplate
+      relationship: component
+      description: Used in smithing the platebody
+    - item_name: Bandos chestplate
       slug: bandos-chestplate
       relationship: upgrade
       description: BiS melee body with strength bonus
-    - item_id: 1127
-      item_name: Rune platebody
+    - item_name: Rune platebody
       slug: rune-platebody
       relationship: downgrade
-      description: F2P alternative
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +117 |
-    | Slash | +120 |
-    | Crush | +113 |
-    | Magic | -6 |
-    | Ranged | +113 |
-
-    Requirements: 60 Defence, Dragon Slayer II
-
-    Best dragon body armour:
-    - Highest defensive stats for 60 Defence
-    - Does not degrade
-    - Cosmetically popular
-
-    Note: Bandos chestplate is preferred for the +4 Strength bonus despite lower Defence.
+      description: F2P tier alternative
+    - item_name: Dragon platebody ornament kit
+      slug: dragon-platebody-ornament-kit
+      relationship: variant
+      description: Adds gold trim cosmetic variant
+  about: "Dragon platebody is a high-tier melee body armour released with Dragon Slayer II. Requires 60 Defence and completion of Dragon Slayer I to equip. Smithed at 90 Smithing using a dragon chainbody, dragon metal lump, and dragon metal shard at the Dragon Forge. Provides the highest defensive stats for 60 Defence body armour but has no strength bonus, making Bandos chestplate the preferred choice for offensive setups."
   market_strategy:
     notes:
-      - Components are rare drops
-      - Popular for fashionscape
-      - Niche use where pure Defence matters
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Components are rare drops"
+      - "Popular for fashionscape and BiS defensive setups"
+      - "Niche use where pure Defence matters"
+  history:
+    - date: "2018-01-04"
+      description: Released with the Dragon Slayer II update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-spear.mdx
@@ -12,10 +12,32 @@ osrs:
   lowalch: 24960
   highalch: 37440
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
   equipment:
     slot: weapon
-    two_handed: true
-    attack_speed: 4
+    weapon_type: spear
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 60
     attack_bonus:
       stab: 55
       slash: 55
@@ -33,74 +55,41 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 60
-    weight: 2.267
   special_attack:
     name: Shove
+    description: Pushes the target back one tile and stuns them for 5 ticks (3.0 seconds). Cannot be used on already-stunned targets or on large multi-tile NPCs.
     energy: 25
-    description: Pushes target back one tile and stuns them for 3 seconds. Cannot be used on already-stunned targets.
   drop_table:
     sources:
       - source: Brutal black dragon
-        combat_level: 318
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/512
-        members_only: true
+        rarity: 1/512
+      - source: Gorak (with ring of wealth)
+        quantity: "1"
+        rarity: 1/325
       - source: Rare drop table
-        combat_level: 0
         quantity: "1"
         rarity: very rare
-        members_only: true
   related_items:
-    - item_id: 11824
-      item_name: Zamorakian spear
+    - item_name: Zamorakian spear
       slug: zamorakian-spear
       relationship: upgrade
-      description: Superior spear from K'ril
-    - item_id: 1347
-      item_name: Rune warhammer
-      slug: rune-warhammer
-      relationship: alternative
-      description: One-handed crush weapon
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Stab | +55 |
-    | Slash | +55 |
-    | Crush | +55 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All styles | +5 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +60 |
-
-    Requirements: 60 Attack | Speed: 4 tick (2.4s) | Two-handed
-
-    The dragon spear has equal bonuses across all three attack styles (+55 each) — the only dragon weapon with this property. It also provides +5 to all defence stats, unusual for a weapon.
-
-    Cost: 25% special attack energy
-
-    Pushes the target back one tile and stuns them for 3 seconds (5 game ticks). Cannot be used on targets already stunned or on large NPCs (multi-tile).
-
-    The Shove spec is notorious in multi-combat PvP:
-    - Teams use coordinated dragon spear specs to chain-stun a single target
-    - The victim cannot eat, drink potions, or teleport while stunned
-    - Combined with smite, this can drain all Prayer points for item protection removal
-    - Known as "spear-speccing" or "spearing out" — a core multi-PK strategy
-
-    Two dragon spears are needed for certain Corporeal Beast team strategies — players use Shove specs to keep Corp pinned against a wall, preventing it from moving to heal at its spawn point.
+      description: Superior spear dropped by K'ril Tsutsaroth
+    - item_name: Dragon hasta
+      slug: dragon-hasta
+      relationship: variant
+      description: One-handed hasta version of the dragon spear
+    - item_name: Rune spear
+      slug: rune-spear
+      relationship: downgrade
+      description: Lower-tier rune equivalent
+  about: "The dragon spear is a two-handed melee weapon with equal +55 bonuses across stab, slash, and crush attack styles — the only dragon weapon with this property — and +5 across every defence style. Its Shove special attack pushes targets back and stuns them for 3 seconds, making it a notorious multi-PK and Corporeal Beast wall-pin tool. The spear cannot be crafted via Smithing and drops from Goraks, Brutal black dragons, and the rare drop table."
   market_strategy:
     notes:
-      - Rare drop table item — obtainable from many bosses/monsters
-      - PvP demand drives price above alch value
-      - Ironmen need two for elite clue emote requirements
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Rare drop table item — obtainable from many bosses and monsters"
+      - "PvP demand drives price above its alch value"
+      - "Ironmen need two for elite clue emote requirements"
+      - "Used in Corp teams as a wall-pin tool, supporting steady niche demand"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonfruit sapling | OSRS Price Data
-description: "Dragonfruit sapling: This sapling is ready to be replanted in a fruit tree patch.. High alch: 1 GP, GE limit: 200."
+description: "Dragonfruit sapling: This sapling is ready to be replanted in a fruit tree patch. High alch: 1 GP, GE limit: 200."
 osrs:
   id: 22866
   name: Dragonfruit sapling
@@ -12,9 +12,52 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Dragonfruit sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sapling
+    tier: low
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+  recipes:
+    - skill: farming
+      level: 81
+      xp: 140
+      materials:
+        - item_name: Dragonfruit seedling (w)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Dragonfruit tree seed
+      slug: dragonfruit-tree-seed
+      relationship: component
+      description: Seed planted to grow this sapling
+    - item_name: Dragonfruit seedling
+      slug: dragonfruit-seedling
+      relationship: component
+      description: Intermediate growth stage before sapling
+    - item_name: Dragonfruit
+      slug: dragonfruit
+      relationship: product
+      description: Harvestable fruit from the grown tree
+  about: "Dragonfruit sapling is a members farming item planted in a fruit tree patch to grow a dragonfruit tree. It requires level 81 Farming and yields 17,335 experience on checking the grown tree."
+  market_strategy:
+    notes:
+      - "Demand driven by high-level Farming training"
+      - "Buy seedlings to produce saplings for profit margin"
+      - "81 Farming is a major bottleneck for supply"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit-tree-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit-tree-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonfruit tree seed | OSRS Price Data
-description: "Dragonfruit tree seed: Plant in a plantpot of soil to grow a sapling.. High alch: 258 GP, GE limit: 200."
+description: "Dragonfruit tree seed is a members farming seed requiring 81 Farming. High alch: 258 GP, GE limit: 200."
 osrs:
   id: 22877
   name: Dragonfruit tree seed
@@ -12,55 +12,67 @@ osrs:
   lowalch: 172
   highalch: 258
   limit: 200
-  item:
+  material:
     type: seed
+    tier: high
+  properties:
+    release_date: "2019-01-10"
     tradeable: true
-    stackable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0
-    requirements:
-      farming: 81
-  farming:
-    patch_type: fruit tree
-    growth_time: 960
-    payment: 15 coconuts
-    xp:
-      planting: 140
-      check_health: 17335
-    yield: Dragonfruit
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: farming
+      level: 81
+      xp: 140
+      materials:
+        - item_name: Dragonfruit tree seed
+          quantity: 1
+        - item_name: Plant pot (filled)
+          quantity: 1
+      tools:
+        - Seed dibber
+      output_quantity: 1
   related_items:
-    - item_id: 22929
-      item_name: Dragonfruit
+    - item_name: Dragonfruit
       slug: dragonfruit
       relationship: product
-      description: Harvested fruit from tree
-    - item_id: 5289
-      item_name: Palm tree seed
+      description: Harvested yield from the dragonfruit tree
+    - item_name: Dragonfruit tree sapling
+      slug: dragonfruit-tree-sapling
+      relationship: product
+      description: Sapling grown from this seed
+    - item_name: Palm tree seed
       slug: palm-tree-seed
-      relationship: alternative
-      description: Lower tier fruit tree option
-    - item_id: 5974
-      item_name: Coconut
+      relationship: downgrade
+      description: Lower-tier fruit tree seed
+    - item_name: Coconut
       slug: coconut
-      relationship: alternative
-      description: Protection payment for dragonfruit
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Fruit Tree Seed |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 81 Farming |
-
-    Plant in fruit tree patches to grow dragonfruit trees.
-
-    Growth Time: 16 hours
-
-    Payment: 15 coconuts (optional protection)
-
-    XP: 140 (planting) + 17,335 (check-health)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: component
+      description: Protection payment to the farmer (15 coconuts)
+  about: "Dragonfruit tree seeds are the highest-level fruit tree seed in Old School RuneScape, requiring 81 Farming to plant in a fruit tree patch. They yield 140 XP on planting and 17,335 XP on check-health, making them a staple of high-XP fruit tree runs. Trees take roughly 16 hours to mature and can be protected from disease by paying a nearby farmer 15 coconuts. Mature trees regrow indefinitely, producing dragonfruit harvested for 70 XP each, used in stews and other consumables."
+  market_strategy:
+    notes:
+      - "Top-tier fruit tree XP makes seeds steadily sought"
+      - "Hespori and high-level Farming bossing drive supply"
+      - "Demand correlates with Farming bot waves"
+      - "200 buy limit caps speculation"
+  trading_tips:
+    - Stock up before Farming-related updates
+    - Flip in bulk during peak Hespori clears
+    - Compare against palm seed XP per GP for arbitrage
+  history:
+    - date: "2019-01-10"
+      description: Added with The Kebos Lowlands update as the highest fruit tree tier.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit.mdx
@@ -12,69 +12,64 @@ osrs:
   lowalch: 38
   highalch: 57
   limit: 11000
-  food:
-    heals: 10
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: fruit
-  farming:
-    skill: farming
-    level: 81
-    xp: 0
-    patch_type: fruit_tree
-    yield_max: 6
-    regrowth_minutes: 30
-    members_only: true
+    tier: mid
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: cooking
       level: 73
       xp: 140
       materials:
         - item_name: Dragonfruit
-          item_id: 22929
           quantity: 1
         - item_name: Pie shell
-          item_id: 2315
           quantity: 1
-      product: Dragonfruit pie
-      product_id: 22795
-      product_quantity: 1
-      facility: Range
-      members_only: true
+      tools:
+        - Range
+      output_quantity: 1
   related_items:
-    - item_id: 22869
-      item_name: Dragonfruit tree seed
+    - item_name: Dragonfruit tree seed
       slug: dragonfruit-tree-seed
       relationship: component
-      description: Planting seed
-    - item_id: 22795
-      item_name: Dragonfruit pie
+      description: Planted at 81 Farming in a fruit tree patch
+    - item_name: Dragonfruit pie
       slug: dragonfruit-pie
       relationship: product
-      description: Cooking product
-    - item_id: 22871
-      item_name: Redwood tree seed
+      description: Cooked product that boosts Fletching by 4
+    - item_name: Bottled dragonbreath
+      slug: bottled-dragonbreath
+      relationship: product
+      description: Consumes 10 dragonfruits per vial
+    - item_name: Redwood tree seed
       slug: redwood-tree-seed
       relationship: alternative
-      description: Tree payment
-    - item_id: 21483
-      item_name: Ultracompost
-      slug: ultracompost
-      relationship: component
-      description: Better yields
-  about: |-
-    | Product | Requirement |
-    |---------|-------------|
-    | Dragonfruit pie | 73 Cooking |
-    | Bottled dragonbreath | 10 fruits per vial |
-    | Redwood tree payment | 6 fruits |
-    | Food | Heals 10 HP |
+      description: Accepts 6 dragonfruits as the farmer protection payment
+  about: "Dragonfruit is a 10-HP heal fruit grown from a dragonfruit tree at 81 Farming, regrowing one fruit every 30 minutes up to a maximum of six per patch. At 73 Cooking it bakes into a Dragonfruit pie (+4 Fletching boost) for 140 experience per pie. Ten fruits also pair with a vial to produce Bottled dragonbreath, anchoring its long-tail demand."
   market_strategy:
     notes:
-      - Plant in Farming Guild
-      - Ultracompost for yield
-      - 6 fruit max per harvest
-      - Passive income source
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Farming Guild patch + Ultracompost maximises daily yield"
+      - "Pie-shell flipping pairs nicely with this fruit"
+      - "Buy heavy when Fletching content discounts the boost target"
+  history:
+    - date: "2019-01-10"
+      description: Released alongside the Farming Guild expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/druid-s-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/druid-s-robe-top.mdx
@@ -12,22 +12,77 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 4
+  drop_table:
+    sources:
+      - source: Druid (level 33, Taverley)
+        quantity: "1"
+        rarity: "6/128"
   related_items:
-    - item_id: 538
-      item_name: Druid's robe
+    - item_name: Druid's robe
       slug: druid-s-robe
       relationship: set-piece
-      description: Matching bottom
-  about: |-
-    > _"I feel closer to the gods when I wear this."_
-
-    The druid's robe top provides +4 Prayer bonus with no requirements. Combined with the bottom, gives +8 Prayer bonus — excellent for low-level prayer setups.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching robe bottom; pairs with the top for the full druid set."
+  about: "Druid's robe top is a members-only body slot prayer robe released on 27 February 2002 and renamed from 'Druid's robe' to 'Druid's robe top' on 10 December 2014. The top grants +4 Prayer with no skill requirements and is dropped by level 33 Druids in the Taverley druid camp at roughly 6/128. Combined with the matching Druid's robe bottom it forms an easily accessible +8 Prayer bonus setup popular for low-level prayer training. High alchemy value: 24 coins. Grand Exchange buy limit: 125 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand comes from early-game prayer setups and ironman uniques, but supply is limited by Druid kill rate."
+      - "Low buy limit (125) keeps flipping volume small; suit accounts that hold inventory."
+      - "Prices follow waves whenever low-level prayer content gets attention."
+  trading_tips:
+    - "Buy at GE during quiet hours and resell when prayer-focused guides go viral."
+    - "Pair with Druid's robe bottom for set sale listings on Discord trading hubs."
+    - "Avoid alching - the GE price is dramatically above the high alch value."
+  history:
+    - date: "2002-02-27"
+      description: "Released into the game."
+    - date: "2005-04-26"
+      description: "Examine text capitalization adjusted."
+    - date: "2014-12-10"
+      description: "Renamed from 'Druid's robe' to 'Druid's robe top'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/easter-egg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/easter-egg.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 50
-  about: "Easter egg is a free-to-play item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: holiday
+    tier: low
+  properties:
+    release_date: "2002-03-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.085
+    options: ["Eat", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: Edible holiday food
+      description: "Heals 14 hitpoints when eaten, on par with a swordfish, although collector value usually outweighs practical use."
+  related_items:
+    - item_name: Chocolate egg
+      slug: chocolate-egg
+      relationship: alternative
+      description: Another Easter-themed food consumable.
+    - item_name: Rubber chicken
+      slug: rubber-chicken
+      relationship: alternative
+      description: Easter event reward from previous years.
+    - item_name: Easter ring
+      slug: easter-ring
+      relationship: alternative
+      description: Holiday ring from an Easter event.
+    - item_name: Easter basket
+      slug: easter-basket
+      relationship: alternative
+      description: Storage container for easter eggs.
+  about: "The Easter egg is a free-to-play holiday item handed out during Easter events in Old School RuneScape. While it heals 14 hitpoints when eaten - the same as a swordfish - the limited annual supply and collector demand drive its market price well above any practical food use, so most players bank theirs rather than munch them."
+  market_strategy:
+    notes:
+      - "Supply only grows during Easter events, so off-season trading is purely flips between collectors."
+      - "Buy limit of 50 caps short-term flipping, but per-unit margins can be high."
+      - "Watch for Easter content reveals - speculation can spike the price weeks in advance."
+  trading_tips:
+    - "Stockpile right after an Easter event when the market is flooded and prices dip."
+    - "List into the build-up before the next Easter event when nostalgia buying lifts the floor."
+  history:
+    - date: "2002-03-31"
+      description: "Released for the first RuneScape Easter event."
+    - date: "2014-04-17"
+      description: "Easter event reintroduced in Old School RuneScape, allowing two new eggs per account from the holiday."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-helm-broken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-helm-broken.mdx
@@ -1,6 +1,6 @@
 ---
 title: Eclipse moon helm (broken) | OSRS Price Data
-description: "Eclipse moon helm (broken): The helm of the Eclipse Moon.. High alch: 61,800 GP, GE limit: 15."
+description: "Eclipse moon helm (broken): The helm of the Eclipse Moon. High alch: 61,800 GP, GE limit: 15."
 osrs:
   id: 29055
   name: Eclipse moon helm (broken)
@@ -12,12 +12,60 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
-  about: "Eclipse moon helm (broken) is a members-only item in Old School RuneScape. High alchemy value: 61,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: eclipse_moon
+    tier: high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options: ["Repair", "Drop"]
+    worn_options: []
+    alchable: true
+  charges:
+    type: degradation
+    description: Broken state of the Eclipse moon helm after fully depleting its 30,000 charge meter; loses one charge per 0.6 seconds of combat use. Repair to restore charges - 1,500,000 coins through Bob the Cat in Lumbridge, reducible to 757,500 coins self-repair at 99 Smithing.
+  related_items:
+    - item_name: Eclipse moon helm
+      slug: eclipse-moon-helm
+      relationship: variant
+      description: Functional charged version repaired from this broken state
+    - item_name: Eclipse moon chestplate
+      slug: eclipse-moon-chestplate
+      relationship: set-piece
+      description: Matching body piece of the Eclipse moon set
+    - item_name: Eclipse moon tassets
+      slug: eclipse-moon-tassets
+      relationship: set-piece
+      description: Matching legs piece of the Eclipse moon set
+    - item_name: Eclipse atlatl
+      slug: eclipse-atlatl
+      relationship: set-piece
+      description: Weapon completing the Eclipse moon ranged set effect
+  about: "The Eclipse moon helm (broken) is the depleted form of the Eclipse moon helm, the ranged head slot piece of the Eclipse moon set introduced with Varlamore: Part One. The helm degrades during combat and falls into this broken state once its charge meter empties - repair it through Bob the Cat in Lumbridge for 1,500,000 coins, or via self-repair on an armour stand for as low as 757,500 coins at 99 Smithing. The base helm drops from the Lunar Chest in Neypotzli at roughly 1/224."
+  market_strategy:
+    notes:
+      - "Broken state often trades below charged variant by repair cost"
+      - "15 GE buy limit caps flip volume"
+      - "Members-only Varlamore reward"
+      - "Repair arbitrage available against the charged variant"
+  trading_tips:
+    - Calculate repair cost vs charged price spread before flipping
+    - Self-repair at 99 Smithing improves margins meaningfully
+  history:
+    - date: "2024-03-20"
+      description: Released with the Varlamore - Part One expansion as part of the Moons of Peril minigame rewards.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-dragonstone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-dragonstone.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enchant dragonstone | OSRS Price Data
-description: "Enchant dragonstone: A tablet containing a magic spell.. High alch: 1 GP, GE limit: 10,000."
+description: "Enchant dragonstone: A tablet containing a magic spell. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 8020
   name: Enchant dragonstone
@@ -12,9 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Enchant dragonstone is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic-tablet
+    tier: mid
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Info
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 68
+      xp: 58.5
+      materials:
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 15
+        - item_name: Water rune
+          quantity: 15
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Mahogany demon lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Required base material for the tablet
+    - item_name: Cosmic rune
+      slug: cosmic-rune
+      relationship: component
+      description: Enchant spell catalyst rune
+    - item_name: Dragonstone
+      slug: dragonstone
+      relationship: alternative
+      description: Cast the enchant directly on a dragonstone instead of breaking a tablet
+  about: "Enchant dragonstone is a Magic tablet that casts the Enchant Level 5 Jewellery spell when broken. Made at a Mahogany demon lectern in a Player-Owned House study with 68 Magic, it consumes 1 soft clay, 1 cosmic rune, 15 earth runes and 15 water runes per tablet, granting 58.5 Magic experience. Tablets let players run the enchant without carrying the full rune set, useful for goldsmiths producing dragonstone jewellery in bulk."
+  market_strategy:
+    notes:
+      - "Demand tied to dragonstone jewellery crafters"
+      - "Production usually runs at a small loss, so supply is thin"
+      - "Prices track cosmic rune fluctuations closely"
+  trading_tips:
+    - Buy during Magic / Construction events when supply rises
+    - Compare per-cast cost to raw rune cost before flipping
+    - High buy limit lets you accumulate quickly for jewellery flips
+  history:
+    - date: "2006-05-31"
+      description: "Added to the game alongside Mage Training Arena."
+    - date: "2017-10-12"
+      description: "Renamed from 'Enchant dragonstn.' to its full in-game name."
+    - date: "2018-03-01"
+      description: "Break option removed in favour of an Info right-click option."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-head.mdx
@@ -1,6 +1,6 @@
 ---
 title: Evil chicken head | OSRS Price Data
-description: "Evil chicken head: Cock-a-doodle-do!. High alch: 1 GP, GE limit: 4."
+description: "Evil chicken head: Cock-a-doodle-do! Part of the evil chicken outfit. GE limit: 4."
 osrs:
   id: 20439
   name: Evil chicken head
@@ -12,9 +12,73 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Evil chicken head is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2016-07-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.25
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Woodcutting Guild shrine (offering bird's eggs)
+        quantity: "1"
+        rarity: 1/300
+  related_items:
+    - item_name: Evil chicken wings
+      slug: evil-chicken-wings
+      relationship: set-piece
+      description: Cape slot of the evil chicken outfit
+    - item_name: Evil chicken legs
+      slug: evil-chicken-legs
+      relationship: set-piece
+      description: Legs slot of the evil chicken outfit
+    - item_name: Evil chicken feet
+      slug: evil-chicken-feet
+      relationship: set-piece
+      description: Feet slot of the evil chicken outfit
+  about: "Evil chicken head is a members cosmetic head slot item obtained by offering bird's eggs at the Woodcutting Guild shrine with a 1/300 chance per offering. Wearing the complete outfit with the Flap emote unlocked plays an enhanced animation where the character briefly lifts off the ground."
+  market_strategy:
+    notes:
+      - "Supply gated by Woodcutting Guild egg offerings"
+      - "Demand from completionists collecting full set"
+      - "Low buy limit keeps prices volatile"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-2.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 88
   highalch: 133
   limit: 2000
-  about: "Extended anti-venom+(2) is a members-only item in Old School RuneScape. High alchemy value: 133 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2024-08-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.07
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: herblore
+      level: 94
+      xp: 40
+      materials:
+        - item_name: Anti-venom+(2)
+          quantity: 1
+        - item_name: Araxyte venom sack
+          quantity: 2
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: Instantly cures venom and poison, grants venom immunity for roughly 6.3 minutes per dose and poison immunity for about 17.7 minutes per dose.
+        duration: null
+  related_items:
+    - item_name: Extended anti-venom+(4)
+      slug: extended-anti-venom-4
+      relationship: variant
+      description: 4-dose version of the same potion
+    - item_name: Extended anti-venom+(3)
+      slug: extended-anti-venom-3
+      relationship: variant
+      description: 3-dose version of the same potion
+    - item_name: Extended anti-venom+(1)
+      slug: extended-anti-venom-1
+      relationship: variant
+      description: 1-dose version of the same potion
+    - item_name: Anti-venom+(2)
+      slug: anti-venom-2
+      relationship: component
+      description: Base potion combined with araxyte venom sacks to make this extended variant
+    - item_name: Araxyte venom sack
+      slug: araxyte-venom-sack
+      relationship: component
+      description: Dropped by Araxxor; required to extend anti-venom+ doses
+  about: "Extended anti-venom+(2) is a 2-dose Herblore potion released in the Araxxor update. It grants long-lasting venom and poison immunity, making it the best antivenom in the game for prolonged PvM trips. Players make it by combining anti-venom+ doses with araxyte venom sacks at 94 Herblore."
+  market_strategy:
+    notes:
+      - "Herblore profit from converting anti-venom+ doses with araxyte venom sacks"
+      - "Demand tied to Araxxor and Toxic team-based PvM uptake"
+      - "2-dose typically trades at a discount per-dose vs the (4)"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-3.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: null
-  about: "Extreme energy potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.09
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: herblore
+      level: 66
+      xp: 63
+      materials:
+        - item_name: Super energy potion(3)
+          quantity: 1
+        - item_name: Yellow fin
+          quantity: 3
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: Restores 40% of the player's run energy per dose. Cannot be used to create stamina potions.
+        duration: null
+  related_items:
+    - item_name: Extreme energy potion(4)
+      slug: extreme-energy-potion-4
+      relationship: variant
+      description: 4-dose version of the same potion
+    - item_name: Extreme energy potion(2)
+      slug: extreme-energy-potion-2
+      relationship: variant
+      description: 2-dose version of the same potion
+    - item_name: Extreme energy potion(1)
+      slug: extreme-energy-potion-1
+      relationship: variant
+      description: 1-dose version of the same potion
+    - item_name: Super energy potion(3)
+      slug: super-energy-potion-3
+      relationship: component
+      description: Base potion upgraded with yellow fin into extreme energy
+    - item_name: Yellow fin
+      slug: yellow-fin
+      relationship: component
+      description: Sailing-source fish added to super energy potions to make extreme energy
+  about: "Extreme energy potion(3) is a 3-dose run energy restore released with the Sailing update. Each dose restores 40% run energy, and the potion is made at 66 Herblore by adding yellow fin to super energy potions. It cannot be used as a stamina potion base."
+  market_strategy:
+    notes:
+      - "Sailing-era potion — supply scales with yellow fin catch rates"
+      - "Doses trade against stamina potion alternative pricing"
+      - "Bulk runners and ironmen are the main consumer base"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fayrg-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fayrg-bones.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Fayrg bones is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bones
+    tier: mid
+  properties:
+    release_date: "2005-05-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options: ["Bury", "Drop"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Ogre coffin (20 Thieving)
+        quantity: "1"
+        rarity: Common
+  recipes:
+    - skill: prayer
+      level: 1
+      xp: 84
+      materials:
+        - item_name: Fayrg bones
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Zogre bones
+      slug: zogre-bones
+      relationship: alternative
+      description: Lower-tier ogre bones from the same tomb.
+    - item_name: Raurg bones
+      slug: raurg-bones
+      relationship: upgrade
+      description: Higher Prayer XP ogre bones.
+    - item_name: Ourg bones
+      slug: ourg-bones
+      relationship: upgrade
+      description: Highest Prayer XP ogre bones.
+  about: "Fayrg bones are ancient ogre remains looted from ogre coffins in the Jiggig burial tomb (20 Thieving). Burying yields 84 Prayer XP; offering at the Chaos Temple multiplies that significantly. Inside Jiggig there is a 1-in-3 chance burying fails and spawns a skogre instead."
+  market_strategy:
+    notes:
+      - "Volume Prayer training material; demand scales with Chaos Temple users."
+      - "GE limit 7,500 makes bulk flipping viable."
+  trading_tips:
+    - Buy in bulk during ToB/Slayer task off-peaks.
+    - Note via banker for stackable transport while training Prayer.
+  history:
+    - date: "2005-05-17"
+      description: Released with the Zogre Flesh Eaters quest update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-boots.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Fremennik boots is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: leather
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weight: 0.34
+    requirements:
+      quest: The Fremennik Trials
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Shoe Store
+      location: Rellekka
+      price: 325
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Fremennik sea boots
+      slug: fremennik-sea-boots
+      relationship: variant
+      description: Upgraded Fremennik footwear from Lunar Diplomacy
+    - item_name: Fremennik helm
+      slug: fremennik-helm
+      relationship: set-piece
+      description: Matching Fremennik headwear
+    - item_name: Fremennik robe
+      slug: fremennik-robe
+      relationship: set-piece
+      description: Matching Fremennik body armour
+  about: "Fremennik boots are dark green footwear exclusive to the Fremennik people. Sold by Yrsa in Rellekka after completing The Fremennik Trials, they can also be obtained as a reward through the Managing Miscellania activity. Provides minor slash and crush defence."
+  market_strategy:
+    notes:
+      - "Steady supply from Miscellania thrall labour"
+      - "Demand limited to fashionscape and quest stragglers"
+      - "High alch sets a near floor on GE price"
+  history:
+    - date: "2004-11-02"
+      description: "Released with The Fremennik Trials quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-grey-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-grey-cloak.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik grey cloak is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      price: 250
+      currency: Coins
+      stock: 10
+  related_items:
+    - item_name: Fremennik cloak
+      slug: fremennik-cloak
+      relationship: variant
+      description: Standard brown Fremennik cloak
+    - item_name: Fremennik black cloak
+      slug: fremennik-black-cloak
+      relationship: variant
+      description: Black colour variant
+    - item_name: Fremennik blue cloak
+      slug: fremennik-blue-cloak
+      relationship: variant
+      description: Blue colour variant
+  about: "The Fremennik grey cloak is a cosmetic cape sold by Yrsa's Accoutrements in Rellekka after completing The Fremennik Trials. It provides minimal defensive bonuses (+1 Slash, +1 Crush, +2 Ranged defence) and is one of eleven colour variants of the Fremennik cloak."
+  history:
+    - date: "2004-11-02"
+      description: Added to the game with The Fremennik Trials quest update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-pink-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-pink-cloak.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik pink cloak is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Fremennik cyan cloak
+      slug: fremennik-cyan-cloak
+      relationship: variant
+      description: Another colour variant of the Fremennik cloak
+    - item_name: Fremennik blue cloak
+      slug: fremennik-blue-cloak
+      relationship: variant
+      description: Another colour variant of the Fremennik cloak
+    - item_name: Fremennik red cloak
+      slug: fremennik-red-cloak
+      relationship: variant
+      description: Another colour variant of the Fremennik cloak
+  about: "The Fremennik pink cloak is one of eleven colourful cloaks representing the latest fashion in Rellekka. Sold by Rasolo the wandering merchant without quest requirements (unlike the other Fremennik cloaks sold by Yrsa, which require The Fremennik Trials), it provides cape-slot defence bonuses identical to a standard cape."
+  market_strategy:
+    notes:
+      - "Niche fashionscape buyers drive most demand"
+      - "Low buy limit keeps swings sharp"
+      - "Alch margin is thin against GE price"
+  history:
+    - date: "2004-11-02"
+      description: "Released alongside The Fremennik Trials."
+    - date: "2014-12-10"
+      description: "Renamed from 'Fremennik cloak' to 'Fremennik pink cloak'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fried-mushrooms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fried-mushrooms.mdx
@@ -12,12 +12,73 @@ osrs:
   lowalch: 16
   highalch: 25
   limit: 13000
-  about: "Fried mushrooms is a members-only item in Old School RuneScape. High alchemy value: 25 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2006-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 46
+      xp: 60
+      materials:
+        - item_name: Sliced mushrooms
+          quantity: 1
+        - item_name: Bowl
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  passive_effects:
+    - name: Heal
+      description: Restores 5 Hitpoints when eaten.
+  related_items:
+    - item_name: Bittercap mushroom
+      slug: bittercap-mushroom
+      relationship: component
+      description: Source mushroom sliced before frying.
+    - item_name: Sliced mushrooms
+      slug: sliced-mushrooms
+      relationship: component
+      description: Prepared mushroom slices used as cooking ingredient.
+    - item_name: Mushroom & onion
+      slug: mushroom-onion
+      relationship: product
+      description: Combines fried mushrooms with fried onions at level 57 Cooking.
+    - item_name: Mushroom potato
+      slug: mushroom-potato
+      relationship: product
+      description: Further dish requiring mushroom & onion plus potato with butter.
+  about: "Fried mushrooms are a Gnome Cookery dish created by frying sliced Bittercap mushrooms in a bowl on a cooking range at Cooking level 46. The recipe grants 60 Cooking experience and the resulting food restores 5 Hitpoints. It is an intermediate ingredient for higher tier Gnome dishes such as mushroom & onion and mushroom potatoes."
+  market_strategy:
+    notes:
+      - "Niche Cooking ingredient; volume is driven by Gnome Cookery recipe chains."
+      - "Burn rate stops at Cooking level 90, simplifying mass production."
+  trading_tips:
+    - Pair purchases with Bittercap mushroom prices to gauge true margin.
+    - High GE limit (13,000) lets cooks restock daily for Gnome Restaurant routes.
+  history:
+    - date: "2006-01-30"
+      description: Released as part of the Gnome Restaurant cookery expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/frog-leather-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/frog-leather-chaps.mdx
@@ -12,60 +12,78 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: frog leather
+    tier: low
+  properties:
+    release_date: "2007-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
   equipment:
     slot: legs
+    attack_speed: null
+    weight: 3
+    requirements:
+      ranged: 25
+      defence: 25
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: -5
-      ranged: 4
+      ranged: 2
     defence_bonus:
-      stab: 8
-      slash: 5
+      stab: 7
+      slash: 7
       crush: 9
       magic: 4
-      ranged: 8
+      ranged: 9
     other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 25
-      defence: 25
-    weight: 3.175
+  drop_table:
+    sources:
+      - source: Dorgesh-Kaan Average Chest
+        quantity: "1"
+        rarity: 1/23
+      - source: Dorgesh-Kaan Rich Chest
+        quantity: "1"
+        rarity: 1/15
+  shops:
+    - shop_name: Reldak's Leather Armour
+      location: Dorgesh-Kaan
+      price: 900
+      currency: coins
+      stock: 50
   related_items:
-    - item_id: 10954
-      item_name: Frog-leather body
+    - item_name: Frog-leather body
       slug: frog-leather-body
       relationship: set-piece
       description: Matching body armour
-    - item_id: 10958
-      item_name: Frog-leather boots
+    - item_name: Frog-leather boots
       slug: frog-leather-boots
       relationship: set-piece
       description: Matching boots
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Ranged | +4 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Crush | +9 |
-    | Stab | +8 |
-    | Ranged | +8 |
-
-    Requirements: 25 Ranged, 25 Defence | Weight: 3.18 kg
-
-    Entry-level ranged armour from the Dorgeshuun city. Fills the gap between leather and snakeskin for accounts with 25 Ranged/Defence.
+  about: "Frog-leather chaps are entry-level ranged armour from the Dorgeshuun city beneath Lumbridge. They require 25 Ranged and 25 Defence to wear and fill the niche between leather and snakeskin, though studded chaps offer superior stats at lower requirements. The chaps cannot be crafted and must be bought from Reldak's Leather Armour in Dorgesh-Kaan."
   market_strategy:
     notes:
-      - Niche low-level ranged armour
-      - Limited demand — most players skip to snakeskin or green d'hide
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Niche low-level ranged armour"
+      - "Limited demand — most players skip to snakeskin or green d'hide"
+      - "Bought from Reldak's at 900 coins, capping retail flips"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/games-necklace-8.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/games-necklace-8.mdx
@@ -12,9 +12,34 @@ osrs:
   lowalch: 420
   highalch: 630
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: jewellery
+    tier: low
+  properties:
+    release_date: "2004-11-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Rub
+      - Drop
+    worn_options:
+      - Rub
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: teleport_jewelry
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -28,76 +53,50 @@ osrs:
       magic: 0
       ranged: 0
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  properties:
-    tradeable: true
-    tradeable_ge: true
-    weight: 0.01
+  charges:
+    type: teleport
+    description: "Holds 8 teleport charges; after the final use the necklace crumbles to dust with the message 'Your games necklace crumbles to dust.'"
   recipes:
     - skill: magic
       level: 7
       xp: 17.5
       materials:
         - item_name: Sapphire necklace
-          item_id: 1656
           quantity: 1
         - item_name: Cosmic rune
-          item_id: 564
           quantity: 1
         - item_name: Water rune
-          item_id: 555
           quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 2552
-      item_name: Ring of dueling(8)
+    - item_name: Ring of dueling(8)
       slug: ring-of-dueling-8
       relationship: alternative
-      description: Alternative teleport jewelry
-    - item_id: 1656
-      item_name: Sapphire necklace
+      description: "Alternative charged teleport jewellery covering Castle Wars and Duel Arena destinations."
+    - item_name: Sapphire necklace
       slug: sapphire-necklace
       relationship: component
-      description: Base item for enchantment
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Neck |
-    | Type | Teleport Jewelry |
-    | Tradeable | Yes |
-    | Weight | 0.01 kg |
-
-    Enchant Sapphire necklace with Lvl-1 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 7 |
-    | Cosmic rune | 1 |
-    | Water rune | 1 |
-
-    - Burthorpe Games Room
-    - Barbarian Outpost
-    - Corporeal Beast
-    - Tears of Guthix (quest required)
-    - Wintertodt Camp (visited Zeah)
-
-    Charges: 8 (crumbles when depleted)
-
-    Essential for:
-    - Corp teleport
-    - Wintertodt access
-    - Barbarian Assault
-
-    Very useful utility teleport.
+      description: "Base necklace enchanted with Lvl-1 Enchant to create the Games necklace(8)."
+  about: "Games necklace(8) is a members-only enchanted teleport necklace released on 24 November 2004 with the Burthorpe Games Room update. It is created by casting Lvl-1 Enchant on a Sapphire necklace and provides eight rub-to-teleport charges to Burthorpe (Games Room), Barbarian Outpost, Corporeal Beast, Tears of Guthix and the Wintertodt Camp. The necklace crumbles to dust on the final charge and offers no combat stats. High alchemy value: 630 coins. Grand Exchange buy limit: 10,000 per 4 hours."
   market_strategy:
     notes:
-      - Best Corp teleport
-      - Good for Wintertodt
-      - Very cheap
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand is steady from Wintertodt and Corporeal Beast trips; supply tracks low-level enchanters."
+      - "Margins are razor-thin per necklace but the 10,000 buy limit enables flip-stacking."
+      - "Watch for Wintertodt update cycles which spike consumption."
+  trading_tips:
+    - "Flip in 10k batches across the buy limit window; small per-unit margin compounds at scale."
+    - "Craft your own from sapphire necklaces when GE price exceeds materials + small profit."
+    - "Stockpile before community Wintertodt events for short-term price bumps."
+  history:
+    - date: "2004-11-24"
+      description: "Released with the Burthorpe Games Room update."
+    - date: "2025-05-29"
+      description: "Exempted from the Grand Exchange convenience fee."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gianne-dough.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gianne-dough.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gianne dough | OSRS Price Data
-description: "Gianne dough: It's made from a secret recipe.. High alch: 1 GP, GE limit: 13,000."
+description: "Gianne dough: It's made from a secret recipe. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 2171
   name: Gianne dough
@@ -12,9 +12,56 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Gianne dough is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cooking-ingredient
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      price: 2
+      currency: coins
+      stock: 50
+  related_items:
+    - item_name: Batta tin
+      slug: batta-tin
+      relationship: component
+      description: Combine with Gianne dough to make raw battas
+    - item_name: Crunchy tray
+      slug: crunchy-tray
+      relationship: component
+      description: Combine with Gianne dough to make raw crunchies
+    - item_name: Gnomebowl mould
+      slug: gnomebowl-mould
+      relationship: component
+      description: Combine with Gianne dough to make raw gnomebowls
+  about: "Gianne dough is a special cooking ingredient used in Gnome Cuisine, sold by the Grand Tree Groceries shop for 2 coins each. The dough cannot be cooked on its own; instead it combines with batta tins, crunchy trays or gnomebowl moulds to make their respective raw gnome dishes. Players also receive 100 doughs as a reward for completing the Gnome Restaurant minigame tutorial."
+  market_strategy:
+    notes:
+      - "Shop-priced near alch value, so spreads are tiny"
+      - "High buy limit means easy bulk flips when GE dips"
+      - "Demand driven by gnome cuisine training and restaurant tasks"
+  trading_tips:
+    - Buy from Grand Tree Groceries when GE listings spike above shop price
+    - Bulk-flip near the 13,000 limit for thin steady margins
+    - Watch for Gnome Restaurant content updates that raise demand
+  history:
+    - date: "2002-12-12"
+      description: "Added to the game with the Gnome Stronghold update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-dragonhide-set.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 5000
   highalch: 7500
   limit: 8
-  about: "Gilded dragonhide set is a free-to-play item in Old School RuneScape. High alchemy value: 7,500 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic-set
+    tier: high
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Gilded d'hide body
+      slug: gilded-dhide-body
+      relationship: set-piece
+      description: Body component of the set
+    - item_name: Gilded chaps
+      slug: gilded-chaps
+      relationship: set-piece
+      description: Legwear component of the set
+    - item_name: Gilded vambraces
+      slug: gilded-vambraces
+      relationship: set-piece
+      description: Glove component of the set
+    - item_name: Gilded coif
+      slug: gilded-coif
+      relationship: alternative
+      description: Matching headwear sold separately
+  about: "Gilded dragonhide set is a Grand Exchange convenience bundle of Gilded d'hide body, Gilded chaps, and Gilded vambraces, exchanged through the clerk's Sets option for one-tick swapping with the individual pieces. The components themselves are hard clue cosmetic rewards from the Treasure Trails system, prized as luxury PvM/PvP show-pieces rather than for stat upgrades."
+  market_strategy:
+    notes:
+      - "Cheaper than buying components when GE volume is thin"
+      - "Limit of 8 per 4 hours throttles flips"
+      - "Watch hard-clue rates after league events"
+  history:
+    - date: "2019-04-11"
+      description: Set placeholder added with the wider Grand Exchange set bundle update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-mask.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
-  about: "Goblin mask is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.002
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Imp mask
+      slug: imp-mask
+      relationship: alternative
+      description: "Another monster cosmetic mask from the same Treasure Trails monster mask line."
+    - item_name: Ankou mask
+      slug: ankou-mask
+      relationship: alternative
+      description: "Higher-tier monster mask reward from medium clue caskets."
+  about: "Goblin mask is a members-only cosmetic head slot reward released on 12 June 2014 with the Treasure Trail Expansion. It is obtained from easy reward caskets at a roughly 1 in 1,404 drop rate and is part of the monster mask collection alongside the imp, ankou and demon masks. The mask gives no combat bonuses, weighs almost nothing and is purely a fashionscape piece, with its examine text referencing the classic RuneScape Goblin Raids event. It can be stored in a costume room treasure chest. High alchemy value: 1,200 coins. Grand Exchange buy limit: 4 per 4 hours."
+  market_strategy:
+    notes:
+      - "Pure cosmetic demand from fashionscape collectors and goblin-themed transmog setups."
+      - "Easy clue supply trickles in but daily volume is low (~50/day), creating thin price walls."
+      - "Buy limit of 4 makes the market resistant to large dumps; expect slow price recovery after spikes."
+  trading_tips:
+    - "Stockpile during easy clue droughts; resell during clue meta events."
+    - "Bundle with other goblin-themed cosmetics (goblin armour) for theme-set Discord sales."
+    - "Watch holidays / Halloween for cosmetic mask price waves."
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grain.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grain.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Grain is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: produce
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.6
+    options:
+      - Drop
+    alchable: true
+  drop_table:
+    sources:
+      - source: Goblin
+        quantity: "1"
+        rarity: Uncommon
+      - source: Imp
+        quantity: "1"
+        rarity: Uncommon
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Grain
+          quantity: 1
+        - item_name: Pot
+          quantity: 1
+      tools:
+        - Windmill
+      output_quantity: 1
+  related_items:
+    - item_name: Pot of flour
+      slug: pot-of-flour
+      relationship: product
+      description: Made by milling grain at a windmill.
+    - item_name: Pot
+      slug: pot
+      relationship: component
+      description: Required to catch flour from the windmill hopper.
+    - item_name: Barley
+      slug: barley
+      relationship: alternative
+      description: Alternative cereal harvested from members fields.
+  about: "Grain is harvested by picking it from wheat fields scattered around Gielinor, including the prominent Draynor Village, Lumbridge, and east of the Champions' Guild fields in free-to-play. Players mill grain at a windmill while holding an empty pot to produce a Pot of flour, a staple Cooking ingredient. Grain is also required in quantities of 10 for the Eadgar's Ruse quest. Released 4 January 2001."
+  market_strategy:
+    notes:
+      - "Free supply from wheat fields keeps GE prices around the alch floor."
+      - "Bulk demand spikes during cooking events and Mahogany Homes baking surges."
+  trading_tips:
+    - Skillers picking wheat fields can flip surplus grain for steady low-volume gp.
+  history:
+    - date: "2001-01-04"
+      description: Released with the original RuneScape Cooking skill.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-body-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-body-g.mdx
@@ -1,100 +1,97 @@
 ---
 title: Green d'hide body (g) | OSRS Price Data
-description: "Green d'hide body (g) is a F2P body slot item requiring 40 Defence. High alch: 4,680 GP, GE limit: 8."
+description: "Green d'hide body (g) is a members body slot item requiring 40 Ranged and 40 Defence. High alch: 4,680 GP, GE limit: 8."
 osrs:
   id: 7370
   name: Green d'hide body (g)
   slug: green-d-hide-body-g
   examine: Made from 100% real dragonhide. With colourful trim!
-  members: false
+  members: true
   icon: Green d'hide body (g).png
   value: 7800
   lowalch: 3120
   highalch: 4680
   limit: 8
+  material:
+    type: dragonhide
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: body
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
     requirements:
       ranged: 40
       defence: 40
-      quest: Dragon Slayer I
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 15
-      defence_stab: 18
-      defence_slash: 27
-      defence_crush: 24
-      defence_magic: 20
-      defence_ranged: 35
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 15
+    defence_bonus:
+      stab: 18
+      slash: 27
+      crush: 24
+      magic: 20
+      ranged: 35
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 6.803
-  obtaining:
-    methods:
-      - source: Reward casket (medium)
-        drop_rate: 1/1,133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 1135
-      item_name: Green d'hide body
+    - item_name: Green d'hide body
       slug: green-dhide-body
       relationship: alternative
-      description: Same stats, non-trimmed
-    - item_id: 7372
-      item_name: Green d'hide body (t)
+      description: Standard non-trimmed body with identical stats
+    - item_name: Green d'hide body (t)
       slug: green-dhide-body-t
-      relationship: alternative
-      description: Trimmed variant, same stats
-    - item_id: 7374
-      item_name: Blue d'hide body (g)
+      relationship: variant
+      description: Trimmed cosmetic variant with the same stats
+    - item_name: Blue d'hide body (g)
       slug: blue-dhide-body-g
-      relationship: alternative
-      description: Higher tier gold-trimmed body
-  about: |-
-    "Made from 100% real dragonhide. With colourful trim!"
-
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -15 |
-    | Ranged Attack | +15 |
-    | Stab Defence | +18 |
-    | Slash Defence | +27 |
-    | Crush Defence | +24 |
-    | Magic Defence | +20 |
-    | Ranged Defence | +35 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 40 Ranged, 40 Defence, Dragon Slayer I
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Green d'hide body (g) | +15 | +35 | +20 | Medium clues |
-    | Green d'hide body | +15 | +35 | +20 | Crafting (63) |
-
-    Stats are identical to the standard green d'hide body. The gold-trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+      relationship: upgrade
+      description: Higher-tier gold-trimmed body
+  about: "Green d'hide body (g) is the gold-trimmed cosmetic variant of the standard green dragonhide body, obtained exclusively as a medium clue reward. It requires 40 Ranged and 40 Defence to wear, with Dragon Slayer I completion needed for all green d'hide bodies. The trim is purely cosmetic with identical combat stats to the regular green d'hide body, including +15 Ranged attack and +35 Ranged defence. Its value comes from clue scroll rarity and fashionscape appeal among collection log completionists."
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Medium clue reward rarity
-      - Collection log completionists
-      - Trimmed d'hide set completion
-      - Identical stats to green d'hide body
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Medium clue rarity drop drives premium price"
+      - "Identical stats to regular green d'hide body"
+      - "Cosmetic flex item for fashionscape"
+      - "Low trade volume so watch for manipulation"
+      - "Demand tracks active medium clue grinders"
+  trading_tips:
+    - Stable cosmetic flips when clue activity is low
+    - Pair with matching trimmed set pieces for resale
+    - Monitor collection log popularity spikes
+  history:
+    - date: "2006-02-20"
+      description: Released as a medium clue scroll reward.
+    - date: "2021-09-29"
+      description: Defence bonuses adjusted as part of the ranged armour rebalance.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-shirt.mdx
@@ -12,21 +12,77 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 10414
-      item_name: Green elegant legs
+    - item_name: Green elegant legs
       slug: green-elegant-legs
       relationship: set-piece
-      description: Matching elegant legs
-  about: |-
-    > *"A well made elegant men's green shirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching elegant lower-body piece
+    - item_name: Green elegant blouse
+      slug: green-elegant-blouse
+      relationship: variant
+      description: Female elegant top counterpart
+    - item_name: Green elegant skirt
+      slug: green-elegant-skirt
+      relationship: set-piece
+      description: Female elegant skirt counterpart
+  about: "Green elegant shirt is a purely cosmetic body-slot reward from Easy Treasure Trails, dropping at a roughly 1/2,808 rate from easy clue caskets. It provides no combat bonuses and is worn for fashionscape alongside the matching Green elegant legs as part of the men's elegant clothing set."
+  market_strategy:
+    notes:
+      - "Supply is constrained by the 4-per-4-hour GE buy limit"
+      - "Cosmetic demand is steady; trim/colour variants influence relative pricing"
+  history:
+    - date: "2006-12-05"
+      description: Released as part of the original elegant clothing line.
+    - date: "2014-01-06"
+      description: Renamed from "Green ele' shirt" to "Green elegant shirt" with the Trading Post update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-bracers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-bracers.mdx
@@ -12,8 +12,33 @@ osrs:
   lowalch: 2400
   highalch: 3600
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: blessed-dragonhide
+    tier: high
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements:
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,48 +56,38 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 10368
-      item_name: Zamorak bracers
+    - item_name: Zamorak bracers
       slug: zamorak-bracers
       relationship: variant
-    - item_id: 12498
-      item_name: Bandos bracers
+      description: Zamorak blessed variant
+    - item_name: Bandos bracers
       slug: bandos-bracers
       relationship: variant
-    - item_id: 12506
-      item_name: Armadyl bracers
+      description: Bandos blessed variant
+    - item_name: Armadyl bracers
       slug: armadyl-bracers
       relationship: variant
-    - item_id: 12490
-      item_name: Ancient bracers
+      description: Armadyl blessed variant
+    - item_name: Ancient bracers
       slug: ancient-bracers
       relationship: variant
-    - item_id: 2491
-      item_name: Black d'hide vambraces
+      description: Ancient blessed variant
+    - item_name: Black d'hide vambraces
       slug: black-d-hide-vambraces
       relationship: downgrade
       description: Standard version requiring 40 Defence
-  about: |-
-    > *"Guthix blessed dragonhide vambraces."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +11 | +11 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+  about: "Guthix bracers are blessed dragonhide vambraces awarded from Hard tier Treasure Trails at a 1/1,625 rarity from reward caskets. They share offensive stats with Black d'hide vambraces (+11 Ranged) but add a +1 prayer bonus and crucially have no Defence requirement, making them best-in-slot ranged gloves for 1-Defence pures. Cannot be crafted; only sourced from clues."
   market_strategy:
     notes:
-      - Hard clue exclusive
-      - Best-in-slot ranged gloves for pures
-      - All god variants are functionally identical
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Hard clue exclusive"
+      - "Best-in-slot ranged gloves for pures"
+      - "All god variants are functionally identical"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-kiteshield.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 8
-  about: "Guthix kiteshield is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: variant
+      description: "Standard untrimmed rune kiteshield with identical defensive stats and no prayer bonus."
+    - item_name: Saradomin kiteshield
+      slug: saradomin-kiteshield
+      relationship: alternative
+      description: "Saradomin-themed variant of the rune kiteshield with the same +1 Prayer bonus."
+    - item_name: Zamorak kiteshield
+      slug: zamorak-kiteshield
+      relationship: alternative
+      description: "Zamorak-themed variant of the rune kiteshield with the same +1 Prayer bonus."
+    - item_name: Guthix platebody
+      slug: guthix-platebody
+      relationship: set-piece
+      description: "Body piece of the Guthix-themed rune armour set."
+  about: "Guthix kiteshield is a free-to-play rune kiteshield in Guthix colours released on 5 May 2004. Obtained at roughly 1 in 1,625 from hard Treasure Trail reward caskets, it requires 40 Defence to wield and grants the same defensive stats as the standard rune kiteshield (+44 stab, +48 slash, +46 crush, -1 magic, +46 ranged) plus a +1 Prayer bonus. The ornamental green trim cannot be reproduced through Smithing and the shield can be stored in the costume room treasure chest. High alchemy value: 32,640 coins. Grand Exchange buy limit: 8 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is driven by fashionscape and Prayer bonus min/maxers; supply is throttled by hard clue completions."
+      - "Buy limit of 8 keeps the GE market thin; large orders move price quickly."
+      - "Price floor is anchored by the high-alch value (32,640) for arbitrage when GE dips."
+  trading_tips:
+    - "Buy during hard clue droughts and sell into popular content updates."
+    - "Pair with Guthix platebody for set sales targeting fashionscape collectors."
+    - "Avoid alching unless GE price collapses below the 32,640 floor."
+  history:
+    - date: "2004-05-05"
+      description: "Released as a Treasure Trail reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix page 2 | OSRS Price Data
-description: "Guthix page 2: This seems to have been torn from a book.... High alch: 120 GP, GE limit: 5."
+description: "Guthix page 2: This seems to have been torn from a book... High alch: 120 GP, GE limit: 5."
 osrs:
   id: 3836
   name: Guthix page 2
@@ -12,43 +12,56 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: god_page
-    god: Guthix
-    page_number: 2
+    tier: mid
+  properties:
+    release_date: "2004-11-17"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 3835
-      item_name: Guthix page 1
+    - item_name: Guthix page 1
       slug: guthix-page-1
       relationship: set-piece
-      description: Page 1 of 4
-    - item_id: 3837
-      item_name: Guthix page 3
+      description: Page 1 of 4 of the Guthix god book
+    - item_name: Guthix page 3
       slug: guthix-page-3
       relationship: set-piece
-      description: Page 3 of 4
-    - item_id: 3838
-      item_name: Guthix page 4
+      description: Page 3 of 4 of the Guthix god book
+    - item_name: Guthix page 4
       slug: guthix-page-4
       relationship: set-piece
-      description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Guthix |
-    | Page | 2 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of balance (Guthix god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Page 4 of 4 of the Guthix god book
+    - item_name: Book of balance
+      slug: book-of-balance
+      relationship: product
+      description: Completed Guthix god book holding all 4 pages
+  about: "Guthix page 2 is a members reward page from Treasure Trail clue scrolls. Combined with pages 1, 3, and 4 and a damaged book, it completes the Book of balance, an equippable shield used for preaching and blessing holy or unholy symbols."
+  market_strategy:
+    notes:
+      - "Supply driven entirely by clue scroll completion"
+      - "Buy-limit of 5 keeps page prices stable"
+      - "Demand spikes with new Prayer training metas"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-rest-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-rest-4.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 2000
-  about: "Guthix rest(4) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2005-02-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 18
+      xp: 59
+      materials:
+        - item_name: Cup of hot water
+          quantity: 1
+        - item_name: Guam leaf
+          quantity: 2
+        - item_name: Harralander
+          quantity: 1
+        - item_name: Marrentill
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: Restores 5 hitpoints per dose (can exceed max by 5)
+        duration: null
+      - description: Recovers 5% run energy per dose
+        duration: null
+      - description: Reduces venom to poison or decreases poison damage by 1 per dose
+        duration: null
+  related_items:
+    - item_name: Guthix rest(1)
+      slug: guthix-rest-1
+      relationship: variant
+      description: 1-dose variant
+    - item_name: Guthix rest(2)
+      slug: guthix-rest-2
+      relationship: variant
+      description: 2-dose variant
+    - item_name: Guthix rest(3)
+      slug: guthix-rest-3
+      relationship: variant
+      description: 3-dose variant
+    - item_name: Cup of tea
+      slug: cup-of-tea
+      relationship: alternative
+      description: Basic tea variant without Herblore
+  about: |-
+    "A cup of Guthix Rest."
+
+    Guthix rest(4) is a 4-dose Herblore tea made at level 18 by combining a cup of hot water with 2 guam, 1 harralander, and 1 marrentill (59 XP). Each dose restores 5 hitpoints (can overheal by 5), recovers 5% run energy, and downgrades venom to poison or reduces poison damage by 1. Functions as a potion, so doses can be consumed during combat without delaying attacks. Requires partial completion of One Small Favour.
+  market_strategy:
+    notes:
+      - "Herblore tea for venom mitigation"
+      - "Niche Zulrah / venom content demand"
+      - "Combat consumable, decanted free at GE"
+      - "Buy limit 2,000 supports flips"
+      - "Low alch value, pure utility"
+  trading_tips:
+    - Decant from lower doses for arbitrage
+    - Watch Zulrah and venom content demand
+    - Bob Barter at GE decants free
+  history:
+    - date: "2005-02-28"
+      description: Released with One Small Favour quest.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/harmonised-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/harmonised-orb.mdx
@@ -12,62 +12,72 @@ osrs:
   lowalch: 1600000
   highalch: 2400000
   limit: 8
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: upgrade material
+    tier: high
+  properties:
+    release_date: "2020-02-06"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.1
-  obtaining:
-    - source: The Nightmare
-      drop_rate: 1/960 to 1/548.7
-    - source: Phosani's Nightmare
-      drop_rate: 1/1,600
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: The Nightmare
+        quantity: "1"
+        rarity: "1/960 to 1/548.7"
+      - source: Phosani's Nightmare
+        quantity: "1"
+        rarity: "1/1,600"
   recipes:
-    - skill: crafting
+    - skill: magic
       level: 1
+      xp: 0
       materials:
-        - item_id: 24511
-          item_name: Harmonised orb
+        - item_name: Harmonised orb
           quantity: 1
-        - item_id: 24422
-          item_name: Nightmare staff
+        - item_name: Nightmare staff
           quantity: 1
-      product: Harmonised nightmare staff
-      product_id: 24508
-  effect:
-    description: Allows casting standard spells at 4-tick speed instead of 5-tick
-    notes: Most valuable orb due to DPS increase
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 24422
-      item_name: Nightmare staff
+    - item_name: Nightmare staff
       slug: nightmare-staff
       relationship: component
-      description: Base weapon for upgrade
-    - item_id: 24508
-      item_name: Harmonised nightmare staff
+      description: Base weapon for the upgrade.
+    - item_name: Harmonised nightmare staff
       slug: harmonised-nightmare-staff
       relationship: product
-      description: Created weapon with faster casting
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Upgrade Material |
-    | Tradeable | Yes |
-    | Weight | 0.1 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Harmonised nightmare staff | Nightmare staff + Harmonised orb |
-
-    Allows casting standard spells at 4-tick speed instead of 5-tick.
-
-    Most valuable orb due to DPS increase.
+      description: Created weapon, casts standard spells at 4-tick.
+    - item_name: Volatile orb
+      slug: volatile-orb
+      relationship: alternative
+      description: Alternative Nightmare orb (special attack focus).
+    - item_name: Eldritch orb
+      slug: eldritch-orb
+      relationship: alternative
+      description: Alternative Nightmare orb (prayer restore special).
+  about: "The Harmonised orb is a rare drop from The Nightmare and Phosani's Nightmare. Combine it with a Nightmare staff to produce the Harmonised nightmare staff, which casts standard spellbook spells at 4-tick instead of 5-tick: a significant DPS upgrade and the most valuable of the three Nightmare orbs."
   market_strategy:
     notes:
-      - Farm Nightmare/Phosani's
-      - Most expensive orb
-      - BiS for fire surge
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Most expensive Nightmare orb due to standard-spellbook DPS uplift."
+      - "Supply tracks Nightmare team participation; price spikes after Magic meta shifts."
+      - "BiS implication for fire surge mainhand training and PvM."
+  trading_tips:
+    - Watch for buyouts after balance changes touching standard spells.
+    - Phosani's solo drop adds independent supply pressure.
+  history:
+    - date: "2020-02-06"
+      description: Released with The Nightmare of Ashihama update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/headless-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/headless-arrow.mdx
@@ -6,89 +6,72 @@ osrs:
   name: Headless arrow
   slug: headless-arrow
   examine: A wooden arrow shaft with flights attached.
-  members: true
+  members: false
   icon: Headless arrow.png
   value: 1
   lowalch: 1
   highalch: 1
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
-    type: fletching
-    tier: intermediate
-  fletching:
-    level: 1
-    xp: 1
-    method: Feathers on arrow shafts
+    type: fletching-component
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
   recipes:
     - skill: fletching
       level: 1
       xp: 15
       materials:
         - item_name: Arrow shaft
-          item_id: 52
           quantity: 15
         - item_name: Feather
-          item_id: 314
           quantity: 15
-      product: Headless arrow
-      product_id: 53
-      product_quantity: 15
+      tools: []
+      output_quantity: 15
   related_items:
-    - item_id: 52
-      item_name: Arrow shaft
+    - item_name: Arrow shaft
       slug: arrow-shaft
       relationship: component
-      description: Base material
-    - item_id: 314
-      item_name: Feather
+      description: Base wooden component for the arrow.
+    - item_name: Feather
       slug: feather
       relationship: component
-      description: Required component
-    - item_id: 39
-      item_name: Bronze arrowtips
+      description: Flights attached to the shaft.
+    - item_name: Bronze arrowtips
       slug: bronze-arrowtips
-      relationship: component
-      description: For bronze arrows
-    - item_id: 44
-      item_name: Rune arrowtips
+      relationship: product
+      description: Combined with headless arrows for bronze arrows.
+    - item_name: Rune arrowtips
       slug: rune-arrowtips
-      relationship: component
-      description: For rune arrows
-    - item_id: 1511
-      item_name: Logs
+      relationship: product
+      description: Combined with headless arrows for rune arrows.
+    - item_name: Logs
       slug: logs
       relationship: component
-      description: Source of arrow shafts
-  about: |-
-    Use Feather on Arrow shaft.
-
-    | Action | Fletching Level | XP |
-    |--------|-----------------|-----|
-    | Add feathers | 1 | 1 per arrow |
-
-    Add arrowtips to create finished arrows:
-
-    | Arrow Type | Tips Needed | Fletching Level |
-    |------------|-------------|-----------------|
-    | Bronze arrow | Bronze arrowtips | 1 |
-    | Iron arrow | Iron arrowtips | 15 |
-    | Steel arrow | Steel arrowtips | 30 |
-    | Mithril arrow | Mithril arrowtips | 45 |
-    | Adamant arrow | Adamant arrowtips | 60 |
-    | Rune arrow | Rune arrowtips | 75 |
-    | Amethyst arrow | Amethyst arrowtips | 82 |
-    | Dragon arrow | Dragon arrowtips | 90 |
+      description: Source of arrow shafts via Fletching knife.
+  about: "Headless arrows are an intermediate Fletching component made by attaching 15 feathers to 15 arrow shafts at Fletching level 1 for 15 experience. They are then combined with arrowtips of any metal tier to finish arrows, from bronze (level 1) up through dragon (level 90). Released 25 March 2002, headless arrows remain a high-volume Grand Exchange staple thanks to the 11,000 hourly buy limit."
   market_strategy:
-    title: Bulk Processing
-    profit_formulas:
-      - Headless arrow price - Arrow shaft price - Feather price = Profit
     notes:
-      - Buy Arrow shaft + Feather
-      - Fletch into Headless arrows
-      - Sell to arrow finishers
-      - High volume, low margin flip
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Bulk flip play: buy arrow shafts plus feathers, fletch, sell finished headless arrows."
+      - "Margins are thin (low gp per arrow); profit comes from volume at the 11k buy limit."
+      - "Track feather price - it usually drives the floor of headless arrow profitability."
+  trading_tips:
+    - Watch the spread between arrow shaft+feather cost and headless arrow price; act when it widens.
+  history:
+    - date: "2002-03-25"
+      description: Introduced with the original Fletching skill release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/headless-atlatl-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/headless-atlatl-dart.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 98
   highalch: 147
   limit: null
-  about: "Headless atlatl dart is a members-only item in Old School RuneScape. High alchemy value: 147 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: fletching-component
+    tier: mid
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: fletching
+      level: 74
+      xp: 20
+      materials:
+        - item_name: Atlatl dart shaft
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Atlatl dart
+      slug: atlatl-dart
+      relationship: product
+      description: Finished dart created by adding a dart tip
+    - item_name: Atlatl dart shaft
+      slug: atlatl-dart-shaft
+      relationship: component
+      description: Wooden shaft fletched from logs to start the chain
+    - item_name: Atlatl dart tip
+      slug: atlatl-dart-tip
+      relationship: component
+      description: Tip chiselled from a broken antler that completes the finished dart
+    - item_name: Broken antler
+      slug: broken-antler
+      relationship: component
+      description: Source of atlatl dart tips when used with a chisel
+  about: "Headless atlatl dart is an intermediate Fletching component made by attaching a feather to an atlatl dart shaft at Fletching level 74 for 20 XP. Adding an atlatl dart tip produces the finished Atlatl dart used with the Twin Fang Atlatl ranged weapon."
+  market_strategy:
+    notes:
+      - "Profit ties to the spread between shaft + feather inputs and the finished dart"
+      - "Fletcher supply scales with Sleeper Cave and broken antler drop rates"
+  history:
+    - date: "2025-07-23"
+      description: Released alongside the Twin Fang Atlatl and the atlatl dart fletching chain.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/honourable-blessing.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/honourable-blessing.mdx
@@ -12,69 +12,84 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 5
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.51
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: ammo
-    type: blessing
-    attack_style: none
-    stats:
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Rare
-        description: Reward from master clue scrolls
-      - source: Treasure Trails
-        requirements:
-          clue_type: Elite
-        rarity: Rare
-        description: Reward from elite clue scrolls
+    weapon_type: null
+    attack_speed: null
+    weight: 0.51
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 20220
-      item_name: Holy blessing
+    - item_name: Holy blessing
       slug: holy-blessing
       relationship: alternative
-      description: Saradomin blessing
-    - item_id: 20223
-      item_name: Unholy blessing
+      description: Saradomin-aligned blessing.
+    - item_name: Unholy blessing
       slug: unholy-blessing
       relationship: alternative
-      description: Zamorak blessing
-    - item_id: 20226
-      item_name: Peaceful blessing
+      description: Zamorak-aligned blessing.
+    - item_name: Peaceful blessing
       slug: peaceful-blessing
       relationship: alternative
-      description: Guthix blessing
-    - item_id: 20232
-      item_name: War blessing
+      description: Guthix-aligned blessing.
+    - item_name: War blessing
       slug: war-blessing
       relationship: alternative
-      description: Bandos blessing
-    - item_id: 20235
-      item_name: Ancient blessing
+      description: Bandos-aligned blessing.
+    - item_name: Ancient blessing
       slug: ancient-blessing
       relationship: alternative
-      description: Zaros blessing
-  about: |-
-    The honourable blessing is an Armadyl-aligned item worn in the ammunition slot, providing +1 prayer bonus. It is the Armadyl equivalent of other god blessings.
-
-    Blessings are valuable because they provide prayer bonus in the ammunition slot, which normally has no prayer-boosting options. This makes them useful for any build that wants to maximize prayer bonus without sacrificing ranging capability.
-
-    God Wars Protection:
-    - Counts as an Armadyl item in the God Wars Dungeon
-    - Armadyl followers will not be aggressive when worn
+      description: Zaros-aligned blessing.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Prices vary between different god blessings
-      - Armadyl version useful for Kree'arra
-      - Popular for ranging setups at Armadyl
-      - Compare prices between all six blessings
-      - Consider God Wars Dungeon utility when pricing
-      - Popular with players wanting prayer bonus in ammo slot
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Prices vary between the six god blessings; compare all of them before committing."
+      - "Armadyl-aligned version is sought after for trips to Kree'arra and the Armadyl bastion."
+      - "Counts as an Armadyl item inside the God Wars Dungeon, keeping Armadyl followers passive."
+      - "Demand spikes follow clue scroll updates and Bounty Hunter prayer-bonus meta shifts."
+      - "Buy limit of five per four hours rewards patient flippers monitoring the spread."
+  about: "Honourable blessing is the Armadyl-aligned ammunition-slot blessing, awarded from medium, hard, elite, and master clue scroll caskets. Equipping it grants +1 prayer bonus in a slot that has almost no other prayer options, and it also functions as an Armadyl item inside the God Wars Dungeon, keeping aviansie followers from attacking. Its examine text quotes Armadyl's philosophy: 'Law is not law if it violates the principles of eternal justice.'"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-bones.mdx
@@ -12,43 +12,55 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 7500
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: bones
+    tier: high
+  properties:
+    release_date: "2019-01-10"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 1.8
-    prayer_xp:
-      buried: 110
-      gilded_altar: 385
-      ectofuntus: 440
-      sinister_offering: 330
+    options:
+      - Bury
+      - Drop
+    worn_options: []
+    alchable: true
+  drop_table:
+    sources:
+      - source: Hydra
+        quantity: "1"
+        rarity: Always
+      - source: Alchemical Hydra
+        quantity: "1"
+        rarity: Always
+      - source: Colossal Hydra
+        quantity: "1"
+        rarity: Always
   related_items:
-    - item_id: 536
-      item_name: Dragon bones
+    - item_name: Dragon bones
       slug: dragon-bones
       relationship: alternative
-      description: Similar tier bones
-    - item_id: 6729
-      item_name: Dagannoth bones
+      description: Lower-tier prayer bone alternative
+    - item_name: Dagannoth bones
       slug: dagannoth-bones
       relationship: alternative
-      description: Higher XP option
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Bones |
-    | Tradeable | Yes |
-    | Weight | 1.8 kg |
-    | Prayer XP | 110 (buried) |
-
-    Prayer training: Bury for 110 XP.
-
-    Enhanced methods:
-    - Gilded/Chaos altar: 385 XP
-    - Ectofuntus: 440 XP
-    - Sinister Offering: 330 XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Higher-XP prayer alternative
+  about: "Hydra bones drop from Hydra, Alchemical Hydra, and Colossal Hydra in the Karuulm Slayer Dungeon. They grant 110 Prayer XP when buried, 385 XP at a Gilded/Chaos altar with two burners, 440 XP at the Ectofuntus, and 330 XP via Sinister Offering, making them one of the strongest bone options in the game."
+  market_strategy:
+    notes:
+      - "Demand scales with Hydra slayer task popularity and Prayer training cost"
+      - "Gilded altar method offers the best XP-to-cost ratio"
+  history:
+    - date: "2019-01-10"
+      description: Introduced with the Karuulm Slayer Dungeon update.
+    - date: "2019-02-07"
+      description: Prayer XP values increased (bury 90 to 110, altar 315 to 385, Ectofuntus 360 to 440).
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-tail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-tail.mdx
@@ -12,55 +12,72 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 15
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: crafting material
+    tier: mid-high
+  properties:
+    release_date: "2019-01-10"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.226
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  drop_table:
+    sources:
+      - source: Alchemical Hydra
+        quantity: "1"
+        rarity: 1/513
+      - source: Colossal Hydra
+        quantity: "1"
+        rarity: 1/1001
+      - source: Hydra
+        quantity: "1"
+        rarity: 1/1001
   recipes:
-    - skill: null
+    - skill: crafting
       level: 0
+      xp: 0
       materials:
-        - item_id: 13116
-          item_name: Bonecrusher
+        - item_name: Bonecrusher
           quantity: 1
-        - item_id: 19720
-          item_name: Dragonbone necklace
+        - item_name: Dragonbone necklace
           quantity: 1
-        - item_id: 22988
-          item_name: Hydra tail
+        - item_name: Hydra tail
           quantity: 1
-      product: Bonecrusher necklace
-      product_id: 22986
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 22986
-      item_name: Bonecrusher necklace
+    - item_name: Bonecrusher necklace
       slug: bonecrusher-necklace
       relationship: product
       description: Created utility necklace
-    - item_id: 13116
-      item_name: Bonecrusher
+    - item_name: Bonecrusher
       slug: bonecrusher
       relationship: component
       description: Component for bonecrusher necklace
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.226 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Bonecrusher necklace | Bonecrusher + Dragonbone necklace + Hydra tail |
-
-    Reversible with confirmation.
+    - item_name: Dragonbone necklace
+      slug: dragonbone-necklace
+      relationship: component
+      description: Component for bonecrusher necklace
+  about: "The Hydra tail is a rare drop from Hydra, Alchemical Hydra and Colossal Hydra. It combines with a bonecrusher and a dragonbone necklace to create the bonecrusher necklace, a utility neckwear that grinds and prays bones automatically. The recipe is reversible with confirmation."
   market_strategy:
     notes:
-      - From any Hydra variant
-      - Creates utility necklace
-      - Cheaper than other hydra drops
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Dropped from any Hydra variant"
+      - "Creates the bonecrusher necklace utility item"
+      - "Cheaper than other Hydra-exclusive drops"
+  history:
+    - date: "2019-01-10"
+      description: Added with the Karuulm Slayer Dungeon and Alchemical Hydra release.
+    - date: "2019-01-24"
+      description: Item value decreased from 1,500,000 to 100,000 coins.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron boots | OSRS Price Data
-description: "Iron boots: These will protect my feet.. High alch: 50 GP, GE limit: 125."
+description: "Iron boots: These will protect my feet. High alch: 50 GP, GE limit: 125."
 osrs:
   id: 4121
   name: Iron boots
@@ -12,12 +12,90 @@ osrs:
   lowalch: 33
   highalch: 50
   limit: 125
-  about: "Iron boots is a members-only item in Old School RuneScape. High alchemy value: 50 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2005-01-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options: ["Wear", "Drop"]
+    worn_options: []
+    alchable: true
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 1.36
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 4
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Cockatrice
+        quantity: "1"
+        rarity: 1/128
+      - source: Cave slime
+        quantity: "1"
+        rarity: 1/128
+      - source: Cockathrice
+        quantity: "1"
+        rarity: 3/128
+      - source: Moonlight Cockatrice
+        quantity: "1"
+        rarity: 1/128
+  related_items:
+    - item_name: Bronze boots
+      slug: bronze-boots
+      relationship: downgrade
+      description: Weaker metal boots tier
+    - item_name: Steel boots
+      slug: steel-boots
+      relationship: upgrade
+      description: Stronger metal boots tier
+    - item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: set-piece
+      description: Matching iron armour piece
+  about: "Iron boots are members-only footwear that cannot be smithed and must be obtained as Slayer drops, primarily from cockatrices, cave slimes, and their Cockathrice/Moonlight variants. They sit in the iron metal tier of crush-defence boots and require no skill levels to equip, making them a budget early-game Slayer drop pickup."
+  market_strategy:
+    notes:
+      - "Slayer-locked supply keeps stock modest"
+      - "GE buy limit of 125 makes mid-volume flips viable"
+      - "Members-only foot slot drop from cockatrice tasks"
+      - "Alch value below GE price - not an alch target"
+  trading_tips:
+    - Watch cockatrice/moonlight cockatrice task popularity
+    - Slayer drop changes can swing supply quickly
+  history:
+    - date: "2005-01-26"
+      description: Released alongside the Slayer skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dart.mdx
@@ -12,62 +12,100 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 1
-  stats:
-    attack:
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 0
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 2
-  fletching:
-    level: 22
-    xp: 3.8
-    method: Attach feathers to iron dart tips
-    quest: Tourist Trap
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 22
+      xp: 3.8
+      materials:
+        - item_name: Iron dart tip
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 820
-      item_name: Iron dart tip
+    - item_name: Iron dart tip
       slug: iron-dart-tip
       relationship: component
-      description: Fletching material
-    - item_id: 314
-      item_name: Feather
+      description: Fletching material used to craft iron darts.
+    - item_name: Feather
       slug: feather
       relationship: component
-      description: Fletching material
-    - item_id: 808
-      item_name: Steel dart
+      description: Attached to iron dart tips to complete the dart.
+    - item_name: Steel dart
       slug: steel-dart
       relationship: upgrade
-      description: Higher tier dart
-    - item_id: 806
-      item_name: Bronze dart
+      description: Next dart tier above iron, higher accuracy and strength.
+    - item_name: Bronze dart
       slug: bronze-dart
       relationship: downgrade
-      description: Lower tier dart
-    - item_id: 12924
-      item_name: Toxic blowpipe
+      description: Lower tier dart used before reaching iron.
+    - item_name: Toxic blowpipe
       slug: toxic-blowpipe
       relationship: alternative
-      description: Uses darts as ammo
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon/Ammo |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 1 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Ranged weapon that consumes darts as ammunition.
+  about: "Iron dart is a members-only thrown weapon released on 14 April 2003. It can be fletched at Fletching level 22 after completing Tourist Trap by attaching a feather to an iron dart tip for 3.8 experience per dart. With a Ranged Strength bonus of +2 and a base attack speed of 3 ticks, iron darts are a budget thrown option for low-level Ranged training and the toxic blowpipe."
+  market_strategy:
+    notes:
+      - "Cheap and stackable, useful in bulk for blowpipe ammo."
+      - "Lower margins than higher-tier darts; flips depend on volume."
+  trading_tips:
+    - Buy in bulk to take advantage of the 7,000 GE buy limit.
+    - Watch fletching XP events that spike feather demand alongside darts.
+  history:
+    - date: "2003-04-14"
+      description: Iron dart released to Old School RuneScape.
+    - date: "2021-06-30"
+      description: Ranged attack bonus reduced from +4 to +0 and ranged strength reduced from +3 to +2.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-set-lg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron set (lg) | OSRS Price Data
-description: "Iron set (lg): A set containing a full helm, platebody, legs and kiteshield.. High alch: 540 GP, GE limit: 8."
+description: "Iron set (lg): A set containing a full helm, platebody, legs and kiteshield. High alch: 540 GP, GE limit: 8."
 osrs:
   id: 12972
   name: Iron set (lg)
@@ -12,12 +12,61 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Iron set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+  related_items:
+    - item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: component
+      description: Helmet contained in the set
+    - item_name: Iron platebody
+      slug: iron-platebody
+      relationship: component
+      description: Body contained in the set
+    - item_name: Iron platelegs
+      slug: iron-platelegs
+      relationship: component
+      description: Legs contained in the set
+    - item_name: Iron kiteshield
+      slug: iron-kiteshield
+      relationship: component
+      description: Shield contained in the set
+    - item_name: Iron set (sk)
+      slug: iron-set-sk
+      relationship: alternative
+      description: Skirt variant of the iron armour set
+  about: "Iron set (lg) is a free-to-play Grand Exchange convenience item that bundles an Iron full helm, Iron platebody, Iron platelegs, and Iron kiteshield into a single tradeable token. The set is mostly used to save bank space and is exchanged with a Grand Exchange clerk to obtain or split the four pieces. Because the bundle typically trades above the sum of the components, it is also a popular set-flip target."
+  market_strategy:
+    notes:
+      - "Set-flip target - assemble pieces and exchange"
+      - "F2P friendly with strong bank-space utility"
+      - "GE buy limit of 8 keeps flips modest"
+      - "Margin tracks the spread vs sum-of-parts"
+  trading_tips:
+    - Compare set price to combined component cost before flipping
+    - Watch armour-set updates and spotlights for demand spikes
+  history:
+    - date: "2015-02-26"
+      description: Introduced with the Grand Exchange set conversion update.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-pyre-logs.mdx
@@ -12,12 +12,69 @@ osrs:
   lowalch: 288
   highalch: 432
   limit: null
-  about: "Ironwood pyre logs is a members-only item in Old School RuneScape. High alchemy value: 432 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 85
+      xp: 435
+      materials:
+        - item_name: Ironwood logs
+          quantity: 1
+        - item_name: Sacred oil(4)
+          quantity: 1
+      tools:
+        - Tinderbox
+      output_quantity: 1
+  related_items:
+    - item_name: Ironwood logs
+      slug: ironwood-logs
+      relationship: component
+      description: Base log soaked in sacred oil to create the pyre version.
+    - item_name: Sacred oil(4)
+      slug: sacred-oil-4
+      relationship: component
+      description: Olive oil consecrated at the Mort'ton temple, four doses per pyre log.
+    - item_name: Magic pyre logs
+      slug: magic-pyre-logs
+      relationship: upgrade
+      description: Higher tier funeral pyre logs.
+    - item_name: Redwood pyre logs
+      slug: redwood-pyre-logs
+      relationship: downgrade
+      description: Lower tier funeral pyre logs.
+  about: "Ironwood pyre logs are produced by applying four doses of sacred oil to ironwood logs, the new high-tier Sailing era log released on 19 November 2025. Burning them at a funeral pyre during Shades of Mort'ton awards 435 Firemaking experience (boosted to 652.5 with the Elite Morytania Diary) and is one of the fastest XP-per-hour Firemaking methods at level 85."
+  market_strategy:
+    notes:
+      - "Demand scales with Shades of Mort'ton popularity for high-tier shade remains."
+      - "Sacred oil bottlenecks supply because of the Mort'ton minigame cadence."
+  trading_tips:
+    - Pre-make pyre logs during quiet periods and sell into Firemaking XP events.
+    - Track ironwood logs prices; raw log spikes ripple into pyre log margins.
+  history:
+    - date: "2025-11-19"
+      description: Released as part of the Sailing update and tied into the Shades of Mort'ton minigame.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-repair-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-repair-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ironwood repair kit | OSRS Price Data
-description: "Ironwood repair kit: An excellent boat repair kit made from ironwood.. High alch: 2,400 GP, GE limit: 13,000."
+description: "Ironwood repair kit: An excellent boat repair kit made from ironwood. High alch: 2,400 GP, GE limit: 13,000."
 osrs:
   id: 31979
   name: Ironwood repair kit
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 13000
-  about: "Ironwood repair kit is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ironwood
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Apply
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: construction
+      level: 80
+      xp: 300
+      materials:
+        - item_name: Ironwood plank
+          quantity: 1
+        - item_name: Runite nails
+          quantity: 10
+        - item_name: Swamp paste
+          quantity: 5
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 3
+  drop_table:
+    sources:
+      - source: Opulent salvage
+        quantity: "1"
+        rarity: 10/424
+      - source: Vampyre kraken
+        quantity: "1"
+        rarity: 4/120
+      - source: Veiled kraken
+        quantity: "1"
+        rarity: 5/272
+  related_items:
+    - item_name: Ironwood plank
+      slug: ironwood-plank
+      relationship: component
+      description: Primary material for crafting the kit
+    - item_name: Runite nails
+      slug: runite-nails
+      relationship: component
+      description: Fastener component for the kit
+  about: "Ironwood repair kit is a members Sailing consumable applied to a boat to restore 45 health while sailing. Multiple players can apply kits simultaneously for faster repairs, and crewmates with higher Deckhandiness restore more hull per kit."
+  market_strategy:
+    notes:
+      - "Demand scales with Sailing skill engagement"
+      - "Construction recipe yields 3 per action for solid margin"
+      - "Kraken drop tables suppress price spikes"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-bolt-tips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jade bolt tips | OSRS Price Data
-description: "Jade bolt tips: Jade bolt tips.. High alch: 6 GP, GE limit: 11,000."
+description: "Jade bolt tips: Jade bolt tips. High alch: 6 GP, GE limit: 11,000."
 osrs:
   id: 9187
   name: Jade bolt tips
@@ -12,12 +12,63 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 11000
-  about: "Jade bolt tips is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: jade
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: fletching
+      level: 26
+      xp: 2
+      materials:
+        - item_name: Jade
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 12
+  related_items:
+    - item_name: Jade
+      slug: jade
+      relationship: component
+      description: Cut gem used to craft the tips
+    - item_name: Jade bolts
+      slug: jade-bolts
+      relationship: product
+      description: Blurite bolts tipped with jade
+    - item_name: Jade dragon bolts
+      slug: jade-dragon-bolts
+      relationship: product
+      description: Dragon bolts tipped with jade
+  about: "Jade bolt tips are members-only fletching components made by using a chisel on a cut jade at level 26 Fletching for 2 experience, producing 12 tips per gem. Attach them to blurite bolts (level 26 Fletching) or dragon bolts (level 84 Fletching) to make jade bolts or jade dragon bolts, both of which can be enchanted for special effects."
+  market_strategy:
+    notes:
+      - "High GE buy limit of 11,000 enables bulk flipping"
+      - "Members-only fletching commodity"
+      - "Supply driven by chisel-on-jade processing"
+      - "Alch value of 6 GP makes alching irrelevant"
+  trading_tips:
+    - Track cut jade price for raw-material arbitrage
+    - Spikes follow ranged content or bolt-enchant updates
+  history:
+    - date: "2006-07-31"
+      description: Released as part of the Crossbows update.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-dirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-dirt.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Jar of dirt is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: collectible
+    tier: low
+  properties:
+    release_date: "2014-04-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "You can get another by killing the Kraken."
+  drop_table:
+    sources:
+      - source: Kraken
+        quantity: "1"
+        rarity: 1/1000
+  related_items:
+    - item_name: Jar of sand
+      slug: jar-of-sand
+      relationship: alternative
+      description: Dagannoth Rex boss jar drop
+    - item_name: Jar of stone
+      slug: jar-of-stone
+      relationship: alternative
+      description: Skotizo boss jar drop
+  about: "Jar of dirt is a rare drop from the Kraken boss with a 1/1000 drop rate. It can be placed on a boss lair display in an Achievement Gallery to commemorate defeating Kraken at least once. The item is a tribute to Pirates of the Caribbean: Dead Man's Chest, referencing Jack Sparrow's jar of dirt."
+  market_strategy:
+    notes:
+      - "Rare collectible from Kraken boss"
+      - "Demand from collection log hunters"
+      - "Limited supply due to low drop rate"
+  history:
+    - date: "2014-04-10"
+      description: Released as a rare drop from Kraken.
+    - date: "2014-04-10"
+      description: Originally intended to be untradeable but was accidentally left tradeable, influencing the design of all subsequent boss jar drops.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/justiciar-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/justiciar-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Justiciar armour set | OSRS Price Data
-description: "Justiciar armour set is a members-only OSRS item. High alch: 87,000 GP, GE limit: 5."
+description: "Justiciar armour set is a members Grand Exchange set bundling Justiciar faceguard, chestguard and legguards. High alch: 87,000 GP, GE limit: 5."
 osrs:
   id: 22438
   name: Justiciar armour set
@@ -12,9 +12,55 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: 5
-  about: "Justiciar armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: justiciar
+    tier: high
+  properties:
+    release_date: "2018-06-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  related_items:
+    - item_name: Justiciar faceguard
+      slug: justiciar-faceguard
+      relationship: set-piece
+      description: Helmet piece bundled in the set
+    - item_name: Justiciar chestguard
+      slug: justiciar-chestguard
+      relationship: set-piece
+      description: Body piece bundled in the set
+    - item_name: Justiciar legguards
+      slug: justiciar-legguards
+      relationship: set-piece
+      description: Legs piece bundled in the set
+    - item_name: Scythe of vitur
+      slug: scythe-of-vitur
+      relationship: alternative
+      description: Premier Theatre of Blood weapon drop
+  about: "Justiciar armour set bundles the three Theatre of Blood unique armour pieces (faceguard, chestguard and legguards) into a single tradeable item via the Grand Exchange's Sets interface. The bundled armour offers best-in-slot defensive bonuses, particularly against magic-heavy bosses, and is highly sought after for tanking content. Players combine the three pieces at the GE clerk to form the set, or exchange the set back into its components for use. The high alch value reflects the bundled price floor across all three pieces."
+  market_strategy:
+    notes:
+      - "Bundled set price tracks ToB unique supply"
+      - "Buy limit 5 caps bulk arbitrage"
+      - "Component vs set arbitrage opportunities when prices diverge"
+      - "Heavy capital lockup per unit"
+  trading_tips:
+    - Compare individual piece sum to set price for arbitrage
+    - Watch ToB completion rates and announcements
+    - Avoid holding through major defensive armour rework rumours
+  history:
+    - date: "2018-06-07"
+      description: Added with the Theatre of Blood update.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leather-body-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leather-body-g.mdx
@@ -12,24 +12,83 @@ osrs:
   lowalch: 340
   highalch: 510
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: leather
+    tier: low
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 8
+      slash: 9
+      crush: 10
+      magic: 4
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 23384
-      item_name: Leather chaps (g)
+    - item_name: Leather chaps (g)
       slug: leather-chaps-g
       relationship: set-piece
-      description: Matching gold-trimmed chaps
-  about: |-
-    > *"Better than no armour! Nice trim too!"*
-
-    The leather body (g) is a gold-trimmed cosmetic variant of the leather body. Identical stats with no requirements to equip. F2P item. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Matching gold-trimmed chaps from the same easy clue set.
+    - item_name: Leather body
+      slug: leather-body
+      relationship: variant
+      description: Ungilded version with identical stats.
+    - item_name: Leather body (t)
+      slug: leather-body-t
+      relationship: variant
+      description: Trimmed cosmetic alternative.
+  about: "Leather body (g) is the gold-trimmed cosmetic variant of the standard leather body, released alongside the Treasure Trails Expansion on 11 April 2019. It is awarded from easy clue scroll Reward caskets and shares defensive stats with the base leather body, making it a fashionscape piece rather than a combat upgrade."
+  market_strategy:
+    notes:
+      - "Tiny GE buy limit (8) makes flips slow and price-sensitive."
+      - "Fashionscape demand drives most trades; combat use is negligible."
+  trading_tips:
+    - Stock up during clue update content cycles when easy clues spike.
+    - Pair with matching leather chaps (g) for higher fashion-set value.
+  history:
+    - date: "2019-04-11"
+      description: Released with the Treasure Trails Expansion update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leather-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leather-boots.mdx
@@ -12,9 +12,101 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 125
-  about: "Leather boots is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: leather
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.34
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 7
+      xp: 16.25
+      materials:
+        - item_name: Leather
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+  shops:
+    - shop_name: Thessalia's Fine Clothes
+      location: Varrock
+      price: 6
+      currency: Coins
+      stock: 5
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 7
+      currency: Coins
+      stock: 5
+    - shop_name: Shayzien Styles
+      location: Shayzien
+      price: 6
+      currency: Coins
+      stock: 5
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - beginner
+      - easy
+      - medium
+  related_items:
+    - item_name: Leather
+      slug: leather
+      relationship: component
+      description: Crafting material used to make leather boots
+    - item_name: Hardleather body
+      slug: hardleather-body
+      relationship: alternative
+      description: Higher-tier leather armour piece
+  about: "Leather boots are a free-to-play feet-slot item granting +1 Slash and +1 Crush Defence. They can be crafted at Crafting level 7 from a piece of leather and thread for 16.25 XP, purchased from clothing shops in Varrock and Shayzien, dropped from low-level monsters, or received as a Beginner, Easy, or Medium clue casket reward."
+  market_strategy:
+    notes:
+      - "Tiny GE buy limit (125) keeps trade margins thin"
+      - "Cheap shop and crafting alternatives cap the GE ceiling"
+  history:
+    - date: "2001-01-04"
+      description: Available since the early days of RuneScape's release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-fang.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-fang.mdx
@@ -12,57 +12,67 @@ osrs:
   lowalch: 40800
   highalch: 61200
   limit: 5
-  item:
-    type: upgrade_material
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: upgrade
+    tier: high
+  properties:
+    release_date: "2015-01-08"
     tradeable: true
-    weight: 0.01
-  obtaining:
-    methods:
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Dismantle
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Dismantle"
+  drop_table:
+    sources:
       - source: Zulrah
-        drop_rate: 1/1,024
-  creation:
-    uses:
-      - item_id: 12899
-        item_name: Trident of the swamp
-        slug: trident-of-the-swamp
-        description: Attaches to Trident of the seas to create Trident of the swamp
+        quantity: "1"
+        rarity: 2/1024
+  recipes:
+    - skill: crafting
+      level: 59
+      xp: 100
+      materials:
+        - item_name: Trident of the seas
+          quantity: 1
+        - item_name: Magic fang
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
   related_items:
-    - item_id: 0
-      item_name: Zulrah
+    - item_name: Zulrah
       slug: zulrah
       relationship: component
-      description: Boss drop
-    - item_id: 11905
-      item_name: Trident of the seas
+      description: Boss source dropping the magic fang
+    - item_name: Trident of the seas
       slug: trident-of-the-seas
       relationship: component
-      description: Base weapon
-    - item_id: 12899
-      item_name: Trident of the swamp
+      description: Base weapon upgraded with the magic fang
+    - item_name: Trident of the swamp
       slug: trident-of-the-swamp
       relationship: product
-      description: Created weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Upgrade Material |
-    | Tradeable | Yes |
-    | Weight | 0.01 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Trident of the swamp | Trident of the seas + Magic fang |
-    | Toxic blowpipe | Tanzanite fang + Magic fang (not used) |
-    | Serpentine helm | Serpentine visage (separate) |
-
-    Attaches to Trident of the seas to create Trident of the swamp.
+      description: Venomous trident created from the upgrade
+  about: "Magic fang is a Zulrah-exclusive upgrade item used to attach to a trident of the seas (or staff of the dead variants) at 59 Crafting to create the trident of the swamp, the strongest non-Sanguinesti charged staff that inflicts venom. The fang can be dismantled to refund Zulrah's scales."
   market_strategy:
     notes:
-      - Zulrah exclusive drop
-      - Creates best non-Sanguinesti staff
-      - Adds venom effect to trident
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Zulrah is the only drop source; supply scales with boss popularity"
+      - "Demand spikes when trident of the swamp becomes BIS for new content"
+      - "Dismantle floor keeps a hard scale-equivalent price minimum"
+  history:
+    - date: "2015-01-08"
+      description: Magic fang released with Zulrah.
+    - date: "2016-02-18"
+      description: Dismantle option added to recover Zulrah's scales.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-stone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-stone.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magic stone | OSRS Price Data
-description: "Magic stone: A magic stone to make high-level furniture.. High alch: 450,000 GP, GE limit: 11,000."
+description: "Magic stone: A magic stone to make high-level furniture. High alch: 450,000 GP, GE limit: 11,000."
 osrs:
   id: 8788
   name: Magic stone
@@ -12,43 +12,76 @@ osrs:
   lowalch: 300000
   highalch: 450000
   limit: 11000
-  item_id: 8788
-  type: construction_material
-  tradeable: true
-  weight: 1
-  buy_limit: 11000
-  obtaining:
-    shops:
-      - shop_name: Keldagrim Stonemason
-        price: 975000
-      - shop_name: Stonecutter Supplies
-        price: 975000
-  construction:
-    usage: Highest-level Construction furniture, gilded altar, premium items
-    also_used: Sailing skill
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: stone
+    tier: high
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Keldagrim Stonemason
+      location: Keldagrim
+      price: 975000
+      currency: coins
+      stock: 10
+    - shop_name: Stonecutter Supplies
+      location: Stonecutter Outpost
+      price: 975000
+      currency: coins
+      stock: 10
+  recipes:
+    - skill: construction
+      level: 95
+      xp: 15000
+      materials:
+        - item_name: Magic stone
+          quantity: 15
+      tools: []
+      output_quantity: 1
+    - skill: construction
+      level: 99
+      xp: 25000
+      materials:
+        - item_name: Magic stone
+          quantity: 25
+      tools: []
+      output_quantity: 1
   related_items:
-    - slug: marble-block
-      name: Marble block
-      relation: lower_tier
-    - slug: gold-leaf
-      name: Gold leaf
-      relation: construction_material
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Construction Material |
-    | Tradeable | Yes |
-    | Weight | 1 kg |
-    | Requirements | High Construction levels |
-
-    Used for highest-level Construction furniture.
-
-    Required for gilded altar and other premium items.
-
-    Also used in Sailing skill.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Marble block
+      slug: marble-block
+      relationship: downgrade
+      description: Lower-tier Construction material
+    - item_name: Gold leaf
+      slug: gold-leaf
+      relationship: component
+      description: Often paired with magic stones in high-level furniture
+  about: "Magic stone is the highest tier Construction material in Old School RuneScape, used to build top-end furniture such as Crystal and Demonic Thrones, gilded altars, and other premium items. It can be bought from the Keldagrim Stonemason and Stonecutter Supplies shops for 975,000 coins, traded on the Grand Exchange, or dropped by a small selection of monsters. With a buy limit of 11,000 it is one of the more capital-intensive flips in the game."
+  market_strategy:
+    notes:
+      - "Demand driven by high-level Construction training"
+      - "Shop price acts as a soft cap on GE spikes"
+      - "Large unit value means even small margins are profitable"
+  trading_tips:
+    - Stockpile when Construction events or DXP weekends are announced
+    - Compare GE price to the 975k shop price before flipping
+    - Use the full 11k buy limit when GE dips noticeably below shop price
+  history:
+    - date: "2006-05-31"
+      description: "Added to the game."
+    - date: "2021-11-24"
+      description: "Item was accidentally swapped with condensed gold at the Keldagrim Stonemason; restored within two hours."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-longbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-longbow.mdx
@@ -12,50 +12,93 @@ osrs:
   lowalch: 256
   highalch: 384
   limit: 18000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: maple
+    tier: mid
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: 2h
-    type: longbow
-    attack_style: ranged
+    weapon_type: bow
     attack_speed: 6
-  requirements:
-    ranged: 30
-  stats:
-    attack:
+    weight: 1.814
+    requirements:
+      ranged: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 29
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-    range: 9
-  fletching:
-    level: 55
-    xp: 58.3
-    method: Maple longbow (u) + bowstring
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 55
+      xp: 58.3
+      materials:
+        - item_name: Maple longbow (u)
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      tools: []
+      output_quantity: 1
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
       price: 640
+      currency: Coins
+      stock: 5
   related_items:
-    - item_id: 855
-      item_name: Yew longbow
+    - item_name: Yew longbow
       slug: yew-longbow
       relationship: upgrade
       description: Higher tier longbow
-    - item_id: 853
-      item_name: Maple shortbow
+    - item_name: Maple shortbow
       slug: maple-shortbow
       relationship: alternative
-      description: Faster attack speed
-    - item_id: 62
-      item_name: Maple longbow (u)
+      description: Faster attack speed alternative
+    - item_name: Maple longbow (u)
       slug: maple-longbow-u
       relationship: component
       description: Unstrung version
-    - item_id: 1777
-      item_name: Bow string
+    - item_name: Bow string
       slug: bow-string
       relationship: component
-      description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Required stringing material
+  about: "The maple longbow is a free-to-play two-handed bow requiring 30 Ranged to wield. It can fire arrows up to adamant and trades attack speed for greater range compared to the maple shortbow. Fletchable at 55 Fletching for 58.3 XP by stringing a maple longbow (u), and is also a reward from the Observatory Quest."
+  market_strategy:
+    notes:
+      - "Fletchers flip large volume daily"
+      - "High alch leaves stable margin against nature runes"
+      - "Maple shortbow competition caps PvM demand"
+  history:
+    - date: "2002-03-25"
+      description: "Released with the Ranged skill rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-body-f.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-body-f.mdx
@@ -12,86 +12,91 @@ osrs:
   lowalch: 640000
   highalch: 960000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ranged armour
+    tier: high
+  properties:
+    release_date: "2022-08-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 10
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 10
     requirements:
       ranged: 80
       defence: 80
-    stats:
-      defence_stab: 59
-      defence_slash: 52
-      defence_crush: 64
-      defence_magic: 74
-      defence_ranged: 60
-      attack_ranged: 43
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 43
+    defence_bonus:
+      stab: 59
+      slash: 52
+      crush: 64
+      magic: 74
+      ranged: 60
+    other_bonus:
       ranged_strength: 4
       prayer: 1
   recipes:
     - skill: crafting
       level: 90
-      xp: 830
+      xp: 3320
       materials:
         - item_name: Masori body
-          item_id: 27229
           quantity: 1
         - item_name: Armadylean plate
-          item_id: 27232
-          quantity: 1
-      product: Masori body (f)
-      product_id: 27238
-      product_quantity: 1
-      facility: Hammer
-      members_only: true
+          quantity: 4
+      tools: ["Hammer"]
+      output_quantity: 1
   related_items:
-    - item_id: 27235
-      item_name: Masori mask (f)
+    - item_name: Masori body
+      slug: masori-body
+      relationship: component
+      description: Base Masori body required for the upgrade.
+    - item_name: Armadylean plate
+      slug: armadylean-plate
+      relationship: component
+      description: Forging material (4 required) from Armadyl armour.
+    - item_name: Masori mask (f)
       slug: masori-mask-f
       relationship: set-piece
-      description: Head slot
-    - item_id: 27241
-      item_name: Masori chaps (f)
+      description: Head slot piece of the fortified set.
+    - item_name: Masori chaps (f)
       slug: masori-chaps-f
       relationship: set-piece
-      description: Legs slot
-    - item_id: 11828
-      item_name: Armadyl chestplate
+      description: Legs slot piece of the fortified set.
+    - item_name: Armadyl chestplate
       slug: armadyl-chestplate
       relationship: alternative
-      description: Budget option
-  about: |-
-    Combine Masori body with Armadylean plate using a hammer (90 Crafting).
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Masori body | Tombs of Amascut | ~100M gp |
-    | Armadylean plate | Armadyl armour | ~1M gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +43 |
-    | Ranged strength | +4 |
-    | Defence bonuses | +52 to +74 |
-    | Prayer bonus | +1 |
-    | Requirements | 80 Ranged, 80 Defence |
-
-    Part of the Masori armour (fortified) set:
-    - Masori mask (f) (head)
-    - Masori body (f) (body)
-    - Masori chaps (f) (legs)
-
-    PvM:
-    - Best-in-slot ranged body
-    - Tombs of Amascut
-    - Theatre of Blood
-    - General ranged content
+      description: Budget ranged body alternative.
+  about: "Masori body (f) is the fortified upgrade of the Masori body, crafted at 90 Crafting with a hammer by combining a Masori body with four Armadylean plates for 3,320 XP. The upgrade is irreversible. At 80 Ranged / 80 Defence it is the best-in-slot ranged body, with +43 ranged attack, +4 ranged strength, and tank-grade defensive bonuses across all styles."
   market_strategy:
     notes:
-      - Most expensive Masori piece
-      - ToA completions affect supply
-      - BiS ranged body
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Most expensive Masori piece; price tracks Tombs of Amascut clear volume."
+      - "Supply also gated by Armadylean plate availability (Armadyl armour shreds)."
+      - "BiS ranged body for ToA, ToB, and general high-end ranged PvM."
+  trading_tips:
+    - Avoid panic-buying after raid update news; check ToA reward changes.
+    - Crafting margin sometimes flips negative; verify base body + plates spread before forging.
+  history:
+    - date: "2022-08-24"
+      description: Released as part of the Tombs of Amascut content update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mirror-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mirror-shield.mdx
@@ -12,8 +12,33 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 40
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: shield
+    tier: mid
+  properties:
+    release_date: "2005-01-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
+    weight: 2.267
+    requirements:
+      defence: 20
+      slayer: 25
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,45 +56,29 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 20
-    weight: 2.267
-  shop_sources:
-    - shop_name: Any Slayer Master
-      location: Various
+  shops:
+    - shop_name: Slayer Equipment
+      location: Burthorpe, Draynor Village, Edgeville, Canifis, Zanaris, Mount Karuulm, Tree Gnome Stronghold, Shilo Village, Edgeville Dungeon
       price: 5000
+      currency: coins
       stock: 10
-      members_only: true
   related_items:
-    - item_id: 6524
-      item_name: Toktz-ket-xil
-      slug: toktz-ket-xil
+    - item_name: V's shield
+      slug: v-s-shield
       relationship: upgrade
-      description: Obsidian shield with better stats
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Slash | +15 |
-    | Stab | +10 |
-    | Ranged | +10 |
-    | Crush | +5 |
-    | Magic | +5 |
-
-    Requirements: 20 Defence, 25 Slayer | Weight: 2.27 kg
-
-    The mirror shield is required when fighting:
-    - Cockatrices (37 Slayer) — without it, your stats are drastically reduced
-    - Basilisks (40 Slayer) — same stat-drain effect
-    - Basilisk Knights (60 Slayer) — upgraded basilisk variant
-
-    The reflective surface prevents these monsters' petrifying gaze from affecting the player. V's shield (from The Fremennik Exiles) provides the same protection with superior stats.
+      description: Fremennik Exiles reward shield with identical petrify protection and stronger stats
+    - item_name: Toktz-ket-xil
+      slug: toktz-ket-xil
+      relationship: alternative
+      description: Obsidian shield used after stat-drain tasks
+  about: "Mirror shield is a Slayer staple required to safely fight cockatrices, basilisks, and basilisk knights. Without it the target's petrifying gaze drastically reduces the player's combat stats. The shield is sold by every Slayer Master for 5,000 coins and requires 20 Defence and 25 Slayer to wield."
   market_strategy:
     notes:
-      - Essential Slayer equipment — steady demand
-      - Cheap from any Slayer Master (5,000 coins)
-      - Keep one in bank for basilisk/cockatrice tasks
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap shop supply caps GE margins near the 5,000 coin base price"
+      - "Steady demand from new Slayer accounts unlocking basilisks and cockatrices"
+  history:
+    - date: "2005-01-26"
+      description: Mirror shield released with the Slayer skill.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mith-grapple.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mith-grapple.mdx
@@ -12,9 +12,107 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Mith grapple is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammunition
+    weapon_type: grapple
+    attack_speed: null
+    weight: 0.001
+    requirements:
+      ranged: 1
+      agility: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 59
+      xp: 0
+      materials:
+        - item_name: Mith grapple tip
+          quantity: 1
+        - item_name: Mithril bolts (unf)
+          quantity: 1
+        - item_name: Rope
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Mithril dragon
+        quantity: "1"
+        rarity: Uncommon
+      - source: Waterfiend
+        quantity: "1"
+        rarity: Uncommon
+      - source: Brutal black dragon
+        quantity: "1"
+        rarity: Uncommon
+      - source: Armadyl's Eyrie crate
+        quantity: "1"
+        rarity: Drop trick
+  related_items:
+    - item_name: Mith grapple tip
+      slug: mith-grapple-tip
+      relationship: component
+      description: Smithed grapple head crafted before attaching to bolt and rope.
+    - item_name: Rope
+      slug: rope
+      relationship: component
+      description: Required cord for assembling the finished mith grapple.
+    - item_name: Mithril crossbow
+      slug: mithril-crossbow
+      relationship: product
+      description: Common crossbow paired with the mith grapple for agility shortcuts.
+    - item_name: Mithril grapple
+      slug: mith-grapple
+      relationship: variant
+      description: Same item under its full name.
+  about: "The mith grapple is a specialised ammunition slot bolt that fires from a crossbow to unlock agility-based grappling shortcuts across Gielinor. It has no combat use - all stats are zero - and exists almost entirely as a transportation tool. There is a 1/25 chance per use that the grapple breaks, although the Hallowed Sepulchre and Shayzien Agility Course never destroy it, making the item effectively reusable in those areas."
+  market_strategy:
+    notes:
+      - "Demand spikes when popular guides recommend grapple shortcuts, especially around new agility content."
+      - "Drop sources from mithril dragons and waterfiends mean supply scales with PvM activity."
+      - "Buy limit of 11,000 with low alch of 1 keeps this a thin-margin volume flip."
+  trading_tips:
+    - "Stock up before content updates that lean on grapple shortcuts, like new Wilderness training routes."
+    - "Convert mith grapple tips and rope into finished grapples when the assembled price beats parts plus tax."
+  history:
+    - date: "2006-07-31"
+      description: "Released with grappling crossbow mechanics for agility shortcuts."
+    - date: "2019-09-26"
+      description: "Hallowed Sepulchre and Shayzien Agility Course added grapple shortcuts that never break the bolt."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-crossbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-crossbow-u.mdx
@@ -12,12 +12,75 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 10000
-  about: "Mithril crossbow (u) is a members-only item in Old School RuneScape. High alchemy value: 450 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 54
+      xp: 64
+      materials:
+        - item_name: Maple stock
+          quantity: 1
+        - item_name: Mithril limbs
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Mithril crossbow
+      slug: mithril-crossbow
+      relationship: product
+      description: Strung crossbow created by adding a crossbow string at level 54 Fletching.
+    - item_name: Maple stock
+      slug: maple-stock
+      relationship: component
+      description: Wooden stock used to assemble the unstrung mithril crossbow.
+    - item_name: Mithril limbs
+      slug: mithril-limbs
+      relationship: component
+      description: Smithed limbs attached to the maple stock.
+    - item_name: Adamant crossbow (u)
+      slug: adamant-crossbow-u
+      relationship: upgrade
+      description: Higher tier unstrung crossbow.
+    - item_name: Steel crossbow (u)
+      slug: steel-crossbow-u
+      relationship: downgrade
+      description: Lower tier unstrung crossbow.
+  about: "Mithril crossbow (u) is the unstrung intermediate product when fletching a mithril crossbow. At Fletching level 54 a player combines a maple stock with mithril limbs (using a hammer) for 64 Fletching experience. Adding a crossbow string finishes the weapon for a further 32 experience. The unstrung crossbow itself cannot be wielded."
+  market_strategy:
+    notes:
+      - "Margin tied to the spread between mithril limbs, maple stock and finished crossbow."
+      - "Profit shifts during Fletching XP events when bulk crossbow training spikes."
+  trading_tips:
+    - Watch maple stock supply; cheap stocks make this recipe profitable.
+    - Bulk buying near the 10,000 limit allows steady fletching XP flips.
+  history:
+    - date: "2006-07-31"
+      description: Released alongside the rest of the crossbow Fletching expansion.
+    - date: "2014-12-10"
+      description: Renamed from "Mith c'bow (u)" to "Mithril crossbow (u)".
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-full-helm.mdx
@@ -12,24 +12,105 @@ osrs:
   lowalch: 572
   highalch: 858
   limit: 125
-  item_id: 1159
-  item_type: armor
-  slot: head
-  type: full_helm
-  tradeable: true
-  weight: 2.267
-  requirements:
-    defence: 20
-  stats:
-    stab_defence: 13
-    slash_defence: 14
-    crush_defence: 11
-    ranged_defence: 13
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: head
+    weight: 2.267
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 13
+      slash: 14
+      crush: 11
+      magic: -1
+      ranged: 13
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 57
+      xp: 100
+      materials:
+        - item_name: Mithril bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Peksa's Helmet Shop
+      location: Barbarian Village
+      price: 1430
+      currency: Coins
+      stock: 3
+    - shop_name: Skulgrimen's Battle Gear
+      location: Jatizso
+      price: 1573
+      currency: Coins
+      stock: 3
+    - shop_name: Aneirin's Armour
+      location: Prifddinas
+      price: 1430
+      currency: Coins
+      stock: 5
+  drop_table:
+    sources:
+      - source: Wall beast
+        quantity: "1"
+        rarity: 1/128
+      - source: Animated Mithril Armour
+        quantity: "1"
+        rarity: Always
   related_items:
-    - slug: adamant-full-helm
-    - slug: mithril-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Mithril med helm
+      slug: mithril-med-helm
+      relationship: downgrade
+      description: Medium helm with weaker defence
+    - item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: set-piece
+      description: Matching mithril body armour
+    - item_name: Adamant full helm
+      slug: adamant-full-helm
+      relationship: upgrade
+      description: Next tier full helm
+  about: "The mithril full helm is the fourth-best full helmet in OSRS, requiring 20 Defence to wear. Smithed from 2 mithril bars at level 57 Smithing for 100 XP. Offers better defensive stats than the mithril med helm at the cost of weight and minor magic/ranged attack penalties."
+  market_strategy:
+    notes:
+      - "Smithing margins vary — usually unprofitable to craft"
+      - "Steady demand from low-level F2P"
+      - "Shop-bought at Peksa's for arbitrage on busy worlds"
+  history:
+    - date: "2001-01-04"
+      description: Released with the original mithril armour set.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mokhaiotl-waystone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mokhaiotl-waystone.mdx
@@ -12,12 +12,54 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 100
-  about: "Mokhaiotl waystone is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magical
+    tier: high
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Channel
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  charges:
+    type: teleport
+    description: "Single-use teleport shard that transports the channeller directly to the Ruins of Mokhaiotl. Requires completion of The Final Dawn before it can be activated."
+  drop_table:
+    sources:
+      - source: Doom of Mokhaiotl
+        quantity: "1"
+        rarity: 7/104
+  related_items:
+    - item_name: Doom of Mokhaiotl
+      slug: doom-of-mokhaiotl
+      relationship: alternative
+      description: Boss whose drop table includes the waystone.
+  about: "Mokhaiotl waystone is a consumable teleportation shard introduced on 23 July 2025 with Varlamore: The Final Dawn. Dropped by the Doom of Mokhaiotl boss at a rate of 7/104 (with one to two rolled per drop), the waystone lets players skip the trek back to the Ruins of Mokhaiotl after completing The Final Dawn. The stackable, alchable nature plus a 100 GE buy limit makes it both a logistic shortcut and a modest gp sink."
+  market_strategy:
+    notes:
+      - "Supply tied to Doom of Mokhaiotl killcounts; price reacts to boss DPS meta shifts."
+      - "High alch (6,000 gp) provides a floor for active flippers."
+  trading_tips:
+    - Hold during raid update droughts when boss farming slows.
+    - 100 GE buy limit makes large flips slow but predictable.
+  history:
+    - date: "2025-07-23"
+      description: "Released with Varlamore: The Final Dawn and the Doom of Mokhaiotl boss fight."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-earth-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-earth-staff.mdx
@@ -12,9 +12,34 @@ osrs:
   lowalch: 17000
   highalch: 25500
   limit: 18000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mystic
+    tier: mid-high
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: weapon
+    weapon_type: staff
     attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
     attack_bonus:
       stab: 10
       slash: -1
@@ -32,57 +57,44 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 40
-      magic: 40
-    weight: 2.267
+  drop_table:
+    sources:
+      - source: Dust devil
+        quantity: "1"
+        rarity: 1/128
+      - source: Lizardman shaman
+        quantity: "1"
+        rarity: 17/500
+      - source: Corporeal Beast
+        quantity: "1"
+        rarity: 1/384
   related_items:
-    - item_id: 1403
-      item_name: Mystic water staff
+    - item_name: Mystic water staff
       slug: mystic-water-staff
       relationship: set-piece
       description: Water elemental mystic staff
-    - item_id: 1401
-      item_name: Mystic fire staff
+    - item_name: Mystic fire staff
       slug: mystic-fire-staff
       relationship: set-piece
       description: Fire elemental mystic staff
-    - item_id: 6563
-      item_name: Mystic mud staff
+    - item_name: Mystic mud staff
       slug: mystic-mud-staff
       relationship: upgrade
-      description: Water+Earth combination staff
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +14 |
-    | Crush | +40 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +14 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +50 |
-
-    Requirements: 40 Attack, 40 Magic
-
-    Provides unlimited earth runes. Useful for:
-    - Earth spells (Earth Blast through Earth Surge)
-    - Bones to Bananas/Peaches — requires earth runes
-    - Charge Earth Orb — saves earth runes
-    - Autocast with standard spellbook
-
-    Earth runes are among the cheapest runes, so the cost-saving benefit is modest compared to fire or water staves. The primary use case is convenience — not needing to carry earth runes in the inventory.
+      description: Water plus Earth combination staff
+    - item_name: Earth battlestaff
+      slug: earth-battlestaff
+      relationship: downgrade
+      description: Unenchanted base staff used in upgrade
+  about: "The mystic earth staff is created by Thormac the Sorcerer after the Scorpion Catcher quest, costing 40,000 coins plus an earth battlestaff. It provides unlimited earth runes and autocasts standard spellbook magic. Requires 40 Attack and 40 Magic to equip."
   market_strategy:
     notes:
-      - Thormac upgrade profitable with diary discounts
-      - High volume item — popular alch target
-      - GE price tracks near high alch value
-      - Least practical of the elemental mystic staves
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Thormac upgrade profitable with diary discounts"
+      - "High volume item — popular alch target"
+      - "GE price tracks near high alch value"
+      - "Least practical of the elemental mystic staves"
+  history:
+    - date: "2002-03-25"
+      description: Released alongside the Scorpion Catcher quest and Thormac's enchantment service.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-fire-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-fire-staff.mdx
@@ -12,9 +12,34 @@ osrs:
   lowalch: 17000
   highalch: 25500
   limit: 18000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mystic
+    tier: mid-high
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: weapon
+    weapon_type: staff
     attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
     attack_bonus:
       stab: 10
       slash: -1
@@ -32,66 +57,26 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 40
-      magic: 40
-    weight: 2.267
   related_items:
-    - item_id: 1403
-      item_name: Mystic water staff
+    - item_name: Mystic water staff
       slug: mystic-water-staff
-      relationship: set-piece
+      relationship: variant
       description: Water elemental mystic staff
-    - item_id: 1407
-      item_name: Mystic earth staff
+    - item_name: Mystic earth staff
       slug: mystic-earth-staff
-      relationship: set-piece
+      relationship: variant
       description: Earth elemental mystic staff
-    - item_id: 3054
-      item_name: Mystic lava staff
+    - item_name: Mystic lava staff
       slug: mystic-lava-staff
       relationship: upgrade
-      description: Earth+Fire combination staff
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +14 |
-    | Crush | +40 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +14 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +50 |
-
-    Requirements: 40 Attack, 40 Magic
-
-    Provides unlimited fire runes — the most universally useful elemental staff:
-    - High Level Alchemy — saves 5 fire runes per cast (most popular use)
-    - Superheat Item — saves 4 fire runes per cast
-    - All fire spells — saves runes for combat magic
-    - Autocast with standard spellbook
-
-    | Staff | Element | Notable Use |
-    |-------|---------|-------------|
-    | Mystic fire | Fire | High Alch, fire spells |
-    | Mystic water | Water | Water spells, ice barrage combo |
-    | Mystic earth | Earth | Earth spells |
-    | Mystic air | Air | Air spells, Charge Orb |
-    | Mystic mud | Water+Earth | Lunar spells, barrage |
-    | Mystic lava | Earth+Fire | Superheat, Enchant |
-
-    All share identical stats (+14 magic atk/def, +40 crush, +50 str). The difference is which rune(s) they provide.
+      description: Earth and Fire combination staff
+  about: "Mystic fire staff is a members magic weapon requiring 40 Attack and 40 Magic to wield. It provides an unlimited supply of fire runes, making it ideal for High Level Alchemy, Superheat Item, and all fire-based combat spells. It shares the +14 magic attack/defence, +40 crush, and +50 melee strength stats with every other mystic elemental staff."
   market_strategy:
     notes:
-      - Thormac upgrade profitable with diary discounts
-      - Multiple boss drop sources
-      - Most popular mystic staff due to fire rune utility
-      - High volume — frequently alched
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Thormac upgrade profitable with diary discounts"
+      - "Multiple boss drop sources"
+      - "Most popular mystic staff due to fire rune utility"
+      - "High volume frequently alched"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pestle-and-mortar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pestle-and-mortar.mdx
@@ -12,13 +12,69 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 40
-  related_items: []
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Jatix's Herblore Shop
+      location: Taverley
+      price: 4
+      currency: coins
+      stock: 5
+    - shop_name: Myths' Guild Herbalist
+      location: Myths' Guild
+      price: 4
+      currency: coins
+      stock: 5
+    - shop_name: Prifddinas Herbal Supplies
+      location: Prifddinas
+      price: 4
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Mortar and pestle
+      slug: mortar-and-pestle
+      relationship: alternative
+      description: Identical-function variant
+    - item_name: Vial
+      slug: vial
+      relationship: component
+      description: Companion Herblore tool
   about: |-
     > _"I can grind things for potions in this."_
 
-    The pestle and mortar is an essential Herblore tool used to crush ingredients into powders and pastes. Required for 20+ quests. Auto-grinds all matching items in inventory when used. Cannot be stored in a tool belt.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The pestle and mortar is an essential Herblore tool used to crush ingredients into powders and pastes. Required for 20+ quests. Auto-grinds matching items in inventory every 3 ticks, eliminating manual repetition. Cannot be stored in a tool belt.
+  market_strategy:
+    notes:
+      - "Universal Herblore tool demand"
+      - "Shop price 4gp anchors floor"
+      - "Buy limit 40 caps speculation"
+      - "Quest requirement broad demand"
+      - "Stable low-value commodity"
+  trading_tips:
+    - Margins are minimal vs shop
+    - Most players buy from shop, not GE
+    - Volume tied to Herblore training streams
+  history:
+    - date: "2002-02-27"
+      description: Released with Herblore skill.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pile-of-salt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pile-of-salt.mdx
@@ -12,9 +12,30 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 15
-  about: "Pile of salt is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2005-04-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+  related_items:
+    - item_name: Bucket of saltwater
+      slug: bucket-of-saltwater
+      relationship: component
+      description: Saltwater is dried on a suntrap to produce piles of salt during Icthlarin's Little Helper.
+    - item_name: Bag of salt
+      slug: bag-of-salt
+      relationship: alternative
+      description: Slayer item used to finish off rockslugs; pile of salt cannot substitute for it.
+  about: "Pile of salt is a quest item created during Icthlarin's Little Helper by drying a bucket of saltwater on the suntrap in Sophanem. Although the item can be traded on the Grand Exchange with a strict limit of 15 per four hours, it has no use outside the quest sequence and cannot substitute for a bag of salt when fighting rockslugs. The Spice Is Right in Sophanem will also sell piles of salt at 30 coins each."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-robe-top.mdx
@@ -12,25 +12,83 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 150
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fine Fashions
+      location: Grand Tree, Tree Gnome Stronghold
+      price: 180
+      currency: coins
+      stock: 3
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 626
-      item_name: Pink boots
+    - item_name: Pink boots
       slug: pink-boots
       relationship: set-piece
       description: Matching boots
-    - item_id: 646
-      item_name: Pink robe bottoms
+    - item_name: Pink robe bottoms
       slug: pink-robe-bottoms
       relationship: set-piece
       description: Matching bottoms
-  about: |-
-    > _"A pink robe top."_
-
-    The pink robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Blue robe top
+      slug: blue-robe-top
+      relationship: variant
+      description: Blue colour gnome robe variant
+    - item_name: Green robe top
+      slug: green-robe-top
+      relationship: variant
+      description: Green colour gnome robe variant
+  about: "Pink robe top is a cosmetic gnome-themed body slot item sold by Heckel Funch at Fine Fashions in the Grand Tree (Tree Gnome Stronghold) for 180 coins. Carries only minor +2 slash and crush defence and otherwise no combat bonuses. Can also be received from easy Treasure Trails emote clues. Part of the gnome robes set with blue, cream, green, pink, and turquoise variants."
+  market_strategy:
+    notes:
+      - "Vendor-capped supply via Fine Fashions"
+      - "Demand from fashionscape gnome sets"
+      - "150 GE buy limit keeps flipping margins thin"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/potato-cactus.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/potato-cactus.mdx
@@ -12,58 +12,83 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: herblore-secondary
+    tier: mid
   properties:
+    release_date: "2004-09-07"
     tradeable: true
-    tradeable_ge: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.5
-  skilling_sources:
+    options:
+      - Drop
+    alchable: false
+    destroy: "How am I supposed to eat that?!"
+  drop_table:
+    sources:
+      - source: Kalphite Queen
+        quantity: "100"
+        rarity: Common (noted)
+      - source: Undead Druid
+        quantity: "1"
+        rarity: Uncommon
+      - source: Tombs of Amascut chest
+        quantity: "1"
+        rarity: Common (noted)
+  recipes:
     - skill: farming
       level: 64
-      xp: 25
-  recipes:
+      xp: 68
+      materials:
+        - item_name: Cactus seed
+          quantity: 1
+      tools:
+        - Seed dibber
+        - Cactus patch
+      output_quantity: 1
     - skill: herblore
       level: 76
       xp: 172.5
       materials:
         - item_name: Lantadyme potion (unf)
-          item_id: 2483
           quantity: 1
         - item_name: Potato cactus
-          item_id: 3138
           quantity: 1
-      product: Magic potion(3)
-      product_id: 3040
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 3040
-      item_name: Magic potion(4)
-      slug: magic-potion-4
+    - item_name: Magic potion(3)
+      slug: magic-potion-3
       relationship: product
-      description: Primary use
-    - item_id: 2481
-      item_name: Lantadyme
-      slug: lantadyme
+      description: Primary Herblore product made with potato cactus.
+    - item_name: Lantadyme potion (unf)
+      slug: lantadyme-potion-unf
       relationship: component
-      description: Partner herb
-    - item_id: 5280
-      item_name: Cactus seed
+      description: Partner unfinished potion for magic potions.
+    - item_name: Cactus seed
       slug: cactus-seed
       relationship: component
-      description: Farming source
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.5 kg |
-
-    Secondary ingredient for:
-    - Magic potion (with lantadyme potion unf)
-    - Celastrus seed protection (8 cacti)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Farming source planted in cactus patches.
+    - item_name: Battlemage potion(3)
+      slug: battlemage-potion-3
+      relationship: product
+      description: Alternate product using cadantine + potato cactus.
+  about: "Potato cactus is a Herblore secondary harvested from cactus farming patches at Farming level 64 or looted from Kalphite Lair spawns and various boss drop tables. Players combine it with a lantadyme potion (unf) at Herblore level 76 for 172.5 experience to make a magic potion(3), and also use it as the secondary in battlemage potions. Released 7 September 2004 alongside the cactus farming patch update."
+  market_strategy:
+    notes:
+      - "Bulk supply driven by Kalphite Queen and Tombs of Amascut noted drops."
+      - "Demand scales with magic potion and battlemage potion consumption at Nightmare/PvP."
+  trading_tips:
+    - Track lantadyme potion (unf) vs magic potion(3) spread - potato cactus margin moves with it.
+  history:
+    - date: "2004-09-07"
+      description: Added with the cactus farming patch and magic potion Herblore recipe.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pottery-statuette.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pottery-statuette.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
-  about: "Pottery statuette is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: pottery
+    tier: low
+  properties:
+    release_date: "2006-07-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "You can get another from Pyramid Plunder."
+  drop_table:
+    sources:
+      - source: Pyramid Plunder sarcophagus (Room 1)
+        quantity: "1"
+        rarity: 1/2
+      - source: Pyramid Plunder sarcophagus (Room 2)
+        quantity: "1"
+        rarity: 1/2
+      - source: Pyramid Plunder sarcophagus (Room 3)
+        quantity: "1"
+        rarity: 1/4
+  shops:
+    - shop_name: Simon Templeton
+      location: Agility Pyramid
+      price: 100
+      currency: Coins
+      stock: 0
+  related_items:
+    - item_name: Pharaoh's sceptre
+      slug: pharaohs-sceptre
+      relationship: product
+      description: Recharged with 24 pottery statuettes
+    - item_name: Pottery scarab
+      slug: pottery-scarab
+      relationship: alternative
+      description: Another Pyramid Plunder artefact
+  about: "Pottery statuette is an artefact obtained through the Pyramid Plunder minigame by looting sarcophagi at three difficulty levels. It can be sold to Simon Templeton at the Agility Pyramid for 100 coins, or used in sets of 24 to recharge the Pharaoh's sceptre. Requires 21/31/41 Thieving depending on room."
+  market_strategy:
+    notes:
+      - "Common Pyramid Plunder drop"
+      - "Used to recharge Pharaoh's sceptre"
+      - "High buy limit reflects high supply"
+  history:
+    - date: "2006-07-17"
+      description: Released with the Pyramid Plunder minigame.
+    - date: "2015-02-26"
+      description: Made tradeable on the Grand Exchange.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-wiz-blz-d.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-wiz-blz-d.mdx
@@ -1,6 +1,6 @@
 ---
 title: Premade wiz blz'd | OSRS Price Data
-description: "Premade wiz blz'd: A Premade Wizard Blizzard.. High alch: 18 GP, GE limit: 2,000."
+description: "Premade wiz blz'd: A Premade Wizard Blizzard. High alch: 18 GP, GE limit: 2,000."
 osrs:
   id: 2040
   name: Premade wiz blz'd
@@ -12,9 +12,68 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Premade wiz blz'd is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: consumable
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Blurberry Bar
+      location: Grand Tree
+      price: 30
+      currency: coins
+      stock: 10
+    - shop_name: Blurberry Bar
+      location: Gnome Stronghold
+      price: 30
+      currency: coins
+      stock: 10
+  potion:
+    effects:
+      - description: "Restores 5 Hitpoints"
+        duration: 0
+      - description: "Boosts Strength by 6% + 1 levels"
+        duration: 0
+      - description: "Reduces Attack by 2% + 3 levels"
+        duration: 0
+  related_items:
+    - item_name: Wizard blizzard
+      slug: wizard-blizzard
+      relationship: variant
+      description: Player-made version of the cocktail
+    - item_name: Premade choc saturday
+      slug: premade-choc-saturday
+      relationship: alternative
+      description: Another Blurberry Bar premade cocktail
+  about: "Premade wiz blz'd is a pre-mixed Wizard Blizzard cocktail sold at the Blurberry Bar inside the Grand Tree and Gnome Stronghold. When drunk it restores 5 Hitpoints, boosts Strength by 6% + 1 levels and reduces Attack by 2% + 3 levels, making it a niche budget Strength boost for certain F2P-adjacent training scenarios. Originally released as 'Wizard blizzard' in 2002, it was renamed to its current short form during the 2006 Gnome Cuisine update."
+  market_strategy:
+    notes:
+      - "Shop-bought item with a soft ceiling around the 30 gp store price"
+      - "Occasional demand spikes from low-level Strength boost users"
+      - "Low margin flipping but steady volume"
+  trading_tips:
+    - Buy from Blurberry Bar at 30 gp when GE prices spike
+    - Bulk flip near the 2,000 buy limit for thin steady margins
+    - Watch for content updates that reference the Strength boost
+  history:
+    - date: "2002-12-12"
+      description: "Added to the game as 'Wizard blizzard'."
+    - date: "2006-08-07"
+      description: "Renamed to 'Premade wiz blz'd' as part of the Gnome Cuisine update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-harness-f.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-harness-f.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 70
-  about: "Proselyte harness f is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour set
+    tier: mid
+  properties:
+    release_date: "2006-09-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 14.514
+    options: ["Unpack", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Proselyte sallet
+      slug: proselyte-sallet
+      relationship: set-piece
+      description: Head slot piece (female variant).
+    - item_name: Proselyte hauberk
+      slug: proselyte-hauberk
+      relationship: set-piece
+      description: Body slot piece.
+    - item_name: Proselyte tasset
+      slug: proselyte-tasset
+      relationship: set-piece
+      description: Legs slot piece (female variant).
+    - item_name: Proselyte harness m
+      slug: proselyte-harness-m
+      relationship: alternative
+      description: Male-cut variant of the same pack.
+  about: "Proselyte harness f packs the female-cut Proselyte armour pieces (sallet, hauberk, tasset) into a single tradeable bundle from the Grand Exchange Sets clerk. Useful when transferring a complete Proselyte kit between accounts without juggling individual slots."
+  market_strategy:
+    notes:
+      - "Compare set GE price to sum of individual pieces to spot arbitrage."
+      - "Demand tracks low-level Prayer-bonus tank gearing."
+  history:
+    - date: "2006-09-20"
+      description: Released alongside the Proselyte armour set.
+    - date: "2014-12-10"
+      description: Renamed from "Pros'yte harness f" to "Proselyte harness f".
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rainbow-fish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rainbow-fish.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rainbow fish | OSRS Price Data
-description: "Rainbow fish: Well, this would certainly add some colour to a meal.. High alch: 72 GP, GE limit: 6,000."
+description: "Rainbow fish: Well, this would certainly add some colour to a meal. High alch: 72 GP, GE limit: 6,000."
 osrs:
   id: 10136
   name: Rainbow fish
@@ -12,12 +12,62 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 6000
-  about: "Rainbow fish is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: fish
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options: ["Eat", "Drop"]
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: cooking
+      level: 35
+      xp: 110
+      materials:
+        - item_name: Raw rainbow fish
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Raw rainbow fish
+      slug: raw-rainbow-fish
+      relationship: component
+      description: Uncooked source caught from gourmet impling jars
+    - item_name: Burnt rainbow fish
+      slug: burnt-rainbow-fish
+      relationship: alternative
+      description: Failure result when cooking below level 63
+    - item_name: Gourmet impling jar
+      slug: gourmet-impling-jar
+      relationship: component
+      description: Jar that can contain a rainbow fish
+  about: "Rainbow fish is a members-only cooked food made by cooking a raw rainbow fish at level 35 Cooking for 110 experience. It heals 11 hitpoints when eaten and stops burning at level 63 Cooking on a fire or range. The raw form is obtained from gourmet implings, making rainbow fish a niche but solid early-to-mid game cooking method for players hunting implings."
+  market_strategy:
+    notes:
+      - "Cooking training food with 110 XP per fish"
+      - "Supply tied to gourmet impling hunting"
+      - "6,000 GE buy limit makes bulk flips viable"
+      - "High alch only 72 GP - not an alch candidate"
+  trading_tips:
+    - Watch impling spawn updates - they can shift supply quickly
+    - Cooking training spikes can move price short term
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill rework that added implings.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-barb-tailed-kebbit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-barb-tailed-kebbit.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw barb-tailed kebbit is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: raw-food
+    tier: low
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Barb-tailed kebbit (Hunter)
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - skill: cooking
+      level: 32
+      xp: 106
+      materials:
+        - item_name: Raw barb-tailed kebbit
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Cooked barb-tailed kebbit
+      slug: cooked-barb-tailed-kebbit
+      relationship: product
+      description: Cooked version of this raw meat
+    - item_name: Quetzal whistle
+      slug: quetzal-whistle
+      relationship: alternative
+      description: Trade to Soar Leader Pitri for whistle charges
+  about: "Raw barb-tailed kebbit is caught while hunting barb-tailed kebbits in the Kandarin area at level 33 Hunter. It can be cooked at level 32 Cooking for 106 XP, used in various herblore butterfly mixes, or exchanged with Soar Leader Pitri for quetzal whistle charges."
+  market_strategy:
+    notes:
+      - "Supply spikes during Hunter training surges"
+      - "Stable demand from herblore mixers"
+      - "Quetzal whistle exchange creates a price floor"
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bear-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bear-meat.mdx
@@ -12,9 +12,95 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw bear meat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: raw-food
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.425
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Bear
+        quantity: "1"
+        rarity: Always
+      - source: Black bear
+        quantity: "1"
+        rarity: Always
+      - source: Grizzly bear
+        quantity: "1"
+        rarity: Always
+      - source: Grizzly bear cub
+        quantity: "1"
+        rarity: Always
+      - source: Polar bear
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw bear meat
+          quantity: 1
+      tools: ["Fire or range"]
+      output_quantity: 1
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Raw bear meat
+          quantity: 1
+      tools: ["Range"]
+      output_quantity: 1
+  shops:
+    - shop_name: Rufus's Meat Emporium
+      location: Canifis
+      price: 1
+      currency: coins
+      stock: 10
+  related_items:
+    - item_name: Bear meat
+      slug: bear-meat
+      relationship: product
+      description: Cooked output of raw bear meat at Cooking level 1.
+    - item_name: Burnt meat
+      slug: burnt-meat
+      relationship: alternative
+      description: Result of failing to cook the raw bear meat.
+    - item_name: Sinew
+      slug: sinew
+      relationship: product
+      description: Crafting material made by cooking raw bear meat on a range.
+    - item_name: Wild pie
+      slug: wild-pie
+      relationship: product
+      description: High-level pie that requires bear meat as an ingredient.
+  about: "Raw bear meat is a free-to-play food drop from the various bear species across Gielinor, used in the Druidic Ritual quest and as a low-level Cooking ingredient. Once cooked at level 1 Cooking it yields bear meat that heals modestly, and at higher levels it appears as part of the wild pie recipe alongside other exotic meats."
+  market_strategy:
+    notes:
+      - "Steady free-to-play supply from bears keeps the market saturated and prices near vendor value."
+      - "Buy limit of 13,000 lets bulk buyers stock cooking training sessions in one go."
+      - "Demand spikes lightly around Druidic Ritual completion seasons for new members."
+  trading_tips:
+    - "Buy in 1k+ batches for cooking XP and resell cooked bear meat for small margins."
+    - "Skip Grand Exchange when Rufus's Meat Emporium has stock at 1 coin per piece."
+  history:
+    - date: "2001-01-04"
+      description: "Released as part of the original Cooking and combat drop tables."
+    - date: "2002-02-27"
+      description: "Druidic Ritual added, giving the raw meat a notable quest use as an enchanted bear ingredient."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-t-bone-steak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-t-bone-steak.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
-  about: "Raw t-bone steak is a free-to-play item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: raw-food
+    tier: low
+  properties:
+    release_date: "2026-02-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    alchable: true
+  recipes:
+    - skill: cooking
+      level: 13
+      xp: 90
+      materials:
+        - item_name: Raw t-bone steak
+          quantity: 1
+      tools:
+        - Fire
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Brutus
+        quantity: "1"
+        rarity: Always
+      - source: Brutus
+        quantity: "1"
+        rarity: 10/81
+  related_items:
+    - item_name: T-bone steak
+      slug: t-bone-steak
+      relationship: product
+      description: Cooked version that heals 9 hitpoints and grants a +2 Strength boost.
+    - item_name: Burnt t-bone steak
+      slug: burnt-t-bone-steak
+      relationship: alternative
+      description: Failed cook result when burning a raw t-bone steak.
+  about: "Raw t-bone steak is a free-to-play raw food dropped by Brutus, the upgraded chicken boss encountered after the rework. It requires level 13 Cooking to prepare on a fire or range, granting 90 Cooking experience per successful cook and producing a t-bone steak that heals nine hitpoints with a small Strength boost. The 13,000-per-four-hours Grand Exchange limit keeps the supply liquid for low-level cooks chasing fast experience."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-boater.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "Red boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Black boater
+      slug: black-boater
+      relationship: variant
+      description: Black colour variant
+    - item_name: Blue boater
+      slug: blue-boater
+      relationship: variant
+      description: Blue colour variant
+    - item_name: Green boater
+      slug: green-boater
+      relationship: variant
+      description: Green colour variant
+    - item_name: Orange boater
+      slug: orange-boater
+      relationship: variant
+      description: Orange colour variant
+    - item_name: Pink boater
+      slug: pink-boater
+      relationship: variant
+      description: Pink colour variant
+    - item_name: Purple boater
+      slug: purple-boater
+      relationship: variant
+      description: Purple colour variant
+    - item_name: White boater
+      slug: white-boater
+      relationship: variant
+      description: White colour variant
+  about: "Red boater is a cosmetic head slot item awarded from medium-tier Treasure Trails, specifically tied to a Master emote clue at Castle Drakan. It provides no combat bonuses and is purely fashion. Available in eight colour variants (black, blue, green, orange, red, pink, purple, white) and can be stored in the costume room of a player-owned house."
+  market_strategy:
+    notes:
+      - "Tiny GE buy limit of 4 drives thin liquidity"
+      - "Medium clue cosmetic, demand driven by fashionscape"
+      - "All boater colours are functionally identical"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-feather.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red feather | OSRS Price Data
-description: "Red feather: A vivid red feather.. High alch: 6 GP, GE limit: 8,000."
+description: "Red feather is a members hunter and fletching material. High alch: 6 GP, GE limit: 8,000."
 osrs:
   id: 10088
   name: Red feather
@@ -12,9 +12,64 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 8000
-  about: "Red feather is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: feather
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  shops:
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 13
+      currency: coins
+      stock: 0
+  drop_table:
+    sources:
+      - source: Crimson swift (Hunter)
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Feather
+      slug: feather
+      relationship: alternative
+      description: Standard white feather used for fletching and fly fishing
+    - item_name: Blue feather
+      slug: blue-feather
+      relationship: variant
+      description: Coloured feather from Tropical wagtail
+    - item_name: Yellow feather
+      slug: yellow-feather
+      relationship: variant
+      description: Coloured feather from Cerulean twitch
+  about: "Red feather is a members-only hunter drop obtained by catching crimson swifts in the Feldip Hunter area, yielding 5-10 feathers per catch at level 1 Hunter. It substitutes for white feathers when fletching arrows, though the finished arrows retain their default appearance. Unlike standard feathers, red feathers cannot be used for fly fishing, limiting their practical role. The Fancy Clothes Store in Varrock both stocks and buys them for cosmetic crafting."
+  market_strategy:
+    notes:
+      - "Supply driven by Hunter training at crimson swifts"
+      - "Niche fletching substitute keeps demand thin"
+      - "Buy limit 8000 enables bulk plays"
+      - "Margins are tight due to low base price"
+  trading_tips:
+    - Flip in bulk for thin per-unit gains
+    - Watch Hunter XP updates for supply shocks
+    - Pair with arrow fletching restocks
+  history:
+    - date: "2006-11-21"
+      description: Added with the introduction of Hunter and crimson swifts.
+    - date: "2007-07-09"
+      description: Visual update following the crimson swift graphical refresh.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-headband.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-headband.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 4
-  about: "Red headband is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic-headwear
+    tier: low
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.04
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Blue headband
+      slug: blue-headband
+      relationship: variant
+      description: Alternate colour reward from hard clue scrolls.
+    - item_name: Black headband
+      slug: black-headband
+      relationship: variant
+      description: Another colour variant of this cosmetic.
+    - item_name: Brown headband
+      slug: brown-headband
+      relationship: variant
+      description: Another colour variant of this cosmetic.
+  about: "The red headband is a cosmetic head slot item awarded from hard treasure trails as an emote clue reward when players perform the Panic emote south of the bridge on the Blighted Volcano. It offers no combat bonuses and is members-only. A low GE buy limit of 4 reflects its status as a rare clue reward. Released 5 May 2004."
+  market_strategy:
+    notes:
+      - "Cosmetic clue reward; price tied to clue completion volume."
+      - "GE limit of 4 makes large flips impractical; treat as long hold."
+  history:
+    - date: "2004-05-05"
+      description: Added as a Treasure Trails emote clue reward.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/revenant-ether.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/revenant-ether.mdx
@@ -12,96 +12,101 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 30000
-  item_type: currency
-  stackable: true
-  tradeable: true
-  members_only: true
-  uses:
-    - type: charging
-      items:
-        - item_id: 22550
-          item_name: Craw's bow
-        - item_id: 22545
-          item_name: Viggora's chainmace
-        - item_id: 22555
-          item_name: Thammaron's sceptre
-        - item_id: 27655
-          item_name: Webweaver bow
-        - item_id: 27660
-          item_name: Ursine chainmace
-        - item_id: 27665
-          item_name: Accursed sceptre
-        - item_id: 21816
-          item_name: Bracelet of ethereum
-  obtaining:
-    methods:
-      - source: Revenants
-        location: Revenant Caves
-        drop_rate: Always
-      - source: Ancient artefacts
-        method: Use chisel (1 ether per 500 coins value)
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: currency
+    tier: high
+  properties:
+    release_date: "2017-11-23"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Revenant imp
+        quantity: "1"
+        rarity: Always
+      - source: Revenant goblin
+        quantity: "1"
+        rarity: Always
+      - source: Revenant icefiend
+        quantity: "1"
+        rarity: Always
+      - source: Revenant pyrefiend
+        quantity: "1"
+        rarity: Always
+      - source: Revenant hobgoblin
+        quantity: "1"
+        rarity: Always
+      - source: Revenant cyclops
+        quantity: "1"
+        rarity: Always
+      - source: Revenant hellhound
+        quantity: "1"
+        rarity: Always
+      - source: Revenant demon
+        quantity: "1"
+        rarity: Always
+      - source: Revenant ork
+        quantity: "1"
+        rarity: Always
+      - source: Revenant dark beast
+        quantity: "1"
+        rarity: Always
+      - source: Revenant knight
+        quantity: "1"
+        rarity: Always
+      - source: Revenant dragon
+        quantity: "1"
+        rarity: Always
   related_items:
-    - item_id: 22550
-      item_name: Craw's bow
+    - item_name: Craw's bow
       slug: craws-bow
-      relationship: variant
-      description: Uses ether for charges
-    - item_id: 22545
-      item_name: Viggora's chainmace
+      relationship: product
+      description: Charged using revenant ether
+    - item_name: Webweaver bow
+      slug: webweaver-bow
+      relationship: product
+      description: Upgraded Craw's bow, also ether fuelled
+    - item_name: Viggora's chainmace
       slug: viggoras-chainmace
-      relationship: variant
-      description: Uses ether for charges
-    - item_id: 22555
-      item_name: Thammaron's sceptre
+      relationship: product
+      description: Wilderness mace charged with ether
+    - item_name: Ursine chainmace
+      slug: ursine-chainmace
+      relationship: product
+      description: Upgraded chainmace, also ether fuelled
+    - item_name: Thammaron's sceptre
       slug: thammarons-sceptre
-      relationship: variant
-      description: Uses ether for charges
-    - item_id: 21816
-      item_name: Bracelet of ethereum
+      relationship: product
+      description: Wilderness sceptre charged with ether
+    - item_name: Accursed sceptre
+      slug: accursed-sceptre
+      relationship: product
+      description: Upgraded sceptre, also ether fuelled
+    - item_name: Bracelet of ethereum
       slug: bracelet-of-ethereum
-      relationship: variant
-      description: Uses ether for charges
-    - item_id: 22557
-      item_name: Amulet of avarice
-      slug: amulet-of-avarice
-      relationship: alternative
-      description: Revenant amulet
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Currency |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    Charges Wilderness Weapons:
-    - Craw's bow
-    - Viggora's chainmace
-    - Thammaron's sceptre
-    - Webweaver bow
-    - Ursine chainmace
-    - Accursed sceptre
-
-    Charges Bracelet of Ethereum:
-    - Provides revenant protection
-    - 1 charge consumed per revenant attack
-
-    | Weapon | Activation | Max Charges |
-    |--------|------------|-------------|
-    | Craw's bow | 1,000 | 17,000 |
-    | Viggora's chainmace | 1,000 | 17,000 |
-    | Thammaron's sceptre | 1,000 | 17,000 |
-    | Webweaver bow | 1,000 | 17,000 |
-    | Ursine chainmace | 1,000 | 17,000 |
-    | Accursed sceptre | 1,000 | 17,000 |
-    | Bracelet of ethereum | 1 | 16,000 |
+      relationship: product
+      description: Stores ether to absorb revenant aggression damage
+  about: "Revenant ether is the always-dropped currency of every revenant in the Revenant Caves, used to charge wilderness-exclusive weapons (Craw's bow, Viggora's chainmace, Thammaron's sceptre and their upgrades) plus the Bracelet of ethereum. Players can also turn ancient artefacts into ether with a chisel at one ether per 500 coins of artefact value. Ether is always dropped on death in the Wilderness, even when stored as weapon charges."
   market_strategy:
     notes:
-      - Always dropped by revenants
-      - Essential for wilderness weapons
-      - High daily volume traded
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Charge cost moves with ether GE price, not weapon price"
+      - "Buy on revenant-killing days, sell during PvM events"
+      - "Ornate undead combat dummy bulk-burns 500 ether"
+  history:
+    - date: "2017-11-23"
+      description: Released with the Revenant Caves rework as the new charging currency.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-seed.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 200
-  about: "Rosewood seed is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: seed
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Plant this in a plantpot of soil to grow a sapling."
+  recipes:
+    - skill: farming
+      level: 92
+      xp: 252
+      materials:
+        - item_name: Rosewood seed
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Stingray
+        quantity: "1"
+        rarity: 1/400
+      - source: Orca
+        quantity: "1"
+        rarity: 1/1840
+      - source: Spined kraken
+        quantity: "1"
+        rarity: 1/2180
+      - source: Fremennik salvage (Sailing)
+        quantity: "1"
+        rarity: 1/2670
+  related_items:
+    - item_name: Rosewood sapling
+      slug: rosewood-sapling
+      relationship: product
+      description: Grown from a rosewood seedling
+    - item_name: Rosewood logs
+      slug: rosewood-logs
+      relationship: product
+      description: Harvested from a mature rosewood tree
+  about: "Rosewood seed is a high-tier Farming seed planted in a plantpot of soil at 92 Farming to grow a rosewood sapling, which can be transplanted into a hardwood tree patch. A fully grown tree produces rosewood logs used in higher-end Construction and crafting recipes."
+  market_strategy:
+    notes:
+      - "High-level Farming seed with niche but steady hardwood demand"
+      - "Limited supply tied to Sailing salvage and aquatic monster drops"
+  history:
+    - date: "2025-11-19"
+      description: Rosewood seed added with the Sailing skill release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-amulet.mdx
@@ -12,51 +12,82 @@ osrs:
   lowalch: 810
   highalch: 1215
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ruby
+    tier: mid
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
+    weight: 0.007
     requirements:
       crafting: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 50
       xp: 85
-      inputs:
-        - item_name: Ruby
+      materials:
+        - item_name: Ruby amulet (u)
           quantity: 1
-        - item_name: Gold bar
+        - item_name: Ball of wool
           quantity: 1
+      tools: []
       output_quantity: 1
   related_items:
-    - item_id: 1696
-      item_name: Emerald amulet
+    - item_name: Emerald amulet
       slug: emerald-amulet
       relationship: downgrade
       description: Previous tier amulet
-    - item_id: 1700
-      item_name: Diamond amulet
+    - item_name: Diamond amulet
       slug: diamond-amulet
       relationship: upgrade
       description: Next tier amulet
-  about: |-
-    Crafting (Level 50): Ruby + Gold bar at a furnace with amulet mould (85 XP). String with ball of wool.
-
-    > *"A ruby amulet."*
-
-    Lvl-3 Enchant (49 Magic): 1 cosmic rune + 5 fire runes (59 XP)
-
-    The Amulet of strength provides +10 melee Strength — the best F2P Strength amulet. Essential for:
-    - F2P melee training (highest Strength bonus available)
-    - Budget P2P training before glory/fury
-    - F2P PKing
-
-    In F2P, the amulet of strength is best-in-slot for melee Strength bonus. Combined with a rune scimitar, it's the core F2P melee setup.
+    - item_name: Amulet of strength
+      slug: amulet-of-strength
+      relationship: product
+      description: Enchanted with Lvl-3 Enchant for +10 Strength bonus
+  about: "Ruby amulet is crafted by stringing an unstrung ruby amulet with a ball of wool, granting 4 Crafting experience. The unstrung amulet is created at a furnace from a ruby, gold bar, and amulet mould at level 50 Crafting (85 XP). When enchanted with Lvl-3 Enchant (49 Magic, 1 cosmic + 5 fire runes), it becomes the Amulet of strength providing +10 melee Strength — the best F2P Strength amulet."
   market_strategy:
     notes:
-      - High F2P demand — BiS Strength amulet for free players
-      - Popular crafting/enchanting training
-      - Cheap to make
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "High F2P demand for Amulet of strength conversion"
+      - "Popular crafting and enchanting training item"
+      - "Cheap to produce"
+  history:
+    - date: "2001-05-08"
+      description: Released with the introduction of jewellery crafting.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-ring.mdx
@@ -12,53 +12,87 @@ osrs:
   lowalch: 810
   highalch: 1215
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gold
+    tier: mid
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: ring
+    weight: 0.006
     requirements:
       crafting: 34
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 34
       xp: 70
-      inputs:
-        - item_id: 1660
-          item_name: Ruby
+      materials:
+        - item_name: Gold bar
           quantity: 1
-        - item_id: 2357
-          item_name: Gold bar
+        - item_name: Ruby
           quantity: 1
+      tools:
+        - Furnace
+        - Ring mould
       output_quantity: 1
   related_items:
-    - item_id: 1639
-      item_name: Emerald ring
+    - item_name: Emerald ring
       slug: emerald-ring
       relationship: downgrade
-      description: Previous tier ring
-    - item_id: 1643
-      item_name: Diamond ring
+      description: Previous tier crafting ring
+    - item_name: Diamond ring
       slug: diamond-ring
       relationship: upgrade
-      description: Next tier ring
-    - item_id: 2568
-      item_name: Ring of forging
+      description: Next tier crafting ring
+    - item_name: Ring of forging
       slug: ring-of-forging
       relationship: upgrade
-      description: Enchanted version (100% smelt success)
-  about: |-
-    Crafting (Level 34): Ruby + Gold bar at a furnace (70 XP)
-
-    > *"A ruby ring."*
-
-    Lvl-3 Enchant (49 Magic): 1 cosmic rune + 5 fire runes (59 XP)
-
-    The Ring of forging guarantees 100% success when smelting iron ore (normally 50% chance). Provides 140 charges before crumbling. Essential for iron bar production at regular furnaces — though unnecessary at the Blast Furnace which already guarantees 100%.
+      description: Enchanted variant granting 100% iron smelt
+  about: "The ruby ring is crafted from a gold bar and ruby at a furnace using a ring mould (level 34 Crafting, 70 XP). It can be enchanted via Lvl-3 Enchant (49 Magic, 1 cosmic + 5 fire runes, 59 XP) into a Ring of forging, granting 140 charges of guaranteed iron-bar smelting. Sellable to Grum's Gold Exchange in Port Sarim above alch value."
   market_strategy:
     notes:
-      - Ring of forging consumed after 140 charges
-      - Demand tied to iron smelting activity
-      - Enchanting margins vary — check before bulk enchanting
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Enchanting margins vary — check costs before bulk enchanting"
+      - "Ring of forging consumed after 140 charges"
+      - "Demand tied to iron smelting and gem cutting activity"
+  history:
+    - date: "2001-05-08"
+      description: Released with the original ruby and ring crafting tier.
+    - date: "2007-11-13"
+      description: Inventory and equipped sprites graphically updated.
+    - date: "2018-09-13"
+      description: Sprite rotated to distinguish from enchanted variants.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta.mdx
@@ -12,9 +12,101 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Rune hasta is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 36
+      slash: 36
+      crush: 36
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -10
+      slash: -10
+      crush: -9
+      magic: 0
+      ranged: -10
+    other_bonus:
+      strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Brutal red dragon
+        quantity: "1"
+        rarity: 1/512
+      - source: Brutal black dragon
+        quantity: "1"
+        rarity: 1/512
+  recipes:
+    - skill: smithing
+      level: 90
+      xp: 75
+      materials:
+        - item_name: Runite bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  related_items:
+    - item_name: Rune spear
+      slug: rune-spear
+      relationship: variant
+      description: Two-handed spear counterpart
+    - item_name: Mithril hasta
+      slug: mithril-hasta
+      relationship: downgrade
+      description: Lower-tier hasta
+    - item_name: Dragon hasta
+      slug: dragon-hasta
+      relationship: upgrade
+      description: Higher-tier hasta
+  about: |-
+    "A rune-tipped, one-handed hasta."
+
+    Rune hasta is a one-handed spear-class weapon requiring 40 Attack, with +36 stab/slash/crush attack bonuses and +42 strength. Unlike the two-handed rune spear, the hasta frees the shield slot. Obtained via 90 Smithing crafting or as a drop from brutal red and brutal black dragons. Can be poisoned for added effectiveness.
+  market_strategy:
+    notes:
+      - "One-handed spear niche"
+      - "Hasta frees shield slot vs spear"
+      - "Smithing 90 crafting loss-making"
+      - "Brutal dragon drops anchor supply"
+      - "Mid-tier weapon for budget builds"
+  trading_tips:
+    - Watch brutal dragon task popularity
+    - Crafting yields loss versus GE
+    - Buy limit 70 supports flips
+  history:
+    - date: "2007-07-03"
+      description: Released with hasta weapon family.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p-5647.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p-5647.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
-  about: "Rune javelin(p+) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: javelin
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 124
+      prayer: 0
+      magic_damage: 0
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 190
+      materials:
+        - item_name: Rune javelin
+          quantity: 5
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      output_quantity: 5
+  related_items:
+    - item_name: Rune javelin
+      slug: rune-javelin
+      relationship: variant
+      description: Unpoisoned base javelin
+    - item_name: Rune javelin(p)
+      slug: rune-javelin-p
+      relationship: downgrade
+      description: Weaker poison tier
+    - item_name: Rune javelin(p++)
+      slug: rune-javelin-p-5648
+      relationship: upgrade
+      description: Stronger poison tier
+    - item_name: Weapon poison(+)
+      slug: weapon-poison-plus
+      relationship: component
+      description: Applied to rune javelins to produce this tier
+  about: "Rune javelin(p+) is the mid-tier poisoned variant of the rune javelin, fired by ballistae for 40+ Ranged. Coating 5 unpoisoned rune javelins with a Weapon poison(+) vial at 73 Herblore yields five poisoned javelins and 190 experience. The poison adds chip damage on hit while preserving the +124 ranged strength of the base ammo."
+  market_strategy:
+    notes:
+      - "Buy unpoisoned javelins + poison vials, flip the spread"
+      - "Poison(+) supply gates daily volume"
+      - "Light Ballista users keep steady demand"
+  history:
+    - date: "2005-07-11"
+      description: Rune javelin line released alongside Tirannwn ranged content.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-knife-p-5660.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-knife-p-5660.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 66
   highalch: 99
   limit: 7000
-  about: "Rune knife(p+) is a members-only item in Old School RuneScape. High alchemy value: 99 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 2
+    weight: 0
+    requirements:
+      ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 25
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 24
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 190
+      materials:
+        - item_name: Rune knife
+          quantity: 5
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      output_quantity: 5
+  related_items:
+    - item_name: Rune knife
+      slug: rune-knife
+      relationship: variant
+      description: Unpoisoned version
+    - item_name: Rune knife(p)
+      slug: rune-knife-p-lower
+      relationship: variant
+      description: Standard poison variant
+    - item_name: Rune knife(p++)
+      slug: rune-knife-p-plus-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_name: Dragon knife(p+)
+      slug: dragon-knife-p-plus
+      relationship: upgrade
+      description: Dragon-tier alternative
+  about: "Rune knife(p+) is a poisoned variant of the rune throwing knife, created by applying Weapon poison(+) at 73 Herblore. Equippable at 40 Ranged with +25 Ranged attack and +24 Ranged strength at a 2-tick rapid attack speed, matching the unpoisoned knife but with an enhanced poison effect. Popular in PvP for its rapid throw rate and animation cancel windows."
+  market_strategy:
+    notes:
+      - "PvP-driven demand from rune-knife stake players"
+      - "High alch 99 caps downside near vendor floor"
+      - "Stackable variant makes inventory storage cheap"
+  trading_tips:
+    - Buy stacks during off-peak hours to flip into PvP weekends
+    - Track 92 Smithing supply via runite bar prices for cost basis
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-med-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-med-helm.mdx
@@ -12,24 +12,82 @@ osrs:
   lowalch: 7680
   highalch: 11520
   limit: 70
-  item_id: 1147
-  item_type: armor
-  slot: head
-  type: med_helm
-  tradeable: true
-  weight: 1.814
-  requirements:
-    defence: 40
-  stats:
-    stab_defence: 22
-    slash_defence: 23
-    crush_defence: 21
-    magic: -3
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2001-07-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements:
+      defence: 40
+    attack_bonus:
+      magic: -3
+    defence_bonus:
+      stab: 22
+      slash: 23
+      crush: 21
+      magic: -1
+      ranged: 22
+    other_bonus: {}
+  recipes:
+    - skill: smithing
+      level: 88
+      xp: 75
+      materials:
+        - item_name: Runite bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Blast Furnace Armour Shop
+      location: Keldagrim
+      price: 19200
+      currency: Coins
+      stock: 10
   related_items:
-    - slug: rune-full-helm
-    - slug: runite-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: upgrade
+      description: Full helm with stronger defensive bonuses.
+    - item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: Smithed at level 88 to produce this helmet.
+    - item_name: Adamant med helm
+      slug: adamant-med-helm
+      relationship: downgrade
+      description: Lower tier med helm.
+  about: "The rune med helm is a medium helmet that requires 40 Defence to wear. It can be smithed at level 88 Smithing from a runite bar for 75 experience and is purchased new from the Blast Furnace armour shop in Keldagrim. Released 26 July 2001 as part of the original rune equipment set, it remains a common starter Defence helm for ironmen and pures who skip the full helm Defence requirement."
+  market_strategy:
+    notes:
+      - "Buy limit of 70 makes bulk reselling slow; better suited for moderate flips."
+      - "Rune bar price drives the smithing margin; helmets typically high-alch profitable."
+  trading_tips:
+    - Compare GE price against high alch (11,520) - common profitable alch when over-supplied.
+  history:
+    - date: "2001-07-26"
+      description: Released with the original rune armour set.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-scimitar-ornament-kit-zamorak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-scimitar-ornament-kit-zamorak.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Rune scimitar ornament kit (zamorak) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Reward casket (beginner)
+        quantity: "1"
+        rarity: "1/360"
+  related_items:
+    - item_name: Rune scimitar
+      slug: rune-scimitar
+      relationship: component
+      description: Base weapon required to apply the kit.
+    - item_name: Rune scimitar (zamorak)
+      slug: rune-scimitar-zamorak
+      relationship: product
+      description: Result after applying the kit (untradeable, detachable).
+  about: "The Rune scimitar ornament kit (zamorak) is a Treasure Trails cosmetic reward from beginner clue scrolls. Apply it to a rune scimitar to produce the Rune scimitar (zamorak); the ornamented weapon becomes untradeable but the kit can be reclaimed by detaching."
+  market_strategy:
+    notes:
+      - "Tight 4-per-4-hour GE limit; flips are slow but margin-friendly."
+      - "Demand spikes during clue scroll/treasure trails events."
+  history:
+    - date: "2019-04-11"
+      description: Released as a beginner clue scroll reward via the Treasure Trails Expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runescroll-of-bloodbark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runescroll-of-bloodbark.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 50
-  about: "Runescroll of bloodbark is a members-only item in Old School RuneScape. High alchemy value: 360 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: scroll
+    tier: mid-high
+  properties:
+    release_date: "2021-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.015
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Steel chest (Shade Catacombs)
+        quantity: "1"
+        rarity: 1/1217
+      - source: Black chest (Shade Catacombs)
+        quantity: "1"
+        rarity: 1/486
+      - source: Silver chest (Shade Catacombs)
+        quantity: "1"
+        rarity: 1/243
+      - source: Gold chest (Shade Catacombs)
+        quantity: "1"
+        rarity: 1/97
+  related_items:
+    - item_name: Runescroll of swampbark
+      slug: runescroll-of-swampbark
+      relationship: variant
+      description: Unlocks splitbark-to-swampbark upgrade
+    - item_name: Splitbark body
+      slug: splitbark-body
+      relationship: component
+      description: Base armour required to upgrade
+    - item_name: Bloodbark body
+      slug: bloodbark-body
+      relationship: product
+      description: Upgraded armour piece this scroll unlocks
+  about: "Reading the Runescroll of bloodbark permanently unlocks the ability to upgrade splitbark armour into bloodbark armour using blood runes at the Blood Altar in Darkmeyer. The scroll itself is consumed on first read and is most commonly obtained from higher-tier chests inside the Shade Catacombs during Shades of Mort'ton."
+  market_strategy:
+    notes:
+      - "Low buy limit of 50 amplifies volatility"
+      - "Supply gated by Shade Catacombs chest RNG"
+      - "Demand spikes whenever bloodbark armour gets a meta boost"
+  history:
+    - date: "2021-01-27"
+      description: "Released alongside bloodbark and swampbark armour."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts.mdx
@@ -12,50 +12,102 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 11000
-  item_id: 9144
-  type: ammunition
-  tradeable: true
-  weight: 0
-  buy_limit: 11000
+  material:
+    type: runite
+    tier: high
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: ammo
-    type: bolts
+    weapon_type: bolts
+    attack_speed: null
+    weight: 0
     requirements:
       ranged: 61
-  fletching:
-    level: 69
-    materials:
-      - item: Runite bolts (unf)
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 115
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 69
+      xp: 10
+      materials:
+        - item_name: Runite bolts (unf)
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      output_quantity: 10
+  drop_table:
+    sources:
+      - source: Corporeal Beast
         quantity: "1"
-      - item: Feathers
+        rarity: 24/512
+      - source: Demonic gorilla
         quantity: "1"
-  obtaining:
-    fletching: Attach feathers to runite bolts (unf) at 69 Fletching
-    drops:
-      - Mithril dragons
-      - King Black Dragon
-      - Demonic gorillas
+        rarity: 25/500
+      - source: King Black Dragon
+        quantity: "1"
+        rarity: 10/128
+      - source: Mithril dragon
+        quantity: "1"
+        rarity: 6/128
   related_items:
-    - slug: rune-crossbow
-      name: Rune crossbow
-      relation: common_weapon
-    - slug: ruby-bolts-e
-      name: Ruby bolts (e)
-      relation: popular_enchanted
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Ammo |
-    | Type | Crossbow Bolts |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 61 Ranged |
-
-    Used with rune crossbow or higher.
-
-    Can be tipped with gems and enchanted for special effects.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Rune crossbow
+      slug: rune-crossbow
+      relationship: component
+      description: Required crossbow tier to fire runite bolts
+    - item_name: Runite bolts (unf)
+      slug: runite-bolts-unf
+      relationship: component
+      description: Unfletched form, needs feathers added
+    - item_name: Ruby bolts (e)
+      slug: ruby-bolts-e
+      relationship: alternative
+      description: Popular enchanted bolt for PvM
+  about: "Runite bolts are members-only crossbow ammunition fired from a rune crossbow or higher, requiring 61 Ranged to wield. They provide +115 Ranged strength, tied with amethyst broad bolts for fourth strongest crossbow ammunition in the game. Players fletch them at level 69 Fletching by attaching feathers to runite bolts (unf), and they also drop from Mithril dragons, the King Black Dragon, Corporeal Beast and Demonic gorillas. The bolts can be tipped with gems and enchanted for special PvP and PvM effects."
+  market_strategy:
+    notes:
+      - "Steady demand from rune crossbow users"
+      - "Base ammunition for diamond and dragonstone enchanted bolts"
+      - "Mithril dragon drops keep raw supply healthy"
+      - "Watch fletching XP demand for price spikes"
+  trading_tips:
+    - Buy in bulk when fletchers flood the market
+    - Resell as enchanted variants for higher margin
+    - Compare against amethyst broad bolt pricing
+  history:
+    - date: "2006-07-31"
+      description: Runite bolts released alongside the rune crossbow.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sarachnis-cudgel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sarachnis-cudgel.mdx
@@ -12,69 +12,84 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid-high
+  properties:
+    release_date: "2019-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: blunt
-    attack_style: crush
+    weapon_type: crush
     attack_speed: 4
+    weight: 0.453
     requirements:
       attack: 65
-    stats:
-      attack_stab: 30
-      attack_crush: 70
+    attack_bonus:
+      stab: 30
+      slash: 0
+      crush: 70
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 70
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
       - source: Sarachnis
-        source_id: 8713
-        combat_level: 318
         quantity: "1"
-        rarity: Rare
-        drop_rate: 1/384
-        members_only: true
+        rarity: "1/384"
   related_items:
-    - item_id: 13263
-      item_name: Abyssal bludgeon
+    - item_name: Abyssal bludgeon
       slug: abyssal-bludgeon
       relationship: upgrade
-      description: Upgrade path
-    - item_id: 24417
-      item_name: Inquisitor's mace
+      description: Upgrade path with higher strength bonus
+    - item_name: Inquisitor's mace
       slug: inquisitors-mace
       relationship: upgrade
-      description: BiS crush
-    - item_id: 11902
-      item_name: Leaf-bladed battleaxe
+      description: Best-in-slot crush weapon
+    - item_name: Leaf-bladed battleaxe
       slug: leaf-bladed-battleaxe
       relationship: alternative
-      description: Alternative
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +30 |
-    | Crush | +70 |
-    | Strength | +70 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 65 Attack
-
-    Budget crush weapon for:
-    - Sarachnis
-    - Gargoyles
-    - Mid-game crush content
-    - Kalphite tasks
-
-    Does not degrade - no maintenance cost.
+      description: Alternative crush option for Slayer tasks
+  about: "The Sarachnis cudgel is a one-handed crush weapon dropped exclusively by Sarachnis at a rate of 1/384. Requiring 65 Attack to wield, it offers +70 crush attack and +70 strength bonus, making it a strong budget option for mid-game crush content such as Gargoyles, Kalphite tasks, and Sarachnis itself. The cudgel does not degrade and has no maintenance cost."
   market_strategy:
     notes:
-      - Easy boss to farm
-      - No Slayer requirement
-      - Good mid-game weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Sarachnis is an accessible boss with no Slayer requirement"
+      - "Strong mid-game crush weapon keeps demand steady"
+      - "Supply tied directly to boss farming popularity"
+  trading_tips:
+    - Watch boss-of-the-week rotations for price dips
+    - Buy during off-peak hours when farmers flip drops
+    - Long-term hold value as a staple crush weapon
+  history:
+    - date: "2019-07-04"
+      description: "Added to the game with the release of Sarachnis."
+    - date: "2025-05-29"
+      description: "Removed from the Grand Exchange item sink list."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-brew-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-brew-2.mdx
@@ -12,72 +12,73 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  item_id: 6689
-  type: potion
-  tradeable: true
-  buy_limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2005-10-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
   potion:
-    doses: 2
-    base_item: Saradomin brew(4)
-    base_item_id: 6685
-    herblore_level: 81
-    herblore_xp: 180
     effects:
-      - stat: Hitpoints
-        boost_formula: floor(level * 0.15) + 2
-        description: Heals 15% + 2 of max HP
-      - stat: Defence
-        boost_formula: floor(level * 0.20) + 2
-        description: Boosts Defence by 20% + 2
-      - stat: Attack
-        boost_formula: -(floor(level * 0.10) + 2)
-        description: Lowers Attack by 10% + 2
-      - stat: Strength
-        boost_formula: -(floor(level * 0.10) + 2)
-        description: Lowers Strength by 10% + 2
-      - stat: Magic
-        boost_formula: -(floor(level * 0.10) + 2)
-        description: Lowers Magic by 10% + 2
-      - stat: Ranged
-        boost_formula: -(floor(level * 0.10) + 2)
-        description: Lowers Ranged by 10% + 2
+      - description: Heals Hitpoints by 15% + 2 of base level (rounded down)
+        duration: null
+      - description: Boosts Defence by 20% + 2 of base level (rounded down)
+        duration: null
+      - description: Lowers Attack by 10% + 2 of current level
+        duration: null
+      - description: Lowers Strength by 10% + 2 of current level
+        duration: null
+      - description: Lowers Magic by 10% + 2 of current level
+        duration: null
+      - description: Lowers Ranged by 10% + 2 of current level
+        duration: null
   related_items:
-    - slug: saradomin-brew-4
-      name: Saradomin brew(4)
-      relation: full_dose_variant
-    - slug: super-restore-4
-      name: Super restore(4)
-      relation: counters_stat_drain
-    - slug: crushed-nest
-      name: Crushed nest
-      relation: creation_material
-  about: |-
-    2-dose variant of Saradomin brew(4).
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 81 |
-    | XP gained | 180 (when making 4-dose) |
-
-    Per dose:
-    - Heals: 15% + 2 of max HP (max +16 at 99 HP)
-    - Boosts Defence: 20% + 2 of base level (max +21 at 99)
-    - Lowers: Attack, Strength, Magic, Ranged by 10% + 2
-
-    Essential for high-level PvM:
-    - Raids (CoX, ToB, ToA)
-    - Inferno attempts
-    - Boss fights (GWD, Nex, etc.)
-    - PvP (combo with Super restore)
-
-    Brew to Restore Ratio: Use 3 doses of brew per 1 dose of super restore to maintain combat stats.
+    - item_name: Saradomin brew(4)
+      slug: saradomin-brew-4
+      relationship: variant
+      description: Full 4-dose version of the same potion
+    - item_name: Saradomin brew(3)
+      slug: saradomin-brew-3
+      relationship: variant
+      description: 3-dose decant variant
+    - item_name: Saradomin brew(1)
+      slug: saradomin-brew-1
+      relationship: variant
+      description: 1-dose decant variant
+    - item_name: Super restore(4)
+      slug: super-restore-4
+      relationship: alternative
+      description: Restores the offensive stats that brew drains
+    - item_name: Crushed nest
+      slug: crushed-nest
+      relationship: component
+      description: Required ingredient when brewing the full 4-dose potion
+  about: "Saradomin brew(2) is a 2-dose variant of the high-level healing potion produced by combining a Toadflax potion (unf) with a Crushed nest at Herblore level 81 for 180 XP. Each dose heals 15% + 2 of max Hitpoints and boosts Defence by 20% + 2, while temporarily lowering Attack, Strength, Magic, and Ranged by 10% + 2. The brew is a staple at raids, Inferno, GWD, and PvP, almost always paired with Super restore to undo the stat drain."
   market_strategy:
     notes:
-      - Decants to/from 4-dose version
-      - Lower doses often used for inventory optimization
-      - Bob Barter in GE can decant potions
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Decants to and from 4-dose for inventory optimisation"
+      - "Bob Barter in the Grand Exchange handles dose conversion"
+      - "2-dose stock often follows raid and high-level PvM demand"
+  trading_tips:
+    - Pair with Super restore at roughly a 3:1 brew-to-restore ratio
+    - Watch decanting margins between (1), (2), (3), and (4) doses
+  history:
+    - date: "2005-10-24"
+      description: Released alongside the Herblore Saradomin brew recipe.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-chaps.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 2400
   highalch: 3600
   limit: 8
-  about: "Saradomin chaps is a members-only item in Old School RuneScape. High alchemy value: 3,600 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: legs
+    weight: 5
+    requirements:
+      ranged: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 31
+      slash: 25
+      crush: 33
+      magic: 28
+      ranged: 31
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Saradomin coif
+      slug: saradomin-coif
+      relationship: set-piece
+      description: Matching Saradomin blessed coif
+    - item_name: Saradomin d'hide body
+      slug: saradomin-dhide-body
+      relationship: set-piece
+      description: Matching Saradomin blessed body
+    - item_name: Black d'hide chaps
+      slug: black-dhide-chaps
+      relationship: alternative
+      description: Unblessed equivalent without prayer bonus
+  about: "Saradomin chaps are part of the Saradomin blessed dragonhide armour set, awarded from hard Treasure Trail caskets. They share the offensive stats of black d'hide chaps but include a +1 Prayer bonus and slightly higher defensive bonuses. Requires 70 Ranged to equip."
+  market_strategy:
+    notes:
+      - "Hard clue reward — supply scales with clue completion"
+      - "Prayer bonus differentiates from standard black chaps"
+      - "Niche but steady demand among ranged prayer hybrids"
+  history:
+    - date: "2006-12-05"
+      description: Released as a hard Treasure Trails reward.
+    - date: "2014-03-06"
+      description: Gained +1 Prayer bonus.
+    - date: "2021-09-22"
+      description: 40 Defence requirement removed.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sawmill-voucher.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sawmill-voucher.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 10000
-  about: "Sawmill voucher is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: forestry-token
+    tier: mid
+  properties:
+    release_date: "2023-10-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  shops:
+    - shop_name: Forestry Shop
+      location: Various forestry locations
+      price: 15
+      currency: anima-infused bark
+      stock: 10
+  related_items:
+    - item_name: Anima-infused bark
+      slug: anima-infused-bark
+      relationship: component
+      description: Currency used to purchase vouchers
+    - item_name: Plank
+      slug: plank
+      relationship: product
+      description: Produced from logs at the sawmill
+  about: "Sawmill voucher is a Forestry-themed consumable purchased from the Forestry Shop for 150 anima-infused bark (yields 10 vouchers). Each voucher redeems for one extra plank per log when used at a sawmill or with the Plank Make spell, effectively doubling output. Requires inventory space for both base and bonus planks; otherwise excess logs convert without consuming a voucher. Cannot be used through butlers."
+  market_strategy:
+    notes:
+      - "Doubles plank yield at sawmills"
+      - "Steady demand from Construction trainers"
+      - "Forestry Shop ceiling keeps price tethered to bark cost"
+  trading_tips:
+    - Stack into Construction training sessions to halve plank cost
+    - Pair with bulk oak/teak logs for fastest XP per voucher
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shortbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shortbow-u.mdx
@@ -12,23 +12,65 @@ osrs:
   lowalch: 9
   highalch: 13
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.992
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 5
+      xp: 5
+      materials:
+        - item_name: Logs
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
   related_items:
-    - item_id: 48
-      item_name: Longbow (u)
+    - item_name: Shortbow
+      slug: shortbow
+      relationship: product
+      description: Strung with a bowstring at level 5 Fletching
+    - item_name: Longbow (u)
       slug: longbow-u
       relationship: variant
       description: Unstrung longbow from regular logs
-    - item_id: 54
-      item_name: Oak shortbow (u)
+    - item_name: Oak shortbow (u)
       slug: oak-shortbow-u
-      relationship: variant
+      relationship: upgrade
       description: Higher tier unstrung shortbow
-  about: |-
-    > _"I need to find a string for this."_
-
-    The shortbow (u) is an unstrung shortbow made from regular logs. String with a bowstring at 5 Fletching to create a shortbow. Members only. The very first item available for Fletching training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Bowstring
+      slug: bowstring
+      relationship: component
+      description: Required to string into a usable shortbow
+  about: "Shortbow (u) is the very first item available for Fletching training, made by using a knife on regular logs at level 5 Fletching for 5 XP. Stringing the unstrung shortbow with a bowstring (also level 5 Fletching) produces a functional shortbow and grants an additional 5 XP. Crafting takes 3 game ticks (1.8 seconds). Members-only despite being a low-level item."
+  market_strategy:
+    notes:
+      - "Entry-level Fletching training item"
+      - "High buy limit reflects high supply"
+      - "Margin between materials and product is tight"
+  history:
+    - date: "2002-03-25"
+      description: Released with the Fletching skill.
+    - date: "2004-06-01"
+      description: Underwent a sprite recolour during June 2004.
+    - date: "2005-05-17"
+      description: Renamed from "Shortbow" to "Shortbow (u)" to disambiguate from the strung product.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-slaughter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-slaughter.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of slaughter is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sigil
+    tier: high
+  properties:
+    release_date: "2021-08-25"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  passive_effects:
+    - name: Slayer task selection
+      description: "Spend Slayer reward points (30-60 per event) to choose specific non-boss Slayer tasks."
+    - name: Superior boost
+      description: "Doubles the appearance rate of Superior slayer monsters while on task."
+    - name: Toggleable kill modifier
+      description: "Toggle either a 25% chance that kills do not consume task count (while still granting XP) or a 25% chance that kills count twice toward the task."
+  related_items:
+    - item_name: Bracelet of slaughter
+      slug: bracelet-of-slaughter
+      relationship: alternative
+      description: "Standard slayer bracelet providing the kills-don't-count effect; does not stack with the sigil."
+  about: "Sigil of slaughter is a members-only Deadman Mode sigil released on 25 August 2021. It is an event-exclusive reward dropped by most monsters during temporary Deadman Mode tournaments and is currently unobtainable in the live game. When attuned the sigil lets the player spend Slayer reward points to lock in specific non-boss slayer tasks, doubles the spawn chance of superior slayer monsters and provides a toggle between a 25% chance kills do not consume the task counter (still granting XP) or a 25% chance kills count twice. It does not stack with the equivalent bracelet effects and must be unattuned before it can be destroyed. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
+  market_strategy:
+    notes:
+      - "Only enters the economy during Deadman events; long-term holders bet on future event reruns."
+      - "Strong demand among Slayer mains during events because it stacks with Slayer reward shop point sinks."
+      - "Buy limit of 8 keeps event-time market thin and volatile."
+  trading_tips:
+    - "Track Jagmod Deadman event announcements to time accumulation."
+    - "Combine with bracelet of slaughter charge stockpiles for slayer task throughput sales."
+    - "Avoid over-leveraging - the item becomes untradeable when Deadman events close."
+  history:
+    - date: "2021-08-25"
+      description: "Released as a Deadman Mode reward drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-feral-fighter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-feral-fighter.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the feral fighter is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sigil
+    tier: mid-high
+  properties:
+    release_date: "2021-08-25"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: true
+    destroy: "An alternative is to sell it on the Grand Exchange"
+  passive_effects:
+    - name: Feral Fighter
+      description: Grants bonus XP in Attack and Strength and increases melee attack speed via proc chance when attuned during a Deadman Mode event.
+  related_items:
+    - item_name: Sigil of the Devout
+      slug: sigil-of-the-devout
+      relationship: alternative
+      description: Alternative Deadman sigil
+    - item_name: Sigil of the Skiller
+      slug: sigil-of-the-skiller
+      relationship: alternative
+      description: Alternative Deadman sigil
+  about: "The Sigil of the feral fighter is a power-enhancing sigil obtainable only during temporary Deadman Mode events. When attuned, it grants 25% bonus XP in Attack and Strength and triggers melee attack speed bonuses with a 10% proc chance (20% in Deadman: Apocalypse). The un-attuned version is tradeable on the Grand Exchange; the attuned version must be unattuned before destruction."
+  history:
+    - date: "2021-08-25"
+      description: Added with the Deadman - Reborn event.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-titanium.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-titanium.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of titanium is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sigil
+    tier: high
+  properties:
+    release_date: "2023-08-23"
+    tradeable: false
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  passive_effects:
+    - name: Titanium hide
+      description: "All attacks from monsters do 60% less damage. Does not stack with the Sigil of Resistance."
+  related_items:
+    - item_name: Sigil of resistance
+      slug: sigil-of-resistance
+      relationship: alternative
+      description: Competing damage-reduction sigil, effect does not stack
+    - item_name: Sigil of finality
+      slug: sigil-of-finality
+      relationship: alternative
+      description: Another tier 3 Deadman combat sigil
+    - item_name: Sigil of fortification
+      slug: sigil-of-fortification
+      relationship: alternative
+      description: Defensive sigil from the same Deadman pool
+    - item_name: Sigil of pious protection
+      slug: sigil-of-pious-protection
+      relationship: alternative
+      description: Prayer-focused sigil from the same Deadman pool
+  about: "Sigil of titanium is a Tier 3 Deadman Mode sigil that cuts incoming monster damage by 60% once attuned. It is restricted to temporary Deadman events (Annihilation, Armageddon, Apocalypse) and does not stack with the Sigil of Resistance, so players slot in either, not both. Untradeable and unalchable, it is destroyed only after being unattuned."
+  market_strategy:
+    notes:
+      - "Untradeable, no GE market"
+      - "Event-only utility, irrelevant in main game"
+      - "Pick over Resistance when PvM dominates the bracket"
+  history:
+    - date: "2023-08-23"
+      description: Introduced as part of the Deadman Apocalypse sigil pool.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snakeskin-chaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Snakeskin chaps | OSRS Price Data
-description: "Snakeskin chaps is a members legs slot item requiring 30 Defence. High alch: 705 GP, GE limit: 125."
+description: "Snakeskin chaps is a members legs slot item requiring 30 Ranged and 30 Defence. High alch: 705 GP, GE limit: 125."
 osrs:
   id: 6324
   name: Snakeskin chaps
@@ -12,8 +12,32 @@ osrs:
   lowalch: 470
   highalch: 705
   limit: 125
+  material:
+    type: snakeskin
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 3.628
+    requirements:
+      ranged: 30
+      defence: 30
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,65 +55,50 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 30
-      defence: 30
-    weight: 3.628
   recipes:
     - skill: crafting
       level: 51
       xp: 50
-      inputs:
+      materials:
         - item_name: Snakeskin
           quantity: 12
         - item_name: Thread
           quantity: 1
+      tools:
+        - Needle
       output_quantity: 1
   related_items:
-    - item_id: 6322
-      item_name: Snakeskin body
+    - item_name: Snakeskin body
       slug: snakeskin-body
       relationship: set-piece
-      description: Matching body piece
-    - item_id: 6328
-      item_name: Snakeskin boots
+      description: Matching body armour
+    - item_name: Snakeskin boots
       slug: snakeskin-boots
       relationship: set-piece
       description: Matching boots
-  about: |-
-    | Ranged | Value |
-    |--------|-------|
-    | Ranged Attack | +6 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab/Slash | +8 |
-    | Crush | +10 |
-    | Magic | +4 |
-    | Ranged | +10 |
-
-    Requirements: 30 Ranged, 30 Defence
-
-    | Stat | Snakeskin Chaps | Studded Chaps | Green D'hide Chaps |
-    |------|----------------|---------------|---------------------|
-    | Ranged Atk | +6 | +6 | +8 |
-    | Stab Def | +8 | +6 | +22 |
-    | Magic Def | +4 | +2 | +8 |
-    | Req | 30 Rng/Def | 20 Rng/Def | 40 Rng/Def |
-
-    Moderate upgrade from studded chaps. The ranged attack bonus is the same, but snakeskin chaps offer slightly better defensive stats across the board.
-
-    - Budget ranged legs for 30 Def bracket
-    - Crafting training product (51-53 range)
-    - Ironman progression piece
-    - 12 snakeskin per pair (~600 GP in materials)
+    - item_name: Studded chaps
+      slug: studded-chaps
+      relationship: downgrade
+      description: Lower-tier chaps with equivalent ranged attack
+    - item_name: Green d'hide chaps
+      slug: green-dhide-chaps
+      relationship: upgrade
+      description: Next-tier ranged chaps
+  about: "Snakeskin chaps are members-only ranged legs requiring 30 Ranged and 30 Defence, crafted from 12 snakeskin and 1 thread at level 51 Crafting for 50 XP. They provide +6 Ranged attack and modest defensive stats across all melee defence types, slotting between studded chaps and green d'hide chaps in the progression. While they are typically skipped for studded chaps (lower requirements with the same attack bonus), they remain a common crafting training product and ironman progression piece."
   market_strategy:
     notes:
-      - Low demand — quickly replaced by green d'hide chaps
-      - Crafting XP is the main reason to make these
-      - Low margins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Crafting XP is the main reason to make these"
+      - "Quickly replaced by green d'hide chaps in main upgrade paths"
+      - "Low margins typical of training products"
+      - "12 snakeskin material cost defines floor price"
+  trading_tips:
+    - Buy chaps under snakeskin material price for arbitrage
+    - Flip during crafting bot waves
+  history:
+    - date: "2005-08-09"
+      description: Released with the snakeskin armour set.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snowy-knight-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snowy-knight-mix-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Snowy knight mix (2) | OSRS Price Data
-description: "Snowy knight mix (2): There's a snowy knight butterfly in here.. High alch: 30 GP."
+description: "Snowy knight mix (2): There's a snowy knight butterfly in here. High alch: 30 GP."
 osrs:
   id: 29183
   name: Snowy knight mix (2)
@@ -12,9 +12,49 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: null
-  about: "Snowy knight mix (2) is a members-only item in Old School RuneScape. High alchemy value: 30 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  potion:
+    effects:
+      - description: Heals 8 hitpoints per dose; in multicombat areas, heals up to three nearby players with Accept Aid enabled.
+        duration: null
+  related_items:
+    - item_name: Snowy knight mix (1)
+      slug: snowy-knight-mix-1
+      relationship: variant
+      description: One-dose version of the same hunter's mix
+    - item_name: Snowy knight
+      slug: snowy-knight
+      relationship: component
+      description: Jarred butterfly used to brew the mix
+    - item_name: Hunter's mix
+      slug: hunters-mix
+      relationship: alternative
+      description: General hunter's mix category
+  about: "Snowy knight mix (2) is a members hunter's mix potion that heals 8 hitpoints per dose and can also heal nearby players in multicombat with Accept Aid enabled. It is made by combining a jarred snowy knight with raw hunter meat using a pestle and mortar."
+  market_strategy:
+    notes:
+      - "Niche potion with limited demand"
+      - "Self-supplied from snowy knight hunting"
+      - "Heal effect weaker than releasing the butterfly directly"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spade.mdx
@@ -12,13 +12,68 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 40
-  related_items: []
-  about: |-
-    > _"A fairly small spade."_
-
-    The spade is a versatile tool used for digging in Farming, completing treasure trails, and various quests. Essential for planting seeds and digging up crops. Also used to dig at specific locations in clue scrolls.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2001-01-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Dig
+      - Drop
+    worn_options: []
+    alchable: true
+  shops:
+    - shop_name: Sarah's Farming Shop
+      location: Catherby
+      price: 3
+      currency: Coins
+      stock: 5
+    - shop_name: Head Farmer Jones' Farming Shop
+      location: Falador
+      price: 3
+      currency: Coins
+      stock: 5
+    - shop_name: Alice's Farming Shop
+      location: East Ardougne
+      price: 3
+      currency: Coins
+      stock: 5
+    - shop_name: Lumbridge General Store
+      location: Lumbridge
+      price: 3
+      currency: Coins
+      stock: 5
+    - shop_name: Varrock General Store
+      location: Varrock
+      price: 3
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Gardening trowel
+      slug: gardening-trowel
+      relationship: alternative
+      description: Farming tool for picking herbs
+    - item_name: Rake
+      slug: rake
+      relationship: alternative
+      description: Farming tool for clearing weeds
+    - item_name: Seed dibber
+      slug: seed-dibber
+      relationship: alternative
+      description: Farming tool for planting seeds
+  about: "The spade is a versatile tool used for digging in Farming, completing Treasure Trail clues, accessing Barrows crypts, and various quests including Pirate's Treasure, X Marks the Spot, and Ernest the Chicken. It is widely stocked at farming shops, general stores and player-owned house tool stores at very low prices, and can also spawn at fixed scenery locations across Gielinor."
+  history:
+    - date: "2001-01-21"
+      description: Added to the game.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-warhammer.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 120000
   highalch: 180000
   limit: 10
-  about: "Statius's warhammer is a members-only item in Old School RuneScape. High alchemy value: 180,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: zarosian
+    tier: high
+  properties:
+    release_date: "2023-05-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: warhammer
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 75
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 123
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 114
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Smash
+    description: "Deals between 25% and 125% of the user's max hit while lowering the target's current Defence level by 75% on a successful hit; reductions stack with further specs."
+    energy: 35
+  drop_table:
+    sources:
+      - source: Nex
+        quantity: "1"
+        rarity: Rare
+      - source: Bounty Hunter Store
+        quantity: "1"
+        rarity: Always (450 points)
+  related_items:
+    - item_name: Statius's full helm
+      slug: statius-s-full-helm
+      relationship: set-piece
+      description: Head slot piece of the Statius's equipment set.
+    - item_name: Statius's platebody
+      slug: statius-s-platebody
+      relationship: set-piece
+      description: Body slot piece of the Statius's equipment set.
+    - item_name: Statius's platelegs
+      slug: statius-s-platelegs
+      relationship: set-piece
+      description: Legs slot piece of the Statius's equipment set.
+    - item_name: Vesta's longsword
+      slug: vesta-s-longsword
+      relationship: alternative
+      description: Sister Zarosian weapon focused on slash damage instead of crush.
+  about: "Statius's warhammer is a Zarosian-themed crush weapon purchasable from the Bounty Hunter Store for 450 points. Its raw crush attack and strength bonuses make it one of the strongest single-target hammers in the game, but its real draw is the Smash special attack, which can stack heavy Defence reductions on a target. The weapon must be activated for 10 million coins before it can be used outside specific PvP-style arenas."
+  market_strategy:
+    notes:
+      - "Activation cost of 10m coins is non-refundable, so buyers prefer pre-activated copies for plug-and-play loadouts."
+      - "PvP tournaments, Castle Wars updates, and Last Man Standing meta shifts drive price spikes."
+      - "Bounty Hunter Store supply keeps a floor on price; flips above shop-equivalent cost are short-lived."
+  trading_tips:
+    - "Track Bounty Hunter point rates - when points are cheap to farm, the market floods and price dips."
+    - "List ahead of weekend PvP events when defence-stripping specs are in highest demand."
+  history:
+    - date: "2023-05-24"
+      description: "Released as part of the Bounty Hunter rework, reintroducing the classic Statius warhammer."
+    - date: "2025-01-15"
+      description: "Activation cost reduced from 50m to 10m coins and the Smash Defence reduction was buffed from 30% to 75%."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-javelin.mdx
@@ -12,31 +12,103 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
-    slot: weapon
-    attack_speed: 6
+    slot: ammo
+    weapon_type: javelin
+    attack_speed: null
+    weight: 0
     requirements:
       ranged: 5
     attack_bonus:
-      ranged: 12
-    ranged_strength: 40
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 64
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 32
+      xp: 75
+      materials:
+        - item_name: Steel javelin heads
+          quantity: 15
+        - item_name: Javelin shaft
+          quantity: 15
+      tools: []
+      output_quantity: 15
+  shops:
+    - shop_name: Void Knight Archery Store
+      location: Void Knights' Outpost
+      price: 24
+      currency: Coins
+      stock: 50
+    - shop_name: Ranging Guild Ticket Exchange
+      location: Ranging Guild
+      price: 31
+      currency: Coins
+      stock: 0
+    - shop_name: Oobapohk's Javelin Store
+      location: Mos Le'Harmless
+      price: 24
+      currency: Coins
+      stock: 100
   related_items:
-    - item_id: 826
-      item_name: Iron javelin
+    - item_name: Iron javelin
       slug: iron-javelin
-      relationship: variant
+      relationship: downgrade
       description: Lower tier javelin
-    - item_id: 828
-      item_name: Mithril javelin
+    - item_name: Mithril javelin
       slug: mithril-javelin
-      relationship: variant
+      relationship: upgrade
       description: Higher tier javelin
-  about: |-
-    > _"A steel tipped javelin."_
-
-    The steel javelin requires 5 Ranged. Mid-low tier javelin.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Light ballista
+      slug: light-ballista
+      relationship: alternative
+      description: Compatible ballista that fires javelins
+  about: "The steel javelin is a members-only ballista ammunition fired from light and heavy ballistae. Once a standalone thrown weapon, it was reclassified as ammunition in May 2016 and adjusted again in October 2016 to its current +64 Ranged strength. Available from several shops and Fletchable at 32 Fletching."
+  market_strategy:
+    notes:
+      - "Shop runs at Void Knights' Outpost cap upside"
+      - "Ballista users absorb supply during Slayer tasks"
+      - "Fletching profit thin against javelin heads cost"
+  history:
+    - date: "2004-03-29"
+      description: "Released as a thrown ranged weapon."
+    - date: "2016-05-30"
+      description: "Reclassified as ballista ammunition with revised stats."
+    - date: "2016-10-06"
+      description: "Ranged strength reduced from +75 to +64."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-knife-p-5663.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-knife-p-5663.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 7000
-  about: "Steel knife(p++) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 8
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 7
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Steel knife
+      slug: steel-knife
+      relationship: variant
+      description: Unpoisoned base version
+    - item_name: Steel knife(p)
+      slug: steel-knife-p-5655
+      relationship: variant
+      description: Standard weak poison variant
+    - item_name: Steel knife(p+)
+      slug: steel-knife-p-5659
+      relationship: variant
+      description: Strong poison variant
+    - item_name: Iron knife(p++)
+      slug: iron-knife-p
+      relationship: downgrade
+      description: Lower-tier poisoned throwing knife
+    - item_name: Black knife(p++)
+      slug: black-knife-p
+      relationship: upgrade
+      description: Higher-tier poisoned throwing knife
+  about: "Steel knife(p++) is the extra-strong-poison variant of the steel throwing knife, requiring Ranged level 5 to wield. It carries Ranged attack +8 and Ranged strength +7, identical to the unpoisoned knife but with the added effect of inflicting venom-strength poison damage on hit. Steel knives are produced 5 per bar at Smithing 37 (37.5 XP)."
+  market_strategy:
+    notes:
+      - "Poisoned knife stocks track weapon-poison(++) supply"
+      - "Niche use means low daily volume; flip in larger lots"
+  history:
+    - date: "2003-04-14"
+      description: Released as part of the original steel throwing knife line.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-spear-p-5722.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-spear-p-5722.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel spear(p++) | OSRS Price Data
-description: "Steel spear(p++): A poisoned steel tipped spear.. High alch: 195 GP, GE limit: 125."
+description: "Steel spear(p++) is a members two-handed melee weapon requiring 5 Attack. High alch: 195 GP, GE limit: 125."
 osrs:
   id: 5722
   name: Steel spear(p++)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  about: "Steel spear(p++) is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Steel spear
+      slug: steel-spear
+      relationship: variant
+      description: Unpoisoned base version
+    - item_name: Steel spear(p)
+      slug: steel-spear-p-1241
+      relationship: variant
+      description: Standard poison variant
+    - item_name: Steel spear(p+)
+      slug: steel-spear-p-5716
+      relationship: variant
+      description: Poison+ variant
+    - item_name: Mithril spear(p++)
+      slug: mithril-spear-p
+      relationship: upgrade
+      description: Higher-tier poison++ spear
+  about: "Steel spear(p++) is a steel tipped spear coated in the strongest poison++. It is a two-handed stab weapon usable from the weapon slot, requiring 5 Attack to wield, and benefits from spear-specific mechanics such as bypassing the Dagannoth Supreme's defensive immunity from certain attack styles. The poison++ coating delivers stronger damage-over-time ticks than the standard poison or poison+ variants. Its 4-tick attack speed (post-2021 rebalance) makes it competitive among low-tier spear options for niche slayer and PvP tasks."
+  market_strategy:
+    notes:
+      - "Niche poison weapon for slayer immunities"
+      - "Buy limit 125 caps bulk flips"
+      - "Demand spikes during dagannoth task chains"
+      - "Poison++ tier commands premium over base poison"
+  trading_tips:
+    - Buy after price dips from PvP nerfs
+    - Watch slayer rework chatter for niche demand bumps
+  history:
+    - date: "2003-04-14"
+      description: Released with the original spear weapon set.
+    - date: "2021-04-21"
+      description: Attack speed improved from 5 ticks to 4 ticks.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-spear.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  about: "Steel spear is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Mount Karuulm Weapon Shop
+      location: Mount Karuulm
+      price: 325
+      currency: Coins
+      stock: 5
+    - shop_name: Fortis Blacksmith
+      location: Fortis
+      price: 325
+      currency: Coins
+      stock: 5
+  recipes:
+    - skill: smithing
+      level: 35
+      xp: 75
+      materials:
+        - item_name: Steel bar
+          quantity: 1
+        - item_name: Willow logs
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  related_items:
+    - item_name: Mithril spear
+      slug: mithril-spear
+      relationship: upgrade
+      description: Higher tier spear
+    - item_name: Iron spear
+      slug: iron-spear
+      relationship: downgrade
+      description: Lower tier spear
+    - item_name: Steel spear (p)
+      slug: steel-spear-p
+      relationship: variant
+      description: Poisoned variant
+  about: "The Steel spear is a two-handed members-only melee weapon requiring 5 Attack to wield. It is created via Barbarian Smithing at level 35 from one steel bar and one willow log (requires Tai Bwo Wannai Trio completion), or purchased from Mount Karuulm Weapon Shop and Fortis Blacksmith. It is dropped by Earth warriors, Hobgoblins and skeletons, and can be poisoned with standard or Karambwan poison."
+  history:
+    - date: "2003-04-14"
+      description: Added to the game.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stockpiling-charm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stockpiling-charm.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Stockpiling charm is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: charm
+    tier: high
+  properties:
+    release_date: "2025-03-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.0
+    options: ["Activate", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Breach boss (Deadman Mode)
+        quantity: "1"
+        rarity: Rare
+      - source: Combat level 200+ monster (Deadman Mode)
+        quantity: "1"
+        rarity: Rare
+  passive_effects:
+    - name: Triple skilling minigame rewards
+      description: "While carried, triples rewards from Wintertodt, Tempoross, Guardians of the Rift, Barbarian Assault, Pest Control, Chompy Bird Hunting, Mage Training Arena, Forestry and Vale Totems."
+    - name: Clue scroll box stacking
+      description: "Caches incoming clue scrolls as scroll boxes that can only be unboxed while the charm is still in your inventory."
+    - name: Auto-bank gathered resources
+      description: "Automatically banks resources gained from Mining, Fishing, Woodcutting, and Farming as you collect them."
+  related_items:
+    - item_name: Clue scroll (master)
+      slug: clue-scroll-master
+      relationship: product
+      description: Example of the clue scrolls stacked into scroll boxes by the charm.
+    - item_name: Wintertodt supply crate
+      slug: supply-crate
+      relationship: product
+      description: One of the boosted minigame reward containers.
+    - item_name: Tempoross reward pool
+      slug: spirit-anglerfish
+      relationship: alternative
+      description: Tempoross rewards similarly tripled while the charm is held.
+  about: "The Stockpiling charm is a Deadman Mode artefact that supercharges skilling and clue progress when kept in the inventory. It triples rewards from a long list of skilling minigames, stacks incoming clue scrolls as boxes that only the charm can unwrap, and auto-banks resources from Mining, Fishing, Woodcutting, and Farming. It only drops from breach bosses and high-level monsters on the permanent Deadman world."
+  market_strategy:
+    notes:
+      - "Supply is entirely Deadman Mode driven, so listings are scarce and price is highly volatile."
+      - "No buy limit means a single whale can move the market in either direction."
+      - "Demand spikes alongside Deadman Mode seasonal patches that buff the charm's coverage."
+  trading_tips:
+    - "Watch Deadman Mode patch notes for new minigames added to the triple-reward list."
+    - "List into the post-patch hype window when Forestry and Vale Totems triples drive demand."
+  history:
+    - date: "2025-03-12"
+      description: "Released on permanent Deadman Mode world 345 with triple-reward, clue stacking, and auto-banking effects."
+    - date: "2026-01-21"
+      description: "Effect list expanded to Barbarian Assault, Pest Control, Chompy Bird Hunting, Mage Training Arena, Forestry, and Vale Totems; vendor value raised from 10,000 to 100,000 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strength-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strength-potion-4.mdx
@@ -12,99 +12,89 @@ osrs:
   lowalch: 5
   highalch: 8
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2001-02-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   potion:
-    doses: 4
-    type: combat
-    boost_stat: strength
-    boost_formula: 3 + 10%
+    effects:
+      - description: "Boosts Strength by 3 + 10% of current Strength level; decays one level per minute (or 90 seconds under Preserve)."
+        duration: null
   recipes:
     - skill: herblore
       level: 12
       xp: 50
       materials:
         - item_name: Tarromin potion (unf)
-          item_id: 95
           quantity: 1
         - item_name: Limpwurt root
-          item_id: 225
           quantity: 1
-      product: Strength potion (4)
-      product_id: 113
-      product_quantity: 1
-      facility: None
-      members_only: true
+      tools: []
+      output_quantity: 1
     - skill: none
       level: 1
       xp: 0
       materials:
         - item_name: Limpwurt root
-          item_id: 225
           quantity: 1
         - item_name: Red spiders' eggs
-          item_id: 223
           quantity: 1
         - item_name: Coins
-          item_id: 995
           quantity: 5
-      product: Strength potion (4)
-      product_id: 113
-      product_quantity: 1
-      facility: Apothecary
+      tools:
+        - Apothecary
+      output_quantity: 1
   related_items:
-    - item_id: 253
-      item_name: Tarromin
+    - item_name: Strength potion(1)
+      slug: strength-potion-1
+      relationship: variant
+      description: 1-dose version
+    - item_name: Strength potion(2)
+      slug: strength-potion-2
+      relationship: variant
+      description: 2-dose version
+    - item_name: Strength potion(3)
+      slug: strength-potion-3
+      relationship: variant
+      description: 3-dose version
+    - item_name: Tarromin
       slug: tarromin
       relationship: component
-      description: Primary herb
-    - item_id: 225
-      item_name: Limpwurt root
+      description: Primary herb for the unfinished potion
+    - item_name: Limpwurt root
       slug: limpwurt-root
       relationship: component
       description: Secondary ingredient
-    - item_id: 2440
-      item_name: Super strength (4)
+    - item_name: Super strength(4)
       slug: super-strength-4
       relationship: upgrade
-      description: Stronger version
-    - item_id: 2428
-      item_name: Attack potion (4)
-      slug: attack-potion-4
-      relationship: alternative
-      description: Pairs for melee
-  about: |-
-    Members (Herblore):
-    Mix Tarromin potion (unf) + Limpwurt root.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 12 |
-    | XP gained | 50 |
-
-    F2P (Apothecary):
-    Bring Limpwurt root + Red spiders' eggs + 5 gp to Apothecary in Varrock.
-
-    Temporarily boosts Strength by 3 + 10% of level:
-
-    | Strength Level | Boost |
-    |----------------|-------|
-    | 1-9 | +3 |
-    | 10-19 | +4 |
-    | 50-59 | +8 |
-    | 90-99 | +12 |
-
-    Boost decays 1 point per minute. Preserve prayer extends to 90 seconds.
-
-    Budget Strength boost for:
-    - F2P combat (via Apothecary)
-    - Early-game members
-    - Ironman accounts
+      description: Members-only stronger version
+  about: "Strength potion(4) is the cheapest sustainable Strength boost in OSRS, granting 3 + 10% of the current Strength level. Herblore players brew it at level 12 from a Tarromin potion (unf) and Limpwurt root for 50 experience; free players have the Varrock Apothecary trade a Limpwurt root, Red spiders' eggs, and 5 coins instantly. The boost decays at one level per minute and pairs naturally with Attack potion for early melee training."
   market_strategy:
     notes:
-      - Low level requirement, accessible early
-      - Apothecary method doesn't require Herblore
-      - Popular for F2P PKing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Apothecary route caps F2P supply, keeping margins thin"
+      - "Limpwurt root volatility drives potion price"
+      - "Bulk-buy during Herblore training events"
+  history:
+    - date: "2001-02-05"
+      description: Released alongside the original Herblore skill rollout.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-pirate-shirt-beige.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-pirate-shirt-beige.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Stripy pirate shirt (beige) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-02-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Dodgy Mike's Second-hand Clothing
+      location: Mos Le'Harmless
+      price: 300
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Stripy pirate shirt (blue)
+      slug: stripy-pirate-shirt-blue
+      relationship: variant
+      description: Blue-coloured variant sold from the same shop.
+    - item_name: Stripy pirate shirt (brown)
+      slug: stripy-pirate-shirt-brown
+      relationship: variant
+      description: Brown-coloured variant of the pirate shirt.
+    - item_name: Stripy pirate shirt (red)
+      slug: stripy-pirate-shirt-red
+      relationship: variant
+      description: Red-coloured variant of the pirate shirt.
+    - item_name: Pirate bandana (beige)
+      slug: pirate-bandana-beige
+      relationship: set-piece
+      description: Matching beige bandana that completes the pirate outfit.
+  about: "Stripy pirate shirt (beige) is a cosmetic body slot garment sold by Dodgy Mike's Second-hand Clothing on Mos Le'Harmless. It grants no combat bonuses and is purely decorative, popular with players completing themed pirate outfits alongside matching bandanas, leggings, and eyepatches. The Grand Exchange buy limit of 150 keeps prices reactive to outfit trends and Mos Le'Harmless activity."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-combat-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-combat-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super combat potion(1) | OSRS Price Data
-description: "Super combat potion(1): 1 dose of super combat potion.. High alch: 24 GP, GE limit: 2,000."
+description: "Super combat potion(1): 1 dose of super combat potion. High alch: 24 GP, GE limit: 2,000."
 osrs:
   id: 12701
   name: Super combat potion(1)
@@ -12,9 +12,86 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  about: "Super combat potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2014-08-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 90
+      xp: 150
+      materials:
+        - item_name: Super attack(4)
+          quantity: 1
+        - item_name: Super strength(4)
+          quantity: 1
+        - item_name: Super defence(4)
+          quantity: 1
+        - item_name: Torstol
+          quantity: 1
+      tools:
+        - Vial
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Boosts Attack by floor(level x 15 / 100) + 5"
+        duration: 0
+      - description: "Boosts Strength by floor(level x 15 / 100) + 5"
+        duration: 0
+      - description: "Boosts Defence by floor(level x 15 / 100) + 5"
+        duration: 0
+  related_items:
+    - item_name: Super combat potion(4)
+      slug: super-combat-potion-4
+      relationship: variant
+      description: Full 4-dose version of the same potion
+    - item_name: Super combat potion(2)
+      slug: super-combat-potion-2
+      relationship: variant
+      description: 2-dose version of the same potion
+    - item_name: Super combat potion(3)
+      slug: super-combat-potion-3
+      relationship: variant
+      description: 3-dose version of the same potion
+    - item_name: Divine super combat potion(4)
+      slug: divine-super-combat-potion-4
+      relationship: upgrade
+      description: Divine variant with no boost decay
+  about: "Super combat potion(1) is the single-dose form of the Super combat potion, made at 90 Herblore for 150 XP by combining a Super attack(4), Super strength(4), Super defence(4) and a Torstol in a vial. Drinking it boosts Attack, Strength and Defence by floor(level x 15 / 100) + 5, decaying at 1 level per minute (or 90 seconds with the Preserve prayer/spell). Single-dose forms are typically the residue of decanting and rarely the primary purchase."
+  market_strategy:
+    notes:
+      - "Often the cheaper per-dose form due to decanting friction"
+      - "Demand from bossers topping off before encounters"
+      - "Tracks the cost of Torstol and component supers"
+  trading_tips:
+    - Decant single doses into 4-doses for higher per-dose value
+    - Buy during Herblore events when supply rises
+    - Compare dose price against (4)/(3)/(2) variants before flipping
+  history:
+    - date: "2014-08-14"
+      description: "Added to the game with the release of Super combat potions."
+    - date: "2015-03-19"
+      description: "Lunar potion-share spell support added."
+    - date: "2016-04-15"
+      description: "Bank placeholder functionality added."
+    - date: "2019-02-14"
+      description: "Unfinished torstol vials became acceptable substitutes for clean torstol in the recipe."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-def-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-def-mix-1.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 52
   highalch: 79
   limit: 2000
-  about: "Super def. mix(1) is a members-only item in Old School RuneScape. High alchemy value: 79 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: herblore
+      level: 71
+      xp: 50
+      materials:
+        - item_name: Super defence(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 2
+  potion:
+    effects:
+      - description: Boosts Defence by 5 + 15% of base level (max +19 at 99 Defence) and restores 6 Hitpoints.
+        duration: null
+  related_items:
+    - item_name: Super def. mix(2)
+      slug: super-def-mix-2
+      relationship: variant
+      description: 2-dose version of the same Barbarian mix
+    - item_name: Super defence(2)
+      slug: super-defence-2
+      relationship: component
+      description: Base super defence potion combined with caviar to make the mix
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore secondary added to super defence to make the mix
+  about: "Super def. mix(1) is a 1-dose Barbarian Herblore potion made by adding caviar to super defence(2) at 71 Herblore after completing Barbarian Herblore training with Otto Godblessed. It gives the same Defence boost as super defence and additionally restores 6 Hitpoints when drunk."
+  market_strategy:
+    notes:
+      - "Niche Barbarian Herblore output — supply tracks caviar prices"
+      - "6 HP heal makes it useful for Slayer or low-HP DIY trips"
+      - "Limit of 2,000 supports modest day-flips"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super fishing potion(1) | OSRS Price Data
-description: "Super fishing potion(1): 1 dose of super fishing potion.. High alch: 24 GP."
+description: "Super fishing potion(1): 1 dose of super fishing potion. High alch: 24 GP."
 osrs:
   id: 31611
   name: Super fishing potion(1)
@@ -12,9 +12,72 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: null
-  about: "Super fishing potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 62
+      xp: 140.5
+      materials:
+        - item_name: Pillar potion (unf)
+          quantity: 1
+        - item_name: Haddock eye
+          quantity: 1
+      tools:
+        - Vial
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Boosts Fishing level by 6"
+        duration: 0
+  related_items:
+    - item_name: Super fishing potion(4)
+      slug: super-fishing-potion-4
+      relationship: variant
+      description: Full 4-dose version of the same potion
+    - item_name: Super fishing potion(3)
+      slug: super-fishing-potion-3
+      relationship: variant
+      description: 3-dose version of the same potion
+    - item_name: Super fishing potion(2)
+      slug: super-fishing-potion-2
+      relationship: variant
+      description: 2-dose version of the same potion
+    - item_name: Fishing potion(4)
+      slug: fishing-potion-4
+      relationship: downgrade
+      description: Standard +3 Fishing boost potion
+  about: "Super fishing potion(1) is the single-dose form of the Super fishing potion, a +6 Fishing boost made at 62 Herblore for 140.5 XP from a Pillar potion (unf) and a Haddock eye. Released alongside the November 2025 Herblore expansion, the potion serves Fishing training, Tempoross runs and master-clue Fishing steps. Note that the super variant cannot currently be stored in a tackle box, which is flagged as a bug on the wiki."
+  market_strategy:
+    notes:
+      - "Newly released potion; price volatility expected during the first months"
+      - "Demand from Tempoross runners and high-level Fishing training"
+      - "Supply depends on Haddock eye availability"
+  trading_tips:
+    - Track Haddock eye price to estimate fair production cost
+    - Decant single doses into 4-doses for higher per-dose value
+    - Expect spreads to tighten as the post-release hype settles
+  history:
+    - date: "2025-11-19"
+      description: "Added to the game with the Fishing/Herblore expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-4.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: null
-  about: "Super fishing potion(4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.12
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  potion:
+    effects:
+      - description: Boosts Fishing level by +6 per dose
+        duration: null
+  recipes:
+    - skill: herblore
+      level: 62
+      xp: 140.5
+      materials:
+        - item_name: Pillar potion (unf)
+          quantity: 1
+        - item_name: Haddock eye
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Super fishing potion(3)
+      slug: super-fishing-potion-3
+      relationship: variant
+      description: 3-dose decant variant
+    - item_name: Super fishing potion(2)
+      slug: super-fishing-potion-2
+      relationship: variant
+      description: 2-dose decant variant
+    - item_name: Super fishing potion(1)
+      slug: super-fishing-potion-1
+      relationship: variant
+      description: 1-dose decant variant
+    - item_name: Fishing potion(4)
+      slug: fishing-potion-4
+      relationship: downgrade
+      description: Lower-tier +3 Fishing boost potion
+    - item_name: Pillar potion (unf)
+      slug: pillar-potion-unf
+      relationship: component
+      description: Unfinished potion base used to brew this super variant
+  about: "Super fishing potion(4) is a four-dose potion that boosts the Fishing level by +6 per dose, brewed at Herblore level 62 from a pillar potion (unf) and a haddock eye for 140.5 XP. Unlike the standard fishing potion, the super variant cannot currently be stored inside a tackle box."
+  market_strategy:
+    notes:
+      - "Decants between (1), (2), (3), and (4) doses for inventory tuning"
+      - "Demand follows high-level Fishing and Stardust-tier minigame activity"
+  trading_tips:
+    - Watch the spread between input pillar potion (unf) and finished super doses
+    - Stock spikes when Fishing XP weekend events run
+  history:
+    - date: "2025-11-19"
+      description: Released as part of the Sleeper Cave Herblore expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-wardrobe-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teak wardrobe (flatpack) | OSRS Price Data
-description: "Teak wardrobe (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Teak wardrobe (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8618
   name: Teak wardrobe (flatpack)
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: mid
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 63
+      xp: 270
+      materials:
+        - item_name: Teak plank
+          quantity: 3
+      tools:
+        - Saw
+        - Hammer
+        - Bench with vice
+      output_quantity: 1
+  related_items:
+    - item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Material consumed when making the flatpack
+    - item_name: Oak wardrobe (flatpack)
+      slug: oak-wardrobe-flatpack
+      relationship: downgrade
+      description: Lower-tier wardrobe flatpack
+    - item_name: Mahogany wardrobe (flatpack)
+      slug: mahogany-wardrobe-flatpack
+      relationship: upgrade
+      description: Higher-tier wardrobe flatpack
+  about: "The Teak wardrobe (flatpack) is a Construction-made item built at a workbench with vice inside a Player-Owned House. At level 63 Construction it consumes 3 teak planks and grants 270 XP per build, then deploys onto a wardrobe space in the bedroom. Flatpacks are typically sold on the Grand Exchange so buyers can decorate their houses without training Construction themselves."
+  market_strategy:
+    notes:
+      - "Sold mainly to low-Construction house decorators"
+      - "Production almost always runs at a loss vs. plank cost"
+      - "Volume is thin; price reflects niche demand"
+  trading_tips:
+    - Compare price to 3x teak plank cost before producing
+    - Watch DXP weekends for short-term supply bursts
+    - Bulk-buy when listings stack near the 500 limit
+  history:
+    - date: "2006-05-31"
+      description: "Added to the game with the launch of the Construction skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-1-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-1-cape.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-1 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: William's Wilderness Cape Shop
+      location: Lava Dragon Isle
+      price: 50
+      currency: Coins
+      stock: 100
+  related_items:
+    - item_name: Team-2 cape
+      slug: team-2-cape
+      relationship: variant
+      description: Sibling team cape with different colour
+    - item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: variant
+      description: Highest numbered team cape variant
+  about: "Team-1 cape is one of fifty numbered team capes used to flag allies during multi-combat encounters. Matching capes hide the attack option and show wearers as allies on the minimap; mismatched capes leave attack on left-click. Sold by William on Lava Dragon Isle in the Wilderness."
+  market_strategy:
+    notes:
+      - "Shop-bought from William for 50 gp — undercuts most GE listings"
+      - "Demand spikes during team-based events and PvP tournaments"
+      - "Low-tier alch target due to thin margins"
+  history:
+    - date: "2005-02-22"
+      description: Released as part of the team cape numbering system.
+    - date: "2013-05-23"
+      description: Made available to free-to-play players.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-30-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-30-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-30 cape | OSRS Price Data
-description: "Team-30 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-30 cape: Ooohhh look at the pretty colours. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4373
   name: Team-30 cape
@@ -12,9 +12,74 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-30 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Team-29 cape
+      slug: team-29-cape
+      relationship: variant
+      description: Adjacent numbered team cape variant
+    - item_name: Team-31 cape
+      slug: team-31-cape
+      relationship: variant
+      description: Adjacent numbered team cape variant
+  about: "The Team-30 cape is one of fifty numbered team capes used for player-organised team events and PvP. Wearing a matching cape causes teammates to appear as blue dots on the minimap, with the attack option shifted to right-click. Originally a members item, the team capes were released to free-to-play players on 23 May 2013. They have minor defensive bonuses but are primarily cosmetic and organisational."
+  market_strategy:
+    notes:
+      - "Cheap free-to-play item with low GE volume"
+      - "Occasional spikes around clan event seasons"
+      - "Profit margins are tight given the 30 gp alch value"
+  trading_tips:
+    - Bulk flip near the 150 buy limit for small consistent margins
+    - Watch for in-game events that drive demand for team capes
+    - Compare against neighbouring numbered team capes for relative value
+  history:
+    - date: "2005-02-22"
+      description: "Added to the game as a members item."
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-35-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-35-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-35 cape | OSRS Price Data
-description: "Team-35 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-35 cape: Ooohhh look at the pretty colours... High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4383
   name: Team-35 cape
@@ -12,9 +12,70 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-35 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Edward's Wilderness Cape Shop
+      location: Near Rogues' Castle, Wilderness
+      price: 50
+      currency: coins
+      stock: 100
+  related_items:
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Another numbered team cape variant
+    - item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: variant
+      description: Highest-numbered team cape variant
+  about: "Team-35 cape is a free-to-play cape sold by Edward's Wilderness Cape Shop. Wearing matching team capes causes fellow wearers to appear as blue dots on the minimap and shifts the Attack option to right-click, supporting PvP team identification."
+  market_strategy:
+    notes:
+      - "Cheap shop restock supports steady supply"
+      - "Casual PvP cosmetic with low demand"
+      - "High alch margin negligible without nature rune discount"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-44-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-44-cape.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-44 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Darren's Wilderness Cape Shop
+      location: East of Wilderness Agility Course
+      price: 50
+      currency: Coins
+      stock: 100
+  related_items:
+    - item_name: Team-43 cape
+      slug: team-43-cape
+      relationship: variant
+      description: Previous numbered team cape
+    - item_name: Team-45 cape
+      slug: team-45-cape
+      relationship: variant
+      description: Next numbered team cape
+  about: "The Team-44 cape is a free-to-play cape sold by Darren's Wilderness Cape Shop for 50 coins. Worn primarily for team identification in PvP and clan events, players wearing matching team capes appear as blue dots on the minimap and require right-clicking to attack each other. It provides +1 Slash, +1 Crush and +2 Ranged defence."
+  history:
+    - date: "2005-02-22"
+      description: Added to the game.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-med.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-med.mdx
@@ -12,9 +12,37 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 100
-  about: "Thatch spar med is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    alchable: true
+  related_items:
+    - item_name: Thatch spar light
+      slug: thatch-spar-light
+      relationship: variant
+      description: Light-grade thatch pole harvested from light jungle in Tai Bwo Wannai.
+    - item_name: Thatch spar dense
+      slug: thatch-spar-dense
+      relationship: variant
+      description: Dense-grade thatch pole harvested from dense jungle.
+    - item_name: Machete
+      slug: machete
+      relationship: component
+      description: Required tool for clearing jungle and collecting thatch spars.
+  about: "Thatch spar med is the medium-grade wooden pole harvested by clearing medium jungle during the Tai Bwo Wannai Cleanup activity. It requires level 20 Woodcutting and a machete to chop, with the resulting pole used to repair Mort'ton's fences during Shades of Mort'ton or to fashion skewer sticks for cooking spider on stick. The Grand Exchange buy limit is 100 per four hours, reflecting its niche role outside of those minigame loops."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tonameyo-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tonameyo-white.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: null
-  about: "Tonameyo white is a members-only item in Old School RuneScape. High alchemy value: 360 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: consumable
+    tier: mid
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+  potion:
+    effects:
+      - description: Restores 16 Hitpoints and 1 Prayer point
+      - description: Reduces Attack by 5
+      - description: Reduces Thieving by 1
+  shops:
+    - shop_name: Moonrise Wines
+      location: Aldarin
+      price: 600
+      currency: Coins
+      stock: 20
+  related_items:
+    - item_name: Tonameyo
+      slug: tonameyo
+      relationship: variant
+      description: Base Darkfrost wine variant
+  about: "Tonameyo white is a sacred Darkfrost wine introduced with the Varlamore: The Rising Darkness update. Drinking it restores 16 Hitpoints and 1 Prayer point while temporarily reducing Attack by 5 and Thieving by 1. Its flavour profile features apple, jangerberry, oak and vanilla, and the name translates from Nahuatl as 'something with clarity, like a ray of sun'. Sold by Moonrise Wines on Aldarin."
+  history:
+    - date: "2024-09-25"
+      description: Added to the game with the Varlamore - The Rising Darkness update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-dragon-bolts-e.mdx
@@ -12,60 +12,92 @@ osrs:
   lowalch: 292
   highalch: 438
   limit: 11000
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: ammo
+    weapon_type: bolts
+    attack_speed: null
+    weight: 0
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
       ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
       ranged_strength: 122
+      magic_damage: 0
       prayer: 0
-    requirements: {}
   recipes:
     - skill: magic
       level: 29
       xp: 33
-      inputs:
+      materials:
         - item_name: Topaz dragon bolts
           quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 2
+      tools: []
       output_quantity: 10
   related_items:
-    - item_id: 9239
-      item_name: Topaz bolts (e)
+    - item_name: Topaz dragon bolts
+      slug: topaz-dragon-bolts
+      relationship: component
+      description: Unenchanted base bolt
+    - item_name: Topaz bolts (e)
       slug: topaz-bolts-e
       relationship: downgrade
-      description: Regular crossbow version
-  about: |-
-    > *"Enchanted Dragon crossbow bolts, tipped with red topaz."*
-
-    Topaz dragon bolts (e) carry the Down to Earth enchantment. On activation, the target's Magic level is lowered by 1. The effect has a 4% trigger chance (4.4% with the hard Kandarin Diary completed). This effect only works against other players and activates regardless of whether the attack hits or misses. While the per-proc drain is small, repeated hits can gradually weaken an opponent's Magic level in PvP.
-
-    Enchant Crossbow Bolt (Topaz) requires Magic level 29 and grants 33 XP per cast. Each cast enchants 10 bolts at a time.
-
-    | Component | Quantity |
-    |-----------|----------|
-    | Topaz dragon bolts | 10 |
-    | Cosmic rune | 1 |
-    | Fire rune | 2 |
-    | Earth rune | 2 |
-
-    | Stat | Dragon (e) | Regular (e) |
-    |------|-----------|-------------|
-    | Ranged Str | +122 | +46 |
-    | Base bolt | Dragon crossbow bolt | Steel bolt |
-
-    The dragon bolt base provides significantly higher ranged strength while retaining the same Magic-draining enchantment.
+      description: Steel-base enchanted variant with lower ranged strength
+    - item_name: Dragon crossbow
+      slug: dragon-crossbow
+      relationship: component
+      description: Minimum crossbow tier for dragon bolts
+  passive_effects:
+    - name: Down to Earth
+      description: 4% chance (4.4% with hard Kandarin Diary) to lower the target's Magic level by 1 per shot. Affects players only and triggers on hits or misses.
+  about: "Topaz dragon bolts (e) are enchanted dragon-tipped crossbow bolts carrying the Down to Earth enchantment. On activation they drain 1 Magic level from the opponent at a 4% trigger chance (4.4% with hard Kandarin Diary), making them a niche PvP utility against Magic-using opponents. Players enchant them at Magic level 29 for 33 XP using 1 cosmic rune and 2 fire runes, producing 10 enchanted bolts per cast. They provide +122 Ranged strength, far above the regular topaz bolt (e) version."
   market_strategy:
     notes:
-      - PvP only - no effect on NPCs
-      - Low activation rate (4%)
-      - Activates regardless of hit/miss
-      - Niche use for Magic level draining in PvP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "PvP-only niche limits demand to bounty hunter and pkers"
+      - "Low 4% activation gates them out of PvM use"
+      - "Enchant cost is minimal so margin = bolt spread"
+      - "Track dragon bolt price to gauge floor"
+  trading_tips:
+    - Buy unenchanted dragon bolts during dips and convert
+    - Watch DMM and PvP event schedules for spikes
+    - Avoid stacking inventory during low PvP cycles
+  history:
+    - date: "2018-01-04"
+      description: Released as part of the Dragon Slayer II update.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torstol-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torstol-seed.mdx
@@ -12,70 +12,83 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 200
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: seed
+    tier: high
   properties:
+    release_date: "2005-06-06"
     tradeable: true
-    tradeable_ge: true
     stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0
-  skilling_sources:
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
     - skill: farming
       level: 85
       xp: 199.5
-      growth_time: 80
+      materials:
+        - item_name: Torstol seed
+          quantity: 1
+      tools:
+        - Seed dibber
+        - Rake
+      output_quantity: 1
   drop_table:
     sources:
-      - source: Master Farmers
-        source_id: 5730
-        combat_level: 0
+      - source: Master Farmer
         quantity: "1"
-        rarity: very-rare
-        members_only: true
+        rarity: "1/302.6"
       - source: Zulrah
-        source_id: 2044
-        combat_level: 725
         quantity: "2"
-        rarity: uncommon
-        members_only: true
+        rarity: "1/204"
       - source: Cerberus
-        source_id: 5862
-        combat_level: 318
         quantity: "3"
-        rarity: uncommon
-        members_only: true
+        rarity: "1/64"
+      - source: Alchemical Hydra
+        quantity: "3"
+        rarity: "1/51.2"
+      - source: Tombs of Amascut reward chest
+        quantity: "varies"
+        rarity: Uncommon
   related_items:
-    - item_id: 269
-      item_name: Torstol
+    - item_name: Grimy torstol
+      slug: grimy-torstol
+      relationship: product
+      description: "Harvested herb produced by a fully grown torstol patch."
+    - item_name: Torstol
       slug: torstol
       relationship: product
-      description: Harvested herb
-    - item_id: 2450
-      item_name: Zamorak brew(4)
+      description: "Clean torstol used in Zamorak brews and the Super combat potion."
+    - item_name: Zamorak brew(4)
       slug: zamorak-brew-4
       relationship: product
-      description: Primary potion use
-    - item_id: 5300
-      item_name: Snapdragon seed
+      description: "Primary potion crafted from clean torstol."
+    - item_name: Snapdragon seed
       slug: snapdragon-seed
       relationship: alternative
-      description: Alternative herb seed
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Seed |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 85 Farming |
-
-    Plant in herb patches to grow grimy torstol.
-
-    Growth Time: 80 minutes (4 cycles)
-
-    Yield: 5-18 herbs (depends on Magic Secateurs, Farming level)
-
-    XP: 199.5 (planting) + 224.5 (harvesting)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Next-tier-below herb seed for super restore production."
+  about: "Torstol seed is a members-only high-tier herb seed released on 6 June 2005. Planting requires 85 Farming and grants 199.5 Farming XP on planting plus 224.5 XP per harvested herb of grimy torstol. The seed grows in 80 minutes (4 x 20-minute cycles) and yields a base of 3 herbs scaling up to 6 with ultracompost. It drops from Master Farmers, several high-end bosses (Zulrah, Cerberus, Alchemical Hydra) and reward chests such as the Tombs of Amascut. The clean herb is a key ingredient for Zamorak brews and Super combat potions. High alchemy value: 42 coins. Grand Exchange buy limit: 200 per 4 hours."
+  market_strategy:
+    notes:
+      - "Price is anchored to clean torstol demand from Super combat potion buyers."
+      - "Supply pulses with boss kill rates; track Zulrah/Cerberus/Hydra meta shifts."
+      - "Low buy limit (200) means whales can swing price meaningfully in single windows."
+  trading_tips:
+    - "Buy when Zulrah dies are in high supply; resell to herb runners ahead of patch resets."
+    - "Pair with ultracompost stockpiles for full farm-run setup bundles."
+    - "Convert into clean torstol when GE herb price beats seed-to-herb yield economics."
+  history:
+    - date: "2005-06-06"
+      description: "Released into the game alongside high-level Farming content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-rejuvenation-pool-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-rejuvenation-pool-scroll.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Trailblazer reloaded rejuvenation pool scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic-scroll
+    tier: high
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues IV Trailblazer Reloaded
+      price: 9000
+      currency: League Points
+      stock: 1
+  related_items:
+    - item_name: Ornate rejuvenation pool
+      slug: ornate-rejuvenation-pool
+      relationship: component
+      description: Pool that the scroll re-themes
+  about: "Trailblazer reloaded rejuvenation pool scroll is a cosmetic Construction reward from Leagues IV: Trailblazer Reloaded, purchased from the Leagues Reward Shop for 9,000 League Points. Reading the scroll on an Ornate rejuvenation pool in a player-owned house re-themes it with a fiery Trailblazer Reloaded appearance. Reverting the pool returns the scroll, so the cosmetic can be moved or resold."
+  market_strategy:
+    notes:
+      - "Supply locked behind a finished league, no ongoing inflow"
+      - "Demand driven by PoH fashionscape collectors"
+      - "Reversible application keeps the asset liquid"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-relic-hunter-t2-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-relic-hunter-t2-armour-set.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Trailblazer reloaded relic hunter (t2) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour set
+    tier: mid
+  properties:
+    release_date: "2023-11-15"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: ["Drop"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Trailblazer reloaded headband (t2)
+      slug: trailblazer-reloaded-headband-t2
+      relationship: set-piece
+      description: Head slot piece
+    - item_name: Trailblazer reloaded top (t2)
+      slug: trailblazer-reloaded-top-t2
+      relationship: set-piece
+      description: Body slot piece
+    - item_name: Trailblazer reloaded trousers (t2)
+      slug: trailblazer-reloaded-trousers-t2
+      relationship: set-piece
+      description: Legs slot piece
+    - item_name: Trailblazer reloaded boots (t2)
+      slug: trailblazer-reloaded-boots-t2
+      relationship: set-piece
+      description: Feet slot piece
+  about: "The Trailblazer reloaded relic hunter (t2) armour set bundles four cosmetic Trailblazer Reloaded League pieces into one tradeable package via the Grand Exchange Sets clerk. Useful for shuffling the cosmetic set between players without juggling individual slots."
+  market_strategy:
+    notes:
+      - "Set premium vs combined components varies; compare set price to sum of pieces."
+      - "Use the GE clerk Sets tab to pack or unpack."
+  history:
+    - date: "2023-11-15"
+      description: Item added to the game.
+    - date: "2023-11-29"
+      description: Became obtainable through the Grand Exchange clerk.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-vengeance-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-vengeance-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer reloaded vengeance scroll | OSRS Price Data
-description: "Trailblazer reloaded vengeance scroll: A scroll which unlocks the Trailblazer Reloaded Vengeance animation.. High alch: 15,000 GP."
+description: "Trailblazer reloaded vengeance scroll: A scroll which unlocks the Trailblazer Reloaded Vengeance animation. High alch: 15,000 GP."
 osrs:
   id: 28696
   name: Trailblazer reloaded vengeance scroll
@@ -12,12 +12,43 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Trailblazer reloaded vengeance scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  properties:
+    release_date: "2023-03-15"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Read", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to destroy this item? You can reclaim it from Adventurer Jon in Lumbridge."
+  related_items:
+    - item_name: Vengeance
+      slug: vengeance
+      relationship: alternative
+      description: Lunar spellbook spell whose animation this scroll cosmetically replaces
+  about: "The Trailblazer reloaded vengeance scroll is a cosmetic scroll obtained from the Trailblazer Reloaded League. Reading it permanently unlocks the Trailblazer Reloaded variant of the Vengeance animation, giving players a way to flex league participation in PvP and PvM. Once unlocked the animation can be toggled from the spellbook interface."
+  market_strategy:
+    notes:
+      - "One-time cosmetic unlock - long-tail demand from completionists"
+      - "No GE buy limit but supply is fixed to league rewards"
+      - "Members-only animation override"
+      - "High alch sits well below market price - not an alch target"
+  trading_tips:
+    - Price drifts toward league hype cycles - cheaper between leagues
+    - Watch for new league announcements before flipping
+  history:
+    - date: "2023-03-15"
+      description: Released as a Trailblazer Reloaded League reward.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-top-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-top-t2.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 5
-  about: "Trailblazer top (t2) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues IV - Trailblazer Reloaded
+      price: 3000
+      currency: League points
+      stock: 1
+  related_items:
+    - item_name: Trailblazer hood (t2)
+      slug: trailblazer-hood-t2
+      relationship: set-piece
+      description: Matching hood for the T2 set
+    - item_name: Trailblazer trousers (t2)
+      slug: trailblazer-trousers-t2
+      relationship: set-piece
+      description: Matching trousers for the T2 set
+    - item_name: Trailblazer boots (t2)
+      slug: trailblazer-boots-t2
+      relationship: set-piece
+      description: Matching boots for the T2 set
+  about: "Trailblazer top (t2) is a cosmetic body slot item from the Trailblazer Relic Hunter (T2) outfit, purchased for 3,000 League points from the Leagues Reward Shop. It provides no combat bonuses and is purely cosmetic. Can be stored in an armour case within a costume room as part of the full set; Ultimate Ironmen cannot retrieve individual pieces until the complete outfit is stored."
+  market_strategy:
+    notes:
+      - "Limited supply from Leagues IV reward shop"
+      - "Low buy limit of 5 per 4 hours"
+      - "Cosmetic demand drives price"
+  history:
+    - date: "2021-01-06"
+      description: Released with the Trailblazer League rewards.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trapper-s-tipple.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trapper-s-tipple.mdx
@@ -12,12 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Trapper's tipple is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily boosts Hunter by +2 levels."
+        duration: null
+      - description: "Reduces Attack by 2 levels and Strength by 1 level."
+        duration: null
+  shops:
+    - shop_name: The Burrow
+      location: Hunter Guild
+      price: 9
+      currency: Coins
+      stock: 10
+  related_items:
+    - item_name: Hunter potion(4)
+      slug: hunter-potion-4
+      relationship: alternative
+      description: Brewed Hunter boost equivalent.
+    - item_name: Hunters' sausage
+      slug: hunters-sausage
+      relationship: alternative
+      description: Food that also boosts Hunter at the Hunter Guild.
+  about: "Trapper's tipple is a Hunter-boosting ale released with the Hunter Guild in Varlamore: Part One on 20 March 2024. Drinking it grants +2 Hunter at the cost of -1 Strength and -2 Attack, making it ideal for catching higher level creatures than your base Hunter level would otherwise allow. It is sold by Huntmaster Gilman at The Burrow pub or scavenged from table spawns inside the same building, but requires Hunter 46 to purchase."
+  market_strategy:
+    notes:
+      - "Sold cheaply from Huntmaster Gilman; little flip margin."
+      - "Useful inventory consumable for Hunter level-boost niches."
+  trading_tips:
+    - Stock up directly from The Burrow when training at the Hunter Guild.
+    - GE listings rarely beat the in-shop price of nine coins per drink.
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore: Part One expansion and Hunter Guild update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trident-of-the-seas-full.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trident-of-the-seas-full.mdx
@@ -12,83 +12,99 @@ osrs:
   lowalch: 27600
   highalch: 41400
   limit: 8
+  material:
+    type: powered_staff
+    tier: high
+  properties:
+    release_date: "2014-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options: ["Wield", "Check", "Drop"]
+    worn_options: ["Check", "Uncharge"]
+    alchable: true
   equipment:
     slot: weapon
-    type: powered_staff
-    tradeable: true
+    weapon_type: powered_staff
+    attack_speed: 4
     weight: 1.814
     requirements:
       magic: 75
-    stats:
-      attack_magic: 15
-  charging:
-    max_charges: 2500
-    cost_per_cast: ~220 gp
-    materials:
-      - item_id: 560
-        item_name: Death rune
-        quantity: "1"
-      - item_id: 562
-        item_name: Chaos rune
-        quantity: "1"
-      - item_id: 554
-        item_name: Fire rune
-        quantity: "5"
-      - item_name: Coins
-        quantity: "10"
-  obtaining:
-    methods:
-      - source: Kraken (boss)
-        drop_rate: 1/512
-        variant: charged
-        requirements:
-          slayer: 87
-      - source: Cave kraken
-        drop_rate: 1/200
-        variant: uncharged
-        requirements:
-          slayer: 87
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 15
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  charges:
+    type: rune_consumption
+    description: Holds up to 2,500 charges. Each charge consumes 1 death rune, 1 chaos rune, 5 fire runes, and 10 coins (approximately 322 coins per charge, around 805,000 coins for a full recharge).
+  recipes:
+    - skill: magic
+      level: 75
+      xp: 0
+      materials:
+        - item_name: Death rune
+          quantity: 1
+        - item_name: Chaos rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 5
+        - item_name: Coins
+          quantity: 10
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 0
-      item_name: Kraken
-      slug: kraken
-      relationship: component
-      description: Boss drop
-    - item_id: 12899
-      item_name: Trident of the swamp
+    - item_name: Trident of the seas (e)
+      slug: trident-of-the-seas-e
+      relationship: variant
+      description: Enhanced variant created with a kraken tentacle
+    - item_name: Trident of the swamp
       slug: trident-of-the-swamp
       relationship: upgrade
-      description: Upgrade
-    - item_id: 12932
-      item_name: Magic fang
+      description: Toxic upgrade using a magic fang
+    - item_name: Kraken
+      slug: kraken
+      relationship: component
+      description: Boss source of the charged trident drop
+    - item_name: Magic fang
       slug: magic-fang
       relationship: component
-      description: Upgrade material
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Magic | +15 |
-
-    | Resource | Amount |
-    |----------|--------|
-    | Death rune | 1 |
-    | Chaos rune | 1 |
-    | Fire rune | 5 |
-    | Coins | 10 |
-    | Cost per cast | ~220 gp |
-    | Max charges | 2,500 |
-
-    Used for:
-    - Budget powered staff
-    - Early Zulrah
-    - General magic
-
-    Upgrade to Trident of the swamp.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Upgrade material to combine into the swamp trident
+  about: "Trident of the seas (full) is the fully charged form of the popular powered staff, dropped by the Kraken boss at roughly 1/512 and unlocked at 75 Magic. It autocasts a magic attack on a 4-tick speed for 7-tile range (9 with longrange), pulling runes and 10 coins from your inventory per cast. The full variant is tradeable so it can be flipped or sold post-grind, and can be upgraded into the Toxic trident of the swamp with a magic fang."
+  market_strategy:
+    notes:
+      - "Tradeable only when uncharged or fully charged"
+      - "GE buy limit of 8 keeps order books shallow"
+      - "Demand tied to Slayer/Zulrah usage and league cycles"
+      - "Watch death/chaos rune prices for charging arbitrage"
+  trading_tips:
+    - Compare charged price to uncharged + recharge cost
+    - Watch Kraken task popularity for supply swings
+  history:
+    - date: "2014-01-30"
+      description: Released with the Kraken boss update.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-boots-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-boots-t3.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 5
-  about: "Twisted boots (t3) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2020-01-16"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: cosmetic
+    attack_speed: null
+    weight: 0.34
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Twisted hat (t3)
+      slug: twisted-hat-t3
+      relationship: set-piece
+      description: Tier 3 head slot piece of the Twisted relic hunter outfit.
+    - item_name: Twisted coat (t3)
+      slug: twisted-coat-t3
+      relationship: set-piece
+      description: Tier 3 body slot piece of the Twisted relic hunter outfit.
+    - item_name: Twisted trousers (t3)
+      slug: twisted-trousers-t3
+      relationship: set-piece
+      description: Tier 3 legs slot piece of the Twisted relic hunter outfit.
+    - item_name: Twisted boots (t2)
+      slug: twisted-boots-t2
+      relationship: downgrade
+      description: Tier 2 colour variant of the same cosmetic boots.
+    - item_name: Twisted boots (t1)
+      slug: twisted-boots-t1
+      relationship: downgrade
+      description: Tier 1 colour variant of the same cosmetic boots.
+  about: "Twisted boots (t3) are the highest-tier colour variant of the Twisted relic hunter outfit, originally redeemed from the Twisted League reward shop. They are purely cosmetic and grant no combat bonuses, but they remain a popular trophy for players who completed the league and a fashionscape staple in costume rooms and outfit stands."
+  market_strategy:
+    notes:
+      - "Supply is fixed - no new boots are minted outside of original Twisted League participants - so price drifts up over time."
+      - "Buy limit of 5 keeps daily flips small; treat this as a long-hold collector item."
+      - "Demand spikes around new league or Leagues V hype as nostalgia kicks in."
+  trading_tips:
+    - "Hold through new league announcements and list during the hype cycle."
+    - "Buy-out lowballs immediately after big PvM updates when collectors quietly liquidate."
+  history:
+    - date: "2020-01-16"
+      description: "Released as a Twisted League Reward Shop cosmetic for the inaugural Leagues event."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-jade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-jade.mdx
@@ -6,15 +6,70 @@ osrs:
   name: Uncut jade
   slug: uncut-jade
   examine: This would be worth more cut.
-  members: true
+  members: false
   icon: Uncut jade.png
   value: 30
   lowalch: 12
   highalch: 18
   limit: 10000
-  about: "Uncut jade is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gem
+    tier: low
+  properties:
+    release_date: "2003-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.003
+    options:
+      - Drop
+    alchable: true
+    destroy: "This would be worth more cut."
+  drop_table:
+    sources:
+      - source: Gem rocks
+        quantity: "1"
+        rarity: 30/128
+      - source: H.A.M. Members
+        quantity: "1"
+        rarity: 2/102
+      - source: Gemstone Crab
+        quantity: "1"
+        rarity: 3/32
+  recipes:
+    - skill: crafting
+      level: 13
+      xp: 20
+      materials:
+        - item_name: Uncut jade
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_name: Jade
+      slug: jade
+      relationship: product
+      description: Cut form used in jewellery crafting.
+    - item_name: Chisel
+      slug: chisel
+      relationship: component
+      description: Required to cut the gem.
+  about: "Uncut jade is a semi-precious gem used in the Crafting skill. Players cut uncut jade with a chisel at level 13 Crafting for 20 experience to make a jade gem. Uncut jades drop from gem rocks (40 Mining), the Gemstone Crab, H.A.M. members, and various mid-tier monsters. Released 27 January 2003."
+  market_strategy:
+    notes:
+      - "Stable Crafting-skiller demand from jade bolt tips and lunar dragonstone jewellery prep."
+      - "Gem rock mining bots push supply; price tends to compress with Shilo Village popularity."
+  trading_tips:
+    - Compare uncut vs cut margins to decide whether to cut at level 13 for free Crafting XP.
+  history:
+    - date: "2003-01-27"
+      description: Introduced with the Shilo Village gem rocks update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unfinished-potion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unfinished-potion.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Unfinished potion is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: unfinished-potion
+    tier: mid
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Ashes
+          quantity: 1
+        - item_name: Vial of water
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Ashes
+      slug: ashes
+      relationship: component
+      description: Combined with a vial of water to create the unfinished potion
+    - item_name: Vial of water
+      slug: vial-of-water
+      relationship: component
+      description: Water base for the unfinished potion
+    - item_name: Tarromin
+      slug: tarromin
+      relationship: component
+      description: Added to produce Serum 207 (3) at 50 Herblore
+    - item_name: Serum 207 (3)
+      slug: serum-207-3
+      relationship: product
+      description: Finished potion produced after adding tarromin
+  about: "Unfinished potion is the ash-based intermediate used during the Shades of Mort'ton quest line. Combining Ashes with a Vial of water yields the unfinished mix; finishing it with Tarromin at 50 Herblore produces Serum 207 (3), the active reagent for purifying shades. Outside the quest, the item exists mostly as a Herblore curio with a tiny 6-coin alch value."
+  market_strategy:
+    notes:
+      - "Demand tracks Shades of Mort'ton minigame popularity"
+      - "Bulk supply piggybacks on cheap ashes"
+      - "High alch unprofitable, hold for serum brewers"
+  history:
+    - date: "2004-10-18"
+      description: Added with the Shades of Mort'ton quest release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-plant-pot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unfired-plant-pot.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Unfired plant pot is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: clay
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+  recipes:
+    - skill: crafting
+      level: 19
+      xp: 20
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Potter's wheel
+      output_quantity: 1
+  related_items:
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Input material shaped on the potter's wheel
+    - item_name: Plant pot
+      slug: plant-pot
+      relationship: product
+      description: Fired version used in Farming
+  about: "Unfired plant pot is a Crafting intermediate created by shaping soft clay on a potter's wheel at 19 Crafting for 20 XP. Firing it in a pottery oven produces a finished plant pot used in Farming for seedling cultivation. Cheap and bulk-trained, with negligible alch value."
+  market_strategy:
+    notes:
+      - "Vendor-floor priced, profit is in the firing XP"
+      - "Soft clay cost dictates breakeven"
+      - "Used in low-level Crafting/Farming setups"
+  trading_tips:
+    - Pair bulk soft clay buy with pottery oven proximity for fastest fire-rate
+    - Flip finished plant pots if margin exceeds firing time cost
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-book-page-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-book-page-set.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 2800
   highalch: 4200
   limit: 5
-  about: "Unholy book page set is a members-only item in Old School RuneScape. High alchemy value: 4,200 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: set
+    tier: mid
+  properties:
+    release_date: "2015-03-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: ["Exchange", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Unholy book
+      slug: unholy-book
+      relationship: product
+      description: Assembled Zamorak book created from the four pages in this set.
+    - item_name: Zamorak page 1
+      slug: zamorak-page-1
+      relationship: component
+      description: First page of the Unholy book included in the set.
+    - item_name: Zamorak page 2
+      slug: zamorak-page-2
+      relationship: component
+      description: Second page of the Unholy book included in the set.
+    - item_name: Zamorak page 3
+      slug: zamorak-page-3
+      relationship: component
+      description: Third page of the Unholy book included in the set.
+    - item_name: Zamorak page 4
+      slug: zamorak-page-4
+      relationship: component
+      description: Fourth page of the Unholy book included in the set.
+    - item_name: Holy book page set
+      slug: holy-book-page-set
+      relationship: alternative
+      description: Saradomin equivalent set of four Holy book pages.
+  about: "Unholy book page set is a tradeable bundle exchanged at any Grand Exchange clerk for the four Zamorak pages needed to assemble the Unholy book. The set exists purely as a convenience listing on the Grand Exchange, letting flippers and bookbinders move all four pages in a single trade slot rather than handling each page individually."
+  market_strategy:
+    notes:
+      - "Compare the set price against the sum of the four Zamorak page prices to spot decombine arbitrage."
+      - "Buy limit is only 5 per 4 hours, so this is a thin flip rather than a high-volume staple."
+      - "Demand spikes alongside Unholy book purchases for melee god book setups in PvP and clue scrolls."
+  trading_tips:
+    - "Use a clerk to break the set into individual pages whenever the combined page price exceeds the set price."
+    - "Re-list combined sets when bulk buyers gathering full books are bidding above the four-page total."
+  history:
+    - date: "2015-03-19"
+      description: "Released alongside other god book page sets so the Grand Exchange could trade complete books in a single listing."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unlit-torch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unlit-torch.mdx
@@ -12,13 +12,52 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 40
-  related_items: []
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: utility
+    tier: low
+  properties:
+    release_date: "2002-09-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Lit torch
+      slug: lit-torch
+      relationship: upgrade
+      description: Activated form, light source
+    - item_name: Tinderbox
+      slug: tinderbox
+      relationship: component
+      description: Required to light the torch
   about: |-
-    > _"An unlit torch."_
+    > _"An unlit home-made torch."_
 
-    An unlit torch can be lit with a tinderbox to create a lit torch, providing a light source in dark areas like the Lumbridge Swamp Caves. Burns out over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The unlit torch becomes a light source when lit with a tinderbox, useful in dark areas like the Lumbridge Swamp Caves. Players can equip up to three lit torches for enhanced brightness. In Hunter at 39+, lit torches smoke traps to boost catch rates by 2%. Renamed from "Torch" in May 2006 when player-owned houses arrived.
+  market_strategy:
+    notes:
+      - "Low-value utility item"
+      - "Demand tied to Lumbridge caves and Hunter"
+      - "Buy limit 40, low liquidity"
+      - "Cheap entry for new players"
+  trading_tips:
+    - Negligible margins, not a flip target
+    - Easier to buy than craft for some
+  history:
+    - date: "2002-09-09"
+      description: Released as "Torch" with original game launch content.
+    - date: "2006-05-30"
+      description: Renamed to "Unlit torch" with POH update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/urium-remains.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/urium-remains.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Urium remains is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: remains
+    tier: high
+  properties:
+    release_date: "2021-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Urium Shade
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Loar remains
+      slug: loar-remains
+      relationship: alternative
+      description: "Lowest-tier shade remains used in the Shades of Mort'ton minigame."
+    - item_name: Phrin remains
+      slug: phrin-remains
+      relationship: alternative
+      description: "Mid-low tier shade remains burned on pyres."
+    - item_name: Riyl remains
+      slug: riyl-remains
+      relationship: alternative
+      description: "Mid-tier shade remains burned on pyres."
+    - item_name: Asyn remains
+      slug: asyn-remains
+      relationship: alternative
+      description: "High-tier shade remains burned on pyres."
+    - item_name: Fiyr remains
+      slug: fiyr-remains
+      relationship: alternative
+      description: "Premium-tier shade remains burned on pyres."
+  about: "Urium remains are the highest-tier shade remains in Old School RuneScape, dropped exclusively by Urium Shades (combat level 140) located behind the solid gold door in the Shade Catacombs beneath Mort'ton. Released on 27 January 2021 with the Shades of Mort'ton Rework, the remains are cremated on a funeral pyre with redwood or rosewood pyre logs and a tinderbox to grant the largest Firemaking and Prayer experience yields of any shade. Each cremation has a 79% chance to drop a gold shade key colour and a 21% chance to drop 2,000-7,000 coins. As of May 2024 dropped remains persist for 5 minutes instead of 30 seconds during the exclusive-pickup window. Grand Exchange buy limit: 7,500 per 4 hours."
+  market_strategy:
+    notes:
+      - "Value scales with redwood pyre log price and the demand for gold shade keys; track both together."
+      - "Supply is bottlenecked by Urium Shade kill rate, so prices spike during double-XP weekends."
+      - "GE buy limit of 7,500 makes accumulation feasible without splitting accounts."
+  trading_tips:
+    - "Buy in bulk during slow weekday hours; resell into weekend Firemaking demand."
+    - "Bundle with redwood pyre logs and tinderboxes for one-stop Firemaking/Prayer XP buyers."
+    - "Monitor gold key drop rates and chest reward patches that may alter cremation profitability."
+  history:
+    - date: "2021-01-27"
+      description: "Released with the Shades of Mort'ton Rework update."
+    - date: "2024-05-15"
+      description: "Dropped remains now despawn after 5 minutes instead of 30 seconds, with exclusive pickup during that window."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/venator-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/venator-shard.mdx
@@ -12,60 +12,53 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 8
-  item:
-    type: material
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crafting material
+    tier: high
+  properties:
+    release_date: "2023-01-11"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0
+    options:
+      - Combine
+      - Drop
+    worn_options: []
+    alchable: true
   drop_table:
     sources:
       - source: Phantom Muspah
-        rate: 1/100
+        quantity: "1"
+        rarity: 1/100
       - source: Frozen cache
-        rate: 1/500
-  recipes:
-    - skill: crafting
-      materials:
-        - item_id: 27614
-          item_name: Venator shard
-          quantity: 5
-      product: Venator bow
-      product_id: 27610
-    - skill: processing
-      materials:
-        - item_id: 27614
-          item_name: Venator shard
-          quantity: 1
-      product: Ancient essence
-      product_id: 27616
-      yield: 50000
+        quantity: "1"
+        rarity: 1/500
   related_items:
-    - item_id: 27610
-      item_name: Venator bow
+    - item_name: Venator bow
       slug: venator-bow
       relationship: product
-      description: Created weapon (5 shards)
-    - item_id: 27616
-      item_name: Ancient essence
+      description: Created weapon (5 shards required)
+    - item_name: Ancient essence
       slug: ancient-essence
       relationship: product
       description: Breakdown product (50,000 per shard)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    | Use | Materials |
-    |-----|-----------|
-    | Venator bow | 5 shards |
-    | Ancient essence | 1 shard -> 50,000 essence |
-
-    Note: Breaking down for essence results in significant loss.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "The Venator shard is a broken fragment of an ancient weapon dropped by the Phantom Muspah and from Frozen caches. Five shards combine into the uncharged Venator bow, or a single shard can be ground with a pestle and mortar into 50,000 ancient essence. Released 11 January 2023, its value was reduced from 3,000,000 to 150,000 coins on 18 January 2023."
+  market_strategy:
+    notes:
+      - "Combine 5 shards into Venator bow (irreversible)"
+      - "Breaking down 1 shard yields 50,000 ancient essence at significant loss"
+      - "Drop sources are Phantom Muspah and Frozen caches only"
+  history:
+    - date: "2023-01-11"
+      description: Released as a drop from the Phantom Muspah.
+    - date: "2023-01-18"
+      description: Item value reduced from 3,000,000 to 150,000 coins.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-2h-sword.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 125
-  about: "White 2h sword is a members-only item in Old School RuneScape. High alchemy value: 1,152 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: white
+    tier: mid
+  properties:
+    release_date: "2005-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: 2h
+    weapon_type: slash_sword
+    attack_speed: 7
+    weight: 3.628
+    requirements:
+      attack: 10
+      quest: Wanted!
+    attack_bonus:
+      stab: -4
+      slash: 27
+      crush: 21
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
+      strength: 26
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  related_items:
+    - item_name: Black 2h sword
+      slug: black-2h-sword
+      relationship: alternative
+      description: Identical attack bonuses without the prayer bonus
+    - item_name: White sword
+      slug: white-sword
+      relationship: variant
+      description: One-handed white sword variant
+    - item_name: Mithril 2h sword
+      slug: mithril-2h-sword
+      relationship: alternative
+      description: Comparable mid-tier two-handed weapon
+  about: "The white 2h sword is a two-handed slash weapon awarded by Sir Vyvin in Falador after reaching Master rank (1,300 Black Knight kills). It mirrors a black 2h sword's bonuses while adding a +1 prayer bonus, making it a niche option for low-level pures and prayer-flickers."
+  market_strategy:
+    notes:
+      - "Tight buy limit causes thin liquidity"
+      - "High alch leaves a small margin if buy price dips"
+      - "Prayer bonus draws collector demand"
+  history:
+    - date: "2005-10-17"
+      description: "Released as a reward in the White Knight ranking system."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wolf-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wolf-mask.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wolf mask | OSRS Price Data
-description: "Wolf mask: Howwwallll!. High alch: 1,440 GP, GE limit: 4."
+description: "Wolf mask: Howwwallll! High alch: 1,440 GP, GE limit: 4."
 osrs:
   id: 23407
   name: Wolf mask
@@ -12,9 +12,78 @@ osrs:
   lowalch: 960
   highalch: 1440
   limit: 4
-  about: "Wolf mask is a members-only item in Old School RuneScape. High alchemy value: 1,440 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Cat mask
+      slug: cat-mask
+      relationship: variant
+      description: Another animal mask from medium clue rewards
+    - item_name: Penguin mask
+      slug: penguin-mask
+      relationship: variant
+      description: Another animal mask from clue rewards
+    - item_name: Unicorn mask
+      slug: unicorn-mask
+      relationship: variant
+      description: Another animal mask from clue rewards
+  about: "Wolf mask is a members cosmetic head slot item rewarded from medium reward caskets with a 1/1,133 rarity. It provides no combat stats but counts as warm clothing for the Wintertodt minigame and can be stored in a costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Clue-only supply with 1/1,133 rarity keeps prices firm"
+      - "Low buy limit causes price spikes during cosmetic trends"
+      - "Doubles as warm clothing for Wintertodt utility play"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wood-camo-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wood-camo-legs.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Wood camo legs is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: hunter-gear
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.226
+    requirements: {}
+    attack_bonus:
+      ranged: -7
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      ranged: 10
+    other_bonus: {}
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Common kebbit fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+      tools:
+        - Fancy Clothes Store (Varrock)
+      output_quantity: 1
+  related_items:
+    - item_name: Wood camo top
+      slug: wood-camo-top
+      relationship: set-piece
+      description: Matching torso for the Woodland camouflage set.
+    - item_name: Common kebbit fur
+      slug: common-kebbit-fur
+      relationship: component
+      description: Crafting material for these legs.
+    - item_name: Larupia legs
+      slug: larupia-legs
+      relationship: upgrade
+      description: Higher tier Hunter camouflage legwear.
+  about: "Wood camo legs are member-only legwear bought tailored at the Fancy Clothes Store in Varrock, the Hunter Guild, or Prifddinas in exchange for two common kebbit furs and 20 coins. Despite the examine text, the legs do not improve catch rates on Hunter creatures and are largely cosmetic. They store in the Costume Room armour case alongside the rest of the Woodland camouflage set. Released 21 November 2006 with the Hunter skill."
+  market_strategy:
+    notes:
+      - "No GE buy limit means players can stock up freely when fur prices dip."
+      - "Cosmetic demand from Hunter completionists keeps modest steady volume."
+  history:
+    - date: "2006-11-21"
+      description: Released with the Hunter skill.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/worm-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/worm-batta.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Worm batta is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: false
+  recipes:
+    - skill: cooking
+      level: 27
+      xp: 154
+      materials:
+        - item_name: Batta tin
+          quantity: 1
+        - item_name: Gianne dough
+          quantity: 1
+        - item_name: King worm
+          quantity: 1
+        - item_name: Equa leaves
+          quantity: 1
+        - item_name: Gnome spice
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  shops:
+    - shop_name: Hudo Glenfad's Grocery Store
+      location: Grand Tree
+      price: 120
+      currency: Coins
+      stock: 3
+  drop_table:
+    sources:
+      - source: Tortoise
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - item_name: King worm
+      slug: king-worm
+      relationship: component
+      description: Worm filling for the batta
+    - item_name: Gianne dough
+      slug: gianne-dough
+      relationship: component
+      description: Gnome cooking dough base
+    - item_name: Batta tin
+      slug: batta-tin
+      relationship: component
+      description: Tin used to bake the batta
+  about: "The worm batta is a gnome cooking food made at level 27 Cooking, granting 154 XP and healing 12 hitpoints per bite. Hudo's Grocery Store stocks a premade version for 120 coins, and tortoises drop it occasionally. Burn rate stops at level 38 Cooking."
+  market_strategy:
+    notes:
+      - "Niche food — primarily used for Gnome Restaurant minigame"
+      - "GE volume thin, often shop-bought"
+      - "Acts as a cheap healing snack for low-level members"
+  history:
+    - date: "2002-12-12"
+      description: Released alongside the gnome cuisine cooking system.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/xerician-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/xerician-top.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 125
-  about: "Xerician top is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2016-01-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.2
+    requirements:
+      magic: 20
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 6
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 22
+      xp: 110
+      materials:
+        - item_name: Xerician fabric
+          quantity: 5
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+  related_items:
+    - item_name: Xerician hat
+      slug: xerician-hat
+      relationship: set-piece
+      description: Matching headpiece in the Xerician robes set.
+    - item_name: Xerician robe
+      slug: xerician-robe
+      relationship: set-piece
+      description: Matching legs in the Xerician robes set.
+    - item_name: Xerician fabric
+      slug: xerician-fabric
+      relationship: component
+      description: Crafted from sandstone in Hosidius to make Xerician armour.
+    - item_name: Mystic robe top
+      slug: mystic-robe-top
+      relationship: upgrade
+      description: Higher-tier magic body that requires 40 Magic.
+  about: "Xerician top is the body piece of the Xerician robes set, the entry-level mage gear obtained by crafting Xerician fabric at level 22 Crafting. Requiring only 20 Magic and 10 Defence to wear, it offers +6 magic attack and +10 magic defence, making it a budget bridge between basic wizard robes and mystic gear. Each top consumes five Xerician fabric and a thread for 110 Crafting experience, and the Grand Exchange limit of 125 per four hours keeps it accessible to early Magic trainers."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-gloves.mdx
@@ -12,12 +12,102 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Yellow gloves is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Crawling Hand
+        quantity: "1"
+        rarity: 2/128
+      - source: Crushing Hand
+        quantity: "1"
+        rarity: 3/128
+  shops:
+    - shop_name: Barker's Haberdashery
+      location: Canifis
+      price: 650
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Red gloves
+      slug: red-gloves
+      relationship: variant
+      description: Red dye Canifis robe set glove variant.
+    - item_name: Teal gloves
+      slug: teal-gloves
+      relationship: variant
+      description: Teal Canifis robe set glove variant.
+    - item_name: Purple gloves
+      slug: purple-gloves
+      relationship: variant
+      description: Purple Canifis robe set glove variant.
+    - item_name: Grey gloves
+      slug: grey-gloves
+      relationship: variant
+      description: Grey Canifis robe set glove variant.
+  about: "Yellow gloves are a free-to-play cosmetic hand slot item released 29 June 2004. They are sold from Barker's Haberdashery in Canifis and dropped by Crawling and Crushing Hands during Slayer tasks. Defensive bonuses are minimal (+1 slash, +2 crush) so they are typically worn for fashionscape rather than combat utility."
+  market_strategy:
+    notes:
+      - "Tight GE limit (150) restricts arbitrage opportunities."
+      - "Fashionscape demand drives most price movement."
+  trading_tips:
+    - Stock can be sourced cheaply from Barker's Haberdashery for resale.
+    - Slayer drops keep supply steady; do not overpay during double XP weekends.
+  history:
+    - date: "2004-06-29"
+      description: Released as part of the Canifis robe set.
+    - date: "2004-07-13"
+      description: Made members-only briefly.
+    - date: "2004-07-20"
+      description: Returned to free-to-play.
+    - date: "2014-12-10"
+      description: Renamed from "Gloves" to "Yellow gloves".
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-stock.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 66
   highalch: 100
   limit: 10000
-  about: "Yew stock is a members-only item in Old School RuneScape. High alchemy value: 100 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid-high
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    alchable: true
+  recipes:
+    - skill: fletching
+      level: 69
+      xp: 50
+      materials:
+        - item_name: Yew logs
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Yew logs
+      slug: yew-logs
+      relationship: component
+      description: Carved into a yew stock with a knife at 69 Fletching.
+    - item_name: Runite crossbow (u)
+      slug: runite-crossbow-u
+      relationship: product
+      description: Attach runite limbs to a yew stock to produce the unstrung runite crossbow.
+    - item_name: Maple stock
+      slug: maple-stock
+      relationship: downgrade
+      description: Lower-tier crossbow stock requiring less Fletching.
+    - item_name: Magic stock
+      slug: magic-stock
+      relationship: upgrade
+      description: Higher-tier crossbow stock used for magic and dragon crossbows.
+  about: "Yew stock is the wooden stock used in the production of runite crossbows, requiring 69 Fletching to carve from a single yew log for 50 Fletching experience. The stock is then fitted with runite limbs and a crossbow string to produce a runite crossbow, making it a staple intermediate good for Fletchers working towards higher-tier ranged weapons. The Grand Exchange buy limit is 10,000 per four hours."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/young-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/young-impling-jar.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  about: "Young impling jar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: hunter-jar
+    tier: low
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Destroy
+    worn_options: []
+    alchable: true
+    destroy: "If you drop this it will disappear. Are you sure you want to do this?"
+  drop_table:
+    sources:
+      - source: Loot from young impling jar
+        quantity: "1"
+        rarity: 1/10
+  related_items:
+    - item_name: Baby impling jar
+      slug: baby-impling-jar
+      relationship: downgrade
+      description: Lower tier impling jar
+    - item_name: Gourmet impling jar
+      slug: gourmet-impling-jar
+      relationship: upgrade
+      description: Next tier of impling jar
+    - item_name: Empty impling jar
+      slug: empty-impling-jar
+      relationship: component
+      description: Required to catch implings
+  about: "Young impling jar contains a captured young impling, caught with an empty impling jar at 22 Hunter. Common loot includes steel nails, lockpicks, pure essence, tuna, chocolate slice, steel axe, meat pizza, coal, and bow strings (each 1/10), plus rare drops at 1/100 and beginner/easy clue scrolls. Many players trade these to Elnock Inquisitor for 3 empty jars rather than loot due to low yield value."
+  market_strategy:
+    notes:
+      - "Often traded to Elnock Inquisitor over loot"
+      - "Steady supply from Puro-Puro hunters"
+      - "Clue scroll chance gives long-tail value"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-brew-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zamorak brew(4) | OSRS Price Data
-description: "Zamorak brew(4): 4 doses of Zamorak brew.. High alch: 120 GP, GE limit: 2,000."
+description: "Zamorak brew(4): 4 doses of Zamorak brew. High alch: 120 GP, GE limit: 2,000."
 osrs:
   id: 2450
   name: Zamorak brew(4)
@@ -12,9 +12,76 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Zamorak brew(4) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  potion:
+    effects:
+      - description: Boosts Attack by 2 + 20% of base Attack level (rounded down)
+        duration: null
+      - description: Boosts Strength by 2 + 12% of base Strength level (rounded down)
+        duration: null
+      - description: Restores Prayer by 10% of current Prayer level
+        duration: null
+      - description: Drains Defence by 2 + 10% of current Defence level (rounded down)
+        duration: null
+      - description: Drains Hitpoints by 12% (rounded down, minimum 1 HP)
+        duration: null
+  recipes:
+    - skill: herblore
+      level: 78
+      xp: 175
+      materials:
+        - item_name: Torstol potion (unf)
+          quantity: 1
+        - item_name: Jangerberries
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Zamorak brew(1)
+      slug: zamorak-brew-1
+      relationship: variant
+      description: 1-dose version of the same potion
+    - item_name: Zamorak brew(2)
+      slug: zamorak-brew-2
+      relationship: variant
+      description: 2-dose version of the same potion
+    - item_name: Zamorak brew(3)
+      slug: zamorak-brew-3
+      relationship: variant
+      description: 3-dose version of the same potion
+    - item_name: Zamorak mix(2)
+      slug: zamorak-mix-2
+      relationship: alternative
+      description: Barbarian-brewed variant that also heals hitpoints
+  about: "Zamorak brew(4) is a members combat potion that aggressively boosts Attack and Strength while restoring Prayer at the cost of Defence and Hitpoints. The four-dose flask is favoured at bosses such as Zulrah and the Theatre of Blood where the offensive boost outweighs the defensive penalty."
+  market_strategy:
+    notes:
+      - "Decanting from 3-dose can produce arbitrage spread"
+      - "Demand spikes during high-tier PvM events"
+      - "Bulk consumption keeps liquidity strong"
+  trading_tips:
+    - Buy 3-dose during inactive hours and decant for margin
+    - Track GE volume during raid weekends for price floors
+    - Stockpile during double XP weekends ahead of Herblore demand
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-dragonhide-set.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 3600
   highalch: 5400
   limit: 8
-  about: "Zamorak dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 5,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: set
+    tier: mid
+  properties:
+    release_date: "2015-03-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Grand Exchange
+      location: Varrock
+      price: 539360
+      currency: Coins
+      stock: 0
+  related_items:
+    - item_name: Zamorak coif
+      slug: zamorak-coif
+      relationship: set-piece
+      description: Head slot piece in the set
+    - item_name: Zamorak dragonhide body
+      slug: zamorak-dragonhide-body
+      relationship: set-piece
+      description: Body slot piece in the set
+    - item_name: Zamorak chaps
+      slug: zamorak-chaps
+      relationship: set-piece
+      description: Legs slot piece in the set
+    - item_name: Zamorak bracers
+      slug: zamorak-bracers
+      relationship: set-piece
+      description: Hands slot piece (vambraces) in the set
+    - item_name: Saradomin dragonhide set
+      slug: saradomin-dragonhide-set
+      relationship: alternative
+      description: Saradomin-aligned god dragonhide set
+    - item_name: Guthix dragonhide set
+      slug: guthix-dragonhide-set
+      relationship: alternative
+      description: Guthix-aligned god dragonhide set
+  about: "Zamorak dragonhide set is a Grand Exchange storage convenience containing Zamorak dragonhide coif, body, chaps, and vambraces. The set is constructed by exchanging individual components with a Grand Exchange clerk. When equipped individually, the four pieces provide +65 ranged attack, +110 ranged defence, and +94 magic defence with a -36 magic attack penalty. Note: this set excludes the shield and boots variants."
+  market_strategy:
+    notes:
+      - "Set premium over component cost"
+      - "Convenience for bulk PvM gearing"
+      - "Cosmetic god-aligned demand"
+  trading_tips:
+    - Compare set price vs component total to spot arbitrage
+    - Low buy limit can constrain bulk dealers
+  history:
+    - date: "2015-03-19"
+      description: Released as a Grand Exchange equipment set.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-page-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-page-2.mdx
@@ -12,46 +12,72 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
-    type: god_page
-    god: Zamorak
-    page_number: 2
+  properties:
+    release_date: "2004-11-17"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+  drop_table:
+    sources:
+      - source: Easy clue casket
+        quantity: "1"
+        rarity: 11/9504
+      - source: Medium clue casket
+        quantity: "1"
+        rarity: 10/8184
+      - source: Hard clue casket
+        quantity: "1"
+        rarity: 1/650
+      - source: Elite clue casket
+        quantity: "1"
+        rarity: 1/775
+      - source: Master clue casket
+        quantity: "1"
+        rarity: 1/702
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers: ["easy", "medium", "hard", "elite", "master"]
   related_items:
-    - item_id: 3831
-      item_name: Zamorak page 1
+    - item_name: Zamorak page 1
       slug: zamorak-page-1
       relationship: set-piece
-      description: Page 1 of 4
-    - item_id: 3833
-      item_name: Zamorak page 3
+      description: Page 1 of 4 of the Unholy book
+    - item_name: Zamorak page 3
       slug: zamorak-page-3
       relationship: set-piece
-      description: Page 3 of 4
-    - item_id: 3834
-      item_name: Zamorak page 4
+      description: Page 3 of 4 of the Unholy book
+    - item_name: Zamorak page 4
       slug: zamorak-page-4
       relationship: set-piece
-      description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Zamorak |
-    | Page | 2 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Unholy book (Zamorak god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Page 4 of 4 of the Unholy book
+    - item_name: Unholy book
+      slug: unholy-book
+      relationship: product
+      description: Completed Zamorak god book
+  about: "Zamorak page 2 is one of four pages torn from the Unholy book of Zamorak. Combining all four pages with an incomplete Unholy book finishes the god book, which is an equipable shield-slot item used for blessing unholy symbols and requires 50 Prayer to wield. The page is obtained as a reward from Treasure Trails of every tier except beginner."
+  market_strategy:
+    notes:
+      - "Set-piece market - demand tied to Unholy book assembly"
+      - "Members-only reward from all clue tiers except beginner"
+      - "GE buy limit of 5 keeps page flips small but steady"
+      - "High alch value of 120 GP makes it useless for alching"
+  history:
+    - date: "2004-11-17"
+      description: Introduced with the original god books update.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zombie-head-treasure-trails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zombie-head-treasure-trails.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Zombie head (Treasure Trails) is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: novelty
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: warhammer
+    attack_speed: 6
+    weight: 1.814
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: -2
+      slash: -2
+      crush: 10
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 8
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Bronze warhammer
+      slug: bronze-warhammer
+      relationship: alternative
+      description: Equivalent crush stats without the zombie sound effects
+  about: "Zombie head (Treasure Trails) is a hard clue scroll reward earned from reward caskets at a roughly 1/1,625 rate. It functions as a novelty warhammer with bronze warhammer stats — +10 crush attack and +8 strength — but plays zombie sound effects when attacking or storing items in containers."
+  market_strategy:
+    notes:
+      - "Pure novelty demand from collectors; price tracks hard clue rarity"
+      - "Low buy limit keeps spreads volatile around fresh casket loot"
+  history:
+    - date: "2016-07-06"
+      description: Zombie head added as a hard Treasure Trail reward.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zul-andra-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zul-andra-teleport.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Zul-andra teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport
+    tier: low
+  properties:
+    release_date: "2015-01-08"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Zulrah
+        quantity: "4"
+        rarity: 15/249
+  related_items:
+    - item_name: Varrock teleport
+      slug: varrock-teleport
+      relationship: alternative
+      description: Standard teleport tablet
+    - item_name: Zulrah's scales
+      slug: zulrahs-scales
+      relationship: alternative
+      description: Currency dropped alongside scrolls
+  about: |-
+    "Teleports you to Zul-Andra."
+
+    Zul-andra teleport scrolls drop from Zulrah at 4 per kill (rarity 15/249 × 2) and ferry players to the Zul-Andra dock for fast Zulrah re-supplies. Usage requires Regicide quest completion. The drop rate was reduced from 20 to 1 in October 2015, then raised to 4 in June 2017 to balance supply.
+  market_strategy:
+    notes:
+      - "Zulrah kill scaling drives supply"
+      - "Bossing convenience demand"
+      - "Buy limit 10,000 supports bulk flips"
+      - "Low alch value, near pure utility"
+      - "Price drifts with Zulrah meta shifts"
+  trading_tips:
+    - Bulk volume flips margins
+    - Watch Zulrah update events
+    - Sub-15gp margins are typical
+  history:
+    - date: "2015-01-08"
+      description: Released with Zulrah boss.
+    - date: "2015-10"
+      description: Drop quantity silently reduced from 20 to 1.
+    - date: "2017-06"
+      description: Drop quantity raised to 4 per kill.
+    - date: "2017-07"
+      description: Graphical update with Master scroll book release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-staff.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 120000
   highalch: 180000
   limit: 10
-  about: "Zuriel's staff is a members-only item in Old School RuneScape. High alchemy value: 180,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: staff
+    tier: high
+  properties:
+    release_date: "2023-05-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Uncharge
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      magic: 75
+      attack: 30
+    attack_bonus:
+      stab: 13
+      slash: -1
+      crush: 65
+      magic: 18
+      ranged: 0
+    defence_bonus:
+      stab: 5
+      slash: 7
+      crush: 4
+      magic: 18
+      ranged: 0
+    other_bonus:
+      melee_strength: 72
+      ranged_strength: 0
+      magic_damage: 10
+      prayer: 0
+  charges:
+    type: coins
+    description: Requires 5,000,000 coins to activate; activation transfers to the killer on PvP death.
+  passive_effects:
+    - name: Ancient Magicks boost
+      description: Increases attack speed of standard and Ancient Magicks; Ice spells gain +10% accuracy, Blood spells restore 50% more health, Smoke spells deal +100% poison damage, Shadow spells double attack drain.
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Daimon's Crater
+      price: 300
+      currency: Bounty Hunter points
+      stock: 0
+  related_items:
+    - item_name: Zuriel's hood
+      slug: zuriel-s-hood
+      relationship: set-piece
+      description: Matching Ancient Magicks set headwear
+    - item_name: Zuriel's robe top
+      slug: zuriel-s-robe-top
+      relationship: set-piece
+      description: Matching Ancient Magicks set top
+    - item_name: Zuriel's robe bottom
+      slug: zuriel-s-robe-bottom
+      relationship: set-piece
+      description: Matching Ancient Magicks set bottom
+  about: "Zuriel's staff is a powerful Ancient Magicks staff purchased from the Bounty Hunter Store for 300 points. It is restricted to PvP-enabled minigames such as Castle Wars, Soul Wars, and Clan Wars, requires 5,000,000 coins to activate, and boosts both standard and Ancient Magicks spells with significant accuracy, damage, and utility bonuses."
+  market_strategy:
+    notes:
+      - "Niche PvP staff with limited usability outside minigames"
+      - "Bounty Hunter points are the primary supply gate"
+  history:
+    - date: "2023-05-24"
+      description: Zuriel's staff reintroduced via the Bounty Hunter rework.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
- Random sample of 200 OSRS item MDX files migrated from `mdx_version: 2` to `3`
- WebFetch-verified wiki stats, drops, recipes, history
- Schema normalization: market_strategy.notes array, materials[].item_name, passive_effects[].name, potion duration → number, dropped null-tier treasure_trail blocks, quoted colon-bearing history descriptions

## Local CI mirror
- `npx astro sync` — clean
- `npx astro build` — 7688 pages in 280.48s, no errors

## Test plan
- [ ] CI manifest guard passes
- [ ] CI build passes
- [ ] Spot-check a couple of pages in preview