### PR TITLE
perf(rareicon): jobify ProfessionDispatchSystem scoring loop (parallel + Burst)

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Messages/ProfessionEventSink.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Messages/ProfessionEventSink.cs
@@ -20,5 +20,19 @@ namespace RareIcon
             buffer.Add(new ProfessionChangedMessage(
                 entity, oldKind, newKind, targetHex, targetEntity, frame, reason));
         }
+
+        public static void Add(
+            ref NativeList<ProfessionChangedMessage>.ParallelWriter writer,
+            Entity entity,
+            byte oldKind,
+            byte newKind,
+            int2 targetHex,
+            Entity targetEntity,
+            uint frame,
+            ProfessionChangeReason reason)
+        {
+            writer.AddNoResize(new ProfessionChangedMessage(
+                entity, oldKind, newKind, targetHex, targetEntity, frame, reason));
+        }
     }
 }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
@@ -1,12 +1,13 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 using Unity.Transforms;
 
 namespace RareIcon
 {
-    /// <summary>Picks the highest-priority profession with nearby work for each Player unit; writes ProfessionIntent. If no scored offer wins, assigns ProfessionKind.Default and rolls a Wander MovementGoal so units never sit idle. Reads the dispatch context + TaskOffer pool from ProfessionOffersSingleton (rebuilt on cadence by ProfessionOfferBuildSystem). Emits ProfessionChangedMessage via ProfessionEventSink on any kind/target change — coalesced + published by ProfessionMessagePipeBridgeSystem. ISystem + [BurstCompile] — every managed dependency routes through ComponentLookup / BufferLookup / Burst-safe singletons.</summary>
+    /// <summary>Picks the highest-priority profession with nearby work for each Player unit; writes ProfessionIntent. If no scored offer wins, assigns ProfessionKind.Default and rolls a Wander MovementGoal so units never sit idle. Reads the dispatch context + TaskOffer pool from ProfessionOffersSingleton (rebuilt on cadence by ProfessionOfferBuildSystem). Emits ProfessionChangedMessage via ProfessionEventSink on any kind/target change — coalesced + published by ProfessionMessagePipeBridgeSystem. Per-unit scoring runs as a [BurstCompile] IJobEntity parallel job — the main thread builds the snapshot inputs (occupancy / activePerKind / reservedPerKind / WriteBuffer capacity), schedules ScheduleParallel, and publishes the handle through ProfessionsDBSingleton.PipelineHandle so downstream consumers chain on it instead of forcing a sync.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateAfter(typeof(ReliefSystem))]
@@ -34,8 +35,14 @@ namespace RareIcon
             state.RequireForUpdate<ProfessionOffersSingleton>();
             state.RequireForUpdate<CombatDBSingleton>();
             state.RequireForUpdate<ItemDBSingleton>();
+            state.RequireForUpdate<ProfessionsDBSingleton>();
 
             _hexOccupancy = new NativeHashMap<int2, int>(4096, Allocator.Persistent);
+        }
+
+        public void OnDestroy(ref SystemState state)
+        {
+            if (_hexOccupancy.IsCreated) _hexOccupancy.Dispose();
         }
 
         static bool CountsTowardHexOccupancy(byte kind)
@@ -45,65 +52,35 @@ namespace RareIcon
                 || kind == ProfessionKind.Looter;
         }
 
