### PR TITLE
content(osrs): migrate batch 17 (200 items) v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-bolts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant bolts | OSRS Price Data
-description: "Adamant bolts is a members ammo slot item requiring 46 Ranged. High alch: 34 GP, GE limit: 11,000."
+description: "Adamant bolts: Adamantite crossbow bolts. Members ammo requiring 46 Ranged, fired from adamant crossbows or higher. High alch: 34 GP, GE limit: 11,000."
 osrs:
   id: 9143
   name: Adamant bolts
@@ -12,49 +12,101 @@ osrs:
   lowalch: 23
   highalch: 34
   limit: 11000
-  item_id: 9143
-  type: ammunition
-  tradeable: true
-  weight: 0
-  buy_limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    type: bolts
+    weapon_type: bolts
+    attack_speed: null
+    weight: 0
     requirements:
       ranged: 46
-  fletching:
-    level: 61
-    materials:
-      - item: Adamant bolts (unf)
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 100
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 61
+      xp: 70
+      materials:
+        - item_name: Adamant bolts (unf)
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      output_quantity: 10
+  drop_table:
+    sources:
+      - source: Iron dragon
         quantity: "1"
-      - item: Feathers
+        rarity: "1/21.33"
+      - source: Skeletal wyvern
         quantity: "1"
-  obtaining:
-    fletching: Smith adamantite bars, then fletch with feathers (61 Fletching)
-    drops:
-      - Iron dragons
-      - Skeletal wyverns
+        rarity: "1/42.67"
+      - source: Hallowed Sepulchre
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - slug: adamant-crossbow
-      name: Adamant crossbow
-      relation: required_weapon
-    - slug: adamant-bolts-e
-      name: Adamant bolts (e)
-      relation: enchanted_variants
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Ammo |
-    | Type | Crossbow Bolts |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 46 Ranged |
-
-    Used with adamant crossbow or higher.
-
-    Can be tipped with gems and enchanted for special effects.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Adamant crossbow
+      slug: adamant-crossbow
+      relationship: component
+      description: Crossbow that fires adamant bolts at minimum required tier.
+    - item_name: Adamant bolts (unf)
+      slug: adamant-bolts-unf
+      relationship: component
+      description: Unfinished adamant bolts before feathering.
+    - item_name: Adamant bolts (e)
+      slug: adamant-bolts-e
+      relationship: variant
+      description: Enchanted adamant bolts with proc effects.
+    - item_name: Rune bolts
+      slug: runite-bolts
+      relationship: upgrade
+      description: Next bolt tier with higher ranged strength.
+  about: "Adamant bolts are mid-game ranged ammunition for adamant or higher crossbows. They are fletched at 61 Fletching from unfinished adamant bolts and feathers, dropped commonly by iron dragons and skeletal wyverns, and can be tipped with gems to make enchanted variants like (e) bolts with strong proc effects."
+  market_strategy:
+    notes:
+      - "Iron dragon and skeletal wyvern droprates control supply; price tracks Slayer task assignments."
+      - "Enchanted variants (e.g. ruby bolts (e), diamond bolts (e)) are the main demand sink."
+  trading_tips:
+    - Buy 11,000 per 4 hours when ranged content is meta and resupply the (e) crafters.
+    - Watch out for downward swings after major Slayer rebalances.
+  history:
+    - date: "2006-07-31"
+      description: "Adamant bolts released alongside the bolt rework and fletching unlock at 61."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h2.mdx
@@ -12,9 +12,95 @@ osrs:
   lowalch: 6656
   highalch: 9984
   limit: 8
-  about: "Adamant platebody (h2) is a free-to-play item in Old School RuneScape. High alchemy value: 9,984 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 11.339
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 11.339
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 65
+      slash: 63
+      crush: 55
+      magic: -6
+      ranged: 63
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Medium Clue Scroll
+        quantity: "1"
+        rarity: "1/1,133"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Adamant platebody
+      slug: adamant-platebody
+      relationship: alternative
+      description: Standard smithable platebody with identical defensive stats.
+    - item_name: Adamant platebody (h1)
+      slug: adamant-platebody-h1
+      relationship: variant
+      description: Alternate heraldic design from medium clue rewards.
+    - item_name: Adamant platebody (h3)
+      slug: adamant-platebody-h3
+      relationship: variant
+      description: Alternate heraldic design from medium clue rewards.
+    - item_name: Adamant platebody (h4)
+      slug: adamant-platebody-h4
+      relationship: variant
+      description: Alternate heraldic design from medium clue rewards.
+    - item_name: Adamant platebody (h5)
+      slug: adamant-platebody-h5
+      relationship: variant
+      description: Alternate heraldic design from medium clue rewards.
+  about: "The adamant platebody (h2) is a heraldic cosmetic variant of the adamant platebody with identical defensive stats and a 30 Defence requirement. It is obtained exclusively from medium Treasure Trails as part of the heraldic h1–h5 series introduced in the 2019 Treasure Trails expansion."
+  market_strategy:
+    notes:
+      - "Heraldic supply is clue-driven; price follows medium clue completion volume."
+      - "Fashionscape demand pegs price slightly above the standard platebody."
+      - "GE buy limit of 8 keeps short-term flips constrained."
+  trading_tips:
+    - "Sell during fashionscape and clue-prep hype windows."
+    - "Bundle with matching h-series kiteshield and full helm for set premium."
+    - "Compare against sibling h1/h3/h4/h5 patterns to spot under-priced designs."
+  history:
+    - date: "2019-04-11"
+      description: "Added as a medium Treasure Trail reward in the Treasure Trails expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-thrownaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-thrownaxe.mdx
@@ -12,31 +12,87 @@ osrs:
   lowalch: 70
   highalch: 105
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ammunition
+    tier: mid
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 5
+    weight: 0
     requirements:
       ranged: 30
     attack_bonus:
-      ranged: 15
-    ranged_strength: 23
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 17
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 23
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Tribal Weapons Shop
+      location: Ranging Guild
+      price: 228
+      currency: Coins
+      stock: 50
   related_items:
-    - item_id: 803
-      item_name: Mithril thrownaxe
+    - item_name: Mithril thrownaxe
       slug: mithril-thrownaxe
-      relationship: variant
-      description: Lower tier thrownaxe
-    - item_id: 805
-      item_name: Rune thrownaxe
+      relationship: downgrade
+      description: Lower-tier thrownaxe requiring less Ranged.
+    - item_name: Rune thrownaxe
       slug: rune-thrownaxe
-      relationship: variant
-      description: Higher tier thrownaxe
-  about: |-
-    > _"A finely balanced throwing axe."_
-
-    The adamant thrownaxe requires 30 Ranged. Features the bouncing special attack.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: upgrade
+      description: Higher-tier thrownaxe with stronger ranged bonus.
+    - item_name: Steel thrownaxe
+      slug: steel-thrownaxe
+      relationship: downgrade
+      description: Mid-low tier predecessor in the thrownaxe progression.
+  about: "The adamant thrownaxe is a members-only thrown Ranged weapon requiring level 30 Ranged. It deals +17 Ranged attack and +23 Ranged Strength with a 5-tick attack speed (4 on Rapid) and features the bouncing special attack. It is purchasable from the Tribal Weapons shop at the Ranging Guild and stackable for convenient bank storage."
+  special_attack:
+    name: Ricochet
+    description: "Throws the axe with extra accuracy; on a successful hit, it ricochets to nearby targets up to two additional times. Consumes 35% special attack energy."
+    energy: 35
+  market_strategy:
+    notes:
+      - "Ranging Guild shop supply keeps GE price tethered slightly above shop value."
+      - "Demand from low-level Ranged trainers and Wilderness PKers keeps it liquid."
+      - "Special-attack ricochet niche keeps a steady, low-volume buyer pool."
+  trading_tips:
+    - "Run Ranging Guild shop circuits for cheap supply when GE price spikes."
+    - "Stockpile before bounty/PvP events that favour cheap throwing weapons."
+    - "Compare against rune thrownaxe demand for tier-shift trades."
+  history:
+    - date: "2004-03-29"
+      description: "Added with the introduction of thrownaxes in the Ranged weapon update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-trimmed-set-lg.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 8
-  about: "Adamant trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour set
+    tier: mid
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Adamant full helm (t)
+      slug: adamant-full-helm-t
+      relationship: set-piece
+      description: "Helm component of the trimmed set"
+    - item_name: Adamant platebody (t)
+      slug: adamant-platebody-t
+      relationship: set-piece
+      description: "Platebody component of the trimmed set"
+    - item_name: Adamant platelegs (t)
+      slug: adamant-platelegs-t
+      relationship: set-piece
+      description: "Platelegs component of the trimmed set"
+    - item_name: Adamant kiteshield (t)
+      slug: adamant-kiteshield-t
+      relationship: set-piece
+      description: "Kiteshield component of the trimmed set"
+  about: |-
+    The Adamant trimmed set (lg) is an item-set obtained by exchanging the four trimmed adamant pieces with a Grand Exchange clerk via the right-click Sets option. It contains an adamant full helm (t), platebody (t), platelegs (t), and kiteshield (t).
+
+    The set exists primarily as a convenience for buying or selling the full kit in one Grand Exchange listing rather than handling four separate items.
+  market_strategy:
+    notes:
+      - "Set provides a price premium over the individual components"
+      - "Convenience listing for collectors and PKers"
+      - "Free-to-play armour with steady but low volume"
+  trading_tips:
+    - Compare set price vs. sum of components for arbitrage opportunities
+    - GE limit of 8 caps short-term flipping volume
+  history:
+    - date: "2015-02-26"
+      description: "Item set added to the game alongside the Grand Exchange set exchange feature."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/airtight-pot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/airtight-pot.mdx
@@ -1,6 +1,6 @@
 ---
 title: Airtight pot | OSRS Price Data
-description: "Airtight pot: This is pretty well sealed.. High alch: 6 GP, GE limit: 15."
+description: "Airtight pot: This is pretty well sealed. Quest item for One Small Favour and Swan Song. High alch: 6 GP, GE limit: 15."
 osrs:
   id: 4436
   name: Airtight pot
@@ -12,9 +12,66 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15
-  about: "Airtight pot is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: quest
+    tier: low
+  properties:
+    release_date: "2005-02-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.595
+    options:
+      - Open
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Empty pot
+          quantity: 1
+        - item_name: Pot lid
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Pot lid
+      slug: pot-lid
+      relationship: component
+      description: Sealing lid combined with an empty pot
+    - item_name: Empty pot
+      slug: empty-pot
+      relationship: component
+      description: Base pot used to assemble the airtight pot
+  about: |-
+    > *"This is pretty well sealed."*
+
+    The airtight pot is created by combining a pot lid with an empty pot during the One Small Favour quest. It is needed by the Apothecary in Varrock during that quest, and also reappears in Swan Song where it is used to store bone seeds when fighting skeleton mages.
+
+    Outside of quest steps, the item is mostly inventory-only with limited use.
+  market_strategy:
+    notes:
+      - "Almost all demand is from players progressing One Small Favour or Swan Song"
+      - "Tiny GE buy limit (15 per 4 hours) keeps the market thin"
+      - "Components (empty pot + pot lid) are very cheap, so flips are low margin"
+      - "Listings spike around quest cape and ironman milestones"
+  trading_tips:
+    - Stock a handful when running One Small Favour or Swan Song accounts
+    - Consider crafting from components instead of buying at high GE markup
+  history:
+    - date: "2005-02-28"
+      description: "Item added with the One Small Favour quest."
+    - date: "2005-07-11"
+      description: "Sprite was recoloured during a graphical update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-broad-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-broad-bolts.mdx
@@ -12,77 +12,95 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 11000
-  ammunition:
-    type: bolt
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ammunition
+    tier: mid-high
+  properties:
+    release_date: "2017-06-22"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammunition
+    weapon_type: crossbow
+    attack_speed: null
     weight: 0
     requirements:
-      slayer_unlock: Broader fletching (300 points)
-    stats:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 115
-  creation:
-    method: Fletching
-    requirements:
-      fletching: 76
-      unlock: Broader fletching
-    materials:
-      - item_id: 21318
-        item_name: Broad bolts
-        quantity: "10"
-      - item_id: 21338
-        item_name: Amethyst bolt tips
-        quantity: "10"
-    xp: 106
-  special_effect:
-    name: Slayer Requirement
-    description: Required for killing Turoth and Kurask with ranged
-  market:
-    buy_limit: 11000
-    price_estimate: 280
-    daily_volume: 460000
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 76
+      xp: 106
+      materials:
+        - item_name: Broad bolts
+          quantity: 10
+        - item_name: Amethyst bolt tips
+          quantity: 10
+      tools: []
+      output_quantity: 10
   related_items:
-    - item_id: 21318
-      item_name: Broad bolts
+    - item_name: Broad bolts
       slug: broad-bolts
       relationship: component
-      description: Base item
-    - item_id: 21338
-      item_name: Amethyst bolt tips
+      description: Base bolt before tipping
+    - item_name: Amethyst bolt tips
       slug: amethyst-bolt-tips
       relationship: component
-      description: Component
-    - item_id: 2150
-      item_name: Turoth
-      slug: turoth
-      relationship: product
-      description: Use target
-    - item_id: 410
-      item_name: Kurask
-      slug: kurask
-      relationship: product
-      description: Use target
+      description: Tipping material
+    - item_name: Runite bolts
+      slug: runite-bolts
+      relationship: alternative
+      description: Equivalent damage tier
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-    | Requirements | Slayer unlock |
+    Amethyst broad bolts are crossbow ammunition tipped with amethyst, equivalent to runite bolts in damage. They are required for ranging Turoth and Kurask on Slayer assignments.
 
-    | Stat | Bonus |
-    |------|-------|
-    | Ranged strength | +115 |
-
-    Equivalent to runite bolts.
-
-    Slayer: Required for killing Turoth and Kurask with ranged.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Fletching them requires 76 Fletching and the Broader fletching unlock from the Slayer rewards interface (300 Slayer reward points).
+  market_strategy:
+    notes:
+      - "High daily volume from Slayer ranged setups"
+      - "Margins are thin; flip in bulk"
+      - "Demand spikes during Slayer competition weekends"
+  trading_tips:
+    - Buy broad bolts and amethyst tips separately when cheaper than the finished bolt
+    - Combine and resell during Slayer task surges for steady profit
+    - Stock up when amethyst mining output is high and tip prices dip
+  history:
+    - date: "2017-06-22"
+      description: "Released alongside the Mining Guild expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-dart-p-25855.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-dart-p-25855.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
-  about: "Amethyst dart(p+) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: amethyst
+    tier: mid-high
+  properties:
+    release_date: "2021-06-30"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 28
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 90
+      xp: 21
+      materials:
+        - item_name: Amethyst dart tip
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Poison+
+      description: Inflicts the upgraded poison effect on hit, dealing more damage than standard poison.
+  related_items:
+    - item_name: Amethyst dart
+      slug: amethyst-dart
+      relationship: variant
+      description: Unpoisoned version of the dart
+    - item_name: Amethyst dart(p)
+      slug: amethyst-dart-p
+      relationship: downgrade
+      description: Standard poisoned variant (lower poison tier)
+    - item_name: Amethyst dart tip
+      slug: amethyst-dart-tip
+      relationship: component
+      description: Crafted from amethyst, used to fletch the dart
+    - item_name: Dragon dart(p+)
+      slug: dragon-dart-p
+      relationship: upgrade
+      description: Higher-tier thrown weapon variant
+  about: |-
+    Amethyst dart(p+) is the upgraded poisoned variant of the amethyst dart, sitting between rune and dragon darts in the throwing weapon hierarchy. Requires 50 Ranged to wield and provides +28 Ranged Strength - 2 higher than rune darts.
+
+    Standard attack speed of 3 ticks (1.8s), or 2 ticks with the Rapid attack style. Range of 3 tiles (5 with Longrange).
+
+    Created at 90 Fletching by combining an amethyst dart tip with a feather, granting 21 XP per dart.
+  market_strategy:
+    notes:
+      - "Mid-tier thrown weapon, niche between rune and dragon darts"
+      - "Margins tracking amethyst mining output"
+      - "Poison+ premium over regular and (p) variants"
+  trading_tips:
+    - Watch amethyst dart tip price as primary input cost
+    - High volume from blowpipe alternates and pures
+    - Use Fletching margin vs amethyst price as proxy
+  history:
+    - date: "2021-06-30"
+      description: "Item released with the amethyst mining and fletching update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amethyst javelin | OSRS Price Data
-description: "Amethyst javelin is a members ammo slot item with +55 ranged strength requiring 50 Ranged. High alch: 252 GP, GE limit: 11,000."
+description: "Amethyst javelin is a members ammo slot item with +135 ranged strength requiring 50 Ranged. High alch: 252 GP, GE limit: 11,000."
 osrs:
   id: 21318
   name: Amethyst javelin
@@ -12,8 +12,34 @@ osrs:
   lowalch: 168
   highalch: 252
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: amethyst
+    tier: mid-high
+  properties:
+    release_date: "2017-06-22"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
+    weapon_type: thrown
+    attack_speed: null
+    weight: 0.02
+    requirements:
+      ranged: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -28,38 +54,50 @@ osrs:
       ranged: 0
     other_bonus:
       melee_strength: 0
-      ranged_strength: 55
+      ranged_strength: 135
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 50
-    weight: 0.02
+  recipes:
+    - skill: fletching
+      level: 84
+      xp: 13.5
+      materials:
+        - item_name: Amethyst javelin heads
+          quantity: 1
+        - item_name: Javelin shaft
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 830
-      item_name: Rune javelin
+    - item_name: Rune javelin
       slug: rune-javelin
       relationship: downgrade
-      description: Lower tier javelin
-  about: |-
-    | Other | Value |
-    |-------|-------|
-    | Ranged Strength | +55 |
-
-    Requirements: 50 Ranged | Weight: 0.02 kg
-
-    The amethyst javelin is the strongest tradeable javelin below dragon tier. With +55 ranged strength, it provides a significant boost over rune javelins (+46) in Heavy ballista setups.
-
-    Amethyst javelins in a heavy ballista are a popular PKing setup:
-    - High single-hit damage potential (70+ with max gear)
-    - One of the best KO weapons in multi-combat
-    - Cheaper than dragon javelins with comparable performance
+      description: Lower tier javelin used before unlocking amethyst tips
+    - item_name: Dragon javelin
+      slug: dragon-javelin
+      relationship: upgrade
+      description: Highest tradeable javelin tier with stronger ranged strength
+    - item_name: Amethyst javelin(p)
+      slug: amethyst-javelin-p
+      relationship: variant
+      description: Poison-tipped variant of the amethyst javelin
+    - item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: component
+      description: Ranged two-hander that fires amethyst javelins as its premier PvP ammo
+  about: "The amethyst javelin is the strongest tradeable javelin below dragon tier and one of the highest ranged-strength ammo types loaded into a Heavy ballista. With +135 ranged strength and the 0.02 kg weight typical of javelins it dominates PvP burst setups, where a single ballista shot can KO targets with 70+ damage. Players fletch them at level 84 by combining amethyst javelin heads (mined at 92 Mining) with javelin shafts for 13.5 Fletching XP each."
   market_strategy:
     notes:
-      - Consumed as ammo — steady PvP demand
-      - Amethyst mining at 92 Mining supplies the heads
-      - Good Fletching XP at level 84
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Consumed as ammo so demand stays cyclical with PvP and Slayer activity"
+      - "Amethyst mining and Fletching keep the supply curve gated behind high-level skills"
+      - "Solid bulk-flipping target with the 11,000 buy limit and tight PvP spreads"
+  trading_tips:
+    - Stockpile heads through amethyst mining for free crafted javelin profit
+    - Watch PvP and Wilderness event weeks for predictable price spikes
+  history:
+    - date: "2017-06-22"
+      description: "Added with the Mining Guild expansion as the second-strongest tradeable javelin."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-avarice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-avarice.mdx
@@ -12,105 +12,103 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: amulet
+    tier: high
+  properties:
+    release_date: "2018-07-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: amulet
-    stats:
-      attack_stab: 10
-      attack_slash: 10
-      attack_crush: 10
-      attack_magic: 10
-      attack_ranged: 10
-      defence_stab: 3
-      defence_slash: 3
-      defence_crush: 3
-      defence_magic: 3
-      defence_ranged: 3
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
       melee_strength: 6
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
   passive_effects:
     - name: Revenant Boost
-      description: 20% accuracy and damage increase when fighting revenants
+      description: 20% accuracy and damage increase when fighting revenants in the Revenant Caves.
     - name: Skull Effect
-      description: Causes the wearer to become skulled
+      description: Wearing the amulet skulls the player, risking all items on death.
     - name: Noted Drops
-      description: Drops from NPCs in Revenant Caves, Wilderness Slayer Cave, and Chaos Temple are noted
-  obtaining:
-    methods:
-      - source: Revenants
-        location: Revenant Caves
-        drop_rate: Rare
+      description: "Drops from NPCs in Revenant Caves, Wilderness Slayer Cave, and Chaos Temple are converted to notes (excluding secondaries and unique drops)."
+  drop_table:
+    sources:
+      - source: Revenant (high-level, on-task)
+        quantity: "1"
+        rarity: 1/2666
+      - source: Revenant (low-level, off-task)
+        quantity: "1"
+        rarity: 1/73334
   related_items:
-    - item_id: 22550
-      item_name: Craw's bow
+    - item_name: Craw's bow
       slug: craws-bow
       relationship: alternative
-      description: Wilderness bow
-    - item_id: 22545
-      item_name: Viggora's chainmace
+      description: Wilderness ranged weapon from the Revenant Caves reward pool.
+    - item_name: Viggora's chainmace
       slug: viggoras-chainmace
       relationship: alternative
-      description: Wilderness mace
-    - item_id: 22555
-      item_name: Thammaron's sceptre
+      description: Wilderness melee weapon from the Revenant Caves reward pool.
+    - item_name: Thammaron's sceptre
       slug: thammarons-sceptre
       relationship: alternative
-      description: Wilderness staff
-    - item_id: 21816
-      item_name: Bracelet of ethereum
+      description: Wilderness magic weapon from the Revenant Caves reward pool.
+    - item_name: Bracelet of ethereum
       slug: bracelet-of-ethereum
-      relationship: alternative
-      description: Revenant protection
-    - item_id: 21820
-      item_name: Revenant ether
+      relationship: component
+      description: Bracelet that absorbs revenant attacks when charged with ether.
+    - item_name: Revenant ether
       slug: revenant-ether
-      relationship: alternative
-      description: Revenant currency
+      relationship: component
+      description: Currency dropped by revenants that powers Wilderness uniques.
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +10 |
-    | Ranged | +10 |
-    | Melee Strength | +6 |
-    | Prayer | +3 |
+    Amulet of avarice is a high-tier neck slot reward from the Revenant Caves, providing the strongest universal attack bonuses of any amulet at +10 across every style.
 
-    | Defense | Value |
-    |---------|-------|
-    | Stab | +3 |
-    | Slash | +3 |
-    | Crush | +3 |
-    | Magic | +3 |
-    | Ranged | +3 |
+    Equipping the amulet automatically skulls the wearer, meaning all items are dropped on death. In return, drops from revenants and Wilderness Slayer enemies are converted to bank notes, dramatically extending trip length for Wilderness PvMers.
 
-    Revenant Boost:
-    - 20% accuracy increase vs revenants
-    - 20% damage increase vs revenants
-
-    Skull Effect:
-    - Wearing this amulet skulls you
-    - Risk all items on death
-
-    Noted Drops:
-    - Drops from Revenant Caves are noted
-    - Drops from Wilderness Slayer Cave are noted
-    - Drops from Chaos Temple are noted
-
-    Best for:
-    - Revenant hunting
-    - Wilderness money-making
-    - Extended trips with noted drops
-
-    Warning: Skulls the wearer.
+    The 20% accuracy and damage bonus against revenants makes it best-in-slot for the Revenant Caves task itself, outperforming amulet of fury or amulet of torture for that specific content.
   market_strategy:
     notes:
-      - Useful for rev hunting
-      - Be aware of skull risk
-      - Noted drops save inventory
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand spikes when revenant ether prices rise"
+      - "Steady consumption from new Wilderness PvMers each week"
+      - "Skull risk keeps casual demand limited"
+  trading_tips:
+    - Watch for dips when bond prices drop and fewer players risk in the Wilderness
+    - Stock during PvM tournaments and Deadman events when revenants are hotspots
+  history:
+    - date: "2018-07-26"
+      description: "Released alongside the Revenant Cave Rewards update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-bounty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-bounty.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 10000
-  about: "Amulet of bounty is a members-only item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: jewellery
+    tier: mid
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Break
+      - Drop
+    worn_options:
+      - Remove
+      - Break
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.007
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: magic
+      level: 7
+      xp: 17
+      materials:
+        - item_name: Opal amulet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Bounty allotment save
+      description: 25% chance to consume only 1 seed instead of 3 when planting in an allotment patch, using 1 of 10 charges per activation
+  related_items:
+    - item_name: Opal amulet
+      slug: opal-amulet
+      relationship: component
+      description: Base amulet that is enchanted with Lvl-1 Enchant
+    - item_name: Amulet of farming
+      slug: amulet-of-farming
+      relationship: alternative
+      description: Different farming-utility amulet (members)
+    - item_name: Cosmic rune
+      slug: cosmic-rune
+      relationship: component
+      description: Cosmic rune for Lvl-1 Enchant
+  about: "Amulet of bounty is an enchanted opal amulet that grants a 25% chance to consume only one allotment seed instead of three per plant, burning one of its ten charges per save. Charges persist across amulets (selling does not reset them), and right-clicking 'Break' destroys the current amulet so the next one resets to full charges."
+  market_strategy:
+    notes:
+      - "Most valuable to high-tier seed farmers (watermelon, snape grass)"
+      - "Cheap to craft if you have Magic 7 and a steady opal supply"
+      - "10 charges per amulet caps how aggressive single-amulet flips can be"
+  trading_tips:
+    - Buy opal amulets and enchant in bulk for margin
+    - Sell to farmers around Hespori or Farming Guild bandwagons
+  history:
+    - date: "2017-02-02"
+      description: "Released as part of the Farming amulet additions to enchanted opal jewellery."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-eternal-glory.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-eternal-glory.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amulet of eternal glory | OSRS Price Data
-description: "Amulet of eternal glory is a members neck slot item. High alch: 10,575 GP, GE limit: 5."
+description: "Amulet of eternal glory is a members neck slot item with unlimited glory teleports. High alch: 10,575 GP, GE limit: 5."
 osrs:
   id: 19707
   name: Amulet of eternal glory
@@ -12,80 +12,81 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 5
+  material:
+    type: dragonstone
+    tier: high
+  properties:
+    release_date: "2016-06-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Rub
+      - Drop
+    worn_options:
+      - Edgeville
+      - Karamja
+      - Draynor Village
+      - Al Kharid
+    alchable: true
   equipment:
     slot: neck
-    type: amulet
-    stats:
-      attack_stab: 10
-      attack_slash: 10
-      attack_crush: 10
-      attack_magic: 10
-      attack_ranged: 10
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
       strength: 6
-      defence_all: 3
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  charges:
+    type: unlimited
+    description: "Holds an unlimited supply of glory teleport charges - never depletes."
   passive_effects:
     - name: Unlimited Teleports
-      description: Edgeville, Karamja, Draynor Village, Al Kharid
+      description: "Right-click teleport to Edgeville, Karamja, Draynor Village, or Al Kharid with no charge cost."
     - name: Gem Mining Boost
-      description: Same as regular glory
-  obtaining:
-    methods:
-      - source: Fountain of Rune
-        method: Charge amulet of glory
-        chance: 1/25,000
-        requirements:
-          quest: Heroes' Quest
+      description: "Increases the chance of finding gems while mining gem rocks, identical to a charged amulet of glory."
   related_items:
-    - item_id: 1712
-      item_name: Amulet of glory
+    - item_name: Amulet of glory
       slug: amulet-of-glory
       relationship: downgrade
-      description: Regular version
-    - item_id: 0
-      item_name: Fountain of Rune
-      slug: fountain-of-rune
-      relationship: component
-      description: Creation location
-    - item_id: 6585
-      item_name: Amulet of fury
+      description: Standard glory amulet with limited charges; required for the Fountain of Rune conversion.
+    - item_name: Amulet of fury
       slug: amulet-of-fury
       relationship: upgrade
-      description: Better stats
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +10 |
-    | Ranged | +10 |
-    | Strength | +6 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +3 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    Unlimited Teleports:
-    - Edgeville
-    - Karamja
-    - Draynor Village
-    - Al Kharid
-
-    Gem Mining Boost: Same as regular glory
-
-    BiS for:
-    - Infinite Edgeville teleports
-    - Abyss runecrafting
-    - Flex item
-
-    Unlimited teleport glory.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Stronger combat amulet without teleport utility.
+  about: "The amulet of eternal glory is a rare upgrade obtained by charging amulets of glory at the Fountain of Rune in the Wilderness, with a 1-in-25,000 conversion chance per charge. It carries identical combat stats to a regular glory amulet but provides unlimited teleports and a permanent gem-mining boost, making it the de facto BiS teleport amulet for any account doing Wilderness, runecrafting, or general overworld content."
+  market_strategy:
+    notes:
+      - "Supply is extremely thin - 1/25,000 from a single high-attention activity (Fountain of Rune charging)."
+      - "Price floor anchored by infinite teleport convenience for ironman-adjacent and main accounts alike."
+      - "GE limit of 5 keeps large flips slow and signals a long-term hold rather than churn item."
+  trading_tips:
+    - Buy on weekday lulls; price tends to spike around Wilderness PvP weekends.
+    - Treat as a long-term hold; spreads tend to widen rather than tighten.
+  history:
+    - date: "2016-06-30"
+      description: "Released as a rare conversion outcome at the Fountain of Rune."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-magic-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-magic-t.mdx
@@ -12,9 +12,32 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 5
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gold-trimmed amulet
+    tier: low
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
+    weapon_type: null
+    attack_speed: null
     weight: 0.01
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,46 +55,46 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy
-        drop_rate: 1/3,960
-        description: Rare reward from easy clue scrolls
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 11/3,960
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 1727
-      item_name: Amulet of magic
+    - item_name: Amulet of magic
       slug: amulet-of-magic
       relationship: variant
-      description: Standard (untrimmed) version
-    - item_id: 6919
-      item_name: Amulet of power
+      description: Standard (untrimmed) version with identical stats
+    - item_name: Amulet of power
       slug: amulet-of-power
       relationship: upgrade
       description: All-round combat amulet upgrade
   about: |-
     > *"An enchanted sapphire amulet of magic."*
 
-    | Property | Amulet of Magic | Amulet of Magic (t) |
-    |----------|----------------|---------------------|
-    | Magic Attack | +10 | +10 |
-    | Appearance | Standard | Gold trimmed |
-    | Source | Crafting (Lvl-1 Enchant) | Easy clue |
-    | F2P | Yes | Yes |
+    The trimmed amulet of magic is a cosmetic variant of the standard amulet of magic, obtained exclusively as a reward from easy Treasure Trails. Stats are identical to the untrimmed version, making this purely a fashionscape and collection log item.
 
-    Stats are identical. The trimmed version is purely cosmetic.
+    Popular with F2P magic pures who want a cosmetic upgrade without sacrificing the +10 Magic Attack bonus available in free-to-play.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Easy clue exclusive cosmetic
-      - Free-to-play tradeable
-      - Low-tier amulet with niche demand from F2P magic pures
-      - Collection log hunters drive some demand
-      - Best magic amulet available in F2P without other requirements
-      - Commonly used by F2P magic pures for the cosmetic upgrade
-      - Price fluctuates with clue scroll reward table changes
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Easy clue exclusive cosmetic"
+      - "Free-to-play tradeable"
+      - "Low-tier amulet with niche demand from F2P magic pures"
+      - "Collection log hunters drive some demand"
+      - "Best magic amulet available in F2P without other requirements"
+      - "Price fluctuates with clue scroll reward table changes"
+  trading_tips:
+    - Watch clue scroll droprate updates for supply shifts
+    - Collection log demand keeps a price floor
+    - Volume is low - use limit orders rather than instant flips
+  history:
+    - date: "2006-12-05"
+      description: "Item released as a reward from easy Treasure Trails."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-power-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-power-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amulet of power (t) | OSRS Price Data
-description: "Amulet of power (t) is a F2P neck slot item with +6 melee strength. High alch: 2,415 GP, GE limit: 5."
+description: "Amulet of power (t) is a F2P neck slot item with +6 stats across the board, +6 strength, +1 prayer. High alch: 2,415 GP, GE limit: 5."
 osrs:
   id: 23354
   name: Amulet of power (t)
@@ -12,9 +12,32 @@ osrs:
   lowalch: 1610
   highalch: 2415
   limit: 5
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: jewellery
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
+    weapon_type: null
+    attack_speed: null
     weight: 0.01
+    requirements: {}
     attack_bonus:
       stab: 6
       slash: 6
@@ -32,55 +55,47 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy
-        drop_rate: 1/1,404
-        description: Rare reward from easy clue scrolls
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 6919
-      item_name: Amulet of power
+    - item_name: Amulet of power
       slug: amulet-of-power
       relationship: variant
-      description: Standard (untrimmed) version
-    - item_id: 1704
-      item_name: Amulet of glory(4)
+      description: Standard untrimmed version with identical stats
+    - item_name: Amulet of glory(4)
       slug: amulet-of-glory-4
       relationship: upgrade
-      description: Superior amulet with teleports
-    - item_id: 6585
-      item_name: Amulet of fury
+      description: Stronger hybrid amulet with teleport charges
+    - item_name: Amulet of fury
       slug: amulet-of-fury
       relationship: upgrade
-      description: Best-in-slot hybrid amulet
+      description: Best-in-slot hybrid amulet for most setups
   about: |-
     > *"An enchanted diamond amulet that looks good."*
 
-    | Property | Amulet of Power | Amulet of Power (t) |
-    |----------|----------------|---------------------|
-    | All Attack | +6 | +6 |
-    | All Defence | +6 | +6 |
-    | Strength | +6 | +6 |
-    | Prayer | +1 | +1 |
-    | Appearance | Standard | Gold trimmed |
-    | Source | Crafting (Lvl-4 Enchant) | Easy clue |
-    | F2P | Yes | Yes |
+    The amulet of power (t) is a free-to-play gold-trimmed cosmetic variant of the amulet of power, obtained from easy Treasure Trails at a 1/1,404 rate. It carries the same +6 bonuses across all attack and defence styles plus +6 strength and +1 prayer.
 
-    Stats are identical. The trimmed version is purely cosmetic.
+    Despite being F2P-tradeable, the standard amulet of power is far more common — the trimmed variant exists primarily as a clue-log collector and fashionscape piece.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Easy clue exclusive cosmetic
-      - Free-to-play tradeable
-      - Popular hybrid amulet for mid-level accounts
-      - Best F2P amulet for balanced combat styles
-      - Solid all-round amulet before accessing glory or fury
-      - No requirements to equip, making it accessible to all account builds
-      - Good choice for F2P PKing due to balanced offensive and defensive stats
-      - Collection log item for completionists
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Easy clue exclusive cosmetic"
+      - "F2P tradeable, popular for mid-level fashionscape"
+      - "Low buy limit of 5 keeps the price volatile"
+      - "Best balanced F2P amulet before glory or fury"
+  trading_tips:
+    - Track easy clue completion events for short supply bumps
+    - Collection log item for completionists drives small but steady demand
+  history:
+    - date: "2019-04-11"
+      description: "Released with the Treasure Trail rework cosmetic batch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-ceremonial-boots.mdx
@@ -12,9 +12,105 @@ osrs:
   lowalch: 16000
   highalch: 24000
   limit: 8
-  about: "Ancient ceremonial boots is a members-only item in Old School RuneScape. High alchemy value: 24,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: high
+  properties:
+    release_date: "2022-01-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Spiritual mage (Ancient Prison)
+        quantity: "1"
+        rarity: 1/640
+      - source: Spiritual ranger (Ancient Prison)
+        quantity: "1"
+        rarity: 1/640
+      - source: Spiritual warrior (Ancient Prison)
+        quantity: "1"
+        rarity: 1/640
+      - source: Blood Reaver
+        quantity: "1"
+        rarity: 1/640
+      - source: Fumus
+        quantity: "1"
+        rarity: 1/1000
+      - source: Umbra
+        quantity: "1"
+        rarity: 1/1000
+      - source: Cruor
+        quantity: "1"
+        rarity: 1/1000
+      - source: Glacies
+        quantity: "1"
+        rarity: 1/1000
+  related_items:
+    - item_name: Ancient ceremonial mask
+      slug: ancient-ceremonial-mask
+      relationship: set-piece
+      description: Head piece of the Ancient Ceremonial Robes
+    - item_name: Ancient ceremonial top
+      slug: ancient-ceremonial-top
+      relationship: set-piece
+      description: Body piece of the Ancient Ceremonial Robes
+    - item_name: Ancient ceremonial legs
+      slug: ancient-ceremonial-legs
+      relationship: set-piece
+      description: Legs piece of the Ancient Ceremonial Robes
+    - item_name: Ancient ceremonial gloves
+      slug: ancient-ceremonial-gloves
+      relationship: set-piece
+      description: Gloves piece of the Ancient Ceremonial Robes
+  about: "Ancient ceremonial boots are the feet slot of the Ancient Ceremonial Robes, a Zarosian cosmetic set released with the Nex update. Dropped by every Ancient Prison NPC excluding Nex herself (best rate 1/640), the full set grants god protection against Zarosian followers inside the God Wars Dungeon and stores in the costume room magic wardrobe."
+  market_strategy:
+    notes:
+      - "Buy limit of 8 keeps day-to-day liquidity thin"
+      - "Demand driven by cosmetic collectors and god-set hunters"
+      - "Drop rate dictates supply more than alch margin"
+  trading_tips:
+    - Track Nex group attendance to forecast Ancient Prison drop supply
+    - Pair with other set pieces to clear faster than singles
+  history:
+    - date: "2022-01-05"
+      description: "Released as part of the Nex - Ancient Prison update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-cloak.mdx
@@ -12,27 +12,96 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid-high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.003
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.003
     requirements:
       prayer: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 12193
-      item_name: Ancient robe top
+    - item_name: Ancient robe top
       slug: ancient-robe-top
       relationship: set-piece
-      description: Ancient vestment body
+      description: Vestment body
+    - item_name: Ancient robe legs
+      slug: ancient-robe-legs
+      relationship: set-piece
+      description: Vestment legs
+    - item_name: Ancient mitre
+      slug: ancient-mitre
+      relationship: set-piece
+      description: Vestment headwear
+    - item_name: Ancient stole
+      slug: ancient-stole
+      relationship: set-piece
+      description: Vestment neckwear
+    - item_name: Ancient crozier
+      slug: ancient-crozier
+      relationship: set-piece
+      description: Vestment weapon
   about: |-
-    > *"An Ancient cloak."*
+    The Ancient cloak is the cape piece of the Ancient vestment set, dropped from medium Treasure Trails caskets at roughly 1 in 1,133. It requires 40 Prayer to equip and grants +3 Prayer alongside +3 defence in every style and a small +1 Magic attack bonus.
 
-    The Ancient cloak is the cape piece of the Ancient vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Zarosian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Counts as a Zarosian item in the God Wars Dungeon and is storable in the costume room treasure chest as part of the full vestment set.
+  market_strategy:
+    notes:
+      - "Tight buy limit (8) keeps margins jumpy"
+      - "Demand from collection log and costume room hunters"
+      - "Full vestment sets sell faster than loose pieces"
+  trading_tips:
+    - Hold during low-volume weeks; price spikes on clue casket droughts
+    - Bundle with the matching mitre, stole, robes, and crozier for set premium
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-page-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-page-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ancient page 3 | OSRS Price Data
-description: "Ancient page 3: This seems to have been torn from a book.... High alch: 240 GP, GE limit: 5."
+description: "Ancient page 3: This seems to have been torn from a book... One of four pages used to repair the damaged Ancient god book. High alch: 240 GP, GE limit: 5."
 osrs:
   id: 12623
   name: Ancient page 3
@@ -12,43 +12,71 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Ancient
-    page_number: 3
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2014-07-03"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: "1/650"
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: Common
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - item_id: 12621
-      item_name: Ancient page 1
+    - item_name: Ancient page 1
       slug: ancient-page-1
       relationship: set-piece
-      description: Page 1 of 4
-    - item_id: 12622
-      item_name: Ancient page 2
+      description: Page 1 of 4 needed for the Ancient god book.
+    - item_name: Ancient page 2
       slug: ancient-page-2
       relationship: set-piece
-      description: Page 2 of 4
-    - item_id: 12624
-      item_name: Ancient page 4
+      description: Page 2 of 4 needed for the Ancient god book.
+    - item_name: Ancient page 4
       slug: ancient-page-4
       relationship: set-piece
-      description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Ancient (Zaros) |
-    | Page | 3 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of darkness (Ancient god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Page 4 of 4 needed for the Ancient god book.
+    - item_name: Book of darkness
+      slug: book-of-darkness
+      relationship: product
+      description: Completed Ancient (Zaros) god book when all four pages are added.
+  about: "Ancient page 3 is one of four loose pages used to complete the Book of darkness, the Ancient (Zaros) god book. Players must first buy a damaged Ancient god book from Jossik for 5,000 coins after completing Horror from the Deep, then add all four pages to restore it."
+  market_strategy:
+    notes:
+      - "Demand is bursty whenever a new God Book unlock route is popular."
+      - "Hard and Elite clue droppers control supply; check clue scroll meta before flipping."
+  trading_tips:
+    - Buy at 5/4h limit; flip alongside the other three pages as a set.
+    - Players assembling the Book of darkness usually want all four pages at once.
+  history:
+    - date: "2014-07-03"
+      description: "Ancient pages added with the Zaros god book content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-stole.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-stole.mdx
@@ -12,24 +12,91 @@ osrs:
   lowalch: 1000
   highalch: 1500
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.002
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 10
+  drop_table:
+    sources:
+      - source: Medium Clue Scroll
+        quantity: "1"
+        rarity: "1/1,133"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 12199
-      item_name: Ancient crozier
+    - item_name: Ancient crozier
       slug: ancient-crozier
       relationship: set-piece
-      description: Ancient vestment weapon
-  about: |-
-    > *"An Ancient stole."*
-
-    The Ancient stole is a neck slot item from the Ancient vestment set. It provides a +10 Prayer bonus and requires 60 Prayer to equip. One of the highest prayer bonus items available in the neck slot. Counts as a Zarosian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Two-handed Ancient vestment weapon worn with the stole.
+    - item_name: Ancient mitre
+      slug: ancient-mitre
+      relationship: set-piece
+      description: Head slot piece of the Ancient vestment set.
+    - item_name: Ancient robe top
+      slug: ancient-robe-top
+      relationship: set-piece
+      description: Body slot piece of the Ancient vestment set.
+    - item_name: Ancient robe legs
+      slug: ancient-robe-legs
+      relationship: set-piece
+      description: Legs slot piece of the Ancient vestment set.
+  about: "The Ancient stole is a neck slot item from the Ancient (Zaros) vestment set, granting a +10 Prayer bonus and requiring 60 Prayer to equip. Acquired as a medium Treasure Trail reward, it counts as a Zarosian item inside the God Wars Dungeon and is one of the highest Prayer-bonus neck items in the game. It is widely used in PvM setups like Fight Caves, Zalcano, and Maniacal monkeys."
+  market_strategy:
+    notes:
+      - "Demand stays steady from prayer-stack PvMers and ironmen seeking GWD aggression items."
+      - "Medium clue droprate keeps supply thin enough to sustain price."
+      - "Track against alternative +10 prayer neck items (god stoles) for relative pricing."
+  trading_tips:
+    - "Flip during clue events when medium casket loot floods the GE."
+    - "Bundle with other Ancient vestment pieces for set premium."
+    - "Watch Zaros-themed content updates for short-term demand spikes."
+  history:
+    - date: "2014-06-12"
+      description: "Added as a medium Treasure Trail reward alongside the Ancient vestment set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/annihilation-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/annihilation-teleport-scroll.mdx
@@ -12,12 +12,59 @@ osrs:
   lowalch: null
   highalch: null
   limit: 5
-  about: "Annihilation teleport scroll is a members-only item in Old School RuneScape. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic-unlock
+    tier: high
+  properties:
+    release_date: "2026-01-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Annihilation weapon scroll
+      slug: annihilation-weapon-scroll
+      relationship: alternative
+      description: "Other Deadman: Annihilation cosmetic unlock"
+    - item_name: Annihilation blueprints
+      slug: annihilation-blueprints
+      relationship: alternative
+      description: Construction-themed Deadman reward
+  about: |-
+    The Annihilation teleport scroll is a Deadman: Annihilation reward that unlocks a wilderness-lever themed Home Teleport animation override. Once read, the override is permanent on the account and can be toggled from the Home Teleport spell.
+
+    The scroll is purchased from the Deadman Reward Store for Deadman points earned during seasonal events.
+  market_strategy:
+    notes:
+      - "Buy limit of 5 keeps supply tight"
+      - "Demand spikes immediately after Deadman seasons end"
+      - "One-time consumable for the account — repeat buyers are rare"
+  trading_tips:
+    - Hold scrolls between seasons; price tends to climb as supply dries up
+    - Avoid flipping during the reward window — supply is highest then
+    - Watch Jagex Deadman announcements for catalysts
+  history:
+    - date: "2026-01-21"
+      description: "Added to the game but initially unobtainable."
+    - date: "2026-02-25"
+      description: "Made available for purchase from the Deadman Reward Store."
+    - date: "2026-03-11"
+      description: "Can now be sacrificed to Death's Coffer."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-1-5958.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-1-5958.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antidote++(1) | OSRS Price Data
-description: "Antidote++(1): 1 dose of super strong antipoison potion.. High alch: 86 GP, GE limit: 4,000."
+description: "Antidote++(1): 1 dose of super strong antipoison potion. High alch: 86 GP, GE limit: 4,000."
 osrs:
   id: 5958
   name: Antidote++(1)
@@ -12,9 +12,81 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 4000
-  about: "Antidote++(1) is a members-only item in Old School RuneScape. High alchemy value: 86 coins. Grand Exchange buy limit: 4,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and grants immunity to poison for 12 minutes."
+        duration: 720
+      - description: "Grants immunity to venom for 18-36 seconds (one dose reduces venom to poison; second dose cures venom)."
+        duration: 36
+  drop_table:
+    sources:
+      - source: Cave kraken
+        quantity: "1"
+        rarity: Uncommon
+      - source: Kraken
+        quantity: "2"
+        rarity: Uncommon
+      - source: Zulrah
+        quantity: "10"
+        rarity: Common
+  related_items:
+    - item_name: Antidote++(2)
+      slug: antidote-2
+      relationship: variant
+      description: 2-dose version
+    - item_name: Antidote++(3)
+      slug: antidote-3
+      relationship: variant
+      description: 3-dose version
+    - item_name: Antidote++(4)
+      slug: antidote-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Antidote+(4)
+      slug: antidote-plus-4
+      relationship: downgrade
+      description: Weaker antipoison made with yew roots
+  about: |-
+    > *"1 dose of super strong antipoison potion."*
+
+    Antidote++(1) is the single-dose version of the strongest antipoison potion in OSRS. Drinking it cures poison and grants 12 minutes of poison immunity, plus partial venom protection.
+
+    The full 4-dose recipe requires 79 Herblore, combining coconut milk, irit leaf, and magic root for 177.5 XP.
+
+    Commonly used at high-tier PvM encounters (Zulrah, Vorkath, Corporeal Beast) where venom or poison damage can quickly stack up.
+  market_strategy:
+    notes:
+      - "Demand driven by venomous PvM bosses (Zulrah, Vorkath)"
+      - "1-dose variants typically trade at a discount vs combined doses"
+      - "Decanters can convert smaller doses into 4-dose for slightly higher value"
+      - "Steady supply from boss drops and Herblore training"
+  trading_tips:
+    - Buy 1-dose, decant to 4-dose for margin
+    - Watch for spikes during venomous boss task weeks
+  history:
+    - date: "2005-07-11"
+      description: "Added with the Farming and Herblore update introducing higher-tier antipoisons."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-mix-1.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 2000
-  about: "Antipoison mix(1) is a members-only item in Old School RuneScape. High alchemy value: 86 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison on consumption."
+        duration: 0
+      - description: "Grants immunity to poison."
+        duration: 90
+      - description: "Heals 3 Hitpoints on consumption."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 6
+      xp: 12
+      materials:
+        - item_name: Antipoison(2)
+          quantity: 1
+        - item_name: Roe
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Antipoison(2)
+      slug: antipoison-2
+      relationship: component
+      description: Base potion mixed with roe to produce the fishy variant.
+    - item_name: Roe
+      slug: roe
+      relationship: component
+      description: Low-tier Barbarian Herblore secondary used to create mixes.
+    - item_name: Antipoison mix(2)
+      slug: antipoison-mix-2
+      relationship: variant
+      description: Two-dose variant of the same Barbarian potion.
+  about: "Antipoison mix(1) is a Barbarian Herblore variant of the regular antipoison. It cures poison, grants 90 seconds of poison immunity, and heals 3 Hitpoints on drink. Roe is used in place of caviar; healing does not increase with caviar."
+  market_strategy:
+    notes:
+      - "Mostly bought by early Herblore trainers grinding 6+ Herblore"
+      - "Buy limit of 2,000 caps speculative volume"
+      - "Margin is sensitive to Roe supply from fishing colonies"
+  trading_tips:
+    - Pair purchases with Antipoison(2) buy orders to capture mixing margin
+    - Sell during early-game ironman seasons / leagues with poison content
+  history:
+    - date: "2007-07-03"
+      description: "Added with the Barbarian Training Herblore expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-d-hide-shield.mdx
@@ -12,80 +12,100 @@ osrs:
   lowalch: 11333
   highalch: 17000
   limit: 8
+  material:
+    type: ranged armour
+    tier: mid-high
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 8
     requirements:
       ranged: 70
       defence: 40
-    stats:
-      attack_stab: -15
-      attack_slash: -15
-      attack_crush: -11
-      attack_magic: -10
-      attack_ranged: 7
-      defence_stab: 21
-      defence_slash: 18
-      defence_crush: 16
-      defence_magic: 15
-      defence_ranged: 14
+    attack_bonus:
+      stab: -15
+      slash: -15
+      crush: -11
+      magic: -10
+      ranged: 7
+    defence_bonus:
+      stab: 21
+      slash: 18
+      crush: 16
+      magic: 15
+      ranged: 14
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Reward from hard clue scroll caskets (1/9,750)
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/9,750
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 23191
-      item_name: Saradomin d'hide shield
+    - item_name: Saradomin d'hide shield
       slug: saradomin-d-hide-shield
       relationship: variant
-      description: Saradomin variant of blessed d'hide shield
-    - item_id: 23188
-      item_name: Guthix d'hide shield
+      description: Saradomin god variant; identical stats.
+    - item_name: Guthix d'hide shield
       slug: guthix-d-hide-shield
       relationship: variant
-      description: Guthix variant of blessed d'hide shield
-    - item_id: 23194
-      item_name: Zamorak d'hide shield
+      description: Guthix god variant; identical stats.
+    - item_name: Zamorak d'hide shield
       slug: zamorak-d-hide-shield
       relationship: variant
-      description: Zamorak variant of blessed d'hide shield
-    - item_id: 23203
-      item_name: Bandos d'hide shield
+      description: Zamorak god variant; identical stats.
+    - item_name: Bandos d'hide shield
       slug: bandos-d-hide-shield
       relationship: variant
-      description: Bandos variant of blessed d'hide shield
-    - item_id: 23197
-      item_name: Ancient d'hide shield
+      description: Bandos god variant; identical stats.
+    - item_name: Ancient d'hide shield
       slug: ancient-d-hide-shield
       relationship: variant
-      description: Ancient variant of blessed d'hide shield
+      description: Ancient god variant; identical stats.
+    - item_name: Black d'hide shield
+      slug: black-d-hide-shield
+      relationship: alternative
+      description: Untrimmed base shield without the +1 prayer bonus.
   about: |-
-    "Armadyl blessed wooden shield covered in dragon leather."
+    The Armadyl d'hide shield is a blessed dragonhide shield aligned with Armadyl, awarded from hard Treasure Trail caskets at a 1/9,750 rate. It requires 70 Ranged and 40 Defence to equip and occupies the shield slot.
 
-    The Armadyl d'hide shield is a blessed dragonhide shield aligned with the god Armadyl. It requires 70 Ranged and 40 Defence to equip and occupies the shield slot. Like all blessed d'hide shields, it offers solid ranged attack and defensive bonuses along with a +1 prayer bonus that regular dragonhide shields lack.
-
-    All six god d'hide shields share identical combat stats, so the choice between them is purely cosmetic or based on God Wars Dungeon faction protection. The Armadyl d'hide shield provides protection from Armadyl-aligned NPCs in the God Wars Dungeon, making it useful for Kree'arra trips.
-
-    The blessed d'hide shields are comparable to the black d'hide shield but with an added +1 prayer bonus. For players seeking a ranged shield with prayer, these are a strong budget option. The book of law and other god books offer different stat distributions for the shield slot and may be preferred for offensive setups where the ranged attack bonus matters more than defence.
+    Stats are identical to the black d'hide shield with an additional +1 prayer bonus. All six god d'hide shields share the same combat stats — choice is purely cosmetic or based on God Wars Dungeon faction protection. The Armadyl variant grants protection from Armadyl-aligned NPCs, which is useful for Kree'arra trips.
   market_strategy:
-    title: Investment Notes
     notes:
-      - All god d'hide shield variants share the same stats, so price differences are driven by cosmetic demand
-      - Armadyl variants tend to command a premium due to aesthetic popularity and association with ranged combat
-      - Supply is tied to hard clue scroll completion rates
-      - Compare prices across all six god variants before buying since stats are identical
-      - Particularly useful for Armadyl protection in the God Wars Dungeon
-      - Buy limit of 8 per 4 hours on the Grand Exchange
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "All god d'hide shield variants share identical stats; pricing is cosmetic-driven"
+      - "Armadyl typically commands a premium due to ranged aesthetic pairing"
+      - "Supply tied to hard clue scroll completion rates and the 1/9,750 drop rate"
+      - "Buy limit 8 — flip in small batches and compare against the other 5 god variants"
+      - "Useful for Armadyl protection in the God Wars Dungeon"
+  history:
+    - date: "2019-04-11"
+      description: "Added to the game with the blessed dragonhide shield set."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Asgarnian ale (flatpack) | OSRS Price Data
-description: "Asgarnian ale (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Asgarnian ale (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8520
   name: Asgarnian ale (flatpack)
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Asgarnian ale (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 18
+      xp: 184
+      materials:
+        - item_name: Oak plank
+          quantity: 3
+        - item_name: Asgarnian ale
+          quantity: 8
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Asgarnian ale
+      slug: asgarnian-ale
+      relationship: component
+      description: Beer used as a material when constructing the flatpack.
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Plank consumed in the flatpack recipe.
+  about: |-
+    Asgarnian ale (flatpack) is a Player-Owned House item produced at a workbench. Flatpacks let Construction trainers and house decorators move furniture between houses without rebuilding it from raw materials in place.
+
+    The flatpack itself sells for only a few coins on the Grand Exchange, but the 184 Construction XP for assembling it from oak planks and Asgarnian ale makes it a popular method for ironmen training Construction without huge plank budgets.
+  market_strategy:
+    notes:
+      - "Low GE price — primarily an XP method, not a flip"
+      - "Asgarnian ale supply caps the flatpack output rate"
+      - "Steady demand from ironman Construction trainers"
+  trading_tips:
+    - Track Asgarnian ale prices — flatpack margin lives or dies on ale cost
+    - Bulk-buy planks during Construction XP events for better fill rates
+  history:
+    - date: "2006-05-31"
+      description: "Added with the Player-Owned House update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Asgarnian ale is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: beer
+    tier: low
+  properties:
+    release_date: "2001-04-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 24
+      xp: 248
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Asgarnian hops
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Beer glass
+          quantity: 8
+      tools: []
+      output_quantity: 8
+  shops:
+    - shop_name: Rising Sun Inn
+      location: Falador
+      price: 2
+      currency: coins
+      stock: 2
+    - shop_name: Blue Moon Inn
+      location: Varrock
+      price: 2
+      currency: coins
+      stock: 2
+  potion:
+    effects:
+      - "description": "Boosts Strength by 2"
+        duration: null
+      - "description": "Drains Attack by 2 to 6 depending on level"
+        duration: null
+      - description: Heals 1 Hitpoint
+        duration: null
+  related_items:
+    - item_name: Asgarnian ale(m)
+      slug: asgarnian-ale-m
+      relationship: variant
+      description: Mature variant brewed by leaving the keg to age
+    - item_name: Asgoldian ale
+      slug: asgoldian-ale
+      relationship: variant
+      description: Quest-exclusive variant from a Recipe for Disaster step
+  about: "Asgarnian ale is a free-to-play brewed beverage that grants a small Strength boost in exchange for a temporary Attack drain. Players can buy it from inns across Falador and Varrock, or brew it themselves at 24 Cooking for 248 experience using the brewing equipment at the Keldagrim or Port Phasmatys breweries. It is also a required input for the Dwarven subquest in Recipe for Disaster and for the Death Plateau quest."
+  market_strategy:
+    notes:
+      - "Quest demand from Recipe for Disaster keeps a steady floor on the price"
+      - "Shop spawns keep ceiling tight; flips usually rely on bulk pickup"
+      - "Mature variant (m) holds more long-term margin than the standard pint"
+  trading_tips:
+    - Bank-stand outside inns to collect free shop spawns for resale
+    - Stockpile during brewery training spikes to flip into Recipe for Disaster waves
+  history:
+    - date: "2001-04-06"
+      description: "Released alongside the original Falador inn during the early days of RuneScape."
+    - date: "2005-01-04"
+      description: "Brewing introduced via the Forgettable Tale of a Drunken Dwarf quest, enabling the mature variant."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/baby-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/baby-impling-jar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Baby impling jar | OSRS Price Data
-description: "Baby impling jar: Baby impling in a jar. That's a bit cruel.. High alch: 30 GP, GE limit: 18,000."
+description: "Baby impling jar: Baby impling in a jar. That's a bit cruel. High alch: 30 GP, GE limit: 18,000."
 osrs:
   id: 11238
   name: Baby impling jar
@@ -12,9 +12,64 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  about: "Baby impling jar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter-loot
+    tier: low
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Destroy
+    worn_options: []
+    alchable: true
+    destroy: "If you drop this it will disappear. Are you sure you want to do this?"
+  drop_table:
+    sources:
+      - source: Baby impling (Puro-Puro / overworld)
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Impling jar
+      slug: impling-jar
+      relationship: component
+      description: Empty jar returned ~90% of the time after looting.
+    - item_name: Young impling jar
+      slug: young-impling-jar
+      relationship: upgrade
+      description: Next impling tier with stronger loot.
+    - item_name: Gourmet impling jar
+      slug: gourmet-impling-jar
+      relationship: upgrade
+      description: Higher-tier impling jar with food-themed loot.
+    - item_name: Imp repellent
+      slug: imp-repellent
+      relationship: alternative
+      description: Used in Puro-Puro to manage impling spawns.
+  about: "The baby impling jar is the lowest-tier impling capture in Hunter, looted for a small drop pool of low-value utility items (chisel, needle, thread, knife, cheese, hammer, ball of wool, anchovies) with rare 1/100 rolls into spices, flax, sapphires, lobsters, and similar. Tertiary rolls add beginner (1/50) and easy (1/100) clue scrolls, making the jar a quiet source of low-tier clues for ironmen and clue hunters."
+  market_strategy:
+    notes:
+      - "High 18,000 buy limit supports large-volume flips for clue scroll farming."
+      - "Demand is bursty - clue scroll competitions and new clue updates spike consumption."
+      - "Empty jar return rate (~90%) reduces the effective per-loot cost for hunters supplying the market."
+  trading_tips:
+    - Open in bulk during clue events for the easy/beginner clue tertiary.
+    - Sell empty jars back to the market to recover most of the supply cost.
+  history:
+    - date: "2007-06-11"
+      description: "Released with Impetuous Impulses and the introduction of Puro-Puro."
+    - date: "2015-02-26"
+      description: "Made tradeable on the Grand Exchange."
+    - date: "2016-09-22"
+      description: "Easy clue scrolls added to the tertiary drop pool."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ballista-spring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ballista-spring.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Ballista spring is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: weapon component
+    tier: high
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 47
+      xp: 15
+      materials:
+        - item_name: Incomplete light ballista
+          quantity: 1
+        - item_name: Ballista spring
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - skill: fletching
+      level: 72
+      xp: 30
+      materials:
+        - item_name: Incomplete heavy ballista
+          quantity: 1
+        - item_name: Ballista spring
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Demonic gorilla
+        quantity: "1"
+        rarity: 1/500
+      - source: Tortured gorilla
+        quantity: "1"
+        rarity: 1/5000
+  related_items:
+    - item_name: Light ballista
+      slug: light-ballista
+      relationship: product
+      description: Two-handed ranged weapon assembled with this spring
+    - item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: product
+      description: Higher-tier ballista crafted with this spring
+    - item_name: Monkey tail
+      slug: monkey-tail
+      relationship: component
+      description: Companion drop used in the same fletching chain
+    - item_name: Ballista limbs
+      slug: ballista-limbs
+      relationship: component
+      description: Paired component required to assemble incomplete ballistae
+  about: "Ballista spring is a rare drop from Demonic gorillas (and Tortured gorillas) in the Crash Site Cavern after Monkey Madness II. The spring is the keystone piece in assembling Light and Heavy ballistae, both endgame two-handed crossbow-style ranged weapons."
+  market_strategy:
+    notes:
+      - "Supply throttled by the 1/500 demonic gorilla drop rate"
+      - "Demand tracks heavy ballista usage at bosses such as Zulrah and Vorkath"
+      - "Tight 8-per-4h buy limit keeps the price reactive to news spikes"
+  trading_tips:
+    - Buy on weekend gorilla farming dumps when sellers fund Magic supplies
+    - Flip alongside monkey tails and ballista limbs to capture full part bundles
+  history:
+    - date: "2016-05-06"
+      description: "Released with Monkey Madness II as a Demonic gorilla drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-rune-armour-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-rune-armour-set-lg.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Bandos rune armour set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid-high
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Rune full helm (Bandos)
+      slug: rune-full-helm-bandos
+      relationship: set-piece
+      description: Helm component of the Bandos rune set
+    - item_name: Rune platebody (Bandos)
+      slug: rune-platebody-bandos
+      relationship: set-piece
+      description: Platebody component of the Bandos rune set
+    - item_name: Rune platelegs (Bandos)
+      slug: rune-platelegs-bandos
+      relationship: set-piece
+      description: Platelegs component of the Bandos rune set
+    - item_name: Rune kiteshield (Bandos)
+      slug: rune-kiteshield-bandos
+      relationship: set-piece
+      description: Kiteshield component of the Bandos rune set
+    - item_name: Bandos rune armour set (sk)
+      slug: bandos-rune-armour-set-sk
+      relationship: variant
+      description: Skirt variant using rune plateskirt instead of platelegs
+  about: "Bandos rune armour set (lg) bundles the Bandos-trimmed rune full helm, platebody, platelegs and kiteshield into a single tradeable container via the Grand Exchange clerk. Released February 2015 and opened to F2P in April 2016, the set is primarily used to save bank space - the whole set trims worth significantly more than the standalone alchable rune pieces."
+  market_strategy:
+    notes:
+      - "Buy limit of 8 forces patient accumulation"
+      - "Watch component vs set arbitrage on the GE clerk swap"
+      - "F2P bank-space buyers form the steady demand floor"
+  trading_tips:
+    - Compare component price sum to the assembled set before flipping
+    - Use the GE clerk to break sets into pieces when component demand spikes
+  history:
+    - date: "2016-04-14"
+      description: "Made available to free-to-play players."
+    - date: "2015-02-26"
+      description: "Introduced alongside the Bandos rune armour cosmetic line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bark.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bark | OSRS Price Data
-description: "Bark: Bark from a hollow tree.. High alch: 1 GP, GE limit: 13,000."
+description: "Bark: Bark from a hollow tree. Used to craft splitbark armour. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 3239
   name: Bark
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Bark is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Vyrewatch
+        quantity: "1"
+        rarity: common
+      - source: Vyrewatch Sentinel
+        quantity: "1"
+        rarity: common
+      - source: Swamp crab
+        quantity: "1"
+        rarity: uncommon
+      - source: Araxxor
+        quantity: "1"
+        rarity: uncommon
+  related_items:
+    - item_name: Splitbark body
+      slug: splitbark-body
+      relationship: product
+      description: Splitbark armour piece
+    - item_name: Fine cloth
+      slug: fine-cloth
+      relationship: component
+      description: Paired material for crafting splitbark
+  about: |-
+    > _"Bark from a hollow tree."_
+
+    Bark is harvested from hollow trees with 45 Woodcutting (82.5 XP per piece) or dropped by Vyrewatch and other creatures. It pairs with fine cloth to craft splitbark armour at Wizard Jalarast in the Wizards' Tower; a full set requires 11 bark.
+  market_strategy:
+    notes:
+      - "High GE limit, low alch value"
+      - "Demand tied to splitbark crafting"
+      - "Steady drop volume from Vyrewatch slayer tasks"
+  trading_tips:
+    - Buy ahead of slayer cape resets when splitbark demand spikes
+    - Stack low entries to fill the 13k limit gradually
+  history:
+    - date: "2004-10-18"
+      description: "Released alongside splitbark armour."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/batta-tin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/batta-tin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Batta tin | OSRS Price Data
-description: "Batta tin: A deep tin used for baking gnome battas in.. High alch: 6 GP, GE limit: 40."
+description: "Batta tin: A deep tin used for baking gnome battas in. High alch: 6 GP, GE limit: 40."
 osrs:
   id: 2164
   name: Batta tin
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 40
-  about: "Batta tin is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: utensil
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      price: 10
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Gnome batta
+      slug: gnome-batta
+      relationship: product
+      description: Gnome cuisine baked inside the batta tin.
+    - item_name: Bowl
+      slug: bowl
+      relationship: alternative
+      description: Standard cooking vessel for non-gnome recipes.
+  about: |-
+    Batta tin is the dedicated baking vessel for gnome battas in the Tree Gnome Stronghold cuisine recipes. It is consumed once per batta and must be restocked between cooking sessions.
+
+    Hudo at Grand Tree Groceries stocks five tins at 10 coins each, making the shop the cheapest source for ironmen and gnome chefs working through the Recipe for Disaster sub-quests.
+  market_strategy:
+    notes:
+      - "Tiny buy limit caps flipping volume"
+      - "Shop restock is the floor price"
+      - "Demand tied to gnome cooking and RFD prep"
+  trading_tips:
+    - Restock at Grand Tree Groceries when GE price spikes above shop value
+    - Buy in 40-unit chunks for full RFD attempts
+  history:
+    - date: "2003-12-01"
+      description: "Added to the RS2 Beta cache."
+    - date: "2004-02-02"
+      description: "Became obtainable during the RS2 Beta."
+    - date: "2004-03-29"
+      description: "Released with the RS2 launch."
+    - date: "2006-08-07"
+      description: "Graphical update and value increased from 1 to 10 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bear-feet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bear-feet.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Bear feet is a free-to-play item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.2
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (beginner)
+        quantity: "1"
+        rarity: 1/360
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+  passive_effects:
+    - name: Warm clothing
+      description: "Counts as warm clothing, providing damage reduction during the Wintertodt fight."
+  related_items:
+    - item_name: Reward casket (beginner)
+      slug: reward-casket-beginner
+      relationship: product
+      description: "Beginner clue casket that drops bear feet"
+  about: "Bear feet are a cosmetic feet-slot item rewarded from beginner Treasure Trail caskets at 1/360. The name is a play on 'bare feet,' and the slippers function as warm clothing during the Wintertodt encounter despite having no combat stats."
+  market_strategy:
+    notes:
+      - "Supply is gated by beginner clue completion, with daily inflow limited"
+      - "Demand pairs with Wintertodt warm-clothing setups and fashionscape collectors"
+      - "Buy limit of 4 forces patience on bulk acquisition"
+  trading_tips:
+    - "Spikes during Wintertodt rate updates - prep inventory before patch days"
+    - "Crosslist with other warm clothing cosmetics to catch the same buyer pool"
+  history:
+    - date: "2019-04-11"
+      description: "Added as a beginner Treasure Trails reward"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/beginner-wand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/beginner-wand.mdx
@@ -12,9 +12,34 @@ osrs:
   lowalch: 480
   highalch: 720
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wand
+    tier: mid
+  properties:
+    release_date: "4 January 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: wand
+    weapon_type: wand
+    attack_speed: 4
+    weight: 0.283
+    requirements:
+      magic: 45
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,37 +57,41 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 45
-    weight: 0.283
-    attack_speed: 4
-    combat_style: staff
-    autocast: standard
-  shop:
-    currency: pizazz_points
-    cost:
-      telekinetic: 30
-      alchemist: 30
-      enchantment: 300
-      graveyard: 30
+  shops:
+    - shop_name: Mage Training Arena rewards
+      location: Mage Training Arena
+      price: 30
+      currency: telekinetic pizazz points
+      stock: infinite
+    - shop_name: Mage Training Arena rewards
+      location: Mage Training Arena
+      price: 30
+      currency: alchemist pizazz points
+      stock: infinite
+    - shop_name: Mage Training Arena rewards
+      location: Mage Training Arena
+      price: 300
+      currency: enchantment pizazz points
+      stock: infinite
+    - shop_name: Mage Training Arena rewards
+      location: Mage Training Arena
+      price: 30
+      currency: graveyard pizazz points
+      stock: infinite
   related_items:
-    - item_id: 6910
-      item_name: Apprentice wand
+    - item_name: Apprentice wand
       slug: apprentice-wand
       relationship: upgrade
       description: Next tier MTA wand (50 Magic)
-    - item_id: 6912
-      item_name: Teacher wand
+    - item_name: Teacher wand
       slug: teacher-wand
       relationship: upgrade
       description: Third tier MTA wand (55 Magic)
-    - item_id: 6914
-      item_name: Master wand
+    - item_name: Master wand
       slug: master-wand
       relationship: upgrade
       description: Highest tier MTA wand (60 Magic)
-    - item_id: 11998
-      item_name: Kodai wand
+    - item_name: Kodai wand
       slug: kodai-wand
       relationship: upgrade
       description: Best-in-slot wand from Chambers of Xeric
@@ -75,7 +104,7 @@ osrs:
     | Magic | +5 | +5 |
     | Ranged | 0 | 0 |
 
-    Requirements: 45 Magic | Weight: 0.28 kg | Speed: 4 ticks (2.4s)
+    Requirements: 45 Magic | Weight: 0.283 kg | Speed: 4 ticks (2.4s)
 
     The beginner wand supports Standard Spellbook autocast with both offensive and defensive casting styles. It cannot autocast Ancient Magicks or Arceuus spells. As a one-handed weapon, it allows a shield or book in the off-hand slot.
 
@@ -90,17 +119,19 @@ osrs:
     | Kodai wand | +28 | +20 | 75 | Best-in-slot, Chambers of Xeric |
 
     The beginner wand offers modest stats. Its primary value is as the starting point for the wand upgrade chain.
-
-    The beginner wand is the cheapest MTA reward, requiring only 30 points in three categories and 300 enchantment points. Players typically acquire it early in the MTA grind and trade it in for the apprentice wand shortly after. Each subsequent upgrade requires trading in the previous tier plus additional points.
   market_strategy:
     notes:
-      - GE price (~176K gp) reflects the time spent at MTA rather than raw stats
-      - Most buyers purchase it to skip early MTA grinding
-      - Demand is steady from players progressing through the wand chain
-      - Significantly cheaper than higher-tier wands
-      - One-handed slot is the main mechanical advantage over staves
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "GE price reflects MTA time saved, not raw stats"
+      - "Most buyers want to skip early MTA grinding"
+      - "Demand steady from players progressing the wand chain"
+      - "One-handed slot is the main mechanical edge over staves"
+      - "Cheaper than higher-tier MTA wands"
+  trading_tips:
+    - Bank-stand wands when MTA point prices spike
+    - Flips work best around major skilling updates
+  history:
+    - date: "4 January 2006"
+      description: "Released with the Mage Training Arena minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-body-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-d-hide-body-t.mdx
@@ -12,89 +12,90 @@ osrs:
   lowalch: 5392
   highalch: 8088
   limit: 8
+  material:
+    type: ranged armour
+    tier: mid-high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
     requirements:
       ranged: 70
       defence: 40
-      quest: Dragon Slayer I
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 30
-      defence_stab: 30
-      defence_slash: 38
-      defence_crush: 45
-      defence_magic: 45
-      defence_ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 30
+      slash: 38
+      crush: 45
+      magic: 45
+      ranged: 50
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 6.803
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: Reward casket (elite)
-        drop_rate: Rare
+        quantity: "1"
+        rarity: 1/1,275
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
   related_items:
-    - item_id: 2503
-      item_name: Black d'hide body
+    - item_name: Black d'hide body
       slug: black-dhide-body
       relationship: alternative
-      description: Same stats, non-trimmed
-    - item_id: 12383
-      item_name: Black d'hide body (g)
+      description: Standard untrimmed body with identical combat stats.
+    - item_name: Black d'hide body (g)
       slug: black-dhide-body-g
       relationship: alternative
-      description: Gold-trimmed variant, same stats
-    - item_id: 12331
-      item_name: Red d'hide body (t)
+      description: Gold-trimmed cosmetic variant; same stats.
+    - item_name: Red d'hide body (t)
       slug: red-dhide-body-t
-      relationship: alternative
-      description: Lower tier trimmed body
+      relationship: downgrade
+      description: Lower-tier trimmed body from medium clues.
   about: |-
-    "Made from 100% real dragonhide. With colourful trim!"
+    Black d'hide body (t) is the trimmed cosmetic variant of the Black d'hide body, awarded from elite Treasure Trails caskets. Its combat stats are identical to the standard black d'hide body, so its market value is driven entirely by clue scroll rarity and fashionscape demand.
 
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -15 |
-    | Ranged Attack | +30 |
-    | Stab Defence | +30 |
-    | Slash Defence | +38 |
-    | Crush Defence | +45 |
-    | Magic Defence | +45 |
-    | Ranged Defence | +50 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 70 Ranged, 40 Defence, Dragon Slayer I
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Black d'hide body (t) | +30 | +50 | +45 | Elite clues |
-    | Black d'hide body | +30 | +50 | +45 | Crafting (84) |
-
-    Stats are identical to the standard black d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+    Requirements are 70 Ranged and 40 Defence. Master clues can drop this item as part of the trimmed dragonhide set rewards, but the elite casket is the primary source.
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Elite clue reward rarity
-      - Collection log completionists
-      - Trimmed d'hide set completion
-      - Identical stats to black d'hide body
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Fashionscape and collection log demand drives pricing, not combat stats"
+      - "Tightly tied to elite clue scroll completion rates"
+      - "Low trade volume — watch order book for manipulation"
+      - "Identical stats to the regular black d'hide body; pure cosmetic premium"
+      - "Trimmed d'hide set completion bonus typically increases value when worn with matching pieces"
+  history:
+    - date: "2014-06-12"
+      description: "Added as part of the Treasure Trails rework expansion."
+    - date: "2021-09-30"
+      description: "Defence bonuses reduced across all damage types as part of the dragonhide armour rebalance."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragon-leather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragon-leather.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black dragon leather | OSRS Price Data
-description: "Black dragon leather: It's a piece of prepared black dragonhide.. High alch: 66 GP, GE limit: 11,000."
+description: "Black dragon leather: It's a piece of prepared black dragonhide. Top-tier crafting material. High alch: 66 GP, GE limit: 11,000."
 osrs:
   id: 2509
   name: Black dragon leather
@@ -12,70 +12,93 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: leather
-    tier: highest
-  tanning:
-    cost: 20
-    source_id: 1747
-    source_name: Black dragonhide
-  crafting_products:
-    - product: Black d'hide vambraces
-      product_id: 2491
+    tier: high
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
       level: 79
       xp: 86
-      leather: 1
-    - product: Black d'hide chaps
-      product_id: 2497
+      materials:
+        - item_name: Black dragon leather
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+    - skill: crafting
       level: 82
       xp: 172
-      leather: 2
-    - product: Black d'hide shield
-      product_id: 2503
-      level: 83
-      xp: 172
-      leather: 2
-    - product: Black d'hide body
-      product_id: 2503
+      materials:
+        - item_name: Black dragon leather
+          quantity: 2
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+    - skill: crafting
       level: 84
       xp: 258
-      leather: 3
+      materials:
+        - item_name: Black dragon leather
+          quantity: 3
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
   related_items:
-    - item_id: 1747
-      item_name: Black dragonhide
+    - item_name: Black dragonhide
       slug: black-dragonhide
       relationship: component
-      description: Raw material
-    - item_id: 2503
-      item_name: Black d'hide body
-      slug: black-dhide-body
+      description: Raw hide tanned into this leather
+    - item_name: Black d'hide body
+      slug: black-d-hide-body
       relationship: product
-      description: Main product
-    - item_id: 2507
-      item_name: Red dragon leather
+      description: Highest-xp leather product
+    - item_name: Red dragon leather
       slug: red-dragon-leather
-      relationship: alternative
-      description: Lower tier
-    - item_id: 2505
-      item_name: Blue dragon leather
+      relationship: downgrade
+      description: Lower-tier dragonhide leather
+    - item_name: Blue dragon leather
       slug: blue-dragon-leather
-      relationship: alternative
-      description: Lower tier
+      relationship: downgrade
+      description: Lower-tier dragonhide leather
+  about: |-
+    > _"It's a piece of prepared black dragonhide."_
+
+    Black dragon leather is the highest-tier dragonhide crafting material. Tan black dragonhides for 20 coins each at standard tanners, 45 at Sbott in Canifis, or 5 per cast via the Tan Leather spell (78 Magic). Crafts into vambraces (79 Crafting), chaps (82), shield (83), and body (84) for high-tier Crafting XP.
   market_strategy:
     notes:
-      - Best dragonhide leather
-      - Good Crafting XP
-      - Tan Leather profit
-      - Crafting training
-      - D'hide armor production
-      - Tan Leather profit
-      - High alch targets
-      - Tan Leather spell efficient
-      - 20 GP tanner fee
-      - Black dragons drop hide
-      - Bodies best XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Best dragonhide leather tier"
+      - "Strong Crafting XP per leather"
+      - "Black d'hide bodies maximise XP"
+      - "Tan Leather spell remains efficient"
+      - "20 GP per tan at standard NPCs"
+      - "Hide supply tied to black dragon kills"
+  trading_tips:
+    - Watch tanning margin vs raw hide GE price
+    - Bulk craft d'hide bodies when leather dips below alch
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 engine update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h4.mdx
@@ -12,12 +12,96 @@ osrs:
   lowalch: 422
   highalch: 633
   limit: 70
-  about: "Black helm (h4) is a free-to-play item in Old School RuneScape. High alchemy value: 633 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 10
+      magic: -1
+      ranged: 12
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Black full helm
+      slug: black-full-helm
+      relationship: alternative
+      description: Plain heraldic-less variant
+    - item_name: Black helm (h1)
+      slug: black-helm-h1
+      relationship: variant
+      description: Different heraldic design
+    - item_name: Black helm (h2)
+      slug: black-helm-h2
+      relationship: variant
+      description: Different heraldic design
+    - item_name: Black helm (h3)
+      slug: black-helm-h3
+      relationship: variant
+      description: Different heraldic design
+    - item_name: Black helm (h5)
+      slug: black-helm-h5
+      relationship: variant
+      description: Different heraldic design
+  about: |-
+    Black helm (h4) is a heraldic variant of the black full helm rewarded from easy Treasure Trails reward caskets at a rate of about 1 in 1,404. It cannot be crafted via Smithing.
+
+    Stats are identical to the regular black full helm — purely cosmetic differentiation through heraldry.
+  market_strategy:
+    notes:
+      - "Free-to-play access broadens the buyer base"
+      - "Supply tied directly to easy clue completion rates"
+      - "Buy limit 70 keeps flipping volume modest"
+  trading_tips:
+    - Track easy clue caskets opened in streams — supply ticks up after content releases
+    - Holiday events boost cosmetic demand; hold inventory before fashionscape pushes
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the Treasure Trails reward expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-kiteshield-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-kiteshield-t.mdx
@@ -12,22 +12,82 @@ osrs:
   lowalch: 652
   highalch: 979
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
     requirements:
       defence: 10
+    attack_bonus:
+      ranged: -2
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 16
+    other_bonus: {}
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 2583
-      item_name: Black platebody (t)
+    - item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: variant
+      description: Untrimmed base variant
+    - item_name: Black platebody (t)
       slug: black-platebody-t
       relationship: set-piece
       description: Matching trimmed platebody
+    - item_name: Black platelegs (t)
+      slug: black-platelegs-t
+      relationship: set-piece
+      description: Matching trimmed legs
   about: |-
     > *"Black kiteshield with trim."*
 
-    The black kiteshield (t) is a trimmed cosmetic variant of the standard black kiteshield. Identical stats, requiring 10 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The black kiteshield (t) is a trimmed cosmetic variant of the standard black kiteshield. Identical stats, requiring 10 Defence. Clue scroll exclusive (easy reward casket, 1/1,404).
+  market_strategy:
+    notes:
+      - "Cosmetic clue reward"
+      - "F2P shield with 10 Defence requirement"
+      - "Tight GE limit (8 per 4 hours)"
+      - "Supply tied to easy clue volume"
+  trading_tips:
+    - Watch easy clue throughput around bonus weekends
+    - Set-piece collectors push price when paired with platebody (t)
+  history:
+    - date: "2004-05-05"
+      description: "Added with Treasure Trails."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-t.mdx
@@ -12,33 +12,91 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
     requirements:
       defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
     defence_bonus:
       stab: 41
       slash: 40
       crush: 30
       magic: -6
       ranged: 40
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Easy Clue Scroll
+        quantity: "1"
+        rarity: "1/1,404"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 2585
-      item_name: Black platelegs (t)
+    - item_name: Black platelegs (t)
       slug: black-platelegs-t
       relationship: set-piece
-      description: Matching trimmed platelegs
-    - item_id: 2591
-      item_name: Black platebody (g)
+      description: Matching trimmed black platelegs.
+    - item_name: Black platebody (g)
       slug: black-platebody-g
       relationship: variant
-      description: Gold-trimmed variant
-  about: |-
-    > *"Black platebody with trim."*
-
-    The black platebody (t) is a trimmed cosmetic variant of the standard black platebody. Identical stats, requiring 10 Defence. Cannot be made through Smithing — clue scroll exclusive. Popular with low-level fashionscape builds.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Gold-trimmed cosmetic variant with identical stats.
+    - item_name: Black platebody
+      slug: black-platebody
+      relationship: alternative
+      description: Untrimmed standard version smithable in Smithing.
+    - item_name: Black full helm (t)
+      slug: black-full-helm-t
+      relationship: set-piece
+      description: Matching trimmed helmet for the trimmed black set.
+  about: "The black platebody (t) is a trimmed cosmetic variant of the standard black platebody with identical defensive stats and a 10 Defence requirement. It cannot be created via Smithing and is exclusively obtained from easy Treasure Trails, making it a popular low-level fashionscape body."
+  market_strategy:
+    notes:
+      - "Supply is fully clue-driven; price tracks easy clue completion volume."
+      - "Demand is fashionscape-focused — bundles with matching trim pieces lift price."
+      - "Compare to gold-trim variant to gauge cosmetic premium."
+  trading_tips:
+    - "Buy during easy clue grind spikes when supply rises."
+    - "Sell as part of a full trimmed black set for higher margin."
+    - "GE buy limit of 8 means patience is required for large stockpiles."
+  history:
+    - date: "2004-05-05"
+      description: "Added to the game as an easy Treasure Trail reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-blue-shell-pointed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-blue-shell-pointed.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 13000
-  about: "Blamish blue shell (pointed) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: shell
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Bruise blue snail
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish blue shell (pointed)
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_name: Pointed bruise blue snelm
+      slug: pointed-bruise-blue-snelm
+      relationship: product
+      description: "Crafting product made by chiseling this shell at 15 Crafting"
+    - item_name: Bruise blue snail
+      slug: bruise-blue-snail
+      relationship: component
+      description: "Mort Myre Swamp snail that drops this shell on kill"
+  about: "The blamish blue shell (pointed) is a Crafting material dropped by bruise blue snails in Mort Myre Swamp. Released with the Morytania Expansion, it can be chiseled at 15 Crafting into a pointed bruise blue snelm for 32.5 experience."
+  market_strategy:
+    notes:
+      - "Supply is entirely driven by snail kills in Mort Myre, keeping the floor low"
+      - "Demand comes from low-level Crafters training snelms for cheap XP"
+      - "Bulk listings are common since the buy limit is 13,000 per 4 hours"
+  trading_tips:
+    - "Watch low-level Crafting training meta posts; shifts there move the snelm shell stack"
+    - "Compare with other coloured shells before listing - blue commonly trades below red and green"
+  history:
+    - date: "2004-10-14"
+      description: "Added with the Morytania Expansion update alongside bruise blue snails"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-tassets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-tassets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blood moon tassets | OSRS Price Data
-description: "Blood moon tassets is a members legs slot item with +2 melee strength requiring 50 Defence. High alch: 173,946 GP, GE limit: 15."
+description: "Blood moon tassets is a members legs slot item with +2 melee strength requiring 75 Strength and 50 Defence. High alch: 173,946 GP, GE limit: 15."
 osrs:
   id: 29025
   name: Blood moon tassets
@@ -12,9 +12,35 @@ osrs:
   lowalch: 115964
   highalch: 173946
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: melee armour
+    tier: high
+  properties:
+    release_date: "20 March 2024"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.082
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
     weight: 4.082
+    requirements:
+      strength: 75
+      defence: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,44 +58,34 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      strength: 75
-      defence: 50
-    degradable: true
-    charges: 3000
   drop_table:
-    primary_source: Lunar Chest (Neypotzli)
-    best_drop_rate: 1/224
     sources:
       - source: Lunar Chest
         quantity: "1"
         rarity: rare
-        drop_rate: 1/224
-        members_only: true
+  passive_effects:
+    - name: Bloodrager
+      description: "When the full Blood moon set is worn with the Dual macuahuitl, successful hits have a 33% chance to attack one tick sooner. Special attacks guarantee the effect."
   related_items:
-    - item_id: 28997
-      item_name: Dual macuahuitl
+    - item_name: Dual macuahuitl
       slug: dual-macuahuitl
       relationship: set-piece
-      description: Weapon for Bloodrager set effect
-    - item_id: 29028
-      item_name: Blood moon helm
+      description: Weapon required for the Bloodrager set effect
+    - item_name: Blood moon helm
       slug: blood-moon-helm
       relationship: set-piece
-      description: Helm in set
-    - item_id: 29022
-      item_name: Blood moon chestplate
+      description: Helm in the Blood moon set
+    - item_name: Blood moon chestplate
       slug: blood-moon-chestplate
       relationship: set-piece
-      description: Body armour in set
+      description: Body armour in the Blood moon set
   about: |-
-    When wearing the full Blood moon armour set with the Dual macuahuitl:
-    - Bloodrager: 33% chance upon successful hit to attack one tick earlier
+    Blood moon tassets are the legs piece of the Blood moon armour set, obtained from the Lunar Chest in Neypotzli (Perilous Moons).
 
     | Property | Value |
     |----------|-------|
     | Total charges | 3,000 |
-    | Charge rate | 1 per 54 seconds |
+    | Charge rate | 1 per 54 seconds of combat |
     | Combat duration | ~45 hours |
     | NPC repair cost | 1,500,000 coins |
     | Repair at 99 Smithing | 757,500 coins |
@@ -78,13 +94,23 @@ osrs:
     - Solid defensive stats
     - +2 strength bonus
     - Good magic defence (+32)
+    - Bloodrager set effect with Dual macuahuitl
   market_strategy:
     notes:
-      - Essential for Blood moon builds
-      - Decent standalone legs option
-      - Factor in repair costs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Essential for Blood moon Bloodrager builds"
+      - "Decent standalone legs option for melee"
+      - "Factor in repair costs and charge decay"
+      - "Supply tied to Lunar Chest grind"
+  trading_tips:
+    - Watch repair-cost rumors before bulk listing
+    - Set-piece flips spike around Varlamore updates
+  history:
+    - date: "June 2024"
+      description: "Removed accidental 1% Magic damage bonus."
+    - date: "April 2024"
+      description: "Weight reduced from 8 to 4.082 kg."
+    - date: "20 March 2024"
+      description: "Released with the Varlamore: The Hunt for Surok update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-hat-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-hat-g.mdx
@@ -12,25 +12,84 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
     requirements: {}
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
+      ranged: 0
     defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: "1/1,404"
   related_items:
-    - item_id: 7390
-      item_name: Blue wizard robe (g)
+    - item_name: Blue wizard hat
+      slug: blue-wizard-hat
+      relationship: variant
+      description: "Standard untrimmed blue wizard hat."
+    - item_name: Blue wizard robe (g)
       slug: blue-wizard-robe-g
       relationship: set-piece
-      description: Matching gold-trimmed wizard robe
-  about: |-
-    > *"A silly pointed hat, with colourful trim."*
-
-    The blue wizard hat (g) is a gold-trimmed cosmetic variant of the standard wizard hat. It provides +2 magic attack and defence with no requirements. Popular with pure accounts as a wealth indicator. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching gold-trimmed body slot piece."
+    - item_name: Black wizard hat (g)
+      slug: black-wizard-hat-g
+      relationship: alternative
+      description: "Black-and-gold trimmed wizard hat alternative."
+  about: "Blue wizard hat (g) is a gold-trimmed cosmetic variant of the standard blue wizard hat. It provides +2 magic attack and defence with no requirements, making it usable by pure accounts as a wealth-display alternative. Awarded from easy-tier clue reward caskets at 1/1,404."
+  market_strategy:
+    notes:
+      - "Supply is gated by easy clue completions; limit of 4 per 4h keeps spreads wide."
+      - "Demand spikes when costume/fashion competitions or league cosmetics trend."
+  trading_tips:
+    - "Flip slowly — daily volume is thin, so set patient buy offers."
+    - "Pair with the matching robe (g) for set bonuses to listings."
+  history:
+    - date: "2006-02-20"
+      description: "Released as part of the trimmed clue reward expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bob-s-red-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bob-s-red-shirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bob's red shirt | OSRS Price Data
-description: "Bob's red shirt: 'Bob says: Never give your password out to anyone.'. High alch: 1 GP, GE limit: 4."
+description: "Bob's red shirt: 'Bob says: Never give your password out to anyone.' An easy clue reward. High alch: 1 GP, GE limit: 4."
 osrs:
   id: 10316
   name: Bob's red shirt
@@ -12,9 +12,94 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Bob's red shirt is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: rare
+  related_items:
+    - item_name: Bob's blue shirt
+      slug: bob-s-blue-shirt
+      relationship: variant
+      description: Blue colour variant
+    - item_name: Bob's green shirt
+      slug: bob-s-green-shirt
+      relationship: variant
+      description: Green colour variant
+    - item_name: Bob's purple shirt
+      slug: bob-s-purple-shirt
+      relationship: variant
+      description: Purple colour variant
+    - item_name: Bob's black shirt
+      slug: bob-s-black-shirt
+      relationship: variant
+      description: Black colour variant
+  about: |-
+    > _"Bob says: Never give your password out to anyone."_
+
+    Bob's red shirt is a cosmetic easy clue scroll reward (drop rate 1/1,404 from easy reward caskets). The shirt provides no combat bonuses and is purely a vanity item that can be stored in a costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Tiny GE limit of 4 per 4 hours"
+      - "Cosmetic-only easy clue reward"
+      - "Demand driven by collection log hunters"
+  trading_tips:
+    - List buy orders early in the day to fill the 4-item limit
+    - Track collection log spikes after easy clue updates
+  history:
+    - date: "2006-12-05"
+      description: "Added as a random reward from easy clue scrolls."
+    - date: "2014-12-10"
+      description: "Renamed from 'Bob shirt' to 'Bob's red shirt'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bottled-storm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bottled-storm.mdx
@@ -12,52 +12,76 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: null
-  item_type: material
-  tradeable: true
-  weight: 0.5
-  high_alch: 4800
-  low_alch: 3200
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crafting material
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Inspect
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
-    primary_source: Vampyre kraken
-    best_drop_rate: 1/512
     sources:
       - source: Vampyre kraken
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/512
-        members_only: true
+        rarity: "1/512"
       - source: Armoured kraken
         quantity: "1"
-        rarity: very_rare
-        drop_rate: 1/1024
-        members_only: true
-  obtaining:
-    source: Vampyre kraken, Armoured kraken
-    location: Kraken encounters while Sailing
-    requirements: Sailing skill access
+        rarity: "1/1024"
+  recipes:
+    - skill: construction
+      level: 69
+      xp: 0
+      materials:
+        - item_name: Ironwood plank
+          quantity: 8
+        - item_name: Rune nails
+          quantity: 32
+        - item_name: Cupronickel bar
+          quantity: 4
+        - item_name: Magic stone
+          quantity: 2
+        - item_name: Bottled storm
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 32230
-      item_name: Greater teleport focus
+    - item_name: Greater teleport focus
       slug: greater-teleport-focus
       relationship: product
-      description: Used to craft the Greater teleport focus facility
+      description: "Crafted using the bottled storm as a key component"
+    - item_name: Vampyre kraken
+      slug: vampyre-kraken
+      relationship: alternative
+      description: "Primary drop source with 1/512 rarity"
   about: |-
-    "The container shakes violently, thrumming with magical energy. You reckon it might be useful for shipbuilding."
+    The Bottled storm is a rare crafting material obtained from kraken encounters while Sailing. The container shakes violently, thrumming with magical energy, and is used to construct the Greater teleport focus facility on player boats.
 
-    The Bottled storm is a crafting material used to create the Greater teleport focus facility on boats.
-
-    Crafting Uses:
-    - Required component for Greater teleport focus (requires 75 Sailing, 69 Construction)
-    - Combined with Ironwood planks, Rune nails, Cupronickel bars, and Magic stones
+    Vampyre krakens offer the best drop rate at 1/512, while Armoured krakens drop the item at a rarer 1/1,024.
   market_strategy:
     notes:
-      - Very valuable crafting material
-      - Vampyre krakens have better drop rate than Armoured krakens
-      - Required for high-level teleport facility
-      - High demand due to Greater teleport focus utility
-      - Consider selling if not building teleport facilities
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Very valuable crafting material with consistent demand"
+      - "Vampyre krakens have better drop rate than Armoured krakens"
+      - "Required for high-level Greater teleport focus facility"
+      - "Consider selling if not actively building teleport facilities"
+  trading_tips:
+    - Check daily price trends before listing - sailing content can shift demand
+    - Bulk drops from successful kraken hunts can flood the market briefly
+  history:
+    - date: "2025-11-19"
+      description: "Item added to the game with the Sailing skill release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/box-trap.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/box-trap.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 250
-  about: "Box trap is a members-only item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter equipment
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Lay
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Aleck's Hunter Emporium
+      location: Yanille
+      price: 38
+      currency: coins
+      stock: 10
+    - shop_name: Nardah Hunter Shop
+      location: Nardah
+      price: 38
+      currency: coins
+      stock: 10
+    - shop_name: Imia's Supplies
+      location: Hunter Guild
+      price: 41
+      currency: coins
+      stock: 10
+  related_items:
+    - item_name: Bird snare
+      slug: bird-snare
+      relationship: alternative
+      description: Lower-tier Hunter trap used for birds.
+    - item_name: Chinchompa
+      slug: chinchompa
+      slug_disambiguation: hunter
+      relationship: product
+      description: Common box-trap quarry from level 53 Hunter.
+  about: |-
+    Box trap is the staple Hunter tool for catching mammals like ferrets, jerboas, and chinchompas. Players must have partially completed Eagles' Peak to use box traps. Hunter level requirements vary by quarry: ferrets (27), embertailed jerboas (39), chinchompas (53), carnivorous chinchompas (63), and black chinchompas (73).
+
+    Bought primarily from Aleck's Hunter Emporium in Yanille and Imia's Supplies at the Hunter Guild, box traps are cheap, stackable, and weightless — making them ideal for travelling Hunter loadouts.
+  market_strategy:
+    notes:
+      - "Buy from Aleck's Hunter Emporium or Nardah at 38 gp for the cheapest source"
+      - "GE price often exceeds shop price — convenient for bulk training trips"
+      - "Stackable since 2025, so single-slot bulk carry is now possible"
+      - "Demand driven by black chinchompa hunters at the Wilderness MTA spot"
+  history:
+    - date: "2006-11-21"
+      description: "Added with the Hunter skill release."
+    - date: "2025-08-20"
+      description: "Made stackable and weight reduced from 0.226 kg to 0 kg in the Doom Tweaks/Summer Sweep Up update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broad-arrowheads.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broad-arrowheads.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 22
   highalch: 33
   limit: 7000
-  about: "Broad arrowheads is a members-only item in Old School RuneScape. High alchemy value: 33 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2014-01-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 52
+      xp: 10
+      materials:
+        - item_name: Headless arrow
+          quantity: 1
+        - item_name: Broad arrowheads
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Slayer Equipment
+      location: Burthorpe
+      price: 55
+      currency: coins
+      stock: 3000
+    - shop_name: Slayer Equipment
+      location: Canifis
+      price: 55
+      currency: coins
+      stock: 3000
+    - shop_name: Slayer Equipment
+      location: Mount Karuulm
+      price: 55
+      currency: coins
+      stock: 3000
+  related_items:
+    - item_name: Broad arrow
+      slug: broad-arrow
+      relationship: product
+      description: Crafted by fletching headless arrows with broad arrowheads
+    - item_name: Broad bolts
+      slug: broad-bolts
+      relationship: alternative
+      description: Crossbow ammunition variant from Slayer shops
+  about: "Broad arrowheads are members-only ammunition components sold by Slayer equipment vendors after unlocking Broader Fletching for 300 Slayer reward points. With 52 Fletching they are combined with headless arrows to produce broad arrows, the standard ranged ammo against Turoths and Kurasks. The arrowheads themselves are weightless and stack in the bank."
+  market_strategy:
+    notes:
+      - "Stock is effectively infinite from Slayer shops, so margins flow with broad arrow demand"
+      - "Slayer task pressure keeps a steady, predictable consumer base"
+      - "High GE limit (7,000) lets fletchers buy enough heads for a level in one cycle"
+  trading_tips:
+    - Flip the heads only when GE price drifts below shop cost to lock margin
+    - Buy 4 sets of 3,000 daily across multiple Slayer shops to stockpile for skilling
+  history:
+    - date: "2014-01-06"
+      description: "Released as a tradeable Slayer-shop ammunition head following community feedback on Broader Fletching."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-cannonball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-cannonball.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze cannonball | OSRS Price Data
-description: "Bronze cannonball: Ammo suited for a boat's cannon.. High alch: 1 GP, GE limit: 11,000."
+description: "Bronze cannonball: Ammo suited for a boat's cannon. High alch: 1 GP, GE limit: 11,000."
 osrs:
   id: 31906
   name: Bronze cannonball
@@ -12,9 +12,78 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Bronze cannonball is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 5
+      xp: 9
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+      tools:
+        - Ammo mould
+        - Furnace
+      output_quantity: 4
+  shops:
+    - shop_name: Trader Stan's Trading Post
+      location: Various ports
+      price: 6
+      currency: Coins
+      stock: 0
+    - shop_name: Port Roberts Cannonball Stall
+      location: Port Roberts
+      price: 6
+      currency: Coins
+      stock: 0
+  drop_table:
+    sources:
+      - source: Dolphin
+        quantity: "1"
+        rarity: common
+      - source: Pirate
+        quantity: "1"
+        rarity: uncommon
+  related_items:
+    - item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: Smithing material
+    - item_name: Cannonball
+      slug: cannonball
+      relationship: alternative
+      description: Standard Dwarf Cannon ammo
+  about: |-
+    > _"Ammo suited for a boat's cannon."_
+
+    Bronze cannonball is the entry-tier boat cannon ammunition released with the Sailing skill update. Smith 4 at level 5 from a single bronze bar (9 XP) using an ammo mould at a furnace. Used in ship combat for bronze and stronger boat cannons.
+  market_strategy:
+    notes:
+      - "Stackable bulk ammo"
+      - "Demand tied to Sailing combat content"
+      - "Cheap entry-tier alternative to higher metals"
+  trading_tips:
+    - Bulk smith when bronze bars are below GE floor
+    - Stockpile ahead of Sailing event weekends
+  history:
+    - date: "2025-11-19"
+      description: "Added with the launch of the Sailing skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-longsword.mdx
@@ -12,26 +12,100 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 125
-  item_id: 1291
-  item_type: equipment
-  slot: weapon
-  type: longsword
-  attack_style: slash
-  attack_speed: 5
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 1
-  stats:
-    stab_attack: 4
-    slash_attack: 5
-    crush_attack: -2
-    strength: 7
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: slash sword
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 4
+      slash: 5
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 6
+      xp: 25
+      materials:
+        - item_name: Bronze bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      price: 80
+      currency: Coins
+      stock: 3
+  drop_table:
+    sources:
+      - source: Hobgoblin (level 28)
+        quantity: "1"
+        rarity: "1/128"
+      - source: Black Knight
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - slug: iron-longsword
-    - slug: bronze-sword
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Iron longsword
+      slug: iron-longsword
+      relationship: upgrade
+      description: "Same attack tier, better stats."
+    - item_name: Bronze sword
+      slug: bronze-sword
+      relationship: alternative
+      description: "Faster but weaker one-handed bronze blade."
+    - item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: "Smelted metal used to forge the longsword."
+  about: "The bronze longsword is the entry-level longsword in OSRS, requiring only level 1 Attack. Smithed at level 6 Smithing using 2 bronze bars (25 xp). Rarely used since the iron longsword offers superior stats with the same Attack requirement, making it primarily a Smithing training byproduct."
+  market_strategy:
+    notes:
+      - "Crafting cost (~120 gp in bars) exceeds GE value — unprofitable to smith for profit."
+      - "Demand is mostly Smithing trainers high-alching the output (24 gp each)."
+  trading_tips:
+    - "Buy if doing alching tasks where 24 gp per cast partially offsets nature rune cost."
+    - "Avoid hoarding — supply is large and price is sticky."
+  history:
+    - date: "2001-01-04"
+      description: "Released with the launch of RuneScape Classic-era melee tiers."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/burnt-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/burnt-bones.mdx
@@ -12,18 +12,65 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 3000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bones
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Bury
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Pyrefiend
+        quantity: "1"
+        rarity: Always
+      - source: Lava dragon
+        quantity: "1"
+        rarity: Always
+      - source: Fire giant
+        quantity: "1"
+        rarity: Common
   related_items:
-    - item_id: 530
-      item_name: Bat bones
+    - item_name: Bones
+      slug: bones
+      relationship: alternative
+      description: Standard bones (same prayer XP per bone)
+    - item_name: Bat bones
       slug: bat-bones
       relationship: variant
-      description: Another bone type
+      description: Higher Prayer XP variant
   about: |-
-    > _"A\"charred\" set of bones."_
+    > _"A charred set of bones."_
 
-    Burnt bones give 4.5 Prayer XP when buried, slightly more than regular bones (4.5). Primarily dropped by fiery creatures and found in Lava Dragon Isle.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Burnt bones grant 4.5 Prayer XP when buried, identical to regular bones. They can be offered at a gilded altar (15.7 XP), the Chaos Temple, or via the Sinister Offering spell (13.5 XP), and the Ectofuntus grants 18 XP.
+
+    Primarily dropped by fiery creatures such as pyrefiends, fire giants, and lava dragons. Several free-to-play spawn locations exist (Demonic Ruins has 8 F2P spawns) but they offer no advantage over regular bones for Prayer training.
+  market_strategy:
+    notes:
+      - "Identical Prayer XP to regular bones"
+      - "High supply from slayer/fiery monster drops"
+      - "Niche demand only from spawn-pickers"
+      - "Low absolute price ceiling"
+  trading_tips:
+    - Buy at GE floor and offer at altar for tiny XP margins
+    - Bulk volume play only - margins are pennies
+    - Not recommended for Prayer training over regular bones
+  history:
+    - date: "2004-03-29"
+      description: "Item released with the RS2 launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cactus-spine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cactus-spine.mdx
@@ -12,57 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  item_id: 6016
-  type: farming_product
-  tradeable: true
-  weight: 0.028
-  buy_limit: 11000
-  requirements:
-    skills:
-      - skill: farming
-        level: 55
-        context: to harvest
-  obtaining:
-    primary:
-      method: Farming
-      details: Harvest from cactus patches
-      locations:
-        - Al Kharid
-        - Farming Guild
-      yield: ~10 spines per harvest
-      regrowth: 75 minutes
-    other_sources:
-      - source: Nature implings
-        requirements: Hunter 58-68
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: herblore secondary
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
       - source: Kalphite Queen
-        quantity: 10 noted
-      - source: Tombs of Amascut chests
-  usage:
-    herblore: Weapon poison+ ingredient
-    farming: Yew tree protection payment (10 spines)
+        quantity: "1"
+        rarity: "3/126"
+      - source: Nature impling
+        quantity: "1"
+        rarity: "1/10"
+      - source: Tombs of Amascut
+        quantity: "1"
+        rarity: "3/27"
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 190
+      materials:
+        - item_name: Weapon poison(+) (unf)
+          quantity: 1
+        - item_name: Cactus spine
+          quantity: 1
+      tools:
+        - Coconut milk
+      output_quantity: 1
   related_items:
-    - slug: weapon-poison-plus
-      name: Weapon poison+
-      relation: herblore_product
-    - slug: cactus-seed
-      name: Cactus seed
-      relation: farming_source
-    - slug: yew-seed
-      name: Yew seed
-      relation: protection_target
+    - item_name: Weapon poison+
+      slug: weapon-poison-plus
+      relationship: product
+      description: "Primary herblore product using cactus spine"
+    - item_name: Cactus seed
+      slug: cactus-seed
+      relationship: component
+      description: "Farming source - grows into cactus that yields spines"
+    - item_name: Yew seed
+      slug: yew-seed
+      relationship: alternative
+      description: "Cactus spines used as protection payment for yew tree patches"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Farming Product |
-    | Tradeable | Yes |
-    | Weight | 0.028 kg |
+    Cactus spine is a herblore secondary obtained by harvesting cactus patches at level 55 Farming. It is the primary ingredient for weapon poison+, combined with coconut milk at 73 Herblore.
 
-    Herblore: Weapon poison+ ingredient
-
-    Farming: Yew tree protection payment (10 spines)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Cactus patches grow in Al Kharid and the Farming Guild, yielding around ten spines per harvest at level 99 with a 75-minute regrowth cycle. Drops also come from the Kalphite Queen, Nature implings, and Tombs of Amascut chests.
+  market_strategy:
+    notes:
+      - "Stable herblore secondary with consistent weapon poison+ demand"
+      - "Farming Guild patch enables high-yield runs"
+      - "Profitable money-making at 55+ Farming"
+  trading_tips:
+    - Harvest in bulk from multiple cactus patches to maximize per-run yield
+    - Sell to herblore-tier players crafting weapon poison+
+  history:
+    - date: "2005-07-11"
+      description: "Item added to the game with the Farming skill release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/calquat-tree-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/calquat-tree-seed.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 136
   highalch: 204
   limit: 200
-  about: "Calquat tree seed is a members-only item in Old School RuneScape. High alchemy value: 204 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: farming seed
+    tier: mid-high
+  properties:
+    release_date: "6 June 2005"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Zulrah
+        quantity: "1"
+        rarity: uncommon
+  recipes:
+    - skill: farming
+      level: 72
+      xp: 129.5
+      materials:
+        - item_name: Calquat tree seed
+          quantity: 1
+      tools:
+        - Seed dibber
+        - Spade
+      output_quantity: 6
+  related_items:
+    - item_name: Calquat fruit
+      slug: calquat-fruit
+      relationship: product
+      description: Harvest from a fully grown calquat tree
+    - item_name: Calquat keg
+      slug: calquat-keg
+      relationship: product
+      description: Container crafted from calquat wood
+  about: |-
+    The Calquat tree seed is a farming seed planted in a plantpot of soil to grow a calquat sapling. Once moved to a calquat tree patch (the only one in Karamja, north of Brimhaven), it grows into a calquat tree and can be harvested for calquat fruit.
+
+    | Requirement | Value |
+    |-------------|-------|
+    | Farming level | 72 |
+    | Yield | 6 calquat fruits per fully grown tree |
+
+    Calquat fruit is primarily used for Karamjan rum during Pirate's Treasure and as a tea-house barrel component.
+  market_strategy:
+    notes:
+      - "Limited supply (single farming patch on Karamja)"
+      - "Zulrah is the main drop source"
+      - "Demand from farmers chasing high farming XP per seed"
+      - "GE limit of 200 caps casual flipping"
+  trading_tips:
+    - Buy during Zulrah drop droughts
+    - Stockpile before farming-XP focused events
+  history:
+    - date: "22 August 2013"
+      description: "Gardener protection feature added: 8 poison ivy berries."
+    - date: "11 July 2005"
+      description: "Examine text updated from the farming skill teaser to its current description."
+    - date: "6 June 2005"
+      description: "Released with the original Farming skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/candle-lantern-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/candle-lantern-white.mdx
@@ -12,12 +12,68 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 40
-  about: "Candle lantern (white) is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: light-source
+    tier: low
+  properties:
+    release_date: "2005-03-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 4
+      xp: 0
+      materials:
+        - item_name: Empty candle lantern
+          quantity: 1
+        - item_name: Candle
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Candle lantern (black)
+      slug: candle-lantern-black
+      relationship: variant
+      description: Black candle variant
+    - item_name: Empty candle lantern
+      slug: empty-candle-lantern
+      relationship: component
+      description: Lantern frame
+    - item_name: Candle
+      slug: candle
+      relationship: component
+      description: White wax candle
+  about: |-
+    The white candle lantern is a light source crafted by placing an unlit candle in an empty candle lantern. It requires 4 Firemaking to assemble and a tinderbox to light. Once lit, it cannot be traded.
+
+    Useful for low-level cave exploration; the black candle variant is dropped by Dark Wizards and Black Knights.
+  market_strategy:
+    notes:
+      - "Low buy limit (40) — niche flips only"
+      - "Demand from quest preppers (Lumbridge Swamp Caves, Witch's House)"
+      - "Margins are coppers; not worth chasing volume"
+  trading_tips:
+    - Stockpile lanterns ahead of Halloween events or cave-themed releases
+    - Combine with bulk candles when crafting for personal use rather than GE flipping
+  history:
+    - date: "2005-03-14"
+      description: "Released as part of the Lumbridge Swamp Caves update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/charge-dragonstone-jewellery-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/charge-dragonstone-jewellery-scroll.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Charge dragonstone jewellery scroll is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: paper
+    tier: low
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: Uncommon
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  related_items:
+    - item_name: Amulet of glory
+      slug: amulet-of-glory
+      relationship: alternative
+      description: "Dragonstone amulet that this scroll can recharge to 4 charges"
+    - item_name: Combat bracelet
+      slug: combat-bracelet
+      relationship: alternative
+      description: "Dragonstone bracelet rechargeable to 4 charges with this scroll"
+    - item_name: Skills necklace
+      slug: skills-necklace
+      relationship: alternative
+      description: "Dragonstone necklace rechargeable to 4 charges with this scroll"
+  about: "The charge dragonstone jewellery scroll is a consumable Treasure Trails reward that recharges amulets of glory, combat bracelets, and skills necklaces to 4 charges each. Recharging amulets of glory requires completion of Heroes' Quest, while combat bracelets and skills necklaces require Legends' Quest. Rings of wealth cannot be recharged with this scroll - only the Fountain of Rune in deep Wilderness will work."
+  market_strategy:
+    notes:
+      - "Supply is steady from all clue tiers above beginner; not a bottlenecked drop"
+      - "Demand is utility - bossers who hate the Fountain of Rune trip buy in bulk"
+      - "10,000 buy limit and stackable status make large flips frictionless"
+  trading_tips:
+    - "Bulk pricing tends to flatten near 150 coins; flip volume not margin"
+    - "Watch for boss meta shifts that drive glory teleport demand"
+  history:
+    - date: "2016-07-06"
+      description: "Added as a clue reward with the 2016 Treasure Trails update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chef-s-delight.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chef's delight | OSRS Price Data
-description: "Chef's delight: A fruity, full-bodied ale.. High alch: 1 GP, GE limit: 2,000."
+description: "Chef's delight: A fruity, full-bodied ale. Members ale that boosts Cooking by up to +5 while draining Attack and Strength. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5755
   name: Chef's delight
@@ -12,9 +12,73 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Chef's delight is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 54
+      xp: 446
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Chocolate dust
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Beer glass
+          quantity: 8
+      tools:
+        - Fermenting vat
+      output_quantity: 8
+  potion:
+    effects:
+      - description: "Restores 1 Hitpoint."
+        duration: 0
+      - description: "Boosts Cooking by 5 percent + 1 (scaling +1 to +5)."
+        duration: 0
+      - description: "Drains Attack and Strength by 5 percent + 2 (scaling -2 to -6)."
+        duration: 0
+  related_items:
+    - item_name: Chef's delight (m)
+      slug: chef-s-delight-m
+      relationship: upgrade
+      description: Mature variant with stronger Cooking boost.
+    - item_name: Gourmet impling jar
+      slug: gourmet-impling-jar
+      relationship: alternative
+      description: Hunter source that often contains Chef's delight.
+    - item_name: Beer glass
+      slug: beer-glass
+      relationship: component
+      description: Vessel used in the brewing recipe.
+  about: "Chef's delight is a brewable ale introduced with the Farming update. It is most often used by cooks to boost the Cooking level for a single tier-locked dish, and it can be stored inside a player-owned house ale rack with 48 Construction and 44 Cooking."
+  market_strategy:
+    notes:
+      - "Brewing is loss-making at GE prices; supply is mostly from impling jars and ironmen."
+      - "Mature variant typically retains far more value than the base ale."
+  trading_tips:
+    - Flip near the buy limit of 2,000 when prices dip below alch value.
+    - Stock up when Cooking boosts are needed for boostable Cooking tasks.
+  history:
+    - date: "2005-07-11"
+      description: "Chef's delight released with the Farming update and brewing system."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chocolate-cake.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chocolate-cake.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chocolate cake | OSRS Price Data
-description: "Chocolate cake: This looks very tasty.. High alch: 42 GP, GE limit: 6,000."
+description: "Chocolate cake: This looks very tasty. High alch: 42 GP, GE limit: 6,000."
 osrs:
   id: 1897
   name: Chocolate cake
@@ -12,9 +12,106 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 6000
-  about: "Chocolate cake is a free-to-play item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.3
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Ardougne Baker's Stall
+      location: East and West Ardougne markets
+      price: 84
+      currency: Coins
+      stock: 2
+    - shop_name: Keldagrim's Best Bread
+      location: Keldagrim
+      price: 84
+      currency: Coins
+      stock: 5
+    - shop_name: Nathifa's Bake Stall
+      location: Sophanem
+      price: 84
+      currency: Coins
+      stock: 2
+    - shop_name: Kourend Castle Baker's Stall
+      location: Kourend Castle
+      price: 84
+      currency: Coins
+      stock: 2
+    - shop_name: Fortis Baker's Stall
+      location: Civitas illa Fortis
+      price: 84
+      currency: Coins
+      stock: 2
+  recipes:
+    - skill: cooking
+      level: 50
+      xp: 30
+      materials:
+        - item_name: Cake
+          quantity: 1
+        - item_name: Chocolate bar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - skill: cooking
+      level: 50
+      xp: 30
+      materials:
+        - item_name: Cake
+          quantity: 1
+        - item_name: Chocolate dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Cake
+      slug: cake
+      relationship: component
+      description: Plain cake base
+    - item_name: Chocolate bar
+      slug: chocolate-bar
+      relationship: component
+      description: Chocolate topping ingredient
+    - item_name: Slice of chocolate cake
+      slug: slice-of-chocolate-cake
+      relationship: variant
+      description: Partially eaten chocolate cake
+    - item_name: Chocolate slice
+      slug: chocolate-slice
+      relationship: variant
+      description: Final bite of the chocolate cake
+  about: |
+    Chocolate cake is a three-bite food that heals 5 Hitpoints per slice, totaling 15 HP per cake. Make one by using a chocolate bar (or chocolate dust) on a plain cake at 50 Cooking for 30 XP. It's a popular cheap food for low-to-mid level training and quest prep, and bakery stalls across Gielinor stock slices.
+  market_strategy:
+    notes:
+      - "Profit cooking when chocolate bar prices are low"
+      - "Buy limit 6,000 supports steady bulk flips"
+      - "GE often pays more than the 84 gp stall buyback"
+  trading_tips:
+    - Steal from bakery stalls for early Thieving XP
+    - Slice variant carries 5 HP heals if you portion the cake
+    - Compare bar vs dust pricing before bulk cooking
+  history:
+    - date: "2001-06-11"
+      description: "Chocolate cake added as a craftable food."
+    - date: "2015-02-05"
+      description: "Partially eaten chocolate cake slices became untradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-oathplate-acquisition.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/contract-of-oathplate-acquisition.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: null
   highalch: null
   limit: 50
-  about: "Contract of oathplate acquisition is a members-only item in Old School RuneScape. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: paper
+    tier: high
+  properties:
+    release_date: "2025-05-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Yama (dossier)
+        quantity: "1"
+        rarity: 13/1740
+  related_items:
+    - item_name: Oathplate helm
+      slug: oathplate-helm
+      relationship: product
+      description: "Possible armour piece guaranteed when the contract is consumed at Yama"
+    - item_name: Oathplate chest
+      slug: oathplate-chest
+      relationship: product
+      description: "Possible armour piece guaranteed when the contract is consumed at Yama"
+    - item_name: Oathplate legs
+      slug: oathplate-legs
+      relationship: product
+      description: "Possible armour piece guaranteed when the contract is consumed at Yama"
+  about: "The contract of oathplate acquisition is issued by Yama and triggers a harder solo encounter with a guaranteed oathplate armour drop of the player's choice. The contract is consumed on use and is obtained from Yama by opening dossiers at a 13/1,740 rate."
+  market_strategy:
+    notes:
+      - "Heavy GE price reflects guaranteed oathplate piece selection on completion"
+      - "Solo-only consumption restricts the buyer base to skilled Yama soloers"
+      - "Buy limit raised to 50/4h in the post-launch tuning still rate-limits whales"
+  trading_tips:
+    - "Track oathplate piece GE prices - contract demand follows the most-sought piece"
+    - "Demonbane meta resurgence (re-enabled May 29 2025) is a leading indicator for clear rates and contract throughput"
+  history:
+    - date: "2025-05-14"
+      description: "Released as part of the Yama boss content drop"
+    - date: "2025-05-23"
+      description: "Yama: contract terms clarified regarding demonbane weapon vulnerability"
+    - date: "2025-05-29"
+      description: "Buy limit raised to 50; Yama: again vulnerable to demonbane weapons"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cosmic-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cosmic-talisman.mdx
@@ -12,34 +12,65 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  item:
-    type: material
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: runecraft talisman
+    tier: low
+  properties:
+    release_date: "2004-03-29"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Abyssal demon
+        quantity: "1"
+        rarity: 1/128
+      - source: Dagannoth
+        quantity: "1"
+        rarity: 1/128
+      - source: Rick Turpentine (random event)
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - item_id: 5539
-      item_name: Cosmic tiara
+    - item_name: Cosmic tiara
       slug: cosmic-tiara
       relationship: product
-      description: Combined with tiara
-    - item_id: 564
-      item_name: Cosmic rune
+      description: Combined with a tiara at the Cosmic Altar
+    - item_name: Cosmic rune
       slug: cosmic-rune
-      relationship: alternative
-      description: Crafted product at Cosmic Altar
+      relationship: product
+      description: Crafted at the Cosmic Altar using pure essence
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Runecraft Talisman |
-    | Tradeable | Yes |
-    | Weight | 0.015 kg |
-    | Requirements | None |
+    The cosmic talisman grants access to the Cosmic Altar in Zanaris, where players can craft cosmic runes at 27 Runecraft. The talisman can also be combined with a tiara to create a cosmic tiara for 40 Runecraft XP, freeing up an inventory slot for runecrafting trips.
 
-    Grants access to Cosmic Altar for runecrafting.
-
-    Can create cosmic tiara for headslot access.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    A common drop from abyssal demons and dagannoths, and occasionally rewarded from random events.
+  market_strategy:
+    notes:
+      - "Common drop, high supply"
+      - "Demand from F2P upgrading to cosmic tiara crafting"
+      - "Low margin per item but high buy limit"
+      - "Price tied to cosmic rune demand cycles"
+  trading_tips:
+    - Bulk flip - 11,000 limit is generous
+    - Watch for cosmic rune price spikes which lift talisman demand
+    - Drop rate makes the floor very stable
+  history:
+    - date: "2004-03-29"
+      description: "Item released with the RS2 launch."
+    - date: "2003-12-01"
+      description: "Item previously available in the RS2 Beta."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cream-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cream-robe-bottoms.mdx
@@ -12,28 +12,90 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 150
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fine Fashions
+      location: Grand Tree (Rometti)
+      price: 180
+      currency: Coins
+      stock: 5
   related_items:
-    - item_id: 642
-      item_name: Cream robe top
+    - item_name: Cream robe top
       slug: cream-robe-top
       relationship: set-piece
-      description: Matching top
-    - item_id: 662
-      item_name: Cream hat
+      description: Matching top half
+    - item_name: Cream hat
       slug: cream-hat
       relationship: set-piece
       description: Matching hat
+    - item_name: Cream boots
+      slug: cream-boots
+      relationship: set-piece
+      description: Matching boots
   about: |-
-    > _"A pair of cream robe bottoms."_
+    Cream robe bottoms are sold by Rometti at Fine Fashions in the Grand Tree for 180 coins. They are a cosmetic gnome clothing set piece with negligible defensive bonuses (+2 slash, +2 crush defence).
 
-    Cream robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Renamed from "Robe bottoms" on 10 December 2014 to disambiguate the cream colour variant.
+  market_strategy:
+    notes:
+      - "Tight buy limit (150) and shop supply makes pricing reactive"
+      - "Demand is purely cosmetic — collection log and fashionscape only"
+      - "Shop-buy floor sets a clean cost basis"
+  trading_tips:
+    - Buy from Rometti at shop price, flip into the GE during fashionscape trends
+    - Stack with the cream top, hat, and boots when selling sets
+  history:
+    - date: "2002-12-12"
+      description: "Released with the Agility skill update."
+    - date: "2014-12-10"
+      description: "Renamed from \"Robe bottoms\" to \"Cream robe bottoms\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dareeyak-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dareeyak-teleport-tablet.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Dareeyak teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport tablet
+    tier: low
+  properties:
+    release_date: "2014-09-18"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Configure
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 78
+      xp: 88
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Air rune
+          quantity: 2
+        - item_name: Fire rune
+          quantity: 3
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Tablet base material crafted at the Ancient lectern
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Teleport rune required to imbue the tablet
+    - item_name: Ancient tablet
+      slug: ancient-tablet
+      relationship: alternative
+      description: Other Ancient Magicks teleport tablets in the same set
+  about: "Dareeyak teleport (tablet) is a members-only Ancient Magicks teleport tablet that breaks to relocate the user to the Dareeyak ruins west of the Bandit Camp in level 23 Wilderness. Created at the Ancient lectern in the player-owned house with 78 Magic after Desert Treasure I."
+  market_strategy:
+    notes:
+      - "Niche Wilderness convenience teleport with thin daily volume"
+      - "Demand spikes during Wilderness slayer or Crazy Archaeologist trips"
+      - "Tablet form lets non-Ancients users teleport without a spellbook swap"
+  trading_tips:
+    - Stock cheaply when bulk crafters dump after Magic XP sessions
+    - Resell during Wilderness boss meta shifts toward Crazy Archaeologist
+  history:
+    - date: "2014-09-18"
+      description: "Released alongside the Ancient teleport tablet rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cannon-barrel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-cannon-barrel.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 100
-  about: "Dragon cannon barrel is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cannon component
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 12
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 84
+      xp: 1857
+      materials:
+        - item_name: Dragon cannon barrel
+          quantity: 1
+        - item_name: Rosewood plank
+          quantity: 4
+        - item_name: Dragon nails
+          quantity: 16
+        - item_name: Dragon metal sheet
+          quantity: 8
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Opulent salvage (Sailing 87)
+        quantity: "1"
+        rarity: 1/20000
+      - source: Veiled kraken
+        quantity: "1"
+        rarity: 1/1000
+  related_items:
+    - item_name: Dragon cannon
+      slug: dragon-cannon
+      relationship: product
+      description: Assembled Dragon cannon built from this barrel and Sailing parts
+    - item_name: Rosewood plank
+      slug: rosewood-plank
+      relationship: component
+      description: Sailing-tier plank used to frame the cannon
+    - item_name: Dragon nails
+      slug: dragon-nails
+      relationship: component
+      description: Fasteners required during cannon assembly
+    - item_name: Dragon metal sheet
+      slug: dragon-metal-sheet
+      relationship: component
+      description: Armoured plating mounted around the barrel
+  about: "Dragon cannon barrel is a rare drop from veiled krakens and opulent salvage sorting, introduced with the Sailing skill. Combined with rosewood planks, dragon nails, and dragon metal sheets at 92 Sailing and 84 Construction, the barrel forms the heart of the Dragon cannon for endgame ship combat."
+  market_strategy:
+    notes:
+      - "1/1000 veiled kraken rarity throttles weekly supply"
+      - "100-per-4h buy limit keeps spreads tight on patch days"
+      - "Demand tracks players completing the Sailing endgame cannon goal"
+  trading_tips:
+    - Buy during veiled kraken weekend rushes when sellers liquidate
+    - Hold inventory tight given heavy 12 kg weight and slow turnover
+  history:
+    - date: "2025-11-19"
+      description: "Released as a Sailing skill drop tied to the Dragon cannon project."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart.mdx
@@ -12,77 +12,91 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dart
+    tier: high
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    type: dart
-    ranged_requirement: 60
-  ranged_bonuses:
-    ranged_strength: 35
-  fletching:
-    level: 95
-    xp: 25
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 35
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 35
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: fletching
       level: 95
       xp: 25
       materials:
         - item_name: Dragon dart tip
-          item_id: 11232
           quantity: 1
         - item_name: Feather
-          item_id: 314
           quantity: 1
-      product: Dragon dart
-      product_id: 11230
-      product_quantity: 1
-      facility: None
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 11232
-      item_name: Dragon dart tip
+    - item_name: Dragon dart tip
       slug: dragon-dart-tip
       relationship: component
-      description: Crafting component
-    - item_id: 314
-      item_name: Feather
+      description: Required tip; obtained from Tooth half of a key combine or Wyrms.
+    - item_name: Feather
       slug: feather
       relationship: component
-      description: Base material
-    - item_id: 12926
-      item_name: Toxic blowpipe
+      description: Attached to each dart tip during fletching.
+    - item_name: Toxic blowpipe
       slug: toxic-blowpipe
       relationship: alternative
-      description: Primary weapon
-    - item_id: 25849
-      item_name: Amethyst dart
+      description: Endgame ranged weapon that consumes darts as ammo.
+    - item_name: Amethyst dart
       slug: amethyst-dart
-      relationship: alternative
-      description: Alternative
-  about: |-
-    | Method | Level | XP |
-    |--------|-------|-----|
-    | Fletching | 95 | 25 (per dart) |
-    | Materials | Dragon dart tip + Feather | - |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged requirement | 60 |
-    | Ranged strength | +35 |
+      relationship: downgrade
+      description: Slightly weaker dart used as a budget blowpipe feeder.
+  about: "Dragon darts are the strongest throwable darts in the game, requiring 60 Ranged to wield. They are the primary ammo for the Toxic blowpipe at endgame PvM content including Chambers of Xeric, Theatre of Blood, Tombs of Amascut, and the Inferno."
   market_strategy:
     notes:
-      - Highest damage darts
-      - Toxic blowpipe meta
-      - High demand always
-      - Toxic blowpipe users
-      - High-level PvM
-      - Raids (CoX/ToB/ToA)
-      - Inferno attempts
-      - Best DPS for blowpipe
-      - Dragon dart tips from bosses
-      - 95 Fletching to make
-      - Always in demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand floor is set by blowpipe users grinding raids and Inferno"
+      - "Dragon dart tips drop from Wyrms; supply tracks slayer task popularity"
+      - "95 Fletching gates self-production, sustaining margin for sellers"
+  trading_tips:
+    - Stack up when wyrm slayer tasks see XP buffs
+    - Resell during major PvM events or league launches
+  history:
+    - date: "2007-06-11"
+      description: "Released with the While Guthix Sleeps quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-pickaxe-upgrade-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-pickaxe-upgrade-kit.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 640
   highalch: 960
   limit: 50
-  about: "Dragon pickaxe upgrade kit is a members-only item in Old School RuneScape. High alchemy value: 960 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2014-10-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Ferox Enclave
+      price: 14
+      currency: Last Man Standing points
+      stock: 50
+  related_items:
+    - item_name: Dragon pickaxe
+      slug: dragon-pickaxe
+      relationship: component
+      description: Target item the kit is applied to
+    - item_name: Dragon pickaxe (or)
+      slug: dragon-pickaxe-or
+      relationship: product
+      description: Resulting cosmetic upgraded pickaxe variant
+  about: "The dragon pickaxe upgrade kit is a Last Man Standing cosmetic reward that re-skins a dragon pickaxe into the ornamental Dragon pickaxe (or). Justine sells the kit for 14 LMS points at the Ferox Enclave shop, and applying it consumes the kit. The upgraded pickaxe becomes untradeable, though it can be reverted to a normal dragon pickaxe at the cost of permanently losing the kit."
+  market_strategy:
+    notes:
+      - "Supply driven entirely by LMS players cashing out reward points"
+      - "Cosmetic-only utility means demand tracks dragon pickaxe popularity"
+      - "50-per-4-hour limit makes large flips slow but stable"
+  trading_tips:
+    - Track LMS event weeks for supply spikes that compress margins
+    - Bundle with dragon pickaxe sales targeting ironman-style cosmetic buyers
+  history:
+    - date: "2014-10-09"
+      description: "Released alongside the original Last Man Standing minigame rewards."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elemental-talisman.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 40
-  about: "Elemental talisman is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: talisman
+    tier: mid
+  properties:
+    release_date: "2005-06-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Abyssal leech
+        quantity: "1"
+        rarity: "1/256"
+      - source: Abyssal guardian
+        quantity: "1"
+        rarity: "1/256"
+      - source: Abyssal walker
+        quantity: "1"
+        rarity: "1/256"
+      - source: Rewards Guardian (Desert)
+        quantity: "1"
+        rarity: "16/4900"
+  recipes:
+    - skill: runecraft
+      level: 40
+      xp: 40
+      materials:
+        - item_name: Gold tiara
+          quantity: 1
+        - item_name: Elemental talisman
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Elemental tiara
+      slug: elemental-tiara
+      relationship: product
+      description: "Crafted by using the talisman on the gold tiara at the Elemental altar"
+    - item_name: Air talisman
+      slug: air-talisman
+      relationship: alternative
+      description: "Alternative elemental-class talisman"
+    - item_name: Water talisman
+      slug: water-talisman
+      relationship: alternative
+      description: "Alternative elemental-class talisman"
+  about: |-
+    The Elemental talisman allows players to enter the elemental runic altars to craft elemental runes. It can be combined with a gold tiara at the Elemental altar to produce an Elemental tiara, granting 40 Runecraft experience.
+
+    Drops come from Abyss creatures (leeches, guardians, walkers) at 1/256, and from Rewards Guardians during the Guardians of the Rift minigame. The talisman includes a Locate option, though it may behave erratically when equidistant from multiple elemental altars.
+  market_strategy:
+    notes:
+      - "Low GE limit (40) restricts large-scale flipping"
+      - "Demand driven by Runecraft training and tiara collectors"
+      - "Guardians of the Rift supplies most of the in-game stock"
+  trading_tips:
+    - List near high alch value as a floor when supply is high
+    - GotR farmers can stockpile from Rewards Guardian rolls
+  history:
+    - date: "2005-06-13"
+      description: "Item added to the game with the Runecraft skill release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Energy potion(3) | OSRS Price Data
-description: "Energy potion(3): 3 doses of energy potion.. High alch: 66 GP, GE limit: 2,000."
+description: "Energy potion(3): 3 doses of energy potion. High alch: 66 GP, GE limit: 2,000."
 osrs:
   id: 3010
   name: Energy potion(3)
@@ -12,9 +12,73 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Energy potion(3) is a free-to-play item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2004-09-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.06
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 10% of the player's run energy per dose."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 26
+      xp: 67.5
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Chocolate dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Energy potion(4)
+      slug: energy-potion-4
+      relationship: variant
+      description: Four-dose variant
+    - item_name: Energy potion(2)
+      slug: energy-potion-2
+      relationship: variant
+      description: Two-dose variant
+    - item_name: Energy potion(1)
+      slug: energy-potion-1
+      relationship: variant
+      description: One-dose variant
+    - item_name: Energy mix
+      slug: energy-mix
+      relationship: upgrade
+      description: Barbarian variant that also heals 3 HP
+  about: "Energy potion(3) restores 10% run energy per dose. Made from a Harralander potion (unf) and chocolate dust at Herblore 26. F2P since March 2017."
+  market_strategy:
+    notes:
+      - "Low-margin Herblore output"
+      - "F2P available since 2017-03-09"
+      - "Steady demand for skiller travel"
+  trading_tips:
+    - Margins follow chocolate dust and harralander prices
+    - Stamina potion competes for high-end demand
+  history:
+    - date: "2004-09-01"
+      description: "Added with the Herblore skill."
+    - date: "2017-03-09"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-4.mdx
@@ -12,62 +12,76 @@ osrs:
   lowalch: 58
   highalch: 87
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2004-09-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   potion:
-    doses: 4
-    herblore_xp: 0
-    effect: Restores 10% of run energy
     effects:
-      - stat: Run energy
-        boost_type: restore
-        boost_value: 10
-        description: Restores 10% run energy per dose
+      - description: Restores 10% of run energy per dose
+        duration: 0
   recipes:
-    - skill: null
-      level: 0
-      xp: 0
+    - skill: herblore
+      level: 26
+      xp: 67
       materials:
-        - item_name: Limpwurt root
-          item_id: 225
-          quantity: 2
-        - item_name: Chocolate dust
-          item_id: 1975
+        - item_name: Harralander potion (unf)
           quantity: 1
-      facility: Apothecary
+        - item_name: Chocolate dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 225
-      item_name: Limpwurt root
+    - item_name: Limpwurt root
       slug: limpwurt-root
       relationship: component
-      description: Required ingredient
-    - item_id: 1975
-      item_name: Chocolate dust
+      description: Required ingredient at the Apothecary recipe
+    - item_name: Chocolate dust
       slug: chocolate-dust
       relationship: component
-      description: Required ingredient
-    - item_id: 3016
-      item_name: Super energy(4)
+      description: Required ingredient for both Apothecary and Herblore recipes
+    - item_name: Super energy(4)
       slug: super-energy-4
       relationship: upgrade
-      description: Better energy restoration
-    - item_id: 12625
-      item_name: Stamina potion(4)
+      description: Restores 20% run energy per dose
+    - item_name: Stamina potion(4)
       slug: stamina-potion-4
       relationship: upgrade
-      description: Best energy option
+      description: Restores energy and reduces drain rate
   about: |-
-    Restores 10% run energy per dose. While weak compared to modern alternatives, useful for:
-    - F2P players
-    - Early-game ironmen
-    - Budget option for walking content
+    Energy potion(4) is a free-to-play potion that restores 10% run energy per dose. Useful for:
+    - F2P players with no access to stamina potions
+    - Early-game ironmen building Herblore
+    - Budget option for walking-heavy content
   market_strategy:
     notes:
-      - Only energy restoration available in F2P
-      - Low volume market
-      - Consider making at Apothecary for profit
-      - Super energy(4) - 20% restore
-      - Stamina potion(4) - 20% + reduced drain
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Only run-energy restoration available in F2P"
+      - "Low volume market with thin spreads"
+      - "Crafting at the Varrock Apothecary can yield profit"
+      - "Outclassed by Super energy(4) and Stamina potion(4) for members"
+  trading_tips:
+    - Bulk Apothecary crafting beats GE flipping for F2P arbitrage
+    - Watch limpwurt root and chocolate bar supply for cost shifts
+  history:
+    - date: "2004-09-01"
+      description: "Released as one of the original Herblore potions in RuneScape 2."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-wings.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/evil-chicken-wings.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Evil chicken wings is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2016-07-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.25
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Woodcutting Guild shrine (offering bird's eggs)
+        quantity: "1"
+        rarity: 1/300
+  related_items:
+    - item_name: Evil chicken head
+      slug: evil-chicken-head
+      relationship: set-piece
+      description: Head piece of the evil chicken outfit
+    - item_name: Evil chicken legs
+      slug: evil-chicken-legs
+      relationship: set-piece
+      description: Legs piece of the evil chicken outfit
+    - item_name: Evil chicken feet
+      slug: evil-chicken-feet
+      relationship: set-piece
+      description: Feet piece of the evil chicken outfit
+  about: "Evil chicken wings are the body slot piece of the evil chicken outfit, a cosmetic set obtained from the shrine in the Woodcutting Guild by offering bird's eggs at a 1/300 rate per piece. Wearing the full outfit with the Flap emote unlocked produces an enhanced animation where the player lifts off the ground."
+  market_strategy:
+    notes:
+      - "Tiny 4-per-4h buy limit keeps prices volatile"
+      - "Demand comes from set completionists, not combat"
+      - "Supply trickles in as Woodcutting Guild bird-nest hunters cash out"
+  trading_tips:
+    - Buy when a Woodcutting update flushes nest farmers' stock
+    - Pair with other evil chicken pieces to flip the full set for premium
+  history:
+    - date: "2016-07-21"
+      description: "Introduced as part of the evil chicken outfit reward from bird's-egg offerings at the Woodcutting Guild shrine."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/explorer-backpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/explorer-backpack.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 620
   highalch: 930
   limit: 4
-  about: "Explorer backpack is a members-only item in Old School RuneScape. High alchemy value: 930 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 2
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Reward casket (hard)
+      slug: reward-casket-hard
+      relationship: product
+      description: "Casket that can yield the explorer backpack as a reward"
+  about: "The explorer backpack is a cosmetic cape-slot item obtained as a reward from hard Treasure Trails. Introduced with the 2014 Treasure Trail Expansion, it has no combat stats and is purely decorative. The examine text references Dora the Explorer's Backpack Song."
+  market_strategy:
+    notes:
+      - "Supply is gated by hard clue completion rate at 1/1,625 from caskets, supporting a stable mid-tier cosmetic price"
+      - "Demand is driven by collectors and clue-hunters working their cosmetic logs"
+      - "Storable in the costume room treasure chest, reducing the need for duplicates"
+  trading_tips:
+    - "Track hard clue completion volume on the GE for short-term price direction"
+    - "Watch for clue scroll event weeks that can flood the market with cosmetics"
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion update as a hard clue cosmetic reward"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fire-element-staff-crown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fire-element-staff-crown.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 8
-  about: "Fire element staff crown is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic
+    tier: high
+  properties:
+    release_date: "2025-02-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Branda the Fire Queen
+        quantity: "1"
+        rarity: 1/75
+  related_items:
+    - item_name: Ice element staff crown
+      slug: ice-element-staff-crown
+      relationship: component
+      description: Sister crown also required to craft the twinflame staff
+    - item_name: Twinflame staff
+      slug: twinflame-staff
+      relationship: product
+      description: Resulting end-game magic weapon crafted from both crowns plus a battlestaff
+    - item_name: Battlestaff
+      slug: battlestaff
+      relationship: component
+      description: Base staff used during twinflame assembly
+  about: "The fire element staff crown is a rare drop from Branda the Fire Queen at the Royal Titans boss encounter. It is a crafting component used together with the ice element staff crown and a battlestaff to build the twinflame staff, one of the strongest magic weapons in the game. Because both crowns are required, demand and price closely track the value of the finished twinflame staff."
+  market_strategy:
+    notes:
+      - "Supply gated by Royal Titans clears at a 1/75 drop rate"
+      - "Tiny 8-per-4-hour limit creates volatile percentage moves"
+      - "Pair-priced with the ice crown since both are required to assemble twinflame"
+  trading_tips:
+    - Watch ice crown supply for divergence trades when one outpaces the other
+    - Track Royal Titans group LFG activity to forecast drop floods
+  history:
+    - date: "2025-02-05"
+      description: "Released with the Royal Titans boss, dropped by Branda the Fire Queen for use in crafting the twinflame staff."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-mix-2.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  about: "Fishing mix(2) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: Boosts Fishing level by 3
+        duration: 0
+      - description: Restores 6 Hitpoints per dose
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 53
+      xp: 38
+      materials:
+        - item_name: Fishing potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Fishing potion
+      slug: fishing-potion
+      relationship: component
+      description: Base potion mixed with caviar to make the Barbarian variant
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore secondary added to the potion
+    - item_name: Fishing mix(1)
+      slug: fishing-mix-1
+      relationship: variant
+      description: Single-dose version of the same potion
+  about: "Fishing mix(2) is a two-dose Barbarian Herblore variant of the Fishing potion. It briefly boosts the Fishing level by 3 and restores 6 Hitpoints per dose, making it a budget self-heal for Barbarian fishing trips at Otto's Grotto."
+  market_strategy:
+    notes:
+      - "Niche skilling consumable with thin volume but stable value"
+      - "Caviar supply (Karambwanji-fed pyre or chompy stew chains) sets price floor"
+      - "Net loss per mix means most supply comes from XP-focused herbloreists"
+  trading_tips:
+    - Buy from XP grinders dumping after Barbarian Herblore sessions
+    - Pair with sturgeon trips to flip into Cooking goods later
+  history:
+    - date: "2007-07-03"
+      description: "Added with the Barbarian Training Herblore expansion."
+    - date: "2016-04-07"
+      description: "Update: became bankable as a placeholder."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-hat.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Fremennik hat is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Shoe Store
+      location: Rellekka
+      price: 650
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Fremennik shirt
+      slug: fremennik-shirt
+      relationship: set-piece
+      description: "Matching Fremennik clothing torso slot"
+    - item_name: Fremennik cloak
+      slug: fremennik-cloak
+      relationship: set-piece
+      description: "Matching Fremennik cape-slot piece"
+  about: "The Fremennik hat is a members-only green pointed hat sold by Yrsa in Rellekka after completing The Fremennik Trials. It grants +3 magic attack and +3 magic defence, making it a budget cosmetic with a small magic bonus."
+  market_strategy:
+    notes:
+      - "Supply is uncapped from Yrsa's shop at 650 coins per stock unit"
+      - "Quest gate on The Fremennik Trials limits casual flippers, keeping listings thin"
+      - "Demand is cosmetic / low-level magic outfit rather than meta combat use"
+  trading_tips:
+    - "When GE price drifts above 1k, restock directly from Yrsa for guaranteed margin"
+    - "Bundle with other Fremennik items for cosmetic-set buyers"
+  history:
+    - date: "2004-11-02"
+      description: "Released with The Fremennik Trials quest as part of the Fremennik clothing line"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fur.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 18000
-  about: "Fur is a free-to-play item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: hide
+    tier: low
+  properties:
+    release_date: "2005-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Werewolf (level 88)
+        quantity: "1"
+        rarity: Always
+      - source: Werewolf (level 93)
+        quantity: "1"
+        rarity: Always
+  shops:
+    - shop_name: Baraek's Fur Stall
+      location: Varrock square
+      price: 12
+      currency: Coins
+      stock: 0
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 15
+      materials:
+        - item_name: Fur
+          quantity: 1
+        - item_name: Plank
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Grey wolf fur
+      slug: grey-wolf-fur
+      relationship: variant
+      description: "Higher-tier fur from grey wolves used in Tailoring/Crafting."
+    - item_name: Wooden cat
+      slug: wooden-cat
+      relationship: product
+      description: "Crafted from fur and a plank at level 15 Crafting."
+    - item_name: Plank
+      slug: plank
+      relationship: component
+      description: "Paired with fur to craft a wooden cat."
+  about: "Fur is dropped by werewolves in Canifis and certain humanoid creatures. F2P-tradeable on the Grand Exchange. It can be sold to Baraek in Varrock square (20 gp with Ring of Charos), used to craft wooden cats at 15 Crafting, or held for The Great Brain Robbery quest."
+  market_strategy:
+    notes:
+      - "Mostly a quest-prep buy — demand spikes around Great Brain Robbery starters."
+      - "Crafting wooden cats yields modest XP but the item itself is cheap; small profit margins."
+  trading_tips:
+    - "Buy in bulk during off-peak hours; sell into questing surges."
+    - "Use Ring of Charos when selling to Baraek to double npc payout."
+  history:
+    - date: "2005-12-12"
+      description: "Released with the Creature of Fenkenstrain quest and Canifis werewolves."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gadderhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gadderhammer.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 8
-  about: "Gadderhammer is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2006-03-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: warhammer
+    attack_speed: 5
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 35
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 35
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Aurel's Shop
+      location: Burgh de Rott
+      price: 3000
+      currency: Coins
+      stock: 1
+  passive_effects:
+    - name: Shade bane
+      description: "Deals a 25% damage bonus against shades and has a 5% chance to deal double damage to them, similar to the keris versus kalphites."
+  related_items:
+    - item_name: Flail of Ivandis
+      slug: flail-of-ivandis
+      relationship: alternative
+      description: "Alternative Myreque-themed weapon used against vampyric foes"
+    - item_name: Rod of ivandis
+      slug: rod-of-ivandis
+      relationship: alternative
+      description: "Another Myreque weapon obtained during the storyline"
+  about: "The gadderhammer is a members-only two-handed crush weapon obtained after defeating Gadderanks during In Aid of the Myreque. Its strength lies against shades, where a 25% damage bonus and 5% double-damage chance make it a niche bossing pick. It cannot be wielded by players who have not completed the quest, even if traded."
+  market_strategy:
+    notes:
+      - "Quest gate locks the wieldable audience to In Aid of the Myreque completers"
+      - "Demand spikes during Mort'ton temple / shade-related events"
+      - "Buy limit of 8 keeps day-to-day flipping volume small"
+  trading_tips:
+    - "Stock up before Halloween or Mort'ton minigame promotions"
+    - "Compare against repurchasing from Aurel at 3,000 coins as a price ceiling"
+  history:
+    - date: "2006-03-22"
+      description: "Released with the In Aid of the Myreque quest update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/garlic-powder.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/garlic-powder.mdx
@@ -1,6 +1,6 @@
 ---
 title: Garlic powder | OSRS Price Data
-description: "Garlic powder: Finely ground garlic powder.. High alch: 6 GP, GE limit: 15."
+description: "Garlic powder: Finely ground garlic powder. Quest ingredient for Desert Treasure. High alch: 6 GP, GE limit: 15."
 osrs:
   id: 4668
   name: Garlic powder
@@ -12,9 +12,55 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15
-  about: "Garlic powder is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: quest-ingredient
+    tier: low
+  properties:
+    release_date: "2005-04-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.007
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Garlic
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  related_items:
+    - item_name: Garlic
+      slug: garlic
+      relationship: component
+      description: Ground in a pestle and mortar to produce the powder.
+    - item_name: Blessed pot
+      slug: blessed-pot
+      relationship: product
+      description: Garlic powder is combined into a blessed pot during Desert Treasure I.
+  about: "Garlic powder is a Desert Treasure I quest ingredient made by grinding a garlic with a pestle and mortar. It is poured into a blessed pot to weaken the vampyre Dessous during the quest. The item can be created at any time, regardless of quest progress, and is freely tradeable on the Grand Exchange."
+  market_strategy:
+    notes:
+      - "Tiny 15-per-4h buy limit caps flipping volume - this is a margin play not a quantity play."
+      - "GE price routinely outpaces the cost of raw garlic, leaving room for steady per-unit profit."
+      - "Demand spikes during Desert Treasure I quest helper events."
+  trading_tips:
+    - Buy raw garlic, grind, and list at GE max to capture the spread.
+    - Inventory churn matters more than per-flip profit due to the tiny limit.
+  history:
+    - date: "2005-04-18"
+      description: "Released with the Desert Treasure quest."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gianne-s-cook-book.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gianne-s-cook-book.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Gianne's cook book is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: book
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.51
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      price: 2
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Toad batta
+      slug: toad-batta
+      relationship: product
+      description: "Gnome dish recipe contained in the book"
+    - item_name: Chocolate bomb
+      slug: chocolate-bomb
+      relationship: product
+      description: "Gnome dish recipe contained in the book"
+    - item_name: Worm hole
+      slug: worm-hole
+      relationship: product
+      description: "Gnome dish recipe contained in the book"
+  about: |-
+    Gianne's cook book is a reference guide for gnome cuisine in Old School RuneScape. It contains instructions for preparing dishes like chocolate bombs, worm holes, battas, and crunchies, all integral to the Gnome Restaurant minigame.
+
+    Players can obtain the book from Aluft Gianne, Hudo the grocer at the Grand Tree, or from their player-owned house bookcase after completing the cooking tutorial.
+  market_strategy:
+    notes:
+      - "Low-value reference item rarely flipped at scale"
+      - "Cheap to buy from Grand Tree Groceries (2 coins)"
+      - "GE limit of 15 caps speculation potential"
+  trading_tips:
+    - Buy directly from the shop rather than the GE for the lowest price
+    - Useful for gnome cooking minigame participants
+  history:
+    - date: "2002-12-12"
+      description: "Item added to the game with the Gnome Restaurant activity."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-full-helm.mdx
@@ -12,63 +12,103 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2004-10-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: melee armour
-    attack_style: melee
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
     requirements:
       defence: 40
-    stats:
-      defence_stab: 30
-      defence_slash: 32
-      defence_crush: 27
-      defence_magic: -1
-      defence_ranged: 30
-      melee_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Rare reward from hard clue scrolls
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Clue Scroll
+        quantity: "1"
+        rarity: "1/35,750"
+      - source: Elite Clue Scroll
+        quantity: "1"
+        rarity: "1/32,257.5"
+      - source: Master Clue Scroll
+        quantity: "1"
+        rarity: "1/149,776"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 3481
-      item_name: Gilded platebody
+    - item_name: Gilded platebody
       slug: gilded-platebody
       relationship: set-piece
-      description: Body slot of gilded set
-    - item_id: 3483
-      item_name: Gilded platelegs
+      description: Body slot of the gilded armour set.
+    - item_name: Gilded platelegs
       slug: gilded-platelegs
       relationship: set-piece
-      description: Leg slot of gilded set
-    - item_id: 3488
-      item_name: Gilded kiteshield
+      description: Leg slot of the gilded armour set.
+    - item_name: Gilded kiteshield
       slug: gilded-kiteshield
       relationship: set-piece
-      description: Shield slot of gilded set
-    - item_id: 12389
-      item_name: Gilded scimitar
-      slug: gilded-scimitar
-      relationship: set-piece
-      description: Weapon of gilded set
-  about: |-
-    The gilded full helm is a cosmetic variant of the rune full helm with identical stats but a prestigious golden appearance. It requires 40 Defence to wear.
-
-    Gilded armour is obtained from Treasure Trails and is valued for its appearance rather than stats. It shares the same defensive bonuses as rune armour but costs significantly more due to its rarity and fashionscape appeal.
+      description: Shield slot of the gilded armour set.
+    - item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: alternative
+      description: Functionally identical rune helmet without the cosmetic gold trim.
+  about: "The gilded full helm is a cosmetic variant of the rune full helm with identical defence bonuses but a prestigious golden appearance. It requires 40 Defence to equip and is obtained exclusively from hard, elite, and master Treasure Trails. Its rarity and fashionscape appeal drive a high Grand Exchange price well above the rune equivalent."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Price driven by cosmetic demand
-      - Popular for fashionscape and showing off
-      - More accessible than 3rd age but still valuable
-      - Compare prices with rune equivalent for value assessment
-      - Watch for dips after clue scroll events
-      - Popular with free-to-play players for fashion
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Price is driven by cosmetic demand and clue scroll supply."
+      - "Popular fashionscape choice for showing off rare drops."
+      - "More accessible than 3rd age but still highly valuable."
+      - "Compare with rune full helm to gauge cosmetic premium."
+      - "Watch for price dips after clue scroll droprate events."
+  trading_tips:
+    - "Stockpile during Hard/Elite clue grind events when supply spikes."
+    - "Bundle with other gilded set pieces for a fashionscape premium."
+    - "Track GE buy limit (8) — high-value flips need patience across multiple windows."
+  history:
+    - date: "2004-10-26"
+      description: "Added to the game as a rare reward from Treasure Trails."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus decreased from -2 to -3."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-med-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-med-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gilded med helm | OSRS Price Data
-description: "Gilded med helm: A medium sized helmet with gold plate.. High alch: 11,520 GP, GE limit: 70."
+description: "Gilded med helm: A medium sized helmet with gold plate. High alch: 11,520 GP, GE limit: 70."
 osrs:
   id: 20146
   name: Gilded med helm
@@ -12,9 +12,95 @@ osrs:
   lowalch: 7680
   highalch: 11520
   limit: 70
-  about: "Gilded med helm is a free-to-play item in Old School RuneScape. High alchemy value: 11,520 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gilded
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: 0
+    defence_bonus:
+      stab: 22
+      slash: 23
+      crush: 21
+      magic: -1
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/35750
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/32258
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/149776
+  related_items:
+    - item_name: Rune med helm
+      slug: rune-med-helm
+      relationship: alternative
+      description: Functionally identical helmet without the cosmetic gilding.
+    - item_name: Gilded full helm
+      slug: gilded-full-helm
+      relationship: set-piece
+      description: Alternative gilded headgear with full-helm aesthetics.
+  about: |-
+    Gilded med helm is a cosmetic Treasure Trail reward with stats identical to the rune med helm. The gold plating gives it a premium look that wealthy F2P players use as a fashion piece for the head slot.
+
+    Because it drops from hard, elite, and master caskets and has no use beyond aesthetics, supply is capped by clue completions while demand is driven entirely by collectors and fashionscapers.
+  market_strategy:
+    notes:
+      - "Pure cosmetic item — price tracks fashion demand"
+      - "Steady supply from clue scroll grinders"
+      - "Holds value during clue scroll content updates"
+  trading_tips:
+    - Buy after large clue events when supply briefly floods the market
+    - Sell to fashion buyers during seasonal cosmetic hype
+  history:
+    - date: "2016-07-06"
+      description: "Added with the Treasure Trail Expansion update."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus adjusted from -1 to 0."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gin.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gin | OSRS Price Data
-description: "Gin: A strong spirit that tastes of Juniper.. High alch: 3 GP, GE limit: 13,000."
+description: "Gin: A strong spirit that tastes of Juniper. High alch: 3 GP, GE limit: 13,000."
 osrs:
   id: 2019
   name: Gin
@@ -12,9 +12,86 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
-  about: "Gin is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: beverage
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Funch's Fine Groceries
+      location: Grand Tree
+      price: 5
+      currency: Coins
+      stock: 10
+    - shop_name: The Lighthouse Store
+      location: Lighthouse
+      price: 5
+      currency: Coins
+      stock: 5
+    - shop_name: Atlazora's Rest
+      location: Outer Fortis
+      price: 5
+      currency: Coins
+      stock: 0
+    - shop_name: The Flaming Arrow
+      location: Civitas illa Fortis
+      price: 5
+      currency: Coins
+      stock: 0
+    - shop_name: Sunlight's Sanctum
+      location: Aldarin
+      price: 5
+      currency: Coins
+      stock: 0
+    - shop_name: The Windbreaker
+      location: Quetzacalli Gorge
+      price: 5
+      currency: Coins
+      stock: 0
+    - shop_name: Auburn Pub
+      location: Auburnvale
+      price: 5
+      currency: Coins
+      stock: 0
+  related_items:
+    - item_name: Beer
+      slug: beer
+      relationship: alternative
+      description: Cheaper alcoholic drink with similar stat-boost mechanics.
+    - item_name: Asgarnian ale
+      slug: asgarnian-ale
+      relationship: alternative
+      description: Members-only ale used for boosts and Construction flatpacks.
+  about: |-
+    Gin is a members-only alcoholic beverage sold by general traders across Gielinor. Drinking it provides a small Attack boost at the cost of Defence, mirroring the standard ale stat swap.
+
+    Most players treat gin as flavour content rather than a meta drink, but it has a niche role in low-level skilling and as a flatpack ingredient in some publican-themed POH builds.
+  market_strategy:
+    notes:
+      - "Multi-shop supply keeps GE price near the shop floor"
+      - "Massive buy limit caps merch potential"
+      - "Niche stat boost limits meta demand"
+  trading_tips:
+    - Restock at unlimited Fortis-region shops if GE spikes
+    - Use as cheap filler for stat-boost-based skilling tasks
+  history:
+    - date: "2002-12-12"
+      description: "Released as part of the early bar and pub content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gloves-of-darkness.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gloves-of-darkness.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gloves of darkness | OSRS Price Data
-description: "Gloves of darkness: A dark power is woven into these gloves.. High alch: 6,000 GP, GE limit: 70."
+description: "Gloves of darkness: A dark power is woven into these gloves. High alch: 6,000 GP, GE limit: 70."
 osrs:
   id: 20134
   name: Gloves of darkness
@@ -12,9 +12,77 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 70
-  about: "Gloves of darkness is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      magic: 3
+    defence_bonus:
+      magic: 3
+    other_bonus: {}
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Hood of darkness
+      slug: hood-of-darkness
+      relationship: set-piece
+      description: Hood piece of the robes of darkness set
+    - item_name: Robe top of darkness
+      slug: robe-top-of-darkness
+      relationship: set-piece
+      description: Robe top of the robes of darkness set
+    - item_name: Robe bottom of darkness
+      slug: robe-bottom-of-darkness
+      relationship: set-piece
+      description: Robe bottom of the robes of darkness set
+    - item_name: Boots of darkness
+      slug: boots-of-darkness
+      relationship: set-piece
+      description: Boots of the robes of darkness set
+  about: "Gloves of darkness are a master clue reward (1/1,133) and part of the robes of darkness set. Provides +3 Magic attack and +3 Magic defence; aligned with Zaros."
+  market_strategy:
+    notes:
+      - "Master clue exclusive (1/1133)"
+      - "Set-piece demand drives long-term price"
+      - "GE limit 70 per 4 hours"
+  trading_tips:
+    - Stock during master clue events
+    - Full robes of darkness set commands a premium
+  history:
+    - date: "2016-07-06"
+      description: "Added as a Master Treasure Trail reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/golden-apron.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/golden-apron.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Golden apron is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic armour
+    tier: low
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Brown apron
+      slug: brown-apron
+      relationship: alternative
+      description: "Standard apron with the same Crafting Guild entry function"
+    - item_name: Easy clue scroll
+      slug: clue-scroll-easy
+      relationship: component
+      description: "Source of the golden apron via easy clue rewards"
+  about: |-
+    The Golden apron is a cosmetic body slot item obtained as a reward from easy clue scrolls. It provides no combat bonuses but can be worn in place of a brown apron to enter the Crafting Guild.
+
+    The apron is storable in the costume room treasure chest of a player-owned house, making it a popular display piece for clue completionists.
+  market_strategy:
+    notes:
+      - "Cosmetic item with strong scarcity from low GE limit (4)"
+      - "Crafting Guild access function adds light utility value"
+      - "Steady collector demand from clue scroll completionists"
+  trading_tips:
+    - Price tracks easy clue scroll completion rates - rises with new clue interest
+    - Stockpile from easy clue grinding for long-term resale
+  history:
+    - date: "2016-07-06"
+      description: "Item added to the game with the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gout-tuber.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gout-tuber.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  about: "Gout tuber is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: farming seed
+    tier: mid
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Jungle hacking (Tai Bwo Wannai Cleanup)
+        quantity: "1"
+        rarity: 1/100 to 1/33 (scales with Woodcutting level)
+  related_items:
+    - item_name: Goutweed
+      slug: goutweed
+      relationship: product
+      description: Harvested crop used in Eadgar's Ruse and Troll-related cooking.
+  about: |-
+    Gout tuber is the seed used to grow Goutweed in a herb patch from level 29 Farming, available after partial completion of Eadgar's Ruse. The crop takes roughly 80 minutes to mature.
+
+    The only renewable source is Tai Bwo Wannai Cleanup jungle hacking. The drop rate scales with Woodcutting level, ranging from 1/100 at level 10 up to 1/33 at level 99, making higher Woodcutting much more efficient for tuber farming.
+  market_strategy:
+    notes:
+      - "Tiny 5 buy limit per 4 hours — illiquid, prone to price swings"
+      - "Supply tied directly to Tai Bwo Wannai Cleanup popularity"
+      - "Demand from Farming trainers and troll-region food crafters"
+      - "High-level Woodcutting players have a much better drop rate; consider farming yourself for profit"
+  history:
+    - date: "2005-08-09"
+      description: "Added to the game with the Tai Bwo Wannai Cleanup minigame."
+    - date: "2020-01-09"
+      description: "Planting XP is now granted at harvest time alongside harvesting XP, instead of on planting."
+    - date: "2025-06-04"
+      description: "Drop rate from jungle hacking now scales with Woodcutting level."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-body-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-body-t.mdx
@@ -12,89 +12,95 @@ osrs:
   lowalch: 3120
   highalch: 4680
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: trimmed dragonhide
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 6.803
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
     requirements:
       ranged: 40
       defence: 40
-      quest: Dragon Slayer I
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 15
-      defence_stab: 18
-      defence_slash: 27
-      defence_crush: 24
-      defence_magic: 20
-      defence_ranged: 35
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 15
+    defence_bonus:
+      stab: 18
+      slash: 27
+      crush: 24
+      magic: 20
+      ranged: 35
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 6.803
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: Reward casket (medium)
-        drop_rate: 1/1,133
+        quantity: "1"
+        rarity: 1/1,133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 1135
-      item_name: Green d'hide body
+    - item_name: Green d'hide body
       slug: green-dhide-body
       relationship: alternative
-      description: Same stats, non-trimmed
-    - item_id: 7370
-      item_name: Green d'hide body (g)
+      description: Same stats, non-trimmed standard version
+    - item_name: Green d'hide body (g)
       slug: green-dhide-body-g
       relationship: alternative
-      description: Gold-trimmed variant, same stats
-    - item_id: 7376
-      item_name: Blue d'hide body (t)
+      description: Gold-trimmed variant with identical stats
+    - item_name: Blue d'hide body (t)
       slug: blue-dhide-body-t
-      relationship: alternative
-      description: Higher tier trimmed body
+      relationship: upgrade
+      description: Higher tier trimmed dragonhide body
   about: |-
-    "Made from 100% real dragonhide. With colourful trim!"
+    > *"Made from 100% real dragonhide. With colourful trim!"*
 
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -15 |
-    | Ranged Attack | +15 |
-    | Stab Defence | +18 |
-    | Slash Defence | +27 |
-    | Crush Defence | +24 |
-    | Magic Defence | +20 |
-    | Ranged Defence | +35 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
+    Trimmed green d'hide body is a cosmetic variant of the standard green dragonhide body, obtained exclusively from medium Treasure Trails. Stats are identical to the untrimmed version (Dragon Slayer I no longer required since the September 2021 rebalance removed the quest gate on hide bodies for body-slot pieces beyond 40 Defence/Ranged).
 
-    Requirements: 40 Ranged, 40 Defence, Dragon Slayer I
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Green d'hide body (t) | +15 | +35 | +20 | Medium clues |
-    | Green d'hide body | +15 | +35 | +20 | Crafting (63) |
-
-    Stats are identical to the standard green d'hide body. The trimmed version is purely cosmetic and more expensive due to its rarity from Treasure Trails.
+    Provides +15 Ranged Attack and strong Ranged defence (+35), making it a solid mid-tier ranger body for F2P clue hunters and fashionscape collectors.
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Medium clue reward rarity
-      - Collection log completionists
-      - Trimmed d'hide set completion
-      - Identical stats to green d'hide body
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cosmetic only - identical stats to standard green d'hide body"
+      - "Medium clue rarity drives price floor"
+      - "Collection log completionist demand"
+      - "Low buy limit (8) and low volume - watch for manipulation"
+  trading_tips:
+    - Use limit orders rather than instant flips - low volume
+    - Watch medium clue completion rates for supply shifts
+    - Premium over standard body is purely cosmetic rarity
+  history:
+    - date: "2006-02-20"
+      description: "Item released as a reward from medium Treasure Trails."
+    - date: "2021-09-22"
+      description: "Defence bonuses rebalanced across the trimmed d'hide body line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-body.mdx
@@ -12,60 +12,77 @@ osrs:
   lowalch: 3120
   highalch: 4680
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: mid
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged_armour
-    ranged_requirement: 40
-    defence_requirement: 0
-  attack_bonuses:
-    ranged: 15
-  defence_bonuses:
-    ranged: 40
-    magic: 20
-  crafting:
-    level: 63
-    xp: 186
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
+    requirements:
+      ranged: 40
+      defence: 40
+    attack_bonus:
+      ranged: 15
+    defence_bonus:
+      stab: 18
+      slash: 27
+      crush: 24
+      magic: 20
+      ranged: 35
+    other_bonus: {}
   recipes:
     - skill: crafting
       level: 63
       xp: 186
       materials:
         - item_name: Green dragon leather
-          item_id: 1745
           quantity: 3
         - item_name: Thread
-          item_id: 1734
           quantity: 1
-      product: Green d'hide body
-      product_id: 1135
-      product_quantity: 1
-      facility: Needle and thread
+      tools:
+        - Needle
+      output_quantity: 1
   related_items:
-    - item_id: 1753
-      item_name: Green dragonhide
+    - item_name: Green dragonhide
       slug: green-dragonhide
       relationship: component
-      description: Raw material
-    - item_id: 1745
-      item_name: Green dragon leather
+      description: Raw material before tanning
+    - item_name: Green dragon leather
       slug: green-dragon-leather
       relationship: component
-      description: Tanned hide
-    - item_id: 1099
-      item_name: Green d'hide chaps
+      description: Tanned hide used in the recipe
+    - item_name: Green d'hide chaps
       slug: green-dhide-chaps
-      relationship: alternative
+      relationship: set-piece
       description: Matching legs
-    - item_id: 1065
-      item_name: Green d'hide vambraces
+    - item_name: Green d'hide vambraces
       slug: green-dhide-vambraces
-      relationship: alternative
+      relationship: set-piece
       description: Matching gloves
-    - item_id: 2499
-      item_name: Blue d'hide body
+    - item_name: Blue d'hide body
       slug: blue-dhide-body
-      relationship: alternative
-      description: Higher tier body
+      relationship: upgrade
+      description: Higher tier (members) body
   about: |-
     | Method | Level | Materials |
     |--------|-------|-----------|
@@ -75,25 +92,23 @@ osrs:
     | Stat | Value |
     |------|-------|
     | Ranged requirement | 40 |
-    | Defence requirement | None |
+    | Defence requirement | 40 |
     | Ranged attack | +15 |
-    | Ranged defence | +40 |
+    | Ranged defence | +35 |
     | Magic defence | +20 |
   market_strategy:
     notes:
-      - First dragonhide body tier
-      - F2P accessible
-      - Popular alch item
-      - Crafting training (186 XP)
-      - High alchemy (4,680 gp)
-      - F2P ranged armor
-      - Budget gear
-      - Best F2P ranged body
-      - 3 leather per body
-      - Popular crafting method
-      - High alch profit potential
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "First dragonhide body tier"
+      - "F2P accessible (requires Dragon Slayer I)"
+      - "Popular alch item (4,680 gp)"
+      - "Crafting training output (186 XP)"
+      - "3 leather per body"
+  trading_tips:
+    - Margins move with green dragon leather supply
+    - Watch high alch profit windows when leather dips
+  history:
+    - date: "2004-03-29"
+      description: "Released with RuneScape 2."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grey-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grey-hat.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Grey hat is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barker's Haberdashery
+      location: Canifis
+      price: 650
+      currency: Coins
+      stock: 2
+  related_items:
+    - item_name: Red hat
+      slug: red-hat
+      relationship: variant
+      description: "Red variant of the Canifis pointed hat."
+    - item_name: Yellow hat
+      slug: yellow-hat
+      relationship: variant
+      description: "Yellow variant of the Canifis pointed hat."
+    - item_name: Teal hat
+      slug: teal-hat
+      relationship: variant
+      description: "Teal variant of the Canifis pointed hat."
+    - item_name: Purple hat
+      slug: purple-hat
+      relationship: variant
+      description: "Purple variant of the Canifis pointed hat."
+  about: "Grey hat is one of five colored pointed hats sold by Barker in Canifis. Originally called 'Hat', it was renamed to Grey hat in December 2014. Provides +3 magic attack and defence with no requirements, making it a low-cost head slot pick for early-magic builds."
+  market_strategy:
+    notes:
+      - "Stock comes from Barker's Haberdashery — shop sink keeps supply available."
+      - "Demand is steady but thin; daily volume around 750 units."
+  trading_tips:
+    - "Buy from Barker at 650 gp to flip when GE price spikes above shop cost."
+    - "Pair with other Canifis robes for fashionscape listings."
+  history:
+    - date: "2004-06-29"
+      description: "Released with Canifis and the Priest in Peril quest area."
+    - date: "2014-12-04"
+      description: "Renamed from 'Hat' to 'Grey hat' for clarity."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-snapdragon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-snapdragon.mdx
@@ -12,68 +12,94 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 11000
-  herb:
-    type: grimy
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: grimy herb
     tier: high
-  herblore:
-    cleaning_level: 59
-    cleaning_xp: 11.8
-    clean_id: 3000
-    clean_name: Snapdragon
-  farming:
-    level: 62
-    seed_id: 5300
-    seed_name: Snapdragon seed
+  properties:
+    release_date: "11 July 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
-      - source: Aberrant spectre
-        source_id: 2927
-        combat_level: 96
+      - source: Kalphite Queen
         quantity: "1"
-        rarity: common
-        members_only: true
+        rarity: uncommon
+      - source: Callisto
+        quantity: "1"
+        rarity: uncommon
+      - source: Venenatis
+        quantity: "1"
+        rarity: uncommon
+      - source: Alchemical Hydra
+        quantity: "1"
+        rarity: rare
+  recipes:
+    - skill: herblore
+      level: 59
+      xp: 11.8
+      materials:
+        - item_name: Grimy snapdragon
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 3000
-      item_name: Snapdragon
+    - item_name: Snapdragon
       slug: snapdragon
       relationship: product
       description: Cleaned version
-    - item_id: 3026
-      item_name: Super restore(3)
+    - item_name: Super restore(3)
       slug: super-restore-3
       relationship: product
-      description: End product
-    - item_id: 223
-      item_name: Red spiders' eggs
+      description: End product after potion brewing
+    - item_name: Red spiders' eggs
       slug: red-spiders-eggs
       relationship: component
-      description: Secondary
-    - item_id: 5300
-      item_name: Snapdragon seed
+      description: Secondary used to make super restore
+    - item_name: Snapdragon seed
       slug: snapdragon-seed
       relationship: component
-      description: Farming seed
+      description: Farming seed source
   about: |-
+    Grimy snapdragon is the unidentified form of the snapdragon herb. Cleaning requires level 59 Herblore and grants 11.8 experience.
+
     | Requirement | Value |
     |-------------|-------|
     | Herblore Level | 59 |
     | XP | 11.8 |
     | Product | Snapdragon |
+
+    Snapdragons are mainly used as the primary ingredient for super restore potions, one of the most valuable utility potions in the game.
   market_strategy:
     notes:
-      - Buy grimy → Clean → Sell
-      - Calculate profit margin
-      - High value herb
-      - Herb cleaning profit
-      - Super restore production
-      - Ironman accounts
-      - Herblore training
-      - Often cheaper than clean
-      - Quick bank cleaning
-      - Check price spread
-      - Super restore demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy grimy, clean, sell for cleaning profit"
+      - "Often cheaper than clean variant due to herblore level gate"
+      - "High-demand herb due to super restore production"
+      - "Check price spread before bulk cleaning"
+      - "Strong choice for herblore training profit"
+  trading_tips:
+    - Cleaning is fast bank XP, batch-clean inventory loads
+    - Watch GE spread between grimy and clean
+    - Stockpile during weekend dips in herb prices
+  history:
+    - date: "12 August 2020"
+      description: "Composting now yields supercompost instead of regular compost."
+    - date: "9 March 2017"
+      description: "Item value increased from 1 to 21 coins."
+    - date: "26 February 2015"
+      description: "Graphics updated, item renamed and made tradeable; \"Identify\" option changed to \"Clean\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-toadflax.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-toadflax.mdx
@@ -12,68 +12,77 @@ osrs:
   lowalch: 7
   highalch: 11
   limit: 13000
-  herb:
-    type: grimy
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: grimy herb
     tier: mid
-  herblore:
-    cleaning_level: 30
-    cleaning_xp: 8
-    clean_id: 2998
-    clean_name: Toadflax
-  farming:
-    level: 38
-    seed_id: 5296
-    seed_name: Toadflax seed
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 30
+      xp: 8
+      materials:
+        - item_name: Grimy toadflax
+          quantity: 1
+      tools: []
+      output_quantity: 1
   drop_table:
     sources:
       - source: Aberrant spectre
-        source_id: 2927
-        combat_level: 96
         quantity: "1"
         rarity: common
-        members_only: true
+      - source: Tree spirit
+        quantity: "1"
+        rarity: 6/128
+      - source: Kalphite Queen
+        quantity: "25 (noted)"
+        rarity: 2/126
   related_items:
-    - item_id: 2998
-      item_name: Toadflax
+    - item_name: Toadflax
       slug: toadflax
       relationship: product
-      description: Cleaned version
-    - item_id: 6687
-      item_name: Saradomin brew(3)
-      slug: saradomin-brew-3
-      relationship: product
-      description: Main product
-    - item_id: 6693
-      item_name: Crushed nest
-      slug: crushed-nest
-      relationship: component
-      description: Secondary
-    - item_id: 5296
-      item_name: Toadflax seed
+      description: Cleaned herb used in agility potions and Saradomin brews
+    - item_name: Toadflax seed
       slug: toadflax-seed
       relationship: component
-      description: Farming seed
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 30 |
-    | XP | 8 |
-    | Product | Toadflax (clean) |
+      description: Seed planted to grow grimy toadflax with 38 Farming
+    - item_name: Saradomin brew(3)
+      slug: saradomin-brew-3
+      relationship: product
+      description: Premier PvM heal made from clean toadflax + crushed nest
+    - item_name: Crushed nest
+      slug: crushed-nest
+      relationship: component
+      description: Secondary ingredient paired with toadflax for brews
+  about: "Grimy toadflax is the uncleaned herb that becomes toadflax once a player with 30+ Herblore identifies it. Toadflax feeds agility potions, antidote+, and most importantly the Saradomin brew supply chain, making this herb a permanent PvM staple."
   market_strategy:
     notes:
-      - Essential for Saradomin brew
-      - High demand from PvM
-      - Consistent value herb
-      - Saradomin brew production
-      - Agility potion demand
-      - Raids and bossing
-      - High-level PvM
-      - Farm runs profitable
-      - 38 Farming required
-      - Sara brew most valuable use
-      - Essential PvM supply
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand tied directly to Saradomin brew consumption at raids"
+      - "Farming runs at 38 Farming produce steady supply pressure"
+      - "Aberrant spectre slayer tasks dump volume that softens spikes"
+  trading_tips:
+    - Stock during Farming run lulls and resell into raid weekends
+    - Pair with crushed nests to lock margin on Sara brew flips
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming skill rework."
+    - date: "2015-02-26"
+      description: "Update: grimy herbs received unique icons for easier identification."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-platebody-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-platebody-0.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 112000
   highalch: 168000
   limit: 15
-  about: "Guthan's platebody 0 is a members-only item in Old School RuneScape. High alchemy value: 168,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: barrows
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure?"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
+    requirements:
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 122
+      slash: 120
+      crush: 107
+      magic: -6
+      ranged: 132
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Barrows reward chest
+        quantity: "1"
+        rarity: 1/2448
+  passive_effects:
+    - name: Guthan's set effect
+      description: "While wearing the complete Guthan the Infested set, successful melee attacks have a 25% chance to heal the wearer for the damage dealt."
+  related_items:
+    - item_name: Guthan's platebody
+      slug: guthan-s-platebody
+      relationship: variant
+      description: Fully charged platebody before degradation
+    - item_name: Guthan's helm
+      slug: guthan-s-helm
+      relationship: set-piece
+      description: Matching Guthan's helm set piece
+    - item_name: Guthan's chainskirt
+      slug: guthan-s-chainskirt
+      relationship: set-piece
+      description: Matching Guthan's chainskirt set piece
+    - item_name: Guthan's warspear
+      slug: guthan-s-warspear
+      relationship: set-piece
+      description: Matching Guthan's warspear set piece
+  about: |-
+    > *"Guthan the Infested's platebody armour."*
+
+    Guthan's platebody 0 is the fully degraded variant of Guthan's platebody, members-only Barrows armour for Guthan the Infested. It needs to be repaired before being equipped: when equipped with the rest of Guthan's set, successful melee attacks have a 25% chance to heal the wearer for damage dealt.
+
+    The platebody is obtained from the Barrows reward chest at a 1/2,448 rate. Repair cost is 90,000 coins at an NPC armour stand or reduced by Smithing using the formula "Cost × (1 − Smithing÷200)". The "0" suffix indicates the armour has fully degraded after 15 combat hours of use.
+  market_strategy:
+    notes:
+      - "Demand follows AFK Slayer and Barrows healing combos."
+      - "Spreads between charged and 0-charge plates open repair arbitrage."
+      - "Buy limit of 15 per 4 hours suits mid-scale flipping."
+  trading_tips:
+    - Repair at high Smithing for cheaper armour-stand resets, then resell as charged.
+    - Track Barrows minigame engagement after content drops for supply spikes.
+  history:
+    - date: "2005-05-09"
+      description: "Released with the original Barrows minigame and Guthan the Infested brother."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-2.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Guthix balance(2) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2006-03-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Used against frozen Vampyre Juveniles and Juvinates: 16% chance to destroy, 16% chance to turn feral, 68% chance to return them to human form."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 22
+      xp: 25
+      materials:
+        - item_name: Guthix balance(3)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Guthix balance(1)
+      slug: guthix-balance-1
+      relationship: variant
+      description: One-dose version of the potion.
+    - item_name: Silver dust
+      slug: silver-dust
+      relationship: component
+      description: Required secondary ingredient added to finish the potion.
+    - item_name: Harralander potion (unf)
+      slug: harralander-potion-unf
+      relationship: component
+      description: Unfinished base used for restore and Guthix balance potions.
+  about: "Guthix balance is a modified restore potion brewed for the Myreque storyline. Once a player freezes a vampyre with the Rod of Ivandis or a similar weapon, drinking and applying Guthix balance may destroy, neutralise, or restore the target to human form."
+  market_strategy:
+    notes:
+      - "Demand tracks Myreque/Sins of the Father questing volume"
+      - "Silver dust supply gates the production rate"
+      - "Low GE volume means thin order books and slow flips"
+  trading_tips:
+    - Stockpile during quest reruns or seasonal Myreque events
+    - Convert higher-dose variants when (2) lags in price
+  history:
+    - date: "2006-03-22"
+      description: "Introduced alongside In Aid of the Myreque."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-3.mdx
@@ -12,12 +12,79 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Guthix balance(3) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2006-03-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Used on frozen Vampyre Juveniles or Juvinates: 16% chance to destroy, 68% chance to revert to human, 16% chance to enrage to feral."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 22
+      xp: 25
+      materials:
+        - item_name: Guthix balance (unf)
+          quantity: 1
+        - item_name: Silver dust
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  related_items:
+    - item_name: Guthix balance(4)
+      slug: guthix-balance-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Guthix balance(2)
+      slug: guthix-balance-2
+      relationship: variant
+      description: 2-dose version
+    - item_name: Guthix balance(1)
+      slug: guthix-balance-1
+      relationship: variant
+      description: 1-dose version
+    - item_name: Silver dust
+      slug: silver-dust
+      relationship: component
+      description: Final mix component
+  about: |-
+    Guthix balance is a Herblore potion used exclusively against frozen Vampyre Juveniles and Juvinates in the Myreque storyline. Each dose has a 16% chance to destroy the vampyre, 68% to revert it to a human, and 16% to transform it into a feral vampyre.
+
+    Brewed at 22 Herblore (partial completion of In Aid of the Myreque required), yielding 25 Herblore XP per dose. Cannot be consumed by players.
+  market_strategy:
+    notes:
+      - "Demand tied to the Myreque quest series and slayer-adjacent vampyre kills"
+      - "Buy limit 2,000 keeps the market shallow"
+      - "Doses convert via decanting NPCs — cross-check 3/4 dose pricing"
+  trading_tips:
+    - Decant 4-dose into 3-dose if margin favours the smaller size
+    - Buy in bulk before quest streamers feature Darkness of Hallowvale
+  history:
+    - date: "2006-03-22"
+      description: "Released with the In Aid of the Myreque quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-platelegs.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Guthix platelegs is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: variant
+      description: Untrimmed base item with the same defensive stats
+    - item_name: Guthix platebody
+      slug: guthix-platebody
+      relationship: set-piece
+      description: Matching Guthix-themed torso
+    - item_name: Guthix plateskirt
+      slug: guthix-plateskirt
+      relationship: variant
+      description: Skirt counterpart with identical stats
+    - item_name: Guthix full helm
+      slug: guthix-full-helm
+      relationship: set-piece
+      description: Matching headpiece in the Guthix god set
+    - item_name: Guthix kiteshield
+      slug: guthix-kiteshield
+      relationship: set-piece
+      description: Matching shield in the Guthix god set
+  about: "Guthix platelegs are the green god-aligned cosmetic variant of rune platelegs, rewarded from Hard Treasure Trails at a 1/1,625 rate from the reward casket. They share rune platelegs' defensive stats and additionally grant +1 Prayer, making them a cheap mid-tier prayer leg option. As free-to-play loot they remain a popular vanity choice for Guthix fans and god-themed transmog sets."
+  market_strategy:
+    notes:
+      - "Pure cosmetic + minor prayer bonus, so demand tracks Treasure Trail completions"
+      - "Tiny 8-per-4-hour buy limit causes large percentage swings on small flips"
+      - "Storable in the costume room, reducing long-term resale supply"
+  trading_tips:
+    - Watch reward casket logs for Hard clue spikes that push supply higher
+    - Pair with other Guthix pieces to flip the full set during god-event hype
+  history:
+    - date: "2004-05-05"
+      description: "Introduced as a Treasure Trails Hard clue reward alongside the rest of the god platelegs."
+    - date: "2014-03-06"
+      description: "Updated to grant +1 Prayer bonus, separating it stat-wise from plain rune platelegs."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-2.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 3
   highalch: 5
   limit: 2000
-  about: "Hunter potion(2) is a members-only item in Old School RuneScape. High alchemy value: 5 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: Boosts Hunter level by 3.
+        duration: 360
+  recipes:
+    - skill: herblore
+      level: 53
+      xp: 120
+      materials:
+        - item_name: Avantoe potion (unf)
+          quantity: 1
+        - item_name: Kebbit teeth dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Hunter potion(1)
+      slug: hunter-potion-1
+      relationship: variant
+      description: Single-dose variant
+    - item_name: Hunter potion(3)
+      slug: hunter-potion-3
+      relationship: variant
+      description: Three-dose variant
+    - item_name: Hunter potion(4)
+      slug: hunter-potion-4
+      relationship: variant
+      description: Full four-dose variant
+  about: |-
+    Hunter potion(2) contains two doses of Hunter potion. Each dose boosts the Hunter skill by 3 levels temporarily, useful for catching kebbits, chinchompas, and other Hunter creatures slightly above the player's base level.
+
+    Created at 53 Herblore by combining an avantoe potion (unf) with kebbit teeth dust, granting 120 Herblore XP per potion.
+  market_strategy:
+    notes:
+      - "Demand spikes with hunter content and bossing prep"
+      - "Made from gathering-tier ingredients - margin tied to herb prices"
+      - "2-dose variant has lower volume than (3) and (4)"
+  trading_tips:
+    - Decant to (4) for higher unit price when the gap widens
+    - Watch avantoe price as input cost driver
+    - Useful for hunters pushing chinchompa requirements
+  history:
+    - date: "2006-11-21"
+      description: "Item released with the Hunter skill."
+    - date: "2016-04-15"
+      description: "Half-full potions could now be turned into bank placeholders."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-3.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 2000
-  about: "Hunter potion(3) is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily boosts Hunter level by 3."
+        duration: 360
+  recipes:
+    - skill: herblore
+      level: 53
+      xp: 130
+      materials:
+        - item_name: Avantoe potion (unf)
+          quantity: 1
+        - item_name: Kebbit teeth dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Hunter potion(4)
+      slug: hunter-potion-4
+      relationship: variant
+      description: "Full 4-dose version."
+    - item_name: Hunter potion(2)
+      slug: hunter-potion-2
+      relationship: variant
+      description: "2-dose version after one sip."
+    - item_name: Hunter potion(1)
+      slug: hunter-potion-1
+      relationship: variant
+      description: "1-dose version after three sips."
+    - item_name: Avantoe potion (unf)
+      slug: avantoe-potion-unf
+      relationship: component
+      description: "Unfinished base for Hunter potions."
+    - item_name: Kebbit teeth dust
+      slug: kebbit-teeth-dust
+      relationship: component
+      description: "Secondary ingredient ground from kebbit teeth."
+  about: "Hunter potion(3) temporarily boosts the Hunter skill by 3 levels. Useful for catching creatures slightly above your level, like reaching a higher kebbit or chinchompa tier. Made at level 53 Herblore by combining an avantoe potion (unf) with kebbit teeth dust."
+  market_strategy:
+    notes:
+      - "Demand spikes around Hunter level milestones (e.g., 80 for red chinchompas, 73 for chinchompas)."
+      - "Cheaper than the 4-dose per dose in some market conditions; arbitrage by decanting."
+  trading_tips:
+    - "Decant 3-dose into 4-dose if the per-dose price is favourable."
+    - "Stock up before bossing trips that rely on Hunter-level checks."
+  history:
+    - date: "2006-11-21"
+      description: "Released with the Hunter skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-hauberk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-hauberk.mdx
@@ -12,77 +12,99 @@ osrs:
   lowalch: 400000
   highalch: 600000
   limit: 8
+  material:
+    type: melee armour
+    tier: high
+  properties:
+    release_date: "2020-02-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: melee armour
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 9.979
     requirements:
       strength: 70
       defence: 30
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 71
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 4
+    attack_bonus:
+      stab: -3
+      slash: -3
+      crush: 12
+      magic: -11
+      ranged: -10
+    defence_bonus:
+      stab: 67
+      slash: 55
+      crush: 71
+      magic: 0
+      ranged: 35
+    other_bonus:
+      melee_strength: 4
       ranged_strength: 0
       magic_damage: 0
-      prayer: 0
-  obtaining:
-    - source: The Nightmare
-      drop_rate: 1/420
-    - source: Phosani's Nightmare
-      drop_rate: 1/700
-  set_bonus:
-    name: Inquisitor's Set
-    per_piece: +0.5% accuracy and damage (crush style)
-    full_set: +2.5% accuracy and damage
-    full_set_with_mace: +7.5% accuracy and damage
+      prayer: 2
+  drop_table:
+    sources:
+      - source: The Nightmare
+        quantity: "1"
+        rarity: 1/420 to 1/240.1 (scales with team size)
+      - source: Phosani's Nightmare
+        quantity: "1"
+        rarity: 1/700
+  passive_effects:
+    - name: Inquisitor's set bonus
+      description: "+0.5% accuracy and damage on crush attacks per piece. Full set grants +2.5%; full set worn with the Inquisitor's mace grants +7.5%."
   related_items:
-    - item_id: 24417
-      item_name: Inquisitor's mace
+    - item_name: Inquisitor's mace
       slug: inquisitors-mace
-      relationship: alternative
-      description: Set weapon for maximum bonus
-    - item_id: 24421
-      item_name: Inquisitor's plateskirt
+      relationship: set-piece
+      description: Set weapon that triples the full-set crush bonus.
+    - item_name: Inquisitor's plateskirt
       slug: inquisitors-plateskirt
-      relationship: alternative
-      description: Set legs piece
-    - item_id: 24419
-      item_name: Inquisitor's great helm
+      relationship: set-piece
+      description: Legs piece of the Inquisitor's set.
+    - item_name: Inquisitor's great helm
       slug: inquisitors-great-helm
+      relationship: set-piece
+      description: Helm piece of the Inquisitor's set.
+    - item_name: Bandos chestplate
+      slug: bandos-chestplate
       relationship: alternative
-      description: Set helm piece
+      description: Common melee body slot alternative without the crush bias.
   about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Strength | +4 |
+    Inquisitor's hauberk is the chest piece of the Inquisitor's set, dropped by The Nightmare and Phosani's Nightmare. It provides exceptional crush defence (+71) and +4 Strength, making it the best-in-slot body for crush-focused setups against monsters with stab/slash weak combat triangles.
 
-    | Defence | Bonus |
-    |---------|-------|
-    | Crush | +71 |
+    Combined with the rest of the Inquisitor's set, it grants a stacking accuracy and damage bonus on crush attacks. The bonus is +0.5% per piece, +2.5% for the full three-piece set, and +7.5% when the full set is paired with the Inquisitor's mace.
 
-    Crush Bonus:
-    - +0.5% accuracy and damage (crush style)
-    - +2.5% with full set
-    - +7.5% with full set + mace
-
-    BiS for:
-    - Crush-focused setups
-    - Tekton
-    - Cerberus
-
-    Part of Inquisitor set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Primary uses include Tekton at Chambers of Xeric, Cerberus, and other monsters with crush weaknesses.
+  market_strategy:
+    notes:
+      - "BiS for crush damage setups (Tekton, Cerberus)"
+      - "Demand tied to The Nightmare's group raid popularity"
+      - "Long-term price stability above 600k alch floor due to high alch backstop"
+      - "Mace synergy (full set + mace = 7.5%) drives bundle pricing"
+      - "Buy limit 8 supports modest flipping in 10M+ ranges"
+  history:
+    - date: "2020-02-06"
+      description: "Added as a drop from The Nightmare."
+    - date: "2020-04-16"
+      description: "Set effect added: per-piece, full-set, and full-set-with-mace crush bonuses."
+    - date: "2024-05-08"
+      description: "Inquisitor's mace synergy buffed, tripling the bonus when worn with the full set."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-claws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron claws | OSRS Price Data
-description: "Iron claws: A set of fighting claws.. High alch: 30 GP, GE limit: 125."
+description: "Iron claws: A set of fighting claws. Two-handed iron melee weapon usable from level 1 Attack. High alch: 30 GP, GE limit: 125."
 osrs:
   id: 3096
   name: Iron claws
@@ -12,9 +12,97 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 125
-  about: "Iron claws is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2004-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: claws
+    attack_speed: 4
+    weight: 0.907
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 4
+      slash: 6
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 28
+      xp: 50
+      materials:
+        - item_name: Iron bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Martin Thwait's Lost and Found
+      location: Rogues' Den
+      price: 50
+      currency: Coins
+      stock: 5
+  drop_table:
+    sources:
+      - source: Hermit crab
+        quantity: "1"
+        rarity: Rare
+  related_items:
+    - item_name: Bronze claws
+      slug: bronze-claws
+      relationship: downgrade
+      description: Lowest-tier claw weapon.
+    - item_name: Steel claws
+      slug: steel-claws
+      relationship: upgrade
+      description: Next tier up of claws.
+    - item_name: Mithril claws
+      slug: mithril-claws
+      relationship: upgrade
+      description: Mid-tier claws progression.
+  about: "Iron claws are a two-handed melee weapon unlocked after completing the Death Plateau quest. They require 28 Smithing to craft from two iron bars and grant 50 Smithing XP. They sit one tier above bronze and one below steel in the claw progression."
+  market_strategy:
+    notes:
+      - "Niche demand from Smithing levellers and claw collectors; 125 buy limit caps flips."
+      - "Rogues' Den shop stock provides a price floor near base value."
+  trading_tips:
+    - Snipe under 50 gp using Martin Thwait's shop as a hedge.
+    - Smithing crafters use them to push past low Smithing levels.
+  history:
+    - date: "2004-08-09"
+      description: "Iron claws released alongside other claw variants when Death Plateau launched."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-crossbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-crossbow-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron crossbow (u) | OSRS Price Data
-description: "Iron crossbow (u): An unstrung iron crossbow.. High alch: 73 GP, GE limit: 10,000."
+description: "Iron crossbow (u): An unstrung iron crossbow. High alch: 73 GP, GE limit: 10,000."
 osrs:
   id: 9457
   name: Iron crossbow (u)
@@ -12,9 +12,66 @@ osrs:
   lowalch: 49
   highalch: 73
   limit: 10000
-  about: "Iron crossbow (u) is a members-only item in Old School RuneScape. High alchemy value: 73 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 39
+      xp: 44
+      materials:
+        - item_name: Willow stock
+          quantity: 1
+        - item_name: Iron crossbow limbs
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Iron crossbow
+      slug: iron-crossbow
+      relationship: product
+      description: Strung version (add crossbow string)
+    - item_name: Willow stock
+      slug: willow-stock
+      relationship: component
+      description: Stock used for crafting
+    - item_name: Iron crossbow limbs
+      slug: iron-crossbow-limbs
+      relationship: component
+      description: Limbs attached to the stock
+  about: "Iron crossbow (u) is the unstrung intermediate in the Iron crossbow Fletching recipe. Combine a willow stock with iron limbs at Fletching 39, then attach a crossbow string for 22 XP to finish."
+  market_strategy:
+    notes:
+      - "Crafting intermediate; demand driven by Fletching trainers"
+      - "Low margin per unit, high volume buy limit (10,000)"
+      - "High alch barely above value (73 gp)"
+  trading_tips:
+    - Buy in bulk when Fletching skillers flip willow stocks
+    - Margins move with iron limbs supply
+  history:
+    - date: "2014-12-08"
+      description: "Renamed from \"Iron c'bow (u)\" to current name."
+    - date: "2015-09-21"
+      description: "Can now be crafted with boosted Fletching levels."
+    - date: "2021-07-14"
+      description: "Female player animation adjusted for proper positioning."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-hull-parts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ironwood hull parts | OSRS Price Data
-description: "Ironwood hull parts: Parts for creating an ironwood hull for a boat.. High alch: 7,500 GP, GE limit: 100."
+description: "Ironwood hull parts: Parts for creating an ironwood hull for a boat. High alch: 7,500 GP, GE limit: 100."
 osrs:
   id: 32056
   name: Ironwood hull parts
@@ -12,9 +12,61 @@ osrs:
   lowalch: 5000
   highalch: 7500
   limit: 100
-  about: "Ironwood hull parts is a members-only item in Old School RuneScape. High alchemy value: 7,500 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ironwood
+    tier: mid-high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: construction
+      level: 77
+      xp: 437.5
+      materials:
+        - item_name: Ironwood plank
+          quantity: 5
+      tools:
+        - Saw
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Ironwood plank
+      slug: ironwood-plank
+      relationship: component
+      description: Five planks craft into one set of hull parts at the shipwrights' workbench.
+    - item_name: Large ironwood hull parts
+      slug: large-ironwood-hull-parts
+      relationship: upgrade
+      description: Five sets of hull parts combine into the large variant.
+    - item_name: Ironwood hull
+      slug: ironwood-hull
+      relationship: product
+      description: Ten hull parts plus nails, swamp tar, and cupronickel bars assemble the skiff hull.
+  about: "Ironwood hull parts are a mid-tier Construction component used at the shipwrights' workbench to assemble boats. Each set requires level 77 Construction and consumes five ironwood planks, feeding either directly into an ironwood hull (skiff) or into the larger ironwood hull parts subassembly used for sloops."
+  market_strategy:
+    notes:
+      - "Pure Construction sink; demand scales with shipwrighting activity."
+      - "Profit per craft is negative at current ironwood plank prices - market clears via player demand for hulls, not arbitrage."
+      - "437.5 XP per craft makes this a sustained drain for 77+ Construction trainers."
+      - "Hotfix on launch halved shipwrights' workbench XP; check for follow-up balance changes before bulk hoarding."
+  trading_tips:
+    - Watch ironwood plank price - it dominates the recipe cost.
+    - Bulk demand spikes when new ship hulls or boats are introduced.
+  history:
+    - date: "2025-11-19"
+      description: "Released with the shipwrighting Construction expansion. Same-day hotfix halved workbench XP."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ironwood-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ironwood sapling | OSRS Price Data
-description: "Ironwood sapling: This sapling is ready to be replanted in a tree patch.. High alch: 1 GP."
+description: "Ironwood sapling: This sapling is ready to be replanted in a tree patch. Sailing-update Farming sapling for the ironwood hardwood tree."
 osrs:
   id: 31505
   name: Ironwood sapling
@@ -12,9 +12,57 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Ironwood sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 80
+      xp: 145
+      materials:
+        - item_name: Ironwood seedling (w)
+          quantity: 1
+      tools:
+        - Gardening trowel
+        - Watering can
+      output_quantity: 1
+  related_items:
+    - item_name: Ironwood seed
+      slug: ironwood-seed
+      relationship: component
+      description: Planted in a filled plant pot to grow the sapling.
+    - item_name: Ironwood logs
+      slug: ironwood-logs
+      relationship: product
+      description: Harvested from the mature ironwood tree.
+    - item_name: Plant pot (filled)
+      slug: plant-pot-filled
+      relationship: component
+      description: Needed alongside the seed and trowel.
+  about: "Ironwood sapling is created by planting an ironwood seed in a filled plant pot and watering it; once mature it can be planted in a hardwood tree patch at level 80 Farming for 145 XP (20,380 XP when fully grown). Curry leaves protect the patch from disease."
+  market_strategy:
+    notes:
+      - "Pricing is tightly tied to ironwood seed supply from Sailing content."
+      - "Demand pulses when high-level hardwood Farming methods are profitable."
+  trading_tips:
+    - Convert seeds to saplings in bulk when the spread is positive.
+    - Watch new Sailing patches and rebalances that may shift seed drop rates.
+  history:
+    - date: "2025-11-19"
+      description: "Ironwood sapling added with the Sailing update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-sand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-sand.mdx
@@ -12,45 +12,58 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 5
-  item:
+  material:
     type: jar
+    tier: high
+  properties:
+    release_date: "2014-12-18"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.02
-  obtaining:
-    methods:
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to destroy this jar?"
+  drop_table:
+    sources:
       - source: Kalphite Queen
-        drop_rate: 1/2,000
-  usage:
-    description: Decoration for Achievement Gallery boss lair display
-    requirements: Defeating Kalphite Queen at least once to place
-    cosmetic: true
+        quantity: "1"
+        rarity: 1/2000
   related_items:
-    - item_id: 12647
-      item_name: Kalphite princess
+    - item_name: Kalphite princess
       slug: kalphite-princess
       relationship: alternative
-      description: KQ pet
-    - item_id: 7158
-      item_name: Dragon 2h sword
+      description: Pet drop from the Kalphite Queen
+    - item_name: Dragon 2h sword
       slug: dragon-2h-sword
       relationship: alternative
-      description: KQ drop
+      description: Notable rare drop from the Kalphite Queen
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Jar |
-    | Tradeable | Yes |
-    | Weight | 0.02 kg |
-    | Requirements | None |
+    > *"It's just a jar of sand."*
 
-    Decoration for Achievement Gallery boss lair display.
+    The jar of sand is a members-only collectible dropped exclusively by the Kalphite Queen at a 1/2,000 rate. Players can place the jar on a boss lair display inside the Achievement Gallery of their player-owned house to commemorate defeating the Kalphite Queen.
 
-    Requires defeating Kalphite Queen at least once to place.
-
-    Cosmetic/collectible item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    An easter egg lets players use the jar of sand on a jar of dirt, swapping their contents while a bucket of sand sound effect plays. The item is highly sought after by collectors and ironmen pursuing the Achievement Gallery display.
+  market_strategy:
+    notes:
+      - "Driven entirely by Kalphite Queen kill volume and collection-log demand."
+      - "Supply is sparse with the 1/2,000 drop rate so prices spike quickly when demand rises."
+      - "Buy limit of 5 per 4 hours makes flipping low-volume but possible during dips."
+  trading_tips:
+    - Watch GE volume on weekly resets when collectors push prices.
+    - Consider stocking before Leagues or Deadman events that revive KQ activity.
+  history:
+    - date: "2014-12-18"
+      description: "Released alongside the Achievement Gallery boss lair displays."
+    - date: "2024-09"
+      description: "Inventory icon refreshed to match the modern jar art style."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/khazard-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/khazard-teleport-tablet.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Khazard teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport-tablet
+    tier: low
+  properties:
+    release_date: "2020-09-30"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 78
+      xp: 76
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Water rune
+          quantity: 4
+        - item_name: Astral rune
+          quantity: 2
+      tools:
+        - Lunar lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Base material for teleport tablet creation.
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Required rune for lunar teleport tablets.
+    - item_name: Astral rune
+      slug: astral-rune
+      relationship: component
+      description: Required rune for lunar spellbook magic.
+  about: "The Khazard teleport tablet teleports the user to Port Khazard, near the Combat Training Camp and east of Tree Gnome Village. Created at a lunar lectern with 78 Magic on the Lunar spellbook, it is a convenient consumable for ranged and slayer task travel."
+  market_strategy:
+    notes:
+      - "High volume makes flipping easy at scale"
+      - "Profitable to craft via lunar lectern as a Magic XP method"
+      - "Buy limit increased from 100 to 10,000 boosts liquidity"
+  trading_tips:
+    - Stock up when Magic training is incentivised by updates
+    - Flip during weekend slayer task volume spikes
+  history:
+    - date: "2020-09-30"
+      description: "Introduced as part of the Lunar teleport tablets update."
+    - date: "2020-10-07"
+      description: "Became tradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/knife.mdx
@@ -1,6 +1,6 @@
 ---
 title: Knife | OSRS Price Data
-description: "Knife: A dangerous looking knife.. High alch: 3 GP, GE limit: 40."
+description: "Knife: A dangerous looking knife. High alch: 3 GP, GE limit: 40."
 osrs:
   id: 946
   name: Knife
@@ -12,13 +12,64 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 40
-  related_items: []
-  about: |-
-    > _"A relatively small knife."_
-
-    The knife is a utility tool used in Crafting (cutting leather, stringing bows) and Fletching (making arrow shafts from logs). One of the most essential tools alongside the tinderbox and chisel.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Bob's Brilliant Axes
+      location: Lumbridge
+      price: 80
+      currency: Coins
+      stock: 5
+    - shop_name: Trader Stan's Trading Post
+      location: Karamja
+      price: 80
+      currency: Coins
+      stock: 5
+    - shop_name: Ardougne Spice Stall
+      location: East Ardougne
+      price: 80
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Tinderbox
+      slug: tinderbox
+      relationship: alternative
+      description: Companion utility tool for Firemaking
+    - item_name: Chisel
+      slug: chisel
+      relationship: alternative
+      description: Companion utility tool for Crafting
+  about: |
+    The knife is a fundamental utility tool used in Fletching (for cutting logs into arrow shafts) and Crafting (for cutting leather and stringing bows). It also cuts webs in Stronghold-style passages and is essential for Hunter trap setup. A free knife spawns in a sack near the Mage Arena bank lever if you arrive without one.
+  market_strategy:
+    notes:
+      - "Buy limit of 40 caps speculative flipping"
+      - "Shop-bought price often beats GE"
+      - "Steady but slow demand from low-level fletchers"
+  trading_tips:
+    - Cheaper to buy from general stores than the GE
+    - Bob's Brilliant Axes in Lumbridge restocks reliably
+    - Used in early Hunter, Fletching, and Crafting tasks
+  history:
+    - date: "2001-01-04"
+      description: "Knife added as a multi-skill utility tool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leaping-sturgeon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leaping-sturgeon.mdx
@@ -1,6 +1,6 @@
 ---
 title: Leaping sturgeon | OSRS Price Data
-description: "Leaping sturgeon: A bloated sturgeon.. High alch: 2 GP, GE limit: 13,000."
+description: "Leaping sturgeon: A bloated sturgeon. High-level Barbarian Fishing catch that can be gutted into caviar and fish offcuts. High alch: 2 GP, GE limit: 13,000."
 osrs:
   id: 11332
   name: Leaping sturgeon
@@ -12,9 +12,72 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  about: "Leaping sturgeon is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 15
+      materials:
+        - item_name: Leaping sturgeon
+          quantity: 1
+        - item_name: Knife
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Barbarian Fishing (Otto's Grotto)
+        quantity: "1"
+        rarity: Always (70 Fishing, 45 Strength, 45 Agility)
+      - source: Barbarian Fishing (Mount Quidamortem)
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Caviar
+      slug: caviar
+      relationship: product
+      description: Gutted from sturgeon with a knife.
+    - item_name: Fish offcuts
+      slug: fish-offcuts
+      relationship: product
+      description: Secondary product when gutting sturgeon.
+    - item_name: Leaping salmon
+      slug: leaping-salmon
+      relationship: alternative
+      description: Lower-tier Barbarian Fishing catch.
+    - item_name: Leaping trout
+      slug: leaping-trout
+      relationship: alternative
+      description: Entry-tier Barbarian Fishing catch.
+  about: "Leaping sturgeon is caught from Barbarian Fishing spots using a barbarian rod with appropriate bait. It cannot be cooked, but using a knife on it gives caviar (chance scaling with Cooking level) plus fish offcuts and 15 Cooking XP. Catching requires 70 Fishing, 45 Strength, and 45 Agility."
+  market_strategy:
+    notes:
+      - "Supply is locked to high-level Barbarian Fishers; price is sensitive to caviar demand."
+      - "Value was reduced from 75 to 4 in March 2017, anchoring alch to low single digits."
+  trading_tips:
+    - Buy in bulk when caviar/Sulliuscep meta drives caviar prices up.
+    - Convert into caviar yourself for higher margins if you have spare Cooking levels.
+  history:
+    - date: "2007-07-03"
+      description: "Leaping sturgeon added with Barbarian Training fishing."
+    - date: "2017-03-16"
+      description: "Item value reduced from 75 to 4 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leather-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leather-body.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 125
-  about: "Leather body is a free-to-play item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: leather
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -2
+      ranged: 2
+    defence_bonus:
+      stab: 8
+      slash: 9
+      crush: 10
+      magic: 4
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 14
+      xp: 25
+      materials:
+        - item_name: Leather
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+  shops:
+    - shop_name: Thessalia's Fine Clothes
+      location: Varrock
+      price: 21
+      currency: coins
+      stock: 10
+    - shop_name: Aaron's Archery Appendages
+      location: Ranging Guild
+      price: 21
+      currency: coins
+      stock: 10
+  related_items:
+    - item_name: Studded body
+      slug: studded-body
+      relationship: upgrade
+      description: Crafted by adding steel studs at 41 Crafting
+    - item_name: Hardleather body
+      slug: hardleather-body
+      relationship: variant
+      description: Tougher leather torso variant
+  about: "Leather body is the entry-level Ranged torso in Old School RuneScape, available to both free-to-play and members. It requires only level 1 Ranged to wear and is the weakest tradeable Ranged body armour. Crafters can fashion it from a single piece of leather and thread at level 14 Crafting, and it can later be upgraded to a studded body at level 41 Crafting using steel studs."
+  market_strategy:
+    notes:
+      - "Cheap entry-point for new Crafters levelling tanning recipes"
+      - "Steady low-level demand from F2P Rangers and ironmen"
+      - "Often flipped in bulk thanks to the 125 GE limit and tight spread"
+  trading_tips:
+    - List buy orders slightly above shop price to skip Thessalia restocks
+    - Pair with leather chaps and leather cowl for full beginner Ranged kit
+  history:
+    - date: "2001-01-04"
+      description: "Added to the game alongside the original release of Crafting."
+    - date: "2014-03-06"
+      description: "Stats unchanged but armour tooltip reformatted to the modern interface."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/left-eye-patch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/left-eye-patch.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Left eye patch is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "6 July 2016"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.006
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: rare
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Right eye patch
+      slug: right-eye-patch
+      relationship: component
+      description: Pairs with left eye patch to make double eye patch
+    - item_name: Eye patch
+      slug: eye-patch
+      relationship: alternative
+      description: Standard pirate eye patch
+  about: |-
+    Left eye patch is a cosmetic head-slot item rewarded from master Treasure Trails. It provides no combat bonuses.
+
+    It can be combined with a right eye patch and 500 coins via Patchy (after completing Cabin Fever) to create a double eye patch. Storable in the costume room's mahogany treasure chest.
+  market_strategy:
+    notes:
+      - "Rare master clue drop with thin supply"
+      - "Demand driven by fashionscape collectors"
+      - "Strict GE buy limit of 4 per 4 hours caps flips"
+      - "Pair value spikes when right eye patch is also expensive"
+  trading_tips:
+    - Watch double eye patch ingredient costs to time buys
+    - Master clue droughts swing the spread fast
+  history:
+    - date: "6 July 2016"
+      description: "Released as a Treasure Trail reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-mix-2.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Magic mix(2) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: barbarian mix potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: Boosts Magic level by 4.
+        duration: 360
+      - description: Restores 6 Hitpoints per dose.
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 83
+      xp: 57
+      materials:
+        - item_name: Magic potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Magic potion(2)
+      slug: magic-potion-2
+      relationship: component
+      description: Base potion used to brew the barbarian mix
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Secondary ingredient added during mixing
+    - item_name: Magic mix(1)
+      slug: magic-mix-1
+      relationship: variant
+      description: Single-dose variant
+  about: |-
+    Magic mix(2) is a barbarian potion containing two doses of "fishy" Magic potion. Each dose boosts Magic by 4 levels and restores 6 Hitpoints, making it useful during PvM and bossing.
+
+    Created at 83 Herblore by combining a Magic potion(2) with caviar, granting 57 XP per mix. Requires completion of Otto Godblessed's Barbarian Herblore training first.
+  market_strategy:
+    notes:
+      - "HP restore + magic boost - dual utility"
+      - "Tied to caviar supply (Barbarian fishing)"
+      - "High Herblore requirement gates supply"
+      - "Niche bossing demand"
+  trading_tips:
+    - Watch caviar price as primary cost driver
+    - Decant pricing - (4) vs (2) spread can be exploitable
+    - Useful for budget bossing alternative to saradomin brews
+  history:
+    - date: "2007-07-03"
+      description: "Item released with the Barbarian Herblore training update."
+    - date: "2015-10-08"
+      description: "Recoloured to distinguish from Ranging mix potions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-pyre-logs.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 256
   highalch: 384
   limit: 11000
-  about: "Magic pyre logs is a members-only item in Old School RuneScape. High alchemy value: 384 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: pyre logs
+    tier: mid
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 1
+      xp: 20
+      materials:
+        - item_name: Magic logs
+          quantity: 1
+        - item_name: Sacred oil(4)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Magic logs
+      slug: magic-logs
+      relationship: component
+      description: Base log treated with sacred oil to produce pyre logs.
+    - item_name: Sacred oil(4)
+      slug: sacred-oil-4
+      relationship: component
+      description: Coats logs to produce pyre variants in Shades of Mort'ton.
+    - item_name: Yew pyre logs
+      slug: yew-pyre-logs
+      relationship: downgrade
+      description: Lower-tier pyre log used at lower Firemaking levels.
+  about: |-
+    Magic pyre logs are produced by using a Sacred oil(4) on Magic logs at level 1 Firemaking, granting 20 Firemaking XP per log treated. They are the highest-tier pyre log and are used in the Shades of Mort'ton minigame to cremate shade remains.
+
+    Lighting magic pyre logs on a funeral pyre requires level 80 Firemaking and grants 404.5 Firemaking XP per cremation (606.7 XP with Morytania Diary 4). Prayer XP varies based on the type of shade remains burned, ranging from 35.5 to 100 XP per cremation.
+  market_strategy:
+    notes:
+      - "Demand driven by Shades of Mort'ton and Firemaking XP routes"
+      - "Profit from making pyre logs is usually thin — check sacred oil dose price first"
+      - "11,000 buy limit supports high-volume Firemaking strategies"
+      - "Tied closely to magic log and sacred oil supply chains"
+  history:
+    - date: "2004-10-18"
+      description: "Added with the Shades of Mort'ton minigame."
+    - date: "2024-07-31"
+      description: "Sacred oil XP standardised to a flat 5 XP per dose used."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-repair-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-repair-kit.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 1000
   highalch: 1500
   limit: 13000
-  about: "Mahogany repair kit is a members-only item in Old School RuneScape. High alchemy value: 1,500 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Apply
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Plundered salvage
+        quantity: "1"
+        rarity: 1/1036
+      - source: Spined kraken
+        quantity: "1"
+        rarity: 1/109
+  recipes:
+    - skill: construction
+      level: 47
+      xp: 210
+      materials:
+        - item_name: Mahogany plank
+          quantity: 2
+        - item_name: Mithril nails
+          quantity: 10
+        - item_name: Swamp paste
+          quantity: 5
+      tools:
+        - Shipwrights' workbench
+      output_quantity: 2
+  related_items:
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: "Plank consumed when building the kit at a Shipwrights' workbench"
+    - item_name: Mithril nails
+      slug: mithril-nails
+      relationship: component
+      description: "Nails consumed when building the kit"
+    - item_name: Swamp paste
+      slug: swamp-paste
+      relationship: component
+      description: "Paste consumed when building the kit"
+  about: "The mahogany repair kit is a Sailing utility item that heals 30 HP per use on a damaged ship during ship combat. Multiple players can stack applications, making it a staple consumable for Sailing crews. It can be crafted at a Shipwrights' workbench with 47 Construction or dropped from plundered salvage and the spined kraken."
+  market_strategy:
+    notes:
+      - "Construction recipe sets a hard cost floor near material price; sub-cost listings are usually bait"
+      - "Demand scales with active Sailing content participation"
+      - "13k buy limit allows whales to corner short-term supply"
+  trading_tips:
+    - "Track Sailing XP rates after balance patches - repair kit demand follows ship combat hours"
+    - "Use Spined kraken drop rate (1/109) as a supply baseline once it goes live"
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the Shipwrights' workbench; Construction XP from Sailing workbenches halved on the same date"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-blackjack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-blackjack.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 480
   highalch: 720
   limit: 125
-  about: "Maple blackjack is a members-only item in Old School RuneScape. High alchemy value: 720 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2005-08-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: blackjack
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      thieving: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 20
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Pollnivneach
+      price: 1200
+      currency: coins
+      stock: 3
+  related_items:
+    - item_name: Willow blackjack
+      slug: willow-blackjack
+      relationship: upgrade
+      description: Higher tier blackjack for stronger knockout chance
+    - item_name: Oak blackjack
+      slug: oak-blackjack
+      relationship: downgrade
+      description: Lower tier blackjack used before maple
+    - item_name: Maple blackjack(o)
+      slug: maple-blackjack-o
+      relationship: variant
+      description: Offensive variant favouring KO chance
+    - item_name: Maple blackjack(d)
+      slug: maple-blackjack-d
+      relationship: variant
+      description: Defensive variant favouring successful blocks
+  about: "The maple blackjack is the mid-tier knockout weapon used for blackjacking bandits in Pollnivneach. After progressing through The Feud and reaching 30 Thieving, players wield it to knock out menaphite thugs and bandits as part of one of the fastest Thieving training methods available. Unlike standard melee weapons its sole equip stat is +20 strength, since blackjacking interactions resolve through Thieving rolls rather than combat bonuses."
+  market_strategy:
+    notes:
+      - "Niche demand tied to mid-game Thieving training routes"
+      - "Shop stock at Ali's Discount Wares caps natural price ceiling"
+      - "Variant (o) and (d) blackjacks trade more frequently than plain version"
+  trading_tips:
+    - List buy orders below shop value to scoop up resold copies cheap
+    - Pair with the (o) variant flip when Thieving content patches release
+  history:
+    - date: "2005-08-15"
+      description: "Added during The Feud quest update as one of three blackjack tiers."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-pyre-logs.mdx
@@ -12,12 +12,77 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 11000
-  about: "Maple pyre logs is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: log
+    tier: mid
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 1
+      xp: 15
+      materials:
+        - item_name: Maple logs
+          quantity: 1
+        - item_name: Sacred oil(3)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Maple logs
+      slug: maple-logs
+      relationship: component
+      description: Base log
+    - item_name: Sacred oil(3)
+      slug: sacred-oil-3
+      relationship: component
+      description: Oil applied to prepare the pyre log
+    - item_name: Willow pyre logs
+      slug: willow-pyre-logs
+      relationship: downgrade
+      description: Lower-tier pyre log
+    - item_name: Yew pyre logs
+      slug: yew-pyre-logs
+      relationship: upgrade
+      description: Higher-tier pyre log
+  about: |-
+    Maple pyre logs are maple logs treated with three doses of sacred oil for use at the Shades of Mort'ton funeral pyre. They require 50 Firemaking to light at a pyre and grant Firemaking + Prayer XP when used to cremate shade remains.
+
+    Cremation XP yields (Firemaking / Prayer):
+    - Loar remains: 175 / 34
+    - Phrin remains: 175 / 46.5
+    - Riyl remains: 175 / 61.5
+  market_strategy:
+    notes:
+      - "Creation typically runs at a loss; demand is from Shades of Mort'ton runners"
+      - "Sacred oil supply controls cost basis"
+      - "Make-All update (2024-07-31) reduced bottlenecks for prep"
+  trading_tips:
+    - Buy bulk maple logs + sacred oil when both dip; profit only on margin spikes
+    - Better to use yourself for Prayer XP than flip — net loss most weeks
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Shades of Mort'ton minigame."
+    - date: "2024-07-31"
+      description: "Firemaking XP for creation standardised to 5 XP per sacred oil dose and a Make-All menu was added."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-red-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-red-robe.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 150
-  about: "Menaphite red robe is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic robe
+    tier: low
+  properties:
+    release_date: "2005-08-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.005
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Al Kharid
+      price: 40
+      currency: Coins
+      stock: 25
+  passive_effects:
+    - name: Desert heat delay
+      description: Wearing the robe delays the onset of desert heat damage by 12 seconds per equipped Menaphite piece.
+  related_items:
+    - item_name: Menaphite red hat
+      slug: menaphite-red-hat
+      relationship: set-piece
+      description: Matching headpiece in the red Menaphite outfit
+    - item_name: Menaphite red top
+      slug: menaphite-red-top
+      relationship: set-piece
+      description: Matching upper-body piece in the red Menaphite outfit
+    - item_name: Menaphite red kilt
+      slug: menaphite-red-kilt
+      relationship: set-piece
+      description: Matching kilt variant for the bottom slot
+    - item_name: Menaphite purple robe
+      slug: menaphite-purple-robe
+      relationship: variant
+      description: Purple recolour of the same robe worn in Pollnivneach
+  about: "Menaphite red robe is the legwear half of the red Menaphite outfit, the casual Sophanem-themed cosmetic set. Each equipped piece extends the player's desert heat grace timer by 12 seconds, making the set a cheap quality-of-life option for desert questing and clue scrolls."
+  market_strategy:
+    notes:
+      - "Shop-priced at 40 coins, GE often trades slightly above"
+      - "Demand spikes during desert clue and quest waves"
+      - "Heat-delay buff added long-term floor value for skillers"
+  trading_tips:
+    - Restock from Ali's Discount Wares in Al Kharid for cheap GE flips
+    - Stockpile before major desert content releases
+  history:
+    - date: "2005-08-15"
+      description: "Released as part of the Menaphite clothing line."
+    - date: "2014-12-04"
+      description: "Renamed from Menaphite robe to Menaphite red robe to differentiate colour variants."
+    - date: "2023-03-15"
+      description: "Update: granted a 12-second desert heat delay per equipped Menaphite piece."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dagger-p-5692.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dagger-p-5692.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril dagger(p++) | OSRS Price Data
-description: "Mithril dagger(p++): A poisoned Mithril dagger.. High alch: 195 GP, GE limit: 125."
+description: "Mithril dagger(p++): A poisoned Mithril dagger. Stab weapon coated in extra-strong weapon poison for 20+ Attack. High alch: 195 GP, GE limit: 125."
 osrs:
   id: 5692
   name: Mithril dagger(p++)
@@ -12,9 +12,79 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  about: "Mithril dagger(p++) is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2005-02-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.396
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.396
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 11
+      slash: 5
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Mithril dagger
+      slug: mithril-dagger
+      relationship: variant
+      description: Unpoisoned base dagger.
+    - item_name: Mithril dagger(p)
+      slug: mithril-dagger-p-1233
+      relationship: downgrade
+      description: Standard poison variant.
+    - item_name: Mithril dagger(p+)
+      slug: mithril-dagger-p-plus
+      relationship: downgrade
+      description: Strong poison variant.
+    - item_name: Adamant dagger(p++)
+      slug: adamant-dagger-p-plus-plus
+      relationship: upgrade
+      description: Next metal tier of extra-strong poisoned dagger.
+  about: "Mithril dagger(p++) is a stab-class dagger coated in extra-strong weapon poison. It requires 20 Attack to wield and is most commonly used as a starting poisoned weapon for low-level PvP, Slayer trash, or carrying as a cheap poison applicator on alts."
+  market_strategy:
+    notes:
+      - "Sees demand from low-level pures and PK alt accounts running poison."
+      - "Crafted by applying weapon poison(++) to a regular mithril dagger."
+  trading_tips:
+    - Margin against base mithril dagger plus weapon poison(++) cost.
+    - Buy limit is only 125 per 4 hours - flip patiently.
+  history:
+    - date: "2005-02-28"
+      description: "Mithril dagger(p++) added when weapon poison(++) was introduced for upgraded poisoning."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-hasta-p-11405.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-hasta-p-11405.mdx
@@ -12,9 +12,101 @@ osrs:
   lowalch: 338
   highalch: 507
   limit: 125
-  about: "Mithril hasta(p++) is a members-only item in Old School RuneScape. High alchemy value: 507 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 17
+      slash: 17
+      crush: 17
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -5
+      slash: -5
+      crush: -4
+      magic: 0
+      ranged: -5
+    other_bonus:
+      strength: 18
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Mithril hasta
+          quantity: 1
+        - item_name: Weapon poison++
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Strong weapon poison
+      description: "Has a chance to inflict poison damage that starts at six and steps down over time."
+  related_items:
+    - item_name: Mithril hasta
+      slug: mithril-hasta
+      relationship: variant
+      description: Unpoisoned mithril hasta base
+    - item_name: Mithril hasta(p)
+      slug: mithril-hasta-p-1067
+      relationship: variant
+      description: Lightly poisoned mithril hasta variant
+    - item_name: Mithril hasta(p+)
+      slug: mithril-hasta-p-plus
+      relationship: variant
+      description: Mid-strength poisoned mithril hasta variant
+    - item_name: Adamant hasta(p++)
+      slug: adamant-hasta-p-plus-plus
+      relationship: upgrade
+      description: Higher-tier hasta with the same poison strength
+  about: |-
+    > *"A poison-tipped, one-handed mithril hasta."*
+
+    The mithril hasta(p++) is a one-handed spear-type melee weapon poisoned with weapon poison++. It requires level 20 Attack to wield plus the Smithing section of the Barbarian Training miniquest before mithril hastae can be equipped at all.
+
+    With a 4-tick attack speed and balanced Stab, Slash, and Crush bonuses, it is a versatile budget pick for Slayer training where consistent poison damage matters more than burst output.
+  market_strategy:
+    notes:
+      - "Used heavily as a budget Slayer poison-tipped weapon."
+      - "Smithing throughput keeps base hasta supply elevated."
+      - "Buy limit of 125 per 4 hours supports flips around herb XP rushes."
+  trading_tips:
+    - Poison the hasta yourself if weapon poison++ flasks are cheap, then resell.
+    - Watch April rebalance anniversaries for renewed Slayer interest.
+  history:
+    - date: "2007-07-03"
+      description: "Added with the Barbarian Training expansion that introduced mithril hastae."
+    - date: "2021-04"
+      description: "Attack speed improved from 5 ticks to 4 ticks in the melee weapon rebalance."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril javelin(p) | OSRS Price Data
-description: "Mithril javelin(p) is a members weapon slot item requiring 20 Ranged. High alch: 38 GP, GE limit: 7,000."
+description: "Mithril javelin(p) is a members ballista ammunition slot item. High alch: 38 GP, GE limit: 7,000."
 osrs:
   id: 834
   name: Mithril javelin(p)
@@ -12,26 +12,77 @@ osrs:
   lowalch: 25
   highalch: 38
   limit: 7000
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
   equipment:
-    slot: weapon
-    attack_speed: 6
-    requirements:
-      ranged: 20
+    slot: ammo
+    weapon_type: javelin
+    attack_speed: null
+    weight: 0
+    requirements: {}
     attack_bonus:
-      ranged: 17
-    ranged_strength: 49
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 85
+      magic_damage: 0
+      prayer: 0
   related_items:
-    - item_id: 828
-      item_name: Mithril javelin
+    - item_name: Mithril javelin
       slug: mithril-javelin
       relationship: variant
-      description: Unpoisoned version
-  about: |-
-    > _"A mithril tipped javelin with a poisoned tip."_
-
-    A mithril javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Unpoisoned base ammunition.
+    - item_name: Light ballista
+      slug: light-ballista
+      relationship: component
+      description: Ranged weapon that fires mithril javelins.
+    - item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: component
+      description: High-tier ballista that fires mithril javelins.
+  about: "Mithril javelin(p) is the basic-poisoned variant of mithril javelins, used as ammunition for both the light and heavy ballista. The poison deals 2-4 damage over time on a successful hit, supplementing the ballista's strong per-shot ranged damage. Since the May 2016 rework, javelins function exclusively as ammunition rather than throwable weapons."
+  market_strategy:
+    notes:
+      - "Steady ballista ammunition demand; price tracks the broader javelin market."
+      - "7,000 buy limit accommodates bulk supply for PvM consumers."
+      - "Poison variant carries a small premium over the unpoisoned base."
+  trading_tips:
+    - Buy unpoisoned mithril javelins and apply weapon poison for margin if the spread allows.
+    - Demand rises during light ballista training events and PvP focus weekends.
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch."
+    - date: "2016-05-12"
+      description: "Reworked into ballista ammunition; ranged strength bumped from prior value."
+    - date: "2016-10-31"
+      description: "Ranged strength reduced from +100 to +85."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-plateskirt-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-plateskirt-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril plateskirt (g) | OSRS Price Data
-description: "Mithril plateskirt (g): Mithril plateskirt with gold trim.. High alch: 1,560 GP, GE limit: 8."
+description: "Mithril plateskirt (g): Mithril plateskirt with gold trim. Medium clue reward. High alch: 1,560 GP, GE limit: 8."
 osrs:
   id: 12285
   name: Mithril plateskirt (g)
@@ -12,9 +12,89 @@ osrs:
   lowalch: 1040
   highalch: 1560
   limit: 8
-  about: "Mithril plateskirt (g) is a free-to-play item in Old School RuneScape. High alchemy value: 1,560 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 7.257
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 7.257
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -14
+      ranged: -7
+    defence_bonus:
+      stab: 24
+      slash: 22
+      crush: 20
+      magic: -4
+      ranged: 22
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: rare
+  related_items:
+    - item_name: Mithril plateskirt
+      slug: mithril-plateskirt
+      relationship: alternative
+      description: Untrimmed base variant (identical stats)
+    - item_name: Mithril platebody (g)
+      slug: mithril-platebody-g
+      relationship: set-piece
+      description: Matching gold-trimmed body
+    - item_name: Mithril full helm (g)
+      slug: mithril-full-helm-g
+      relationship: set-piece
+      description: Matching gold-trimmed helm
+  about: |-
+    > _"Mithril plateskirt with gold trim."_
+
+    Mithril plateskirt (g) is a cosmetic medium clue scroll reward (drop rate 1/1,133 from medium reward caskets). Stats mirror the standard mithril plateskirt; the gold trim is purely visual. Cannot be smithed.
+  market_strategy:
+    notes:
+      - "Tiny GE limit of 8 per 4 hours"
+      - "Cosmetic medium clue reward"
+      - "Vanity demand from clue grinders"
+  trading_tips:
+    - Camp small buy orders to slowly fill the 8-item limit
+    - Stable price; treat as long-hold collection log piece
+  history:
+    - date: "2014-06-12"
+      description: "Re-added with gold-trim clue rewards."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-top-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-top-g.mdx
@@ -12,28 +12,85 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 4
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 6
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 20202
-      item_name: Monk's robe (g)
+    - item_name: Monk's robe top
+      slug: monks-robe-top
+      relationship: variant
+      description: Standard untrimmed monk's robe top
+    - item_name: Monk's robe (g)
       slug: monks-robe-g
       relationship: set-piece
       description: Matching gold-trimmed monk's robe legs
-    - item_id: 23303
-      item_name: Monk's robe top (t)
+    - item_name: Monk's robe top (t)
       slug: monks-robe-top-t
       relationship: variant
-      description: Trimmed variant
+      description: Trimmed variant of the monk's robe top
   about: |-
     > *"I feel the gods don't enjoy my materialistic obsessions."*
 
-    The monk's robe top (g) is a gold-trimmed cosmetic variant of the monk's robe top. It provides an identical +6 Prayer bonus with no requirements to equip. F2P item. Highly valued due to rarity.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The monk's robe top (g) is the gold-trimmed cosmetic variant of the monk's robe top. It offers the same +6 Prayer bonus with no skill requirements to equip, making it a popular F2P fashionscape pick.
+
+    The robe top drops exclusively from easy clue scroll reward caskets at roughly 1/14,040 and is part of a tradeable set that can be stored in the costume room treasure chest of a player-owned house.
+  market_strategy:
+    notes:
+      - "Easy clue throughput is sky-high so supply is steady but slow per casket."
+      - "F2P-eligible cosmetics command attention during F2P weekends."
+      - "Buy limit of 4 per 4 hours means thin flipping windows."
+  trading_tips:
+    - Bundle with matching legs for set premium pricing.
+    - Stock during easy clue droprate buffs from updates.
+  history:
+    - date: "2016-07-06"
+      description: "Added to easy Treasure Trail reward caskets alongside other gold-trimmed cosmetics."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-mead-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-mead-m.mdx
@@ -1,6 +1,6 @@
 ---
 title: Moonlight mead(m) | OSRS Price Data
-description: "Moonlight mead(m): This looks a good deal stronger than normal Moonlight Mead.. High alch: 3 GP, GE limit: 2,000."
+description: "Moonlight mead(m): This looks a good deal stronger than normal Moonlight Mead. High alch: 3 GP, GE limit: 2,000."
 osrs:
   id: 5749
   name: Moonlight mead(m)
@@ -12,9 +12,53 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 2000
-  about: "Moonlight mead(m) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: Restores 6 Hitpoints when drunk.
+        duration: 0
+  related_items:
+    - item_name: Moonlight mead
+      slug: moonlight-mead
+      relationship: downgrade
+      description: Standard non-mature variant
+    - item_name: Beer glass
+      slug: beer-glass
+      relationship: component
+      description: Used to extract mead from the keg
+  about: |
+    Moonlight mead(m) is the mature variant of moonlight mead, produced as a chance outcome when brewing the standard drink. Players extract it from a brewing keg using a beer glass (one pint per use). Drinking it heals 6 Hitpoints with no other notable stat effects.
+  market_strategy:
+    notes:
+      - "Mature variant chance gates supply"
+      - "Limit 2,000 keeps flips modest"
+      - "Brewing batch yields drive pricing swings"
+  trading_tips:
+    - Always extract with a beer glass for one pint
+    - Brewing the regular variant produces this as a chance drop
+    - 6 HP heal makes it a niche food
+  history:
+    - date: "2005-07-11"
+      description: "Moonlight mead(m) added with the Brewing update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-mead-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-mead-m4.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Moonlight mead(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ale keg
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Mature dose: heals 6 Hitpoints per pint, restoring 24 HP across a full 4-pint keg."
+        duration: 0
+  recipes:
+    - skill: cooking
+      level: 44
+      xp: 0
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Mushroom
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Calquat keg
+          quantity: 2
+      tools: []
+      output_quantity: 2
+  related_items:
+    - item_name: Moonlight mead
+      slug: moonlight-mead
+      relationship: variant
+      description: Standard single-pint version of the mead
+    - item_name: Calquat keg
+      slug: calquat-keg
+      relationship: component
+      description: Container used to bottle and mature 4-pint kegs
+    - item_name: Ale yeast
+      slug: ale-yeast
+      relationship: component
+      description: Brewing secondary needed for any mead in the vat
+    - item_name: Barley malt
+      slug: barley-malt
+      relationship: component
+      description: Processed barley input for the brewing vat
+  about: "Moonlight mead(m4) is the mature 4-pint keg version of the namesake mead. After fermenting for 1-1.5 days in a brewing vat and filling Calquat kegs, drinking a pint heals 6 Hitpoints, making the keg a cheap food-like supply for low-level skillers."
+  market_strategy:
+    notes:
+      - "Effectively a junk-value drink; GE alch values are 1 coin"
+      - "Niche bulk supply for low-level mead collectors"
+      - "Limited brewers feed the supply because mature flag adds time risk"
+  trading_tips:
+    - Treat as flavour content rather than profit; flip only for collector demand
+    - Hold inventory minimal because spoiled brews tank profit
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming and brewing vat expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic robe top | OSRS Price Data
-description: "Mystic robe top is a members body slot item requiring 20 Defence. High alch: 72,000 GP, GE limit: 125."
+description: "Mystic robe top is a members body slot item requiring 40 Magic and 20 Defence. +20 magic attack. High alch: 72,000 GP, GE limit: 125."
 osrs:
   id: 4091
   name: Mystic robe top
@@ -12,8 +12,34 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mystic
+    tier: mid
+  properties:
+    release_date: "2005-01-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      magic: 40
+      defence: 20
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,60 +57,57 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 40
-      defence: 20
+  drop_table:
+    sources:
+      - source: Kraken
+        quantity: "1"
+        rarity: 1/128
+      - source: Corporeal Beast
+        quantity: "1"
+        rarity: 18/512
+      - source: Callisto
+        quantity: "1"
+        rarity: 2/126
+      - source: Vet'ion
+        quantity: "1"
+        rarity: 2/126
+  shops:
+    - shop_name: Wizards' Guild Magic Store
+      location: Yanille
+      price: 120000
+      currency: Coins
+      stock: 2
   related_items:
-    - item_id: 4101
-      item_name: Mystic robe top (dark)
+    - item_name: Mystic robe top (dark)
       slug: mystic-robe-top-dark
       relationship: variant
-      description: Dark recolor (same stats)
-    - item_id: 4093
-      item_name: Mystic robe bottom
+      description: Dark recoloured cosmetic variant with identical stats
+    - item_name: Mystic robe bottom
       slug: mystic-robe-bottom
       relationship: set-piece
-      description: Matching leg piece
+      description: Matching leg piece in the mystic set
+    - item_name: Ahrim's robetop
+      slug: ahrims-robetop
+      relationship: upgrade
+      description: Higher-tier 70 Magic/70 Defence top with +30 magic attack
   about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +20 |
+    > *"The upper half of a magical robe."*
 
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +20 |
+    The mystic robe top is the body piece of the mystic robes set, providing +20 magic attack and +20 magic defence at only 40 Magic and 20 Defence. It is the standard mid-game magic body slot before progressing to Ahrim's, Infinity, or Ancestral.
 
-    Requirements: 40 Magic, 20 Defence
-
-    | Variant | Source | Stats |
-    |---------|--------|-------|
-    | Mystic robe top (blue) | Slayer monsters, shops | Identical |
-    | Mystic robe top (dark) | Slayer monsters | Identical |
-    | Mystic robe top (light) | Aberrant spectres | Identical |
-    | Mystic robe top (dusk) | Hallowed Sepulchre | Identical |
-
-    All variants share identical stats — the difference is purely cosmetic. Dark and dusk variants trade at a premium for fashionscape.
-
-    | Stat | Mystic Top | Splitbark Body | Ahrim's Robetop | Infinity Top |
-    |------|-----------|----------------|-----------------|-------------|
-    | Magic Atk | +20 | +10 | +30 | +22 |
-    | Stab Def | 0 | +36 | 0 | 0 |
-    | Magic Def | +20 | +15 | +30 | +22 |
-    | Req | 40 Mage/20 Def | 40 Mage/40 Def | 70 Mage/70 Def | 50 Mage/25 Def |
-
-    The mystic robe top offers the best magic bonus at 40 Magic without requiring significant Defence. Splitbark trades magic power for melee defence.
-
-    - Standard magic top for Barrows runs
-    - Budget magic gear for Slayer tasks
-    - Common PKing item (cheap to risk)
-    - Stepping stone before Ahrim's or Ancestral
+    Stats are identical across the blue, dark, dusk, and light variants — the difference is purely cosmetic, with the dark and dusk versions trading at a premium for fashionscape.
   market_strategy:
     notes:
-      - High supply from Slayer drops
-      - Very affordable for its magic bonus
-      - Dark/dusk variants trade at premium
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Strong steady supply from Slayer monsters and Wilderness bosses"
+      - "Affordable mid-game body slot for magic"
+      - "Dark/dusk variants trade at premium for fashionscape"
+      - "Common stepping stone before Ahrim's or Ancestral"
+  trading_tips:
+    - Buy after major bossing rebalance patches when supply spikes
+    - Pair with mystic bottom for full-set flips
+  history:
+    - date: "2005-01-26"
+      description: "Added to the game with the original mystic set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-set-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-set-blue.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic set (blue) | OSRS Price Data
-description: "Mystic set (blue): A set containing blue mystic hat, robe top and bottom, gloves and boots.. High alch: 141,000 GP, GE limit: 70."
+description: "Mystic set (blue): A set containing blue mystic hat, robe top and bottom, gloves and boots. High alch: 141,000 GP, GE limit: 70."
 osrs:
   id: 23113
   name: Mystic set (blue)
@@ -12,9 +12,68 @@ osrs:
   lowalch: 94000
   highalch: 141000
   limit: 70
-  about: "Mystic set (blue) is a members-only item in Old School RuneScape. High alchemy value: 141,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: set
+    tier: high
+  properties:
+    release_date: "2019-03-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Mystic hat
+      slug: mystic-hat
+      relationship: set-piece
+      description: Helmet piece of the blue mystic set
+    - item_name: Mystic robe top
+      slug: mystic-robe-top
+      relationship: set-piece
+      description: Body piece of the blue mystic set
+    - item_name: Mystic robe bottom
+      slug: mystic-robe-bottom
+      relationship: set-piece
+      description: Leg piece of the blue mystic set
+    - item_name: Mystic gloves
+      slug: mystic-gloves
+      relationship: set-piece
+      description: Hands piece of the blue mystic set
+    - item_name: Mystic boots
+      slug: mystic-boots
+      relationship: set-piece
+      description: Feet piece of the blue mystic set
+    - item_name: Mystic set (light)
+      slug: mystic-set-light
+      relationship: variant
+      description: Light coloured mystic set bundle
+    - item_name: Mystic set (dark)
+      slug: mystic-set-dark
+      relationship: variant
+      description: Dark coloured mystic set bundle
+  about: |
+    Mystic set (blue) is a Grand Exchange convenience bundle that contains a blue mystic hat, robe top, robe bottom, gloves, and boots. It exists purely to streamline buying or selling the full magic set in a single trade via the Sets option at any Grand Exchange clerk.
+  market_strategy:
+    notes:
+      - "Compare bundle price vs sum of pieces"
+      - "GE Sets option converts between bundle and pieces"
+      - "Limit 70 caps daily turnover"
+  trading_tips:
+    - Use the GE Sets option to assemble/break apart
+    - Watch for arbitrage between bundle and individual pieces
+    - Pieces drop from Dagannoth Kings and other mid-level monsters
+  history:
+    - date: "2019-03-14"
+      description: "Mystic set (blue) added to the Grand Exchange as a tradeable bundle."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nature-offerings.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nature-offerings.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nature offerings | OSRS Price Data
-description: "Nature offerings: A sacrifice to nature in the hope of an increase of yield in logs.. High alch: 12 GP."
+description: "Nature offerings: A sacrifice to nature in the hope of an increase of yield in logs. Forestry consumable. High alch: 12 GP."
 osrs:
   id: 28152
   name: Nature offerings
@@ -12,9 +12,66 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Nature offerings is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: consumable
+    tier: mid
+  properties:
+    release_date: "2023-06-28"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: Bonus log chance
+      description: "While carried (or stored in a forestry kit) during Woodcutting, grants a 60% chance per log to receive an additional log. The bonus scales with nearby players up to 80% (cap reached at 10+ players). Offerings are consumed regardless of whether a bonus log is awarded; bonus logs grant no extra Woodcutting XP."
+  recipes:
+    - skill: woodcutting
+      level: 68
+      xp: 0
+      materials:
+        - item_name: Ritual mulch
+          quantity: 1
+        - item_name: Avantoe
+          quantity: 1
+      tools: []
+      output_quantity: 40
+  related_items:
+    - item_name: Ritual mulch
+      slug: ritual-mulch
+      relationship: component
+      description: Base ingredient combined with herbs to produce offerings
+    - item_name: Forestry kit
+      slug: forestry-kit
+      relationship: alternative
+      description: Storage that holds offerings during Woodcutting sessions
+  about: |-
+    > *"A sacrifice to nature in the hope of an increase of yield in logs."*
+
+    Nature offerings are a stackable Forestry consumable introduced in June 2023. Carrying them (or storing them in a Forestry kit) while chopping trees gives a 60-80% chance for a bonus log per chop, with the chance scaling up based on the number of nearby Woodcutting players.
+
+    Crafted by combining ritual mulch with a herb (avantoe, kwuarm, snapdragon, cadantine, lantadyme, dwarf weed, or torstol). Each combination requires 68 Woodcutting and 50 Farming, producing 40 offerings.
+  market_strategy:
+    notes:
+      - "Strong demand from XP-focused Forestry players"
+      - "Price tied to which herb is currently cheapest as input"
+      - "No GE buy limit listed — bulk trading is possible"
+      - "Bonus logs themselves create downstream supply for fletching and firemaking markets"
+  trading_tips:
+    - Watch herb prices weekly — input swaps can shift margins
+    - Stock up during Forestry events when demand spikes
+  history:
+    - date: "2023-06-28"
+      description: "Added with the Forestry update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/necklace-of-faith.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/necklace-of-faith.mdx
@@ -1,6 +1,6 @@
 ---
 title: Necklace of faith | OSRS Price Data
-description: "Necklace of faith is a members neck slot item. High alch: 855 GP, GE limit: 10,000."
+description: "Necklace of faith is a members neck slot item. Restores 25% Prayer when HP drops below 20%. High alch: 855 GP, GE limit: 10,000."
 osrs:
   id: 21157
   name: Necklace of faith
@@ -12,8 +12,32 @@ osrs:
   lowalch: 570
   highalch: 855
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: jewellery
+    tier: mid
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,55 +55,57 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements: {}
-    weight: 0.01
+  passive_effects:
+    - name: Emergency prayer restore
+      description: "When the wearer's HP drops below 20% of maximum, the necklace restores Prayer points equal to 25% of the wearer's Prayer level and crumbles to dust. Does not activate if a single hit takes the wearer directly to 0 HP."
   recipes:
     - skill: magic
       level: 49
       xp: 59
-      inputs:
+      materials:
         - item_name: Topaz necklace
           quantity: 1
         - item_name: Cosmic rune
           quantity: 1
         - item_name: Fire rune
           quantity: 5
+      tools: []
       output_quantity: 1
   related_items:
-    - item_id: 2570
-      item_name: Ring of life
+    - item_name: Topaz necklace
+      slug: topaz-necklace
+      relationship: component
+      description: Base necklace enchanted by Lvl-3 Enchant spell
+    - item_name: Phoenix necklace
+      slug: phoenix-necklace
+      relationship: alternative
+      description: Heals 30% HP when HP drops below 20%, more popular than Prayer restore
+    - item_name: Ring of life
       slug: ring-of-life
       relationship: alternative
-      description: Emergency teleport ring
+      description: Emergency teleport when HP drops to 10%
   about: |-
-    No combat bonuses.
+    > *"Can grant me prayer in an emergency."*
 
-    Requirements: None to wear | Weight: 0.01 kg
+    The necklace of faith is an enchanted topaz necklace that triggers when the wearer's HP drops below 20% of maximum, restoring 25% of their Prayer level (about 24 points at 99 Prayer). The necklace is destroyed when the effect fires.
 
-    When HP drops below 20% of maximum, the necklace activates and restores 25% of your Prayer level. The necklace is then destroyed.
+    Useful for keeping Protect Item or overhead prayers active in the Wilderness, but generally less popular than the phoenix necklace because Prayer restoration is rarely the limiting factor compared to staying alive.
 
-    At 99 Prayer: restores ~24 Prayer points when triggered.
-
-    - Single use — destroyed after activation
-    - Does not trigger if a single hit takes you from above 20% straight to 0
-    - Only restores Prayer, does not heal HP
-
-    - Wilderness Prayer protection — backup Prayer restore to keep Protect Item active
-    - Budget PvM safety — maintain overhead prayers in dangerous situations
-    - Ironman accounts — cheap emergency Prayer restore
-
-    | Item | Trigger | Effect |
-    |------|---------|--------|
-    | Necklace of faith | <20% HP | Restore 25% Prayer |
-    | Phoenix necklace | <20% HP | Heal 30% HP |
-    | Ring of life | ≤10% HP | Teleport to spawn |
+    Crafted via Lvl-3 Enchant on a topaz necklace at 49 Magic for 59 XP.
   market_strategy:
     notes:
-      - Very cheap to enchant (topaz necklace + cosmic + fire runes)
-      - Niche demand — most players prefer phoenix necklace or ring of life
-      - Useful for keeping Protect Item active in Wilderness
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap to enchant from a topaz necklace plus cosmic and fire runes"
+      - "Niche demand — most players prefer phoenix necklace or ring of life"
+      - "Useful for keeping Protect Item active in PvP/Wilderness"
+      - "Prayer restore was buffed from 10% to 25% in May 2024"
+  trading_tips:
+    - Enchanting topaz necklaces is reliable Magic XP and small flips
+    - Watch Wilderness event weeks for short demand spikes
+  history:
+    - date: "2017-02-02"
+      description: "Item added to the game alongside the topaz jewellery line."
+    - date: "2024-05-08"
+      description: "Prayer restoration increased from 10% to 25% of Prayer level."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-blackjack-d.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-blackjack-d.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 125
-  about: "Oak blackjack(d) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2005-08-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: blackjack
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      defence: 10
+      thieving: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 4
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Pollnivneach
+      price: 400
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Oak blackjack
+      slug: oak-blackjack
+      relationship: variant
+      description: Standard variant with balanced stats
+    - item_name: Oak blackjack(o)
+      slug: oak-blackjack-o
+      relationship: variant
+      description: Offensive variant trading defence for attack
+    - item_name: Willow blackjack(d)
+      slug: willow-blackjack-d
+      relationship: upgrade
+      description: Higher-tier defensive blackjack for Pollnivneach thieving
+  about: "Oak blackjack(d) is the defensive Pollnivneach blackjack purchased from Ali's Discount Wares. Used for luring and knocking out NPCs in the Thieving sub-game, the defensive variant trades attack speed and offence for +4 Crush defence so missed knockouts hurt less. Equip requires 10 Defence and 10 Thieving."
+  market_strategy:
+    notes:
+      - "Shop price 400 gp sets a hard floor under GE flips"
+      - "Demand spikes during Thieving training events"
+      - "Defensive variant has a smaller user base than the offensive one"
+  trading_tips:
+    - Buy from Ali's Discount Wares as a baseline arbitrage
+    - Stock up before bonus Thieving XP weekends
+  history:
+    - date: "2005-08-15"
+      description: "Released alongside the Pollnivneach Thieving content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-chair-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-chair-flatpack.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak chair (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: construction flatpack
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 19
+      xp: 120
+      materials:
+        - item_name: Oak plank
+          quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Material used to build the flatpack
+    - item_name: Oak chair
+      slug: oak-chair
+      relationship: product
+      description: Assembled chair built from the flatpack in a parlour
+  about: |-
+    Oak chair (flatpack) is a Construction flatpack created at a wooden workbench in a player's workshop. Built at 19 Construction from 2 oak planks for 120 XP, the flatpack can be assembled on any chair space in a parlour without further material requirements.
+
+    Useful for low-cost Construction XP training when buying planks is cheaper than tree-chopping yourself, and for friends/alts furnishing parlours without their own Construction level.
+  market_strategy:
+    notes:
+      - "Niche flatpack demand from low-level Construction trainers"
+      - "Tied directly to oak plank price"
+      - "Tax-adjusted profit is typically negative"
+      - "500 buy limit caps bulk plays"
+  trading_tips:
+    - Track oak plank GE price to find arbitrage windows
+    - Best for Construction trainers buying flatpacks for XP
+    - Volume is low - use limit orders
+  history:
+    - date: "2006-05-31"
+      description: "Item released with the Construction flatpack system update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-legs.mdx
@@ -12,9 +12,95 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: null
-  about: "Oathplate legs is a members-only item in Old School RuneScape. High alchemy value: 240,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: infernal metal
+    tier: high
+  properties:
+    release_date: "2025-05-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 0
+      slash: 12
+      crush: 0
+      magic: -12
+      ranged: -14
+    defence_bonus:
+      stab: 75
+      slash: 100
+      crush: 73
+      magic: -3
+      ranged: 81
+    other_bonus:
+      melee_strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 83
+      xp: 2000
+      materials:
+        - item_name: Infernal plate
+          quantity: 9
+      tools:
+        - Hammer
+      output_quantity: 1
+  passive_effects:
+    - name: Zamorakian alignment
+      description: Provides protection in the Zamorakian boss area of the God Wars Dungeon.
+  related_items:
+    - item_name: Oathplate helm
+      slug: oathplate-helm
+      relationship: set-piece
+      description: Matching head slot of the Oathplate armour set
+    - item_name: Oathplate chest
+      slug: oathplate-chest
+      relationship: set-piece
+      description: Matching torso slot of the Oathplate armour set
+    - item_name: Oathplate shards
+      slug: oathplate-shards
+      relationship: component
+      description: Produced by breaking down at the Ancient Forge
+  about: |-
+    Oathplate legs are part of the Oathplate armour set forged from infernal metal at the Ancient Forge. Requiring 78 Defence to wear and 83 Smithing to create (using 9 infernal plates), they are the only leg-slot item to grant a slash bonus aside from Vesta's plateskirt.
+
+    As a Zamorakian-aligned piece, they provide automatic protection in the Zamorak section of the God Wars Dungeon, removing the need for an Unholy book or Zamorak monk top.
+
+    Can be broken down at the Ancient Forge for 50 oathplate shards.
+  market_strategy:
+    notes:
+      - "High-tier defence gear with Zamorakian GWD utility"
+      - "No GE buy limit"
+      - "Tied to infernal plate / Ancient Forge supply"
+      - "Shard breakdown sets a hard price floor relative to shard value"
+  trading_tips:
+    - Watch infernal plate price - drives the production cost floor
+    - Demand spikes during GWD rushes and PvM events
+    - Premium item - use larger order spreads
+  history:
+    - date: "2025-05-14"
+      description: "Item released with the Forestry: The Way of the Forester / Oathplate update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/occult-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/occult-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Occult ornament kit | OSRS Price Data
-description: "Occult ornament kit: Use on an occult necklace to make it look fancier!. High alch: 3,000 GP, GE limit: 4."
+description: "Occult ornament kit: Use on an occult necklace to make it look fancier! High alch: 3,000 GP, GE limit: 4."
 osrs:
   id: 20065
   name: Occult ornament kit
@@ -12,9 +12,56 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Occult ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ornament-kit
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  drop_table:
+    sources:
+      - source: Master Treasure Trails
+        quantity: "1"
+        rarity: 1/851
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Occult necklace
+      slug: occult-necklace
+      relationship: component
+      description: Base amulet the kit attaches to.
+    - item_name: Occult necklace (or)
+      slug: occult-necklace-or
+      relationship: product
+      description: Cosmetic ornamented result; becomes untradeable when combined.
+  about: "The occult ornament kit is a cosmetic master Treasure Trail reward (drop rate 1/851) used on an occult necklace to create the ornamented occult necklace (or). The combined item becomes untradeable, but the kit itself can be removed and resold, which keeps the secondary market liquid despite the tiny buy limit of 4."
+  market_strategy:
+    notes:
+      - "Strict supply from master clues only; price is sticky."
+      - "GE limit of 4 makes accumulation slow but spreads stay reasonable."
+      - "Reversible attach means the kit retains long-term value as a fashion item."
+      - "Demand tracks magic gear updates - new BiS magic items shift attention to occult cosmetics."
+  trading_tips:
+    - Track master clue completion rates; supply rises during clue-focused events.
+    - Hold during quiet market periods; flipping benefits from patience.
+  history:
+    - date: "2016-07-06"
+      description: "Added to the master Treasure Trails reward pool."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/odium-ward.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/odium-ward.mdx
@@ -12,90 +12,102 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ranged-shield
+    tier: high
+  properties:
+    release_date: "2014-03-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: ranged_shield
+    weapon_type: shield
+    attack_speed: null
+    weight: 3.628
     requirements:
       defence: 60
-    stats:
-      attack_ranged: 12
-      defence_magic: 24
-      defence_ranged: 52
-  drop_table:
-    sources:
-      - source: Volcanic Forge
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: N/A
-        members_only: true
+    attack_bonus:
+      stab: -12
+      slash: -12
+      crush: -12
+      magic: -8
+      ranged: 12
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 24
+      ranged: 52
+    other_bonus:
+      strength: 0
+      ranged_strength: 4
+      magic_damage: 0
+      prayer: 0
   recipes:
-    - skill: N/A
+    - skill: none
       level: 0
       xp: 0
       materials:
-        - item_id: 11928
-          item_name: Odium shard 1
+        - item_name: Odium shard 1
           quantity: 1
-        - item_id: 11929
-          item_name: Odium shard 2
+        - item_name: Odium shard 2
           quantity: 1
-        - item_id: 11930
-          item_name: Odium shard 3
+        - item_name: Odium shard 3
           quantity: 1
-      product: Odium ward
-      product_id: 11926
-      facility: Volcanic Forge
-      members_only: true
+      tools:
+        - Volcanic Forge
+      output_quantity: 1
   related_items:
-    - item_id: 11924
-      item_name: Malediction ward
+    - item_name: Odium shard 1
+      slug: odium-shard-1
+      relationship: component
+      description: "Dropped by Chaos Fanatic in the Wilderness; one of three shards needed."
+    - item_name: Odium shard 2
+      slug: odium-shard-2
+      relationship: component
+      description: "Dropped by Crazy Archaeologist in the Wilderness; one of three shards needed."
+    - item_name: Odium shard 3
+      slug: odium-shard-3
+      relationship: component
+      description: "Dropped by Scorpia in the Wilderness; one of three shards needed."
+    - item_name: Malediction ward
       slug: malediction-ward
       relationship: alternative
-      description: Magic version
-    - item_id: 22002
-      item_name: Dragonfire ward
+      description: Magic-focused counterpart shield assembled at the same Volcanic Forge.
+    - item_name: Dragonfire ward
       slug: dragonfire-ward
       relationship: upgrade
-      description: BiS ranged shield
-    - item_id: 21000
-      item_name: Twisted buckler
+      description: Best-in-slot ranged shield, upgraded from Odium ward with a Skeletal visage.
+    - item_name: Twisted buckler
       slug: twisted-buckler
       relationship: alternative
-      description: Alternative
-  about: |-
-    Combine 3 shards at Volcanic Forge (NE Wilderness):
-
-    | Shard | Source | Price |
-    |-------|--------|-------|
-    | Odium shard 1 | Chaos Fanatic | ~1.4M |
-    | Odium shard 2 | Crazy Archaeologist | ~1.9M |
-    | Odium shard 3 | Scorpia | ~131K |
-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +12 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +24 |
-    | Ranged | +52 |
-
-    Requirements: 60 Defence
-
-    Budget ranged shield for:
-    - Ranged training
-    - Slayer tasks
-    - Mid-game bossing
-
-    Good magic defence for ranged setups.
+      description: Chambers of Xeric ranged shield with stronger ranged bonuses.
+  about: "Odium ward is a ranged-focused shield assembled at the Volcanic Forge in the northeastern Wilderness by combining three Odium shards. It ranks among the top ranged shields, behind only the Dragonfire ward and Twisted buckler, and is commonly used as a mid-game ranged shield and stepping stone to the Dragonfire ward upgrade."
   market_strategy:
     notes:
-      - Wilderness bosses for shards
-      - Cheaper to buy complete
-      - Upgrade to dragonfire ward
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Floor supported by shard cost from three Wilderness demi-bosses"
+      - "Build cost vs assembled price often shows small flipping margin"
+      - "Demand softens as players upgrade to Dragonfire ward or Twisted buckler"
+  trading_tips:
+    - Compare GE price of the assembled ward against the sum of the three shards plus tax
+    - Buy completed wards during off-peak hours; resell during PvM/Slayer surges
+  history:
+    - date: "2014-03-13"
+      description: "Released alongside the Wilderness demi-bosses Chaos Fanatic, Crazy Archaeologist, and Scorpia."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-1.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 5
   highalch: 8
   limit: 10000
-  about: "Olive oil(1) is a members-only item in Old School RuneScape. High alchemy value: 8 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: oil
+    tier: low
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Razmire General Store
+      location: Mort'ton
+      price: 28
+      currency: Coins
+      stock: 5
+    - shop_name: Rasolo the Wandering Merchant
+      location: West of Fred the Farmer
+      price: 40
+      currency: Coins
+      stock: 2
+  related_items:
+    - item_name: Sacred oil(1)
+      slug: sacred-oil-1
+      relationship: product
+      description: Blessed oil produced by lighting olive oil at the Mort'ton altar
+    - item_name: Olive oil(2)
+      slug: olive-oil-2
+      relationship: variant
+      description: Two-dose version of the same oil
+    - item_name: Olive oil(3)
+      slug: olive-oil-3
+      relationship: variant
+      description: Three-dose version of the same oil
+    - item_name: Olive oil(4)
+      slug: olive-oil-4
+      relationship: variant
+      description: Four-dose version of the same oil
+  about: "Olive oil is the base reagent for sacred oil, the consumable used to make pyre logs and to bless funeral pyres in the Shades of Mort'ton minigame. Buy doses cheaply from Razmire or convert them at the temple altar for Prayer-adjacent rewards."
+  market_strategy:
+    notes:
+      - "Single-dose stock thin because most players buy 4-dose kegs"
+      - "Pyre log producers occasionally bulk-buy for offering chains"
+      - "GE price hovers near shop price floor of 28 coins"
+  trading_tips:
+    - Buy from Razmire's general store on consistent restock loops
+    - Convert excess to sacred oil during pyre log XP grinds
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Shades of Mort'ton minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onion-tomato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onion-tomato.mdx
@@ -1,6 +1,6 @@
 ---
 title: Onion & tomato | OSRS Price Data
-description: "Onion & tomato: A mixture of chopped onions and tomatoes in a bowl.. High alch: 3 GP, GE limit: 11,000."
+description: "Onion & tomato: A mixture of chopped onions and tomatoes in a bowl. High alch: 3 GP, GE limit: 11,000."
 osrs:
   id: 1875
   name: Onion & tomato
@@ -12,9 +12,82 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  about: "Onion & tomato is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Chopped onion
+          quantity: 1
+        - item_name: Tomato
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Chopped tomato
+          quantity: 1
+        - item_name: Onion
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Onion
+      slug: onion
+      relationship: component
+      description: Whole onion ingredient
+    - item_name: Tomato
+      slug: tomato
+      relationship: component
+      description: Whole tomato ingredient
+    - item_name: Kebab mix
+      slug: kebab-mix
+      relationship: product
+      description: Combine with ugthanki meat for kebab mix
+    - item_name: Ugthanki kebab
+      slug: ugthanki-kebab
+      relationship: product
+      description: Final ugthanki kebab recipe at 58 Cooking
+  about: |
+    Onion & tomato is an intermediate Cooking ingredient on the path to an ugthanki kebab. Combining a chopped onion with a tomato (or vice versa) using a knife produces the mix instantly with no Cooking level required. Eating it heals 3 Hitpoints, but its real role is in the kebab production chain.
+  market_strategy:
+    notes:
+      - "Margin is tight - both recipes typically loss-make"
+      - "GE flipping benefits from kebab task demand spikes"
+      - "Bulk buys peak around Gnome Restaurant rotations"
+  trading_tips:
+    - Intermediate for Ugthanki kebab at 58 Cooking
+    - Quick 2-tick prep, knife required
+    - Heals 3 HP - poor combat food
+  history:
+    - date: "2003-04-14"
+      description: "Onion & tomato added with the Shilo Village update."
+    - date: "2006-01-30"
+      description: "Graphical update added the Eat option."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bracelet.mdx
@@ -12,46 +12,96 @@ osrs:
   lowalch: 80400
   highalch: 120600
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gem
+    tier: high
+  properties:
+    release_date: "2007-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.25
     requirements:
       crafting: 84
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 84
       xp: 125
-      inputs:
+      materials:
         - item_name: Onyx
           quantity: 1
         - item_name: Gold bar
           quantity: 1
+      tools:
+        - Bracelet mould
+        - Furnace
       output_quantity: 1
   related_items:
-    - item_id: 11115
-      item_name: Dragonstone bracelet
+    - item_name: Onyx
+      slug: onyx
+      relationship: component
+      description: Premium gem crafted with a gold bar to form the bracelet.
+    - item_name: Dragonstone bracelet
       slug: dragonstone-bracelet
       relationship: downgrade
-      description: Previous tier bracelet
-    - item_id: 11133
-      item_name: Regen bracelet
+      description: Previous-tier bracelet requiring lower Crafting and gem cost.
+    - item_name: Regen bracelet
       slug: regen-bracelet
       relationship: upgrade
-      description: Enchanted version (2x HP regen)
-  about: |-
-    Crafting (Level 84): Onyx + Gold bar at a furnace with bracelet mould (125 XP)
-
-    > *"An onyx bracelet."*
-
-    Lvl-6 Enchant (87 Magic): 1 cosmic rune + 20 fire runes + 20 earth runes (97 XP)
-
-    The Regen bracelet doubles natural HP regeneration (2 HP/min instead of 1). Also provides solid combat stats (+8 melee attack, +7 Str) — making it the best gloves for 1 Defence pures.
+      description: Lvl-6 Enchant of the onyx bracelet — doubles natural HP regeneration.
+    - item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Required base metal smelted before bracelet crafting.
+  about: "The onyx bracelet is a members-only jewellery piece crafted at level 84 Crafting from an onyx and a gold bar at a furnace using a bracelet mould (125 XP). On its own it has no combat bonuses, but when enchanted with Lvl-6 Enchant (87 Magic) it becomes a regen bracelet that doubles natural Hitpoint regeneration and grants +8 melee attack and +7 Strength — making it a staple for low-Defence pures."
   market_strategy:
     notes:
-      - Onyx is the main cost component
-      - Regen bracelet popular with pures
-      - High-value enchant — check margins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Onyx supply dominates margin — track TzHaar token exchanges and Sliske drops."
+      - "Demand peaks from pures upgrading to regen bracelets."
+      - "Enchanting overhead via Magic spells eats margin; compute fully-enchanted profit."
+  trading_tips:
+    - "Buy unenchanted bracelets when Magic-trainer supply spikes."
+    - "Sell as enchanted regen bracelets to pure communities for premium."
+    - "Watch onyx price floors — TzHaar token farming bursts can compress margins."
+  history:
+    - date: "2007-04-30"
+      description: "Added to the game alongside the introduction of onyx gems."
+    - date: "2018-02-22"
+      description: "Inventory sprite rotated to differentiate from enchanted jewellery variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/orange-feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/orange-feather.mdx
@@ -12,12 +12,66 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 8000
-  about: "Orange feather is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: feather
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Copper longtail
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Feather
+      slug: feather
+      relationship: alternative
+      description: Standard fletching feather
+    - item_name: Red feather
+      slug: red-feather
+      relationship: variant
+      description: Coloured hunter feather
+    - item_name: Yellow feather
+      slug: yellow-feather
+      relationship: variant
+      description: Coloured hunter feather
+    - item_name: Blue feather
+      slug: blue-feather
+      relationship: variant
+      description: Coloured hunter feather
+  about: |-
+    Orange feathers are obtained by catching Copper longtails with bird snares (Hunter level 9 required). They can be used as a substitute for regular feathers in Fletching but always produce arrows with white fletching.
+
+    Caught alongside copper longtails in the Piscatoris Hunter area, with 5–10 feathers per successful trap.
+  market_strategy:
+    notes:
+      - "Sold to Fancy Dress Shop in Varrock as a coin sink"
+      - "Demand is cosmetic — driven by collection log hunters"
+      - "Buy limit 8,000 supports bulk flips"
+  trading_tips:
+    - Snipe undercut listings from new hunters offloading bulk feathers
+    - Compare alch vs GE price; high alch covers the floor when GE dries up
+  history:
+    - date: "2006-11-21"
+      description: "Released as part of the Hunter skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ourania-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ourania-teleport-tablet.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Ourania teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport-tablet
+    tier: mid
+  properties:
+    release_date: "2020-09-30"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 71
+      xp: 69
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 6
+        - item_name: Astral rune
+          quantity: 2
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Ourania Teleport
+      slug: ourania-teleport
+      relationship: alternative
+      description: Spell version requiring Lunar spellbook to cast directly
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Tablet substrate used at the lunar lectern
+  about: "The Ourania teleport tablet transports players to the entrance of the Ourania Cave, the home of the Ourania Altar, a popular runecrafting location for unique rune-mix outputs. Players craft the tablet at the lunar lectern in the ceremonial building on Lunar Isle, requiring 71 Magic, Lunar Diplomacy completion, and Baba Yaga's permission. Breaking the tablet does not require the lunar spellbook, making it a convenient access option for any spellbook user."
+  market_strategy:
+    notes:
+      - "Demand tied to Runecrafting training at the Ourania Altar"
+      - "Mass-produced by Lunar spellbook players keeping supply consistent"
+      - "Soft clay and law rune costs anchor the production floor price"
+  trading_tips:
+    - Track law rune and soft clay swings to anticipate tablet price moves
+    - Bulk-buy ahead of Runecrafting double-XP events for predictable demand
+  history:
+    - date: "2020-09-30"
+      description: "Released alongside other lunar teleport tablets giving non-Lunar players altar access."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oyster.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oyster.mdx
@@ -12,23 +12,81 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 11000
+  material:
+    type: crafting material
+    tier: low
+  properties:
+    release_date: "2002-09-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Open
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Rock crab
+        quantity: "1"
+        rarity: Uncommon
+      - source: Sand crab
+        quantity: "1"
+        rarity: Uncommon
+      - source: Ammonite crab
+        quantity: "1"
+        rarity: Uncommon
+      - source: Mogre
+        quantity: "1"
+        rarity: Uncommon
+      - source: Mudskipper
+        quantity: "1"
+        rarity: Uncommon
+      - source: Waterfiend
+        quantity: "1"
+        rarity: Uncommon
+      - source: Giant lobster
+        quantity: "1"
+        rarity: Uncommon
+      - source: River troll
+        quantity: "1"
+        rarity: Uncommon
+      - source: Cave kraken
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - item_id: 411
-      item_name: Oyster pearl
+    - item_name: Oyster pearl
       slug: oyster-pearl
       relationship: product
-      description: Possible contents
-    - item_id: 413
-      item_name: Oyster pearls
+      description: Common reward from opening an oyster.
+    - item_name: Oyster pearls
       slug: oyster-pearls
       relationship: product
-      description: Possible contents
+      description: Rare double-pearl reward from opening an oyster.
+    - item_name: Empty oyster
+      slug: empty-oyster
+      relationship: product
+      description: 7/32 chance of an empty oyster on opening.
   about: |-
-    > _"It's a big oyster."_
+    Oysters are obtained by fishing with a big fishing net at level 16 Fishing, drift net fishing, panning at the Digsite, and as drops from many sea-themed monsters. They were introduced with the Sea Slug Quest in 2002.
 
-    Opening an oyster may yield an oyster pearl or oyster pearls, used in Crafting to make pearl items. Can also be empty.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Opening an oyster has a 25/32 chance to yield an oyster pearl (worth around 33 coins) and a 7/32 chance to be empty. Oyster pearls are used in Crafting to make pearl bolt tips, pearl items, and other crafting outputs.
+  market_strategy:
+    notes:
+      - "Drop volume from rock/sand/ammonite crabs gives a steady supply floor"
+      - "High 11,000 buy limit suits bulk crafting flips"
+      - "7/32 empty chance is the main loss on opening — factor into ROI"
+      - "Oyster pearl bolt tip demand drives mid-game spikes"
+  history:
+    - date: "2002-09-09"
+      description: "Added to the game with the Sea Slug quest."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/papaya-fruit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/papaya-fruit.mdx
@@ -12,38 +12,68 @@ osrs:
   lowalch: 25
   highalch: 38
   limit: 11000
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: food
-    subtype: fruit
+    tier: low
+  properties:
+    release_date: "2005-07-11"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.028
-  farming:
-    level: 57
-    patch_type: fruit_tree
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Kurask
+        quantity: "1"
+        rarity: "1/64"
+      - source: Fruit stall (Thieving)
+        quantity: "1"
+        rarity: "common"
+  shops:
+    - shop_name: Heckel Funch's Grocery Store
+      location: Tree Gnome Stronghold
+      price: 86
+      currency: coins
+      stock: 0
   related_items:
-    - item_id: 5288
-      item_name: Palm tree seed
+    - item_name: Papaya tree seed
+      slug: papaya-tree-seed
+      relationship: component
+      description: "Farming source for papaya fruits"
+    - item_name: Palm tree seed
       slug: palm-tree-seed
       relationship: alternative
-      description: Protection payment target
-    - item_id: 5289
-      item_name: Papaya tree seed
-      slug: papaya-tree-seed
-      relationship: alternative
-      description: Farming source
+      description: "Papayas are used as protection payment for palm tree patches"
+    - item_name: Supercompost
+      slug: supercompost
+      relationship: product
+      description: "Can be used to create supercompost"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Farming Product / Food |
-    | Tradeable | Yes |
-    | Weight | 0.028 kg |
+    Papaya fruit is a tropical food item obtained by farming papaya trees with level 57 Farming. It restores 8 Hitpoints and 5 percent run energy when eaten.
 
-    Farming: Palm tree protection payment (15 papaya fruits)
-
-    Summoning (RS3-era references): Fruit bat familiar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Beyond consumption, papaya fruits serve as protection payment for palm tree patches (15 fruits per gardener) and can be added to a compost bin to create supercompost. Additional sources include thieving fruit stalls, killing Kurasks, and Varlamore region shops.
+  market_strategy:
+    notes:
+      - "Steady demand from palm tree farmers paying gardener protection"
+      - "High GE limit (11,000) supports volume flipping"
+      - "Supercompost production absorbs surplus supply"
+  trading_tips:
+    - Stockpile during farming runs to sell in bulk
+    - Palm tree farmers buy in batches of 15 - target that quantity
+  history:
+    - date: "2005-07-11"
+      description: "Item added to the game with the Farming skill release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/papyrus.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/papyrus.mdx
@@ -12,18 +12,67 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crafting-component
+    tier: low
+  properties:
+    release_date: "2003-08-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Ali Morrisane's Discount Goods
+      location: Al Kharid
+      price: 30
+      currency: Coins
+      stock: 5
+    - shop_name: Razmire Builders' Merchants
+      location: Mort'ton
+      price: 20
+      currency: Coins
+      stock: 2
+    - shop_name: Wingstone Agility Shop
+      location: Pollnivneach
+      price: 20
+      currency: Coins
+      stock: 5
   related_items:
-    - item_id: 973
-      item_name: Charcoal
+    - item_name: Charcoal
       slug: charcoal
       relationship: component
-      description: Used together for notes
-  about: |-
-    > _"A\"piece\" of\"papyrus\"."_
-
-    Papyrus is used with charcoal to make notes and maps. Required in several quests including Nature Spirit and Shilo Village. Also used in Treasure Trails.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Combined with papyrus to write notes and maps.
+    - item_name: Note (item)
+      slug: note
+      relationship: product
+      description: Created when papyrus is paired with charcoal in inventory.
+    - item_name: Bowl of hot water
+      slug: bowl-of-hot-water
+      relationship: component
+      description: Used with papyrus for origami balloon construction in Enlightened Journey.
+  about: "Papyrus is a members crafting component used to make notes (with charcoal), maps, origami balloons, and several Construction items. It is required across multiple quests including Legends' Quest, Nature Spirit, Shilo Village, Enlightened Journey, and While Guthix Sleeps, and is also consumed when constructing a balloon hot-air balloon."
+  market_strategy:
+    notes:
+      - "Shop supply is plentiful; GE price stays well above alch due to convenience demand."
+      - "Quest and Construction usage drives steady throughput."
+      - "Bulk shop runs (Ali Morrisane / Razmire / Wingstone) profit consistently versus GE flips."
+  trading_tips:
+    - "Run multi-shop circuits during quest hype to undercut GE listings."
+    - "Stockpile during league or event prep windows when balloon and notes usage spikes."
+    - "Pair with charcoal supply chains for combined-item flips."
+  history:
+    - date: "2003-08-20"
+      description: "Added to the game alongside the Legends' Quest content update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pastry-dough.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pastry-dough.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pastry dough | OSRS Price Data
-description: "Pastry dough: Potentially pastry.. High alch: 1 GP, GE limit: 13,000."
+description: "Pastry dough: Potentially pastry. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 1953
   name: Pastry dough
@@ -12,9 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Pastry dough is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food-ingredient
+    tier: low
+  properties:
+    release_date: "2001-03-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.17
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Pot of flour
+          quantity: 1
+        - item_name: Bucket of water
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Pot of flour
+      slug: pot-of-flour
+      relationship: component
+      description: Combine with water to produce pastry dough.
+    - item_name: Pie dish
+      slug: pie-dish
+      relationship: component
+      description: Pastry dough is used on a pie dish to make pie shells.
+    - item_name: Pie shell
+      slug: pie-shell
+      relationship: product
+      description: Created by using pastry dough on a pie dish.
+  about: "Pastry dough is a free-to-play cooking ingredient made by combining a pot of flour with a bucket, bowl, or jug of water. It is the first step toward any pie in OSRS and feeds into the pie-shell pipeline used by cooks of every level."
+  market_strategy:
+    notes:
+      - "Margin is razor-thin; only viable in bulk volume."
+      - "Demand is steady from cooks making pies for higher-level skilling food."
+      - "Buy limit of 13,000 supports large-volume flips."
+  trading_tips:
+    - Stack with pot of flour flips for higher hourly profit.
+    - Avoid alching - pastry dough is not high-alchable.
+  history:
+    - date: "2001-03-17"
+      description: "Released alongside the introduction of pies in early RuneScape."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pat-of-butter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pat-of-butter.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pat of butter | OSRS Price Data
-description: "Pat of butter: A pat of freshly churned butter.. High alch: 2 GP, GE limit: 11,000."
+description: "Pat of butter: A pat of freshly churned butter. High alch: 2 GP, GE limit: 11,000."
 osrs:
   id: 6697
   name: Pat of butter
@@ -12,9 +12,68 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Pat of butter is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dairy
+    tier: low
+  properties:
+    release_date: "2005-10-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 38
+      xp: 40
+      materials:
+        - item_name: Bucket of milk
+          quantity: 1
+      tools:
+        - Dairy churn
+      output_quantity: 1
+    - skill: cooking
+      level: 38
+      xp: 22
+      materials:
+        - item_name: Pot of cream
+          quantity: 1
+      tools:
+        - Dairy churn
+      output_quantity: 1
+  related_items:
+    - item_name: Bucket of milk
+      slug: bucket-of-milk
+      relationship: component
+      description: Primary input churned into a pat of butter.
+    - item_name: Pot of cream
+      slug: pot-of-cream
+      relationship: component
+      description: Faster but less XP-efficient alternative input for the dairy churn.
+  about: |-
+    Pat of butter is a Cooking ingredient produced at a dairy churn from a bucket of milk or pot of cream at level 38 Cooking. It is the topping for baked potatoes and the base for several gnome cuisine recipes.
+
+    Both ironmen and casual cooks rely on butter, but its low GE price keeps it niche on the merch side — most demand comes from players cooking baked-potato food for Slayer trips.
+  market_strategy:
+    notes:
+      - "Low margin, high buy limit"
+      - "Tied to baked potato and gnome cooking demand"
+      - "Steady ironman consumption keeps floor stable"
+  trading_tips:
+    - Buy in bulk for baked potato preparation
+    - Watch for Cooking XP events that briefly spike demand
+  history:
+    - date: "2005-10-24"
+      description: "Added with the Mogres, Lizards, Pet Fish, Potions and Potatoes update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pegasian-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pegasian-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pegasian boots | OSRS Price Data
-description: "Pegasian boots is a members feet slot item requiring 60 Magic. High alch: 45,000 GP, GE limit: 15."
+description: "Pegasian boots is a members feet slot item requiring 75 Ranged and 75 Defence. High alch: 45,000 GP, GE limit: 15."
 osrs:
   id: 13237
   name: Pegasian boots
@@ -12,67 +12,98 @@ osrs:
   lowalch: 30000
   highalch: 45000
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ranged boots
+    tier: high
+  properties:
+    release_date: "27 August 2015"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
-    type: boots
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
     requirements:
-      magic: 60
-      runecraft: 60
-    stats:
-      attack_ranged: 12
-      defence_ranged: 5
-      defence_stab: 5
-      defence_slash: 5
-      defence_crush: 5
-      attack_magic: -12
+      ranged: 75
+      defence: 75
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -12
+      ranged: 12
+    defence_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 5
+      ranged: 5
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
-    - skill: crafting
-      level: 1
+    - skill: magic
+      level: 60
       xp: 200
       materials:
         - item_name: Ranger boots
-          item_id: 2577
           quantity: 1
         - item_name: Pegasian crystal
-          item_id: 13229
           quantity: 1
-      product: Pegasian boots
-      product_id: 13237
-      product_quantity: 1
-      facility: None
-      members_only: true
+      tools: []
+      output_quantity: 1
+    - skill: runecraft
+      level: 60
+      xp: 200
+      materials:
+        - item_name: Ranger boots
+          quantity: 1
+        - item_name: Pegasian crystal
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 13235
-      item_name: Eternal boots
+    - item_name: Eternal boots
       slug: eternal-boots
       relationship: alternative
-      description: Magic variant
-    - item_id: 13239
-      item_name: Primordial boots
+      description: Magic-focused crystal boot variant
+    - item_name: Primordial boots
       slug: primordial-boots
       relationship: alternative
-      description: Melee variant
-    - item_id: 13229
-      item_name: Pegasian crystal
+      description: Melee-focused crystal boot variant
+    - item_name: Pegasian crystal
       slug: pegasian-crystal
       relationship: component
-      description: From Cerberus
-    - item_id: 2577
-      item_name: Ranger boots
+      description: Cerberus drop used in creation
+    - item_name: Ranger boots
       slug: ranger-boots
       relationship: component
-      description: Base boots (medium clues)
+      description: Base boots from medium clues
   about: |-
-    Combine Ranger boots + Pegasian crystal.
+    Pegasian boots are created by combining Ranger boots with a Pegasian crystal. The process requires level 60 Magic and Runecraft (no boosts) and is irreversible.
 
     | Requirement | Value |
     |-------------|-------|
     | Magic | 60 |
     | Runecraft | 60 |
     | XP | 200 Magic, 200 Runecraft |
-
-    Process is irreversible.
 
     | Stat | Value |
     |------|-------|
@@ -81,20 +112,23 @@ osrs:
     | All defence | +5 |
     | Magic attack | -12 |
 
-    Second-best ranged boots (behind Avernic treads)
-
-    BiS ranged boots for:
-    - All ranged combat
+    Pegasian boots are the second-best ranged boots in the game (behind Avernic treads) and remain the standard BiS option for:
+    - General ranged combat
     - Slayer
     - Bossing
     - Raids
   market_strategy:
     notes:
-      - Ranger boots are expensive base (~38M)
-      - Crystal from Cerberus (~5M)
-      - Total cost can exceed finished boots
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Ranger boots are the expensive base (~38M)"
+      - "Crystal drops from Cerberus (~5M)"
+      - "Total cost can exceed finished boots — check GE first"
+      - "Demand is steady due to BiS status"
+  trading_tips:
+    - Compare crystal + base cost vs finished price before assembling
+    - Flip during Cerberus dry stretches
+  history:
+    - date: "27 August 2015"
+      description: "Released with the Cerberus boss update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-regeneration-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-regeneration-potion-1.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  about: "Prayer regeneration potion(1) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores one Prayer point every 12 ticks for the duration of the effect."
+        duration: 480
+      - description: "Total restoration of approximately 66 Prayer points per dose."
+        duration: 480
+  related_items:
+    - item_name: Prayer regeneration potion(2)
+      slug: prayer-regeneration-potion-2
+      relationship: variant
+      description: Two-dose variant
+    - item_name: Prayer regeneration potion(3)
+      slug: prayer-regeneration-potion-3
+      relationship: variant
+      description: Three-dose variant
+    - item_name: Prayer regeneration potion(4)
+      slug: prayer-regeneration-potion-4
+      relationship: variant
+      description: Four-dose variant
+    - item_name: Huasca potion (unf)
+      slug: huasca-potion-unf
+      relationship: component
+      description: Unfinished base used to brew the potion
+    - item_name: Aldarium
+      slug: aldarium
+      relationship: component
+      description: Secondary ingredient added to huasca unf
+  about: |-
+    > *"1 dose of Prayer Regeneration potion."*
+
+    The prayer regeneration potion is a members-only buff potion released with Varlamore on 25 September 2024. Each dose passively restores one Prayer point every 12 ticks for eight minutes, yielding roughly 66 Prayer points total.
+
+    Players brew it at 58 Herblore by combining a huasca potion (unf) with aldarium for 132 Herblore experience, producing a three-dose potion. It is also obtained from lost ironwood crates from level 95 Sailing voyages at a 1/8 rate.
+  recipes:
+    - skill: herblore
+      level: 58
+      xp: 132
+      materials:
+        - item_name: Huasca potion (unf)
+          quantity: 1
+        - item_name: Aldarium
+          quantity: 1
+      tools: []
+      output_quantity: 3
+  market_strategy:
+    notes:
+      - "Demand spikes around longform PvM trips where Prayer drain is high."
+      - "Sailing crate drops keep supply elevated when Sailing is active."
+      - "The 2,000 buy limit supports volume flipping for steady margins."
+  trading_tips:
+    - Brewing 3-dose and decanting often outperforms straight 1-dose flips.
+    - Watch Sailing crate yield patches for supply-side price swings.
+  history:
+    - date: "2024-09-25"
+      description: "Added with the Varlamore: The Final Dawn update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-w-m-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-w-m-batta.mdx
@@ -12,9 +12,40 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 6000
-  about: "Premade w'm batta is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: |-
+    Premade w'm batta is a Gnome Cuisine food item sold by Gnome waiters in the Grand Tree and other gnome establishments. It is a pre-made version of the Worm batta, which players can craft themselves at higher Cooking levels.
+
+    Right-click "Eat" heals a small amount of Hitpoints, making it a budget healing snack while questing through the gnome stronghold or running gnome restaurant deliveries for the Gnome Restaurant minigame.
+  market_strategy:
+    notes:
+      - "Stable low-margin snack tied to Gnome Restaurant deliveries"
+      - "High alch break-even close to GE — flip only on dips"
+      - "Buy limit 6,000 supports steady mid-volume flipping"
+      - "Demand is driven by minigame turn-ins, not combat use"
+  history:
+    - date: "2002-12-12"
+      description: "Added to the game alongside the Gnome Cuisine update."
+    - date: "2006-08-07"
+      description: "Renamed from \"Worm batta\" to \"Premade w'm batta\" to disambiguate the shop-bought version from the player-cooked version."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/priest-gown-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/priest-gown-bottom.mdx
@@ -1,6 +1,6 @@
 ---
 title: Priest gown (bottom) | OSRS Price Data
-description: "Priest gown (bottom) is a F2P legs slot item. High alch: 3 GP, GE limit: 150."
+description: "Priest gown (bottom) is a F2P legs slot item with +3 Prayer. High alch: 3 GP, GE limit: 150."
 osrs:
   id: 428
   name: Priest gown (bottom)
@@ -12,22 +12,80 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2002-10-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: true
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  shops:
+    - shop_name: Thessalia's Fine Clothes
+      location: Varrock
+      price: 5
+      currency: Coins
+      stock: 3
+    - shop_name: Fancy Clothes Store
+      location: West Varrock
+      price: 6
+      currency: Coins
+      stock: 0
   related_items:
-    - item_id: 426
-      item_name: Priest gown (top)
+    - item_name: Priest gown (top)
       slug: priest-gown-top
       relationship: set-piece
       description: Matching top
   about: |-
     > _"Bottom half of a priest suit."_
 
-    The priest gown bottom provides +3 Prayer bonus with no requirements. Combined with the top, gives +6 Prayer bonus for just 10 coins total.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The priest gown bottom provides +3 Prayer bonus with no requirements. Combined with the top, the set delivers +6 Prayer bonus for under 15 coins, making it the cheapest no-requirement prayer outfit. Also used in the Biohazard quest.
+  market_strategy:
+    notes:
+      - "Cheap prayer bonus for F2P"
+      - "Quest item for Biohazard"
+      - "Easy resupply from Varrock shop"
+  trading_tips:
+    - Bank the shop price vs GE arbitrage on resets
+  history:
+    - date: "2002-10-23"
+      description: "Released alongside the Biohazard quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-curtains.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-curtains.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: null
-  about: "Raging echoes curtains is a members-only item in Old School RuneScape. High alchemy value: 300 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: construction-decor
+    tier: mid
+  properties:
+    release_date: "2025-01-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 65
+      xp: 487
+      materials:
+        - item_name: Raging echoes curtains
+          quantity: 1
+        - item_name: Mahogany plank
+          quantity: 3
+        - item_name: Bolt of cloth
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Trailblazer reloaded curtains
+      slug: trailblazer-reloaded-curtains
+      relationship: variant
+      description: Previous league-themed curtain variant
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Construction material used to mount the curtains
+    - item_name: Bolt of cloth
+      slug: bolt-of-cloth
+      relationship: component
+      description: Cloth secondary used for the curtain build
+  about: |-
+    > *"Opulent curtains dyed with the colours of the Raging Echoes league."*
+
+    The raging echoes curtains are a members-only Construction reward dropped from the Leagues Reward Shop at Lumbridge Castle for 500 League Points after the Raging Echoes League.
+
+    Building the matching curtain space inside a player-owned house requires 65 Construction, 3 mahogany planks, and 3 bolts of cloth, yielding 487 Construction experience. Although members-only, the curtains are tradeable and treated as a cosmetic flex piece for high-end POH layouts.
+  market_strategy:
+    notes:
+      - "League-themed cosmetics rise with player housing rework rumors."
+      - "Supply is capped by the original Raging Echoes participation pool."
+      - "Not alchable, so price is purely cosmetic demand."
+  trading_tips:
+    - Long-hold cosmetic — flip on POH content updates rather than daily.
+    - Watch league anniversaries for nostalgia-driven spikes.
+  history:
+    - date: "2025-01-15"
+      description: "Added to the Leagues Reward Shop following the Raging Echoes League event."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rainbow-crab-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rainbow-crab-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rainbow crab (1) | OSRS Price Data
-description: "Rainbow crab (1): You'll need something to break through that shell.. High alch: 180 GP."
+description: "Rainbow crab (1): You'll need something to break through that shell. High alch: 180 GP."
 osrs:
   id: 31677
   name: Rainbow crab (1)
@@ -12,9 +12,58 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: null
-  about: "Rainbow crab (1) is a members-only item in Old School RuneScape. High alchemy value: 180 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crustacean
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.6
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Crab trap (Crown Jewel)
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Rainbow crab (2)
+      slug: rainbow-crab-2
+      relationship: variant
+      description: Second colour variant from the same trapping content.
+    - item_name: Rainbow crab (3)
+      slug: rainbow-crab-3
+      relationship: variant
+      description: Third colour variant from the same trapping content.
+    - item_name: Raw rainbow crab meat
+      slug: raw-rainbow-crab-meat
+      relationship: product
+      description: Extracted with a knife to access cooking and brewing chains.
+  about: |-
+    Rainbow crab (1) is one of three colour variants caught via crab trapping on the Crown Jewel after the Sailing update. Each catch grants 216 Hunter XP at level 77 Hunter and yields the closed crab item, which players then process for meat or brewing paste.
+
+    The three variants are functionally identical and exist purely for visual flavour at the catch site.
+  market_strategy:
+    notes:
+      - "Sailing content keeps Hunter demand steady"
+      - "Three-way variant supply keeps any single colour cheaper than the pool average"
+      - "Meat and paste downstream sustain consumption"
+  trading_tips:
+    - Stock raw crabs ahead of herblore XP events
+    - Compare variant prices and arbitrage the cheapest into shelled product
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-mix-1.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 2000
-  about: "Ranging mix(1) is a members-only item in Old School RuneScape. High alchemy value: 86 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.022
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 80
+      xp: 54
+      materials:
+        - item_name: Ranging potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Ranging mix(2)
+      slug: ranging-mix-2
+      relationship: variant
+      description: Two-dose version of the same Barbarian mix
+    - item_name: Ranging potion(2)
+      slug: ranging-potion-2
+      relationship: component
+      description: Base potion used during Barbarian Herblore mixing
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore additive that converts the potion into a mix
+  potion:
+    effects:
+      - description: Boosts Ranged level by 4 + 10% of the player's Ranged level
+        duration: null
+      - description: Heals 6 Hitpoints per dose drunk
+        duration: null
+  about: "Ranging mix is the Barbarian Herblore variant of the ranging potion, made by combining a 2-dose ranging potion with caviar at 80 Herblore for 54 experience. Each dose boosts the player's Ranged level and also restores 6 Hitpoints, making the one-dose flask a popular emergency sip during PvM trips. The single-dose version trades weightless after sip and is most often used to top off inventory slots without committing to a full 4-dose potion."
+  market_strategy:
+    notes:
+      - "Demand spikes around Barbarian Herblore training and boss prep"
+      - "Profit hinges on caviar supply from Pyre logs and fishing diaries"
+      - "Lower stack value than 2-dose mix; flip in tandem with sister item"
+  trading_tips:
+    - Pair flips with Ranging potion(2) and caviar to ride margin moves on both sides
+    - Use during ranged boss rushes such as Zulrah PvM rotations for HP top-ups
+  history:
+    - date: "2007-07-03"
+      description: "Released with Barbarian Herblore as part of the Barbarian Training update."
+
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-cod.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-cod.mdx
@@ -12,18 +12,65 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15000
+  material:
+    type: raw fish
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 18
+      xp: 75
+      materials:
+        - item_name: Raw cod
+          quantity: 1
+      tools:
+        - Range or fire
+      output_quantity: 1
   related_items:
-    - item_id: 339
-      item_name: Cod
+    - item_name: Cod
       slug: cod
       relationship: product
-      description: Cooked version
+      description: Cooked form; gained at level 18 Cooking for 75 XP.
+    - item_name: Big fishing net
+      slug: big-fishing-net
+      relationship: component
+      description: Tool used to net raw cod at sea fishing spots.
   about: |-
-    > _"I should try cooking this."_
+    Raw cod is netted alongside mackerel and bass at big-net fishing spots from level 23 Fishing, granting 45 Fishing XP per catch. Players cook it at level 18 Cooking on a range or fire for 75 Cooking XP, producing the cooked Cod.
 
-    Raw cod can be cooked at 18 Cooking. Caught alongside mackerel, bass, and other sea fish.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Although Raw cod is members-only, it is one of the cheapest tradeable raw fishes, making it useful for low-level Cooking training when buying bulk on the Grand Exchange.
+  market_strategy:
+    notes:
+      - "15,000 buy limit supports bulk Cooking XP routes"
+      - "Margin between raw and cooked cod typically tight — cook only for XP, not profit"
+      - "Supply varies with big-net fishing popularity at Catherby and Fishing Trawler"
+      - "Watch for spikes during Cooking-themed events"
+  history:
+    - date: "2002-02-27"
+      description: "Added to the game."
+    - date: "2015-02-26"
+      description: "Briefly made available to free-to-play players via the Grand Exchange."
+    - date: "2015-03-05"
+      description: "Removed from free-to-play availability."
+    - date: "2018-09-26"
+      description: "Base value reduced from 25 to 10 coins."
+    - date: "2024-11-06"
+      description: "Catch message updated from \"You catch a cod\" to \"You catch a raw cod\" for consistency."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-dashing-kebbit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-dashing-kebbit.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw dashing kebbit is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: raw food
+    tier: mid
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 82
+      xp: 215
+      materials:
+        - item_name: Raw dashing kebbit
+          quantity: 1
+      tools:
+        - Fire or range
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Dashing kebbit
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Dashing kebbit
+      slug: dashing-kebbit
+      relationship: product
+      description: "Cooked version that heals when eaten."
+    - item_name: Burnt kebbit
+      slug: burnt-kebbit
+      relationship: alternative
+      description: "Failed cooking attempt below mastery threshold."
+    - item_name: Quetzal whistle
+      slug: quetzal-whistle
+      relationship: alternative
+      description: "Trade 1 raw kebbit to Soar Leader Pitri for 3 whistle charges."
+  about: "Raw dashing kebbit is caught with level 69 Hunter from dashing kebbits in the Avium Savannah (Varlamore). Cooking it requires 82 Cooking plus 50 Hunters' Rumours completions, granting 215 cooking xp on success. Players also exchange them with Soar Leader Pitri for quetzal whistle charges."
+  market_strategy:
+    notes:
+      - "Supply driven by Hunter trainers chasing 99 in the savannah."
+      - "Cooking it is unprofitable at current prices — flip raw rather than cook."
+  trading_tips:
+    - "Resell to whistle-charge buyers during Varlamore traversal grinds."
+    - "Watch for Hunter XP rate updates that change supply pressure."
+  history:
+    - date: "2024-03-20"
+      description: "Added with Varlamore: The Final Dawn (Avium Savannah hunting area)."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-moonlight-antelope.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-moonlight-antelope.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw moonlight antelope is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: raw food
+    tier: mid-high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 92
+      xp: 220
+      materials:
+        - item_name: Raw moonlight antelope
+          quantity: 1
+      tools:
+        - Range
+      output_quantity: 1
+  related_items:
+    - item_name: Moonlight antelope
+      slug: moonlight-antelope
+      relationship: product
+      description: "Cooked version of the raw moonlight antelope"
+    - item_name: Quetzal whistle
+      slug: quetzal-whistle
+      relationship: alternative
+      description: "Can be exchanged with Soar Leader Pitri for whistle charges"
+    - item_name: Hunters' loot sack (master)
+      slug: hunters-loot-sack-master
+      relationship: component
+      description: "Source of raw moonlight antelopes via Hunter loot sacks"
+  about: |-
+    Raw moonlight antelope is obtained by hunting moonlight antelopes with level 91 Hunter in the Varlamore region. Players can also receive them from Hunters' loot sacks (expert, master, or supplies).
+
+    Cooking requires level 92 Cooking and 50 completed Hunters' Rumours, granting 220 experience per successful cook. Alternative uses include exchanging three raw antelopes with Soar Leader Pitri for quetzal whistle charges.
+  market_strategy:
+    notes:
+      - "Top-tier raw food with strong cooking XP rate"
+      - "Locked behind 92 Cooking plus 50 Hunters' Rumours"
+      - "Hourly profit from cooking around 399k coins"
+  trading_tips:
+    - Cooks net solid margins - buy raw, cook, sell as moonlight antelope
+    - Hunters with the rumour unlock can clear surplus stock at premium
+  history:
+    - date: "2024-03-20"
+      description: "Item added to the game with Varlamore: Part One."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-rabbit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-rabbit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw rabbit | OSRS Price Data
-description: "Raw rabbit: Might taste better cooked.. High alch: 12 GP, GE limit: 13,000."
+description: "Raw rabbit: Might taste better cooked. High alch: 12 GP, GE limit: 13,000."
 osrs:
   id: 3226
   name: Raw rabbit
@@ -12,9 +12,100 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 13000
-  about: "Raw rabbit is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: raw-food
+    tier: low
+  properties:
+    release_date: "2004-09-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.17
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Rabbit (Isafdar)
+        quantity: "1"
+        rarity: Always
+      - source: Rabbit (Miscellania)
+        quantity: "1"
+        rarity: Always
+      - source: Rabbit (Isle of Souls)
+        quantity: "1"
+        rarity: Always
+  shops:
+    - shop_name: Trader Stan's Trading Post
+      location: Port Sarim / Karamja
+      price: 50
+      currency: Coins
+      stock: 20
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw rabbit
+          quantity: 1
+      tools:
+        - Fire or range
+      output_quantity: 1
+    - skill: cooking
+      level: 16
+      xp: 0
+      materials:
+        - item_name: Raw rabbit
+          quantity: 1
+        - item_name: Iron spit
+          quantity: 1
+      tools:
+        - Fire
+      output_quantity: 1
+    - skill: cooking
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Raw rabbit
+          quantity: 1
+        - item_name: Pie shell
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Cooked rabbit
+      slug: cooked-rabbit
+      relationship: product
+      description: Cooked at 1 Cooking for 30 XP
+    - item_name: Skewered rabbit
+      slug: skewered-rabbit
+      relationship: product
+      description: Iron spit + raw rabbit at 16 Cooking
+    - item_name: Raw wild pie
+      slug: raw-wild-pie
+      relationship: product
+      description: Used to make wild pie at 85 Cooking
+  about: |
+    Raw rabbit is a Hunter and Cooking pipeline staple. Hunters at Piscatoris (27+) catch rabbits with snares, and they also drop from rabbits across Isafdar, Miscellania, and Isle of Souls. Cook at level 1 for 30 XP, or upgrade into skewered rabbit or wild pie at higher tiers. Required (cooked or roasted) for Regicide.
+  market_strategy:
+    notes:
+      - "Margin sits between Hunter loot and Cooking demand"
+      - "Buy limit 13,000 supports volume flipping"
+      - "Trader Stan stocks at 50 gp - sometimes cheaper than GE"
+  trading_tips:
+    - 1 Cooking + fire is the cheapest cook
+    - Iron spit unlocks skewered rabbit at 16 Cooking
+    - Wild pie filling at 85 Cooking is a high-XP path
+  history:
+    - date: "2004-09-20"
+      description: "Raw rabbit added with the Hunter skill expansion preview."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-beret.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-beret.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red beret | OSRS Price Data
-description: "Red beret: Parlez-vous francais?. High alch: 48 GP, GE limit: 4."
+description: "Red beret: Parlez-vous francais? High alch: 48 GP, GE limit: 4."
 osrs:
   id: 12247
   name: Red beret
@@ -12,9 +12,71 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 4
-  about: "Red beret is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.04
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Black beret
+      slug: black-beret
+      relationship: variant
+      description: Black-colour variant
+    - item_name: Blue beret
+      slug: blue-beret
+      relationship: variant
+      description: Blue-colour variant
+    - item_name: White beret
+      slug: white-beret
+      relationship: variant
+      description: White-colour variant
+  about: "Red beret is a cosmetic head slot item rewarded from easy clue scrolls (1/1,404). Purely fashionscape, no combat bonuses; storable in costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Cosmetic clue reward, fashionscape demand"
+      - "Tight GE limit (4 per 4 hours)"
+      - "Supply tied to easy clue volume"
+  trading_tips:
+    - Stock up when easy clue events drop supply
+    - Prices reflect rarity (1/1404) not utility
+  history:
+    - date: "2014-06-12"
+      description: "Added with Treasure Trail Expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-crab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-crab.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Red crab is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter-catch
+    tier: low
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.6
+    options:
+      - Cut
+      - Crush
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: hunter
+      level: 21
+      xp: 64
+      materials: []
+      tools:
+        - Crab cage
+      output_quantity: 1
+  related_items:
+    - item_name: Raw red crab meat
+      slug: raw-red-crab-meat
+      relationship: product
+      description: Cut a red crab with a knife to obtain raw meat
+    - item_name: Crab paste
+      slug: crab-paste
+      relationship: product
+      description: Crush a red crab with a pestle and mortar for paste
+  about: |-
+    > *"You'll need something to break through that shell."*
+
+    The red crab is a members-only Hunter catch released with the Sailing skill update on 19 November 2025. Players trap it on the Pandemonium at level 21 Hunter for 64 Hunter experience per catch.
+
+    The crab is processed in two ways. Cutting it with a knife yields raw red crab meat that can be cooked at level 21 Cooking, while crushing it with a pestle and mortar produces crab paste used in Herblore for anti-odour salt and super hunter potions.
+  market_strategy:
+    notes:
+      - "Hunter throughput grew with Sailing, keeping supply consistent."
+      - "Herblore demand from anti-odour salt and super hunter potions sets the price floor."
+      - "No buy limit makes bulk crab paste processing viable."
+  trading_tips:
+    - Margins are tight; flip in bulk through Hunter rush windows.
+    - Track Sailing event spikes for short-term price moves.
+  history:
+    - date: "2025-11-19"
+      description: "Added to OSRS as part of the Sailing skill launch."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-chaps-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-chaps-t.mdx
@@ -12,57 +12,83 @@ osrs:
   lowalch: 2072
   highalch: 3108
   limit: 8
+  material:
+    type: red-dragonhide
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
   equipment:
     slot: legs
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
     requirements:
       ranged: 60
-    stats:
-      attack_ranged: 14
-      attack_magic: -10
-      defence_stab: 15
-      defence_slash: 18
-      defence_crush: 22
-      defence_magic: 18
-      defence_ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 14
+    defence_bonus:
+      stab: 15
+      slash: 18
+      crush: 22
+      magic: 18
+      ranged: 20
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails
+        quantity: "1"
         rarity: Rare
-        description: Rare reward from hard clue scrolls
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 2495
-      item_name: Red d'hide chaps
+    - item_name: Red d'hide chaps
       slug: red-dhide-chaps
       relationship: variant
-      description: Standard version with identical stats
-    - item_id: 12329
-      item_name: Red d'hide chaps (g)
+      description: Standard untrimmed version with identical stats.
+    - item_name: Red d'hide chaps (g)
       slug: red-dhide-chaps-g
       relationship: variant
-      description: Gold-trimmed variant with identical stats
-  about: |-
-    Made from 100% real dragonhide. With colourful trim!
-
-    Red d'hide chaps (t) are a cosmetic variant of red d'hide chaps featuring team-coloured trim. They are obtained exclusively from hard Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard red d'hide chaps, making this item purely aesthetic.
-
-    These chaps require 60 Ranged to equip and provide strong ranged defence bonuses for higher-level rangers. The coloured trimming is the only visual difference from the base version.
+      description: Gold-trimmed cosmetic variant.
+  about: "Red d'hide chaps (t) are a cosmetic team-trimmed variant of red d'hide chaps obtained exclusively from hard Treasure Trail reward caskets. Stats are identical to the base chaps - 60 Ranged to wear, strong ranged defence for mid-game rangers - making the item purely a fashionscape pick rather than a combat upgrade."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Purely cosmetic upgrade over standard red d'hide chaps
-      - Price is driven by fashion demand rather than combat utility
-      - Hard clue scroll rewards have lower supply than medium clue items
-      - Compare price to standard red d'hide chaps to gauge the cosmetic premium
-      - Hard clue trimmed items tend to hold more value than medium clue equivalents
-      - Team-trimmed variants may have different demand patterns than gold-trimmed
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Pure cosmetic premium over standard red d'hide chaps."
+      - "Hard clue supply is leaner than medium clue trims; price tends to be sticky."
+      - "Costume room storage softens inventory drag for collectors."
+      - "Watch the gold-trimmed (g) variant as a comparable to gauge demand spread."
+  trading_tips:
+    - Defence stats were trimmed in the September 2021 ranged armour rebalance; older guides will quote inflated numbers.
+    - Demand tends to track the broader Treasure Trail meta - rises with clue scroll updates.
+  history:
+    - date: "2014-06-12"
+      description: "Released as a hard Treasure Trails reward."
+    - date: "2021-09-23"
+      description: "Defence bonuses reduced as part of the ranged armour rebalance."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragonhide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragonhide.mdx
@@ -12,77 +12,76 @@ osrs:
   lowalch: 58
   highalch: 87
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: hide
     tier: mid-high
-  tanning:
-    cost: 20
-    product_id: 2507
-    product_name: Red dragon leather
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Red dragon
-        source_id: 247
-        combat_level: 152
         quantity: "1"
-        rarity: always
-        members_only: true
+        rarity: Always
       - source: Brutal red dragon
-        source_id: 7275
-        combat_level: 289
         quantity: "2"
-        rarity: always
-        members_only: true
+        rarity: Always
+      - source: Vorkath
+        quantity: "1"
+        rarity: Common
+      - source: Sarachnis
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - item_id: 2507
-      item_name: Red dragon leather
+    - item_name: Red dragon leather
       slug: red-dragon-leather
       relationship: product
-      description: Tanned version
-    - item_id: 2501
-      item_name: Red d'hide body
+      description: Tanned form used in Crafting
+    - item_name: Red d'hide body
       slug: red-dhide-body
       relationship: product
-      description: Main product
-    - item_id: 1747
-      item_name: Black dragonhide
+      description: Common crafted output
+    - item_name: Black dragonhide
       slug: black-dragonhide
-      relationship: alternative
-      description: Higher tier
-    - item_id: 1751
-      item_name: Blue dragonhide
+      relationship: upgrade
+      description: Next-tier dragonhide
+    - item_name: Blue dragonhide
       slug: blue-dragonhide
-      relationship: alternative
-      description: Lower tier
+      relationship: downgrade
+      description: Lower-tier dragonhide
   about: |-
-    Take to any tanner to convert to Red dragon leather.
+    Red dragonhide is the second-highest dragonhide tier and a staple Crafting training material. Take it to any tanner (20 GP standard, 45 GP at Canifis) to convert it into red dragon leather for crafting red dragonhide armour.
 
-    | Tanner | Cost |
-    |--------|------|
-    | Regular | 20 GP |
-    | Canifis | 45 GP |
+    Dropped reliably by red dragons (Brimhaven Dungeon, Forthos Dungeon) and brutal red dragons, plus various high-level bosses including Vorkath and Sarachnis.
   market_strategy:
-    profit_formulas:
-      - Red dragon leather - Red dragonhide - 20 = Profit
-      - Body price - (Leather × 3) = Profit
     notes:
-      - Buy hides → Tan → Sell leather
-      - "Calculate:"
-      - Crafting Guild tanner (bank nearby)
-      - Red d'hide body is most common
-      - "Check:"
-      - Popular crafting training
-      - Red dragons (Brimhaven Dungeon, Forthos)
-      - Brutal red dragons
-      - Red dragon bots common
-      - Second-highest dragonhide tier
-      - Higher volume than black
-      - Good crafting XP/GP balance
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Stable demand from Crafting trainers"
+      - "Tan margin vs leather is a reliable arbitrage when tanner cost is low"
+      - "Bot-suppressed supply at Brimhaven keeps hide price soft"
+  trading_tips:
+    - Buy hides → tan → sell leather for steady profit when leather margin > 20 GP
+    - Check Red d'hide body price vs leather × 3 for a second arbitrage leg
+    - Crafting Guild tanner has a bank nearby for fast cycles
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 (RS2) launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/relicym-s-mix-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Relicym's mix(2) | OSRS Price Data
-description: "Relicym's mix(2): Two doses of fishy Relicym's balm.. High alch: 90 GP, GE limit: 2,000."
+description: "Relicym's mix(2): Two doses of fishy Relicym's balm. High alch: 90 GP, GE limit: 2,000."
 osrs:
   id: 11437
   name: Relicym's mix(2)
@@ -12,9 +12,65 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  about: "Relicym's mix(2) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures disease."
+        duration: 0
+      - description: "Restores 3 Hitpoints per dose."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 9
+      xp: 14
+      materials:
+        - item_name: Relicym's balm(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Relicym's balm
+      slug: relicym-s-balm
+      relationship: component
+      description: Base potion before adding roe/caviar
+    - item_name: Relicym's mix(1)
+      slug: relicym-s-mix-1
+      relationship: variant
+      description: One-dose variant
+  about: "Relicym's mix(2) is the two-dose Barbarian Herblore variant of Relicym's balm, made by adding caviar at level 9 Herblore. Cures disease and restores 3 HP per dose."
+  market_strategy:
+    notes:
+      - "Niche potion; low daily demand"
+      - "Useful for low-level Herblore XP via Barbarian training"
+      - "High alch only 90 gp, thin margins"
+  trading_tips:
+    - Flip alongside Relicym's balm and caviar swings
+    - Limit (2,000) accommodates small-scale flipping
+  history:
+    - date: "2007-07-03"
+      description: "Added with Barbarian Training Herblore."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-life.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-life.mdx
@@ -12,8 +12,34 @@ osrs:
   lowalch: 1410
   highalch: 2115
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: enchanted-ring
+    tier: mid
+  properties:
+    release_date: "2004-04-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Toggle-respawn
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ring
+    weapon_type: null
+    attack_speed: null
+    weight: 0.006
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,64 +57,58 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements: {}
-    weight: 0.006
+  passive_effects:
+    - name: Emergency Teleport
+      description: "Teleports the wearer to their respawn point when HP drops to 10% or below from a hit. Single use — the ring crumbles to dust after triggering."
+    - name: Activation Caveats
+      description: "Does not trigger if a single hit takes the wearer from above 10% directly to 0 HP. Blocked by Tele Block, fails in Wilderness above level 30, and is disabled in select boss arenas including Fight Caves and Inferno."
   recipes:
     - skill: magic
       level: 57
       xp: 67
-      inputs:
+      materials:
         - item_name: Diamond ring
           quantity: 1
         - item_name: Cosmic rune
           quantity: 1
         - item_name: Earth rune
           quantity: 10
+      tools: []
       output_quantity: 1
   related_items:
-    - item_id: 2572
-      item_name: Ring of wealth
+    - item_name: Ring of wealth
       slug: ring-of-wealth
       relationship: upgrade
-      description: RDT improvement ring
-    - item_id: 2550
-      item_name: Ring of recoil
+      description: "Improves Rare Drop Table rolls: a strict upgrade for non-emergency content."
+    - item_name: Ring of recoil
       slug: ring-of-recoil
       relationship: alternative
-      description: Damage reflection ring
+      description: Damage-reflecting alternative for tanking content.
+    - item_name: Diamond ring
+      slug: diamond-ring
+      relationship: component
+      description: Pre-enchantment base ring used in the Lvl-4 Enchant recipe.
   about: |-
-    No combat bonuses. The ring's value is entirely in its passive effect.
+    Ring of life is a low-cost insurance ring that teleports the wearer to their respawn point when struck below 10% Hitpoints. It excels for AFK Wilderness skilling, Slayer tasks with spike-damage monsters, and Hardcore Ironmen who want cheap death insurance.
 
-    Requirements: None to wear | Weight: 0.006 kg
-
-    When HP drops to 10% or below of your maximum Hitpoints after taking damage, the ring automatically teleports you to your respawn point and crumbles to dust.
-
-    Example: At 99 HP, the ring triggers at 9 HP or below.
-
-    - Single use — destroyed after activating
-    - Does not trigger if a single hit takes you from above 10% straight to 0
-    - Does not cure poison (you may still die after teleporting)
-    - Blocked by Tele Block in PvP
-    - Works up to level 30 Wilderness (higher than most jewelry at level 20)
-    - Does not activate in some boss arenas (e.g., Fight Caves, Inferno)
-
-    - Wilderness skilling — safety net while training Agility, hunting black chinchompas, or collecting resources
-    - Slayer tasks — insurance against unexpected high damage
-    - AFK training — reduces risk of dying while semi-AFK
-    - HCIM accounts — cheap life insurance for Hardcore Ironmen
-
-    | Item | Effect | Reusable? |
-    |------|--------|-----------|
-    | Ring of life | Teleport at ≤10% HP | No (destroyed) |
-    | Defence cape | Same as ring of life | Yes (99 Def perk) |
-    | Phoenix necklace | Heal 30% HP at ≤20% | No (destroyed) |
+    The ring is consumed on activation, creating recurring demand from skillers who slot it as a safety net. It does not trigger if a single hit takes the wearer straight from above 10% to zero, so it is not a substitute for proper food management.
   market_strategy:
     notes:
-      - Cheap to enchant (diamond ring + cosmic + earth runes)
-      - Steady demand from Wilderness skillers and HCIM
-      - Consumed on use — recurring demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap to enchant from diamond ring + cosmic + earth runes"
+      - "Single-use mechanic creates recurring demand"
+      - "HCIM and AFK skiller demand keeps the price stable"
+  trading_tips:
+    - Track diamond ring and cosmic rune prices for enchant margin
+    - Sell during Wilderness events and bounty hunter updates
+  history:
+    - date: "2004-04-20"
+      description: "Released as part of the early enchanted jewellery line."
+    - date: "2007-04-30"
+      description: "Graphical update applied to the ring sprite."
+    - date: "2015-03-05"
+      description: "Toggle-respawn option added to worn options."
+    - date: "2018-12-06"
+      description: "Sprite adjusted for visual consistency."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-plank.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-plank.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: null
-  about: "Rosewood plank is a members-only item in Old School RuneScape. High alchemy value: 900 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: plank
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Rosewood logs
+          quantity: 1
+        - item_name: Coins
+          quantity: 7500
+      tools: []
+      output_quantity: 1
+    - skill: magic
+      level: 86
+      xp: 90
+      materials:
+        - item_name: Rosewood logs
+          quantity: 1
+        - item_name: Coins
+          quantity: 5250
+        - item_name: Nature rune
+          quantity: 1
+        - item_name: Astral rune
+          quantity: 2
+        - item_name: Earth rune
+          quantity: 15
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Rosewood logs
+      slug: rosewood-logs
+      relationship: component
+      description: Raw logs sawn or Plank Make'd into the plank
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: downgrade
+      description: Previous tier high-end Construction plank
+    - item_name: Dragon cannon barrel
+      slug: dragon-cannon-barrel
+      relationship: alternative
+      description: Sailing endgame project that consumes rosewood planks
+    - item_name: Plank
+      slug: plank
+      relationship: alternative
+      description: Base Construction plank line that rosewood sits above
+  about: "Rosewood plank is the highest-tier Construction plank introduced with the Sailing skill. Players convert rosewood logs either at the sawmill or via the Plank Make spell, then spend them on top-end Sailing shipbuilding recipes including Dragon cannon barrels, Dragon helms, and full hull assemblies."
+  market_strategy:
+    notes:
+      - "Sawmill cost of 7,500 gp sets a hard floor on plank price"
+      - "Plank Make at 86 Magic with Dream Mentor is the cheaper path"
+      - "Demand driven by Sailing endgame shipbuilding projects"
+  trading_tips:
+    - Watch for Sailing endgame build patches that consume bulk planks
+    - Compare Plank Make break-even versus sawmill spread before bulk buying
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the Sailing skill launch and Construction tier expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolts-e.mdx
@@ -12,54 +12,94 @@ osrs:
   lowalch: 55
   highalch: 82
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: enchanted-bolts
+    tier: mid-high
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    type: enchanted_bolts
-    tradeable: true
+    weapon_type: bolts
+    attack_speed: null
     weight: 0
     requirements:
       ranged: 46
-  effect:
-    name: Blood Forfeit
-    description: Deals 20% of target's current HP as damage
-    max_damage: 100
-    cost: 10% of your HP
-  enchanting:
-    spell: Enchant Crossbow Bolt (Ruby)
-    magic_level: 49
-    runes:
-      - item_name: Fire rune
-        quantity: "5"
-      - item_name: Blood rune
-        quantity: "1"
-      - item_name: Cosmic rune
-        quantity: "1"
-    bolts_per_cast: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 103
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Blood Forfeit
+      description: "Has a 6% chance (PvM, 6.6% with Hard Kandarin Diary) of dealing damage equal to 20% of the target's current HP, capped at 100. The user loses 10% of their own HP when the effect activates. PvP activation chance is 11% (12.1% with diary)."
+  recipes:
+    - skill: magic
+      level: 49
+      xp: 59
+      materials:
+        - item_name: Ruby bolts
+          quantity: 10
+        - item_name: Fire rune
+          quantity: 5
+        - item_name: Blood rune
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+      tools: []
+      output_quantity: 10
   related_items:
-    - item_id: 9339
-      item_name: Ruby bolts
+    - item_name: Ruby bolts
       slug: ruby-bolts
       relationship: component
-      description: Unenchanted version
-    - item_id: 9243
-      item_name: Diamond bolts (e)
+      description: Unenchanted base used in the Enchant Crossbow Bolt (Ruby) spell.
+    - item_name: Diamond bolts (e)
       slug: diamond-bolts-e
       relationship: alternative
-      description: Alternative for low HP targets
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Ammo |
-    | Type | Enchanted Bolts |
-    | Tradeable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 46 Ranged |
-
-    Blood Forfeit: Deals 20% of target's current HP as damage.
-
-    Maximum 100 damage cap. Costs 10% of your HP.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Flat damage proc preferred against low-HP / high-defence targets.
+    - item_name: Onyx bolts (e)
+      slug: onyx-bolts-e
+      relationship: upgrade
+      description: Higher-tier enchanted bolt with a life-leech proc.
+  about: "Ruby bolts (e) carry the Blood Forfeit special effect, making them strong against bosses with very large HP pools such as Vorkath and Corporeal Beast. They are produced via the Enchant Crossbow Bolt (Ruby) spell at 49 Magic, ten bolts per cast."
+  market_strategy:
+    notes:
+      - "Long-standing PvM staple at Vorkath and other high-HP bosses"
+      - "Demand spikes with each new boss with large HP pool"
+      - "Enchanters typically buy ruby bolts cheap and sell (e) variants for margin"
+  trading_tips:
+    - Stack inventory before new boss releases
+    - Flip with rune cost swings; Blood/Cosmic runes drive enchant profit
+  history:
+    - date: "2006-07-31"
+      description: "Added with the original Enchant Crossbow Bolt expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow.mdx
@@ -12,13 +12,34 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
-  ammunition:
-    type: arrow
-    ranged_strength: 49
-    slot: ammo
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
+    weapon_type: arrow
+    attack_speed: null
     weight: 0
+    requirements:
+      ranged: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -36,75 +57,107 @@ osrs:
       ranged_strength: 49
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 40
-  fletching:
-    level: 75
-    xp: 12.5
-    product: Rune arrow
-    product_id: 892
-    quantity_per_action: 15
+  drop_table:
+    sources:
+      - source: Mithril dragon
+        quantity: "1"
+        rarity: 3/128
+      - source: Fire giant
+        quantity: "1"
+        rarity: 5/128
+      - source: Kalphite Queen
+        quantity: "1"
+        rarity: 3/126
+      - source: Chaos Elemental
+        quantity: "1"
+        rarity: 5/128
+      - source: Ankou (Wilderness Slayer Cave)
+        quantity: "1"
+        rarity: 4/92
+  shops:
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      price: 400
+      currency: Coins
+      stock: 1000
+    - shop_name: Lletya Archery Shop
+      location: Lletya
+      price: 520
+      currency: Coins
+      stock: 1000
+    - shop_name: Dargaud's Bow and Arrows
+      location: Ranging Guild
+      price: 400
+      currency: Coins
+      stock: 1000
+    - shop_name: Sian's Ranged Weaponry
+      location: Prifddinas
+      price: 400
+      currency: Coins
+      stock: 1000
+    - shop_name: Daryl's Ranging Surplus
+      location: Shayzien
+      price: 400
+      currency: Coins
+      stock: 1000
   recipes:
     - skill: fletching
       level: 75
       xp: 187.5
       materials:
         - item_name: Headless arrow
-          item_id: 53
           quantity: 15
         - item_name: Rune arrowtips
-          item_id: 44
           quantity: 15
-      product: Rune arrow
-      product_id: 892
-      product_quantity: 15
-      members_only: true
+      tools: []
+      output_quantity: 15
   related_items:
-    - item_id: 53
-      item_name: Headless arrow
+    - item_name: Headless arrow
       slug: headless-arrow
       relationship: component
       description: Arrow shaft component
-    - item_id: 44
-      item_name: Rune arrowtips
+    - item_name: Rune arrowtips
       slug: rune-arrowtips
       relationship: component
       description: Rune tip component
-    - item_id: 890
-      item_name: Adamant arrow
+    - item_name: Adamant arrow
       slug: adamant-arrow
       relationship: downgrade
       description: Lower tier arrow
-    - item_id: 11212
-      item_name: Dragon arrow
+    - item_name: Dragon arrow
       slug: dragon-arrow
       relationship: upgrade
       description: Higher tier arrow
-    - item_id: 21326
-      item_name: Amethyst arrow
+    - item_name: Amethyst arrow
       slug: amethyst-arrow
       relationship: alternative
       description: Alternative high-tier arrow
+  about: |
+    Rune arrows are the second-best non-special arrow in OSRS, providing +49 ranged strength and requiring 40 Ranged to wield. They're widely used for PKing, general PvM, and crystal bow setups. With 75 Fletching, you can craft them in batches of 15 from headless arrows and rune arrowtips.
   market_strategy:
-    title: Component Chain
-    profit_formulas:
-      - (Rune arrow × 15) - (Headless arrow × 15) - (Rune arrowtips × 15) = Profit
     notes:
-      - "Calculate:"
-      - 75 Fletching required
-      - Check arrowtip vs arrow margins
-      - Arrow shaft + Feather = Headless arrow
-      - Runite bar → Rune arrowtips
-      - High-level ranged training
-      - Crystal bow alternative ammo
-      - PKing (cheaper than dragon)
-      - General PvM
-      - Dragon arrows are often cheaper
-      - Popular for ironmen
-      - Check dragon arrow prices first
-      - Used in ballista
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Calculate: (Rune arrow x 15) - (Headless arrow x 15) - (Rune arrowtips x 15) = Profit"
+      - "75 Fletching required for crafting"
+      - "Check arrowtip vs arrow margins"
+      - "Arrow shaft + Feather = Headless arrow"
+      - "Runite bar yields Rune arrowtips"
+      - "High-level Ranged training staple"
+      - "Crystal bow alternative ammo"
+      - "Cheaper than dragon arrows for PKing"
+      - "General PvM workhorse"
+      - "Dragon arrows occasionally undercut rune"
+      - "Popular for ironmen via Fletching"
+      - "Compare dragon arrow prices before bulk buy"
+      - "Used with Heavy ballista as well"
+  trading_tips:
+    - Catherby/Ranging Guild shops sell at 400 gp each
+    - Lletya stock is overpriced at 520 gp
+    - Fletch in batches of 15 for tick efficiency
+  history:
+    - date: "2002-03-25"
+      description: "Rune arrows added to the game."
+    - date: "2006-08-22"
+      description: "The extra strong poisoned variant was renamed from 'Rune arrow(+)' to 'Rune arrow(p+)'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-full-helm-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-full-helm-g.mdx
@@ -12,68 +12,91 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    stats:
-      attack_magic: -6
-      attack_ranged: -3
-      defence_stab: 30
-      defence_slash: 32
-      defence_crush: 27
-      defence_magic: -1
-      defence_ranged: 30
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
     requirements:
       defence: 40
-  obtaining:
-    methods:
-      - source: Hard Treasure Trails
-        type: Reward casket (hard)
-        rarity: 1/1,625
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 1163
-      item_name: Rune full helm
+    - item_name: Rune full helm
       slug: rune-full-helm
-      relationship: component
-      description: Standard version with identical stats
-    - item_id: 2627
-      item_name: Rune full helm (t)
+      relationship: variant
+      description: Standard untrimmed version with identical stats
+    - item_name: Rune full helm (t)
       slug: rune-full-helm-t
       relationship: variant
-      description: Trimmed version
-    - item_id: 2615
-      item_name: Rune platebody (g)
+      description: Trimmed cosmetic variant
+    - item_name: Rune platebody (g)
       slug: rune-platebody-g
       relationship: set-piece
       description: Matching gold-trimmed platebody
   about: |-
     > *"Rune full helmet with gold trim."*
 
-    | Bonus | Value |
-    |-------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -6 |
-    | Ranged Attack | -3 |
-    | Stab Defence | +30 |
-    | Slash Defence | +32 |
-    | Crush Defence | +27 |
-    | Magic Defence | -1 |
-    | Ranged Defence | +30 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | 0% |
-    | Prayer | +0 |
+    The rune full helm (g) is a cosmetic gold-trimmed version of the rune full helm. Stats are identical to the regular helm, but the gold trim makes it a sought-after fashionscape item for both F2P and members. It requires 40 Defence to equip.
 
-    Requirements: 40 Defence
+    The helm cannot be made through Smithing — the only way to obtain it is as a reward from hard Treasure Trails.
   market_strategy:
     notes:
-      - F2P tradeable, popular in free-to-play fashion
-      - Low buy limit due to treasure trail rarity
-      - Price driven by cosmetic demand, not utility
-      - Identical stats to regular rune full helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "F2P tradeable, popular in free-to-play fashionscape"
+      - "Low GE buy limit due to treasure trail rarity (1/1,625 from hard caskets)"
+      - "Price driven by cosmetic demand, not utility"
+      - "Identical stats to regular rune full helm — purely a fashion item"
+  trading_tips:
+    - Margin trade in small batches due to the 8-per-4-hours limit
+    - Demand spikes during F2P PvP and fashion events
+  history:
+    - date: "2004-05-05"
+      description: "Item released alongside the original rune armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-full-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune full helm | OSRS Price Data
-description: "Rune full helm is a F2P head slot item. High alch: 21,120 GP, GE limit: 70."
+description: "Rune full helm is a F2P head slot item requiring 40 Defence. High alch: 21,120 GP, GE limit: 70."
 osrs:
   id: 1163
   name: Rune full helm
@@ -12,80 +12,113 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2001-08-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: full_helm
-    attack_style: melee
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 2.721
-  requirements:
-    defence: 40
-  stats:
-    attack:
+    requirements:
+      defence: 40
+    attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: -6
       ranged: -3
-    defence:
+    defence_bonus:
       stab: 30
       slash: 32
       crush: 27
       magic: -1
       ranged: 30
-    other:
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  smithing:
-    level: 92
-    xp: 150
-    bars_required: 2
-    bar_id: 2363
-    bar_name: Runite bar
+  recipes:
+    - skill: smithing
+      level: 92
+      xp: 150
+      materials:
+        - item_name: Runite bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
   shops:
-    - shop_name: Blast Furnace
+    - shop_name: Blast Furnace Shop
+      location: Keldagrim
       price: 35200
+      currency: Coins
+      stock: 0
     - shop_name: Prifddinas armour shop
+      location: Prifddinas
       price: 35200
+      currency: Coins
+      stock: 0
   drop_table:
     sources:
       - source: Mithril dragon
-        source_id: 5363
-        combat_level: 304
         quantity: "1"
         rarity: rare
-        members_only: true
       - source: Jelly
-        source_id: 437
-        combat_level: 78
         quantity: "1"
         rarity: rare
-        members_only: true
   related_items:
-    - item_id: 1147
-      item_name: Rune med helm
+    - item_name: Rune med helm
       slug: rune-med-helm
       relationship: alternative
       description: Lighter alternative
-    - item_id: 2363
-      item_name: Runite bar
+    - item_name: Runite bar
       slug: runite-bar
       relationship: component
       description: Smithing material
-    - item_id: 1079
-      item_name: Rune platelegs
+    - item_name: Rune platelegs
       slug: rune-platelegs
-      relationship: alternative
-      description: Set piece
-    - item_id: 1127
-      item_name: Rune platebody
+      relationship: set-piece
+      description: Matching legs
+    - item_name: Rune platebody
       slug: rune-platebody
-      relationship: alternative
-      description: Set piece
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: set-piece
+      description: Matching body
+  about: |-
+    > _"A full face helmet."_
+
+    Rune full helm is the strongest free-to-play helmet, granting +30 stab, +32 slash, and +27 crush defence at 40 Defence. Smithable at 92 Smithing from 2 runite bars (150 XP), or obtained as a rare drop from monsters like mithril dragons.
+  market_strategy:
+    notes:
+      - "Top F2P helmet"
+      - "92 Smithing barrier limits supply"
+      - "Demand from mid-level mains"
+  trading_tips:
+    - Buy after rune bar dips for smithing margin
+    - Flip near high alch value on slow days
+  history:
+    - date: "2001-08-13"
+      description: "Released as part of the rune armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-gold-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-gold-trimmed-set-sk.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Rune gold-trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour set
+    tier: mid
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Rune full helm (g)
+      slug: rune-full-helm-g
+      relationship: set-piece
+      description: Helm component of the set
+    - item_name: Rune platebody (g)
+      slug: rune-platebody-g
+      relationship: set-piece
+      description: Platebody component of the set
+    - item_name: Rune plateskirt (g)
+      slug: rune-plateskirt-g
+      relationship: set-piece
+      description: Plateskirt component of the set
+    - item_name: Rune kiteshield (g)
+      slug: rune-kiteshield-g
+      relationship: set-piece
+      description: Kiteshield component of the set
+    - item_name: Rune gold-trimmed set (lg)
+      slug: rune-gold-trimmed-set-lg
+      relationship: alternative
+      description: Plate-legs (lg) variant of the same trimmed set
+  about: |-
+    The Rune gold-trimmed set (sk) is a Grand Exchange convenience set containing four pieces: a Rune full helm (g), Rune platebody (g), Rune plateskirt (g), and Rune kiteshield (g). The "sk" suffix denotes the plateskirt variant as opposed to the (lg) plate-legs version.
+
+    Released alongside the Grand Exchange set system, players can exchange the set with a Grand Exchange clerk to receive the individual pieces. Cosmetic only - stats are identical to standard rune armour.
+
+    Components are obtained from medium Treasure Trails.
+  market_strategy:
+    notes:
+      - "Convenience set - price tied to sum of component pieces"
+      - "Arbitrage opportunity vs unboxing into individual (g) parts"
+      - "F2P tradeable - large buyer pool"
+      - "Low buy limit (8) caps daily volume"
+  trading_tips:
+    - Compare set price to sum of components for arbitrage
+    - Skirt variant is typically cheaper than legs variant
+    - Watch medium clue drop adjustments for supply shifts
+  history:
+    - date: "2015-02-26"
+      description: "Item released with The Grand Exchange set system update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-kiteshield-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-kiteshield-t.mdx
@@ -12,22 +12,81 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 8
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
   equipment:
     slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
     requirements:
       defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -2
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 2621
-      item_name: Rune kiteshield (g)
+    - item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: variant
+      description: Standard untrimmed version with identical stats.
+    - item_name: Rune kiteshield (g)
       slug: rune-kiteshield-g
       relationship: variant
-      description: Gold-trimmed variant
-  about: |-
-    > *"Rune kiteshield with trim."*
-
-    The rune kiteshield (t) is a trimmed cosmetic variant of the standard rune kiteshield. Identical stats, requiring 40 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Gold-trimmed cosmetic variant.
+  about: "The rune kiteshield (t) is a trimmed cosmetic variant of the standard rune kiteshield, dropped exclusively from hard Treasure Trail reward caskets at roughly 1/1,625. It cannot be smithed and shares identical combat stats with the untrimmed version, requiring 40 Defence to wield."
+  market_strategy:
+    notes:
+      - "Purely cosmetic premium over the standard rune kiteshield."
+      - "Supply tied to hard clue completion rates."
+      - "Stores in costume room treasure chest, reducing active inventory drain."
+      - "Compare price gap to base kiteshield to gauge fashion premium."
+  trading_tips:
+    - Buy after large clue scroll events when supply spikes.
+    - Watch for double XP/clue weekends that flood the market.
+  history:
+    - date: "2004-05-05"
+      description: "Released as a hard clue Treasure Trail reward."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h4.mdx
@@ -12,22 +12,94 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
     requirements:
       defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 23209
-      item_name: Rune platebody (h1)
+    - item_name: Rune platebody
+      slug: rune-platebody
+      relationship: variant
+      description: Standard rune platebody with identical stats
+    - item_name: Rune platebody (h1)
       slug: rune-platebody-h1
       relationship: variant
       description: Heraldic variant 1
+    - item_name: Rune platebody (h2)
+      slug: rune-platebody-h2
+      relationship: variant
+      description: Heraldic variant 2
+    - item_name: Rune platebody (h3)
+      slug: rune-platebody-h3
+      relationship: variant
+      description: Heraldic variant 3
+    - item_name: Rune platebody (h5)
+      slug: rune-platebody-h5
+      relationship: variant
+      description: Heraldic variant 5
   about: |-
     > *"Provides excellent protection with a heraldic design."*
 
-    The rune platebody (h4) is a heraldic cosmetic variant of the rune platebody. Identical stats, requiring 40 Defence and Dragon Slayer I quest.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The rune platebody (h4) is a heraldic cosmetic variant of the rune platebody. It carries the same combat statistics as the standard plate, requiring 40 Defence and the Dragon Slayer I quest completion to equip.
+
+    The (h4) variant is obtained exclusively as a reward from hard Treasure Trails caskets at a roughly 1/8,125 rate. F2P-eligible cosmetic, popular among collectors for matching heraldic kits.
+  market_strategy:
+    notes:
+      - "Supply is entirely driven by hard clue completion rates."
+      - "Heraldic crests trend with fashionscape demand and event cosmetics."
+      - "Buy limit of 8 per 4 hours suits low-volume flipping."
+  trading_tips:
+    - Stock during Treasure Trail content updates when supply spikes.
+    - Sets featuring matching plateskirt and kiteshield carry pricing power.
+  history:
+    - date: "2019-04-11"
+      description: "Added to the hard Treasure Trail reward pool as part of the clue scroll expansion."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-scimitar-ornament-kit-guthix.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-scimitar-ornament-kit-guthix.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Rune scimitar ornament kit (guthix) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic kit
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: beginner
+    is_reward: true
+    reward_tiers:
+      - beginner
+  drop_table:
+    sources:
+      - source: Reward casket (beginner)
+        quantity: "1"
+        rarity: "1/360"
+  related_items:
+    - item_name: Rune scimitar
+      slug: rune-scimitar
+      relationship: component
+      description: "Base weapon the kit attaches to."
+    - item_name: Rune scimitar (guthix)
+      slug: rune-scimitar-guthix
+      relationship: product
+      description: "Ornate Guthix-themed rune scimitar produced after applying the kit."
+    - item_name: Rune scimitar ornament kit (saradomin)
+      slug: rune-scimitar-ornament-kit-saradomin
+      relationship: alternative
+      description: "Saradomin god-themed cosmetic alternative."
+    - item_name: Rune scimitar ornament kit (zamorak)
+      slug: rune-scimitar-ornament-kit-zamorak
+      relationship: alternative
+      description: "Zamorak god-themed cosmetic alternative."
+  about: "A purely cosmetic kit added with the April 2019 god-themed clue rewards. Apply it to a rune scimitar to create a Guthix-themed scimitar with identical stats. The ornate version is untradeable but the kit can be detached and resold."
+  market_strategy:
+    notes:
+      - "Supply is rate-limited by beginner clue completions (1/360 from caskets)."
+      - "Demand is mostly cosmetic — F2P-eligible buyers pump price when god-themed cosmetics trend."
+  trading_tips:
+    - "Buy in clue-content lulls; flip during god-themed events."
+    - "Detach before selling if you applied it — kit alone is tradeable."
+  history:
+    - date: "2019-04-11"
+      description: "Added as a beginner-tier clue reward alongside Saradomin and Zamorak variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-s-tear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-s-tear.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 16000
   highalch: 24000
   limit: 50
-  about: "Saradomin's tear is a members-only item in Old School RuneScape. High alchemy value: 24,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crystal
+    tier: high
+  properties:
+    release_date: "2014-10-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Last Man Standing lobby
+      price: 150
+      currency: Last Man Standing points
+      stock: 1
+  related_items:
+    - item_name: Saradomin sword
+      slug: saradomin-sword
+      relationship: component
+      description: Combined with tear to make Saradomin's blessed sword
+    - item_name: Saradomin's blessed sword
+      slug: saradomin-s-blessed-sword
+      relationship: product
+      description: Upgraded sword requiring 75 Attack, degrades after 10,000 hits
+  about: "Saradomin's tear is a Last Man Standing reward used to upgrade the Saradomin sword into Saradomin's blessed sword. The blessed sword degrades after 10,000 hits and returns the tear."
+  market_strategy:
+    notes:
+      - "Bottleneck for Saradomin's blessed sword crafting"
+      - "Supply tied to LMS points spend (150 per tear)"
+      - "GE limit 50 per 4 hours"
+  trading_tips:
+    - Track LMS popularity for supply shifts
+    - Blessed sword breakage triggers tear reappearance
+  history:
+    - date: "2014-10-09"
+      description: "Added as a Bounty Hunter reward."
+    - date: "2018-10-04"
+      description: "Migrated to Justine's Last Man Standing shop after Bounty Hunter rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-faith.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-faith.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of faith | OSRS Price Data
-description: "Sigil of faith: A power enhancing sigil not yet attuned to you."
+description: "Sigil of faith: A power enhancing sigil not yet attuned to you. Deadman Mode sigil that boosts Prayer point regeneration from potions."
 osrs:
   id: 28520
   name: Sigil of faith
@@ -12,9 +12,51 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of faith is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2023-08-23"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: false
+    destroy: "You will lose this sigil if you destroy it. You must unattune the sigil first."
+  passive_effects:
+    - name: Faithful Recovery (Annihilation)
+      description: "Doubles Prayer points restored from Prayer-restoring potions."
+    - name: Faithful Recovery (Armageddon)
+      description: "40 percent chance to double Prayer points restored from Prayer-restoring potions."
+    - name: Faithful Recovery (Apocalypse)
+      description: "20 percent chance to double Prayer points restored from Prayer-restoring potions."
+  related_items:
+    - item_name: Sigil of resilience
+      slug: sigil-of-resilience
+      relationship: alternative
+      description: Defensive Deadman sigil unlocked via the same skull shop.
+    - item_name: Sigil of restoration
+      slug: sigil-of-restoration
+      relationship: alternative
+      description: Stat-restoration Deadman sigil from the same event pool.
+  about: "Sigil of faith is one of the unlockable power sigils introduced with the Deadman: Apocalypse tournament. Players must first unattune the sigil before it can be destroyed. It is generally only obtainable during active Deadman Mode events and may not be tradeable depending on the season."
+  market_strategy:
+    notes:
+      - "Only available during seasonal Deadman events; outside windows it is effectively unobtainable."
+      - "Value resets each season because the sigil pool is event-bound."
+  trading_tips:
+    - Stockpile or unlock during active Deadman seasons before the event ends.
+    - Decide whether to attune or trade based on the current event's economy.
+  history:
+    - date: "2023-08-23"
+      description: "Sigil of faith added with the Deadman: Apocalypse tournament."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-woodcraft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-woodcraft.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Sigil of woodcraft is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sigil
+    tier: mid
+  properties:
+    release_date: "2023-08-23"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  passive_effects:
+    - name: Plank Conversion
+      description: "Automatically converts logs into planks while woodcutting at a coin cost: 50 per regular plank, 125 per oak, 250 per teak, and 700 per mahogany."
+    - name: Restricted Areas
+      description: "Does not function in guarded areas or while using an infernal axe."
+  related_items:
+    - item_name: Deadman's skull
+      slug: deadmans-skull
+      relationship: component
+      description: Currency used at the skull shop to purchase Sigil of woodcraft and trade in duplicates.
+  about: |-
+    Sigil of woodcraft is a Deadman Mode reward that streamlines Construction prep by auto-planking logs as you chop. It is unobtainable in the live game and currently exclusive to temporary Deadman seasons such as Deadman: Annihilation.
+
+    Because the sigil consumes coins per plank, it is a quality-of-life upgrade for high-level Construction training rather than a free shortcut. Duplicates can be sold back at the skull shop for refunds.
+  market_strategy:
+    notes:
+      - "Untradeable — no GE price"
+      - "Value tied to Deadman season activity"
+      - "Sells back to skull shop for partial refund"
+  trading_tips:
+    - Pick up during Deadman seasons before duplicates flood the shop
+    - Useful as a backup utility during shorter Deadman events
+  history:
+    - date: "2023-08-23"
+      description: "Released as part of the Deadman Mode reward pool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-p-9306.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-p-9306.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  about: "Silver bolts (p++) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: silver
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: crossbow
+    attack_speed: null
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 36
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 43
+      xp: 50
+      materials:
+        - item_name: Silver bolts (unf)
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      output_quantity: 10
+  related_items:
+    - item_name: Silver bolts
+      slug: silver-bolts
+      relationship: variant
+      description: "Unpoisoned silver bolts."
+    - item_name: Silver bolts (p)
+      slug: silver-bolts-p
+      relationship: variant
+      description: "Standard poison-tipped silver bolts."
+    - item_name: Silver bolts (p+)
+      slug: silver-bolts-p-plus
+      relationship: variant
+      description: "Stronger poison-tipped silver bolts."
+    - item_name: Silver bolts (unf)
+      slug: silver-bolts-unf
+      relationship: component
+      description: "Unfeathered base used during fletching."
+    - item_name: Feather
+      slug: feather
+      relationship: component
+      description: "Required to fletch the bolt heads."
+  about: "Silver bolts (p++) are the strongest poisoned variant of silver bolts. Crafted by adding extra-strength weapon poison to silver bolts, they apply poison damage on hit and remain particularly effective against vampyre juvinates and similar undead targets. Ranged strength bonus is +36."
+  market_strategy:
+    notes:
+      - "Demand is niche — mainly Morytania vampyre tasks and certain Slayer assignments."
+      - "Profit comes from making p++ from base silver bolts plus extra-strength poison vials."
+  trading_tips:
+    - "Bulk-buy silver bolts and weapon poison (++) during low-volume hours."
+    - "Sell pre-stacked thousands for vampyre Slayer flippers."
+  history:
+    - date: "2006-07-31"
+      description: "Added when poisoned bolts were introduced."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Silver bolts (p) | OSRS Price Data
-description: "Silver bolts (p): Some poisoned silver bolts.. High alch: 3 GP, GE limit: 11,000."
+description: "Silver bolts (p): Some poisoned silver bolts. Poisoned silver crossbow bolts effective against Vampyre Juvinates. High alch: 3 GP, GE limit: 11,000."
 osrs:
   id: 9292
   name: Silver bolts (p)
@@ -12,9 +12,75 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  about: "Silver bolts (p) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: silver
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: bolts
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 36
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Silver bolts
+      slug: silver-bolts
+      relationship: variant
+      description: Unpoisoned base bolts.
+    - item_name: Silver bolts (p+)
+      slug: silver-bolts-p-plus
+      relationship: upgrade
+      description: Stronger poison variant.
+    - item_name: Silver bolts (p++)
+      slug: silver-bolts-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant.
+  about: "Silver bolts (p) are silver crossbow bolts coated in weak poison. They are most notable for their effectiveness against Vampyre Juvinates, where silver-based ammunition is one of the few options that deal meaningful damage. Fired from a crossbow at 46+ Ranged."
+  market_strategy:
+    notes:
+      - "Niche demand tied to Vampyre Juvinate killing in Morytania content."
+      - "Crafted by poisoning silver bolts with weapon poison, narrow supply pool."
+  trading_tips:
+    - Buy in 11,000 stacks for resale around vampyric Slayer tasks.
+    - Compare against unpoisoned silver bolts to gauge poison premium.
+  history:
+    - date: "2006-07-31"
+      description: "Silver bolts (p) released alongside silver bolts and other crossbow bolt variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-dust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-dust.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 13000
-  about: "Silver dust is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: secondary-ingredient
+    tier: low
+  properties:
+    release_date: "2006-03-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.15
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+      tools:
+        - Bone grinder
+      output_quantity: 1
+  related_items:
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Ground at a bone grinder to produce silver dust.
+    - item_name: Guthix balance(1)
+      slug: guthix-balance-1
+      relationship: product
+      description: Used as a secondary in Guthix balance potion variants.
+    - item_name: Guthix balance(2)
+      slug: guthix-balance-2
+      relationship: product
+      description: Used as a secondary in Guthix balance potion variants.
+  about: "Silver dust is created by grinding a silver bar at a bone grinder (located at the Ectofuntus). It is the key secondary ingredient for Guthix balance potions, used against vampyres in the Myreque quest series."
+  market_strategy:
+    notes:
+      - "Demand driven by Guthix balance brewing for vampyre quests"
+      - "Profitable to craft from silver bars when GE price exceeds bar cost"
+      - "Low daily volume makes large flips slow"
+  trading_tips:
+    - Buy silver bars cheap and grind for steady profit
+    - Stock up before quest releases referencing Myreque content
+  history:
+    - date: "2006-03-22"
+      description: "Added to the game with the In Aid of the Myreque quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-gloves.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 125
-  about: "Skeletal gloves is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic gloves
+    tier: mid
+  properties:
+    release_date: "1 August 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 3.175
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Wallasalki
+        quantity: "1"
+        rarity: uncommon
+  related_items:
+    - item_name: Skeletal helm
+      slug: skeletal-helm
+      relationship: set-piece
+      description: Helm piece in the Skeletal armour set
+    - item_name: Skeletal top
+      slug: skeletal-top
+      relationship: set-piece
+      description: Body piece in the Skeletal armour set
+    - item_name: Skeletal bottoms
+      slug: skeletal-bottoms
+      relationship: set-piece
+      description: Legs piece in the Skeletal armour set
+    - item_name: Skeletal boots
+      slug: skeletal-boots
+      relationship: set-piece
+      description: Boots piece in the Skeletal armour set
+  about: |-
+    Skeletal gloves are part of the Fremennik Skeletal armour set, dropped exclusively by Wallasalki on Waterbirth Island. Unlike the body and legs pieces, gloves and boots do not require wearing the full set for Fremennik name honor.
+
+    | Stat | Defence |
+    |------|---------|
+    | Slash | +1 |
+    | Crush | +2 |
+
+    Storable in the costume room magic wardrobe.
+  market_strategy:
+    notes:
+      - "Limited supply from a single mid-tier drop source"
+      - "Demand driven by Skeletal set completion"
+      - "Cheap entry-level Fremennik-themed gloves"
+      - "GE limit of 125 keeps flips small but consistent"
+  trading_tips:
+    - Buy during Waterbirth content lulls
+    - Pair purchases with other skeletal pieces for set listings
+  history:
+    - date: "1 August 2005"
+      description: "Released as a Wallasalki drop on Waterbirth Island."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snowy-knight-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snowy-knight-mix-1.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: null
-  about: "Snowy knight mix (1) is a members-only item in Old School RuneScape. High alchemy value: 30 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Heals 8 Hitpoints to the player on consumption."
+        duration: 0
+      - description: "Heals nearby players with Accept Aid enabled in multicombat areas."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Jarred snowy knight
+          quantity: 1
+        - item_name: Hunter creature meat
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  related_items:
+    - item_name: Snowy knight mix (2)
+      slug: snowy-knight-mix-2
+      relationship: variant
+      description: Two-dose variant of the same potion
+    - item_name: Jarred snowy knight
+      slug: jarred-snowy-knight
+      relationship: component
+      description: Base ingredient combined with hunter meat
+  about: |-
+    > *"There's a snowy knight butterfly in here."*
+
+    The snowy knight mix is a members-only healing potion released alongside Varlamore: Part One on 20 March 2024. Each dose heals the drinker for 8 Hitpoints and applies the same heal to nearby players running Accept Aid in multicombat zones, making it a popular group support item.
+
+    It is created by combining a jarred snowy knight with hunter creature meat (wild kebbit, larupia, barb-tailed kebbit, graahk, kyatt, pyre fox, sunlight antelope, dashing kebbit, or moonlight antelope) using a pestle and mortar.
+  market_strategy:
+    notes:
+      - "Group-content metas drive most buying pressure for stacks of mixes."
+      - "Supply scales with Hunter activity in Varlamore."
+      - "Healing nerf from 15 to 8 per dose softens long-term demand."
+  trading_tips:
+    - Watch group bossing events for spike opportunities.
+    - Bulk decanting is sometimes profitable when 1-dose stock outpaces 2-dose.
+  history:
+    - date: "2024-03-20"
+      description: "Released with Varlamore: Part One."
+    - date: "2024-03-21"
+      description: "Heal per dose reduced from 15 to 8 Hitpoints."
+    - date: "2026-01-07"
+      description: "Patched so the heal no longer triggers when a player is at zero Hitpoints."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/soulflame-horn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/soulflame-horn.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 88000
   highalch: 132000
   limit: 5
-  about: "Soulflame horn is a members-only item in Old School RuneScape. High alchemy value: 132,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bone
+    tier: high
+  properties:
+    release_date: "2025-05-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.375
+    options:
+      - Drop
+    worn_options:
+      - Pound
+      - Pummel
+      - Spike
+      - Block
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spiked
+    attack_speed: 5
+    weight: 0.375
+    requirements:
+      magic: 80
+    attack_bonus:
+      stab: 2
+      crush: 21
+    defence_bonus:
+      slash: 7
+      crush: 3
+      magic: 11
+    other_bonus:
+      strength: 23
+      magic_damage: 1
+  drop_table:
+    sources:
+      - source: Yama
+        quantity: "1"
+        rarity: 2/600
+      - source: Yama Contract (Harmony Acquisition)
+        quantity: "1"
+        rarity: Always
+  passive_effects:
+    - name: Entice
+      description: "Special attack: empowers up to 3 nearby players within a 3-tile radius for 10 ticks, guaranteeing their next melee attack hits. Costs 25% special attack energy per affected player. Requires Accept Aid enabled on recipients."
+  related_items:
+    - item_name: Yama
+      slug: yama
+      relationship: component
+      description: Boss that drops the horn
+  about: "Soulflame horn is a members-only one-handed magic weapon dropped by Yama. Its Entice special attack empowers nearby allies, making it a premium support weapon for group PvM."
+  market_strategy:
+    notes:
+      - "High-tier boss drop (Yama 2/600)"
+      - "Premium support weapon for group PvM"
+      - "High alch 132,000 gp floor"
+      - "GE limit 5 per 4 hours"
+  trading_tips:
+    - Watch Yama kill volume to predict supply
+    - Group PvM demand drives long-term price
+  history:
+    - date: "2025-05-14"
+      description: "Item released as a drop from Yama."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spatula.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spatula.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 50
-  about: "Spatula is a members-only item in Old School RuneScape. High alchemy value: 1,152 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: kitchen weapon
+    tier: low
+  properties:
+    release_date: "15 March 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: 2h_sword
+    attack_speed: 7
+    weight: 3.628
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 0
+      slash: 27
+      crush: 21
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 26
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle basement
+      price: 2496
+      currency: coins
+      stock: infinite
+  related_items:
+    - item_name: Frying pan
+      slug: frying-pan
+      relationship: alternative
+      description: Other Culinaromancer's Chest kitchen weapon
+    - item_name: Rolling pin
+      slug: rolling-pin
+      relationship: alternative
+      description: Crush-style kitchen weapon
+    - item_name: Black 2h sword
+      slug: black-2h-sword
+      relationship: alternative
+      description: Stat-equivalent generic 2h sword
+  about: |-
+    The Spatula is a two-handed kitchen weapon purchased from the Culinaromancer's Chest in Lumbridge Castle basement after completing three Recipe for Disaster subquests. It shares its stats with the Black 2h sword.
+
+    | Stat | Attack | Defence |
+    |------|--------|---------|
+    | Stab | 0 | 0 |
+    | Slash | +27 | +1 |
+    | Crush | +21 | 0 |
+    | Strength | +26 | - |
+
+    A pure novelty wield with niche cooking-themed roleplay value.
+  market_strategy:
+    notes:
+      - "Cheap collectible kitchen weapon"
+      - "Limited demand outside fashionscape"
+      - "GE limit of 50 caps any flipping"
+      - "Buyable on demand from Culinaromancer's Chest, capping the ceiling"
+  trading_tips:
+    - Compare GE price to 2,496 gp shop floor before buying
+    - Use as a low-cost RfD-locked fashionscape piece
+  history:
+    - date: "15 March 2006"
+      description: "Added with the Recipe for Disaster quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/squid-paste.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/squid-paste.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Squid paste is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crafting material
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Raw swordtip squid
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Raw jumbo squid
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  related_items:
+    - item_name: Raw swordtip squid
+      slug: raw-swordtip-squid
+      relationship: component
+      description: "Crushed with a pestle and mortar to make squid paste"
+    - item_name: Raw jumbo squid
+      slug: raw-jumbo-squid
+      relationship: component
+      description: "Alternate crushable squid for squid paste"
+    - item_name: Haemostatic poultice
+      slug: haemostatic-poultice
+      relationship: product
+      description: "Made from squid paste as part of the haemostatic dressing chain"
+  about: |-
+    Squid paste is a crafting material produced by crushing raw swordtip squid or raw jumbo squid with a pestle and mortar. Both raw squid types come from lantern harpooning content released alongside the Sailing skill.
+
+    The paste is used to make haemostatic poultice, the penultimate ingredient in haemostatic dressings.
+  market_strategy:
+    notes:
+      - "Profitability depends on which squid source is used (swordtip favourable)"
+      - "No GE buy limit gives flexibility for bulk listings"
+      - "Demand tied to haemostatic dressing crafting throughput"
+  trading_tips:
+    - Crush raw swordtip squid for the better profit margin
+    - Watch GE volume - over 30k daily indicates steady market depth
+  history:
+    - date: "2025-11-19"
+      description: "Item added to the game with the Sailing skill release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-mix-2.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 2000
-  about: "Stamina mix(2) is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2014-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 20% run energy."
+        duration: 0
+      - description: "Reduces run energy depletion rate by 70%."
+        duration: 120
+      - description: "Heals 6 Hitpoints on consumption."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 86
+      xp: 60
+      materials:
+        - item_name: Stamina potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Stamina potion(2)
+      slug: stamina-potion-2
+      relationship: component
+      description: Base potion mixed with caviar to create the fishy variant.
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore secondary used to create mixes.
+    - item_name: Stamina mix(1)
+      slug: stamina-mix-1
+      relationship: variant
+      description: One-dose version of the same Barbarian potion.
+  about: "Stamina mix(2) is the two-dose Barbarian Herblore variant of the stamina potion, adding a 6 HP heal on each drink while preserving the run energy restore and 70% energy drain reduction effect. Mixing at Seers' Village bank counts toward Elite Kandarin Diary."
+  market_strategy:
+    notes:
+      - "Provides the only universal stamina effect outside of regular stamina potions"
+      - "Mixing margin compresses when caviar restocks at fishing colonies dip"
+      - "Used by PvM/slayer accounts that want extra healing per inventory slot"
+  trading_tips:
+    - Watch caviar GE prices; mix profit follows them inversely
+    - Buy during weekday lulls and offload at weekend PvM peaks
+  history:
+    - date: "2014-07-03"
+      description: "Added when stamina potions joined the Barbarian Herblore mix list."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-full-helm-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-full-helm-t.mdx
@@ -12,22 +12,89 @@ osrs:
   lowalch: 220
   highalch: 330
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 9
+      slash: 10
+      crush: 7
+      magic: -1
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 20184
-      item_name: Steel platebody (t)
+    - item_name: Steel full helm
+      slug: steel-full-helm
+      relationship: variant
+      description: Standard untrimmed version with identical stats
+    - item_name: Steel platebody (t)
       slug: steel-platebody-t
       relationship: set-piece
       description: Matching trimmed platebody
   about: |-
-    > *"Steel full helm with trim."*
+    > *"A steel full helmet with trim."*
 
-    The steel full helm (t) is a trimmed cosmetic variant of the standard steel full helm. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The steel full helm (t) is a cosmetic trimmed variant of the standard steel full helm, released with the 2016 Treasure Trail Expansion. Stats are identical to the regular steel full helm, requiring only 5 Defence to equip.
+
+    Obtained exclusively from easy clue scroll caskets at a rate of roughly 1 in 1,404.
+  market_strategy:
+    notes:
+      - "F2P tradeable, low-cost fashionscape"
+      - "Steady supply from easy clue rewards"
+      - "Used in low-level cosmetic sets"
+      - "Identical stats to standard steel full helm"
+  trading_tips:
+    - Margin small due to low alch and large GE buy limit
+    - Demand picks up around clue scroll events
+  history:
+    - date: "2016-07-06"
+      description: "Item added with the Treasure Trail Expansion."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus decreased from -2 to -3."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platebody-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platebody-g.mdx
@@ -12,27 +12,86 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 32
+      slash: 31
+      crush: 24
+      magic: -6
+      ranged: 38
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 20172
-      item_name: Steel platelegs (g)
+    - item_name: Steel platelegs (g)
       slug: steel-platelegs-g
       relationship: set-piece
-      description: Matching gold-trimmed platelegs
-    - item_id: 20184
-      item_name: Steel platebody (t)
+      description: "Matching gold-trimmed platelegs for the set"
+    - item_name: Steel platebody (t)
       slug: steel-platebody-t
       relationship: variant
-      description: Trimmed variant
-  about: |-
-    > *"Steel platebody with a gold trim."*
-
-    The steel platebody (g) is a gold-trimmed cosmetic variant of the standard steel platebody. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Trimmed cosmetic variant of the same platebody"
+    - item_name: Steel platebody
+      slug: steel-platebody
+      relationship: variant
+      description: "Standard untrimmed steel platebody with identical stats"
+  about: "The steel platebody (g) is a gold-trimmed cosmetic variant of the standard steel platebody, identical in stats and requiring only 5 Defence to equip. It cannot be made via Smithing and only drops from easy Treasure Trail reward caskets at a 1/1,404 rarity."
+  market_strategy:
+    notes:
+      - "Supply tracks easy clue completion volume, with a hard cap from the 1/1,404 drop rate"
+      - "Demand is largely cosmetic from low-level F2P fashionscape and set collectors"
+      - "F2P tradeable, so listings move across both game modes"
+  trading_tips:
+    - "Pair pricing with steel platelegs (g) since collectors usually buy the set together"
+    - "Watch for clue scroll bonus events that can briefly flood supply"
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of an easy Treasure Trails reward expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platelegs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel platelegs | OSRS Price Data
-description: "Steel platelegs: These look pretty heavy.. High alch: 600 GP, GE limit: 125."
+description: "Steel platelegs: These look pretty heavy. High alch: 600 GP, GE limit: 125."
 osrs:
   id: 1069
   name: Steel platelegs
@@ -12,24 +12,92 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
-  item_id: 1069
-  item_type: armor
-  slot: legs
-  type: platelegs
-  tradeable: true
-  weight: 9.071
-  requirements:
-    defence: 5
-  stats:
-    stab_defence: 17
-    slash_defence: 16
-    crush_defence: 15
-    ranged_defence: 16
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
+    requirements:
+      defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 17
+      slash: 16
+      crush: 15
+      magic: -4
+      ranged: 16
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 46
+      xp: 112.5
+      materials:
+        - item_name: Steel bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Louie's Armoured Legs Bazaar
+      location: Al Kharid
+      price: 1000
+      currency: Coins
+      stock: 2
   related_items:
-    - slug: black-platelegs
-    - slug: steel-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Black platelegs
+      slug: black-platelegs
+      relationship: alternative
+      description: Lower-tier alternative
+    - item_name: Steel platebody
+      slug: steel-platebody
+      relationship: set-piece
+      description: Matching body
+  about: |-
+    > _"These look pretty heavy."_
+
+    Steel platelegs are a free-to-play leg slot armour requiring 5 Defence to wear. Smith them at level 46 with 3 steel bars for 112.5 XP, or buy them in Al Kharid.
+  market_strategy:
+    notes:
+      - "Common F2P armour"
+      - "Steel bar price drives floor"
+      - "Used in smithing training"
+  trading_tips:
+    - Watch steel bar costs for profit margin
+    - Bulk smith for Defence XP via High Alch
+  history:
+    - date: "2001-01-04"
+      description: "Released alongside the original armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-energy-mix-1.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
-  about: "Super energy mix(1) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 20% run energy."
+        duration: 0
+      - description: "Heals 6 Hitpoints on consumption."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 56
+      xp: 39
+      materials:
+        - item_name: Super energy(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Super energy(2)
+      slug: super-energy-2
+      relationship: component
+      description: Base potion mixed with caviar to create the fishy variant.
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore secondary that converts potions to mixes.
+    - item_name: Super energy mix(2)
+      slug: super-energy-mix-2
+      relationship: variant
+      description: Two-dose variant of the same potion.
+  about: "Super energy mix(1) is a single-dose Barbarian Herblore variant of the super energy potion. Mixing with caviar adds a small heal-on-drink on top of the standard run energy restore. Requires completion of the Otto Godblessed Barbarian Herblore training."
+  market_strategy:
+    notes:
+      - "Useful for long PvM trips where every healing tick matters"
+      - "Mostly bought by Herblore trainers chasing the 39 XP per dose"
+      - "Buy limit of 2,000 caps speculative volume"
+  trading_tips:
+    - Buy when caviar prices spike and players cash out partial mixes
+    - Look for arbitrage vs Super energy(2) plus caviar cost
+  history:
+    - date: "2007-07-03"
+      description: "Added with the Barbarian Training Herblore expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-fishing-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super fishing potion(3) | OSRS Price Data
-description: "Super fishing potion(3): 3 doses of super fishing potion.. High alch: 102 GP."
+description: "Super fishing potion(3): 3 doses of super fishing potion. +6 Fishing boost. High alch: 102 GP."
 osrs:
   id: 31605
   name: Super fishing potion(3)
@@ -12,9 +12,77 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: null
-  about: "Super fishing potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.09
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily boosts the Fishing level by +6."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 62
+      xp: 140
+      materials:
+        - item_name: Pillar potion (unf)
+          quantity: 1
+        - item_name: Haddock eye
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Super fishing potion(4)
+      slug: super-fishing-potion-4
+      relationship: variant
+      description: 4-dose version of the same potion
+    - item_name: Super fishing potion(2)
+      slug: super-fishing-potion-2
+      relationship: variant
+      description: 2-dose version
+    - item_name: Super fishing potion(1)
+      slug: super-fishing-potion-1
+      relationship: variant
+      description: 1-dose version
+    - item_name: Fishing potion
+      slug: fishing-potion
+      relationship: downgrade
+      description: Standard fishing potion (+3 Fishing) before the Sailing rework
+  about: |-
+    > *"3 doses of super fishing potion."*
+
+    The super fishing potion is a Sailing-update potion (released 19 November 2025) that grants a +6 Fishing boost on consumption. It is brewed at 62 Herblore by combining an unfinished pillar potion with a haddock eye for 140.5 XP per dose set.
+
+    Unlike the standard fishing potion, the super version cannot be stored in a tackle box, which limits inventory strategies for long Sailing trips.
+  market_strategy:
+    notes:
+      - "Demand driven by Sailing content and Fishing XP boosting"
+      - "Cannot be stored in a tackle box — limits supply-side carry strategies"
+      - "No GE buy limit listed currently"
+      - "3-dose form decants down from 4-dose, supporting a small flipping margin"
+  trading_tips:
+    - Decant 4-dose into 3-dose for small flips when 3-dose is in demand
+    - Watch haddock eye and unfinished pillar potion supply for inputs
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Super restore(3) | OSRS Price Data
-description: "Super restore(3) is a 3-dose members potion that restores all stats (except hitpoints) and prayer. High alch: 144 GP, GE limit: 2,000."
+description: "Super restore(3) is a 3-dose members potion that restores stats and Prayer. High alch: 144 GP, GE limit: 2,000."
 osrs:
   id: 3026
   name: Super restore(3)
@@ -12,76 +12,79 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 2000
-  potion:
-    doses: 3
-    type: restore
-    effect: Restores all stats (except Hitpoints) and Prayer
-    effects:
-      - stat: All stats
-        boost_formula: 8 + floor(level / 4)
-      - stat: Prayer
-        boost_formula: 8 + floor(level / 4)
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
   properties:
+    release_date: "2004-07-27"
     tradeable: true
-    tradeable_ge: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores all lowered stats (except Hitpoints) by floor(level x 0.25) + 8 per dose"
+        duration: 0
+      - description: "Restores Prayer points by floor(level x 0.25) + 8 per dose (boosted to floor(level x 0.27) + 8 with Holy wrench or Prayer cape)"
+        duration: 0
   recipes:
     - skill: herblore
       level: 63
       xp: 142.5
       materials:
         - item_name: Snapdragon potion (unf)
-          item_id: 3004
           quantity: 1
         - item_name: Red spiders' eggs
-          item_id: 223
           quantity: 1
-      members_only: true
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
   related_items:
-    - item_id: 3024
-      item_name: Super restore(4)
+    - item_name: Super restore(4)
       slug: super-restore-4
-      relationship: variant
+      relationship: upgrade
       description: Full dose variant
-    - item_id: 3000
-      item_name: Snapdragon
+    - item_name: Snapdragon
       slug: snapdragon
       relationship: component
       description: Primary herb
-    - item_id: 6685
-      item_name: Saradomin brew(4)
+    - item_name: Saradomin brew(4)
       slug: saradomin-brew-4
       relationship: alternative
-      description: Paired consumable (3:1 ratio)
+      description: Paired consumable (3:1 brew/restore ratio)
   about: |-
-    Mix Snapdragon potion (unf) + Red spiders' eggs.
+    > _"3 doses of super restore potion."_
 
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 63 |
-    | XP gained | 142.5 |
-
-    Per dose restores:
-    - All stats except Hitpoints
-    - Prayer points: 8 + 25% of level
-    - Other stats: 8 + 25% of level
-
-    At 99 Prayer: Restores 32 prayer points per dose.
-
-    Essential for high-level PvM:
-    - Raids (CoX, ToB, ToA)
-    - Bossing (GWD, Nex, etc.)
-    - Inferno attempts
-    - Used with Saradomin brew (3:1 ratio)
-
-    Note: Counters stat drain from Saradomin brews.
+    Super restore(3) restores all lowered stats (except Hitpoints) and Prayer points per dose. Essential for raids (CoX, ToB, ToA), GWD bossing, Nex, and Inferno attempts. Frequently paired with Saradomin brews to counter stat drain.
   market_strategy:
     notes:
-      - High demand from raiders
-      - Price tied to Snapdragon
-      - Essential consumable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "High demand from raiders"
+      - "Price tracks Snapdragon herb"
+      - "Essential PvM consumable"
+  trading_tips:
+    - Decant 3s into 4s when premium > decant cost
+    - Buy ahead of weekend raid surges
+  history:
+    - date: "2004-07-27"
+      description: "Released as a snapdragon-based potion."
+    - date: "2004-09-01"
+      description: "Updated to restore non-combat stats."
+    - date: "2004-10-26"
+      description: "Added the 'Empty' option."
+    - date: "2016-04-15"
+      description: "Enabled as bank placeholders."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-toad-item.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-toad-item.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Swamp toad (item) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: herblore secondary
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Remove-legs
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Swamp toad (item)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Toad's legs
+      slug: toads-legs
+      relationship: product
+      description: "Obtained by removing the legs from a swamp toad"
+    - item_name: Agility potion
+      slug: agility-potion
+      relationship: product
+      description: "Toad's legs are a herblore secondary for agility potions"
+    - item_name: Toad batta
+      slug: toad-batta
+      relationship: product
+      description: "Gnome cooking dish using toad's legs"
+  about: |-
+    The Swamp toad (item) is a herblore-adjacent ingredient obtained from gnome thieving (75 Thieving) or from various spawn locations including the Tree Gnome Stronghold swamp and west of Taverley lake.
+
+    Using the Remove-legs option yields toad's legs, which heal 3 hitpoints and serve as a herblore secondary for agility potions plus several gnome cooking dishes such as tangled toad's legs, toad batta, and toad crunchies.
+  market_strategy:
+    notes:
+      - "Cheap herblore secondary chain (toad to legs to agility potion)"
+      - "High GE limit (13,000) supports volume listings"
+      - "Gnome cooking demand keeps the price floor stable"
+  trading_tips:
+    - Buy swamp toads in bulk and convert to toad's legs for resale margin
+    - Useful filler for herblore alts training agility potions
+  history:
+    - date: "2002-12-12"
+      description: "Item added to the game with the original Tree Gnome Stronghold release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem-b.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem-b.mdx
@@ -1,20 +1,95 @@
 ---
 title: Swords and emblem (b) | OSRS Price Data
-description: "Swords and emblem (b): Sadly, the blades are only decorative."
+description: "Swords and emblem (b): Sadly, the blades are only decorative. Cosmetic Grid Master event reward."
 osrs:
   id: 31196
   name: Swords and emblem (b)
   slug: swords-and-emblem-b
-  examine: Sadly, the blades are only decorative
+  examine: Sadly, the blades are only decorative.
   members: true
   icon: Swords and emblem (b).png
   value: 100000
-  lowalch: null
-  highalch: null
+  lowalch: 40000
+  highalch: 60000
   limit: null
-  about: Swords and emblem (b) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2025-10-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: cosmetic
+    attack_speed: null
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Events Reward Shop
+      location: Varrock Square
+      price: 1100
+      currency: Event points
+      stock: 1
+  related_items:
+    - item_name: Swords and emblem
+      slug: swords-and-emblem
+      relationship: variant
+      description: Standard variant of the cosmetic.
+    - item_name: Swords and emblem (g)
+      slug: swords-and-emblem-g
+      relationship: variant
+      description: Gold-coloured variant.
+    - item_name: Swords and emblem (p)
+      slug: swords-and-emblem-p
+      relationship: variant
+      description: Purple-coloured variant.
+    - item_name: Grid Master tabard (b)
+      slug: grid-master-tabard-b
+      relationship: set-piece
+      description: Pairs with the blue tabard from the same event shop.
+  about: "Swords and emblem (b) is a purely cosmetic blue variant of the Grid Master event reward, sold at the Events Reward Shop in Varrock Square for 1,100 event points. The blades are decorative - all combat bonuses are zero - and the piece is intended to round out the blue Grid Master set alongside its matching tabard."
+  market_strategy:
+    notes:
+      - "No combat utility; value is driven entirely by fashionscape demand for the Grid Master set."
+      - "Supply gated by event participation and 1,100-point shop price."
+      - "No GE buy limit listed - large flips are possible but liquidity is thin."
+      - "Demand should cool once the Grid Master event window fully closes."
+  trading_tips:
+    - Buy during the active event window when point holders flood supply.
+    - Compare against gold (g) and purple (p) variants; rare colours tend to outperform.
+  history:
+    - date: "2025-10-15"
+      description: "Released as part of the Grid Master community event reward shop."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-stock.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 30
   highalch: 46
   limit: 10000
-  about: "Teak stock is a members-only item in Old School RuneScape. High alchemy value: 46 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: fletching-component
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 46
+      xp: 27
+      materials:
+        - item_name: Teak logs
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  shops:
+    - shop_name: Lowe's Archery Emporium
+      location: Varrock
+      price: 77
+      currency: Coins
+      stock: 0
+    - shop_name: Hirko's crossbow shop
+      location: Keldagrim
+      price: 46
+      currency: Coins
+      stock: 5
+    - shop_name: Dargaud's bow and arrow shop
+      location: White Wolf Mountain
+      price: 38
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Teak logs
+      slug: teak-logs
+      relationship: component
+      description: Raw material used to fletch the teak stock.
+    - item_name: Teak stock (u)
+      slug: teak-stock-u
+      relationship: product
+      description: Combined with steel limbs to create an unstrung steel crossbow.
+    - item_name: Maple stock
+      slug: maple-stock
+      relationship: downgrade
+      description: Lower-tier crossbow stock requiring less Fletching.
+    - item_name: Mahogany stock
+      slug: mahogany-stock
+      relationship: upgrade
+      description: Higher-tier crossbow stock requiring more Fletching.
+  about: "Teak stock is a members-only Fletching component crafted from teak logs at level 46 Fletching for 27 experience. It serves as the stock for the steel crossbow, accepting steel limbs to form an unstrung steel crossbow. Sold in dwarven crossbow shops and tradeable on the Grand Exchange with a 10,000 buy limit."
+  market_strategy:
+    notes:
+      - "Profit margins are tight; teak log costs frequently exceed alch value."
+      - "Demand is driven by Fletching trainers and steel crossbow producers."
+      - "Shop restocks in Keldagrim and White Wolf Mountain can undercut GE pricing during low-volume hours."
+  trading_tips:
+    - "Buy teak logs in bulk and fletch stocks if Fletching level permits cheaper supply."
+    - "Watch for steel limbs price spikes — paired demand can briefly lift stock prices."
+    - "Use noted stocks when stockpiling for crossbow production."
+  history:
+    - date: "2006-07-31"
+      description: "Added to the game alongside the Fletching expansion for crossbow components."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-16-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-16-cape.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-16 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Richard's Wilderness Cape Shop
+      location: Edgeville
+      price: 50
+      currency: coins
+      stock: 100
+  related_items:
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: First entry in the Team cape family
+    - item_name: Team-15 cape
+      slug: team-15-cape
+      relationship: variant
+      description: Adjacent team number, identical mechanics
+    - item_name: Team-17 cape
+      slug: team-17-cape
+      relationship: variant
+      description: Adjacent team number, identical mechanics
+  about: "Team-16 cape is one of 50 numbered team capes sold by Richard's Wilderness Cape Shop in Edgeville for 50 gp. Players wearing the same team cape appear as blue dots on each other's minimap (instead of white) and PvP attack options are pushed to right-click, mimicking same-level combat behaviour."
+  market_strategy:
+    notes:
+      - "Shop floor of 50 gp under-cuts most GE flips"
+      - "F2P PvP teams drive small bursts of demand"
+      - "Random number variants trade nearly interchangeably"
+  trading_tips:
+    - Stock up around F2P PvP events or clan wars
+    - Compare Richard's restock price before listing
+  history:
+    - date: "2005-02-22"
+      description: "Released with Richard's Wilderness Cape Shop in Edgeville for F2P PvP groups."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-3-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-3-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-3 cape | OSRS Price Data
-description: "Team-3 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-3 cape: Ooohhh look at the pretty colours... High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4319
   name: Team-3 cape
@@ -12,9 +12,85 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-3 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Larry's Wilderness Cape Shop
+      location: Bone Yard (Wilderness)
+      price: 50
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Different team number variant
+    - item_name: Team-2 cape
+      slug: team-2-cape
+      relationship: variant
+      description: Different team number variant
+    - item_name: Team-4 cape
+      slug: team-4-cape
+      relationship: variant
+      description: Different team number variant
+  about: |
+    The Team-3 cape is one of 50 team capes sold by Larry in the Wilderness Bone Yard. Players use these capes to identify allies in PvP and clan events. Despite the wilderness origin, they're a free-to-play cosmetic with light defensive stats.
+  market_strategy:
+    notes:
+      - "Low GE volume but cheap shop floor"
+      - "Limit 150 caps any meaningful flip"
+      - "Demand spikes briefly during clan/PvP events"
+  trading_tips:
+    - Buy bulk from Larry for 50 gp each
+    - F2P-accessible since the 2013 update
+    - Pick a team number when organizing PvP groups
+  history:
+    - date: "2005-02-22"
+      description: "Team capes added with Larry's Wilderness shop."
+    - date: "2013-05-23"
+      description: "Team capes opened up to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teleport-to-boat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teleport-to-boat.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Teleport to boat is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport tablet
+    tier: mid
+  properties:
+    release_date: "19 November 2025"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Last Boat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 67
+      xp: 77
+      materials:
+        - item_name: Earth rune
+          quantity: 2
+        - item_name: Water rune
+          quantity: 2
+        - item_name: Law rune
+          quantity: 2
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Required rune for the spell
+    - item_name: Earth rune
+      slug: earth-rune
+      relationship: component
+      description: Required rune for the spell
+    - item_name: Water rune
+      slug: water-rune
+      relationship: component
+      description: Required rune for the spell
+  about: |-
+    Teleport to boat is a tablet form of the Standard Spellbook spell unlocked through Pandemonium. Breaking the tablet transports the caster to their player-owned boat's mooring location, provided the boat has a greater teleport focus installed.
+
+    | Property | Value |
+    |----------|-------|
+    | Magic level | 67 |
+    | XP | 77 |
+    | Spellbook | Standard |
+    | Runes | 2 Earth, 2 Water, 2 Law |
+
+    Boats are selected via menu (spacebar for last-used, number keys otherwise). Non-equipped boats are greyed out. Casting while aboard a boat with focus teleports the caster to the last docking point and loses the boat.
+
+    Common destinations include Brittle Isle, Drumstick Isle, Wintumber Island, Lledrith Island, Tear of the Soul, Charred Island, Chinchompa Island, Sunbleak Island, and Ynysdail.
+  market_strategy:
+    notes:
+      - "Niche tablet tied to Pandemonium completion"
+      - "Low alch keeps NPC value floor minimal"
+      - "Tablet supply scales with player boat ownership"
+  trading_tips:
+    - Stockpile before island-content updates push demand
+    - Compare tablet price to raw rune cost as fair-value anchor
+  history:
+    - date: "20 May 2026"
+      description: "Added right-click \"Last Boat\" option for quick return."
+    - date: "19 November 2025"
+      description: "Released with Pandemonium quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thunder-khopesh.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thunder-khopesh.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Thunder khopesh is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: weapon
+    tier: high
+  properties:
+    release_date: "2024-11-27"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: slash_sword
+    attack_speed: 4
+    weight: 1.36
+    requirements:
+      attack: 75
+    attack_bonus:
+      stab: 65
+      slash: 110
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 100
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Lightning Strike
+      description: 20% chance on hit to summon a delayed lightning bolt at the target's location, damaging enemies in a 3x3 area for up to 50% of the player's max hit.
+    - name: Lingering Lightning
+      description: Special attack consuming 50% special energy that deals two rapid hits; on success it triggers an additional lightning bolt dealing damage up to 100% of the player's maximum hit.
+  related_items:
+    - item_name: Keris partisan of the sun
+      slug: keris-partisan-of-the-sun
+      relationship: alternative
+      description: Alternative high-tier one-handed slash weapon
+    - item_name: Osmumten's fang
+      slug: osmumtens-fang
+      relationship: alternative
+      description: Top-tier stab weapon comparable in slot
+  about: |
+    Thunder khopesh is a Leagues V: Raging Echoes weapon (released 27 November 2024) that returned via the Grid Master demonic throne event. It's a 4-tick slash sword with +110 slash and +100 strength, plus a 20% chance lightning AoE passive and a 50% special attack that fires two hits and a follow-up lightning bolt. Untradeable and currently retired from standard gameplay.
+  market_strategy:
+    notes:
+      - "Untradeable - no GE pricing"
+      - "Acquired only via Leagues V or Grid Master event"
+      - "Out of game since 12 November 2025"
+  trading_tips:
+    - Not on the Grand Exchange
+    - Was a 1/25 drop from Echo King Black Dragon during Leagues V
+    - Returned briefly via the Grid Master demonic throne build
+  history:
+    - date: "2024-11-27"
+      description: "Thunder khopesh released with Leagues V: Raging Echoes."
+    - date: "2025-11-12"
+      description: "Thunder khopesh removed from the live game."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tome-of-fire-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tome-of-fire-empty.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 15
-  about: "Tome of fire (empty) is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magical
+    tier: high
+  properties:
+    release_date: "2016-09-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wield
+      - Pages
+      - Drop
+    worn_options:
+      - Pages
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements:
+      magic: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 8
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 8
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward Cart (Wintertodt)
+        quantity: "1"
+        rarity: 1/1000
+  passive_effects:
+    - name: Infinite fire runes
+      description: When charged with burnt or searing pages, the tome supplies unlimited fire runes to cast spells
+    - name: Fire spell damage boost
+      description: Charged tome boosts fire spell damage by 10% against NPCs and 50% against players, consuming one charge per cast
+  related_items:
+    - item_name: Tome of fire
+      slug: tome-of-fire
+      relationship: variant
+      description: Charged form holding up to 1,000 burnt or searing pages
+    - item_name: Burnt page
+      slug: burnt-page
+      relationship: component
+      description: Standard charge fuel for the tome
+    - item_name: Searing page
+      slug: searing-page
+      relationship: component
+      description: Premium charge fuel from the Wintertodt
+    - item_name: Tome of water (empty)
+      slug: tome-of-water-empty
+      relationship: alternative
+      description: Water-spell equivalent shield tome
+  about: "The empty tome of fire is the tradeable form of the fire spell shield, dropped at 1/1,000 from the Wintertodt reward cart. Once charged with burnt or searing pages it provides infinite fire runes and a 10% damage boost to fire spells in PvM (50% in PvP), holding up to 1,000 charges that each consume one page per cast."
+  market_strategy:
+    notes:
+      - "Only tradeable empty; charged tomes are locked to the owner"
+      - "Supply is gated by Wintertodt activity and high-level firemaker farming"
+      - "Buy limit of 15 makes large flips slow"
+  trading_tips:
+    - Buy after Wintertodt content spikes flood the market with drops
+    - Page price (burnt vs searing) often shifts demand for empty tomes
+  history:
+    - date: "2016-09-08"
+      description: "Released as a Wintertodt reward alongside the Wintertodt minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-banner.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: null
-  about: "Trailblazer reloaded banner is a members-only item in Old School RuneScape. High alchemy value: 600 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic banner
+    tier: mid
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer banner
+      slug: trailblazer-banner
+      relationship: variant
+      description: Original Leagues III banner cosmetic
+    - item_name: Twisted banner
+      slug: twisted-banner
+      relationship: alternative
+      description: Earlier Leagues banner from Twisted League
+    - item_name: Shattered banner
+      slug: shattered-banner
+      relationship: alternative
+      description: Leagues II Shattered Relics cosmetic banner
+  about: "Trailblazer reloaded banner is the Leagues IV: Trailblazer Reloaded cosmetic weapon awarded from the league reward shop. Players can wield it for show, hang it on a player-owned house banner stand, or use it as a single-slot bank substitute for ironmen displays."
+  market_strategy:
+    notes:
+      - "Cosmetic with no combat stats; price tracks collector demand"
+      - "Limited initial supply because banners are bought with finite League Points"
+      - "GE price tends to drift up as supply ages without re-issuance"
+  trading_tips:
+    - Pick up dips when Leagues nostalgia events resurface
+    - Hold long-term given the inability to re-mint banners post-league
+  history:
+    - date: "2023-11-15"
+      description: "Initially added to the game files."
+    - date: "2023-11-29"
+      description: "Released as a Leagues IV reward shop purchase for 500 League Points."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tzhaar-ket-om.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tzhaar-ket-om.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 70
-  about: "Tzhaar-ket-om is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: obsidian
+    tier: mid-high
+  properties:
+    release_date: "2005-09-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: bludgeon
+    attack_speed: 7
+    weight: 3.628
+    requirements:
+      strength: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 80
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 85
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: TzHaar-Ket (level 149)
+        quantity: "1"
+        rarity: "1/512"
+      - source: TzHaar-Ket (level 221)
+        quantity: "1"
+        rarity: "1/512"
+  shops:
+    - shop_name: Tzhaar-Hur-Lek's Ore and Gem Store
+      location: Mor Ul Rek
+      price: 375000
+      currency: Tokkul
+      stock: 0
+  related_items:
+    - item_name: Obsidian cape
+      slug: obsidian-cape
+      relationship: set-piece
+      description: "Worn with obsidian armour and weapon for damage bonus."
+    - item_name: Berserker necklace
+      slug: berserker-necklace
+      relationship: set-piece
+      description: "Adds +20 percent strength when wielding obsidian melee weapons."
+    - item_name: Toktz-xil-ak
+      slug: toktz-xil-ak
+      relationship: alternative
+      description: "Faster obsidian sword alternative with stab/slash."
+    - item_name: Toktz-xil-ek
+      slug: toktz-xil-ek
+      relationship: alternative
+      description: "Obsidian dagger alternative."
+  about: "Tzhaar-ket-om is a two-handed obsidian maul requiring 60 Strength. Popular with mid-level PvP 'obby maulers' for its +85 strength bonus and synergy with the Berserker necklace (+20 percent strength). Slow attack speed (7 ticks) limits its DPS at higher tiers."
+  market_strategy:
+    notes:
+      - "Demand is steady from obby pure builds and PvP world flippers."
+      - "Tokkul purchase route caps incoming supply when chaos rune prices stay high."
+  trading_tips:
+    - "Watch chaos rune prices — chaos-to-Tokkul conversion sets the floor."
+    - "Stock up before bossing leagues that favor low-defence pures."
+  history:
+    - date: "2005-09-19"
+      description: "Released with the Karamja Volcano update introducing TzHaar."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-comp-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-comp-bow.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 10000
-  about: "Unstrung comp bow is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2005-05-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 30
+      xp: 45
+      materials:
+        - item_name: Achey tree logs
+          quantity: 1
+        - item_name: Wolf bones
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Comp ogre bow
+      slug: comp-ogre-bow
+      relationship: product
+      description: String this with a bowstring for 45 Fletching XP
+    - item_name: Achey tree logs
+      slug: achey-tree-logs
+      relationship: component
+      description: Primary log used to carve the comp bow
+    - item_name: Wolf bones
+      slug: wolf-bones
+      relationship: component
+      description: Required reinforcement for the composite shaft
+    - item_name: Bow string
+      slug: bow-string
+      relationship: component
+      description: Stringing material to finish the bow
+  about: "The unstrung comp bow is the Fletching intermediate for the composite ogre bow, gated behind Zogre Flesh Eaters. Players with 30 Fletching combine Achey tree logs with wolf bones using a knife to produce it, then string it with a bowstring for another 45 XP and a final Comp ogre bow."
+  market_strategy:
+    notes:
+      - "Profit margin depends on the Achey log + wolf bones supply chain"
+      - "Limited audience (only Fletchers post-quest) keeps volume thin"
+      - "Stringing flip via bowstring can outpace raw unstrung sales"
+  trading_tips:
+    - Watch wolf-bone supply spikes from White Wolf Mountain farmers
+    - Compare unstrung vs strung margin before listing
+  history:
+    - date: "2005-05-17"
+      description: "Released alongside the Zogre Flesh Eaters quest as part of the composite ogre bow line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vampyre-dust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vampyre-dust.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Vampyre dust is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: organic
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Feral Vampyre
+        quantity: "1"
+        rarity: Always
+      - source: Vyrewatch
+        quantity: "1"
+        rarity: Always
+      - source: Vampyre Juvenile
+        quantity: "1"
+        rarity: Always
+      - source: Vampyre Juvinate
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Rod of ivandis
+      slug: rod-of-ivandis
+      relationship: alternative
+      description: Used together with vampyre dust in quests and Sepulchre prep
+    - item_name: Silver dust
+      slug: silver-dust
+      relationship: alternative
+      description: Similar dust reagent used in anti-vampyre crafting
+  about: "Vampyre dust is a members-only drop obtained from various vampyres around Morytania. It is used to bypass holy barriers on Saradomin Braziers in the Hallowed Sepulchre (54 Prayer, 200 XP per use) and is also a quest item in Forgettable Tale... where 20 dust enchant an ornate undead combat dummy."
+  market_strategy:
+    notes:
+      - "Reliable always-drop from Morytania vampyres makes supply steady"
+      - "Sepulchre prayer trainers create consistent buy-side demand"
+      - "Low unit price means flips need volume to be worthwhile"
+  trading_tips:
+    - Stack 4-hour limits across alts when supplying Sepulchre runners
+    - Monitor Sepulchre meta updates that change prayer XP rates
+  history:
+    - date: "2018-05-24"
+      description: "Renamed from Vampire dust to Vampyre dust to match the Morytania spelling convention."
+    - date: "2004-10-14"
+      description: "Item added to Old School RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vodka.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vodka.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vodka | OSRS Price Data
-description: "Vodka: An absolutely clear spirit.. High alch: 3 GP, GE limit: 13,000."
+description: "Vodka: An absolutely clear spirit. High alch: 3 GP, GE limit: 13,000."
 osrs:
   id: 2015
   name: Vodka
@@ -12,9 +12,68 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
-  about: "Vodka is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Drunken man
+        quantity: "1"
+        rarity: Common
+      - source: Drink troll
+        quantity: "1"
+        rarity: 1/10
+  shops:
+    - shop_name: Blurberry Bar
+      location: Grand Tree
+      price: 5
+      currency: Coins
+      stock: 2
+    - shop_name: Asyff's Bar
+      location: Pollnivneach
+      price: 5
+      currency: Coins
+      stock: 2
+  related_items:
+    - item_name: Beer
+      slug: beer
+      relationship: alternative
+      description: Cheaper, weaker brewed alternative
+    - item_name: Whisky
+      slug: whisky
+      relationship: alternative
+      description: Alternative spirit drink
+  about: |
+    Vodka is a members-only spirit served at bars across Gielinor. Drinking it heals 5 Hitpoints, temporarily boosting Strength while lowering Attack. It's primarily used as a quest ingredient and in Gnome Restaurant cocktail recipes rather than for combat training.
+  market_strategy:
+    notes:
+      - "Steady demand from cocktail crafters and questers"
+      - "Low margin per unit but consistent volume"
+      - "Profit comes from buying bulk at shop price vs GE flip"
+  trading_tips:
+    - Cocktail-tier ingredient for Cooking 18-37
+    - Required for King's Ransom and Eadgar's Ruse
+    - Used in Potion of sealegs recipe
+  history:
+    - date: "2002-12-12"
+      description: "Vodka introduced as a bar-served spirit."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/water-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/water-talisman.mdx
@@ -1,6 +1,6 @@
 ---
 title: Water talisman | OSRS Price Data
-description: "Water talisman: A mysterious power emanates from the talisman.... High alch: 2 GP, GE limit: 11,000."
+description: "Water talisman: A mysterious power emanates from the talisman. High alch: 2 GP, GE limit: 11,000."
 osrs:
   id: 1444
   name: Water talisman
@@ -12,9 +12,79 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Water talisman is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: talisman
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: runecraft
+      level: 23
+      xp: 30
+      materials:
+        - item_name: Tiara
+          quantity: 1
+        - item_name: Water talisman
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Water wizard
+        quantity: "1"
+        rarity: Common
+      - source: Waterfiend
+        quantity: "1"
+        rarity: Uncommon
+      - source: Dagannoth
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Temple Supplies
+      location: Guardians of the Rift
+      price: 10
+      currency: Abyssal pearls
+      stock: 1
+  related_items:
+    - item_name: Water tiara
+      slug: water-tiara
+      relationship: product
+      description: Bound to a tiara for the Water Altar
+    - item_name: Water rune
+      slug: water-rune
+      relationship: product
+      description: Crafted at the Water Altar with pure essence
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: product
+      description: Crafted at the Earth Altar with essence + water talisman (members)
+  about: "Water talisman locates and accesses the Water Altar for water rune crafting. Members combine it at other altars for combination runes (mist, steam, mud). Bind with a tiara for 30 Runecraft XP."
+  market_strategy:
+    notes:
+      - "High limit (11,000) supports bulk flipping"
+      - "Drop-heavy supply keeps price low"
+      - "Niche demand from Runecraft tiara crafters"
+  trading_tips:
+    - Watch combination rune demand (mud, steam, mist) for spikes
+    - Abyssal pearl exchange floors supply via Temple Supplies
+  history:
+    - date: "2004-03-29"
+      description: "Released with the Runecraft skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/watermelon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/watermelon.mdx
@@ -1,6 +1,6 @@
 ---
 title: Watermelon | OSRS Price Data
-description: "Watermelon: A juicy watermelon.. High alch: 28 GP, GE limit: 11,000."
+description: "Watermelon: A juicy watermelon. Allotment-grown crop used for supercompost, scarecrows, summer pies, and watermelon slices. High alch: 28 GP, GE limit: 11,000."
 osrs:
   id: 5982
   name: Watermelon
@@ -12,48 +12,67 @@ osrs:
   lowalch: 19
   highalch: 28
   limit: 11000
-  item:
-    type: crop
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2005-07-11"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.113
-  farming:
-    level: 47
-    patch_type: allotment
-  uses:
-    - name: Composting
-      description: Used to make supercompost
-    - name: Cooking
-      description: Ingredient for summer pies
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Catherby seed market
+      location: Catherby
+      price: 48
+      currency: Coins
+      stock: 0
+    - shop_name: Alice's farming shop
+      location: South of East Ardougne
+      price: 48
+      currency: Coins
+      stock: 0
+    - shop_name: Heskel's Farming Supplies
+      location: Civitas illa Fortis
+      price: 48
+      currency: Coins
+      stock: 0
   related_items:
-    - item_id: 5321
-      item_name: Watermelon seed
+    - item_name: Watermelon seed
       slug: watermelon-seed
-      relationship: alternative
-      description: Farming source
-    - item_id: 6034
-      item_name: Supercompost
+      relationship: component
+      description: Planted in allotments to grow watermelons.
+    - item_name: Supercompost
       slug: supercompost
       relationship: product
-      description: Primary use
-    - item_id: 7218
-      item_name: Summer pie
+      description: 15 watermelons in a compost bin make supercompost.
+    - item_name: Summer pie
       slug: summer-pie
-      relationship: alternative
-      description: Cooking use
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Farming Product |
-    | Tradeable | Yes |
-    | Weight | 0.113 kg |
-    | Requirements | 47 Farming |
-
-    Composting: Used to make supercompost
-
-    Cooking: Ingredient for summer pies
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: product
+      description: Watermelon is the headline ingredient in summer pies.
+    - item_name: Watermelon slice
+      slug: watermelon-slice
+      relationship: product
+      description: Using a knife slices a watermelon into 3 healing slices.
+  about: "Watermelon is a members-only allotment crop introduced with the Farming update. It grows from a watermelon seed at 47 Farming and yields fruit used for supercompost, scarecrows, summer pies, and sliced into watermelon slices that heal 1 + 5 percent of base Hitpoints per slice."
+  market_strategy:
+    notes:
+      - "Allotment seed runs drive most supply; flips depend on supercompost demand."
+      - "Summer pie chefs absorb the higher-quality stock."
+  trading_tips:
+    - Stack up to 11,000 per 4 hours when summer pie meta returns.
+    - Use the 48 gp shop floor as a sanity check against under-priced GE listings.
+  history:
+    - date: "2005-07-11"
+      description: "Watermelon released with the Farming skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-halberd.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 125
-  about: "White halberd is a members-only item in Old School RuneScape. High alchemy value: 1,152 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2005-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: halberd
+    attack_speed: 7
+    weight: 3.175
+    requirements:
+      attack: 10
+      strength: 5
+    attack_bonus:
+      stab: 19
+      slash: 25
+      crush: 0
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 2
+      crush: 3
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 20
+      prayer: 1
+  shops:
+    - shop_name: Sir Vyvin's White Knight Armoury
+      location: Falador
+      price: 1920
+      currency: Coins
+      stock: 0
+  related_items:
+    - item_name: White sword
+      slug: white-sword
+      relationship: alternative
+      description: One-handed white knight melee weapon sold by Sir Vyvin.
+    - item_name: White claws
+      slug: white-claws
+      relationship: alternative
+      description: Faster off-hand white knight weapon for crush attacks.
+    - item_name: Black halberd
+      slug: black-halberd
+      relationship: alternative
+      description: Black knight equivalent halberd available to free players.
+    - item_name: Mithril halberd
+      slug: mithril-halberd
+      relationship: upgrade
+      description: Stronger members halberd at higher Attack requirement.
+  about: "The white halberd is a two-handed polearm sold by Sir Vyvin in Falador's White Knight Armoury after reaching Master rank in the White Knight order. Requires 10 Attack and 5 Strength to wield along with completion of the Wanted! quest. Its long reach (2 tiles) makes it useful for safespotting larger NPCs."
+  market_strategy:
+    notes:
+      - "Demand is largely cosmetic since stronger halberds eclipse it past low-level training."
+      - "Wanted! quest completion gating limits the buyer pool — volume is thin."
+      - "Best moved during fashionscape events or as part of full white knight sets."
+  trading_tips:
+    - "Quote against the white knight set buyers rather than combat traders."
+    - "Track Sir Vyvin shop restocks; live shop prices can undercut GE listings."
+    - "Bundle with white platebody and white kiteshield for cosmetic completionists."
+  history:
+    - date: "2005-10-17"
+      description: "Released alongside the Wanted! quest and Sir Vyvin's expanded White Knight Armoury."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-sword.mdx
@@ -1,6 +1,6 @@
 ---
 title: White sword | OSRS Price Data
-description: "White sword: A razor sharp sword.. High alch: 374 GP, GE limit: 125."
+description: "White sword: A razor sharp sword. High alch: 374 GP, GE limit: 125."
 osrs:
   id: 6605
   name: White sword
@@ -12,9 +12,85 @@ osrs:
   lowalch: 249
   highalch: 374
   limit: 125
-  about: "White sword is a members-only item in Old School RuneScape. High alchemy value: 374 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: white
+    tier: mid
+  properties:
+    release_date: "2005-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 14
+      slash: 10
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: White Knight Armoury
+      location: Falador
+      price: 624
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Rune sword
+      slug: rune-sword
+      relationship: alternative
+      description: Stronger one-handed stab sword without quest gating.
+    - item_name: White longsword
+      slug: white-longsword
+      relationship: variant
+      description: Longsword counterpart from the White Knight armoury set.
+    - item_name: White scimitar
+      slug: white-scimitar
+      relationship: variant
+      description: Slash-focused White Knight sidearm.
+  about: |-
+    White sword is a stab-focused one-handed sword sold by the White Knight Armoury in Falador after completion of the Wanted! quest. It mirrors the mithril sword's stats while granting +1 prayer, giving it a niche use for low-level prayer-conscious players.
+
+    Most players move past it quickly toward rune or dragon weapons, but it remains a popular fashionscape weapon for white-themed outfits.
+  market_strategy:
+    notes:
+      - "Quest-locked supply caps casual flipping"
+      - "Falador shop price serves as a soft floor"
+      - "Demand driven by fashion and white-knight cosplay"
+  trading_tips:
+    - Stock during Wanted! quest popularity windows
+    - Lean on shop restock for guaranteed fill at floor price
+  history:
+    - date: "2005-10-17"
+      description: "Released alongside the Wanted! quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wilderness-crabs-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wilderness-crabs-teleport.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 25
   highalch: 37
   limit: null
-  about: "Wilderness crabs teleport is a members-only item in Old School RuneScape. High alchemy value: 37 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport scroll
+    tier: mid
+  properties:
+    release_date: "19 September 2019"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Configure
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Edgeville
+      price: 1
+      currency: last man standing points
+      stock: infinite
+  related_items:
+    - item_name: Dark crab
+      slug: dark-crab
+      relationship: product
+      description: Primary fish caught at the teleport destination
+    - item_name: Lava dragon bones
+      slug: lava-dragon-bones
+      relationship: alternative
+      description: Other LMS reward usable in Wilderness training trips
+  about: |-
+    The Wilderness crabs teleport scroll transports the player to the dark crab fishing spots in level 33 eastern Wilderness, a single-way combat zone southeast of Venenatis. Used primarily by dark crab fishers to skip Wilderness travel risk.
+
+    A Wilderness warning prompt appears on use. The Configure option toggles the warning on or off, and Break activates the teleport (left-click after the 14 October 2020 update).
+
+    Purchased from Justine's stuff for the Last Shopper Standing at one Last Man Standing point per scroll.
+  market_strategy:
+    notes:
+      - "Cheap, high-volume scroll for skillers"
+      - "Steady demand from dark crab fishing trips"
+      - "LMS supply caps the ceiling"
+      - "Volume above 19k per day, very liquid"
+  trading_tips:
+    - Stockpile when LMS rewards spike in supply
+    - Flip in small lots to dodge stale-buy delays
+  history:
+    - date: "14 October 2020"
+      description: "Break option became left-click with added Wilderness warning; Configure option added to toggle the warning."
+    - date: "19 September 2019"
+      description: "Released as a Last Man Standing reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-blackjack-o.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-blackjack-o.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 125
-  about: "Willow blackjack(o) is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: willow
+    tier: low
+  properties:
+    release_date: "2005-08-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: blackjack
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 20
+      thieving: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 8
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Pollnivneach
+      price: 800
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Willow blackjack(d)
+      slug: willow-blackjack-d
+      relationship: variant
+      description: Defensive willow blackjack variant
+    - item_name: Maple blackjack(o)
+      slug: maple-blackjack-o
+      relationship: upgrade
+      description: Higher-tier offensive blackjack
+    - item_name: Oak blackjack(o)
+      slug: oak-blackjack-o
+      relationship: downgrade
+      description: Lower-tier offensive blackjack
+  about: |-
+    > *"An offensive blackjack."*
+
+    The willow blackjack(o) is a members-only one-handed blackjack used in the Pollnivneach pickpocketing rotation. The offensive variant biases combat bonuses toward Crush attack and Strength, making it the more popular pick when knocking out tougher NPCs like Menaphite thugs.
+
+    Players unlock the ability to wield blackjacks via the blackjack section of the Rogue Trader miniquest. The weapon itself is sold by Ali's Discount Wares in Al Kharid for 800 coins.
+  market_strategy:
+    notes:
+      - "Demand is driven almost entirely by Thieving training routes through Pollnivneach."
+      - "Shop supply keeps a soft price ceiling unless Ali's stock dries up."
+      - "Buy limit of 125 per 4 hours allows light flipping."
+  trading_tips:
+    - Watch for Thieving XP events that spike demand from new trainers.
+    - Skill rework rumors around blackjacking can move pricing quickly.
+  history:
+    - date: "2005-08-15"
+      description: "Added with the Rogue Trail update featuring blackjacking in Pollnivneach."
+    - date: "2006-08-22"
+      description: 'Renamed from "Willow blackjack(a)" to "Willow blackjack(o)" for clarity.'
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Willow sapling | OSRS Price Data
-description: "Willow sapling: This sapling is ready to be replanted in a tree patch.. High alch: 1 GP, GE limit: 200."
+description: "Willow sapling: This sapling is ready to be replanted in a tree patch. Requires 30 Farming. High alch: 1 GP, GE limit: 200."
 osrs:
   id: 5371
   name: Willow sapling
@@ -12,9 +12,67 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Willow sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sapling
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Check-health
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 30
+      xp: 25
+      materials:
+        - item_name: Willow seed
+          quantity: 1
+        - item_name: Plant pot (filled)
+          quantity: 1
+      tools:
+        - Gardening trowel
+        - Watering can
+      output_quantity: 1
+  related_items:
+    - item_name: Willow seed
+      slug: willow-seed
+      relationship: component
+      description: Seed planted in a filled plant pot to grow a seedling
+    - item_name: Willow logs
+      slug: willow-logs
+      relationship: product
+      description: Logs harvested from the fully grown tree
+    - item_name: Willow tree seed
+      slug: willow-tree-seed
+      relationship: alternative
+      description: Disambiguation - alternate naming
+  about: |-
+    > _"This sapling is ready to be replanted in a tree patch."_
+
+    Willow sapling is the planted form of a willow seed. Plant in a tree patch (30 Farming) for 25 XP; the tree grows in 240 minutes (4 hours) and grants 1,456.5 XP on full growth. Protect with 1 basket of five apples to skip the disease cycle. Stump yields willow logs when chopped and willow roots when dug up.
+  market_strategy:
+    notes:
+      - "Daily tree-run staple"
+      - "Limited shelf life vs seed flipping"
+      - "Demand spikes during farming bonus weekends"
+  trading_tips:
+    - Buy seeds and convert when sapling margin > seed margin
+    - Stock saplings on bonus XP weekends for resale
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-cat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-cat.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Wooden cat is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2007-03-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.03
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 16
+      xp: 15
+      materials:
+        - item_name: Wooden plank
+          quantity: 1
+        - item_name: Fur
+          quantity: 1
+      tools:
+        - Crafting table
+      output_quantity: 1
+  related_items:
+    - item_name: Wooden plank
+      slug: wooden-plank
+      relationship: component
+      description: "Plank consumed when crafting the wooden cat at a crafting table"
+    - item_name: Fur
+      slug: fur
+      relationship: component
+      description: "Fur consumed during crafting; bear fur and grey wolf fur also work"
+    - item_name: The Great Brain Robbery
+      slug: the-great-brain-robbery
+      relationship: alternative
+      description: "Quest that requires 10 wooden cats during a deception sequence"
+  about: "The wooden cat is a quest item used in The Great Brain Robbery, where players need ten of them to deceive Caroline's son into thinking the toys are real cats. Outside the quest it remains craftable at 16 Crafting on a crafting table, using a wooden plank and any fur piece for 15 Crafting experience."
+  market_strategy:
+    notes:
+      - "Tiny 15/4h buy limit chokes flipping despite cheap unit cost"
+      - "Demand spikes only when players progress The Great Brain Robbery"
+      - "Crafting alternative undercuts GE pricing for self-suppliers"
+  trading_tips:
+    - "Sniping at GE during quest event weeks usually beats crafting"
+    - "Grey wolf fur is the cheapest craft input - track that price for cost basis"
+  history:
+    - date: "2007-03-06"
+      description: "Released with The Great Brain Robbery quest"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/worm-crunchies.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/worm-crunchies.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Worm crunchies is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 14
+      xp: 104
+      materials:
+        - item_name: Unfinished crunchy
+          quantity: 1
+        - item_name: King worm
+          quantity: 2
+        - item_name: Equa leaves
+          quantity: 1
+        - item_name: Gnome spice
+          quantity: 1
+      tools:
+        - Range
+      output_quantity: 1
+  shops:
+    - shop_name: Hudo's Grocery Store
+      location: Grand Tree
+      price: 85
+      currency: Coins
+      stock: 3
+  related_items:
+    - item_name: Unfinished crunchy
+      slug: unfinished-crunchy
+      relationship: component
+      description: Intermediate step before cooking worm crunchies on a range.
+    - item_name: King worm
+      slug: king-worm
+      relationship: component
+      description: Primary filling ingredient used in the dough.
+    - item_name: Toad crunchies
+      slug: toad-crunchies
+      relationship: alternative
+      description: Sibling gnome cuisine crunchy with a different filling.
+    - item_name: Spicy crunchies
+      slug: spicy-crunchies
+      relationship: alternative
+      description: Spicier crunchy variant from Gnome Cooking.
+  about: "Worm crunchies are gnome cuisine cooked at level 14 Cooking for 104 experience, healing 8 hitpoints per bite. They are a popular Gnome Restaurant minigame item, and pre-made versions can be bought from gnome waiters in the Grand Tree. The bulk XP per crunchy keeps them competitive for low-level Cooking training."
+  market_strategy:
+    notes:
+      - "GE price often exceeds raw alch value due to Gnome Cooking demand."
+      - "Hudo's Grocery offers a cheap shop alternative for self-supply."
+      - "King worm scarcity periodically lifts crunchy prices."
+  trading_tips:
+    - "Stock up on king worms via Hunter to undercut GE crunchy pricing."
+    - "Watch for Gnome Restaurant delivery quest spikes — order demand boosts crunchy turnover."
+    - "Pair with the unfinished crunchy supply chain for end-to-end profit."
+  history:
+    - date: "2002-12-12"
+      description: "Added with the Gnome Restaurant minigame and Gnome Cooking expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yak-hide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yak-hide.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 13000
-  about: "Yak-hide is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: hide
+    tier: low
+  properties:
+    release_date: "2007-02-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Yak
+        quantity: "1"
+        rarity: Always
+  shops:
+    - shop_name: Contraband Yak Produce
+      location: Jatizso
+      price: 35
+      currency: Coins
+      stock: 25
+  related_items:
+    - item_name: Cured yak-hide
+      slug: cured-yak-hide
+      relationship: product
+      description: Cured by Thakkrad of Neitiznot for 5 coins per hide.
+    - item_name: Yak-hide armour (legs)
+      slug: yak-hide-armour-legs
+      relationship: product
+      description: Crafted from cured yak-hide; legs piece.
+    - item_name: Yak-hide armour (body)
+      slug: yak-hide-armour-body
+      relationship: product
+      description: Crafted from cured yak-hide; body piece.
+  about: "Yak-hide is dropped by every Yak on Neitiznot and Jatizso. After partial completion of The Fremennik Isles quest, hides can be cured into cured yak-hide by Thakkrad Sigmundson, then crafted into yak-hide armour."
+  market_strategy:
+    notes:
+      - "Volume is steady from yak slayer tasks and AFK farming hotspots"
+      - "Cured yak-hide armour is required for cold protection in some content"
+      - "Shop arbitrage from Jatizso supports a hard price floor"
+  trading_tips:
+    - Buy direct from Contraband Yak Produce when GE price exceeds 35 coins
+    - Resell raw hides; let crafters cure them for the armour markup
+  history:
+    - date: "2007-02-06"
+      description: "Added to the game with The Fremennik Isles quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-roots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-roots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Yew roots | OSRS Price Data
-description: "Yew roots: The roots of the Yew tree.. High alch: 1 GP, GE limit: 11,000."
+description: "Yew roots: The roots of the Yew tree. GE limit: 11,000. Used in Herblore for Antidote+."
 osrs:
   id: 6049
   name: Yew roots
@@ -9,75 +9,70 @@ osrs:
   members: true
   icon: Yew roots.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: secondary
     tier: mid
-  farming:
-    source: Yew tree
-    level: 60
-    location: Tree farming patches
-    method: Dig up yew tree
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
   recipes:
     - skill: herblore
       level: 68
       xp: 155
       materials:
-        - item_name: Irit potion (unf)
-          item_id: 101
+        - item_name: Antidote+ (unf)
           quantity: 1
         - item_name: Yew roots
-          item_id: 6049
           quantity: 1
-      product: Antidote+(3)
-      product_id: 5945
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 101
-      item_name: Irit potion (unf)
-      slug: irit-potion-unf
-      relationship: component
-      description: For antidote+
-    - item_id: 5945
-      item_name: Antidote+(3)
-      slug: antidote-plus-3
+    - item_name: Antidote+(4)
+      slug: antidote-plus-4
       relationship: product
-      description: Stronger antipoison
-    - item_id: 6051
-      item_name: Magic roots
+      description: Crafted using yew roots and coconut milk
+    - item_name: Magic roots
       slug: magic-roots
-      relationship: variant
-      description: Higher tier roots
-    - item_id: 1515
-      item_name: Yew logs
+      relationship: upgrade
+      description: Higher-tier farming root used in Antidote++
+    - item_name: Yew logs
       slug: yew-logs
       relationship: alternative
-      description: From same tree
+      description: Logs from chopping the same yew tree
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.05 kg |
+    > *"The roots of the Yew tree."*
 
-    Secondary ingredient for:
-    - Antidote+ (with irit potion unf, 68 Herblore)
+    Yew roots are obtained by digging up a fully grown yew tree planted via Farming. A minimum of 60 Farming is required to plant the tree, with root yields scaling with Farming level: 1 root at 60, 2 at 68, 3 at 76, and 4 at 84.
 
-    Provides stronger poison immunity than regular antipoison.
+    Their main use is as the secondary ingredient for the Antidote+ Herblore potion, providing extended poison immunity. Yew roots can also be combined with crossbow stocks and string in Crafting, or used to make supercompost.
   market_strategy:
     notes:
-      - Antidote+ production
-      - Tree farming byproduct
-      - PvM supplies
-      - Farm yew trees for roots
-      - Combines well with tree runs
-      - Check antidote+ prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Steady demand from Herblore (Antidote+ production)"
+      - "Supply comes from Farming tree runs — limited each game tick"
+      - "Buy limit of 11,000 supports bulk trading"
+      - "Often paired with coconut milk and unfinished potions for full Antidote+ flips"
+  trading_tips:
+    - Track antidote+ market when planning bulk purchases
+    - Stockpile during tree-run resets when supply spikes
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming and Herblore update introducing tree roots."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-armour-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-armour-set-lg.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Zamorak armour set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Zamorak full helm
+      slug: zamorak-full-helm
+      relationship: set-piece
+      description: "Head slot piece included in the set."
+    - item_name: Zamorak platebody
+      slug: zamorak-platebody
+      relationship: set-piece
+      description: "Body slot piece included in the set."
+    - item_name: Zamorak platelegs
+      slug: zamorak-platelegs
+      relationship: set-piece
+      description: "Legs slot piece included in the set."
+    - item_name: Zamorak kiteshield
+      slug: zamorak-kiteshield
+      relationship: set-piece
+      description: "Shield slot piece included in the set."
+    - item_name: Zamorak armour set (sk)
+      slug: zamorak-armour-set-sk
+      relationship: alternative
+      description: "Skirt variant of the set instead of platelegs."
+  about: "Zamorak armour set (lg) bundles a Zamorak full helm, platebody, platelegs, and kiteshield into a single tradeable token via the Grand Exchange Sets interface. The set is a free-to-play cosmetic god armour roll for rune-tier gear with the Zamorak symbol."
+  market_strategy:
+    notes:
+      - "Set premium typically 5 to 8 percent above piece-wise cost — exchange when premium is high."
+      - "Demand driven by clue rerollers, costume room hunters, and PvPers."
+  trading_tips:
+    - "Compare set vs. individual piece totals via the GE Sets interface before buying."
+    - "Buy pieces individually, combine into set, sell set at premium."
+  history:
+    - date: "2015-02-26"
+      description: "Added with the OSRS Grand Exchange Sets interface launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-ring.mdx
@@ -12,71 +12,95 @@ osrs:
   lowalch: 80400
   highalch: 120600
   limit: 8
+  material:
+    type: zenyte jewellery
+    tier: high
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ring
+    weapon_type: null
+    attack_speed: null
+    weight: 0.006
     requirements:
       crafting: 89
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 89
       xp: 150
-      inputs:
-        - item_id: 19493
-          item_name: Zenyte
+      materials:
+        - item_name: Zenyte
           quantity: 1
-        - item_id: 2357
-          item_name: Gold bar
+        - item_name: Gold bar
           quantity: 1
+        - item_name: Ring mould
+          quantity: 1
+      tools: []
       output_quantity: 1
   related_items:
-    - item_id: 6575
-      item_name: Onyx ring
+    - item_name: Onyx ring
       slug: onyx-ring
       relationship: downgrade
-      description: Previous tier ring
-    - item_id: 19550
-      item_name: Ring of suffering
+      description: Previous tier ring crafted from onyx and gold bar.
+    - item_name: Ring of suffering
       slug: ring-of-suffering
       relationship: upgrade
-      description: Enchanted version (BiS defensive ring)
-    - item_id: 19493
-      item_name: Zenyte
+      description: Enchanted form via Lvl-7 Enchant; best-in-slot defensive ring.
+    - item_name: Zenyte
       slug: zenyte
       relationship: component
-      description: Key component from demonic gorillas
+      description: Crafted gem from Monkey Madness II content; main ingredient.
   about: |-
-    Crafting (Level 89): Zenyte + Gold bar at a furnace (150 XP)
+    Crafted at level 89 Crafting by combining a Zenyte with a gold bar at a furnace for 150 XP. Players use the Lvl-7 Enchant spell (93 Magic) on the ring to create the Ring of suffering, the strongest defensive ring in the game.
 
-    > *"A zenyte ring."*
-
-    Lvl-7 Enchant (93 Magic): 1 cosmic rune + 20 blood runes + 20 soul runes (110 XP)
-
-    The Ring of suffering is the best-in-slot defensive ring:
-    - +20 to all defence styles (highest of any ring)
-    - +4 Prayer bonus
-    - Can store up to 100,000 ring of recoil charges — automatically reflects damage without consuming individual recoil rings
-    - Can be imbued at the Nightmare Zone for doubled stats (+20 → +20 stays, but adds offensive bonuses)
-
-    Zenyte is crafted from:
-    1. Zenyte shard — dropped by Demonic gorillas (1/300, after Monkey Madness II)
-    2. Combine with an Onyx at a furnace using the Crafting skill (89 Crafting)
-
-    This makes zenyte jewelry the most valuable craftable jewelry in the game.
-
-    | Jewelry | Slot | Key Stat | Enchanted |
-    |---------|------|----------|-----------|
-    | Zenyte ring | Ring | → Ring of suffering | BiS defensive ring |
-    | Zenyte necklace | Neck | → Necklace of anguish | BiS ranged necklace |
-    | Zenyte bracelet | Hands | → Tormented bracelet | BiS magic bracelet |
-    | Zenyte amulet | Neck | → Amulet of torture | BiS melee amulet |
+    Because zenyte shards drop from Demonic gorillas (1/300) and require Monkey Madness II, supply is bottlenecked behind a long mid-game quest chain. This makes zenyte jewellery the most valuable craftable jewellery line.
   market_strategy:
     notes:
-      - Zenyte shard from Demonic gorillas (requires MM2)
-      - Very high value enchant — check margins
-      - Ring of suffering has permanent demand as BiS defensive ring
-      - Blood and soul runes for Lvl-7 Enchant add to enchant cost
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand floor set by Ring of suffering as the BiS defensive ring"
+      - "Zenyte shard supply gated behind Monkey Madness II and Demonic gorillas"
+      - "Lvl-7 Enchant cost (cosmic + 20 blood + 20 soul runes) eats most of the enchant margin"
+      - "Buy limit 8 — flip in small lots, watch overnight volume"
+  history:
+    - date: "2016-05-06"
+      description: "Added with the Monkey Madness II quest update."
+    - date: "2018-02-22"
+      description: "Inventory sprite rotated for visual consistency."
+    - date: "2018-12-13"
+      description: "Inventory sprite adjusted again."
+    - date: "2020-09-10"
+      description: "Grand Exchange buy limit reduced from 10,000 to 8."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
- Random sample of 200 OSRS item MDX files migrated from `mdx_version: 2` to `3`
- WebFetch-verified wiki stats, drops, recipes, history
- Schema normalization: market_strategy.notes array, materials[].item_name, passive_effects[].name, quoted colon-bearing descriptions

## Local CI mirror
- `npx astro sync` — clean
- `npx astro build` — 7688 pages in 388.80s, no errors

## Test plan
- [ ] CI manifest guard passes
- [ ] CI build passes
- [ ] Spot-check a couple of pages in preview