### PR TITLE
test(astro-kbve): nanostore service unit tests — argoService + grafanaService (closes #11594)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.test.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+	argoService,
+	healthColor,
+	syncColor,
+	formatAge,
+	detectAppStall,
+	detectResourceStall,
+	STALL_THRESHOLD_MS,
+	type ArgoApplication,
+	type ResourceNode,
+	type ResourceSelector,
+} from './argoService';
+
+function makeApp(overrides: Partial<ArgoApplication> = {}): ArgoApplication {
+	return {
+		metadata: { name: 'demo-app', namespace: 'argocd' },
+		spec: { project: 'default', source: { repoURL: '', path: '' } },
+		status: {
+			sync: { status: 'Synced', revision: 'abc' },
+			health: { status: 'Healthy' },
+			reconciledAt: new Date().toISOString(),
+		},
+		...overrides,
+	} as ArgoApplication;
+}
+
+describe('argoService — healthColor', () => {
+	it('returns green for Healthy', () => {
+		expect(healthColor('Healthy')).toBe('#22c55e');
+	});
+
+	it('returns red for Degraded + Missing', () => {
+		expect(healthColor('Degraded')).toBe('#ef4444');
+		expect(healthColor('Missing')).toBe('#ef4444');
+	});
+
+	it('returns amber for Progressing', () => {
+		expect(healthColor('Progressing')).toBe('#f59e0b');
+	});
+
+	it('returns grey for Suspended + unknown', () => {
+		expect(healthColor('Suspended')).toBe('#6b7280');
+		expect(healthColor('something-new')).toBe('#6b7280');
+	});
+});
+
+describe('argoService — syncColor', () => {
+	it('returns green for Synced', () => {
+		expect(syncColor('Synced')).toBe('#22c55e');
+	});
+
+	it('returns amber for OutOfSync', () => {
+		expect(syncColor('OutOfSync')).toBe('#f59e0b');
+	});
+
+	it('returns grey for unknown', () => {
+		expect(syncColor('Unknown')).toBe('#6b7280');
+		expect(syncColor('')).toBe('#6b7280');
+	});
+});
+
+describe('argoService — formatAge', () => {
+	it('seconds under 60s', () => {
+		expect(formatAge(0)).toBe('0s');
+		expect(formatAge(45_000)).toBe('45s');
+	});
+
+	it('minutes under 1h', () => {
+		expect(formatAge(60_000)).toBe('1m');
+		expect(formatAge(59 * 60_000)).toBe('59m');
+	});
+
+	it('hours under 1d', () => {
+		expect(formatAge(60 * 60_000)).toBe('1h');
+		expect(formatAge(23 * 3_600_000)).toBe('23h');
+	});
+
+	it('days', () => {
+		expect(formatAge(24 * 3_600_000)).toBe('1d');
+		expect(formatAge(7 * 86_400_000)).toBe('7d');
+	});
+});
+
+describe('argoService — detectAppStall', () => {
+	it('returns null when sync is Synced + health is Healthy', () => {
+		expect(detectAppStall(makeApp())).toBeNull();
+	});
+
+	it('flags Sync running when operation Running > 5 min', () => {
+		const startedAt = new Date(
+			Date.now() - STALL_THRESHOLD_MS - 1_000,
+		).toISOString();
+		const stall = detectAppStall(
+			makeApp({
+				status: {
+					sync: { status: 'Synced', revision: 'abc' },
+					health: { status: 'Healthy' },
+					operationState: { phase: 'Running', startedAt },
+				},
+			} as Partial<ArgoApplication>),
+		);
+		expect(stall?.reason).toBe('Sync running');
+	});
+
+	it('flags Progressing health when reconciled > 5 min ago', () => {
+		const reconciledAt = new Date(
+			Date.now() - STALL_THRESHOLD_MS - 1_000,
+		).toISOString();
+		const stall = detectAppStall(
+			makeApp({
+				status: {
+					sync: { status: 'Synced', revision: 'abc' },
+					health: { status: 'Progressing' },
+					reconciledAt,
+				},
+			} as Partial<ArgoApplication>),
+		);
+		expect(stall?.reason).toBe('Progressing');
+	});
+
+	it('flags OutOfSync only after 30 min, not 5 min', () => {
+		const shortAgo = new Date(Date.now() - 6 * 60_000).toISOString();
+		const longAgo = new Date(Date.now() - 31 * 60_000).toISOString();
+		const notStalled = detectAppStall(
+			makeApp({
+				status: {
+					sync: { status: 'OutOfSync', revision: 'abc' },
+					health: { status: 'Healthy' },
+					reconciledAt: shortAgo,
+				},
+			} as Partial<ArgoApplication>),
+		);
+		expect(notStalled).toBeNull();
+
+		const stalled = detectAppStall(
+			makeApp({
+				status: {
+					sync: { status: 'OutOfSync', revision: 'abc' },
+					health: { status: 'Healthy' },
+					reconciledAt: longAgo,
+				},
+			} as Partial<ArgoApplication>),
+		);
+		expect(stalled?.reason).toBe('OutOfSync');
+	});
+});
+
+describe('argoService — detectResourceStall', () => {
+	it('flags Degraded immediately regardless of age', () => {
+		const node = { health: { status: 'Degraded' } } as ResourceNode;
+		expect(detectResourceStall(node)?.reason).toBe('Degraded');
+	});
+
+	it('flags Missing immediately', () => {
+		const node = { health: { status: 'Missing' } } as ResourceNode;
+		expect(detectResourceStall(node)?.reason).toBe('Missing');
+	});
+
+	it('flags Progressing only after 5 min', () => {
+		const recent = {
+			health: { status: 'Progressing' },
+			createdAt: new Date().toISOString(),
+		} as ResourceNode;
+		expect(detectResourceStall(recent)).toBeNull();
+
+		const stale = {
+			health: { status: 'Progressing' },
+			createdAt: new Date(
+				Date.now() - STALL_THRESHOLD_MS - 1_000,
+			).toISOString(),
+		} as ResourceNode;
+		expect(detectResourceStall(stale)?.reason).toBe('Progressing');
+	});
+
+	it('returns null for Healthy node', () => {
+		const node = { health: { status: 'Healthy' } } as ResourceNode;
+		expect(detectResourceStall(node)).toBeNull();
+	});
+});
+
+describe('argoService — expand / select / tab atoms', () => {
+	beforeEach(() => {
+		argoService.$expandedApp.set(null);
+		argoService.$selectedResource.set(null);
+		argoService.$appTab.set('resources');
+	});
+
+	it('toggleExpandedApp expands when nothing is open', () => {
+		argoService.toggleExpandedApp('app-a');
+		expect(argoService.$expandedApp.get()).toBe('app-a');
+		expect(argoService.$appTab.get()).toBe('resources');
+		expect(argoService.$selectedResource.get()).toBeNull();
+	});
+
+	it('toggleExpandedApp collapses when called with the same name', () => {
+		argoService.toggleExpandedApp('app-a');
+		argoService.toggleExpandedApp('app-a');
+		expect(argoService.$expandedApp.get()).toBeNull();
+		expect(argoService.$selectedResource.get()).toBeNull();
+	});
+
+	it('toggleExpandedApp switches between apps + clears selection', () => {
+		argoService.toggleExpandedApp('app-a');
+		argoService.$selectedResource.set({
+			appName: 'app-a',
+			kind: 'Deployment',
+			namespace: 'ns',
+			name: 'd',
+		} as ResourceSelector);
+		argoService.toggleExpandedApp('app-b');
+		expect(argoService.$expandedApp.get()).toBe('app-b');
+		expect(argoService.$selectedResource.get()).toBeNull();
+	});
+
+	it('selectResource sets the selection', () => {
+		const sel = {
+			appName: 'app-a',
+			kind: 'Pod',
+			namespace: 'ns',
+			name: 'p1',
+		} as ResourceSelector;
+		argoService.selectResource(sel);
+		expect(argoService.$selectedResource.get()).toEqual(sel);
+	});
+
+	it('selectResource called twice with the same selection clears it', () => {
+		const sel = {
+			appName: 'app-a',
+			kind: 'Pod',
+			namespace: 'ns',
+			name: 'p1',
+		} as ResourceSelector;
+		argoService.selectResource(sel);
+		argoService.selectResource(sel);
+		expect(argoService.$selectedResource.get()).toBeNull();
+	});
+
+	it('selectResource with a different selection replaces, not clears', () => {
+		argoService.selectResource({
+			appName: 'app-a',
+			kind: 'Pod',
+			namespace: 'ns',
+			name: 'p1',
+		} as ResourceSelector);
+		const next = {
+			appName: 'app-a',
+			kind: 'Pod',
+			namespace: 'ns',
+			name: 'p2',
+		} as ResourceSelector;
+		argoService.selectResource(next);
+		expect(argoService.$selectedResource.get()).toEqual(next);
+	});
+
+	it('setAppTab updates the atom', () => {
+		argoService.setAppTab('events');
+		expect(argoService.$appTab.get()).toBe('events');
+		argoService.setAppTab('history');
+		expect(argoService.$appTab.get()).toBe('history');
+		argoService.setAppTab('resources');
+		expect(argoService.$appTab.get()).toBe('resources');
+	});
+});