-        public void OnDestroy(ref SystemState state)
-        {
-            if (_hexOccupancy.IsCreated) _hexOccupancy.Dispose();
-        }
-
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
-        {
-            RunDispatch(ref state);
-        }
-
-        [BurstCompile]
-        void RunDispatch(ref SystemState state)
         {
             var offersDB = SystemAPI.GetSingleton<ProfessionOffersSingleton>();
             var combatDB = SystemAPI.GetSingleton<CombatDBSingleton>();
             var itemDB   = SystemAPI.GetSingleton<ItemDBSingleton>();
 
-            // CombatThreatScanSystem now schedules a parallel job that
-            // populates combatDB.Threats + FriendlyEmitters — the reads
-            // below are on the main thread, so we sync the pipeline here.
-            combatDB.PipelineHandle.Complete();
+            // CombatThreatScanSystem fills threats / friendlyEmitters via a
+            // parallel job; chain on its handle so the dispatch job sees a
+            // consistent snapshot without a main-thread sync.
+            state.Dependency = JobHandle.CombineDependencies(state.Dependency, combatDB.PipelineHandle);
 
             bool doFullDispatch = offersDB.BuildVersion != _lastSeenBuildVersion;
             if (doFullDispatch)
-            {
                 _lastSeenBuildVersion = offersDB.BuildVersion;
-                state.CompleteDependency();
-            }
 
-            bool hasCapital     = offersDB.HasCapital;
-            bool capitalHasFood = offersDB.CapitalHasFood;
+            ref var dbRef = ref SystemAPI.GetSingletonRW<ProfessionsDBSingleton>().ValueRW;
+            var writeBuffer = dbRef.WriteBuffer;
 
-            var offersPerKind      = offersDB.OffersPerKind;
-            var offersSortedByKind = offersDB.OffersSortedByKind;
-            var offerKindStart     = offersDB.OfferKindStart;
-            var offerKindCount     = offersDB.OfferKindCount;
-            var needyCaves         = offersDB.NeedyCaves;
-
-            var threats          = combatDB.Threats;
-            var friendlyEmitters = combatDB.FriendlyEmitters;
-            bool anyHostile      = threats.Length > 0;
-
-            var controlledLookup = SystemAPI.GetComponentLookup<ControlledUnitTag>(true);
-
-            var justAssignedPerKind = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
-
-            BufferLookup<PackSlot> unitPackLookup = default;
-            NativeArray<int> activePerKind   = default;
-            NativeArray<int> reservedPerKind = default;
+            // activePerKind / reservedPerKind / occupancy build runs on the
+            // main thread when a full dispatch tick fires. Cheap O(units +
+            // reserved-role entities), no per-unit cost in the inner loop.
+            var activePerKind   = new NativeArray<int>(ProfessionKind.Count, Allocator.TempJob);
+            var reservedPerKind = new NativeArray<int>(ProfessionKind.Count, Allocator.TempJob);
 
             if (doFullDispatch)
             {
-                unitPackLookup = SystemAPI.GetBufferLookup<PackSlot>(true);
-
+                state.CompleteDependency();
                 _hexOccupancy.Clear();
-
-                activePerKind   = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
-                reservedPerKind = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
 
                 foreach (var jobRO in
                          SystemAPI.Query<RefRO<ProfessionIntent>>().WithAll<ProfessionPriorities>())
@@ -134,25 +111,103 @@ namespace RareIcon
                 }
             }
 
-            uint nowTick = (uint)SystemAPI.Time.ElapsedTime;
+            // Pre-allocate WriteBuffer headroom so AddNoResize is safe under
+            // ParallelWriter contention. Worst case = one event per unit per
+            // dispatch tick (Relief / Manual / Preempt / Retarget / Fallback
+            // are exclusive paths). The query count is an upper bound; we
+            // never trim, the bridge consumes the buffer next frame.
+            var unitQuery = SystemAPI.QueryBuilder()
+                .WithAll<ProfessionPriorities, ReliefIntent, ProfessionIntent, UnitMovement, LocalTransform, MovementGoal, TaskMemory>()
+                .Build();
+            int unitCount = unitQuery.CalculateEntityCount();
+            int requiredCapacity = writeBuffer.Length + unitCount;
+            if (writeBuffer.Capacity < requiredCapacity)
+                writeBuffer.SetCapacity(math.max(requiredCapacity, writeBuffer.Capacity * 2));
 
