### PR TITLE
release(kasm-void): v0.0.3 + align containerx production with monorepo pattern

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
@@ -14,7 +14,7 @@ tags:
 key: kasm_void
 pipeline: docker
 app_name: kasm-void
-version: "0.0.2"
+version: "0.0.3"
 source_path: packages/docker/kasm-void
 version_toml: packages/docker/kasm-void/version.toml
 runner: ubuntu-latest

--- a/apps/kube/kasm/manifest/deployment.yaml
+++ b/apps/kube/kasm/manifest/deployment.yaml
@@ -158,7 +158,7 @@ spec:
                           cpu: '500m'
 
                 - name: workspace
-                  image: ghcr.io/kbve/kasm-void:0.0.2
+                  image: ghcr.io/kbve/kasm-void:0.0.3
                   imagePullPolicy: IfNotPresent
                   securityContext:
                       runAsNonRoot: true

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -33,10 +33,11 @@
 					"tags": ["ghcr.io/kbve/kasm-void:dev"]
 				},
 				"production": {
-					"tags": ["ghcr.io/kbve/kasm-void:latest"],
-					"push": true,
+					"load": true,
+					"push": false,
 					"metadata": {
-						"images": ["ghcr.io/kbve/kasm-void"]
+						"images": ["ghcr.io/kbve/kasm-void", "kbve/kasm-void"],
+						"tags": ["latest"]
 					},
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/kasm-void:buildcache"

--- a/packages/docker/kasm-void/version.toml
+++ b/packages/docker/kasm-void/version.toml
@@ -1,2 +1,2 @@
-version = "0.0.2"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
## Summary
The 0.0.2 publish run ([CI - Docker / kasm-void](https://github.com/KBVE/kbve/actions/runs/26863897586)) reported success but only pushed `ghcr.io/kbve/kasm-void:main` to GHCR. Version and latest tags never landed, which is why \`kasm-vpn\` is currently stuck in \`ImagePullBackOff\` on \`ghcr.io/kbve/kasm-void:0.0.2\`.

Root cause is in our own \`packages/docker/kasm-void/project.json\` — \`containerx.configurations.production\` was the odd one out in the monorepo:

```jsonc
// kasm-void (before): one tag, no metadata.tags, no load
"production": {
  "tags": ["ghcr.io/kbve/kasm-void:latest"],
  "push": true,
  "metadata": { "images": ["ghcr.io/kbve/kasm-void"] },
  ...
}
```

vs. the working pattern used by **axum-kbve**, **irc-gateway**, **axum-memes**, etc.:

```jsonc
"production": {
  "load": true,
  "push": false,
  "metadata": {
    "images": ["ghcr.io/kbve/<x>", "kbve/<x>"],
    "tags": ["latest"]
  },
  ...
}
```

With our broken shape, \`docker-metadata-action\` fell back to the default \`type=ref,event=branch\` rule and nx-tools pushed exactly one tag (\`:main\`) directly to the registry. The downstream \`Ensure image is in Docker daemon\` step then warned out (\`Could not re-export image for daemon\`), \`Push Docker Images\` found nothing local to retag as \`:0.0.2\` / \`:latest\`, and the version tag never made it to GHCR.

## Changes
- \`packages/docker/kasm-void/project.json\` — production aligned with axum-kbve/irc-gateway: \`load:true\`, \`push:false\`, both registry names under \`metadata.images\`, \`metadata.tags:[latest]\`. Workflow then handles version + latest push from the local daemon.
- \`apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx\` — \`version: "0.0.3"\`. Bumped past the broken 0.0.2 so the version gate triggers a fresh publish.
- \`packages/docker/kasm-void/version.toml\` — reset to \`0.0.1\` sentinel per the `version_source` workflow contract (MDX 0.0.3 > toml 0.0.1 ⇒ publish).
- \`apps/kube/kasm/manifest/deployment.yaml\` — workspace image \`0.0.2\` → \`0.0.3\` so once dev → main → publish runs, ArgoCD reconciles to the tag that actually exists.

## Test plan
- [ ] CI - Docker / kasm-void run after merge pushes \`ghcr.io/kbve/kasm-void:0.0.3\` AND \`:latest\` (verify via `gh api /v2/kbve/kasm-void/tags/list` or anon token query)
- [ ] Dev → Main release PR includes the deployment manifest bump
- [ ] After ArgoCD reconcile, \`kubectl -n kasm get pod\` shows the workspace container pulling \`0.0.3\` cleanly, exits \`ImagePullBackOff\`