--- a/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.test.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { formatBytes, getThresholdColor } from './grafanaService';
+
+describe('grafanaService — formatBytes', () => {
+	it('returns -- for null', () => {
+		expect(formatBytes(null)).toBe('--');
+	});
+
+	it('B/s under 1 KB', () => {
+		expect(formatBytes(0)).toBe('0 B/s');
+		expect(formatBytes(999)).toBe('999 B/s');
+	});
+
+	it('KB/s in the 1k..1M range', () => {
+		expect(formatBytes(1_000)).toBe('1.0 KB/s');
+		expect(formatBytes(900_000)).toBe('900.0 KB/s');
+	});
+
+	it('MB/s in the 1M..1G range', () => {
+		expect(formatBytes(1_000_000)).toBe('1.0 MB/s');
+		expect(formatBytes(15_500_000)).toBe('15.5 MB/s');
+	});
+
+	it('GB/s at or above 1G', () => {
+		expect(formatBytes(1_000_000_000)).toBe('1.0 GB/s');
+		expect(formatBytes(2_500_000_000)).toBe('2.5 GB/s');
+	});
+});
+
+describe('grafanaService — getThresholdColor', () => {
+	const thresholds = { warn: 70, crit: 90 };
+
+	it('green below warn', () => {
+		expect(getThresholdColor(0, thresholds)).toBe('#22c55e');
+		expect(getThresholdColor(69.9, thresholds)).toBe('#22c55e');
+	});
+
+	it('yellow at + above warn, below crit', () => {
+		expect(getThresholdColor(70, thresholds)).toBe('#eab308');
+		expect(getThresholdColor(89.9, thresholds)).toBe('#eab308');
+	});
+
+	it('red at + above crit', () => {
+		expect(getThresholdColor(90, thresholds)).toBe('#ef4444');
+		expect(getThresholdColor(100, thresholds)).toBe('#ef4444');
+	});
+
+	it('crit takes precedence over warn when both met', () => {
+		expect(getThresholdColor(100, { warn: 50, crit: 60 })).toBe('#ef4444');
+	});
+});