-            var events = default(NativeList<ProfessionChangedMessage>);
-            if (SystemAPI.HasSingleton<ProfessionsDBSingleton>())
-                events = SystemAPI.GetSingletonRW<ProfessionsDBSingleton>().ValueRW.WriteBuffer;
-
-            foreach (var (priorities, reliefIntent, jobIntentRef, movement, transform, goalRef, tasksRef, entity) in
-                     SystemAPI.Query<
-                         RefRO<ProfessionPriorities>,
-                         RefRO<ReliefIntent>,
-                         RefRW<ProfessionIntent>,
-                         RefRO<UnitMovement>,
-                         RefRO<LocalTransform>,
-                         RefRW<MovementGoal>,
-                         DynamicBuffer<TaskMemory>>().WithEntityAccess())
+            var job = new DispatchJob
             {
-                var tasks = tasksRef;
+                OffersPerKind      = offersDB.OffersPerKind,
+                OffersSortedByKind = offersDB.OffersSortedByKind.AsArray(),
+                OfferKindStart     = offersDB.OfferKindStart,
+                OfferKindCount     = offersDB.OfferKindCount,
+                NeedyCaves         = offersDB.NeedyCaves.AsArray(),
 
-                if (reliefIntent.ValueRO.Kind != ReliefKind.None)
+                Threats          = combatDB.Threats.AsArray(),
+                FriendlyEmitters = combatDB.FriendlyEmitters.AsArray(),
+
+                HexOccupancy     = _hexOccupancy,
+                ActivePerKind    = activePerKind,
+                ReservedPerKind  = reservedPerKind,
+
+                ItemDefs         = itemDB.Defs,
+                ItemValidBits    = itemDB.ValidBits,
+                ItemMaxId        = itemDB.MaxItemId,
+
+                ControlledLookup = SystemAPI.GetComponentLookup<ControlledUnitTag>(true),
+                UnitPackLookup   = SystemAPI.GetBufferLookup<PackSlot>(true),
+
+                Events           = writeBuffer.AsParallelWriter(),
+
+                HasCapital       = offersDB.HasCapital,
+                CapitalHasFood   = offersDB.CapitalHasFood,
+                AnyHostile       = combatDB.Threats.Length > 0,
+                DoFullDispatch   = doFullDispatch,
+                NowTick          = (uint)SystemAPI.Time.ElapsedTime,
+            };
+
+            state.Dependency = job.ScheduleParallel(state.Dependency);
+
+            // Publish the dispatch handle so the bridge system + any other
+            // ProfessionIntent reader can chain on it without forcing the
+            // main thread to sync here.
+            dbRef.PipelineHandle = state.Dependency;
+
+            activePerKind.Dispose(state.Dependency);
+            reservedPerKind.Dispose(state.Dependency);
+        }
+
+        [BurstCompile]
+        partial struct DispatchJob : IJobEntity
+        {
+            [ReadOnly] public NativeArray<int>       OffersPerKind;
+            [ReadOnly] public NativeArray<TaskOffer> OffersSortedByKind;
+            [ReadOnly] public NativeArray<int>       OfferKindStart;
+            [ReadOnly] public NativeArray<int>       OfferKindCount;
+            [ReadOnly] public NativeArray<NeedyCave> NeedyCaves;
+
+            [ReadOnly] public NativeArray<ThreatRecord>    Threats;
+            [ReadOnly] public NativeArray<FriendlyEmitter> FriendlyEmitters;
+
+            [ReadOnly] public NativeHashMap<int2, int> HexOccupancy;
+            [ReadOnly] public NativeArray<int>         ActivePerKind;
+            [ReadOnly] public NativeArray<int>         ReservedPerKind;
+
+            [ReadOnly] public NativeArray<ItemDefRuntime> ItemDefs;
+            [ReadOnly] public NativeArray<ulong>          ItemValidBits;
+            public ushort ItemMaxId;
+
+            [ReadOnly] public ComponentLookup<ControlledUnitTag> ControlledLookup;
+            [ReadOnly] public BufferLookup<PackSlot>             UnitPackLookup;
+
+            public NativeList<ProfessionChangedMessage>.ParallelWriter Events;
+
+            public bool HasCapital;
+            public bool CapitalHasFood;
+            public bool AnyHostile;
+            public bool DoFullDispatch;
+            public uint NowTick;
+
+            public void Execute(
+                Entity entity,
+                in ProfessionPriorities priorities,
+                in ReliefIntent reliefIntent,
+                ref ProfessionIntent intent,
+                in UnitMovement movement,
+                in LocalTransform transform,
+                ref MovementGoal goal,
+                DynamicBuffer<TaskMemory> tasks)
+            {
+                if (reliefIntent.Kind != ReliefKind.None)
                 {
                     if (tasks.Length > 0)
                     {
@@ -163,38 +218,27 @@ namespace RareIcon
                             tasks[0]   = head;
                         }
                     }
-                    var prev = jobIntentRef.ValueRO;
+                    var prev = intent;
                     if (prev.Kind != ProfessionKind.None)
                     {
-                        jobIntentRef.ValueRW = default;
-                        if (events.IsCreated)
-                            ProfessionEventSink.Add(ref events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, nowTick, ProfessionChangeReason.ReliefOverride);
+                        intent = default;
+                        ProfessionEventSink.Add(ref Events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, NowTick, ProfessionChangeReason.ReliefOverride);
                     }
-                    continue;
+                    return;
                 }
 
-                // Manually-driven units (King by default, or any
-                // possessed goblin) skip job assignment — the player is
-                // steering them, the AI shouldn't assign work in
-                // parallel. Releasing control returns the unit to the
-                // dispatcher next tick.
-                if (controlledLookup.HasComponent(entity))
+                if (ControlledLookup.HasComponent(entity))
                 {
                     if (tasks.Length > 0) tasks.Clear();
-                    var prev = jobIntentRef.ValueRO;
+                    var prev = intent;
                     if (prev.Kind != ProfessionKind.None)
                     {
-                        jobIntentRef.ValueRW = default;
-                        if (events.IsCreated)
-                            ProfessionEventSink.Add(ref events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, nowTick, ProfessionChangeReason.ManualOverride);
+                        intent = default;
+                        ProfessionEventSink.Add(ref Events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, NowTick, ProfessionChangeReason.ManualOverride);
                     }
-                    continue;
+                    return;
                 }
 
-                // Queue reconciliation — pop drained/invalid heads, promote
-                // Pending → Active, skip re-scoring when the Active head is
-                // still valid (TaskInvalidationSystem is authoritative on
-                // validity — we only react to state here).
                 while (tasks.Length > 0 &&
                        (tasks[0].State == TaskState.Invalidated ||
                         tasks[0].State == TaskState.Completed))
@@ -209,24 +253,24 @@ namespace RareIcon
                     {
                         head.State = TaskState.Active;
                         tasks[0]   = head;
-                        jobIntentRef.ValueRW = new ProfessionIntent
+                        intent = new ProfessionIntent
                         {
                             Kind         = head.Kind,
                             TargetHex    = head.TargetHex,
                             TargetEntity = head.TargetEntity,
                         };
-                        continue;
+                        return;
                     }
-                    if (anyHostile
+                    if (AnyHostile
                         && head.State == TaskState.Active
                         && head.Kind != ProfessionKind.Guard
-                        && priorities.ValueRO.Guard >= GuardPreemptThreshold
-                        && TryFindClosestThreat(threats, transform.ValueRO.Position,
+                        && priorities.Guard >= GuardPreemptThreshold
+                        && TryFindClosestThreat(Threats, transform.Position,
                                                 out var preemptHex, out var preemptHostile, out _))
                     {
                         tasks.Clear();
-                        var preemptedIntent = jobIntentRef.ValueRO;
-                        jobIntentRef.ValueRW = new ProfessionIntent
+                        var preemptedIntent = intent;
+                        intent = new ProfessionIntent
                         {
                             Kind         = ProfessionKind.Guard,
                             TargetHex    = preemptHex,
@@ -238,63 +282,47 @@ namespace RareIcon
                             TargetHex    = preemptHex,
                             TargetEntity = preemptHostile,
                             State        = TaskState.Active,
-                            IssuedTick   = nowTick,
+                            IssuedTick   = NowTick,
                         });
-                        if (events.IsCreated && preemptedIntent.Kind != ProfessionKind.Guard)
-                            ProfessionEventSink.Add(ref events, entity, preemptedIntent.Kind, ProfessionKind.Guard, preemptHex, preemptHostile, nowTick, ProfessionChangeReason.Preempted);
-                        if (ProfessionKind.Guard < justAssignedPerKind.Length) justAssignedPerKind[ProfessionKind.Guard]++;
-                        continue;
+                        if (preemptedIntent.Kind != ProfessionKind.Guard)
+                            ProfessionEventSink.Add(ref Events, entity, preemptedIntent.Kind, ProfessionKind.Guard, preemptHex, preemptHostile, NowTick, ProfessionChangeReason.Preempted);
+                        return;
                     }
                     if (head.State == TaskState.Active)
-                    {
-                        // Unit is committed — don't re-score. ProfessionIntent is
-                        // already in sync (BuilderJobSystem may refine
-                        // TargetHex between dispatcher runs, which is fine).
-                        continue;
-                    }
+                        return;
                 }
 
-                // Queue is empty / drained. Only re-score on dispatch
-                // ticks; on idle ticks the unit simply waits.
-                if (!doFullDispatch) continue;
+                if (!DoFullDispatch) return;
 
-                var p = priorities.ValueRO;
-                var currentHex = movement.ValueRO.CurrentHex;
-                var currentTarget = jobIntentRef.ValueRO.TargetEntity;
+                var p = priorities;
+                var currentHex = movement.CurrentHex;
+                var currentTarget = intent.TargetEntity;
 
                 byte  bestKind   = ProfessionKind.None;
                 int2  bestHex    = currentHex;
                 Entity bestEntity = Entity.Null;
                 long  bestScore  = long.MinValue;
 
-                // Per-unit Looter mode derives from inventory + global
-                // state. Precomputed so the offer loop does a single
-                // variant-bit test per Looter candidate instead of
-                // re-checking inventory each time.
-                bool carryingFood = unitPackLookup.HasBuffer(entity)
-                                    && PackHasFood(itemDB, unitPackLookup[entity]);
+                bool carryingFood = UnitPackLookup.HasBuffer(entity)
+                                    && PackHasFood(ItemDefs, ItemValidBits, ItemMaxId, UnitPackLookup[entity]);
                 byte looterMode;
-                if (carryingFood && needyCaves.Length > 0)
+                if (carryingFood && NeedyCaves.Length > 0)
                     looterMode = OfferVariant.LooterDeliver;
-                else if (!carryingFood && needyCaves.Length > 0 && capitalHasFood && hasCapital)
+                else if (!carryingFood && NeedyCaves.Length > 0 && CapitalHasFood && HasCapital)
                     looterMode = OfferVariant.LooterFetch;
                 else
-                    looterMode = 0xFF;  // forage fallback
+                    looterMode = 0xFF;
 
-                // Walk only the per-kind slices this unit has priority for.
-                // At 100k units this turns the inner work from O(all_offers)
-                // into O(sum(offers_per_active_kind)) — units with sparse
-                // JobPriorities skip most of the pool entirely.
                 for (byte kind = ProfessionKind.Default; kind < ProfessionKind.Count; kind++)
                 {
                     byte prio = p.Get(kind);
                     if (prio == 0) continue;
 
-                    int kindStart = offerKindStart[kind];
-                    int kindCount = offerKindCount[kind];
-                    int oNk = offersPerKind[kind];
-                    int aNk = activePerKind[kind] + justAssignedPerKind[kind];
-                    int rNk = reservedPerKind[kind];
+                    int kindStart = OfferKindStart[kind];
+                    int kindCount = OfferKindCount[kind];
+                    int oNk = OffersPerKind[kind];
+                    int aNk = ActivePerKind[kind];
+                    int rNk = ReservedPerKind[kind];
                     int deficit = oNk - aNk;
                     int reservationShortfall = rNk - aNk;
                     long deficitBonus = deficit > 0
@@ -309,7 +337,7 @@ namespace RareIcon
 
                     for (int si = 0; si < kindCount; si++)
                     {
-                        var offer = offersSortedByKind[kindStart + si];
+                        var offer = OffersSortedByKind[kindStart + si];
 
                         if (kind == ProfessionKind.Looter)
                         {
@@ -333,7 +361,7 @@ namespace RareIcon
 
                         int crowdOcc = 0;
                         if (IsHarvestVariant(kind, offer.Variant)
-                            && _hexOccupancy.TryGetValue(offer.Hex, out var occ))
+                            && HexOccupancy.TryGetValue(offer.Hex, out var occ))
                         {
                             if (occ >= HexClusterCap) continue;
                             crowdOcc = occ;
@@ -361,14 +389,14 @@ namespace RareIcon
                     Entity hostileEntity = Entity.Null;
                     int    hostileDist   = int.MaxValue;
                     bool   foundHostile  = false;
-                    if (anyHostile && p.Guard >= GuardPreemptThreshold)
+                    if (AnyHostile && p.Guard >= GuardPreemptThreshold)
                     {
                         foundHostile = TryFindClosestThreat(
-                            threats, transform.ValueRO.Position,
+                            Threats, transform.Position,
                             out hostileHex, out hostileEntity, out hostileDist);
                     }
 
-                    int guardReservationShortfall = math.max(0, reservedPerKind[ProfessionKind.Guard] - (activePerKind[ProfessionKind.Guard] + justAssignedPerKind[ProfessionKind.Guard]));
+                    int guardReservationShortfall = math.max(0, ReservedPerKind[ProfessionKind.Guard] - ActivePerKind[ProfessionKind.Guard]);
 
                     if (foundHostile)
                     {
@@ -385,15 +413,10 @@ namespace RareIcon
                             bestEntity = hostileEntity;
                         }
                     }
-                    else if (friendlyEmitters.Length > 0 && p.Guard >= GuardPatrolThreshold)
+                    else if (FriendlyEmitters.Length > 0 && p.Guard >= GuardPatrolThreshold)
                     {
-                        // Patrol fallback — pick a random hex inside the
-                        // Capital's territory disc. Seed mixes entity index
-                        // + WanderStep so each unit picks a different target
-                        // AND re-rolls on each arrival (WanderStep advances
-                        // when UnitMovementSystem snaps to the new hex).
-                        var e = friendlyEmitters[0];
-                        uint rng = UnitHashOps.Spread(in entity) ^ (movement.ValueRO.WanderStep * 0x85EBCA77u);
+                        var e = FriendlyEmitters[0];
+                        uint rng = UnitHashOps.Spread(in entity) ^ (movement.WanderStep * 0x85EBCA77u);
                         int span = e.Radius * 2 + 1;
                         int dq = (int)(rng % (uint)span) - e.Radius;
                         rng ^= rng >> 7; rng *= 0x27D4EB2Fu;
@@ -414,29 +437,21 @@ namespace RareIcon
                     }
                 }
 
-                var prevIntent = jobIntentRef.ValueRO;
-                var oldTarget  = prevIntent.TargetHex;
-                if (CountsTowardHexOccupancy(prevIntent.Kind)
-                    && _hexOccupancy.TryGetValue(oldTarget, out var oldCount)
-                    && oldCount > 0)
-                {
-                    if (oldCount == 1) _hexOccupancy.Remove(oldTarget);
-                    else               _hexOccupancy[oldTarget] = oldCount - 1;
-                }
+                var prevIntent = intent;
 
                 if (bestKind == ProfessionKind.None)
                 {
-                    uint rng = UnitHashOps.Spread(in entity) ^ (nowTick * 0x85EBCA77u);
+                    uint rng = UnitHashOps.Spread(in entity) ^ (NowTick * 0x85EBCA77u);
                     int dir = (int)(rng % 6u);
                     rng ^= rng >> 7; rng *= 0x27D4EB2Fu;
                     int dist = (int)(3u + (rng % 3u));
-                    bestHex    = movement.ValueRO.CurrentHex + HexMeshUtil.HexNeighbor(dir) * dist;
+                    bestHex    = movement.CurrentHex + HexMeshUtil.HexNeighbor(dir) * dist;
                     bestEntity = Entity.Null;
                     bestKind   = ProfessionKind.Default;
 
-                    if (goalRef.ValueRO.Priority <= GoalPriority.Wander)
+                    if (goal.Priority <= GoalPriority.Wander)
                     {
-                        goalRef.ValueRW = new MovementGoal
+                        goal = new MovementGoal
                         {
                             Kind      = GoalKind.Wander,
                             Priority  = GoalPriority.Wander,
@@ -445,27 +460,22 @@ namespace RareIcon
                     }
                 }
 
-                _hexOccupancy[bestHex] = _hexOccupancy.TryGetValue(bestHex, out var newCount) ? newCount + 1 : 1;
-
-                jobIntentRef.ValueRW = new ProfessionIntent
+                intent = new ProfessionIntent
                 {
                     Kind         = bestKind,
                     TargetHex    = bestHex,
                     TargetEntity = bestEntity,
                 };
 
-                if (bestKind < justAssignedPerKind.Length) justAssignedPerKind[bestKind]++;
-
-                if (events.IsCreated
-                    && (prevIntent.Kind != bestKind
-                        || !prevIntent.TargetHex.Equals(bestHex)
-                        || prevIntent.TargetEntity != bestEntity))
+                if (prevIntent.Kind != bestKind
+                    || !prevIntent.TargetHex.Equals(bestHex)
+                    || prevIntent.TargetEntity != bestEntity)
                 {
                     ProfessionChangeReason reason;
                     if (bestKind == ProfessionKind.Default)       reason = ProfessionChangeReason.Fallback;
                     else if (prevIntent.Kind == bestKind)         reason = ProfessionChangeReason.Retargeted;
                     else                                          reason = ProfessionChangeReason.Assigned;
-                    ProfessionEventSink.Add(ref events, entity, prevIntent.Kind, bestKind, bestHex, bestEntity, nowTick, reason);
+                    ProfessionEventSink.Add(ref Events, entity, prevIntent.Kind, bestKind, bestHex, bestEntity, NowTick, reason);
                 }
 
                 if (bestKind == ProfessionKind.None || bestKind == ProfessionKind.Default)
@@ -482,7 +492,7 @@ namespace RareIcon
                             TargetHex    = bestHex,
                             TargetEntity = bestEntity,
                             State        = TaskState.Active,
-                            IssuedTick   = nowTick,
+                            IssuedTick   = NowTick,
                         });
                     }
                     else
@@ -493,23 +503,26 @@ namespace RareIcon
                             TargetHex    = bestHex,
                             TargetEntity = bestEntity,
                             State        = TaskState.Active,
-                            IssuedTick   = nowTick,
+                            IssuedTick   = NowTick,
                         };
                     }
                 }
             }
-
-            if (activePerKind.IsCreated)   activePerKind.Dispose();
-            if (reservedPerKind.IsCreated) reservedPerKind.Dispose();
-            justAssignedPerKind.Dispose();
         }
 
-        static bool PackHasFood(in ItemDBSingleton itemDB, DynamicBuffer<PackSlot> buf)
+        static bool PackHasFood(
+            NativeArray<ItemDefRuntime> defs,
+            NativeArray<ulong>          validBits,
+            ushort                      maxId,
+            DynamicBuffer<PackSlot>     buf)
         {
             for (int i = 0; i < buf.Length; i++)
             {
                 if (buf[i].Count == 0) continue;
-                if (itemDB.EnergyValue(buf[i].ItemId) > 0f) return true;
+                ushort id = buf[i].ItemId;
+                if (id >= maxId) continue;
+                if ((validBits[id >> 6] & (1ul << (id & 63))) == 0) continue;
+                if (defs[id].RestoreEnergy > 0f) return true;
             }
             return false;
         }