### PR DESCRIPTION
Closes #11594. Tracker #11592.

## Why

Nanostore-backed \`*Service.ts\` files own dashboard application state. Per #11594 audit, only \`serviceFooter\` had unit tests; failures in argoService / grafanaService etc. ripple silently through every consumer.

## Changes

Two new test files in the existing \`node\`-env vitest suite (no jsdom needed — pure state + pure helpers).

### \`argoService.test.ts\` — 26 cases

**Pure helpers** (no atoms touched):

- \`healthColor\` — Healthy / Degraded / Progressing / Suspended / Missing / unknown branches
- \`syncColor\` — Synced / OutOfSync / Unknown / empty branches
- \`formatAge\` — sec / min / hour / day boundaries
- \`detectAppStall\` — Sync running > 5 min, Progressing > 5 min, OutOfSync only > 30 min (the 30-min boundary is the regression-prone bit)
- \`detectResourceStall\` — Degraded + Missing fire immediately, Progressing only after 5 min

**Atom transitions on the singleton**:

- \`toggleExpandedApp\` — opens when nothing open, collapses on second call with the same name, switches apps + clears selection
- \`selectResource\` — sets, toggles off when called twice with the same sel, replaces on a different sel
- \`setAppTab\` — round-trips resources / events / history

Each atom-mutation test resets the singleton in \`beforeEach\` so order doesn't matter.

### \`grafanaService.test.ts\` — 9 cases

- \`formatBytes\` — null → \`--\`, B/s / KB/s / MB/s / GB/s branches at each decade boundary
- \`getThresholdColor\` — green below warn, yellow at + above warn, red at + above crit, crit-precedence when both met

## Skipped scope (call out for follow-ups)

\`fetchData\`, \`initAuth\`, \`fetchPodMetrics\`, \`fetchAlerts\` — all need fetch + Supabase mocks. Defer to a separate PR that promotes the existing #11586 auth-mock harness pattern into the unit suite.

## Test plan

- [ ] \`nx run astro-kbve:test\` → 285 tests pass across 35 files (35 net new cases here)
- [ ] No production source changes — strictly additive