@@ -548,7 +561,7 @@ namespace RareIcon
         }
 
         static bool TryFindClosestThreat(
-            NativeList<ThreatRecord> threats,
+            NativeArray<ThreatRecord> threats,
             float3 originWorld,
             out int2 outHex, out Entity outEntity, out int outDist)
         {


### PR DESCRIPTION
Roadmap item **#4** from #11716. Per-unit work now runs as a `[BurstCompile] IJobEntity` parallel job instead of a main-thread `foreach`. Targets 100k+ unit scale.

Builds on #11719 (per-kind slicing + occupancy filter + capacity).

## Shape change

Main-thread `RunDispatch` shrinks to: snapshot construction + `ScheduleParallel` + handle publish.

The entire foreach body — relief override, manual override, task queue cleanup, pending→active promotion, preempt, scoring, wander fallback, intent write, event emission, task buffer rewrite — lives in `DispatchJob : IJobEntity` and runs on worker threads.

```csharp
[BurstCompile]
partial struct DispatchJob : IJobEntity
{
    [ReadOnly] public NativeArray<TaskOffer> OffersSortedByKind;
    [ReadOnly] public NativeArray<int>       OfferKindStart;
    [ReadOnly] public NativeArray<int>       OfferKindCount;
    [ReadOnly] public NativeArray<int>       OffersPerKind;
    [ReadOnly] public NativeArray<NeedyCave> NeedyCaves;
    [ReadOnly] public NativeArray<ThreatRecord>    Threats;
    [ReadOnly] public NativeArray<FriendlyEmitter> FriendlyEmitters;
    [ReadOnly] public NativeHashMap<int2, int> HexOccupancy;
    [ReadOnly] public NativeArray<int> ActivePerKind;
    [ReadOnly] public NativeArray<int> ReservedPerKind;
    [ReadOnly] public NativeArray<ItemDefRuntime> ItemDefs;
    [ReadOnly] public NativeArray<ulong>          ItemValidBits;
    public ushort ItemMaxId;
    [ReadOnly] public ComponentLookup<ControlledUnitTag> ControlledLookup;
    [ReadOnly] public BufferLookup<PackSlot>             UnitPackLookup;
    public NativeList<ProfessionChangedMessage>.ParallelWriter Events;
    // …
}
```

## Events

[ProfessionEventSink](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Messages/ProfessionEventSink.cs) gets a parallel-writer overload that calls `AddNoResize`. WriteBuffer capacity grown on the main thread before scheduling so AddNoResize is safe across threads.

## Pipeline handoff

```csharp
state.Dependency = job.ScheduleParallel(state.Dependency);
dbRef.PipelineHandle = state.Dependency;
```

[ProfessionsDomainSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionsDomainSystem.cs#L31) and [ProfessionMessagePipeBridgeSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionMessagePipeBridgeSystem.cs#L22) already call `db.PipelineHandle.Complete()` before reading the buffer, so they sync transparently.

Combat sync also moved off the main thread:

```csharp
state.Dependency = JobHandle.CombineDependencies(state.Dependency, combatDB.PipelineHandle);
```

Replaces the prior explicit `combatDB.PipelineHandle.Complete()` block.

## Trade-offs (acknowledged, not breaks)

- **Snapshot occupancy.** `_hexOccupancy` is built on the main thread when a full dispatch fires, then read-only inside the job. The per-unit decrement-old / increment-new dance from the previous main-thread loop is dropped — every unit in the same tick sees the start-of-tick snapshot. The hard cap (`HexClusterCap = 4`) becomes "fuzzy" within one tick: if 10 units all score against `occ=3`, 10 commit. Next dispatch tick's rebuild self-corrects. Spiral packing (#11714) + quadratic crowd penalty (#11715) mask the one-tick visual artifact.
- **No justAssignedPerKind.** The "this dispatch already assigned N units to kind X" counter goes away — cross-thread coordination via Interlocked isn't worth the complexity at this stage. Deficit term bounded by `DeficitCap = 2`, so over-corrections cap at `PriorityWeight/2 = 5000` — well under a priority level (`PriorityWeight = 10000`).
- **ItemDB decomposition.** Singleton contains `NativeArray` fields; passing it whole would need `NativeDisableContainerSafetyRestriction`. Decomposed to `ItemDefs` + `ItemValidBits` + `ItemMaxId` (the only bits `PackHasFood` reads) with explicit `[ReadOnly]`.

## What's preserved

- Per-kind slicing from #11719 (outer kind loop + per-kind bonus extraction).
- Crowd penalty + HexClusterCap from #11715.
- Guard preempt + patrol fallback paths.
- Relief / manual / preempt event reasons (ReliefOverride, ManualOverride, Preempted, Retargeted, Assigned, Fallback).
- Wander fallback when no offer scores.
- All static helpers (HexDistance, OfferDistanceCap, IsHarvestVariant, TryFindClosestThreat, PackHasFood).

## Test plan

- [ ] Burst compiles `ProfessionDispatchSystem` + `DispatchJob` clean (no BC1xxx / EA0006).
- [ ] No safety errors in `Entities.NativeContainer` mode (ENABLE_UNITY_COLLECTIONS_CHECKS).
- [ ] Frame time at current scale: expect parity or improvement vs main; the threading win compounds at higher unit counts.
- [ ] All event reasons fire correctly (smoke test each path: relief, manual, preempt, normal scoring, fallback).
- [ ] ProfessionMessagePipeBridgeSystem still drains WriteBuffer without empty/stale frames.
- [ ] Stress test 1000+ units harvesting — visual spreading from #11714 + #11715 still works under the snapshot occupancy model.
- [ ] No "Branch is dirty" CI regression (#11719's deterministic-codegen + atlas-gate work stays green).

## Follow-up

Next on the roadmap: **#1** (spatial hash `OffersByHex`) — useful when per-kind slices grow beyond ~1000 offers. **#11** (split coordinator into 4 systems) — would let Reconcile / Preempt / Dispatch / IntentEvent each have its own scheduling rhythm. Hygiene items #2 (added in #11719), #7, #8, #9 still parked.

Refs #11716.