### PR TITLE
content(osrs): migrate batch 18 (200 items) v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-p-5652.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-p-5652.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant javelin(p++) | OSRS Price Data
-description: "Adamant javelin(p++): An adamant tipped javelin.. High alch: 96 GP, GE limit: 11,000."
+description: "Adamant javelin(p++): An adamant tipped javelin. High alch: 96 GP, GE limit: 11,000."
 osrs:
   id: 5652
   name: Adamant javelin(p++)
@@ -12,9 +12,69 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 11000
-  about: "Adamant javelin(p++) is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: adamant
+    tier: mid-high
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    attack_speed: 6
+    weight: 0
+    requirements:
+      ranged: 30
+    attack_bonus:
+      ranged: 0
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 102
+  related_items:
+    - item_name: Adamant javelin
+      slug: adamant-javelin
+      relationship: variant
+      description: Unpoisoned variant
+    - item_name: Adamant javelin(p)
+      slug: adamant-javelin-p-5638
+      relationship: variant
+      description: Weak poison variant
+    - item_name: Adamant javelin(p+)
+      slug: adamant-javelin-p-5645
+      relationship: variant
+      description: Stronger poison variant
+    - item_name: Rune javelin(p++)
+      slug: rune-javelin-p-5653
+      relationship: upgrade
+      description: Higher tier poisoned javelin
+  about: "Adamant javelin(p++) is the extra-strength poisoned adamant javelin used as ballista ammunition. With +102 ranged strength and the strongest weapon poison applied, it's a popular choice for ironmen and PvMers who need consistent poison damage on heavy ballista hits."
+  market_strategy:
+    notes:
+      - "Demand tracks Heavy ballista usage at slayer and PvM bosses"
+      - "Poison++ variant trades at a small premium over base javelin"
+  trading_tips:
+    - Buy in bulk while ballista metas are quiet for cheap stock
+  history:
+    - date: "2005-07-11"
+      description: "Poisoned javelin variants added to the game."
+    - date: "2016-05-06"
+      description: "Moved to ammunition slot only; ranged strength increased significantly."
+    - date: "2016-10-31"
+      description: "Ranged strength adjusted to +102."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-tips.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 176
   highalch: 264
   limit: 10000
-  about: "Adamant javelin tips is a members-only item in Old School RuneScape. High alchemy value: 264 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "6 May 2016"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 76
+      xp: 62.5
+      materials:
+        - item_name: Adamantite bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 5
+    - skill: fletching
+      level: 62
+      xp: 150
+      materials:
+        - item_name: Adamant javelin tips
+          quantity: 15
+        - item_name: Javelin shaft
+          quantity: 15
+      tools: []
+      output_quantity: 15
+  related_items:
+    - item_name: Adamantite bar
+      slug: adamantite-bar
+      relationship: component
+      description: "Smelted bar used to forge the tips"
+    - item_name: Javelin shaft
+      slug: javelin-shaft
+      relationship: component
+      description: "Wooden shaft combined with the tip to form a javelin"
+    - item_name: Adamant javelin
+      slug: adamant-javelin
+      relationship: product
+      description: "Finished javelin assembled from tip + shaft"
+  about: |-
+    Adamant javelin tips are smithed from an adamantite bar at level 76 Smithing, producing 5 tips per bar for 62.5 xp. Fletching them onto javelin shafts at level 62 Fletching yields 15 adamant javelins for 150 xp per fletch cycle.
+
+    The tips are a key intermediate for stocking Vorkath / Zulrah javelin specials, sitting between rune and dragon equivalents.
+  market_strategy:
+    notes:
+      - "Smithing-bound supply; price tracks adamantite bar margins"
+      - "Demand cycles with Fletching skiller activity"
+  trading_tips:
+    - Flip alongside javelin shafts to capture full crafting margin
+  history:
+    - date: "6 May 2016"
+      description: "Released with the Monkey Madness II update."
+    - date: "5 November 2025"
+      description: "Renamed from 'Adamant javelin heads' to 'Adamant javelin tips.'"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h2.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 2176
   highalch: 3264
   limit: 70
-  about: "Adamant shield (h2) is a free-to-play item in Old School RuneScape. High alchemy value: 3,264 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: adamantite
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.896
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.896
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: 0
+    defence_bonus:
+      stab: 27
+      slash: 31
+      crush: 29
+      magic: -1
+      ranged: 29
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: "1/1,133"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Adamant kiteshield
+      slug: adamant-kiteshield
+      relationship: variant
+      description: Identical stats without the heraldic design
+    - item_name: Adamant shield (h1)
+      slug: adamant-shield-h1
+      relationship: variant
+      description: Alternate heraldic decoration
+    - item_name: Adamant shield (h3)
+      slug: adamant-shield-h3
+      relationship: variant
+      description: Alternate heraldic decoration
+  about: "The adamant shield (h2) is a heraldic variant of the adamant kiteshield, sharing identical equipment stats. Requires 30 Defence to wield. Obtained exclusively from medium-tier reward caskets at a 1/1,133 rate, making it a Treasure Trails collectible. Often kept for the costume room rather than combat."
+  market_strategy:
+    notes:
+      - "Medium clue casket exclusive — supply tied to clue completions"
+      - "Stats mirror the standard adamant kiteshield — purely cosmetic"
+      - "Low buy limit (70) keeps trade volume tight"
+      - "Costume room storage drives long-term demand"
+      - "High alch above value — alch floor on excess stock"
+  trading_tips:
+    - Watch medium clue casket supply for margin swings
+    - F2P availability widens the buyer pool
+    - Stack with other h-shields for collectors
+  history:
+    - date: "2006-02-20"
+      description: "Item added to the game as a medium clue reward."
+    - date: "2006-03-15"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h5.mdx
@@ -1,20 +1,104 @@
 ---
 title: Adamant shield (h5) | OSRS Price Data
-description: "Adamant shield (h5): A shield with a heraldic design. High alch: 3,264 GP, GE limit: 70."
+description: "Adamant shield (h5) is a medium clue heraldic kiteshield with adamant kite stats. High alch: 3,264 GP, GE limit: 70."
 osrs:
   id: 7358
   name: Adamant shield (h5)
   slug: adamant-shield-h5
-  examine: A shield with a heraldic design
+  examine: A shield with a heraldic design.
   members: false
   icon: Adamant shield (h5).png
   value: 5440
   lowalch: 2176
   highalch: 3264
   limit: 70
-  about: "Adamant shield (h5) is a free-to-play item in Old School RuneScape. High alchemy value: 3,264 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.896
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: shield
+    attack_speed: null
+    weight: 5.896
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 27
+      slash: 31
+      crush: 29
+      magic: -1
+      ranged: 29
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Adamant kiteshield
+      slug: adamant-kiteshield
+      relationship: alternative
+      description: Standard non-heraldic version with identical stats
+    - item_name: Adamant shield (h1)
+      slug: adamant-shield-h1
+      relationship: variant
+      description: Asgarnia heraldic colour variant
+    - item_name: Adamant shield (h2)
+      slug: adamant-shield-h2
+      relationship: variant
+      description: Dorgeshuun heraldic colour variant
+    - item_name: Adamant shield (h3)
+      slug: adamant-shield-h3
+      relationship: variant
+      description: Heraldic colour variant
+    - item_name: Adamant shield (h4)
+      slug: adamant-shield-h4
+      relationship: variant
+      description: Heraldic colour variant
+  about: |-
+    > _"A shield with a heraldic design."_
+
+    Adamant shield (h5) is one of five cosmetic heraldic adamant kiteshield variants obtained from medium Treasure Trails at a rate of 1/1,133 from the reward casket. Stats are identical to a regular adamant kiteshield.
+  market_strategy:
+    notes:
+      - "Cosmetic-only item; price tracks medium clue completion volume."
+      - "Thin GE buy limit (70) means demand pops can quickly drain offers."
+  trading_tips:
+    - Margin-flip across the heraldic variants — collectors complete sets.
+    - Buy after clue scroll content drops drive medium clue popularity.
+  history:
+    - date: "2006-02-20"
+      description: "Released as a medium Treasure Trail reward."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -2 to -3 alongside other heraldic shields."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-power.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-power.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amulet of power | OSRS Price Data
-description: "Amulet of power is a F2P neck slot item. High alch: 2,115 GP, GE limit: 125."
+description: "Amulet of power: An enchanted diamond amulet of power. High alch: 2,115 GP, GE limit: 125."
 osrs:
   id: 1731
   name: Amulet of power
@@ -12,39 +12,89 @@ osrs:
   lowalch: 1410
   highalch: 2115
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: diamond
+    tier: mid
+  properties:
+    release_date: "2001-05-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: amulet
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 0.01
-    stats:
-      attack_stab: 6
-      attack_slash: 6
-      attack_crush: 6
-      attack_magic: 6
-      attack_ranged: 6
-      defence_stab: 6
-      defence_slash: 6
-      defence_crush: 6
-      defence_magic: 6
-      defence_ranged: 6
+    requirements: {}
+    attack_bonus:
+      stab: 6
+      slash: 6
+      crush: 6
+      magic: 6
+      ranged: 6
+    defence_bonus:
+      stab: 6
+      slash: 6
+      crush: 6
+      magic: 6
+      ranged: 6
+    other_bonus:
       strength: 6
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
+  recipes:
+    - skill: magic
+      level: 57
+      xp: 67
+      materials:
+        - item_name: Diamond amulet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 10
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 1700
-      item_name: Diamond amulet
+    - item_name: Diamond amulet
       slug: diamond-amulet
       relationship: component
-      description: Unenchanted form
-    - item_id: 1712
-      item_name: Amulet of glory
+      description: "Unenchanted form, enchanted with Lvl-4 Enchant."
+    - item_name: Amulet of glory
       slug: amulet-of-glory
       relationship: upgrade
-      description: P2P upgrade
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Members-only upgrade with identical combat bonuses and teleports."
+    - item_name: Amulet of strength
+      slug: amulet-of-strength
+      relationship: alternative
+      description: "Higher strength bonus but no other combat bonuses."
+  about: "The amulet of power is an enchanted diamond amulet giving balanced +6 attack, defence, and strength bonuses across every combat style. It is the best free-to-play neck amulet for general combat and a cheap starter for ironmen until amulet of glory becomes available."
+  market_strategy:
+    notes:
+      - "Crafting margin tracks diamond amulet plus 1 cosmic and 10 earth runes - usually break-even after the 4-hour limit."
+      - "Solid f2p demand keeps daily volume strong; price hugs alch value."
+  trading_tips:
+    - "Profitable when diamond amulets dip below the GE price minus rune cost."
+    - "Buy when high alch beats GE and convert excess stock at the magic altar."
+  history:
+    - date: "2001-05-24"
+      description: "Released as a free-to-play balanced combat amulet."
+    - date: "2015-02-26"
+      description: "Buy limit raised when Grand Exchange limits were rebalanced."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-rancour.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-rancour.mdx
@@ -12,9 +12,33 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: zenyte
+    tier: high
+  properties:
+    release_date: "2024-08-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.012
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    weight: 0.01
+    weapon_type: null
+    attack_speed: null
+    weight: 0.012
+    requirements:
+      hitpoints: 90
     attack_bonus:
       stab: 25
       slash: 25
@@ -32,62 +56,54 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 2
-    requirements:
-      hitpoints: 90
-      crafting: 86
-    degradable: false
+  recipes:
+    - skill: crafting
+      level: 86
+      xp: 500
+      materials:
+        - item_name: Amulet of torture
+          quantity: 1
+        - item_name: Araxyte fang
+          quantity: 1
+      tools: []
+      output_quantity: 1
   drop_table:
-    primary_source: Crafted
     sources:
-      - source: Araxxor (via Araxyte fang)
-        source_id: 12018
-        combat_level: 890
-        quantity: Component
-        rarity: rare
-        drop_rate: 1/600
-        members_only: true
+      - source: Araxxor (via Araxyte fang component)
+        quantity: "1"
+        rarity: 1/600
   related_items:
-    - item_id: 19553
-      item_name: Amulet of torture
+    - item_name: Amulet of torture
       slug: amulet-of-torture
       relationship: component
-      description: Base amulet required for crafting
-    - item_id: 29799
-      item_name: Araxyte fang
+      description: Base amulet upgraded into the amulet of rancour
+    - item_name: Araxyte fang
       slug: araxyte-fang
       relationship: component
-      description: Rare drop from Araxxor
-    - item_id: 29796
-      item_name: Noxious halberd
+      description: Rare Araxxor drop fused into the torture amulet
+    - item_name: Noxious halberd
       slug: noxious-halberd
       relationship: alternative
-      description: Another Araxxor reward
+      description: Alternative tradeable melee reward from Araxxor
   about: |-
-    | Stat | Torture | Rancour | Difference |
-    |------|---------|---------|------------|
-    | Melee attack | +15 | +25 | +10 |
-    | Strength | +10 | +12 | +2 |
-    | Prayer | +0 | +2 | +2 |
-    | Magic | +0 | -6 | -6 |
-    | Ranged | +0 | -8 | -8 |
+    The amulet of rancour is the best-in-slot melee amulet, upgraded from an amulet of torture by combining it with an araxyte fang at 86 Crafting for 500 experience. It requires 90 Hitpoints to equip.
 
-    Best-in-slot melee amulet for:
-    - All melee combat
-    - Bossing
-    - Slayer
-    - PvP
-
-    Note: Significant magic/ranged penalties make it unsuitable for hybrid setups.
+    Compared to the amulet of torture it gains +10 melee attack, +2 strength, and +2 prayer, at the cost of -6 magic and -8 ranged attack, making it unsuitable for hybrid setups but dominant for pure melee play.
   market_strategy:
     notes:
-      - Araxyte fang is untradeable, only the finished amulet is tradeable
-      - High demand as BiS melee neck
-      - 90 HP requirement limits some accounts
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Araxyte fang is untradeable, only the finished amulet is tradeable"
+      - "High demand as BiS melee neck for bossing and slayer"
+      - "90 HP requirement gates lower-tier accounts"
+      - "Price closely tied to Araxxor kill rates and fang drops"
+  trading_tips:
+    - Watch fang prices alongside torture amulets for crafting margin
+  history:
+    - date: "2024-08-28"
+      description: "Amulet of rancour released as a melee upgrade from Araxxor's araxyte fang drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anchovy-pizza.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anchovy-pizza.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 10000
-  about: "Anchovy pizza is a free-to-play item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.9
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 55
+      xp: 39
+      materials:
+        - item_name: Plain pizza
+          quantity: 1
+        - item_name: Anchovies
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Healing
+      description: "Restores 18 Hitpoints split across two 9 HP bites, currently the top-tier free-to-play food per inventory slot."
+  related_items:
+    - item_name: Plain pizza
+      slug: plain-pizza
+      relationship: component
+      description: Base pizza topped with anchovies to make an anchovy pizza.
+    - item_name: Anchovies
+      slug: anchovies
+      relationship: component
+      description: Topping cooked onto a plain pizza at 55 Cooking.
+    - item_name: 1/2 anchovy pizza
+      slug: 12-anchovy-pizza
+      relationship: variant
+      description: Remaining half after the first bite is eaten.
+    - item_name: Pineapple pizza
+      slug: pineapple-pizza
+      relationship: upgrade
+      description: Members-only upgrade that heals more per pizza than the anchovy variant.
+  about: "Anchovy pizza is a free-to-play, two-bite cooking food made by adding anchovies to a plain pizza at 55 Cooking for 39 XP. It heals 18 Hitpoints in two 9 HP bites and remains the best healing-per-slot food available to F2P accounts."
+  market_strategy:
+    notes:
+      - "Volume product - 10k buy limit makes it easy to scale flips through quests and events."
+      - "F2P PKers create reliable demand spikes during F2P Bounty Hunter and tournament worlds."
+      - "Margins are razor thin because plain pizzas and anchovies are mass-produced by bots."
+  trading_tips:
+    - Time buys around F2P tournament weekends when pizza demand spikes.
+    - Cook from scratch when GE pizza spread is below 5gp per pizza.
+    - Watch combat update polls that might change F2P food tiering.
+  history:
+    - date: "2001-06-11"
+      description: "Added to the game during the early RuneScape Classic Cooking expansion."
+    - date: "2015-02-26"
+      description: "Update ensured pizzas remain in the same inventory slot after the first half is eaten."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-coif.mdx
@@ -12,8 +12,35 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: mid-high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.9
+    requirements:
+      defence: 40
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,27 +58,30 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
-      defence: 40
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails reward casket
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 10382
-      item_name: Guthix coif
+    - item_name: Guthix coif
       slug: guthix-coif
       relationship: variant
       description: God blessed coif variant
-    - item_id: 10374
-      item_name: Zamorak coif
+    - item_name: Zamorak coif
       slug: zamorak-coif
       relationship: variant
       description: God blessed coif variant
-    - item_id: 12504
-      item_name: Bandos coif
+    - item_name: Bandos coif
       slug: bandos-coif
       relationship: variant
       description: God blessed coif variant
-    - item_id: 12512
-      item_name: Armadyl coif
+    - item_name: Armadyl coif
       slug: armadyl-coif
       relationship: variant
       description: God blessed coif variant
@@ -61,11 +91,12 @@ osrs:
     All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
   market_strategy:
     notes:
-      - Hard clue exclusive — supply tied to clue completion rates
-      - Price differences between gods are cosmetic preference only
-      - Armadyl and Ancient tend to command slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Hard clue exclusive — supply tied to clue completion rates"
+      - "Price differences between gods are cosmetic preference only"
+      - "Armadyl and Ancient tend to command slight premiums"
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the blessed dragonhide coif set in the God Wars update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-full-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ancient full helm | OSRS Price Data
-description: "Ancient full helm: Rune full helmet in the colours of a long-forgotten god.. High alch: 21,120 GP, GE limit: 8."
+description: "Ancient full helm: Rune full helmet in the colours of a long-forgotten god. High alch: 21,120 GP, GE limit: 8."
 osrs:
   id: 12466
   name: Ancient full helm
@@ -12,9 +12,85 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 8
-  about: "Ancient full helm is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 40
+    attack_bonus:
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  related_items:
+    - item_name: Ancient platebody
+      slug: ancient-platebody
+      relationship: set-piece
+      description: Ancient rune armour body
+    - item_name: Ancient platelegs
+      slug: ancient-platelegs
+      relationship: set-piece
+      description: Ancient rune armour legs
+    - item_name: Ancient plateskirt
+      slug: ancient-plateskirt
+      relationship: set-piece
+      description: Ancient rune armour skirt
+    - item_name: Ancient kiteshield
+      slug: ancient-kiteshield
+      relationship: set-piece
+      description: Ancient rune armour shield
+    - item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: alternative
+      description: Standard rune full helm without prayer bonus
+  about: "Ancient full helm is the Zaros-aligned decorative rune full helm featuring a light purple plume. Requiring 40 Defence to equip, it carries identical defence stats to a regular rune full helm plus a unique +1 prayer bonus that distinguishes it from the base item. Obtained as a 1/1,625 reward from hard clue caskets."
+  market_strategy:
+    notes:
+      - "Prayer bonus makes it a niche budget choice for F2P prayer setups"
+      - "Cosmetic premium drives most of the price above base rune full helm"
+  trading_tips:
+    - Clue scroll DMM/league events spike Ancient set pieces concurrently
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -2 to -3."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-relic.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-relic.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 6400000
   highalch: 9600000
   limit: 250
-  about: "Ancient relic is a members-only item in Old School RuneScape. High alchemy value: 9,600,000 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: artifact
+    tier: high
+  properties:
+    release_date: "2018-02-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "You will have to obtain another one from the Revenant Caves."
+  drop_table:
+    sources:
+      - source: Revenant imp
+        quantity: "1"
+        rarity: "1/44,000"
+      - source: Revenant goblin
+        quantity: "1"
+        rarity: "1/36,000"
+      - source: Revenant cyclops
+        quantity: "1"
+        rarity: "1/14,000"
+      - source: Revenant dark beast
+        quantity: "1"
+        rarity: "1/4,400"
+      - source: Bounty Hunter crate
+        quantity: "1"
+        rarity: "2/1,000"
+  related_items:
+    - item_name: Revenant ether
+      slug: revenant-ether
+      relationship: product
+      description: Chiselling the relic yields 32,000 revenant ether
+    - item_name: Ancient emblem
+      slug: ancient-emblem
+      relationship: alternative
+      description: Higher-tier Wilderness artefact upgraded via Emblem Trader
+    - item_name: Ancient effigy
+      slug: ancient-effigy
+      relationship: alternative
+      description: Mid-tier Wilderness artefact sold to the Emblem Trader
+  about: "Ancient relic is a high-tier Wilderness artefact dropped by revenants in the Revenant Caves and from Bounty crates. Sell to the Emblem Trader on a Bounty Hunter world for 16,000,000 coins, or chisel into 32,000 revenant ether. Always lost on death — even when it is the only item carried — mirroring the bracelet of ethereum and other Wilderness artefacts."
+  market_strategy:
+    notes:
+      - "Always lost on death — never carry casually"
+      - "Emblem Trader buyout is the price floor in BH worlds"
+      - "Chisel route yields 32,000 revenant ether — track ether GE price"
+      - "High alch above 9.5M makes alching viable on margin"
+      - "Supply driven by revenant cave activity and BH crate openings"
+  trading_tips:
+    - Compare 16M Emblem Trader payout vs GE flips before selling
+    - Chisel to ether when ether trades above 500 gp/unit
+    - Treat as Wilderness PvP risk — never carry without intent
+  history:
+    - date: "2018-02-08"
+      description: "Item added with the Revenant Caves rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anti-venom(1) | OSRS Price Data
-description: "Anti-venom(1): 1 dose of antivenom potion.. High alch: 66 GP, GE limit: 2,000."
+description: "Anti-venom(1): 1 dose of antivenom potion. High alch: 66 GP, GE limit: 2,000."
 osrs:
   id: 12911
   name: Anti-venom(1)
@@ -12,9 +12,66 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Anti-venom(1) is a members-only item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2015-01-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Instantly cures venom and poison and grants immunity to poison for 12 minutes."
+        duration: 720
+      - description: "Grants immunity to venom for 36-54 seconds depending on dose."
+        duration: 54
+  related_items:
+    - item_name: Anti-venom(2)
+      slug: anti-venom-2
+      relationship: variant
+      description: "Two-dose variant of the same potion."
+    - item_name: Anti-venom(3)
+      slug: anti-venom-3
+      relationship: variant
+      description: "Three-dose variant."
+    - item_name: Anti-venom(4)
+      slug: anti-venom-4
+      relationship: variant
+      description: "Four-dose variant; most efficient stack size."
+    - item_name: "Anti-venom+(4)"
+      slug: anti-venom-plus-4
+      relationship: upgrade
+      description: "Stronger version with longer venom immunity."
+  about: "Anti-venom(1) is a single-dose members potion that cures and prevents venom and poison. Crafted from Zulrah's scales and antidote++ at 87 Herblore, it is the staple anti-poison potion at Zulrah, Vorkath, and other venomous bosses."
+  market_strategy:
+    notes:
+      - "Demand spikes with Zulrah and Vorkath activity; one-dose vials are a byproduct of decanting."
+      - "Buy limit of 2,000 per 4 hours allows large rotations for decanters."
+      - "High alch under value, so always exit via GE rather than nature runes."
+  trading_tips:
+    - "Buy single doses cheap and decant into 4-dose potions for profit."
+    - "Watch for Zulrah scale price swings as they drive antivenom margins."
+  history:
+    - date: "2015-01-08"
+      description: "Released alongside the Zulrah boss update."
+    - date: "2016-04-07"
+      description: "Drinking antipoison no longer decreases poison immunity granted by anti-venom."
+    - date: "2025-01-08"
+      description: "Players can now initiate potion-making without canceling movement."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-2.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 88
   highalch: 132
   limit: 2000
-  about: "Anti-venom(2) is a members-only item in Old School RuneScape. High alchemy value: 132 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2015-01-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and venom instantly, then grants venom immunity for 36 to 54 seconds and poison immunity for 12 minutes."
+        duration: 54
+      - description: "Long poison immunity that persists after the venom immunity wears off."
+        duration: 720
+  recipes:
+    - skill: herblore
+      level: 87
+      xp: 60
+      materials:
+        - item_name: Antidote++ (2)
+          quantity: 1
+        - item_name: Zulrah's scales
+          quantity: 10
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Anti-venom(4)
+      slug: anti-venom-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Anti-venom+(4)
+      slug: anti-venom-plus-4
+      relationship: upgrade
+      description: Longer venom immunity duration
+    - item_name: Antidote++
+      slug: antidote-plus-plus
+      relationship: component
+      description: Base potion for Anti-venom
+    - item_name: Zulrah's scales
+      slug: zulrahs-scales
+      relationship: component
+      description: Required to convert Antidote++ into Anti-venom
+  about: "Anti-venom(2) is a 2-dose members potion that immediately cures poison and venom, then grants venom immunity for roughly 36 to 54 seconds plus poison immunity for 12 minutes. Created at 87 Herblore by adding 5 Zulrah's scales per dose to an Antidote++. High alchemy value: 132 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand spikes with Zulrah, Theatre of Blood and other venom-heavy content"
+      - "Supply is gated by Zulrah's scales availability"
+      - "87 Herblore decant route gives steady scale-to-coin conversion margin"
+  trading_tips:
+    - Convert Anti-venom(4) into 2-dose forms via a NPC decanter for arbitrage
+    - Stockpile Zulrah's scales on price dips to hedge production cost
+  history:
+    - date: "2015-01-08"
+      description: "Anti-venom potions released alongside the Zulrah boss."
+    - date: "2016-04-07"
+      description: "Drinking any kind of antipoison no longer decreases poison immunity."
+    - date: "2025-01-08"
+      description: "Players can now initiate Make-X processes without cancelling movement."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/axeman-s-folly.mdx
@@ -12,12 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Axeman's folly is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ale
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: cooking
+      level: 49
+      xp: 413
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Oak roots
+          quantity: 1
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Beer glass
+          quantity: 8
+      tools: []
+      output_quantity: 8
+  shops:
+    - shop_name: Auburn Pub
+      location: Auburnvale
+      price: 2
+      currency: Coins
+      stock: 5
+    - shop_name: Nemus Retreat pub
+      location: Nemus Retreat
+      price: 2
+      currency: Coins
+      stock: 5
+  passive_effects:
+    - name: Woodcutting boost
+      description: Temporarily boosts Woodcutting by 1 level while draining Attack and Strength by 3 levels each. Restores 1 Hitpoint.
+  related_items:
+    - item_name: Axeman's folly(m)
+      slug: axeman-s-folly-m
+      relationship: variant
+      description: Matured ale variant with stronger effect.
+  about: "Axeman's folly is a members-only ale brewed in the Player-owned house Brewery at Cooking level 49. It temporarily boosts Woodcutting at the cost of Attack and Strength, making it niche for wood gathering."
+  market_strategy:
+    notes:
+      - "Low-volume niche ale; supply tied to PoH brewers and shop runs."
+      - "Pure utility item for Woodcutting boosts, not combat."
+  trading_tips:
+    - Stock up before high-level Woodcutting events.
+    - Shops in Auburnvale offer cheap restocks at 2 gp each.
+  history:
+    - date: "2005-07-11"
+      description: "Item released with the Farming and brewing update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandana-eyepatch-white.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Bandana eyepatch (white) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements:
+      cabin_fever: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Bandana eyepatch (blue)
+      slug: bandana-eyepatch-blue
+      relationship: variant
+      description: Blue colour variant of the bandana eyepatch.
+    - item_name: Bandana eyepatch (brown)
+      slug: bandana-eyepatch-brown
+      relationship: variant
+      description: Brown colour variant of the bandana eyepatch.
+    - item_name: Bandana eyepatch (red)
+      slug: bandana-eyepatch-red
+      relationship: variant
+      description: Red colour variant of the bandana eyepatch.
+  about: "Bandana eyepatch (white) is a cosmetic pirate head item assembled by Patchy on Mos Le'Harmless from a white pirate bandana and a right eyepatch for 500 coins. Requires completion of Cabin Fever to wear, and now satisfies elite clue requirements for a bandana."
+  market_strategy:
+    notes:
+      - "Demand spikes when elite clue scrolls request pirate cosmetics."
+      - "Supply is restocked from Patchy at fixed 500gp assembly cost, capping practical ceiling."
+  trading_tips:
+    - Buy white pirate bandanas first if assembly margin is profitable.
+    - Watch GE volume around bond/event weekends for cosmetic flips.
+  history:
+    - date: "2025-12-17"
+      description: "Renamed from 'Bandana eyepatch' to 'Bandana eyepatch (white)' to disambiguate from colour variants."
+    - date: "2025-09-24"
+      description: "Updated to satisfy elite clue scroll requirements for a bandana."
+    - date: "2006-07-04"
+      description: "Released alongside the Trouble Brewing minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bastion-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bastion-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bastion potion(3) | OSRS Price Data
-description: "Bastion potion(3): 3 doses of Bastion potion.. High alch: 162 GP, GE limit: 2,000."
+description: "Bastion potion(3) boosts Ranged and Defence; brewed at 80 Herblore. High alch: 162 GP, GE limit: 2,000."
 osrs:
   id: 22464
   name: Bastion potion(3)
@@ -12,9 +12,83 @@ osrs:
   lowalch: 108
   highalch: 162
   limit: 2000
-  about: "Bastion potion(3) is a members-only item in Old School RuneScape. High alchemy value: 162 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2018-06-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.09
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Ranged by 4 + 10% of current Ranged level."
+        duration: 300
+      - description: "Boosts Defence by 5 + 15% of current Defence level."
+        duration: 300
+  recipes:
+    - skill: herblore
+      level: 80
+      xp: 155
+      materials:
+        - item_name: Cadantine blood potion (unf)
+          quantity: 1
+        - item_name: Wine of Zamorak
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Bastion potion(1)
+      slug: bastion-potion-1
+      relationship: variant
+      description: One-dose version
+    - item_name: Bastion potion(2)
+      slug: bastion-potion-2
+      relationship: variant
+      description: Two-dose version
+    - item_name: Bastion potion(4)
+      slug: bastion-potion-4
+      relationship: variant
+      description: Four-dose version
+    - item_name: Divine bastion potion(4)
+      slug: divine-bastion-potion-4
+      relationship: upgrade
+      description: Divine variant with no stat drain
+    - item_name: Ranging potion(4)
+      slug: ranging-potion-4
+      relationship: alternative
+      description: Pure ranged boost without defence
+    - item_name: Super defence(4)
+      slug: super-defence-4
+      relationship: alternative
+      description: Pure defence boost without ranged
+  about: |-
+    > _"3 doses of Bastion potion."_
+
+    Combo potion that boosts Ranged by 4 + 10% and Defence by 5 + 15% of the player's current levels. Boost drains at 1 per minute (90 seconds with Preserve). Brewed by combining a Cadantine blood potion (unf) with Wine of Zamorak at 80 Herblore for 155 XP.
+  market_strategy:
+    notes:
+      - "Demand tracks ranged PvM content (ToA, CG, Nex) and weekly Herblore XP events."
+      - "Three-dose decant from a four-dose is often cheaper than direct."
+  trading_tips:
+    - Buy cadantine blood potions (unf) bulk and brew during XP events.
+    - Decant between dose sizes to capture spread mispricings.
+  history:
+    - date: "2018-06-07"
+      description: "Released alongside the Theatre of Blood update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-axe.mdx
@@ -12,26 +12,82 @@ osrs:
   lowalch: 153
   highalch: 230
   limit: 40
-  item_id: 1361
-  item_type: equipment
-  slot: weapon
-  type: axe
-  tradeable: true
-  weight: 1.36
-  requirements:
-    attack: 10
-    woodcutting: 11
-  stats:
-    stab: -2
-    slash: 10
-    crush: 8
-    strength: 12
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: axe
+    attack_speed: 5
+    weight: 1.36
+    requirements:
+      attack: 10
+      woodcutting: 11
+    attack_bonus:
+      stab: -2
+      slash: 10
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   related_items:
-    - slug: mithril-axe
-    - slug: adamant-axe
-  about: Woodcutting tool. 12.5% better than steel axe.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Steel axe
+      slug: steel-axe
+      relationship: downgrade
+      description: Standard metal-tier axe, slower at woodcutting than black.
+    - item_name: Mithril axe
+      slug: mithril-axe
+      relationship: upgrade
+      description: Next tier up in standard woodcutting axes.
+    - item_name: Adamant axe
+      slug: adamant-axe
+      relationship: upgrade
+      description: Higher-tier axe with better cut rate.
+    - item_name: Black felling axe handle
+      slug: black-felling-axe-handle
+      relationship: component
+      description: Combine with this axe to create a black felling axe.
+  about: "Black axe is a free-to-play hatchet roughly 12.5% better than a steel axe at chopping trees. It cannot be smithed, requires 10 Attack to wield and 11 Woodcutting to use, and combines with a felling axe handle to upgrade into a black felling axe."
+  market_strategy:
+    notes:
+      - "Niche tier between steel and mithril, demand mostly from felling axe upgraders."
+      - "Small buy limit keeps spread tight; high-volume flips are impractical."
+  trading_tips:
+    - Hold for felling axe handle release weekends for short demand spikes.
+    - Skip alching; market price exceeds high alch value.
+  history:
+    - date: "2014-09-01"
+      description: "Random event ents no longer spawn; axes no longer break or degrade."
+    - date: "2002-02-27"
+      description: "Released as part of the original black equipment range."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart-p-5638.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart-p-5638.mdx
@@ -12,12 +12,86 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 7000
-  about: "Black dart(p++) is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: thrown
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 6
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Super strong poison
+      description: Inflicts a stronger poison damage-over-time effect on hit, with longer poison duration than the (p) and (p+) variants.
+  related_items:
+    - item_name: Black dart
+      slug: black-dart
+      relationship: variant
+      description: Unpoisoned base variant of this thrown weapon.
+    - item_name: Black dart(p)
+      slug: black-dart-p-standard
+      relationship: variant
+      description: Standard poison variant.
+    - item_name: Black dart(p+)
+      slug: black-dart-p-plus
+      relationship: variant
+      description: Strong poison variant.
+    - item_name: Weapon poison(++)
+      slug: weapon-poison-plus-plus
+      relationship: component
+      description: Herblore poison applied to create this variant.
+  about: "Black dart(p++) is the super-poisoned form of the black thrown dart, requiring 10 Ranged to wield. Created by applying weapon poison(++) to five unpoisoned black darts, it is a niche pick for poison-stacking strategies."
+  market_strategy:
+    notes:
+      - "Niche demand tied to PvM poison tactics and PvP setups."
+      - "Crafted from weapon poison(++) at 82 Herblore."
+  trading_tips:
+    - Buy unpoisoned darts in bulk to poison and resell.
+    - Watch weapon poison(++) prices for arbitrage opportunities.
+  history:
+    - date: "2005-07-11"
+      description: "Item released alongside the dart variant set."
+    - date: "2006-08-22"
+      description: "Renamed from \"Black dart(s)\" to \"Black dart(p++)\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dart-p.mdx
@@ -12,12 +12,100 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 7000
-  about: "Black dart(p) is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dart
+    tier: low
+  properties:
+    release_date: "9 August 2004"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 6
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Black dart
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Weapon poison
+      description: "Has a chance to inflict regular weapon poison damage on hit, starting at 2 damage and ticking down over time."
+  related_items:
+    - item_name: Black dart
+      slug: black-dart
+      relationship: component
+      description: Base unpoisoned dart
+    - item_name: Black dart(p+)
+      slug: black-dart-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_name: Black dart(p++)
+      slug: black-dart-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+    - item_name: Adamant dart(p)
+      slug: adamant-dart-p
+      relationship: upgrade
+      description: Higher tier poisoned dart
+  about: "The black dart(p) is the weapon poison variant of the black dart, a thrown ranged weapon requiring level 10 Ranged. Created by applying weapon poison to a regular black dart. Each thrown dart has a chance to inflict weapon poison damage, useful for low-level slayer tasks and PK setups. Black darts are only obtainable from Burthorpe soldiers, which makes the supply chain narrow."
+  market_strategy:
+    notes:
+      - "Black darts only drop from Burthorpe soldiers"
+      - "Constrained supply keeps base price elevated"
+      - "Poison version uses cheap weapon poison"
+      - "Demand from low-level rangers and pures"
+  trading_tips:
+    - Stockpile base black darts when farmed in bulk
+    - Apply weapon poison during Herblore events for cheap margins
+    - Watch pure account meta for demand spikes
+  history:
+    - date: "9 August 2004"
+      description: "Item was added to the game alongside the Burthorpe and Trollheim content release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h2.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 422
   highalch: 633
   limit: 70
-  about: "Black helm (h2) is a free-to-play item in Old School RuneScape. High alchemy value: 633 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 10
+      magic: -1
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Black full helm
+      slug: black-full-helm
+      relationship: variant
+      description: Standard untrimmed version with identical stats
+    - item_name: Black helm (h1)
+      slug: black-helm-h1
+      relationship: variant
+      description: First heraldic design variant
+    - item_name: Black helm (h3)
+      slug: black-helm-h3
+      relationship: variant
+      description: Third heraldic design variant
+  about: |-
+    The black helm (h2) is a heraldic variant of the black full helm awarded from easy Treasure Trails. It shares identical stats with the base black full helm and is purely cosmetic, displaying a unique crest. It requires 10 Defence to wear and is available to free-to-play players.
+  market_strategy:
+    notes:
+      - "Cosmetic-only over the base black full helm"
+      - "Supply tracks easy clue scroll completions"
+      - "Low buy limit keeps the market thin"
+  trading_tips:
+    - Flip on holiday cosmetic spikes
+    - Compare against (h1)/(h3) variants when buying
+  history:
+    - date: "2006-12-05"
+      description: "Released as an easy Treasure Trails reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-helm-h5.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black helm (h5) | OSRS Price Data
-description: "Black helm (h5): A black helmet with a heraldic design.. High alch: 633 GP, GE limit: 70."
+description: "Black helm (h5): A black helmet with a heraldic design. High alch: 633 GP, GE limit: 70."
 osrs:
   id: 10314
   name: Black helm (h5)
@@ -12,9 +12,93 @@ osrs:
   lowalch: 422
   highalch: 633
   limit: 70
-  about: "Black helm (h5) is a free-to-play item in Old School RuneScape. High alchemy value: 633 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 10
+      magic: 0
+      ranged: 12
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Reward casket (easy)"
+        quantity: "1"
+        rarity: "1/1,404"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Black full helm
+      slug: black-full-helm
+      relationship: variant
+      description: "Plain black full helm with identical stats."
+    - item_name: Black helm (h1)
+      slug: black-helm-h1
+      relationship: alternative
+      description: "Asgarnia heraldic variant."
+    - item_name: Black helm (h2)
+      slug: black-helm-h2
+      relationship: alternative
+      description: "Saradomin heraldic variant."
+    - item_name: Black helm (h3)
+      slug: black-helm-h3
+      relationship: alternative
+      description: "Guthix heraldic variant."
+    - item_name: Black helm (h4)
+      slug: black-helm-h4
+      relationship: alternative
+      description: "Zamorak heraldic variant."
+  about: "Black helm (h5) is the Misthalin heraldic full helm rewarded from easy Treasure Trails (1/1,404). Stats are identical to the plain black full helm, so value comes entirely from cosmetic and clue completion demand."
+  market_strategy:
+    notes:
+      - "Pricing is collector-driven; easy clue volume is high so floor is set by casual cluers."
+      - "Buy limit of 70 every 4 hours leaves room for steady flipping."
+  trading_tips:
+    - "Compare all five (h1-h5) variants before listing - dump on the rarest of the day."
+    - "Can be stored in costume room to free bank slots while collecting clue cosmetics."
+  history:
+    - date: "2006-12-05"
+      description: "Released with the heraldic black armour clue rewards."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-plateskirt-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-plateskirt-t.mdx
@@ -12,22 +12,88 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2004-10-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
     requirements:
       defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 21
+      slash: 20
+      crush: 19
+      magic: -4
+      ranged: 20
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
   related_items:
-    - item_id: 3473
-      item_name: Black plateskirt (g)
+    - item_name: Black plateskirt (g)
       slug: black-plateskirt-g
       relationship: variant
       description: Gold-trimmed variant
+    - item_name: Black plateskirt
+      slug: black-plateskirt
+      relationship: variant
+      description: Standard untrimmed black plateskirt
   about: |-
-    > *"Black plateskirt with trim."*
-
-    The black plateskirt (t) is a trimmed cosmetic variant of the black plateskirt. Same stats as black platelegs with slightly less weight, requiring 10 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The black plateskirt (t) is a trimmed cosmetic variant of the black plateskirt, dropped exclusively from easy-tier Treasure Trail reward caskets. It carries the same stats as black platelegs but with slightly less weight, requiring 10 Defence to wear. Trimmed cosmetics like this remain popular F2P clue-hunter rewards.
+  market_strategy:
+    notes:
+      - "Easy clue reward with consistent supply trickle"
+      - "Buy limit of 8 caps flip volume per cycle"
+      - "Demand mostly driven by F2P fashion-scape collectors"
+      - "Price floor rises slowly with general inflation"
+      - "Watch easy clue rate update news for supply shocks"
+  trading_tips:
+    - Stagger sub-mid offers across multiple 4-hour cycles
+    - Pair-flip with matching black trim set pieces
+    - Avoid loading inventory near high alch ceiling
+  history:
+    - date: "2004-10-26"
+      description: "Released as a Treasure Trails clue scroll reward."
+    - date: "2021-04-21"
+      description: "Ranged defence bonus adjusted from -7 to -11."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-overload-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-overload-1.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 50
-  about: "Blighted overload (1) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2024-07-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Attack, Strength, Ranged, and Magic while reducing Defence; boosts re-apply every 15 seconds."
+        duration: 300
+      - description: "Inflicts damage over time on the player while active."
+        duration: 6
+  related_items:
+    - item_name: Blighted super restore (4)
+      slug: blighted-super-restore-4
+      relationship: alternative
+      description: Other Wilderness-only consumable
+    - item_name: Blighted anglerfish
+      slug: blighted-anglerfish
+      relationship: alternative
+      description: Wilderness-only food
+    - item_name: Overload (4)
+      slug: overload-4
+      relationship: alternative
+      description: Non-blighted overload variant
+  about: |-
+    > *"1 dose of blighted overload potion."*
+
+    Single-dose Deadman Mode overload that boosts Attack, Strength, Ranged, and Magic on a 15-second tick for five minutes while also dealing periodic self-damage.
+  market_strategy:
+    notes:
+      - "Deadman Mode exclusive — illiquid on standard worlds"
+      - "Demand spikes during Deadman seasonal events"
+  history:
+    - date: "2024-07-17"
+      description: "Released with the Deadman: Armageddon update."
+    - date: "2026-01-21"
+      description: "Self-damage reduced from 25 to 10 over 6 seconds."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragonhide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-dragonhide.mdx
@@ -12,80 +12,77 @@ osrs:
   lowalch: 56
   highalch: 84
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: hide
     tier: mid
-  tanning:
-    cost: 20
-    product_id: 2505
-    product_name: Blue dragon leather
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Blue dragon
-        source_id: 265
-        combat_level: 111
         quantity: "1"
         rarity: always
-        members_only: true
       - source: Brutal blue dragon
-        source_id: 7274
-        combat_level: 271
-        quantity: "2"
+        quantity: "1"
         rarity: always
-        members_only: true
       - source: Vorkath
-        source_id: 8061
-        combat_level: 732
-        quantity: 25 (noted)
+        quantity: "1"
         rarity: common
-        members_only: true
   related_items:
-    - item_id: 2505
-      item_name: Blue dragon leather
+    - item_name: Blue dragon leather
       slug: blue-dragon-leather
       relationship: product
-      description: Tanned version
-    - item_id: 2499
-      item_name: Blue d'hide body
+      description: Tanned version, 20 gp at standard tanner
+    - item_name: Blue d'hide body
       slug: blue-dhide-body
       relationship: product
-      description: Main product
-    - item_id: 1749
-      item_name: Red dragonhide
+      description: End-tier crafted ranged body
+    - item_name: Red dragonhide
       slug: red-dragonhide
-      relationship: alternative
-      description: Higher tier
-    - item_id: 1753
-      item_name: Green dragonhide
+      relationship: upgrade
+      description: Next dragonhide tier above blue
+    - item_name: Green dragonhide
       slug: green-dragonhide
-      relationship: alternative
-      description: Lower tier
-  about: |-
-    Take to any tanner to convert to Blue dragon leather.
-
-    | Tanner | Cost |
-    |--------|------|
-    | Regular | 20 GP |
-    | Canifis | 45 GP |
+      relationship: downgrade
+      description: Lower dragonhide tier below blue
+  about: "Blue dragonhide is the mid-tier dragonhide, harvested from blue dragons in Taverley Dungeon and the Heroes' Guild as well as from brutal blue dragons and Vorkath. Tan to blue dragon leather (20 coins regular, 45 coins Sbott in Canifis) or via the Tan Leather lunar spell. Used to craft the blue d'hide body — the highest-defence ranged body for low-Crafting routes."
   market_strategy:
-    profit_formulas:
-      - Blue dragon leather - Blue dragonhide - 20 = Profit
-      - Body price - (Leather × 3) = Profit
     notes:
-      - Buy hides → Tan → Sell leather
-      - "Calculate:"
-      - High volume F2P equivalent
-      - Blue d'hide body most common
-      - "Check:"
-      - Popular mid-level training
-      - Blue dragons (Taverley Dungeon, Heroes' Guild)
-      - Brutal blue dragons
-      - Vorkath (noted drops)
-      - Mid-tier dragonhide
-      - Highest F2P ranged body
-      - Good crafting XP/GP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy hides, tan, craft, then sell finished armour"
+      - "Blue d'hide body anchors most demand"
+      - "Vorkath noted drops keep supply steady"
+      - "Brutal blue dragons spike supply during slayer tasks"
+      - "Mid-tier dragonhide — accessible Crafting XP/GP"
+      - "High GE buy limit makes bulk flips practical"
+  trading_tips:
+    - Crunch blue dragon leather and body margins together
+    - Track Vorkath kill counts on community trackers
+    - Pair with eye of newts for crafting trips
+  history:
+    - date: "2003-12-01"
+      description: "Item added to the RS2 Beta."
+    - date: "2004-03-29"
+      description: "Released to the live game with the RS2 launch."
+    - date: "2004-09-01"
+      description: "Value adjusted from 0 to 40 coins."
+    - date: "2005-11-01"
+      description: "Renamed to Blue dragonhide with an updated examine."
+    - date: "2018-09-01"
+      description: "Value increased from 40 to 140 coins for ground visibility."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-moon-spear.mdx
@@ -5,19 +5,42 @@ osrs:
   id: 28988
   name: Blue moon spear
   slug: blue-moon-spear
-  examine: A magical staff of ancient origin...
+  examine: A magical staff of ancient origin.
   members: true
   icon: Blue moon spear.png
   value: 100000
   lowalch: 40000
   highalch: 60000
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    weapon_type: staff
-    weight: 3
+    weapon_type: bladed_staff
     attack_speed: 5
-    attack_range: 1
+    weight: 3
+    requirements:
+      attack: 70
+      magic: 75
     attack_bonus:
       stab: 70
       slash: 62
@@ -35,68 +58,39 @@ osrs:
       ranged_strength: 0
       magic_damage: 5
       prayer: 0
-    requirements:
-      attack: 70
-      magic: 75
-    degradable: false
-    two_handed: true
   drop_table:
-    primary_source: Lunar Chest (Neypotzli)
-    best_drop_rate: 1/224
     sources:
-      - source: Lunar Chest
+      - source: Lunar Chest (Neypotzli)
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/224
-        members_only: true
+        rarity: 1/224
+  passive_effects:
+    - name: Frostweaver (set bonus)
+      description: "With the full Blue moon armour set equipped, after casting a bind or freeze spell there is a 20% chance the next melee attack is unaffected by action delays, enabling instant follow-up melee."
   related_items:
-    - item_id: 29019
-      item_name: Blue moon helm
+    - item_name: Blue moon helm
       slug: blue-moon-helm
       relationship: set-piece
       description: Required for Frostweaver effect
-    - item_id: 29013
-      item_name: Blue moon chestplate
+    - item_name: Blue moon chestplate
       slug: blue-moon-chestplate
       relationship: set-piece
       description: Required for Frostweaver effect
-    - item_id: 29016
-      item_name: Blue moon tassets
+    - item_name: Blue moon tassets
       slug: blue-moon-tassets
       relationship: set-piece
       description: Required for Frostweaver effect
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Attack speed | 5 ticks (3.0s) |
-    | Attack range | 1 tile |
-    | Combat style | Bladed Staff |
-
-    Unique hybrid weapon with both melee and magic capabilities.
-
-    When wearing full Blue moon armour:
-    - Frostweaver: After casting a bind or freeze spell, 20% chance for next melee attack to be unaffected by action delays
-
-    Allows instant follow-up melee attacks after freeze spells.
-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab | +70 |
-    | Magic | +30 |
-    | Strength | +71 |
-    | Magic damage | +5% |
-
-    Powerful for magic-melee hybrid combat:
-    - Freeze then stab combos
-    - Neypotzli content
-    - PvP hybrid builds
+  about: "Blue moon spear is a hybrid melee-magic bladed staff dropped by the Lunar Chest in Neypotzli. With +70 stab, +30 magic, +71 strength and +5% magic damage it shines in freeze-then-stab combos when paired with the rest of the Blue moon armour for the Frostweaver effect. High alchemy value: 60,000 coins. Grand Exchange buy limit: 15 per 4 hours."
   market_strategy:
     notes:
-      - Best used with Blue moon armour
-      - Unique hybrid playstyle
-      - High value for set synergy
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Best used with the full Blue moon armour set for Frostweaver synergy"
+      - "Unique hybrid playstyle covers both freeze magic and melee follow-up"
+      - "Demand tied to Neypotzli boss popularity and set-piece arbitrage"
+  trading_tips:
+    - Track Lunar Chest completion volume after Varlamore updates
+    - Compare spot price vs combined helm+chestplate+tassets to gauge set premium
+  history:
+    - date: "2024-03-20"
+      description: "Released with Varlamore: Part One as a Lunar Chest reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-hat.mdx
@@ -12,42 +12,100 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
   equipment:
     slot: head
-    type: magic hat
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 0.453
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 2
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 2
-      defence_ranged: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    other_bonus:
       strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  drop_table:
+    sources:
+      - source: Imp
+        quantity: "1"
+        rarity: 8/128
+      - source: Wizard
+        quantity: "1"
+        rarity: 3/128
+  shops:
+    - shop_name: Betty's Magic Emporium
+      location: Port Sarim
+      price: 2
+      currency: Coins
+      stock: 1
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 2
+      currency: Coins
+      stock: 3
+    - shop_name: Regath's Wares
+      location: Arceuus
+      price: 2
+      currency: Coins
+      stock: 1
   related_items:
-    - item_id: 577
-      item_name: Blue wizard robe
+    - item_name: Blue wizard robe
       slug: blue-wizard-robe
-      relationship: alternative
-      description: Set piece
-    - item_id: 740
-      item_name: Wizard hat
+      relationship: set-piece
+      description: Matching body slot piece of the blue wizard outfit.
+    - item_name: Wizard hat
       slug: wizard-hat
       relationship: component
-      description: Base item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Base hat used to create the blue version.
+    - item_name: Black wizard hat
+      slug: black-wizard-hat
+      relationship: variant
+      description: Black colour variant crafted via dyeing.
+  about: "Blue wizard hat is a free-to-play head slot magic item providing +2 magic attack and +2 magic defence. Sold in multiple shops and commonly dropped by imps and wizards, it serves as low-level magic gear and a cosmetic staple."
+  market_strategy:
+    notes:
+      - "F2P magic starter gear; sustained low-level demand."
+      - "Cheap shop restocks keep ceiling tight."
+  trading_tips:
+    - Buy at shop price for tiny resale margins on the Grand Exchange.
+    - Pairs with blue wizard robe for the full magic set.
+  history:
+    - date: "2001-01-04"
+      description: "Item released with RuneScape Classic."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger-p-8878.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bone-dagger-p-8878.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 70
-  about: "Bone dagger (p++) is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bone
+    tier: mid
+  properties:
+    release_date: "2006-06-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 5
+      slash: 3
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Bone dagger
+      slug: bone-dagger
+      relationship: variant
+      description: Unpoisoned base dagger
+    - item_name: Weapon poison++
+      slug: weapon-poison-pp
+      relationship: component
+      description: Poison applied to upgrade to p++
+  about: "Bone dagger (p++) is the strongest-poison variant of the Dorgeshuun bone dagger, obtained as a drop in the Lumbridge Catacombs or by applying weapon poison++ to a regular bone dagger. Its Backstab special attack will never miss while the target is undamaged and reduces Defence by the damage dealt, costing 75% special energy."
+  passive_effects:
+    - name: Backstab
+      description: "Special attack: cannot miss against undamaged targets and lowers Defence by damage dealt; 75% special energy cost."
+  market_strategy:
+    notes:
+      - "Niche stab special-attack tool, lower volume than dragon dagger"
+      - "Premium over base bone dagger reflects weapon poison++ scarcity"
+  history:
+    - date: "2006-06-21"
+      description: "Released alongside the Death to the Dorgeshuun quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bones-to-bananas-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bones-to-bananas-tablet.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Bones to bananas (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: clay
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 15
+      xp: 15
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Nature rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 2
+        - item_name: Water rune
+          quantity: 2
+      tools:
+        - Demon lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Bones to peaches (tablet)
+      slug: bones-to-peaches-tablet
+      relationship: alternative
+      description: Higher level variant converting bones to peaches
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Required base material for tablet creation
+    - item_name: Nature rune
+      slug: nature-rune
+      relationship: component
+      description: Rune required for the spell
+  about: "Bones to bananas (tablet) is a Construction-made tablet that casts the Bones to Bananas spell when broken, converting all bones and big bones in the inventory into bananas regardless of the player's current spellbook. Created at a demon lectern requiring 15 Magic, 1 soft clay, 1 nature rune, 2 earth runes and 2 water runes. High alchemy value: 1 coin. Grand Exchange buy limit: 10,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Tablet bypasses spellbook requirement, useful on Ancient/Lunar/Arceuus"
+      - "Production cost around 242 coins vs ~460 coin GE price for steady margin"
+      - "Buy limit of 10,000 supports bulk flipping and bulk training stock"
+  trading_tips:
+    - Run tablets at a demon lectern for passive Magic experience and profit
+    - Track soft clay and nature rune prices to time bulk production
+  history:
+    - date: "2006-05-31"
+      description: "Bones to bananas tablet released alongside Construction tablet updates."
+    - date: "2013-05-31"
+      description: "Tablet versions of 'Bones to Bananas' and 'Bones to Peaches' updated to work on the same bone types as the spellbook versions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bread-dough.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bread-dough.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  about: "Bread dough is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dough
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.6
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Pot of flour
+          quantity: 1
+        - item_name: Jug of water
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Pot of flour
+      slug: pot-of-flour
+      relationship: component
+      description: Combined with water to form dough
+    - item_name: Jug of water
+      slug: jug-of-water
+      relationship: component
+      description: Water source for dough
+    - item_name: Bread
+      slug: bread
+      relationship: product
+      description: Cooked product, heals 5 HP
+    - item_name: Burnt bread
+      slug: burnt-bread
+      relationship: alternative
+      description: Failed cooking attempt
+  about: |-
+    Bread dough is an uncooked dough made by using a jug of water on a pot of flour. Cook on a range or fire at level 1 Cooking for 40 XP to produce bread, which heals 5 hitpoints. Featured in Tutorial Island as a basic cooking introduction.
+  market_strategy:
+    notes:
+      - "Used for low-level Cooking training"
+      - "High buy limit of 13,000 per 4 hours"
+      - "Margins driven by flour/water input costs"
+  history:
+    - date: "2001-01-04"
+      description: "Released with the original RuneScape Cooking skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-gold-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-gold-trimmed-set-lg.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 8
-  about: "Bronze gold-trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armor_set
+    tier: low
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Bronze full helm (g)
+      slug: bronze-full-helm-g
+      relationship: set-piece
+      description: Helm piece of the set
+    - item_name: Bronze platebody (g)
+      slug: bronze-platebody-g
+      relationship: set-piece
+      description: Body piece of the set
+    - item_name: Bronze platelegs (g)
+      slug: bronze-platelegs-g
+      relationship: set-piece
+      description: Leg piece of the set
+    - item_name: Bronze kiteshield (g)
+      slug: bronze-kiteshield-g
+      relationship: set-piece
+      description: Shield piece of the set
+    - item_name: Bronze gold-trimmed set (sk)
+      slug: bronze-gold-trimmed-set-sk
+      relationship: alternative
+      description: Skirt variant of the set
+  about: |-
+    Bronze gold-trimmed set (lg) bundles a Bronze full helm (g), platebody (g), platelegs (g), and kiteshield (g) into a single tradeable item via the Grand Exchange Sets tab. Designed to reduce bank space and bundle clue scroll loot for resale.
+  market_strategy:
+    notes:
+      - "Demand from F2P clue scroll collectors"
+      - "Low buy limit of 8 per 4 hours"
+      - "Use Sets tab to convert individual pieces"
+      - "Margin depends on piece float on the GE"
+  history:
+    - date: "2015-02-26"
+      description: "Released when armour sets were added to the Grand Exchange Sets tab."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-hasta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-hasta.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 125
-  about: "Bronze hasta is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: -1
+      crush: -1
+      magic: 0
+      ranged: -1
+    other_bonus:
+      strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 5
+      xp: 25
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+        - item_name: Logs
+          quantity: 1
+      tools:
+        - Hammer
+        - Barbarian anvil
+      output_quantity: 1
+  related_items:
+    - item_name: Bronze spear
+      slug: bronze-spear
+      relationship: variant
+      description: Two-handed counterpart of the hasta forged from the same bronze materials.
+    - item_name: Iron hasta
+      slug: iron-hasta
+      relationship: upgrade
+      description: Next-tier hasta requiring higher Smithing and Attack to forge and wield.
+    - item_name: Steel hasta
+      slug: steel-hasta
+      relationship: upgrade
+      description: Mid-tier hasta in the Barbarian Smithing chain.
+  about: "Bronze hasta is the entry-level one-handed hasta unlocked through Barbarian Smithing after completing the Barbarian Training miniquest. It is smithed at level 5 Smithing on the Barbarian anvil using a bronze bar and logs, and remains a niche choice mainly for skilling unlocks and Defence training."
+  market_strategy:
+    notes:
+      - "Niche supply - most stock comes from Barbarian Smithing tutorials and dropped runs."
+      - "125 buy limit and low alch value keep margins razor thin."
+      - "Useful as a Smithing XP filler for ironmen leveling beyond bronze daggers."
+  trading_tips:
+    - Use the Barbarian anvil to cycle bronze bars when training Smithing under level 15.
+    - Flip in bulk only when alchers list under high alch.
+    - Treat as a feeder item; profit is mostly from XP gained while crafting.
+  history:
+    - date: "2007-07-03"
+      description: "Added with the Barbarian Training miniquest, opening the Barbarian Smithing weapon tree."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife-p-5654.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife-p-5654.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze knife(p+) | OSRS Price Data
-description: "Bronze knife(p+): A finely balanced throwing knife.. High alch: 1 GP, GE limit: 7,000."
+description: "Bronze knife(p+): A finely balanced throwing knife. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 5654
   name: Bronze knife(p+)
@@ -12,9 +12,81 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Bronze knife(p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 3
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Bronze knife
+      slug: bronze-knife
+      relationship: variant
+      description: Unpoisoned base variant.
+    - item_name: Bronze knife(p)
+      slug: bronze-knife-p
+      relationship: variant
+      description: Standard poisoned variant.
+    - item_name: Bronze knife(p++)
+      slug: bronze-knife-p-plus-plus
+      relationship: variant
+      description: Strongest poison variant.
+  about: |-
+    Bronze knife(p+) is the strong-poison version of the entry-level thrown weapon. With no requirements to wield, it's mostly used for early ranged training or as a novelty stack to test mechanics.
+
+    The (p+) suffix applies weapon poison+, which has a short-lived effect at low levels but is rarely worth the cost vs an unpoisoned knife.
+
+    Requirements: None | Slot: Weapon | Attack speed: 2 ticks (rapid)
+  market_strategy:
+    notes:
+      - "Low alch value caps the floor; tiny margin movement."
+      - "Almost no demand beyond low-level training or set collectors."
+      - "Stack size makes bulk flipping high-effort, low-reward."
+  trading_tips:
+    - Skip unless you are a near-instant flipper on tiny margins.
+  history:
+    - date: "2006-09"
+      description: "Naming convention updated from \"Bronze knife(+)\" to \"Bronze knife(p+)\"."
+    - date: "2005-07-11"
+      description: "Released with the Farming skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-milk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-milk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bucket of milk | OSRS Price Data
-description: "Bucket of milk: It's a bucket of milk.. High alch: 3 GP, GE limit: 13,000."
+description: "Bucket of milk: It's a bucket of milk. High alch: 3 GP, GE limit: 13,000."
 osrs:
   id: 1927
   name: Bucket of milk
@@ -12,9 +12,82 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 13000
-  about: "Bucket of milk is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dairy
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 2.2
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle basement
+      price: 7
+      currency: coins
+      stock: 0
+    - shop_name: Funch's Fine Groceries
+      location: Grand Tree
+      price: 6
+      currency: coins
+      stock: 5
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      price: 6
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Bucket
+      slug: bucket
+      relationship: component
+      description: Empty bucket used on a dairy cow to produce milk.
+    - item_name: Pot of cream
+      slug: pot-of-cream
+      relationship: product
+      description: Created from a bucket of milk via the dairy churn.
+    - item_name: Pat of butter
+      slug: pat-of-butter
+      relationship: product
+      description: Churned from a bucket of milk for members cooking recipes.
+    - item_name: Cheese
+      slug: cheese
+      relationship: product
+      description: Top-tier dairy churn output from a bucket of milk.
+  about: |-
+    Bucket of milk is a free-to-play cooking staple obtained by using an empty bucket on a dairy cow or buffalo. It is required for cakes, chocolate cake, chocolatey milk, and is the base for cream, butter and cheese at a dairy churn (members).
+
+    The item is also asked for in Cook's Assistant, Gertrude's Cat, Plague City, and the Skippy and the Mogres miniquest, making demand surprisingly diverse.
+
+    Weight: 2.2 kg | Slot: None | Filled by using a bucket on a dairy cow (3 ticks).
+  market_strategy:
+    notes:
+      - "Steady demand from cake/cheese cooks and quest helpers."
+      - "Cheapest stockpile comes from Funch's Fine Groceries restocks."
+      - "Buy limit of 13,000 lets bulk buyers refill GE supply quickly."
+  trading_tips:
+    - Buy near 5-7 gp and resell to questers and cake cooks at higher tick.
+    - Pair with chocolate bar and cake of bread flips for cake margins.
+  history:
+    - date: "2006-03-28"
+      description: "Inventory sprite rotated."
+    - date: "2006-03-22"
+      description: "Bucket of milk received a graphical update."
+    - date: "2005-07-11"
+      description: "Milking regular cows replaced by dairy cows."
+    - date: "2001-01-04"
+      description: "Bucket of milk added to RuneScape Classic."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Bucket is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: General store
+      location: Across the world
+      price: 2
+      currency: Coins
+      stock: 5
+    - shop_name: Wydin's Food Store
+      location: Port Sarim
+      price: 2
+      currency: Coins
+      stock: 2
+    - shop_name: Aemad's Adventuring Supplies
+      location: Ardougne
+      price: 2
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Bucket of water
+      slug: bucket-of-water
+      relationship: product
+      description: "Bucket filled from a water source"
+    - item_name: Bucket of milk
+      slug: bucket-of-milk
+      relationship: product
+      description: "Bucket filled from a dairy cow"
+    - item_name: Bucket of sand
+      slug: bucket-of-sand
+      relationship: product
+      description: "Bucket filled with sand for glassblowing"
+    - item_name: Compost
+      slug: compost
+      relationship: product
+      description: "Buckets are used to hold compost from compost bins"
+  about: |-
+    Bucket is a basic wooden container used across nearly every gathering and processing skill in OSRS. It can be filled with water, milk, sand, compost, slime, wax, or sap depending on the interaction.
+
+    Buckets spawn naturally across 40+ locations and are sold for 2 coins at most general stores, making them one of the cheapest reusable items in the game.
+  market_strategy:
+    notes:
+      - "F2P utility staple with very deep demand across skills"
+      - "Shop-bought floor at 2 gp keeps GE arbitrage tight"
+      - "Empty bucket packs (100 noted) are a popular bulk option for skillers"
+  trading_tips:
+    - Buy from Wydin or Aemad in bulk if the GE is dry
+    - Empty bucket pack flips track the Construction crab trap / Farming compost demand
+  history:
+    - date: "4 January 2001"
+      description: "Released with the original game."
+    - date: "22 March 2006"
+      description: "Bucket sprite received a graphical update."
+    - date: "28 April 2006"
+      description: "Inventory sprite rotation adjusted."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/charcoal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/charcoal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Charcoal | OSRS Price Data
-description: "Charcoal: A lump of charcoal.. High alch: 27 GP, GE limit: 13,000."
+description: "Charcoal: A lump of charcoal. High alch: 27 GP, GE limit: 13,000."
 osrs:
   id: 973
   name: Charcoal
@@ -12,18 +12,59 @@ osrs:
   lowalch: 18
   highalch: 27
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: resource
+    tier: low
+  properties:
+    release_date: "2003-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.005
+    options:
+      - Use
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Hajedy's Cart Service
+      location: Brimhaven
+      price: 67
+      currency: Coins
+      stock: 50
+    - shop_name: Shilo Village General Store
+      location: Shilo Village
+      price: 58
+      currency: Coins
+      stock: 0
   related_items:
-    - item_id: 970
-      item_name: Papyrus
+    - item_name: Papyrus
       slug: papyrus
       relationship: component
-      description: Used together for notes
-  about: |-
-    > _"A\"piece\" of charcoal."_
-
-    Charcoal is used with papyrus to write notes and maps. Required in several quests. Also used in some Crafting recipes.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Used together to write notes and sketches
+    - item_name: Ground charcoal
+      slug: ground-charcoal
+      relationship: product
+      description: Charcoal ground in a pestle and mortar
+    - item_name: Logs
+      slug: logs
+      relationship: component
+      description: Some quests produce charcoal from burnt trees
+  about: "Charcoal is a free-to-play resource used primarily as a quest item across nine quests including Desert Treasure I, Legends' Quest, and While Guthix Sleeps. It pairs with papyrus to write notes and is required to ground in a pestle and mortar for several niche recipes. Buy from Hajedy in Brimhaven or Shilo Village shops, or obtain from quest rewards."
+  market_strategy:
+    notes:
+      - "Quest demand creates steady but limited price floor"
+      - "Shop restock arbitrage from Brimhaven/Shilo to GE"
+  trading_tips:
+    - Bulk-buy from charcoal shops when GE price spikes during quest streamer cycles
+  history:
+    - date: "2003-01-27"
+      description: "Released as part of early F2P quest content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/claws-of-callisto.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/claws-of-callisto.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: null
-  about: "Claws of callisto is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: boss-drop
+    tier: high
+  properties:
+    release_date: "2023-01-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Callisto
+        quantity: "1"
+        rarity: 1/196
+      - source: Artio
+        quantity: "1"
+        rarity: 1/618
+  recipes:
+    - skill: smithing
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Viggora's chainmace
+          quantity: 1
+        - item_name: Claws of callisto
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Ursine chainmace
+      slug: ursine-chainmace
+      relationship: product
+      description: Upgraded chainmace using these claws
+    - item_name: Viggora's chainmace
+      slug: viggoras-chainmace
+      relationship: component
+      description: Base weapon for the upgrade
+    - item_name: Tyrannical ring
+      slug: tyrannical-ring
+      relationship: alternative
+      description: Other unique drop from Callisto / Artio
+    - item_name: Callisto cub
+      slug: callisto-cub
+      relationship: alternative
+      description: Pet from Callisto / Artio
+  about: "Claws of callisto is a unique Wilderness boss drop from Callisto and Artio used to upgrade Viggora's chainmace into the Ursine chainmace. The upgrade requires either 85 Smithing or a 500,000 gp fee paid to Andros Mai in Ferox Enclave."
+  market_strategy:
+    notes:
+      - "Price floors near alch value when supply spikes after Wilderness events"
+      - "Demand cycles with Wilderness combat meta and chainmace popularity"
+      - "Supply concentrated in a small set of PvM mains"
+  trading_tips:
+    - Watch Wilderness Wars / bounty events for sell-side pressure
+    - Bid into the alch floor when sentiment is bearish
+  history:
+    - date: "2023-01-25"
+      description: "Added alongside the Wilderness boss rework, dropping from Callisto and Artio."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Combat potion(2) | OSRS Price Data
-description: "Combat potion(2): 2 doses of combat potion.. High alch: 63 GP, GE limit: 2,000."
+description: "Combat potion(2): 2 doses of combat potion. High alch: 63 GP, GE limit: 2,000."
 osrs:
   id: 9743
   name: Combat potion(2)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 42
   highalch: 63
   limit: 2000
-  about: "Combat potion(2) is a members-only item in Old School RuneScape. High alchemy value: 63 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Attack by 10% of base level + 3."
+        duration: 60
+      - description: "Boosts Strength by 10% of base level + 3."
+        duration: 60
+  recipes:
+    - skill: herblore
+      level: 36
+      xp: 84
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Goat horn dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Combat potion(1)
+      slug: combat-potion-1
+      relationship: variant
+      description: One-dose version of the same Attack and Strength boost.
+    - item_name: Combat potion(3)
+      slug: combat-potion-3
+      relationship: variant
+      description: Three-dose version of the same Attack and Strength boost.
+    - item_name: Combat potion(4)
+      slug: combat-potion-4
+      relationship: variant
+      description: Four-dose version - the standard form created at Herblore.
+    - item_name: Attack potion(4)
+      slug: attack-potion-4
+      relationship: alternative
+      description: Attack-only potion when Strength boost is not needed.
+    - item_name: Strength potion(4)
+      slug: strength-potion-4
+      relationship: alternative
+      description: Strength-only potion when Attack boost is not needed.
+  about: |-
+    Combat potion(2) is a two-dose potion that boosts both Attack and Strength by 10% of base level plus 3, decaying at 1 point per minute (90 seconds per point with the Preserve prayer). It replaces drinking an Attack potion and Strength potion separately for melee training and lower-tier PvM.
+
+    Combat potions are made by combining harralander potion (unf) with goat horn dust at 36 Herblore, granting 84 experience per 3-dose mix. The (2) version typically appears via splitting a 4 dose or sipping down a 3-dose.
+
+    Requirements: 36 Herblore | Slot: None | Duration: ~5 minutes per dose.
+  market_strategy:
+    notes:
+      - "Niche dose count - most buyers want (4) for full-trip boosts."
+      - "High alch parity sets a price floor near 63 gp."
+      - "Steady demand from Herblore mixers splitting doses for XP banks."
+  trading_tips:
+    - Snipe (2) listings near alch parity, decant to (4) for resale.
+    - Watch harralander and goat horn dust margins for fresh-mix arbitrage.
+  history:
+    - date: "2006-10-18"
+      description: "Combat potion family released for members."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-sunlight-antelope.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-sunlight-antelope.mdx
@@ -12,12 +12,68 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 10000
-  about: "Cooked sunlight antelope is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Eat
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 68
+      xp: 175
+      materials:
+        - item_name: Raw sunlight antelope
+          quantity: 1
+      tools:
+        - Fire or range
+      output_quantity: 1
+  related_items:
+    - item_name: Raw sunlight antelope
+      slug: raw-sunlight-antelope
+      relationship: component
+      description: Raw form cooked into this food
+    - item_name: Cooked moonlight antelope
+      slug: cooked-moonlight-antelope
+      relationship: alternative
+      description: Nocturnal Varlamore hunter food counterpart
+  about: |-
+    Cooked sunlight antelope is a members-only food obtained by cooking a raw sunlight antelope at level 68 Cooking, yielding 175 experience. Players must complete 50 Hunters' Rumours before they can cook these.
+
+    When eaten, it restores a combined 21 Hitpoints — 12 immediately, plus 9 more after a 7-tick delay (4.2 seconds). Eating another hunter meat quickly cancels the pending heal from the prior bite, so it is best used as a primary food.
+  potion:
+    effects:
+      - description: "Restores 12 Hitpoints immediately on consumption."
+        duration: 0
+      - description: "Restores an additional 9 Hitpoints after a 7-tick delay."
+        duration: 4
+  market_strategy:
+    notes:
+      - "Cooking from raw is currently unprofitable due to material costs"
+      - "Used by hunter pet farmers leveling cooking with side meat"
+      - "Demand spikes during Varlamore content patches"
+  history:
+    - date: "2024-03-20"
+      description: "Cooked sunlight antelope released as part of the Varlamore update."
+    - date: "2026-05-13"
+      description: "Graphical update made the cooked sunlight antelope sprite more vibrant."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-scythe-of-vitur-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-scythe-of-vitur-uncharged.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: null
-  about: "Corrupted scythe of vitur (uncharged) is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: deadman reward
+    tier: high
+  properties:
+    release_date: "2023-08-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Check
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: scythe
+    attack_speed: 5
+    weight: 3.175
+    requirements:
+      attack: 60
+      strength: 70
+    attack_bonus:
+      stab: 40
+      slash: 60
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 40
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Corrupted scythe sweep
+      description: Hits up to three targets in a 1x3 arc in front of the player with diminishing damage on the second and third targets.
+  related_items:
+    - item_name: Scythe of vitur (uncharged)
+      slug: scythe-of-vitur-uncharged
+      relationship: variant
+      description: Standard scythe of vitur uncharged variant
+    - item_name: Blood rune
+      slug: blood-rune
+      relationship: component
+      description: Required to charge the corrupted scythe
+    - item_name: Trinket of advanced weaponry
+      slug: trinket-of-advanced-weaponry
+      relationship: component
+      description: Deadman trinket that yields the corrupted scythe
+  about: |-
+    The corrupted scythe of vitur (uncharged) is a Deadman Mode variant of the scythe of vitur released in August 2023. Unlike the regular scythe, the corrupted version charges with blood runes only at 300 per 100 charges, but its combat bonuses are around 20 percent lower than the standard variant. It is currently unobtainable outside of seasonal Deadman events.
+  market_strategy:
+    notes:
+      - "Deadman seasonal item with constrained supply"
+      - "Demand spikes around DMM season announcements"
+      - "No GE buy limit on rare deadman variants"
+      - "Long-term value tied to blood rune economics"
+      - "Speculative hold for collectors during off-seasons"
+  trading_tips:
+    - Watch DMM seasonal news for demand inflection
+    - Avoid panic selling between seasons
+    - Cross-reference standard scythe price ratios
+  history:
+    - date: "2023-08-23"
+      description: "Released during the Deadman Mode Apocalypse seasonal."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-of-power-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-of-power-flatpack.mdx
@@ -12,12 +12,40 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Crystal of power (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: |-
+    The Crystal of power (flatpack) is an unobtainable flatpack item that exists in the game files but cannot be created. It was originally designed for the Construction skill's study room but was scrapped before launch.
+
+    According to Mod John C, these flatpacks "exist as objects in the game but you can't actually create them" because they were abandoned during Construction's initial development around 2005-2006.
+  market_strategy:
+    notes:
+      - "Currently unobtainable through normal gameplay"
+      - "No active supply on the Grand Exchange"
+      - "Historical curio with no practical use"
+  history:
+    - date: "2006-05-31"
+      description: "Crystal of power (flatpack) introduced as an unobtainable flatpack item alongside the Player-Owned Houses update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-cavalier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-cavalier.mdx
@@ -12,12 +12,100 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 4
-  about: "Dark cavalier is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.001
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  related_items:
+    - item_name: Black cavalier
+      slug: black-cavalier
+      relationship: variant
+      description: Black colour variant of the cavalier hat.
+    - item_name: Tan cavalier
+      slug: tan-cavalier
+      relationship: variant
+      description: Tan colour variant.
+    - item_name: Red cavalier
+      slug: red-cavalier
+      relationship: variant
+      description: Red colour variant.
+    - item_name: Navy cavalier
+      slug: navy-cavalier
+      relationship: variant
+      description: Navy colour variant.
+    - item_name: White cavalier
+      slug: white-cavalier
+      relationship: variant
+      description: White colour variant.
+    - item_name: Cavalier mask
+      slug: cavalier-mask
+      relationship: alternative
+      description: Mask version of the cavalier cosmetic line.
+  about: "Dark cavalier is a cosmetic hard clue scroll reward in OSRS. It provides no combat bonuses and is purely aesthetic, popular for its musketeer-style appearance and stored in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Steady cosmetic demand from clue completionists."
+      - "Low buy limit (4) keeps prices firm."
+  trading_tips:
+    - Cosmetic margin item; flip slowly due to thin volume.
+    - Pairs with cavalier mask for full musketeer aesthetic.
+  history:
+    - date: "2004-05-05"
+      description: "Item released as a Treasure Trails reward."
+    - date: "2005-05-17"
+      description: "Renamed from \"Cavalier\" to \"Dark cavalier\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolts.mdx
@@ -12,67 +12,96 @@ osrs:
   lowalch: 76
   highalch: 115
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: adamantite
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    stats:
+    weapon_type: crossbow_bolts
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 105
-    requirements: {}
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: fletching
       level: 65
       xp: 70
-      inputs:
+      materials:
         - item_name: Adamant bolts
           quantity: 10
         - item_name: Diamond bolt tips
           quantity: 10
+      tools: []
       output_quantity: 10
   related_items:
-    - item_id: 9243
-      item_name: Diamond bolts (e)
+    - item_name: Diamond bolts (e)
       slug: diamond-bolts-e
       relationship: product
-      description: Enchanted version with Armour Piercing special
-    - item_id: 9143
-      item_name: Adamant bolts
+      description: Enchanted version with Armour Piercing special effect
+    - item_name: Adamant bolts
       slug: adamant-bolts
       relationship: component
-      description: Base bolt used in creation
-    - item_id: 9192
-      item_name: Diamond bolt tips
+      description: Base bolt used in fletching
+    - item_name: Diamond bolt tips
       slug: diamond-bolt-tips
       relationship: component
-      description: Gem tips used in creation
+      description: Gem tips attached to adamant bolts
   about: |-
-    > *"Diamond tipped Adamantite crossbow bolts."*
+    Diamond bolts are members-only adamantite crossbow bolts tipped with cut diamonds. They are crafted by attaching diamond bolt tips to adamant bolts at level 65 Fletching, yielding 70 experience per set of 10.
 
-    | Bonus | Value |
-    |-------|-------|
-    | Ranged Strength | +105 |
-    | All other bonuses | +0 |
-
-    | Detail | Value |
-    |--------|-------|
-    | Skill | Fletching |
-    | Level | 65 |
-    | XP | 70 (per 10 bolts) |
-    | Inputs | 10 Adamant bolts + 10 Diamond bolt tips |
-    | Output | 10 Diamond bolts |
-
-    Diamond bolt tips are crafted by using a chisel on a cut diamond, requiring 65 Crafting.
-
-    Diamond bolts can be enchanted into Diamond bolts (e) using the Enchant Crossbow Bolt spell at level 57 Magic. The enchanted version has the Armour Piercing special effect, which has a chance to ignore a portion of the target's ranged defence.
+    The bolts provide a strong +105 Ranged Strength bonus, making them a popular mid-game ammunition. They can be enchanted into Diamond bolts (e) using the Enchant Crossbow Bolt spell at 57 Magic, gaining the Armour Piercing special effect widely used at bosses like Vorkath.
   market_strategy:
     notes:
-      - Popular bolt choice for mid-level PvM and PvP
-      - Enchanted version widely used at bosses like Vorkath
-      - Price fluctuates with diamond bolt tip supply
-      - Members only item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Popular bolt choice for mid-level PvM and PvP"
+      - "Enchanted version widely used at bosses like Vorkath"
+      - "Price fluctuates with diamond bolt tip supply"
+      - "Members only item"
+  trading_tips:
+    - Buy unenchanted, enchant in bulk for profit when alch margins are tight
+    - Track diamond bolt tip and adamant bolt prices for fletching margins
+  history:
+    - date: "2006-07-31"
+      description: "Diamond bolts released as part of the Crossbows update."
+    - date: "2007-01-29"
+      description: "Base value adjusted upward from 1 coin to 192 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-bastion-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-bastion-potion-4.mdx
@@ -12,12 +12,89 @@ osrs:
   lowalch: 288
   highalch: 432
   limit: 2000
-  about: "Divine bastion potion(4) is a members-only item in Old School RuneScape. High alchemy value: 432 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2020-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.135
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+  potion:
+    effects:
+      - description: "Boosts Ranged level by floor(level * 0.10) + 4."
+        duration: 300
+      - description: "Boosts Defence level by floor(level * 0.15) + 5."
+        duration: 300
+      - description: "Prevents the boosted stats from draining below the boosted ceiling for the duration."
+        duration: 300
+      - description: "Deals 10 Hitpoints of damage to the player upon drinking."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 86
+      xp: 2
+      materials:
+        - item_name: Bastion potion(4)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 4
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Divine bastion potion(3)
+      slug: divine-bastion-potion-3
+      relationship: variant
+      description: 3-dose variant of this potion.
+    - item_name: Divine bastion potion(2)
+      slug: divine-bastion-potion-2
+      relationship: variant
+      description: 2-dose variant.
+    - item_name: Divine bastion potion(1)
+      slug: divine-bastion-potion-1
+      relationship: variant
+      description: 1-dose variant.
+    - item_name: Bastion potion(4)
+      slug: bastion-potion-4
+      relationship: component
+      description: Base potion used in the divine variant recipe.
+    - item_name: Divine super combat potion(4)
+      slug: divine-super-combat-potion-4
+      relationship: alternative
+      description: Related divine potion focused on melee combat.
+    - item_name: Divine super defence potion(4)
+      slug: divine-super-defence-potion-4
+      relationship: alternative
+      description: Related divine potion focused on Defence boosts only.
+  about: "Divine bastion potion(4) is a high-end Herblore brew combining Ranged and Defence boosts that resist drain for 5 minutes. Created at 86 Herblore from a Bastion potion(4) and 4 crystal dust, ideal for Ranged bossing."
+  market_strategy:
+    notes:
+      - "Tied to crystal dust supply and Bastion potion pricing."
+      - "Demand spikes during Ranged-focused PvM metas."
+  trading_tips:
+    - Decants between dose sizes via Bob Barter for inventory efficiency.
+    - Watch crystal dust prices for arbitrage opportunities.
+  history:
+    - date: "2020-04-30"
+      description: "Item released alongside divine bastion and other divine variants."
+    - date: "2020-07-02"
+      description: "Inventory icon updated to match the standard potion look."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dagger-p-5698.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dagger-p-5698.mdx
@@ -12,9 +12,97 @@ osrs:
   lowalch: 9600
   highalch: 14400
   limit: 70
-  about: "Dragon dagger(p++) is a members-only item in Old School RuneScape. High alchemy value: 14,400 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 40
+      slash: 25
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 40
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 95
+      xp: 190
+      materials:
+        - item_name: Dragon dagger
+          quantity: 1
+        - item_name: Weapon poison(++)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Puncture special attack
+      description: "Costs 25 percent special energy to deliver two simultaneous hits with plus 15 percent accuracy and damage each, capped at 50 damage per hit."
+    - name: Weapon poison++
+      description: "Applies the strongest weapon poison variant, dealing repeated venom-tier damage on hit until the poison charges expire."
+  related_items:
+    - item_name: Dragon dagger
+      slug: dragon-dagger
+      relationship: variant
+      description: Base unpoisoned dagger used to craft the poisoned variants.
+    - item_name: Dragon dagger(p)
+      slug: dragon-dagger-p
+      relationship: variant
+      description: Lowest poison tier of the dragon dagger family.
+    - item_name: Dragon dagger(p+)
+      slug: dragon-dagger-p-5680
+      relationship: variant
+      description: Mid-tier poisoned variant using Weapon poison(+).
+    - item_name: Abyssal dagger
+      slug: abyssal-dagger
+      relationship: upgrade
+      description: Stronger stab dagger that outpaces the dragon dagger in most PvM scenarios.
+  about: "Dragon dagger(p++) is the strongest poisoned dagger tier outside the abyssal dagger, requiring 60 Attack and Lost City to wield. Its Puncture special attack costs 25 percent energy and is a staple opener for PvP burst combos and slayer boss damage spikes."
+  market_strategy:
+    notes:
+      - "Demand follows PvP weekends and Bounty Hunter events when DDS specs are king."
+      - "Buy limit of 70 per 4 hours keeps daily flip volume capped; spread is wide."
+      - "Poisoned variant sells faster than unpoisoned for PvPers who skip the Herblore step."
+  trading_tips:
+    - Buy the unpoisoned dragon dagger and poison yourself for the highest margin.
+    - Watch league economies - dagger demand collapses during Trailblazer reset windows.
+    - Track Bounty Hunter resets; spec weapons spike right before tournaments.
+  history:
+    - date: "2004-03-29"
+      description: "Dragon dagger introduced with RuneScape 2, later joined by p, p+, and p++ poison tiers."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-full-helm-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-full-helm-ornament-kit.mdx
@@ -12,60 +12,61 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: ornament_kit
+    tier: high
+  properties:
+    release_date: "12 June 2014"
     tradeable: true
-    target_item: Dragon full helm
-    target_id: 11335
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Elite
-        drop_rate: Rare from reward casket
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/1275
   related_items:
-    - item_id: 11335
-      item_name: Dragon full helm
+    - item_name: Dragon full helm
       slug: dragon-full-helm
-      relationship: product
-      description: Base item to upgrade
-    - item_id: 12417
-      item_name: Dragon full helm (or)
+      relationship: component
+      description: "Base helm: combined with the kit to produce the trimmed version"
+    - item_name: Dragon full helm (or)
       slug: dragon-full-helm-or
       relationship: product
-      description: Ornamented version
+      description: "Result: gold-trimmed cosmetic variant of the dragon full helm"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ornament Kit |
-    | Target | Dragon full helm |
-    | Tradeable | Yes |
+    Dragon full helm ornament kit is an elite-tier Treasure Trail reward used to cosmetically upgrade a Dragon full helm into a Dragon full helm (or).
 
-    Use on a Dragon full helm to create a Dragon full helm (or).
-
-    The ornament kit:
-    - Adds gold trim to the helm
-    - Purely cosmetic change
-    - Does not affect stats
-    - Can be reverted
-
-    Materials:
-    - Dragon full helm
-    - Dragon full helm ornament kit
-
-    Result:
-    - Dragon full helm (or) - gold trimmed version
-
-    The ornamented helm can be reverted to return:
-    - Dragon full helm
-    - Dragon full helm ornament kit
+    Using the kit on the helm produces an untradeable trimmed version. The kit can be detached at any time, returning both items to their original tradeable state.
   market_strategy:
     notes:
-      - Elite clue exclusive
-      - Cosmetic upgrade only
-      - Popular fashionscape item
-      - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Elite clue exclusive drop from reward caskets"
+      - "Pure cosmetic upgrade with no stat impact"
+      - "Popular fashionscape and collection log target"
+  trading_tips:
+    - Watch supply spikes after elite clue tick-rate buffs
+    - Cheapest alternative to a dragon full helm (g) for trimmed look
+  history:
+    - date: "12 June 2014"
+      description: "Released as an elite Treasure Trail reward."
+    - date: "25 January 2018"
+      description: "Received a graphical update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-knife-p-22810.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-knife-p-22810.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon knife(p++) | OSRS Price Data
-description: "Dragon knife(p++): A finely balanced and powerful throwing knife.. High alch: 99 GP, GE limit: 7,000."
+description: "Dragon knife(p++): A finely balanced and powerful throwing knife. High alch: 99 GP, GE limit: 7,000."
 osrs:
   id: 22810
   name: Dragon knife(p++)
@@ -12,9 +12,83 @@ osrs:
   lowalch: 66
   highalch: 99
   limit: 7000
-  about: "Dragon knife(p++) is a members-only item in Old School RuneScape. High alchemy value: 99 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 28
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 30
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Dragon knife
+      slug: dragon-knife
+      relationship: variant
+      description: Unpoisoned base variant.
+    - item_name: Dragon knife(p)
+      slug: dragon-knife-p-22808
+      relationship: variant
+      description: Poisoned variant inflicting weaker damage over time.
+    - item_name: Dragon knife(p+)
+      slug: dragon-knife-p-plus
+      relationship: variant
+      description: Strong poison variant.
+  about: |-
+    Dragon knife(p++) is the top-tier poisoned dragon throwing knife, requiring 60 Ranged to wield. With +28 Ranged attack and +30 Ranged strength on a 2-tick rapid attack speed, it's one of the fastest single-target damage tools in the game.
+
+    The (p++) suffix carries weapon poison++, dealing the highest poison damage tier and making this knife a strong pick for short bursts on bosses where poison sticks.
+
+    Requirements: 60 Ranged | Slot: Weapon | Attack speed: 2 ticks (rapid)
+  market_strategy:
+    notes:
+      - "Used in burst-damage setups where poison procs matter."
+      - "Demand scales with PvM activity and slayer task popularity."
+      - "Stacks let big buyers liquidate quickly without margin pressure."
+  trading_tips:
+    - Watch margin against the unpoisoned dragon knife to spot poison-up arbitrage.
+    - Boss release weeks reliably push price upward.
+  history:
+    - date: "2021-07-07"
+      description: "Female character weapon positioning adjusted for proper display."
+    - date: "2019-01-10"
+      description: "Released with The Kebos Lowlands update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfruit-pie.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 10000
-  about: "Dragonfruit pie is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 73
+      xp: 220
+      materials:
+        - item_name: Uncooked dragonfruit pie
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  passive_effects:
+    - name: Fletching boost
+      description: "Eating a dragonfruit pie temporarily raises the Fletching level by 4, the highest reliable Fletching boost in the game."
+    - name: Healing
+      description: "Restores 20 Hitpoints over two 10 HP bites."
+  related_items:
+    - item_name: Uncooked dragonfruit pie
+      slug: uncooked-dragonfruit-pie
+      relationship: component
+      description: Raw pie that is baked at 73 Cooking to make the dragonfruit pie.
+    - item_name: Half a dragonfruit pie
+      slug: half-a-dragonfruit-pie
+      relationship: variant
+      description: Remaining half after the first bite is eaten.
+    - item_name: Dragonfruit
+      slug: dragonfruit
+      relationship: component
+      description: Filling used in the uncooked dragonfruit pie recipe.
+    - item_name: Pie dish
+      slug: pie-dish
+      relationship: component
+      description: Dish that remains after the second bite is consumed.
+  about: "Dragonfruit pie is a high-level food cooked at 73 Cooking and the only consumable that reliably boosts Fletching, granting +4 to the skill on consumption. It heals 20 Hitpoints in two bites and is widely used by ironmen who need the Fletching boost for quest or daily skill thresholds."
+  market_strategy:
+    notes:
+      - "Demand tracks Fletching boost meta - league seasons and skilling competitions raise prices."
+      - "Profit is best when crafted directly from dragonfruit and pastry dough rather than flipping pies."
+      - "Buy limit of 10,000 makes it viable for high-volume cook-to-flip plays."
+  trading_tips:
+    - Stock during ironman skilling weeks when boost demand spikes.
+    - Compare cost per Fletching boost vs cooking your own uncooked pies.
+    - List during peak EU/NA hours when skilling bots are offline.
+  history:
+    - date: "2019-01-10"
+      description: "Added to the game as part of the Kebos Lowlands expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-amulet-u.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 10000
-  about: "Dragonstone amulet (u) is a members-only item in Old School RuneScape. High alchemy value: 10,575 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gold
+    tier: high
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 80
+      xp: 150
+      materials:
+        - item_name: Gold bar
+          quantity: 1
+        - item_name: Cut dragonstone
+          quantity: 1
+        - item_name: Amulet mould
+          quantity: 1
+      tools:
+        - Furnace
+      output_quantity: 1
+  related_items:
+    - item_name: Cut dragonstone
+      slug: cut-dragonstone
+      relationship: component
+      description: Gem cut from an uncut dragonstone, needed for crafting
+    - item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Smithed bar used as the amulet base
+    - item_name: Dragonstone amulet
+      slug: dragonstone-amulet
+      relationship: upgrade
+      description: Strung version wearable in the amulet slot
+    - item_name: Amulet of glory
+      slug: amulet-of-glory
+      relationship: upgrade
+      description: Enchanted via Lvl-5 Enchant for teleports and bonuses
+  about: "Dragonstone amulet (u) is the unstrung output of crafting a dragonstone gem onto a gold bar at any furnace (80 Crafting, 150 XP). String with a ball of wool (1 Crafting, 4 XP) to wear it, then enchant with Lvl-5 Enchant (68 Magic) to upgrade it into an amulet of glory. Required for a Sherlock master clue scroll skill challenge."
+  market_strategy:
+    notes:
+      - "Crafted at 80 Crafting from dragonstone, gold bar, amulet mould"
+      - "Net loss per craft when raw materials run above 11,000 gp"
+      - "Demand driven by amulet of glory production"
+      - "Master clue Sherlock challenge keeps niche demand"
+      - "High GE buy limit suits bulk flips"
+  trading_tips:
+    - Compare margin between unstrung, strung and enchanted glory
+    - Watch dragonstone prices — main input cost
+    - Strung amulet route is cheapest path to amulet of glory
+  history:
+    - date: "2002-02-27"
+      description: "Item added to the game as part of the gem and amulet system."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout-m.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dwarven stout(m) | OSRS Price Data
-description: "Dwarven stout(m): This looks a good deal stronger than normal Dwarven Stout.. High alch: 1 GP, GE limit: 2,000."
+description: "Dwarven stout(m): This looks a good deal stronger than normal Dwarven Stout. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5747
   name: Dwarven stout(m)
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Dwarven stout(m) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: beverage
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Mining and Smithing by 2 levels (mature variant)."
+        duration: 0
+      - description: "Drains Attack, Strength, and Defence by 3 + 4% of current level."
+        duration: 0
+      - description: "Heals 1 hitpoint when consumed."
+        duration: 0
+  recipes:
+    - skill: cooking
+      level: 19
+      xp: 80
+      materials:
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: The stuff
+          quantity: 1
+        - item_name: Water
+          quantity: 4
+      tools:
+        - Brewing vat
+      output_quantity: 8
+  related_items:
+    - item_name: Dwarven stout
+      slug: dwarven-stout
+      relationship: downgrade
+      description: Standard (non-mature) version with weaker boost
+    - item_name: Asgarnian ale(m)
+      slug: asgarnian-ale-m
+      relationship: alternative
+      description: Mature brew boosting Strength
+    - item_name: Greenman's ale(m)
+      slug: greenmans-ale-m
+      relationship: alternative
+      description: Mature brew boosting Herblore
+  about: "Dwarven stout(m) is the matured version of Dwarven stout, brewed with The stuff added to the vat. It boosts Mining and Smithing by 2 levels while draining combat stats. The mature variant has a 5% base chance to produce when brewing, raised to 64% with The stuff added."
+  market_strategy:
+    notes:
+      - "Popular for Blast Furnace and pre-LMS Mining trips"
+      - "Brewers profit when stout(m) prices spike around skiller events"
+  trading_tips:
+    - Stockpile during brewery downtime for resale into skilling metas
+  history:
+    - date: "2005-07-11"
+      description: "Added with the brewery and mature ale mechanics."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-tassets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-tassets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Eclipse moon tassets | OSRS Price Data
-description: "Eclipse moon tassets is a members legs slot item with +1 melee strength requiring 50 Defence. High alch: 173,946 GP, GE limit: 15."
+description: "Eclipse moon tassets is a members legs slot item with +1 melee strength requiring 75 Ranged and 50 Defence. High alch: 173,946 GP, GE limit: 15."
 osrs:
   id: 29007
   name: Eclipse moon tassets
@@ -12,9 +12,35 @@ osrs:
   lowalch: 115964
   highalch: 173946
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: eclipse-moon
+    tier: high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
     weight: 1
+    requirements:
+      ranged: 75
+      defence: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,59 +58,42 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 75
-      defence: 50
-    degradable: true
-    charges: 3000
   drop_table:
-    primary_source: Lunar Chest (Neypotzli)
-    best_drop_rate: 1/224
     sources:
-      - source: Lunar Chest
+      - source: Lunar Chest (Neypotzli)
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/224
-        members_only: true
+        rarity: 1/224
+  passive_effects:
+    - name: Eclipse set effect
+      description: "When wearing the full eclipse moon armour with the eclipse atlatl, attacks have a 20 percent chance to inflict burn damage (10 damage over 24 seconds, up to 5 stacks)."
   related_items:
-    - item_id: 29000
-      item_name: Eclipse atlatl
+    - item_name: Eclipse atlatl
       slug: eclipse-atlatl
       relationship: set-piece
-      description: Weapon for Eclipse set effect
-    - item_id: 29010
-      item_name: Eclipse moon helm
+      description: Weapon that triggers Eclipse set effect
+    - item_name: Eclipse moon helm
       slug: eclipse-moon-helm
       relationship: set-piece
-      description: Helm in set
-    - item_id: 29004
-      item_name: Eclipse moon chestplate
+      description: Helm in the Eclipse moon set
+    - item_name: Eclipse moon chestplate
       slug: eclipse-moon-chestplate
       relationship: set-piece
-      description: Body armour in set
+      description: Body armour in the Eclipse moon set
   about: |-
-    When wearing the full Eclipse moon armour set with the Eclipse atlatl:
-    - Successful attacks have a 20% chance to inflict burn damage on non-immune targets
+    Eclipse moon tassets are the leg piece of the Eclipse moon set, dropped from the Lunar Chest in Neypotzli. They provide a small strength bonus alongside strong magic and crush defence. The set, when worn with the Eclipse atlatl, has a 20 percent chance to apply a stacking burn on hit.
 
-    | Property | Value |
-    |----------|-------|
-    | Total charges | 3,000 |
-    | Charge rate | 1 per 54 seconds |
-    | Combat duration | ~45 hours |
-    | NPC repair cost | 1,500,000 coins |
-    | Repair at 99 Smithing | 757,500 coins |
-
-    Part of the Eclipse moon armour set for ranged combat:
-    - Solid magic defence (+31)
-    - Decent ranged attack bonus (+17)
-    - Small strength bonus for atlatl damage
+    The tassets are degradable, holding 3,000 charges (lost at one per 54 seconds in combat, roughly 45 hours). Repair costs 1,500,000 coins at an NPC or 757,500 coins at level 99 Smithing via an armour stand.
   market_strategy:
     notes:
-      - Essential for Eclipse atlatl builds
-      - Good defensive stats for the slot
-      - Factor in repair costs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Essential for the Eclipse atlatl burn set effect"
+      - "Strong magic defence for mid-tier ranged setups"
+      - "Repair costs eat into long-term GP/hour"
+  trading_tips:
+    - Buy after Lunar Chest popularity peaks for cheaper supply
+    - Sell during ranged content updates that buff atlatl builds
+  history:
+    - date: "2024-03-20"
+      description: "Released with Varlamore: Part One."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-bracelet.mdx
@@ -12,46 +12,98 @@ osrs:
   lowalch: 610
   highalch: 915
   limit: 10000
+  material:
+    type: emerald
+    tier: mid
+  properties:
+    release_date: "2007-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.25
     requirements:
       crafting: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 30
       xp: 65
-      inputs:
-        - item_name: Emerald
-          quantity: 1
+      materials:
         - item_name: Gold bar
           quantity: 1
+        - item_name: Emerald
+          quantity: 1
+        - item_name: Bracelet mould
+          quantity: 1
+      tools:
+        - Furnace
       output_quantity: 1
   related_items:
-    - item_id: 11072
-      item_name: Sapphire bracelet
+    - item_name: Castle wars bracelet
+      slug: castle-wars-bracelet
+      relationship: product
+      description: Enchanted form via Lvl-2 Enchant
+    - item_name: Sapphire bracelet
       slug: sapphire-bracelet
       relationship: downgrade
       description: Previous tier bracelet
-    - item_id: 11085
-      item_name: Ruby bracelet
+    - item_name: Ruby bracelet
       slug: ruby-bracelet
       relationship: upgrade
       description: Next tier bracelet
-  about: |-
-    Crafting (Level 30): Emerald + Gold bar at a furnace with bracelet mould (65 XP)
-
-    > *"An emerald bracelet."*
-
-    Lvl-2 Enchant (27 Magic): 1 cosmic rune + 3 air runes (37 XP)
-
-    The Castle Wars bracelet provides +3 damage to the opposing team's flag bearer in Castle Wars. Very niche — only useful within the Castle Wars minigame (3 charges).
+    - item_name: Emerald
+      slug: emerald
+      relationship: component
+      description: Cut gem input
+    - item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: Metal input for the bracelet
+  about: "Emerald bracelet is crafted at a furnace from a gold bar plus emerald using a bracelet mould at 30 Crafting (65 XP). It can be enchanted into a Castle wars bracelet using Lvl-2 Enchant at 27 Magic (37 XP, 1 cosmic + 3 air runes), which grants +3 damage against the opposing team's flag bearer in Castle Wars (3 charges)."
   market_strategy:
     notes:
-      - Very niche demand — Castle Wars only
-      - Most value as crafting training material
-      - Low enchant demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Very niche demand — Castle Wars only"
+      - "Most value as crafting training material"
+      - "Low enchant demand"
+  trading_tips:
+    - Spread vs Castle wars bracelet drives enchant flips
+    - Track emerald and gold bar inputs for crafting floor
+  history:
+    - date: "2007-04-30"
+      description: "Released as part of the Crafting bracelet line."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/empty-oil-lamp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/empty-oil-lamp.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 10000
-  about: "Empty oil lamp is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: glass
+    tier: low
+  properties:
+    release_date: "2005-03-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 12
+      xp: 25
+      materials:
+        - item_name: Molten glass
+          quantity: 1
+      tools:
+        - Glassblowing pipe
+      output_quantity: 1
+  shops:
+    - shop_name: Miltog's Lamps
+      location: Dorgesh-Kaan
+      price: 37
+      currency: coins
+      stock: 10
+    - shop_name: Darkmeyer Lantern Shop
+      location: Darkmeyer
+      price: 30
+      currency: coins
+      stock: 10
+  related_items:
+    - item_name: Oil lamp
+      slug: oil-lamp
+      relationship: product
+      description: Filled with lamp oil
+    - item_name: Empty oil lantern
+      slug: empty-oil-lantern
+      relationship: upgrade
+      description: Combined with oil lantern frame
+    - item_name: Molten glass
+      slug: molten-glass
+      relationship: component
+      description: Glassblowing input
+  about: "Empty oil lamp is the unfilled base item produced by glassblowing molten glass at 12 Crafting. Fill it with lamp oil for a functional oil lamp, or combine with an oil lantern frame to craft an oil lantern (50 Crafting XP, no furnace needed)."
+  market_strategy:
+    notes:
+      - "Tiny margin per unit — only relevant for bulk Crafting training"
+      - "Supply driven by Crafting alts and AFK glassblowing"
+      - "High-volume buy limit (10k) makes scaling possible"
+  trading_tips:
+    - Useful as a sink for surplus molten glass
+    - Pair flips with lantern lens or oil lantern frame demand
+  history:
+    - date: "2005-03-14"
+      description: "Released as part of the lantern crafting system."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-crystal-teleport-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enhanced-crystal-teleport-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enhanced crystal teleport seed | OSRS Price Data
-description: "Enhanced crystal teleport seed: A seed to be sung into a infinite teleport crystal.. High alch: 60,000 GP, GE limit: 100."
+description: "Enhanced crystal teleport seed: A seed to be sung into a infinite teleport crystal. High alch: 60,000 GP, GE limit: 100."
 osrs:
   id: 23959
   name: Enhanced crystal teleport seed
@@ -12,12 +12,72 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 100
-  about: "Enhanced crystal teleport seed is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crystal
+    tier: high
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Sing
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Elf (Thieving, 85+)
+        quantity: "1"
+        rarity: 1/1024
+      - source: Guard (Prifddinas)
+        quantity: "1"
+        rarity: 1/1024
+      - source: Iorwerth Warrior
+        quantity: "1"
+        rarity: 1/1024
+  recipes:
+    - skill: smithing
+      level: 80
+      xp: 1000
+      materials:
+        - item_name: Enhanced crystal teleport seed
+          quantity: 1
+        - item_name: Crystal shard
+          quantity: 100
+      tools:
+        - Singing bowl
+      output_quantity: 1
+  related_items:
+    - item_name: Crystal teleport seed
+      slug: crystal-teleport-seed
+      relationship: downgrade
+      description: Basic limited-charge version
+    - item_name: Eternal teleport crystal
+      slug: eternal-teleport-crystal
+      relationship: product
+      description: Infinite-charge teleport crystal sung from this seed
+  about: "Enhanced crystal teleport seed is sung at a singing bowl with 100 crystal shards (80 Smithing/Crafting) to produce the eternal teleport crystal with unlimited Prifddinas teleports. Players short on stats can pay Conwenna or Reese 50 extra shards to do the work."
+  market_strategy:
+    notes:
+      - "Steady demand from Prifddinas teleport unlock seekers"
+      - "Rogue equipment doubles seed drops, boosting supply"
+  trading_tips:
+    - Stock typically thin; check GE several hours after buy offer
+  history:
+    - date: "2019-07-25"
+      description: "Released with the Song of the Elves quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-abyssal-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-abyssal-head.mdx
@@ -12,51 +12,64 @@ osrs:
   lowalch: 234
   highalch: 351
   limit: 3000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: ensouled_head
-    tier: master
-  prayer:
-    xp_reanimate: 1300
-    magic_level: 90
-    spell: Master Reanimation
+    tier: high
+  properties:
+    release_date: "2016-01-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Abyssal demon
-        source_id: 415
-        combat_level: 124
         quantity: "1"
-        rarity: uncommon
-        members_only: true
+        rarity: "1/25"
+      - source: Greater abyssal demon
+        quantity: "1"
+        rarity: always
+      - source: Abyssal walker
+        quantity: "1"
+        rarity: "1/40"
   related_items:
-    - item_id: 13502
-      item_name: Ensouled demon head
+    - item_name: Ensouled demon head
       slug: ensouled-demon-head
       relationship: downgrade
-      description: Lower XP (1,170)
-    - item_id: 13511
-      item_name: Ensouled dragon head
+      description: "Lower Prayer XP per cast: 1,170"
+    - item_name: Ensouled dragon head
       slug: ensouled-dragon-head
       relationship: upgrade
-      description: Best XP (1,560)
-    - item_id: 26997
-      item_name: Ensouled hellhound head
+      description: "Best Prayer XP per cast: 1,560"
+    - item_name: Ensouled hellhound head
       slug: ensouled-hellhound-head
       relationship: alternative
-      description: Similar XP (1,200)
-  about: |-
-    1. Cast Master Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+      description: "Similar tier head: 1,200 Prayer XP"
+  about: "Ensouled abyssal head is reanimated via the Master Reanimation spell (90 Magic) from the Arceuus spellbook, granting 1,300 Prayer XP. The reanimated abyssal creature requires 85 Slayer to kill. Required for a Sherlock master clue scroll skill challenge. Dropped by abyssal demons, greater abyssal demons, and abyssal walkers — supply is gated by the 85 Slayer requirement for the hunters."
   market_strategy:
     notes:
-      - Second-best Prayer XP from heads
-      - Supply from abyssal demon tasks
-      - High Slayer requirement limits supply
-      - 85 Slayer gates supply
-      - Whip hunters produce these
-      - Compare GP/XP to dragon heads
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Second-best Prayer XP per cast from ensouled heads"
+      - "85 Slayer requirement gates supply to whip hunters"
+      - "Steady demand from high-level Prayer trainers"
+      - "Compare GP per Prayer XP against ensouled dragon heads"
+      - "Master clue Sherlock challenge maintains baseline demand"
+  trading_tips:
+    - Buy during slayer task spikes at abyssal demons
+    - Sell to Master Reanimation Prayer trainers
+    - Watch dragon head spread — substitute if cheaper per XP
+  history:
+    - date: "2016-01-07"
+      description: "Item added alongside the Arceuus reanimation spells."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-elf-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-elf-head.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 143
   highalch: 214
   limit: 7500
-  about: "Ensouled elf head is a members-only item in Old School RuneScape. High alchemy value: 214 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ensouled_head
+    tier: mid
+  properties:
+    release_date: "2016-01-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Elf Warrior
+        quantity: "1"
+        rarity: "1/40"
+      - source: Elf Archer
+        quantity: "1"
+        rarity: "1/50"
+      - source: Iorwerth Warrior
+        quantity: "1"
+        rarity: uncommon
+      - source: Iorwerth Guard
+        quantity: "1"
+        rarity: uncommon
+  related_items:
+    - item_name: Ensouled abyssal head
+      slug: ensouled-abyssal-head
+      relationship: upgrade
+      description: "Master tier reanimation: 1,300 Prayer XP"
+    - item_name: Ensouled dragon head
+      slug: ensouled-dragon-head
+      relationship: upgrade
+      description: "Best Prayer XP per cast: 1,560"
+    - item_name: Ensouled bloodveld head
+      slug: ensouled-bloodveld-head
+      relationship: alternative
+      description: Similar tier reanimation head
+  about: "Ensouled elf head is reanimated via the Adept Reanimation spell (41 Magic) on the Arceuus spellbook, granting 754 Prayer XP after the reanimated creature is killed. Reanimation can occur within a 31x31 tile area of the drop point or at the Dark Altar in Arceuus. Spell components: 1 Soul, 3 Nature, 4 Body runes."
+  market_strategy:
+    notes:
+      - "Adept Reanimation: 754 Prayer XP per head"
+      - "Supplied primarily by Tirannwn elf hunters"
+      - "Steady demand from Prayer trainers"
+      - "Compare GP per Prayer XP against ensouled bloodveld and abyssal heads"
+      - "Bulk-tradeable on the GE with a high buy limit"
+  trading_tips:
+    - Buy in bulk during Tirannwn slayer task spikes
+    - Sell to mid-level Prayer trainers
+    - Spell cost roughly 751 coins per cast
+  history:
+    - date: "2016-01-07"
+      description: "Item added to the game alongside the Arceuus reanimation spells."
+    - date: "2019-10-14"
+      description: "Graphical update applied to the ensouled head."
+    - date: "2021-04-28"
+      description: "Examine text revised for consistency across all ensouled heads."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eternal-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eternal-crystal.mdx
@@ -12,66 +12,83 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 15
-  item:
-    type: crafting_material
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crystal
+    tier: high
+  properties:
+    release_date: "27 August 2015"
     tradeable: true
-  obtaining:
-    methods:
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
       - source: Cerberus
-        drop_rate: 1/520
-        requirements:
-          slayer: 91
-  creation:
-    creates:
-      item_id: 13235
-      item_name: Eternal boots
-      slug: eternal-boots
-    combine_with:
-      item_id: 6920
-      item_name: Infinity boots
-      slug: infinity-boots
-    requirements:
-      magic: 60
-      runecraft: 60
-    warning: Irreversible process
+        quantity: "1"
+        rarity: 1/512
+  recipes:
+    - skill: magic
+      level: 60
+      xp: 200
+      materials:
+        - item_name: Eternal crystal
+          quantity: 1
+        - item_name: Infinity boots
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - skill: runecraft
+      level: 60
+      xp: 200
+      materials:
+        - item_name: Eternal crystal
+          quantity: 1
+        - item_name: Infinity boots
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 0
-      item_name: Cerberus
-      slug: cerberus
-      relationship: component
-      description: Boss drop
-    - item_id: 13235
-      item_name: Eternal boots
+    - item_name: Eternal boots
       slug: eternal-boots
       relationship: product
-      description: Created item
-    - item_id: 13231
-      item_name: Primordial crystal
+      description: "Boots produced by combining the crystal with infinity boots"
+    - item_name: Infinity boots
+      slug: infinity-boots
+      relationship: component
+      description: "Base boots upgraded with the eternal crystal"
+    - item_name: Primordial crystal
       slug: primordial-crystal
       relationship: alternative
-      description: Melee version
+      description: "Melee-focused Cerberus crystal that upgrades dragon boots"
+    - item_name: Pegasian crystal
+      slug: pegasian-crystal
+      relationship: alternative
+      description: "Ranged-focused Cerberus crystal that upgrades ranger boots"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Stackable | No |
+    Eternal crystal is a rare magical crystal dropped by Cerberus. Combining it with a pair of infinity boots produces eternal boots, the best-in-slot magic boots for most situations.
 
-    Combine with Infinity boots to create Eternal boots.
-
-    | Requirement | Level |
-    |-------------|-------|
-    | Magic | 60 |
-    | Runecraft | 60 |
-
-    Warning: Irreversible process.
+    The combine requires level 60 in both Magic and Runecraft (no boosts), grants 200 xp in each skill, and is irreversible.
   market_strategy:
     notes:
-      - Mid-value Cerberus crystal
-      - Creates BiS mage boots
-      - Farm Cerberus on task
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cerberus crystal drop with a fixed end-product demand floor"
+      - "Slayer-only supply; price tracks Cerberus task popularity"
+      - "Cheapest of the three Cerberus crystals on most days"
+  trading_tips:
+    - Flip alongside infinity boots dips before combine
+    - Watch for Cerberus rework or BiS shake-up news before holding stock
+  history:
+    - date: "27 August 2015"
+      description: "Released as part of the Cerberus boss update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extended antifire(4) | OSRS Price Data
-description: "Extended antifire(4) is a 3-dose members potion that dragonfire. High alch: 264 GP, GE limit: 2,000."
+description: "Extended antifire(4) is a 4-dose members potion that grants dragonfire protection. High alch: 264 GP, GE limit: 2,000."
 osrs:
   id: 11951
   name: Extended antifire(4)
@@ -12,78 +12,75 @@ osrs:
   lowalch: 176
   highalch: 264
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2014-03-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   potion:
-    doses: 3
-    type: protection
-    effect: dragonfire
-    duration: 720
-  herblore:
-    level: 84
-    xp: 27.5
+    effects:
+      - description: "Slight dragonfire protection on its own; combined with an anti-dragon shield or dragonfire shield grants full immunity to dragonfire."
+        duration: 720
   recipes:
     - skill: herblore
       level: 84
-      xp: 27.5
+      xp: 110
       materials:
         - item_name: Antifire potion(4)
-          item_id: 2454
           quantity: 1
         - item_name: Lava scale shard
-          item_id: 11992
           quantity: 4
-      product: Extended antifire(4)
-      product_id: 11951
-      product_quantity: 1
-      facility: None
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 2452
-      item_name: Antifire potion(3)
-      slug: antifire-potion-3
+    - item_name: Antifire potion(4)
+      slug: antifire-potion-4
       relationship: component
-      description: Base potion
-    - item_id: 11992
-      item_name: Lava scale shard
+      description: Base potion before extension
+    - item_name: Lava scale shard
       slug: lava-scale-shard
       relationship: component
-      description: Upgrade material
-    - item_id: 21978
-      item_name: Super antifire(3)
-      slug: super-antifire-3
+      description: Upgrade material from lava dragons
+    - item_name: Super antifire(4)
+      slug: super-antifire-4
       relationship: alternative
-      description: Full protection version
-    - item_id: 11283
-      item_name: Dragonfire shield
-      slug: dragonfire-shield
-      relationship: alternative
-      description: Alternative protection
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 84 |
-    | XP | 27.5 per shard |
-    | Ingredients | Antifire potion + Lava scale shard |
-
-    | Effect | Value |
-    |--------|-------|
-    | Dragonfire protection | Partial (slight) |
-    | With anti-dragon shield | Full immunity |
-    | Duration | 12 minutes per dose |
+      description: Full standalone dragonfire immunity variant
+    - item_name: Extended super antifire(4)
+      slug: extended-super-antifire-4
+      relationship: upgrade
+      description: Combined extended and super effect
+  about: "Extended antifire(4) doubles the duration of a regular antifire potion to 12 minutes per dose, granting partial dragonfire protection alone and full immunity when paired with an anti-dragon or dragonfire shield. Created at 84 Herblore by adding 4 lava scale shards to an Antifire potion(4) for 110 Herblore experience. High alchemy value: 264 coins. Grand Exchange buy limit: 2,000 per 4 hours."
   market_strategy:
     notes:
-      - Double duration of regular
-      - Popular for dragon tasks
-      - Lava scale shards from Wilderness
-      - Long dragon tasks
-      - Vorkath farming
-      - Efficient dragon killing
-      - Less potion switching
-      - Low buy limit (2,000)
-      - Lava scale shards from lava dragons
-      - 12 min vs 6 min duration
-      - Worth the upgrade cost
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Lava scale shards from Wilderness lava dragons gate supply"
+      - "Popular for long Vorkath and dragon Slayer tasks"
+      - "12 min per dose vs 6 min on regular antifire halves potion swaps"
+  trading_tips:
+    - Buy lava scale shards on dips and convert for steady Herblore profit
+    - Track Vorkath and dragon Slayer task popularity for demand spikes
+  history:
+    - date: "2014-03-27"
+      description: "Extended antifire potions released with Herblore expansion."
+    - date: "2018-01-25"
+      description: "Renamed from 'Extended antifire (n)' to 'Extended antifire(n)'."
+    - date: "2025-01-08"
+      description: "Players can now start the Make-X creation process without cancelling movement."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extreme energy potion(2) | OSRS Price Data
-description: "Extreme energy potion(2): 2 doses of extreme energy potion.. High alch: 54 GP."
+description: "Extreme energy potion(2) restores 40% run energy per dose. High alch: 54 GP."
 osrs:
   id: 31620
   name: Extreme energy potion(2)
@@ -12,9 +12,77 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: null
-  about: "Extreme energy potion(2) is a members-only item in Old School RuneScape. High alchemy value: 54 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.06
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 40% of the player's run energy per dose."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 66
+      xp: 42
+      materials:
+        - item_name: Super energy(2)
+          quantity: 1
+        - item_name: Yellow fin
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Extreme energy potion(1)
+      slug: extreme-energy-potion-1
+      relationship: variant
+      description: One-dose version
+    - item_name: Extreme energy potion(3)
+      slug: extreme-energy-potion-3
+      relationship: variant
+      description: Three-dose version
+    - item_name: Extreme energy potion(4)
+      slug: extreme-energy-potion-4
+      relationship: variant
+      description: Four-dose version
+    - item_name: Super energy(4)
+      slug: super-energy-4
+      relationship: component
+      description: Ingredient before adding yellow fin
+    - item_name: Yellow fin
+      slug: yellow-fin
+      relationship: component
+      description: Sailing ingredient
+  about: |-
+    > _"2 doses of extreme energy potion."_
+
+    Released with the Sailing update, the extreme energy potion restores 40% of run energy per dose. Brewed from super energy and a yellow fin, it is the strongest pure energy restore in OSRS.
+  market_strategy:
+    notes:
+      - "Demand is bounded by Sailing activity and run-heavy PvM cycles."
+      - "Two-dose variant trades thinner than 4-dose; decant for the better margin."
+  trading_tips:
+    - Watch yellow fin supply on the GE — bait pricing follows fishing trends.
+    - Combine and decant doses where the spread is favourable.
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the Sailing skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fangs-of-venenatis.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fangs-of-venenatis.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Fangs of venenatis is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2023-01-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Venenatis
+        quantity: "1"
+        rarity: 1/196
+      - source: Spindel
+        quantity: "1"
+        rarity: 1/618
+  recipes:
+    - skill: fletching
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Craw's bow
+          quantity: 1
+        - item_name: Fangs of venenatis
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Webweaver bow
+      slug: webweaver-bow
+      relationship: product
+      description: Upgrade result when combining Craw's bow with the fangs.
+    - item_name: Craw's bow
+      slug: craws-bow
+      relationship: component
+      description: Base bow upgraded with the fangs.
+    - item_name: Voidwaker hilt
+      slug: voidwaker-hilt
+      relationship: alternative
+      description: Sibling Wilderness boss upgrade component from Venenatis.
+    - item_name: Treasonous ring
+      slug: treasonous-ring
+      relationship: alternative
+      description: Another unique drop from Venenatis and Spindel.
+  about: "Fangs of venenatis are a rare drop from Venenatis (1/196) and Spindel (1/618) used to upgrade Craw's bow into the Webweaver bow. The upgrade requires either 85 Fletching or a 500,000 coin payment to Derse Venator at Ferox Enclave."
+  market_strategy:
+    notes:
+      - "Price tracks Webweaver bow demand and Wilderness boss meta shifts."
+      - "Drop scarcity gives strong long-term floor; PvP supply pressure swings short-term price."
+  trading_tips:
+    - Compare fangs price against Webweaver / Craw's bow spread to find arbitrage.
+    - Watch DMM and Wilderness flash events for supply shocks.
+  history:
+    - date: "2023-01-25"
+      description: "Released with the Wilderness Boss Rework as a Venenatis and Spindel unique drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fat-snail.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fat-snail.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 13000
-  about: "Fat snail is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: organic
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Bruise Blamish Snail (Round)
+        quantity: "1"
+        rarity: Always
+      - source: Bruise Blamish Snail (Pointed)
+        quantity: "1"
+        rarity: Always
+      - source: Blood Blamish Snail (Round)
+        quantity: "1"
+        rarity: Always
+      - source: Blood Blamish Snail (Pointed)
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - skill: cooking
+      level: 22
+      xp: 95
+      materials:
+        - item_name: Fat snail
+          quantity: 1
+      tools:
+        - Fire or Range
+      output_quantity: 1
+  related_items:
+    - item_name: Fat snail meat
+      slug: fat-snail-meat
+      relationship: product
+      description: Cooked food (heals 7-9 HP)
+    - item_name: Blamish snail slime
+      slug: blamish-snail-slime
+      relationship: product
+      description: Pestle and mortar output used in Heroes' Quest
+    - item_name: Thin snail
+      slug: thin-snail
+      relationship: alternative
+      description: Lower tier snail corpse
+  about: "Fat snail is the corpse dropped by Blamish snail variants (bruise blue, blood) in Mort Myre Swamp. Cook at 22 Cooking to produce fat snail meat (95 XP) or grind with pestle and mortar plus a sample bottle for blamish snail slime used in Heroes' Quest. Also required for Fairytale I — Growing Pains."
+  market_strategy:
+    notes:
+      - "Supply driven by Mort Myre slayer routes and quest seekers"
+      - "Buy limit (13k) supports bulk Cooking training"
+      - "Demand mostly from low-level Cooking XP grinders"
+  trading_tips:
+    - Margin is thin; play volume, not spread
+    - Quest weeks (Fairytale or Heroes' Quest reruns) lift demand
+  history:
+    - date: "2004-10-14"
+      description: "Released with the Morytania Expansion."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-offcuts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-offcuts.mdx
@@ -12,12 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 8000
-  about: "Fish offcuts is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 8,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bait
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Knife
+      slug: knife
+      relationship: component
+      description: Used on raw fish to produce offcuts
+    - item_name: Raw leaping trout
+      slug: raw-leaping-trout
+      relationship: component
+      description: Barbarian Fishing source for offcuts
+    - item_name: Feather
+      slug: feather
+      relationship: alternative
+      description: Alternative bait at certain fishing spots
+  about: "Fish offcuts are a stackable bait obtained by using a knife on most raw fish, including barbarian leaping fish and aerial fishing catches. They serve as bait for barbarian fishing, aerial cormorant feeding, deep sea trawling, and crab trapping, and are also fed to cats and used to fill some Hunter Rumours."
+  market_strategy:
+    notes:
+      - "Large 8,000 buy limit suits high-volume aerial fishers stocking up"
+      - "Price is anchored close to the value of a single coin"
+      - "Supply scales with Barbarian and Aerial Fishing popularity"
+  trading_tips:
+    - Buy in bulk before long aerial fishing sessions
+    - Resell stacks left over from finished Hunter Rumours
+  history:
+    - date: "2007-07-03"
+      description: "Released with Barbarian Fishing as a knife-cut byproduct of raw fish."
+    - date: "2015-09-10"
+      description: "Granted priority bait status during Barbarian Fishing."
+    - date: "2022-10-26"
+      description: "Cutting leaping fish became automatic on knife use, although manual cuts remained slightly faster."
+    - date: "2025-04-16"
+      description: "Item appearance updated; obtainable from most raw fish and aerial fishing chunks were converted to offcuts."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gnome-scarf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gnome-scarf.mdx
@@ -12,12 +12,86 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Gnome scarf is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid-high
+  properties:
+    release_date: "2006-08-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
+      ranged_strength: 0
+      magic_damage: 0
+  passive_effects:
+    - name: Warm clothing
+      description: Counts as warm clothing at Wintertodt, reducing damage from the cold; the only tradeable neck slot item with this property.
+  drop_table:
+    sources:
+      - source: Captain Daerkin (Gnome Restaurant reward)
+        quantity: "1"
+        rarity: 1/17
+      - source: Captain Ninto (Gnome Restaurant reward)
+        quantity: "1"
+        rarity: 1/17
+  related_items:
+    - item_name: Gnome goggles
+      slug: gnome-goggles
+      relationship: set-piece
+      description: Other Gnome Restaurant reward
+    - item_name: Mint cake
+      slug: mint-cake
+      relationship: alternative
+      description: Common Gnome Restaurant reward
+  about: "Gnome scarf is a neck slot fashion item earned from the Gnome Restaurant minigame at roughly a 1 in 17 chance per delivery. It has no combat bonuses but counts as warm clothing at Wintertodt, the only tradeable neck slot item that does so, which keeps it in steady demand."
+  market_strategy:
+    notes:
+      - "Buy limit of 4 keeps the price highly volatile"
+      - "Wintertodt demand sustains a long-term premium"
+      - "Supply is gated by Gnome Restaurant completion rates"
+  trading_tips:
+    - Flip in small lots due to the 4 per 4 hour limit
+    - Long-term holds tend to drift up with Wintertodt popularity
+  history:
+    - date: "2006-08-07"
+      description: "Added as a reward from the Gnome Restaurant activity."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gnomebowl-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gnomebowl-mould.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 40
-  about: "Gnomebowl mould is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.15
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      price: 10
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Gianne dough
+      slug: gianne-dough
+      relationship: component
+      description: Dough shaped by this mould
+    - item_name: Raw gnomebowl
+      slug: raw-gnomebowl
+      relationship: product
+      description: Output of using the mould on gianne dough
+  about: "Gnomebowl mould is a members-only cooking tool used to shape gianne dough into raw gnomebowls, the foundation for gnome bowl recipes. Buy from Hudo at Grand Tree Groceries for 10 coins or grab one free from the Grand Tree kitchen cabinet. High alchemy value: 6 coins. Grand Exchange buy limit: 40 per 4 hours."
+  trading_tips:
+    - Free spawn in Grand Tree kitchen makes GE arbitrage low-yield
+    - Useful as a buffer stock for gnome cooking sessions
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch."
+    - date: "2006-08-07"
+      description: "Item value increased from 1 to 10 coins during the Gnome Cuisine update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-boots.mdx
@@ -12,84 +12,101 @@ osrs:
   lowalch: 5000
   highalch: 7500
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: granite
+    tier: high
+  properties:
+    release_date: "2017-09-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
-    type: melee_boots
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
     requirements:
       defence: 50
       strength: 50
-    stats:
-      attack_magic: -6
-      attack_ranged: -3
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 15
+      slash: 16
+      crush: 17
+      magic: 0
+      ranged: 5
+    other_bonus:
       strength: 2
-      defence_stab: 15
-      defence_slash: 16
-      defence_crush: 17
-      defence_ranged: 5
+      prayer: 0
+      ranged_strength: 0
+      magic_damage: 0
   drop_table:
-    primary_source: Spiritual ranger
-    best_drop_rate: 1/128
     sources:
       - source: Spiritual ranger
-        source_id: 2242
-        combat_level: 115
         quantity: "1"
         rarity: 1/128
-        members_only: true
       - source: Spiritual ranger (Zaros)
-        source_id: 6219
-        combat_level: 118
         quantity: "1"
         rarity: 1/128
-        members_only: true
+      - source: Long-tailed Wyvern
+        quantity: "1"
+        rarity: 1/2560
+      - source: Spitting Wyvern
+        quantity: "1"
+        rarity: 1/2560
+      - source: Taloned Wyvern
+        quantity: "1"
+        rarity: 1/600
+      - source: Ancient Wyvern
+        quantity: "1"
+        rarity: 1/600
   related_items:
-    - item_id: 11840
-      item_name: Dragon boots
+    - item_name: Dragon boots
       slug: dragon-boots
       relationship: alternative
-      description: Better strength bonus for melee
-    - item_id: 4131
-      item_name: Rune boots
+      description: Lighter melee boots with higher strength bonus
+    - item_name: Rune boots
       slug: rune-boots
       relationship: downgrade
-      description: Lower tier alternative with no requirements
-    - item_id: 21733
-      item_name: Guardian boots
+      description: Free-to-play tier melee boots with no stat requirement
+    - item_name: Guardian boots
       slug: guardian-boots
       relationship: upgrade
-      description: Best defensive boots
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Magic | -6 |
-    | Ranged | -3 |
-    | Strength | +2 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +15 |
-    | Slash | +16 |
-    | Crush | +17 |
-    | Ranged | +5 |
-
-    Requirements: 50 Defence, 50 Strength
-
-    Heavy defensive boots used for:
-    - Tank setups
-    - High-defence builds
-    - Alternative to Dragon boots
-
-    Heavier but more defensive than Dragon boots.
+      description: Best in slot defensive melee boots
+  about: "Granite boots are heavy feet slot armour requiring 50 Defence and 50 Strength. They give the strongest defensive bonuses of any granite gear and add a small strength bonus, making them a niche tank option. Dropped exclusively by the Wyvern Cave fossil island wyverns."
   market_strategy:
     notes:
-      - Less popular than Dragon boots
-      - Used by tank builds
-      - Good for activities requiring high defence
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Less popular than Dragon boots due to weight and strength gap"
+      - "Demand spikes during Wyvern Cave drop hunts and tank-build metas"
+      - "Buy limit of 70 keeps price elastic to small supply shifts"
+  trading_tips:
+    - Track Fossil Island slayer task popularity for entry-price dips
+    - Decant alongside Guardian boots flips when defensive metas trend
+  history:
+    - date: "2017-09-07"
+      description: "Added to the drop tables of Wyvern Cave wyverns in the Fossil Island update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-chaps-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-chaps-g.mdx
@@ -12,40 +12,70 @@ osrs:
   lowalch: 1560
   highalch: 2340
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: low
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
     requirements:
       ranged: 40
-    stats:
-      attack_ranged: 8
-      attack_magic: -10
-      defence_stab: 12
-      defence_slash: 15
-      defence_crush: 18
-      defence_magic: 8
-      defence_ranged: 17
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 8
+    defence_bonus:
+      stab: 12
+      slash: 15
+      crush: 18
+      magic: 8
+      ranged: 17
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Medium
-        rarity: Rare
-        description: Rare reward from medium clue scrolls
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 2487
-      item_name: Green d'hide chaps
+    - item_name: Green d'hide chaps
       slug: green-dhide-chaps
       relationship: variant
-      description: Standard version with identical stats
-    - item_id: 7380
-      item_name: Green d'hide chaps (t)
+      description: Standard untrimmed version with identical stats
+    - item_name: Green d'hide chaps (t)
       slug: green-dhide-chaps-t
       relationship: variant
-      description: Trimmed variant with team-coloured trim
+      description: Team-trimmed cosmetic variant
   about: |-
     Made from 100% real dragonhide. With colourful trim!
 
@@ -53,16 +83,19 @@ osrs:
 
     These chaps require 40 Ranged to equip, making them accessible to lower-level rangers. The gold trimming is the only visual difference from the base version.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Purely cosmetic upgrade over standard green d'hide chaps
-      - Price is driven by fashion demand rather than combat utility
-      - Medium clue scroll rewards tend to have moderate supply
-      - Compare price to standard green d'hide chaps to gauge the cosmetic premium
-      - Green d'hide trimmed items are among the most affordable treasure trail rewards
-      - Gold-trimmed variants are generally more popular than team-trimmed versions
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Purely cosmetic upgrade over standard green d'hide chaps"
+      - "Price is driven by fashion demand rather than combat utility"
+      - "Medium clue scroll rewards tend to have moderate supply"
+      - "Compare price to standard green d'hide chaps to gauge the cosmetic premium"
+      - "Green d'hide trimmed items are among the most affordable treasure trail rewards"
+      - "Gold-trimmed variants are generally more popular than team-trimmed versions"
+  trading_tips:
+    - Buy when medium clue completions spike supply
+    - Sell to fashion collectors during cosmetic events
+  history:
+    - date: "2006-02-20"
+      description: "Released as a medium Treasure Trails reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-dye.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-dye.mdx
@@ -12,12 +12,87 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
-  about: "Green dye is a free-to-play item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dye
+    tier: low
+  properties:
+    release_date: "8 December 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Lletya Seamstress
+      location: Lletya
+      price: 6
+      currency: Coins
+      stock: 10
+    - shop_name: Guinevere's Dyes
+      location: Prifddinas
+      price: 6
+      currency: Coins
+      stock: 10
+    - shop_name: Dyes to Die For
+      location: Tal Teklan
+      price: 6
+      currency: Coins
+      stock: 10
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Blue dye
+          quantity: 1
+        - item_name: Yellow dye
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Blue dye
+      slug: blue-dye
+      relationship: component
+      description: Mixed to create green dye
+    - item_name: Yellow dye
+      slug: yellow-dye
+      relationship: component
+      description: Mixed to create green dye
+    - item_name: Red dye
+      slug: red-dye
+      relationship: alternative
+      description: Alternative primary dye
+    - item_name: Orange dye
+      slug: orange-dye
+      relationship: alternative
+      description: Alternative mixed dye
+  about: "Green dye is a free-to-play crafting reagent created by combining blue dye and yellow dye, or purchased from various dye shops for 6 coins. It is primarily used to colour capes green (granting 2.5 Crafting XP per cape), dye goblin mail, and to apply colour to other miscellaneous items such as orange slices and ogre bellows. Cheap, plentiful, and stable in price."
+  market_strategy:
+    notes:
+      - "F2P accessible, large supply"
+      - "Stable low-price commodity"
+      - "Demand from cape dyers and goblin diplomats"
+      - "Shop floor at 6 coins limits downside"
+  trading_tips:
+    - Bulk craft from blue + yellow dye when prices dip
+    - Useful for fashionscape resellers
+    - Low margins, volume play only
+  history:
+    - date: "8 December 2001"
+      description: "Item was added to the game."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ground-guam.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ground-guam.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 100
-  about: "Ground guam is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: herb
+    tier: low
+  properties:
+    release_date: "2005-10-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Guam leaf
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+    - skill: herblore
+      level: 19
+      xp: 30
+      materials:
+        - item_name: Ground guam
+          quantity: 15
+        - item_name: Swamp tar
+          quantity: 15
+      tools:
+        - Pestle and mortar
+      output_quantity: 15
+  related_items:
+    - item_name: Guam leaf
+      slug: guam-leaf
+      relationship: component
+      description: Base herb ground into this powder
+    - item_name: Guam tar
+      slug: guam-tar
+      relationship: product
+      description: Made by combining ground guam with swamp tar
+    - item_name: Fish food
+      slug: fish-food
+      relationship: product
+      description: Used in the Tai Bwo Wannai Trio quest recipe
+  about: "Ground guam is produced by grinding a guam leaf with a pestle and mortar. Unlike whole guam leaves, ground guam cannot be used to mix potions. Its main uses are crafting fish food for the Tai Bwo Wannai Trio quest and producing guam tar (Herblore 19) for use with the Sleight of Hand minigame."
+  market_strategy:
+    notes:
+      - "Niche demand from Tai Bwo Wannai Trio completion"
+      - "Guam tar production for thieving training"
+      - "Very low buy limit (100) caps speculation"
+      - "Cheap to produce — guam leaf + pestle and mortar"
+      - "Cannot make potions, limiting demand vs whole herbs"
+  trading_tips:
+    - Grind your own guam leaves for guaranteed supply
+    - Watch demand during league events that reset quests
+    - Low alch value — never alch
+  history:
+    - date: "2005-10-24"
+      description: "Item added to the game alongside the Tai Bwo Wannai Trio quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-armour-set-sk.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Guthix armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Guthix full helm
+      slug: guthix-full-helm
+      relationship: set-piece
+      description: Head component of the Guthix armour set (sk).
+    - item_name: Guthix platebody
+      slug: guthix-platebody
+      relationship: set-piece
+      description: Body component of the Guthix armour set (sk).
+    - item_name: Guthix plateskirt
+      slug: guthix-plateskirt
+      relationship: set-piece
+      description: Legs component of the Guthix armour set (sk).
+    - item_name: Guthix kiteshield
+      slug: guthix-kiteshield
+      relationship: set-piece
+      description: Shield component of the Guthix armour set (sk).
+    - item_name: Guthix armour set (lg)
+      slug: guthix-armour-set-lg
+      relationship: alternative
+      description: Plate-legs variant of the same God armour set.
+  about: "Guthix armour set (sk) bundles the Guthix full helm, platebody, plateskirt and kiteshield into a single tradeable container via the Grand Exchange Sets interface. It is used primarily to compress bank space for Guthix-themed cosmetic kits."
+  market_strategy:
+    notes:
+      - "Set typically trades at a premium over the sum of components; flip components into sets when premium is positive."
+      - "Free-to-play accessibility broadens demand pool versus member-only sets."
+  trading_tips:
+    - Exchange the set for individual pieces if the component value exceeds the set price.
+    - Use the Grand Exchange clerk 'Sets' option to convert in either direction.
+  history:
+    - date: "2015-02-26"
+      description: "Released alongside the introduction of Grand Exchange armour sets for free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-3.mdx
@@ -12,46 +12,91 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
-    type: god_page
-    god: Guthix
-    page_number: 3
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: god-page
+    tier: mid
+  properties:
+    release_date: "2004-11-17"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 11/9504
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 10/8184
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/650
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/775
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/702
   related_items:
-    - item_id: 3835
-      item_name: Guthix page 1
+    - item_name: Guthix page 1
       slug: guthix-page-1
       relationship: set-piece
-      description: Page 1 of 4
-    - item_id: 3836
-      item_name: Guthix page 2
+      description: Page 1 of 4 for the Book of balance.
+    - item_name: Guthix page 2
       slug: guthix-page-2
       relationship: set-piece
-      description: Page 2 of 4
-    - item_id: 3838
-      item_name: Guthix page 4
+      description: Page 2 of 4 for the Book of balance.
+    - item_name: Guthix page 4
       slug: guthix-page-4
       relationship: set-piece
-      description: Page 4 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Guthix |
-    | Page | 3 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of balance (Guthix god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Page 4 of 4 for the Book of balance.
+    - item_name: Book of balance
+      slug: book-of-balance
+      relationship: product
+      description: Completed Guthix god book once all four pages are inserted.
+    - item_name: Damaged book (Guthix)
+      slug: damaged-book-guthix
+      relationship: component
+      description: Base damaged book obtained from Horror from the Deep that accepts the pages.
+  about: "Guthix page 3 is one of four torn pages used to assemble the Book of balance, the Guthix god book equipped in the shield slot. Pages are obtained from Treasure Trails reward caskets across all clue tiers except Beginner."
+  market_strategy:
+    notes:
+      - "Tight buy limit (5) keeps prices firm despite multi-tier supply."
+      - "Demand driven by god book completionists and clue scroll farmers."
+  trading_tips:
+    - Collect all four Guthix pages to assemble a Book of balance for resale.
+    - Page set decant available via Grand Exchange Clerk.
+  history:
+    - date: "2004-11-17"
+      description: "Item released with the Horror from the Deep update."
+    - date: "2004-11-29"
+      description: "Originally listed as \"Torn page 3\" before later renaming."
+    - date: "2006-07-11"
+      description: "Renamed from \"Torn page 3(g)\" to \"Guthix page 3\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-4.mdx
@@ -12,43 +12,68 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
-    type: god_page
-    god: Guthix
-    page_number: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2004-11-17"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/775
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/541
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/612
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/408
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/541
   related_items:
-    - item_id: 3835
-      item_name: Guthix page 1
+    - item_name: Guthix page 1
       slug: guthix-page-1
       relationship: set-piece
       description: Page 1 of 4
-    - item_id: 3836
-      item_name: Guthix page 2
+    - item_name: Guthix page 2
       slug: guthix-page-2
       relationship: set-piece
       description: Page 2 of 4
-    - item_id: 3837
-      item_name: Guthix page 3
+    - item_name: Guthix page 3
       slug: guthix-page-3
       relationship: set-piece
       description: Page 3 of 4
+    - item_name: Book of balance
+      slug: book-of-balance
+      relationship: product
+      description: Completed god book using all four pages
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Guthix |
-    | Page | 4 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of balance (Guthix god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Guthix page 4 is one of four pages used to complete the Book of balance (Guthix god book). Pages are rewarded from all Treasure Trails tiers except beginner. Add all four pages to a damaged Guthix god book obtained from Horror from the Deep or purchased from Jossik for 5,000 coins.
+  market_strategy:
+    notes:
+      - "Drops only from medium/hard/elite/master clue caskets"
+      - "Demand driven by god book completion"
+      - "Low buy limit of 5 per 4 hours"
+      - "Slow flipping margin, low volume"
+  history:
+    - date: "2004-11-17"
+      description: "Released alongside the Horror from the Deep quest as Torn page 4."
+    - date: "2006-07-04"
+      description: "Renamed to Guthix page 4."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-rest-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-rest-2.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 2000
-  about: "Guthix rest(2) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2005-02-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 5 Hitpoints (can exceed max HP by 5)"
+        duration: 0
+      - description: "Restores 5 percent run energy"
+        duration: 0
+      - description: "Reduces venom to poison or decreases poison damage by 1"
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 18
+      xp: 59
+      materials:
+        - item_name: Cup of hot water
+          quantity: 1
+        - item_name: Guam leaf
+          quantity: 2
+        - item_name: Harralander
+          quantity: 1
+        - item_name: Marrentill
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Guthix rest(1)
+      slug: guthix-rest-1
+      relationship: variant
+      description: One-dose variant
+    - item_name: Guthix rest(3)
+      slug: guthix-rest-3
+      relationship: upgrade
+      description: Three-dose variant
+    - item_name: Guthix rest(4)
+      slug: guthix-rest-4
+      relationship: upgrade
+      description: Four-dose variant
+  about: |-
+    Guthix rest is a tea brewed via the Herblore skill that restores hit points, run energy, and reduces venom or poison damage. The two-dose version is a mid-tier carry of the four sizes. It was introduced via One Small Favour and remains a popular cheap utility tea.
+  market_strategy:
+    notes:
+      - "Cheap utility potion with steady demand from low-level players"
+      - "Bulk Herblore xp grinders supply the GE"
+      - "Price tracks guam, harralander, and marrentill herb costs"
+  trading_tips:
+    - Buy raw herbs and craft when GE markup is below brew cost
+    - Sell into clue scroll spikes that demand poison cures
+  history:
+    - date: "2005-02-28"
+      description: "Released with the One Small Favour quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hood-of-darkness.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hood-of-darkness.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hood of darkness | OSRS Price Data
-description: "Hood of darkness: A dark power is woven into this hood.. High alch: 6,000 GP, GE limit: 70."
+description: "Hood of darkness: A dark power is woven into this hood. High alch: 6,000 GP, GE limit: 70."
 osrs:
   id: 20128
   name: Hood of darkness
@@ -12,9 +12,96 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 70
-  about: "Hood of darkness is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid-high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/851
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Robe top of darkness
+      slug: robe-top-of-darkness
+      relationship: set-piece
+      description: Body slot piece of the robes of darkness set.
+    - item_name: Robe bottom of darkness
+      slug: robe-bottom-of-darkness
+      relationship: set-piece
+      description: Leg slot piece of the robes of darkness set.
+    - item_name: Gloves of darkness
+      slug: gloves-of-darkness
+      relationship: set-piece
+      description: Hand slot piece of the robes of darkness set.
+    - item_name: Boots of darkness
+      slug: boots-of-darkness
+      relationship: set-piece
+      description: Foot slot piece of the robes of darkness set.
+  about: |-
+    Hood of darkness is a Zaros-aligned head slot piece rewarded only from master clue scroll caskets at a 1/851 drop rate. It demands 40 Magic and 20 Defence to wear, and grants +4 Magic attack and +4 Magic defence.
+
+    Inside the Ancient Prison area of the God Wars Dungeon, wearing the hood (and the rest of the robes of darkness) provides safe passage past Zarosian followers, similar to how other faction items work elsewhere in GWD.
+
+    Requirements: 40 Magic, 20 Defence | Slot: Head | Weight: 0.453 kg
+  market_strategy:
+    notes:
+      - "Hard-locked supply: master clue completions only."
+      - "Buy limit of 70 caps quick flips, but spreads stay wide."
+      - "Demand tied to Ancient Prison content and cosmetic collectors."
+  trading_tips:
+    - Track master clue popularity (boss drops, leagues) for supply spikes.
+    - List near the 4h limit during prime EU/US activity for fastest fills.
+  history:
+    - date: "2016-07-06"
+      description: "Released as a reward from master Treasure Trails."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/horn-of-plenty-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/horn-of-plenty-empty.mdx
@@ -1,6 +1,6 @@
 ---
 title: Horn of plenty (empty) | OSRS Price Data
-description: "Horn of plenty (empty): Sound the horn for a better hunt.. High alch: 12,000 GP."
+description: "Horn of plenty (empty): Sound the horn for a better hunt. High alch: 12,000 GP."
 osrs:
   id: 31243
   name: Horn of plenty (empty)
@@ -12,9 +12,94 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: null
-  about: "Horn of plenty (empty) is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: horn
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.0
+    options:
+      - Wield
+      - Charge
+      - Drop
+    worn_options:
+      - Blow
+      - Toggle
+      - Check
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 1.0
+    requirements:
+      hunter: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Gryphon"
+        quantity: "1"
+        rarity: "1/2,500"
+      - source: "Gryphon (on Slayer task)"
+        quantity: "1"
+        rarity: "1/1,000"
+      - source: "Dire gryphon"
+        quantity: "1"
+        rarity: "1/1,000"
+  passive_effects:
+    - name: "Hunter boost (empty)"
+      description: "Provides an invisible +2 Hunter boost when worn empty."
+    - name: "Hunter boost (charged)"
+      description: "Boost rises to +4 when charged with gryphon feathers."
+    - name: "Double catch"
+      description: "Charged horn grants a 1/10 chance to double Hunter catches without extra XP. Does not apply to implings, molch pearls during aerial fishing, or falconry catches."
+  related_items:
+    - item_name: Gryphon feathers
+      slug: gryphon-feathers
+      relationship: component
+      description: "Charge material for the horn (up to 20,000)."
+    - item_name: Huntsman's kit
+      slug: huntsmans-kit
+      relationship: alternative
+      description: "Stores the horn alongside other hunter gear."
+  about: "The empty horn of plenty is a Sailing-era Hunter shield rewarded from gryphons. Worn empty it gives a quiet +2 Hunter boost; charged with up to 20,000 gryphon feathers it bumps to +4 and rolls a 1/10 double-catch on most Hunter activities."
+  market_strategy:
+    notes:
+      - "No GE buy limit, but listings are scarce until gryphon hunting becomes mainstream."
+      - "Charged versions are not tradeable, so buyers pay a premium for empty stock."
+  trading_tips:
+    - "Watch hunter meta updates - any buff to gryphon catch rates compresses sell prices."
+    - "Pair with a large pile of gryphon feathers if reselling to active hunters."
+  history:
+    - date: "2025-06"
+      description: "First appeared in the Sailing Beta cache without being obtainable."
+    - date: "2025-11-19"
+      description: "Released live alongside the Sailing skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hosidius-banner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hosidius-banner.mdx
@@ -12,12 +12,90 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 4
-  about: "Hosidius banner is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: banner
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+  equipment:
+    slot: weapon
+    weapon_type: polestaff
+    attack_speed: 5
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  related_items:
+    - item_name: Arceuus banner
+      slug: arceuus-banner
+      relationship: variant
+      description: House Arceuus variant from the same banner set.
+    - item_name: Lovakengj banner
+      slug: lovakengj-banner
+      relationship: variant
+      description: House Lovakengj variant from the same banner set.
+    - item_name: Piscarilius banner
+      slug: piscarilius-banner
+      relationship: variant
+      description: House Piscarilius variant from the same banner set.
+    - item_name: Shayzien banner
+      slug: shayzien-banner
+      relationship: variant
+      description: House Shayzien variant from the same banner set.
+  about: "Hosidius banner is a one-handed polestaff representing House Hosidius of Great Kourend. Earned from medium Treasure Trails, it offers full +12 melee attack and strength bonuses on par with other Kourend banners."
+  market_strategy:
+    notes:
+      - "One of five Kourend banners with identical combat stats but visual differences."
+      - "Tight buy limit (4) keeps prices stable."
+  trading_tips:
+    - Collect all five Kourend banners for cosmetic completeness.
+    - Buy when medium clue rewards are saturated and prices dip.
+  history:
+    - date: "2016-07-06"
+      description: "Item released with the Treasure Trail Expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunter-potion-1.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 2000
-  about: "Hunter potion(1) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily boosts the Hunter level by 3."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 53
+      xp: 30
+      materials:
+        - item_name: Hunter potion(2)
+          quantity: 1
+      tools: []
+      output_quantity: 2
+  related_items:
+    - item_name: Hunter potion(4)
+      slug: hunter-potion-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Hunter potion(3)
+      slug: hunter-potion-3
+      relationship: variant
+      description: 3-dose version
+    - item_name: Hunter potion(2)
+      slug: hunter-potion-2
+      relationship: variant
+      description: 2-dose version
+    - item_name: Clean avantoe
+      slug: clean-avantoe
+      relationship: component
+      description: Herb ingredient for the base potion
+    - item_name: Kebbit teeth dust
+      slug: kebbit-teeth-dust
+      relationship: component
+      description: Secondary ingredient for the base potion
+  about: "Hunter potion(1) is the 1-dose form of the Hunter potion, boosting Hunter level by 3 when consumed. Created from higher-dose variants via decanting; the base recipe at 53 Herblore combines a clean avantoe with kebbit teeth dust for a 4-dose potion. High alchemy value: 3 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "1-dose form is the unwanted side product of decanting higher doses"
+      - "Useful for new Hunters chasing specific level thresholds"
+      - "Buy limit of 2,000 supports bulk decant flipping"
+  trading_tips:
+    - Profit from decanting (4) into (1) only when 4x(1) price exceeds (4) price
+    - Stockpile cheap singles when stat boost +3 matters at low Hunter levels
+  history:
+    - date: "2006-11-21"
+      description: "Hunter potions released alongside the Hunter skill expansion."
+    - date: "2016-04-15"
+      description: "Half-full potions can now be turned into bank placeholders."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunters-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunters-crossbow.mdx
@@ -12,92 +12,89 @@ osrs:
   lowalch: 520
   highalch: 780
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bone
+    tier: mid
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: crossbow
-    attack_style: ranged
-    attack_speed: 4
+    weapon_type: crossbow
+    attack_speed: 5
+    weight: 5
     requirements:
       ranged: 50
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 55
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      melee_strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 55
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 5
-  obtaining:
-    methods:
-      - source: Leon's Prototype Crossbow shop
-        location: Yanille
-        cost: 1300
-      - source: Grand Exchange
-        notes: Tradeable
+  shops:
+    - shop_name: Leon's Prototype Crossbow shop
+      location: Yanille
+      price: 1300
+      currency: coins
+      stock: 2
   related_items:
-    - item_id: 10158
-      item_name: Kebbit bolts
+    - item_name: Kebbit bolts
       slug: kebbit-bolts
       relationship: component
-      description: Standard ammo for this crossbow
-    - item_id: 10159
-      item_name: Long kebbit bolts
+      description: Standard ammunition for this crossbow
+    - item_name: Long kebbit bolts
       slug: long-kebbit-bolts
       relationship: component
-      description: Long-range ammo variant
-    - item_id: 9174
-      item_name: Adamant crossbow
+      description: Long-range ammunition variant
+    - item_name: Hunters' sunlight crossbow
+      slug: hunters-sunlight-crossbow
+      relationship: upgrade
+      description: Fletching 74 upgrade using a sunlight antelope antler
+    - item_name: Adamant crossbow
       slug: adamant-crossbow
       relationship: alternative
-      description: Similar ranged requirement crossbow
-  about: |-
-    "A weapon made of bone and wood."
-
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | +0 |
-    | Ranged Attack | +55 |
-    | Stab Defence | +0 |
-    | Slash Defence | +0 |
-    | Crush Defence | +0 |
-    | Magic Defence | +0 |
-    | Ranged Defence | +0 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 50 Ranged
-
-    | Crossbow | Ranged Atk | Requirements | Ammo |
-    |----------|-----------|-------------|------|
-    | Hunter's crossbow | +55 | 50 Ranged | Kebbit bolts |
-    | Adamant crossbow | +46 | 46 Ranged | Bolts up to adamant |
-    | Rune crossbow | +90 | 61 Ranged | Bolts up to rune |
-
-    The hunter's crossbow has a high ranged attack bonus for its level but is limited to kebbit bolts, which have low ranged strength. This makes it a niche weapon primarily used for the Hunter skill rather than general combat.
+      description: Similar tier crossbow accepting bolts up to adamant
+  about: "The hunters' crossbow is a 50 Ranged crossbow restricted to kebbit bolts and long kebbit bolts. It boasts a +55 Ranged Attack bonus — higher than the rune crossbow's accuracy ceiling against certain targets — but the ammo's low Ranged Strength keeps it a niche Hunter utility. Sold by Leon in Yanille for 1,300 coins; upgrades into the hunters' sunlight crossbow at 74 Fletching."
   market_strategy:
     notes:
-      - Hunter skill training
-      - Niche PvM use with kebbit bolts
-      - Low overall demand
-      - Very cheap, available from NPC shop for 1,300 gp
-      - Only fires kebbit bolts and long kebbit bolts
-      - Not practical for general combat due to limited ammo
-      - Primarily a Hunter utility item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Hunter skill training primary use"
+      - "Cheap from Leon's shop floors the GE price"
+      - "Niche PvM use with kebbit bolts"
+      - "Limited ammunition pool drags general combat demand"
+      - "Used as a component in the hunters' sunlight crossbow upgrade"
+  trading_tips:
+    - NPC stock from Leon caps the GE price
+    - Demand spikes during Hunter contracts and bingos
+    - Pair with kebbit bolts for full Hunter loadout
+  history:
+    - date: "2006-11-21"
+      description: "Item added to the game alongside expanded Hunter content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-s-claw.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hydra-s-claw.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hydra's claw | OSRS Price Data
-description: "Hydra's claw is a members weapon slot item requiring 78 Attack. High alch: 90,000 GP, GE limit: 15."
+description: "Hydra's claw is a rare drop from the Alchemical Hydra used to craft the Dragon Hunter Lance. High alch: 90,000 GP, GE limit: 15."
 osrs:
   id: 22966
   name: Hydra's claw
@@ -12,106 +12,70 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 15
-  equipment:
-    slot: weapon
-    type: spear
-    attack_style: stab
-    attack_speed: 4
-    requirements:
-      attack: 78
-    stats:
-      attack_stab: 85
-      attack_slash: 65
-      attack_crush: 65
-      strength: 70
-  effect:
-    dragon_bane: true
-    accuracy_bonus: 20
-    damage_bonus: 20
-    targets:
-      - dragons
-      - wyverns
-      - Great Olm
-      - hydras
-      - draconic creatures
-    stacks_with:
-      - Void
-      - Slayer helm
-  creation:
-    base_item_id: 11889
-    base_item_name: Zamorakian hasta
-    component_id: 22966
-    component_name: Hydra's claw
-    reversible: false
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: organic
+    tier: high
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Alchemical Hydra
-        source_id: 8621
-        combat_level: 426
-        quantity: 1 (Hydra's claw)
-        rarity: Rare
-        drop_rate: 1/1000
-        members_only: true
+        quantity: "1"
+        rarity: 1/1001
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Zamorakian hasta
+          quantity: 1
+        - item_name: Hydra's claw
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 21012
-      item_name: Dragon hunter crossbow
-      slug: dragon-hunter-crossbow
-      relationship: alternative
-      description: Ranged equivalent
-    - item_id: 11889
-      item_name: Zamorakian hasta
+    - item_name: Dragon hunter lance
+      slug: dragon-hunter-lance
+      relationship: product
+      description: Result of combining Hydra's claw with Zamorakian hasta
+    - item_name: Zamorakian hasta
       slug: zamorakian-hasta
       relationship: component
-      description: Base weapon
-    - item_id: 22966
-      item_name: Hydra's claw
-      slug: hydras-claw
-      relationship: component
-      description: Required component
-  about: |-
-    Combine Zamorakian hasta + Hydra's claw.
-
-    Process is irreversible.
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Zamorakian hasta | K'ril Tsutsaroth | ~10M |
-    | Hydra's claw | Alchemical Hydra | ~48M |
-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +85 |
-    | Slash | +65 |
-    | Crush | +65 |
-    | Strength | +70 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 78 Attack, Barbarian Training
-
-    Dragon Bane:
-    - +20% accuracy vs dragons/draconic creatures
-    - +20% damage vs dragons/draconic creatures
-    - Stacks with Void and Slayer helm
-
-    Works on: Dragons, wyverns, Great Olm, hydras
-
-    BiS for dragons:
-    - Vorkath
-    - Alchemical Hydra
-    - Chambers of Xeric (Olm)
-    - All dragon Slayer tasks
-
-    Essential for dragon content.
+      description: Base weapon required to craft the Dragon hunter lance
+    - item_name: Alchemical hydra heads
+      slug: alchemical-hydra-heads
+      relationship: alternative
+      description: Other rare drop from the Alchemical Hydra
+  about: "Hydra's claw is a rare drop from the Alchemical Hydra (combat level 426, 95 Slayer to fight) used to combine with a Zamorakian hasta to create the Dragon hunter lance. The combination is irreversible. High alchemy value: 90,000 coins. Grand Exchange buy limit: 15 per 4 hours."
   market_strategy:
     notes:
-      - Hydra claw from Alchemical Hydra
-      - 95 Slayer to obtain claw
-      - Best dragon-killing weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Drop rate 1/1001 from Alchemical Hydra throttles supply tightly"
+      - "Demand follows Vorkath and Olm popularity for the Dragon hunter lance"
+      - "Buy limit of 15 makes large flips slow but high margin"
+  trading_tips:
+    - Track Alchemical Hydra kill counts and Slayer task weighting for supply
+    - Hold ahead of any dragon boss release that boosts DHL demand
+  history:
+    - date: "2019-01-10"
+      description: "Released with The Kebos Lowlands and Alchemical Hydra boss."
+    - date: "2019-01-17"
+      description: "Base shop value reduced from 1,500,000 to 150,000 coins."
+    - date: "2025-05-29"
+      description: "Removed from the Grand Exchange item sink list."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/imperial-ros.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/imperial-ros.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: null
-  about: "Imperial rosé is a members-only item in Old School RuneScape. High alchemy value: 240 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "25 September 2024"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 16 Hitpoints on drink."
+        duration: 0
+      - description: "Temporarily boosts Slayer by 1 level."
+        duration: 0
+      - description: "Drains Attack by 5 levels."
+        duration: 0
+      - description: "Drains Agility by 1 level."
+        duration: 0
+  shops:
+    - shop_name: Moonrise Wines
+      location: Aldarin, Varlamore
+      price: 400
+      currency: Coins
+      stock: 20
+  related_items:
+    - item_name: Imperial steak
+      slug: imperial-steak
+      relationship: alternative
+      description: "Other Varlamore high-end consumable"
+  about: |-
+    Imperial rosé is a herbal wine sold from Moonrise Wines in Aldarin, introduced with the Varlamore: The Rising Darkness update.
+
+    Drinking restores 16 Hitpoints and grants a +1 Slayer boost while draining Attack by 5 and Agility by 1. According to lore, the rosé features flavours of watermelon, pineapple, marrentill, and tarromin.
+  market_strategy:
+    notes:
+      - "Shop-bought; price tracks Varlamore travel convenience"
+      - "Niche +1 Slayer boost use case for clue puzzles"
+  trading_tips:
+    - Buy directly from Moonrise Wines rather than the GE for predictable pricing
+  history:
+    - date: "25 September 2024"
+      description: "Released with the Varlamore: 'The Rising Darkness' update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/infinity-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/infinity-bottoms.mdx
@@ -12,60 +12,95 @@ osrs:
   lowalch: 36000
   highalch: 54000
   limit: 125
-  item_id: 6924
-  type: equipment
-  tradeable: true
-  weight: 0.907
-  buy_limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic_robe
+    tier: high
+  properties:
+    release_date: "2006-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: magic_legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
     requirements:
-      skills:
-        - skill: magic
-          level: 50
-        - skill: defence
-          level: 25
-    stats:
-      attack_magic: 17
-      defence_magic: 12
-      defence_ranged: -7
-  obtaining:
-    minigame:
-      name: Mage Training Arena
-      points_required:
-        telekinetic: 450
-        alchemist: 500
-        enchantment: 5000
-        graveyard: 450
+      magic: 50
+      defence: 25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 17
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 17
+      ranged: -7
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Mage Training Arena (Pizazz exchange)
+        quantity: "1"
+        rarity: always
   related_items:
-    - slug: infinity-hat
-      name: Infinity hat
-      relation: set_piece
-    - slug: infinity-top
-      name: Infinity top
-      relation: set_piece
-    - slug: infinity-boots
-      name: Infinity boots
-      relation: set_piece
-    - slug: infinity-gloves
-      name: Infinity gloves
-      relation: set_piece
-    - slug: ancestral-robe-bottom
-      name: Ancestral robe bottom
-      relation: best_upgrade
+    - item_name: Infinity hat
+      slug: infinity-hat
+      relationship: set-piece
+      description: Head slot of the Infinity robes set
+    - item_name: Infinity top
+      slug: infinity-top
+      relationship: set-piece
+      description: Torso slot of the Infinity robes set
+    - item_name: Infinity boots
+      slug: infinity-boots
+      relationship: set-piece
+      description: Boots slot of the Infinity robes set
+    - item_name: Infinity gloves
+      slug: infinity-gloves
+      relationship: set-piece
+      description: Hands slot of the Infinity robes set
+    - item_name: Ancestral robe bottom
+      slug: ancestral-robe-bottom
+      relationship: upgrade
+      description: Best-in-slot magic legs upgrade
   about: |-
-    The full Infinity set includes:
-    - Infinity hat
-    - Infinity top
-    - Infinity bottoms
-    - Infinity boots
-    - Infinity gloves
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Infinity bottoms are the leg slot piece of the Infinity robes set, awarded for participating in the Mage Training Arena minigame. They require 50 Magic and 25 Defence to equip and provide strong magic offensive and defensive bonuses with +1% magic damage.
+
+    To obtain, a player must accumulate the required pizazz points across all four MTA rooms (450 Telekinetic, 500 Alchemist, 5,000 Enchantment, 450 Graveyard).
+  market_strategy:
+    notes:
+      - "Mid-game magic leg slot used before Ancestral"
+      - "Set demand can spike when Mage Arena tasks rotate"
+      - "Magic damage bonus makes them BiS-style for budget mages"
+  trading_tips:
+    - Compare set price vs. individual pieces to spot arbitrage
+  history:
+    - date: "2006-01-04"
+      description: "Infinity bottoms released with the Mage Training Arena minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-harness-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/initiate-harness-m.mdx
@@ -12,12 +12,67 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 70
-  about: "Initiate harness m is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour-set
+    tier: mid
+  properties:
+    release_date: "2006-09-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 14.514
+    options:
+      - Unpack
+      - Drop
+    worn_options: []
+    alchable: false
+  shops:
+    - shop_name: Sir Tiffy Cashien
+      location: Falador Park
+      price: 20000
+      currency: Coins
+      stock: 100
+  related_items:
+    - item_name: Initiate sallet
+      slug: initiate-sallet
+      relationship: component
+      description: Helmet contained in this harness pack.
+    - item_name: Initiate hauberk
+      slug: initiate-hauberk
+      relationship: component
+      description: Body piece contained in this harness pack.
+    - item_name: Initiate cuisse
+      slug: initiate-cuisse
+      relationship: component
+      description: Legs piece contained in this harness pack.
+    - item_name: Proselyte harness m
+      slug: proselyte-harness-m
+      relationship: upgrade
+      description: Higher-tier male prayer armour harness.
+    - item_name: Initiate harness f
+      slug: initiate-harness-f
+      relationship: variant
+      description: Female counterpart of the harness.
+  about: "Initiate harness m is the male armour pack of Temple Knight initiate gear, sold by Sir Tiffy Cashien after the Recruitment Drive quest. Unpacking yields an initiate sallet, hauberk, and cuisse for budget Prayer bonus melee armour."
+  market_strategy:
+    notes:
+      - "Quest-gated supply via Sir Tiffy Cashien; PvM and Prayer setups drive demand."
+      - "Pack price vs individual component pricing creates flip opportunities."
+  trading_tips:
+    - Buy harness at shop, unpack and sell components on the GE for markup.
+    - Compare harness GE price against summed component prices before flipping.
+  history:
+    - date: "2006-09-20"
+      description: "Item released with The Slug Menace update line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/inoculation-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/inoculation-bracelet.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 1024
   highalch: 1536
   limit: 10000
-  about: "Inoculation bracelet is a members-only item in Old School RuneScape. High alchemy value: 1,536 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2007-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.25
+    requirements:
+      quest: Zogre Flesh Eaters
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: magic
+      level: 49
+      xp: 59
+      materials:
+        - item_name: Ruby bracelet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 5
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Disease protection
+      description: Absorbs up to 275 disease damage while worn, then degrades to dust
+  related_items:
+    - item_name: Ruby bracelet
+      slug: ruby-bracelet
+      relationship: component
+      description: Unenchanted base bracelet
+    - item_name: Relicym's balm
+      slug: relicym-s-balm
+      relationship: alternative
+      description: Cures disease via potion
+    - item_name: Cosmic rune
+      slug: cosmic-rune
+      relationship: component
+      description: Required for the Lvl-3 Enchant spell
+  about: |-
+    Inoculation bracelet protects the wearer from disease damage, absorbing up to 275 disease hits before crumbling to dust. Requires completion of Zogre Flesh Eaters. Useful at Skogres/Zogres and in the Trouble Brewing minigame. Created by casting Lvl-3 Enchant on a ruby bracelet (49 Magic, 59 XP).
+  market_strategy:
+    notes:
+      - "Niche demand from disease content"
+      - "Quest gate limits buyer pool"
+      - "Buy limit of 10,000 per 4 hours"
+      - "Supply from ruby bracelet enchanters"
+  history:
+    - date: "2007-04-30"
+      description: "Released alongside ruby bracelet enchantment options."
+    - date: "2015-02-26"
+      description: "Renamed from Inoculation brace to Inoculation bracelet."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-brutal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-brutal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron brutal | OSRS Price Data
-description: "Iron brutal: Blunt iron arrow... ouch.. High alch: 6 GP, GE limit: 11,000."
+description: "Iron brutal arrows for ogre bows used in chompy hunting and zogre combat. High alch: 6 GP, GE limit: 11,000."
 osrs:
   id: 4778
   name: Iron brutal
@@ -12,9 +12,93 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 11000
-  about: "Iron brutal is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2005-05-17"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: arrow
+    attack_speed: null
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 13
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 18
+      xp: 15.6
+      materials:
+        - item_name: Flighted ogre arrow
+          quantity: 6
+        - item_name: Iron nails
+          quantity: 6
+      tools:
+        - Chisel
+      output_quantity: 6
+  related_items:
+    - item_name: Bronze brutal
+      slug: bronze-brutal
+      relationship: downgrade
+      description: Weaker ogre arrow tier
+    - item_name: Steel brutal
+      slug: steel-brutal
+      relationship: upgrade
+      description: Next tier ogre arrow
+    - item_name: Ogre bow
+      slug: ogre-bow
+      relationship: alternative
+      description: Required bow to fire brutals
+    - item_name: Comp ogre bow
+      slug: comp-ogre-bow
+      relationship: alternative
+      description: Composite ogre bow upgrade
+  about: |-
+    > _"Blunt iron arrow... ouch."_
+
+    Brutal arrows are fired from ogre bows and comp ogre bows, used to hunt chompy birds and fight zogres/skogres at Jiggig. Iron brutal sits second in the brutal tier ladder.
+  market_strategy:
+    notes:
+      - "Demand spikes with new chompy bird hat hunters chasing kills."
+      - "Fletched by stacking iron nails onto flighted ogre arrows."
+  trading_tips:
+    - Bulk-buy iron nails when chompy quests trend on social channels.
+    - Sell in stacks of 1,000 to chompy-hunting alts for higher margins than GE.
+  history:
+    - date: "2005-05-17"
+      description: "Released with the Zogre Flesh Eaters quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dart-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dart-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron dart (p) | OSRS Price Data
-description: "Iron dart (p) is a members weapon slot item requiring 1 Ranged. High alch: 1 GP, GE limit: 7,000."
+description: "Iron dart (p): A deadly poisoned dart with an iron tip. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 813
   name: Iron dart (p)
@@ -12,31 +12,78 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 1
     attack_bonus:
-      ranged: 4
-    ranged_strength: 3
+      ranged: 0
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 2
+  recipes:
+    - skill: fletching
+      level: 22
+      xp: 38
+      materials:
+        - item_name: Iron dart tip
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      output_quantity: 10
   related_items:
-    - item_id: 812
-      item_name: Bronze dart (p)
+    - item_name: Iron dart
+      slug: iron-dart
+      relationship: variant
+      description: Unpoisoned version
+    - item_name: Bronze dart (p)
       slug: bronze-dart-p
-      relationship: variant
+      relationship: downgrade
       description: Lower tier poisoned dart
-    - item_id: 814
-      item_name: Steel dart (p)
+    - item_name: Steel dart (p)
       slug: steel-dart-p
-      relationship: variant
+      relationship: upgrade
       description: Higher tier poisoned dart
-  about: |-
-    > _"An iron tipped dart with a poisoned tip."_
-
-    An iron dart tipped with basic weapon poison. Requires 1 Ranged. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Weapon poison
+      slug: weapon-poison
+      relationship: component
+      description: Applied to base dart to make poisoned version
+  about: "Iron dart (p) is a basic poisoned thrown weapon, fletched from iron dart tips and feathers at 22 Fletching, then dipped in weapon poison. With +0 ranged attack and +2 ranged strength, it's an entry-level option for low-Ranged accounts wanting poison damage."
+  market_strategy:
+    notes:
+      - "Niche demand from low-level pures wanting poison procs"
+      - "Limited margin given low alch and cheap fletch"
+  trading_tips:
+    - Better as a fletching by-product than a market focus
+  history:
+    - date: "2003-04-14"
+      description: "Released in the New Throwing Weapons update."
+    - date: "2021-06-30"
+      description: "Ranged attack reduced from +4 to 0; ranged strength reduced from +3 to +2."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-p-5643.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-p-5643.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 7000
-  about: "Iron javelin(p+) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: javelin
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 42
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Strong weapon poison
+      description: Has a chance to inflict poison on the target dealing higher initial damage than basic weapon poison.
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Iron javelin
+          quantity: 5
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      output_quantity: 5
+  related_items:
+    - item_name: Iron javelin
+      slug: iron-javelin
+      relationship: downgrade
+      description: Unpoisoned base javelin
+    - item_name: Iron javelin(p)
+      slug: iron-javelin-p-825
+      relationship: variant
+      description: Basic weapon poison variant
+    - item_name: Iron javelin(p++)
+      slug: iron-javelin-p-5644
+      relationship: upgrade
+      description: Stronger weapon poison(++) variant
+    - item_name: Weapon poison(+)
+      slug: weapon-poison-plus
+      relationship: component
+      description: Applied to poison the javelin
+  about: |-
+    Iron javelin(p+) is the weapon poison(+) variant of the iron javelin, used as ammunition for light and heavy ballistae. Applying weapon poison(+) to 5 iron javelins yields 5 poisoned javelins with a stronger initial poison damage tier than basic weapon poison. It functions as ammo rather than a wielded weapon, providing +42 ranged strength.
+  market_strategy:
+    notes:
+      - "Stackable ammo with stable mid-level demand"
+      - "Buy limit of 7000 supports bulk flips"
+      - "Poison crafting margin tracks weapon poison(+) supply"
+      - "PvP demand spikes during BH and DMM seasons"
+      - "Usually trades above alch but below crafting cost"
+  trading_tips:
+    - Track weapon poison(+) market for crafting arbitrage
+    - Stage offers in 1000 unit lots for clean fills
+    - Hold during ballista meta shifts for upside
+  history:
+    - date: "2004-03-29"
+      description: "Released with RuneScape 2 as ballista ammunition variant."
+    - date: "2016-10-06"
+      description: "Ranged strength bonus reduced from +50 to +42 and repositioned as ammunition slot."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-kiteshield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron kiteshield | OSRS Price Data
-description: "Iron kiteshield: A large metal shield.. High alch: 142 GP, GE limit: 125."
+description: "Iron kiteshield: A large metal shield. High alch: 142 GP, GE limit: 125."
 osrs:
   id: 1191
   name: Iron kiteshield
@@ -12,27 +12,105 @@ osrs:
   lowalch: 95
   highalch: 142
   limit: 125
-  item_id: 1191
-  item_type: armor
-  slot: shield
-  type: kiteshield
-  tradeable: true
-  weight: 5.443
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 8
-    slash_defence: 10
-    crush_defence: 9
-    ranged_defence: 9
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 8
+      slash: 10
+      crush: 9
+      magic: -1
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hill Giant
+        quantity: "1"
+        rarity: 3/128
+  shops:
+    - shop_name: Cassie's Shield Shop
+      location: Falador
+      price: 238
+      currency: coins
+      stock: 10
+    - shop_name: Shields of Mistrock
+      location: Mistrock
+      price: 238
+      currency: coins
+      stock: 10
+    - shop_name: Elder Blunn's Spear and Shield Stall
+      location: Varlamore
+      price: 238
+      currency: coins
+      stock: 10
+  recipes:
+    - skill: smithing
+      level: 27
+      xp: 75
+      materials:
+        - item_name: Iron bar
+          quantity: 3
+      tools:
+        - Hammer
+      output_quantity: 1
   related_items:
-    - slug: steel-kiteshield
-    - slug: iron-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Steel kiteshield
+      slug: steel-kiteshield
+      relationship: upgrade
+      description: Stronger steel-tier kiteshield
+    - item_name: Iron platebody
+      slug: iron-platebody
+      relationship: set-piece
+      description: Matching iron armour piece
+  about: "Iron kiteshield is an F2P kiteshield smithed from 3 iron bars at 27 Smithing for 75 xp. Provides modest defensive bonuses and is a step up from the bronze kiteshield."
+  market_strategy:
+    notes:
+      - "Cheap and abundant from F2P smiths"
+      - "High alch barely above value, not profitable to alch"
+  trading_tips:
+    - Stock readily available from Cassie's Shield Shop in Falador
+  history:
+    - date: "2001-01-04"
+      description: "Iron kiteshield released with the launch of RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-longsword.mdx
@@ -12,29 +12,91 @@ osrs:
   lowalch: 56
   highalch: 84
   limit: 125
-  item_id: 1293
-  item_type: equipment
-  slot: weapon
-  type: longsword
-  attack_style: slash
-  attack_speed: 5
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 1
-  stats:
-    stab_attack: 6
-    slash_attack: 8
-    crush_attack: -2
-    strength: 10
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: longsword
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 6
+      slash: 8
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 10
+      prayer: 0
+      ranged_strength: 0
+      magic_damage: 0
+  recipes:
+    - skill: smithing
+      level: 21
+      xp: 50
+      materials:
+        - item_name: Iron bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
   related_items:
-    - slug: steel-longsword
-    - slug: iron-sword
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Steel longsword
+      slug: steel-longsword
+      relationship: upgrade
+      description: Stronger longsword variant
+    - item_name: Iron sword
+      slug: iron-sword
+      relationship: variant
+      description: One-handed iron sword with lower bonuses
+    - item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Smithing material used to forge the longsword
+  about: "Iron longsword is an entry-level slash weapon usable by any attack level. It hits faster than two-handed alternatives at speed 5 and gives a +10 strength bonus, making it a budget pick for early melee training in F2P."
+  market_strategy:
+    notes:
+      - "Cheap nature-rune-margin alch when bought near GE low"
+      - "Steady demand from new accounts skilling Smithing"
+      - "Often used as a smithed-then-alched flip for Smithing XP"
+  trading_tips:
+    - Smith from iron bars at 21 Smithing for XP plus a sellable item
+    - High alch margin only works when GE price stays well below 84 gp
+  history:
+    - date: "2001-01-04"
+      description: "Released with the launch of RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-set-sk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron set (sk) | OSRS Price Data
-description: "Iron set (sk): A set containing a full helm, platebody, skirt and kiteshield.. High alch: 540 GP, GE limit: 8."
+description: "Iron set (sk): A set containing a full helm, platebody, skirt and kiteshield. High alch: 540 GP, GE limit: 8."
 osrs:
   id: 12974
   name: Iron set (sk)
@@ -12,9 +12,58 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Iron set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6.0
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: set-piece
+      description: "Helm component of the set."
+    - item_name: Iron platebody
+      slug: iron-platebody
+      relationship: set-piece
+      description: "Body component of the set."
+    - item_name: Iron plateskirt
+      slug: iron-plateskirt
+      relationship: set-piece
+      description: "Skirt component of the set."
+    - item_name: Iron kiteshield
+      slug: iron-kiteshield
+      relationship: set-piece
+      description: "Shield component of the set."
+    - item_name: Iron set (lg)
+      slug: iron-set-lg
+      relationship: alternative
+      description: "Same set but with platelegs instead of skirt."
+  about: "Iron set (sk) bundles iron full helm, platebody, plateskirt, and kiteshield into a single tradeable item via the Grand Exchange clerk. It is a free-to-play bank-saver primarily used to ship low-level smithing or armour suite resells in one slot."
+  market_strategy:
+    notes:
+      - "Set price is usually slightly above component sum; small arbitrage by buying parts and merging."
+      - "Buy limit of only 8 throttles volume; large flips need rotating accounts."
+  trading_tips:
+    - "Combine cheap components from the GE then list as a set for a small premium."
+    - "Useful for f2p ironman gift swaps via the Grand Exchange clerk."
+  history:
+    - date: "2015-02-26"
+      description: "Released alongside other armour set bundles to relieve bank pressure."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-machete.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-machete.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jade machete | OSRS Price Data
-description: "Jade machete: A jungle specific slashing device.. High alch: 600 GP, GE limit: 15."
+description: "Jade machete: A jungle specific slashing device. High alch: 600 GP, GE limit: 15."
 osrs:
   id: 6315
   name: Jade machete
@@ -12,9 +12,86 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 15
-  about: "Jade machete is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: jade
+    tier: mid
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: slash_sword
+    attack_speed: 4
+    weight: 1.36
+    requirements:
+      attack: 30
+    attack_bonus:
+      stab: -2
+      slash: 11
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Safta Doc's machete shop"
+      location: "Tai Bwo Wannai"
+      price: 600
+      currency: "Trading sticks"
+      stock: 5
+    - shop_name: "Gabooty's Cooperative"
+      location: "Tai Bwo Wannai"
+      price: 1200
+      currency: "Trading sticks"
+      stock: 5
+  related_items:
+    - item_name: Machete
+      slug: machete
+      relationship: downgrade
+      description: "Base tier machete without gem inlay."
+    - item_name: Opal machete
+      slug: opal-machete
+      relationship: alternative
+      description: "First-tier gem machete."
+    - item_name: Red topaz machete
+      slug: red-topaz-machete
+      relationship: upgrade
+      description: "Best-in-slot for Tai Bwo Wannai cleanup."
+  about: "The jade machete is a slashing weapon used in Tai Bwo Wannai Cleanup to chop jungle and unlock gem hotspots. It is the second-best machete, beaten only by the red topaz variant, and doubles as a viable 30 Attack one-handed slash weapon for low-level training."
+  market_strategy:
+    notes:
+      - "Tiny 15 buy limit keeps GE liquidity thin; flips are slow but margins healthy."
+      - "Demand tracks Karamja Diary completion and gem cleanup grinders."
+  trading_tips:
+    - "Stock up before each league/seasonal mode that resets Karamja Diary tasks."
+    - "Buy from Safta Doc with Karamja gloves for cheapest acquisition."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Cleanup update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-mahogany-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-mahogany-hull-parts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Large mahogany hull parts | OSRS Price Data
-description: "Large mahogany hull parts: Parts for creating a mahogany hull for larger boats.. High alch: 11,250 GP, GE limit: 100."
+description: "Large mahogany hull parts: Parts for creating a mahogany hull for larger boats. High alch: 11,250 GP, GE limit: 100."
 osrs:
   id: 32071
   name: Large mahogany hull parts
@@ -12,9 +12,64 @@ osrs:
   lowalch: 7500
   highalch: 11250
   limit: 100
-  about: "Large mahogany hull parts is a members-only item in Old School RuneScape. High alchemy value: 11,250 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid-high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 41
+      xp: 2.5
+      materials:
+        - item_name: Mahogany hull parts
+          quantity: 5
+      tools:
+        - Saw
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Mahogany hull parts
+      slug: mahogany-hull-parts
+      relationship: component
+      description: Five small mahogany hull parts are combined to produce one large set.
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Planks used to fabricate mahogany hull parts upstream.
+  about: |-
+    Large mahogany hull parts are intermediate Construction materials used to assemble mahogany hulls for sloops at the Shipwrights' Workbench. Each large set is built from five regular mahogany hull parts.
+
+    Construction takes 5 ticks (3 seconds) and grants 2.5 Construction experience. A complete sloop requires sixteen large hull parts, equating to 400 mahogany planks worth of upstream material.
+
+    Requirements: 41 Construction | Tools: Saw, Hammer | Facility: Shipwrights' Workbench.
+  market_strategy:
+    notes:
+      - "High GE price relative to mahogany planks - profit pipeline for Construction grinders."
+      - "Buy limit of 100 caps speculation but allows steady flipping."
+      - "Demand tied to sloop production cycles and shipwright content."
+  trading_tips:
+    - Watch mahogany plank cost vs assembled price for live arbitrage.
+    - Volume spikes shortly after new shipwright content updates.
+  history:
+    - date: "2025-11-19"
+      description: "Hotfix halved the Construction experience gained from the Shipwrights' Workbench."
+    - date: "2025-11-19"
+      description: "Released alongside the Shipwrights' Workbench Construction content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lava-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lava-battlestaff.mdx
@@ -12,9 +12,35 @@ osrs:
   lowalch: 6800
   highalch: 10200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: battlestaff
+    tier: mid
+  properties:
+    release_date: "2004-09-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: bladed_staff
     attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 30
+      magic: 30
     attack_bonus:
       stab: 7
       slash: -1
@@ -28,72 +54,47 @@ osrs:
       magic: 12
       ranged: 0
     other_bonus:
-      melee_strength: 35
+      strength: 35
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 30
-      magic: 30
-    weight: 2.267
+  drop_table:
+    sources:
+      - source: Cerberus
+        quantity: "1"
+        rarity: 2/130
+      - source: Kalphite Queen
+        quantity: "1"
+        rarity: 2/126
+      - source: Barbarian Assault reward
+        quantity: "1"
+        rarity: 1/32
+  passive_effects:
+    - name: Unlimited earth and fire runes
+      description: Acts as an infinite source of both earth and fire runes while equipped, powering fire spells, Lvl-6 Enchant, Shadow Veil, Battlefront Teleport, and Superheat Item.
   related_items:
-    - item_id: 3054
-      item_name: Mystic lava staff
+    - item_name: Mystic lava staff
       slug: mystic-lava-staff
       relationship: upgrade
-      description: Mystic version via Thormac
-    - item_id: 6562
-      item_name: Mud battlestaff
+      description: Mystic version crafted by Thormac
+    - item_name: Mud battlestaff
       slug: mud-battlestaff
       relationship: alternative
-      description: Water+Earth combination staff
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +12 |
-    | Crush | +28 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +12 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +35 |
-
-    Requirements: 30 Attack, 30 Magic
-
-    Provides unlimited earth and fire runes simultaneously. This enables:
-    - Lvl-6 Enchant (Onyx) — saves fire + earth runes
-    - Shadow Veil (Arceuus spellbook) — requires earth + fire runes
-    - Battlefront Teleport — earth + fire runes
-    - Superheat Item — saves fire runes (with earth already covered)
-    - Autocast with standard spellbook
-
-    | Option | Cost | Result |
-    |--------|------|--------|
-    | Thormac (base) | 40,000 coins | Mystic lava staff |
-    | Thormac (Hard Kandarin) | 30,000 coins | Mystic lava staff |
-    | Thormac (Elite Kandarin) | 20,000 coins | Mystic lava staff |
-
-    | Stat | Lava Bstaff | Mud Bstaff |
-    |------|-------------|------------|
-    | Elements | Earth + Fire | Water + Earth |
-    | Rarity | Common | Rare (DK Prime) |
-    | GE Price | ~10K | ~35K+ |
-    | Best spells | Fire spells, Superheat | Lunar spells, Barrage |
-
-    Lava is much more common and cheaper, but mud is more versatile for high-level spellcasting.
+      description: Water plus earth combination staff
+  about: "Lava battlestaff combines unlimited earth and fire rune supply with a strong crush attack (+28) and +35 melee strength. Requires 30 Attack and 30 Magic. Common drops from Cerberus, Kalphite Queen, and Barbarian Assault reward chest make it relatively cheap, and Thormac upgrades to the mystic lava staff."
   market_strategy:
     notes:
-      - Multiple drop sources (easier to obtain than mud)
-      - Thormac upgrade can be profitable with diary discounts
-      - Useful for specific spell combinations
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Multiple drop sources keep supply higher than mud battlestaff"
+      - "Thormac upgrade can be profitable with Kandarin diary discounts"
+  trading_tips:
+    - Watch for spikes around new spellbook releases that use fire and earth runes
+  history:
+    - date: "2004-09-07"
+      description: "Released alongside the Heroes' Quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/light-frame.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/light-frame.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Light frame is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid-high
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.25
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Demonic gorilla
+        quantity: "1"
+        rarity: 1/750
+      - source: Tortured gorilla
+        quantity: "1"
+        rarity: 1/7500
+  recipes:
+    - skill: fletching
+      level: 47
+      xp: 15
+      materials:
+        - item_name: Light frame
+          quantity: 1
+        - item_name: Ballista limbs
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Ballista limbs
+      slug: ballista-limbs
+      relationship: component
+      description: Combined with the light frame to begin construction of an incomplete light ballista.
+    - item_name: Incomplete light ballista
+      slug: incomplete-light-ballista
+      relationship: product
+      description: Result of attaching ballista limbs to a light frame at 47 Fletching.
+    - item_name: Light ballista
+      slug: light-ballista
+      relationship: product
+      description: Final ranged weapon assembled from a light frame and supporting Monkey Madness II components.
+  about: "Light frame is a members-only Fletching component dropped by demonic and tortured gorillas after completing Monkey Madness II. It is the wooden core used to build a light ballista, requiring level 47 Fletching when paired with ballista limbs."
+  market_strategy:
+    notes:
+      - "GE buy limit is only 8 per 4 hours, so stockpile when the price dips between ballista crafting flips."
+      - "Light frame demand spikes whenever ranged Slayer or boss metas push light ballista usage; track combat content updates."
+      - "Tortured gorillas are an inefficient farm at 1/7,500, so most supply comes from demonic gorilla Slayer tasks."
+  trading_tips:
+    - Buy ahead of league or DMM events that push more players toward Monkey Madness II unlocks.
+    - List 1-2gp above current GE price when flipping in bulk to clear the 8-unit limit quickly.
+    - Compare light frame and ballista limb spreads before crafting to confirm Fletching profit per cast.
+  history:
+    - date: "2016-05-06"
+      description: "Added to the game with the Monkey Madness II update as the wooden core of the light ballista."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/machete.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/machete.mdx
@@ -1,6 +1,6 @@
 ---
 title: Machete | OSRS Price Data
-description: "Machete is a members weapon slot item. High alch: 24 GP, GE limit: 15."
+description: "Machete is a members weapon slot item used to cut jungle vegetation on Karamja. High alch: 24 GP, GE limit: 15."
 osrs:
   id: 975
   name: Machete
@@ -12,15 +12,89 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2003-08-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-  related_items: []
+    weapon_type: slash_sword
+    attack_speed: 5
+    weight: 1.36
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 6
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Jiminua's Jungle Store
+      location: Tai Bwo Wannai, Karamja
+      price: 40
+      currency: coins
+      stock: 5
+    - shop_name: Obli's General Store
+      location: Shilo Village
+      price: 40
+      currency: coins
+      stock: 3
+  related_items:
+    - item_name: Opal machete
+      slug: opal-machete
+      relationship: upgrade
+      description: Faster jungle cutting speed
+    - item_name: Jade machete
+      slug: jade-machete
+      relationship: upgrade
+      description: Even faster jungle cutting speed
+    - item_name: Red topaz machete
+      slug: red-topaz-machete
+      relationship: upgrade
+      description: Fastest jungle cutting speed variant
   about: |-
-    > _"Good for\"cutting\" through\"vegetation\"."_
+    > _"Good for cutting through vegetation."_
 
-    The machete is used to cut through jungle undergrowth on Karamja and in Tai Bwo Wannai Cleanup. Required for accessing various areas on Karamja. Can be upgraded to jade, red topaz, or opal machetes for faster cutting.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The machete is a jungle-specific slashing tool used to clear undergrowth on Karamja and in Tai Bwo Wannai Cleanup. It is required to access several Karamja areas without using the 79 Agility shortcut. Three upgraded variants (opal, jade, red topaz) cut faster.
+  market_strategy:
+    notes:
+      - "Cheap entry-level jungle tool"
+      - "Demand tied to Tai Bwo Wannai Cleanup activity"
+      - "Upgraded variants outclass on speed for serious harvesting"
+  trading_tips:
+    - Buy at shop price from Jiminua when GE markup is high
+    - Sell to questers ahead of Legends' Quest pushes
+  history:
+    - date: "2003-08-20"
+      description: "Released with the Legends' Quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/malediction-shard-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/malediction-shard-3.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 12400
   highalch: 18600
   limit: 10000
-  about: "Malediction shard 3 is a members-only item in Old School RuneScape. High alchemy value: 18,600 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: shard
+    tier: mid
+  properties:
+    release_date: "2014-03-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Scorpia
+        quantity: "1"
+        rarity: 1/256
+  related_items:
+    - item_name: Malediction shard 1
+      slug: malediction-shard-1
+      relationship: component
+      description: First shard required for Malediction ward
+    - item_name: Malediction shard 2
+      slug: malediction-shard-2
+      relationship: component
+      description: Second shard required for Malediction ward
+    - item_name: Malediction ward
+      slug: malediction-ward
+      relationship: product
+      description: Combined product of all three shards
+  about: |-
+    Malediction shard 3 is one of three broken shield pieces that combine at the Blighted Volcano to create the Malediction ward, a strong magic shield. It drops from Scorpia in the Wilderness at a 1/256 rarity, making the shard chase a Wilderness PvM grind.
+  market_strategy:
+    notes:
+      - "Only obtainable from Scorpia in the Wilderness"
+      - "Demand driven by Malediction ward assembly orders"
+      - "Price typically lockstep across all three shards"
+  trading_tips:
+    - Buy the cheapest of the three shards when assembling a ward
+    - Flip on PvM updates that buff Wilderness boss XP
+  history:
+    - date: "2014-03-13"
+      description: "Added with the Wilderness Rejuvenation update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-leaves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-leaves.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Maple leaves is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: organic
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Maple tree (chop with Forestry kit)
+        quantity: "1"
+        rarity: 1/4
+      - source: Maple tree (cure diseased via Farming)
+        quantity: "1"
+        rarity: Always
+      - source: Forestry Struggling sapling event
+        quantity: "1"
+        rarity: Common
+      - source: Forestry Friendly Ent event
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Maple logs
+      slug: maple-logs
+      relationship: alternative
+      description: Primary product from cutting maple trees
+    - item_name: Forestry kit
+      slug: forestry-kit
+      relationship: component
+      description: Required to receive leaves while woodcutting
+  about: "Maple leaves are a stackable Forestry byproduct from chopping maple trees with a Forestry kit equipped, curing diseased maple farming trees, or completing Forestry events. They serve as flavour drops with no direct combat or alchemy use. High alchemy value: 1 coin."
+  market_strategy:
+    notes:
+      - "No GE buy limit and stackable storage make hoarding trivial"
+      - "Supply is incidental to Forestry-active woodcutters at 45+ WC"
+      - "Alch value of 1 coin means leaves trade as a cosmetic curio only"
+  trading_tips:
+    - Bank leaves while doing Forestry events for future cosmetic flips
+    - Watch for any future Forestry rewards that consume maple leaves
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming skill update as 'Leaves' from maple trees."
+    - date: "2023-06-12"
+      description: "Renamed to 'Maple leaves', made tradeable on the Grand Exchange and received a graphical update."
+    - date: "2023-10-25"
+      description: "Made stackable in inventory."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marble-magic-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marble-magic-wardrobe-flatpack.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Marble magic wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: high
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 96
+      xp: 500
+      materials:
+        - item_name: Marble block
+          quantity: 1
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Marble block
+      slug: marble-block
+      relationship: component
+      description: Sole material required to flatpack
+    - item_name: Mahogany magic wardrobe (flatpack)
+      slug: mahogany-magic-wardrobe-flatpack
+      relationship: downgrade
+      description: Lower-tier magic wardrobe flatpack
+  about: |-
+    The marble magic wardrobe flatpack is a high-end Construction training method introduced in 2006 with the flatpack update. Made from a single marble block at level 96 Construction, it grants 500 XP per craft on a 5-tick cycle. The flatpack is widely used by mass-trained construction players because it offers exceptional XP per click compared to direct house builds.
+  market_strategy:
+    notes:
+      - "Niche flatpack with sharp price ties to marble block cost"
+      - "Demand driven by Construction trainers chasing 99"
+      - "Buy limit of 500 caps bulk strategies"
+      - "Profit per item is volatile with marble block supply"
+      - "Often used as a XP-per-GP arbitrage signal"
+  trading_tips:
+    - Track marble block price as the leading indicator
+    - Flip into Construction XP event windows for spikes
+    - Bulk hold during marble block scarcity periods
+  history:
+    - date: "2006-10-18"
+      description: "Added with the Construction flatpack update."
+    - date: "2015-02-26"
+      description: "Renamed from 'Marble mw' to 'Marble magic wardrobe'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mind-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mind-tiara.mdx
@@ -12,12 +12,93 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 40
-  about: "Mind tiara is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: silver
+    tier: low
+  properties:
+    release_date: "2005-06-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
+      ranged_strength: 0
+      magic_damage: 0
+  passive_effects:
+    - name: Mind Altar access
+      description: Allows the wearer to enter the Mind Altar without a Mind talisman, saving inventory space while crafting Mind runes.
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 27.5
+      materials:
+        - item_name: Tiara
+          quantity: 1
+        - item_name: Mind talisman
+          quantity: 1
+      tools:
+        - Mind Altar
+      output_quantity: 1
+  related_items:
+    - item_name: Tiara
+      slug: tiara
+      relationship: component
+      description: Base tiara used in creation
+    - item_name: Mind talisman
+      slug: mind-talisman
+      relationship: component
+      description: Consumed at the Mind Altar during creation
+    - item_name: Mind rune
+      slug: mind-rune
+      relationship: product
+      description: Rune crafted at the Mind Altar
+  about: "Mind tiara is a head slot item made by using a Mind talisman on a tiara at the Mind Altar for 27.5 Runecraft XP. When worn it grants direct access to the Mind Altar, removing the need to carry the talisman."
+  market_strategy:
+    notes:
+      - "Buy limit of 40 keeps it suitable for diary completion shopping only"
+      - "Production cost massively exceeds GE price, supply is mostly Runecraft XP byproduct"
+  trading_tips:
+    - Most players buy rather than craft due to the talisman cost gap
+    - Useful as a cheap Falador Diary requirement purchase
+  history:
+    - date: "2005-06-13"
+      description: "Added to the game with the rework of the Runecrafting skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-p-9303.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-p-9303.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 11000
-  about: "Mithril bolts (p++) is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: low
+  properties:
+    release_date: "31 July 2006"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: crossbow_ammunition
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 36
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 82
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Super poison
+      description: "Has a chance to apply a stronger poison than the standard (p+) variant when striking opponents."
+  related_items:
+    - item_name: Mithril bolts
+      slug: mithril-bolts
+      relationship: variant
+      description: "Unpoisoned base variant of the bolt"
+    - item_name: Mithril bolts (p)
+      slug: mithril-bolts-p
+      relationship: variant
+      description: "Standard poison-tipped variant"
+    - item_name: Mithril bolts (p+)
+      slug: mithril-bolts-p-plus
+      relationship: variant
+      description: "Stronger poison-tipped variant"
+  about: |-
+    Mithril bolts (p++) are super-poisoned mithril bolts, fired from a mithril crossbow or higher. They share the ranged strength of regular mithril bolts but apply a stronger poison effect.
+
+    The bolts are produced by applying super weapon poison to a stack of mithril bolts.
+  market_strategy:
+    notes:
+      - "Niche poison-application bolt; demand is thin compared to base mithril bolts"
+      - "Bound to weapon poison++ supply cycles"
+  trading_tips:
+    - Stock up when weapon poison++ flips below 1k
+    - Often profitable to craft from base bolts + poison rather than buy direct
+  history:
+    - date: "31 July 2006"
+      description: "Released alongside the poisoned bolt family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dagger.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril dagger | OSRS Price Data
-description: "Mithril dagger: A dangerous dagger.. High alch: 195 GP, GE limit: 125."
+description: "Mithril dagger: A dangerous dagger. High alch: 195 GP, GE limit: 125."
 osrs:
   id: 1209
   name: Mithril dagger
@@ -12,29 +12,126 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  item_id: 1209
-  item_type: equipment
-  slot: weapon
-  type: dagger
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 0.396
-  requirements:
-    attack: 20
-  stats:
-    stab_attack: 11
-    slash_attack: 5
-    crush_attack: -4
-    strength: 10
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.396
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 0.396
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 11
+      slash: 5
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Cyclops
+        quantity: "1"
+        rarity: uncommon
+      - source: Zombie pirate
+        quantity: "1"
+        rarity: uncommon
+      - source: Sorebones
+        quantity: "1"
+        rarity: uncommon
+      - source: Bronze chest
+        quantity: "1"
+        rarity: uncommon
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      price: 325
+      currency: coins
+      stock: 5
+    - shop_name: Warriors' Guild Armoury
+      location: Burthorpe
+      price: 390
+      currency: coins
+      stock: 10
+    - shop_name: Blades by Urbi
+      location: Al Kharid
+      price: 325
+      currency: coins
+      stock: 5
+    - shop_name: Shayzien Armour Shop
+      location: Shayzien
+      price: 325
+      currency: coins
+      stock: 5
+    - shop_name: Cam Torum Blacksmith
+      location: Cam Torum
+      price: 325
+      currency: coins
+      stock: 5
+  recipes:
+    - skill: smithing
+      level: 50
+      xp: 50
+      materials:
+        - item_name: Mithril bar
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
   related_items:
-    - slug: adamant-dagger
-    - slug: mithril-sword
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Adamant dagger
+      slug: adamant-dagger
+      relationship: upgrade
+      description: Next-tier dagger above mithril
+    - item_name: Mithril sword
+      slug: mithril-sword
+      relationship: alternative
+      description: Same-tier slash weapon
+  about: "Mithril dagger is a one-handed stab sword smithed from 1 mithril bar at 50 Smithing for 50 xp. Requires 20 Attack to wield and offers solid mid-tier stab and strength bonuses."
+  market_strategy:
+    notes:
+      - "Mithril bar cost typically higher than dagger value (smithing loss)"
+      - "High alch above shop price provides marginal alch profit"
+  trading_tips:
+    - Buy directly from Varrock Swordshop for fast restock
+  history:
+    - date: "2001-01-04"
+      description: "Mithril dagger released with the launch of RuneScape."
+    - date: "2021-07-07"
+      description: "Female equipment positioning adjusted for proper appearance."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-p-5651.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-p-5651.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril javelin(p++) | OSRS Price Data
-description: "Mithril javelin(p++): A mithril tipped javelin.. High alch: 38 GP, GE limit: 7,000."
+description: "Mithril javelin(p++): A mithril tipped javelin. High alch: 38 GP, GE limit: 7,000."
 osrs:
   id: 5651
   name: Mithril javelin(p++)
@@ -12,9 +12,69 @@ osrs:
   lowalch: 25
   highalch: 38
   limit: 7000
-  about: "Mithril javelin(p++) is a members-only item in Old School RuneScape. High alchemy value: 38 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    attack_speed: 6
+    weight: 0
+    requirements:
+      ranged: 20
+    attack_bonus:
+      ranged: 0
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 85
+  related_items:
+    - item_name: Mithril javelin
+      slug: mithril-javelin
+      relationship: variant
+      description: Unpoisoned variant
+    - item_name: Mithril javelin(p)
+      slug: mithril-javelin-p-5637
+      relationship: variant
+      description: Weak poison variant
+    - item_name: Mithril javelin(p+)
+      slug: mithril-javelin-p-5644
+      relationship: variant
+      description: Stronger poison variant
+    - item_name: Adamant javelin(p++)
+      slug: adamant-javelin-p
+      relationship: upgrade
+      description: Higher tier poisoned javelin
+  about: "Mithril javelin(p++) is the extra-strength poisoned mithril javelin used as Heavy ballista ammunition. At +85 ranged strength with the strongest weapon poison, it's a budget option for ballista users who want consistent poison procs without committing to adamant or rune ammo."
+  market_strategy:
+    notes:
+      - "Cheap entry-point ballista ammo for low ranged accounts"
+      - "Poison variant typically only modestly more expensive than base"
+  trading_tips:
+    - Bulk stock during quiet markets for resale into slayer metas
+  history:
+    - date: "2005-07-11"
+      description: "Poisoned javelin variants added to the game."
+    - date: "2016-05-06"
+      description: "Moved to ammunition slot only; ranged strength increased significantly."
+    - date: "2016-10-31"
+      description: "Ranged strength adjusted to +85."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-spear-p-5710.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-spear-p-5710.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 338
   highalch: 507
   limit: 125
-  about: "Mithril spear(p+) is a members-only item in Old School RuneScape. High alchemy value: 507 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: two-handed
+    weapon_type: spear
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 17
+      slash: 17
+      crush: 17
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 18
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Mount Karuulm Weapon Shop
+      location: Mount Karuulm
+      price: 845
+      currency: coins
+      stock: 0
+    - shop_name: Fortis Blacksmith
+      location: Fortis
+      price: 845
+      currency: coins
+      stock: 0
+    - shop_name: Elder Blunn's Spear and Shield Stall
+      location: Land's End
+      price: 845
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Mithril spear
+      slug: mithril-spear
+      relationship: variant
+      description: Unpoisoned base spear
+    - item_name: Mithril spear(p)
+      slug: mithril-spear-p-1247
+      relationship: variant
+      description: Standard poison variant
+    - item_name: Mithril spear(p++)
+      slug: mithril-spear-p-5716
+      relationship: upgrade
+      description: Super strong poison variant
+    - item_name: Mithril spear(kp)
+      slug: mithril-spear-kp
+      relationship: variant
+      description: Karambwan poison variant
+  about: "Mithril spear(p+) is the strong-poison variant of the mithril spear, a two-handed stab weapon requiring 20 Attack. Applies a stronger poison than the standard (p) variant on hit, useful for slayer tasks and PvM where venom is desired. Created via Barbarian Smithing using a mithril bar plus maple logs."
+  market_strategy:
+    notes:
+      - "Niche demand limited to early-game spearing or poison utility"
+      - "Crafted via Barbarian Smithing — supply tied to training activity"
+      - "Attack speed buff in 2021 (5 to 4 ticks) modestly improved viability"
+  trading_tips:
+    - Flip in low volume; depth is thin
+    - Check Wintertodt / Slayer event days for spikes
+  history:
+    - date: "2003-04-14"
+      description: "Item released alongside the original mithril spear line."
+    - date: "2021-04-21"
+      description: "Attack speed increased from 5 to 4 ticks."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-moth-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-moth-mix-2.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 125
-  about: "Moonlight moth mix (2) is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Moonlight moth (jar)
+          quantity: 1
+        - item_name: Raw barb-tailed kebbit
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Restores 22 Prayer points per dose."
+        duration: 0
+      - description: "In multicombat areas the dose also restores up to three nearby players with Accept Aid enabled."
+        duration: 0
+  related_items:
+    - item_name: Moonlight moth mix (1)
+      slug: moonlight-moth-mix-1
+      relationship: variant
+      description: Lower-dose version of the same Prayer mix.
+    - item_name: Moonlight moth
+      slug: moonlight-moth
+      relationship: component
+      description: Jarred moth used as the base ingredient before adding hunter meat.
+    - item_name: Moonlight potion
+      slug: moonlight-potion
+      relationship: alternative
+      description: Non-mix Prayer potion variant that cannot be shared with allies.
+  about: "Moonlight moth mix (2) is a two-dose Prayer restore introduced with Varlamore Part One, made by combining a jarred moonlight moth with hunter meat. Each dose restores 22 Prayer and shares with up to three nearby Accept Aid players, making it the go-to group ironman Prayer mix."
+  market_strategy:
+    notes:
+      - "Demand follows group ironman PvM trips that rely on shared Prayer doses."
+      - "Raw barb-tailed kebbit is the most profitable hunter meat input - track its GE price."
+      - "Mixes do not benefit from the holy wrench bonus, so solo PvMers prefer regular potions."
+  trading_tips:
+    - Make in bulk during Varlamore event weekends when GIM activity spikes.
+    - Avoid flipping during competitive league reset windows when supply floods the market.
+    - Pair with Prayer potion margins to decide which to craft each evening.
+  history:
+    - date: "2024-03-20"
+      description: "Added with the Varlamore: The Final Dawn (Part One) update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/muddy-key.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/muddy-key.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 11000
-  about: "Muddy key is a free-to-play item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: key
+    tier: low
+  properties:
+    release_date: "2001-08-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Chaos dwarf
+        quantity: "1"
+        rarity: 7/128
+      - source: Crazy archaeologist
+        quantity: "1"
+        rarity: 4/128
+  related_items:
+    - item_name: Larran's key
+      slug: larrans-key
+      relationship: alternative
+      description: Modern Wilderness chest key
+    - item_name: Brass key
+      slug: brass-key
+      relationship: alternative
+      description: Other early-era chest key
+  about: "Muddy key opens the muddy chest at the centre of the Lava Maze in the Wilderness — a knife or sword is required to reach the chest. Following the 7 February 2024 rework the chest now drops blighted supplies and Larran's keys alongside increased mithril and rune quantities. Using the key once counts as a Medium Wilderness Diary task."
+  market_strategy:
+    notes:
+      - "Supply tied to Chaos dwarf and Crazy archaeologist kills"
+      - "Demand jumps after blighted supply or Larran's key meta shifts"
+      - "F2P availability broadens the buyer pool"
+  trading_tips:
+    - Spread widens when Wilderness PKers thin out chaos dwarf trips
+    - Watch for diary-week buyers if a Wilderness Diary update lands
+  history:
+    - date: "2001-08-13"
+      description: "Released as part of the original Wilderness chest system."
+    - date: "2024-02-07"
+      description: "Muddy chest loot rework — added blighted supplies and Larran's keys."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic boots | OSRS Price Data
-description: "Mystic boots is a members feet slot item requiring 20 Defence. High alch: 6,000 GP, GE limit: 125."
+description: "Mystic boots: Magical boots. High alch: 6,000 GP, GE limit: 125."
 osrs:
   id: 4097
   name: Mystic boots
@@ -12,97 +12,87 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2005-01-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
-    attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 3
-      ranged: 0
-    defence_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 3
-      ranged: 0
-    other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
+    weight: 0.453
     requirements:
       magic: 40
       defence: 20
+    attack_bonus:
+      magic: 3
+    defence_bonus:
+      magic: 3
+    other_bonus: {}
+  drop_table:
+    sources:
+      - source: Hammerhead shark
+        quantity: "1"
+        rarity: 1/512
+      - source: Veiled kraken
+        quantity: "1"
+        rarity: 1/512
+  shops:
+    - shop_name: Wizards' Guild Robe Store
+      location: Yanille
+      price: 10000
+      currency: Coins
+      stock: 2
   related_items:
-    - item_id: 4091
-      item_name: Mystic robe top
-      slug: mystic-robe-top
-      relationship: set-piece
-      description: Mystic set body
-    - item_id: 4093
-      item_name: Mystic robe bottom
-      slug: mystic-robe-bottom
-      relationship: set-piece
-      description: Mystic set legs
-    - item_id: 4089
-      item_name: Mystic hat
+    - item_name: Mystic hat
       slug: mystic-hat
       relationship: set-piece
       description: Mystic set hat
-    - item_id: 4095
-      item_name: Mystic gloves
+    - item_name: Mystic robe top
+      slug: mystic-robe-top
+      relationship: set-piece
+      description: Mystic set body
+    - item_name: Mystic robe bottom
+      slug: mystic-robe-bottom
+      relationship: set-piece
+      description: Mystic set legs
+    - item_name: Mystic gloves
       slug: mystic-gloves
       relationship: set-piece
       description: Mystic set gloves
-    - item_id: 6920
-      item_name: Infinity boots
+    - item_name: Wizard boots
+      slug: wizard-boots
+      relationship: alternative
+      description: Alternative magic boots with +4 magic defence
+    - item_name: Infinity boots
       slug: infinity-boots
       relationship: upgrade
-      description: Upgraded magic boots
-  about: |-
-    > *"Magical boots."*
-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +3 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +3 |
-
-    Requirements: 40 Magic, 20 Defence
-
-    Weight: 0.453 kg
-
-    | Variant | Source | Stats |
-    |---------|--------|-------|
-    | Mystic boots (blue) | Slayer monsters, shops, implings | Identical |
-    | Mystic boots (dark) | Slayer monsters | Identical |
-    | Mystic boots (light) | Aberrant spectres | Identical |
-    | Mystic boots (dusk) | Hallowed Sepulchre | Identical |
-
-    All colour variants share identical stats — the difference is purely cosmetic.
-
-    | Stat | Mystic Boots | Infinity Boots | Eternal Boots |
-    |------|-------------|----------------|---------------|
-    | Magic Atk | +3 | +5 | +8 |
-    | Magic Def | +3 | +5 | +8 |
-    | Req | 40 Mage/20 Def | 50 Mage/25 Def | 75 Mage/75 Def |
-
-    Mystic boots are the standard budget magic footwear. Infinity boots offer a direct upgrade at higher requirements.
-
-    - Standard magic boots for Barrows runs
-    - Budget magic footwear for Slayer tasks
-    - Common PKing boots (cheap to risk)
-    - Entry-level magic footwear before Infinity or Eternal boots
+      description: Higher tier magic boots (+5 magic atk/def)
+  about: "Mystic boots are the magic-set footwear introduced with the Slayer skill. Requiring 40 Magic and 20 Defence, they provide +3 magic attack and +3 magic defence. They're sold at the Wizards' Guild in Yanille and drop from Hammerhead sharks and Veiled kraken, with colour variants (blue, dark, light, dusk, shattered) sharing identical stats."
   market_strategy:
     notes:
-      - Implings are a good source for ironmen
-      - Very affordable magic boot option
-      - Dark/dusk variants trade at a cosmetic premium
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap risk-friendly magic boots for PKers and ironmen"
+      - "Implings provide steady supply for solo accounts"
+      - "Dark/dusk cosmetic variants trade at a premium"
+  trading_tips:
+    - Stock up when Slayer monster popularity dips for resale into PvP metas
+  history:
+    - date: "2005-01-26"
+      description: "Released with the Slayer skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-bottom-dark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-bottom-dark.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 70
-  about: "Mystic robe bottom (dark) is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mystic
+    tier: mid-high
+  properties:
+    release_date: "26 January 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Aberrant spectre
+        quantity: "1"
+        rarity: 1/512
+      - source: Deviant spectre
+        quantity: "1"
+        rarity: 1/512
+      - source: Repugnant spectre
+        quantity: "1"
+        rarity: 3/512
+  related_items:
+    - item_name: Mystic robe top (dark)
+      slug: mystic-robe-top-dark
+      relationship: set-piece
+      description: "Matching body piece of the dark mystic robe set"
+    - item_name: Mystic hat (dark)
+      slug: mystic-hat-dark
+      relationship: set-piece
+      description: "Matching head piece of the dark mystic robe set"
+    - item_name: Mystic robe bottom
+      slug: mystic-robe-bottom
+      relationship: variant
+      description: "Standard (blue) variant of the mystic robe bottom"
+    - item_name: Mystic robe bottom (light)
+      slug: mystic-robe-bottom-light
+      relationship: variant
+      description: "Light-coloured cosmetic variant"
+  about: |-
+    Mystic robe bottom (dark) is the leg piece of the dark mystic robe set, providing 40 Magic and 20 Defence-locked magic attack and defence bonuses. It is dropped by the spectre family of slayer monsters.
+
+    Mechanically identical to other mystic robe bottom colour variants, distinguished only by its dark appearance.
+  market_strategy:
+    notes:
+      - "Cosmetic re-skin of standard mystic robe bottom"
+      - "Supply tied to spectre slayer task popularity"
+  trading_tips:
+    - Pair with matching dark hat and top for set premium
+    - Cheaper than dark trim variant but more expensive than blue base
+  history:
+    - date: "26 January 2005"
+      description: "Released with the Slayer skill."
+    - date: "30 October 2014"
+      description: "Renamed from 'Dark mystic robe bottom' to disambiguate the colour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nardah-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nardah-teleport.mdx
@@ -12,51 +12,70 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: teleport_scroll
-    destination: Nardah
+    tier: low
+  properties:
+    release_date: "2014-06-12"
     tradeable: true
     stackable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite/Master
-        drop_rate: Varies by tier
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Teleport
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/340.5
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/203
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/190.6
   related_items:
-    - item_id: 12403
-      item_name: Digsite teleport
+    - item_name: Digsite teleport
       slug: digsite-teleport
       relationship: alternative
-      description: Another clue teleport scroll
+      description: Sibling clue-scroll teleport scroll
+    - item_name: Spirits of the Elid
+      slug: spirits-of-the-elid
+      relationship: alternative
+      description: Quest that unlocks Elidinis Statuette utility at the destination
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Teleport Scroll |
-    | Destination | Nardah |
-    | Tradeable | Yes |
-    | Stackable | Yes |
+    The Nardah teleport is a stackable scroll obtained from Treasure Trails reward caskets across the easy, medium, hard, elite, and master tiers. Right-click "Teleport" to travel directly to Nardah in the Kharidian Desert, near both the bank and Desert diary NPCs.
 
-    Right-click and select "Teleport" to travel to Nardah.
-
-    Teleport Location:
-    - Nardah in the Kharidian Desert
-    - Near the bank
-    - Close to Desert Diary NPCs
-
-    - Desert Treasure quest
-    - Elidinis Statuette (restore stats)
-    - Desert diary completion
-    - Faster than walking through desert
+    After completing Spirits of the Elid, players can use the scroll for fast access to the Elidinis Statuette, which restores prayer points, run energy, special attack energy, and hitpoints — a popular utility for Barrows and other restore-heavy activities.
   market_strategy:
     notes:
-      - Useful for desert activities
-      - Stock up for clue hunting
-      - Cheaper than construction teleport
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap utility teleport for desert content"
+      - "Stock up for clue hunting and statuette restores"
+      - "Cheaper than building the Nardah construction teleport"
+  history:
+    - date: "2014-06-12"
+      description: "Nardah teleport scroll added as a Treasure Trails reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-dresser-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-dresser-flatpack.mdx
@@ -12,12 +12,70 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak dresser (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Assemble
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 37
+      xp: 121
+      materials:
+        - item_name: Oak plank
+          quantity: 2
+        - item_name: Molten glass
+          quantity: 1
+      tools:
+        - Hammer
+        - Saw
+        - Oak workbench
+      output_quantity: 1
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Primary build material for the flatpack
+    - item_name: Molten glass
+      slug: molten-glass
+      relationship: component
+      description: Required component for the dresser
+    - item_name: Mahogany dresser (flatpack)
+      slug: mahogany-dresser-flatpack
+      relationship: upgrade
+      description: Higher-tier dresser flatpack variant
+  about: |-
+    Oak dresser (flatpack) is a Construction flatpack that assembles into an oak dresser furniture piece for a player-owned house bedroom. Building it requires level 37 Construction and grants 121 experience, taking 5 ticks (3 seconds) at an oak workbench.
+
+    Flatpacks are produced at the workbench from 2 oak planks and 1 molten glass with a hammer and saw, letting players sell or trade construction work to others.
+  market_strategy:
+    notes:
+      - "Net loss to manually flatpack at current GE prices"
+      - "Useful for Construction XP without storing furniture"
+      - "Stable buy limit but low daily volume"
+  trading_tips:
+    - Watch oak plank price for break-even windows on flatpacking
+  history:
+    - date: "2006-05-31"
+      description: "Oak dresser (flatpack) added with the Player-Owned Houses update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-fancy-dress-box-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-fancy-dress-box-flatpack.mdx
@@ -12,12 +12,65 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak fancy dress box (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+  recipes:
+    - skill: construction
+      level: 44
+      xp: 120
+      materials:
+        - item_name: Oak plank
+          quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Teak fancy dress box (flatpack)
+      slug: teak-fancy-dress-box-flatpack
+      relationship: upgrade
+      description: Higher-tier teak variant of this furniture flatpack.
+    - item_name: Mahogany fancy dress box (flatpack)
+      slug: mahogany-fancy-dress-box-flatpack
+      relationship: upgrade
+      description: Top-tier mahogany variant.
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Primary material used to build this flatpack.
+  about: "Oak fancy dress box (flatpack) is a Player-owned house furniture pack built at a steel framed workbench. Used on the fancy dress box space in the costume room to store outfits."
+  market_strategy:
+    notes:
+      - "Cheap construction XP method when oak planks are inexpensive."
+      - "Demand fluctuates with PoH costume room popularity."
+  trading_tips:
+    - Buy bulk during oak plank price dips for resale flips.
+    - Pairs with teak and mahogany variants for diversified flatpack inventory.
+  history:
+    - date: "2006-10-18"
+      description: "Item released with the Costume Room update."
+    - date: "2015-02-26"
+      description: "Item renamed from \"Oak fdb\" to its full name."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-longbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-longbow-u.mdx
@@ -12,23 +12,80 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: unstrung_bow
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.332
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 25
+      xp: 25
+      materials:
+        - item_name: Oak logs
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+    - skill: fletching
+      level: 25
+      xp: 25
+      materials:
+        - item_name: Oak longbow (u)
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 48
-      item_name: Longbow (u)
+    - item_name: Longbow (u)
       slug: longbow-u
       relationship: variant
-      description: Lower tier unstrung longbow
-    - item_id: 54
-      item_name: Oak shortbow (u)
+      description: Lower-tier unstrung longbow
+    - item_name: Oak shortbow (u)
       slug: oak-shortbow-u
       relationship: variant
       description: Matching unstrung oak shortbow
+    - item_name: Oak longbow
+      slug: oak-longbow
+      relationship: product
+      description: Strung version made with a bowstring
+    - item_name: Oak logs
+      slug: oak-logs
+      relationship: component
+      description: Raw material cut into the bow shape
+    - item_name: Bow string
+      slug: bow-string
+      relationship: component
+      description: Added to string the bow
   about: |-
-    > _"An unstrung oak longbow; I need a bowstring for this."_
-
-    The oak longbow (u) is an unstrung longbow made from oak logs. String with a bowstring at 25 Fletching to create an oak longbow. Members only.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Oak longbow (u) is the unstrung form of the Oak longbow. Cut from oak logs with a knife at 25 Fletching for 25 XP. String with a bowstring (also at 25 Fletching, 25 XP) to create an Oak longbow. Members only.
+  market_strategy:
+    notes:
+      - "Buy oak logs, fletch, sell unstrung longbows"
+      - "Compare against strung Oak longbow margin"
+      - "Buy limit of 10,000 per 4 hours"
+      - "Common low-level Fletching training output"
+  history:
+    - date: "2002-03-25"
+      description: "Released alongside the Fletching skill."
+    - date: "2005-05-17"
+      description: "Renamed from Oak longbow to Oak longbow (u)."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-plank.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-plank.mdx
@@ -12,102 +12,88 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: plank
     tier: low
-  construction:
-    xp_per_plank: 60
-    common_builds:
-      - name: Oak larders
-        planks: 8
-        xp: 480
-      - name: Oak dungeon doors
-        planks: 10
-        xp: 600
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: construction
+      level: 15
+      xp: 60
       materials:
         - item_name: Oak logs
-          item_id: 1521
           quantity: 1
-      product: Oak plank
-      product_id: 8778
-      product_quantity: 1
-      facility: Sawmill
-      cost: 250
-      members_only: true
+        - item_name: Coins
+          quantity: 250
+      tools: []
+      output_quantity: 1
     - skill: magic
       level: 86
       xp: 90
       materials:
         - item_name: Oak logs
-          item_id: 1521
           quantity: 1
         - item_name: Astral rune
-          item_id: 9075
           quantity: 2
         - item_name: Nature rune
-          item_id: 561
           quantity: 1
         - item_name: Earth rune
-          item_id: 557
           quantity: 15
-      product: Oak plank
-      product_id: 8778
-      product_quantity: 1
-      cost: 175
-      members_only: true
-      spell: Plank Make
+        - item_name: Coins
+          quantity: 175
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 1521
-      item_name: Oak logs
+    - item_name: Oak logs
       slug: oak-logs
       relationship: component
-      description: Raw material
-    - item_id: 960
-      item_name: Plank
+      description: Raw material converted to planks at the sawmill
+    - item_name: Plank
       slug: plank
       relationship: alternative
-      description: Lower tier (regular logs)
-    - item_id: 8780
-      item_name: Teak plank
+      description: Lower-tier plank from regular logs
+    - item_name: Teak plank
       slug: teak-plank
       relationship: alternative
-      description: Mid tier
-    - item_id: 8782
-      item_name: Mahogany plank
+      description: Mid-tier construction plank
+    - item_name: Mahogany plank
       slug: mahogany-plank
       relationship: alternative
-      description: Highest tier
-    - item_id: 9075
-      item_name: Astral rune
+      description: Highest-tier construction plank
+    - item_name: Astral rune
       slug: astral-rune
       relationship: component
-      description: For Plank Make
+      description: Required for the Plank Make spell
   about: |-
-    | XP per plank | 60 |
-    |--------------|-----|
-    | Buy limit | 13,000 per 4 hours |
-
-    Common builds:
-    - Oak larders (8 planks, 480 XP) - popular training method
-    - Oak dungeon doors (10 planks, 600 XP)
-    - Mahogany Homes contracts (~variable XP)
+    Oak plank is a construction material made by paying 250 coins per oak log at a sawmill, or by casting Plank Make (Lunar Magic, requires Dream Mentor) for 86 Magic and 90 XP. Grants 60 Construction XP when built into furniture. Used in popular training methods like Oak larders and Oak dungeon doors.
   market_strategy:
-    profit_formulas:
-      - Oak plank price - Oak log price - 250 GP = Profit
     notes:
-      - Buy Oak logs → Sawmill → Sell Oak planks
-      - "Calculate:"
-      - 86 Magic required
-      - "Uses: 2 Astral rune, 1 Nature rune, 15 Earth rune"
-      - Only 175 GP per plank (cheaper than sawmill)
-      - Can profit if rune costs are lower than 75 GP savings
-      - High volume item for Construction training
-      - Steady demand from Mahogany Homes
-      - Compare sawmill vs Plank Make profitability
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy oak logs cheap, convert at sawmill, sell planks"
+      - "Plank Make spell cuts cost to 175 GP per plank"
+      - "High buy limit of 13,000 per 4 hours"
+      - "Steady demand from Mahogany Homes contracts"
+  trading_tips:
+    - Compare oak log spot price to plank price for sawmill margin
+    - Plank Make profitability swings with rune prices
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Construction skill and Player-Owned Houses update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-pyre-logs.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 11000
-  about: "Oak pyre logs is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: pyre_logs
+    tier: low
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 1
+      xp: 10
+      materials:
+        - item_name: Oak logs
+          quantity: 1
+        - item_name: Sacred oil(1)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Oak logs
+      slug: oak-logs
+      relationship: component
+      description: Base log treated with sacred oil
+    - item_name: Sacred oil(1)
+      slug: sacred-oil-1
+      relationship: component
+      description: Sanctifies the logs for funeral pyres
+    - item_name: Pyre logs
+      slug: pyre-logs
+      relationship: alternative
+      description: Lower-tier regular pyre log
+    - item_name: Willow pyre logs
+      slug: willow-pyre-logs
+      relationship: alternative
+      description: Higher-tier pyre log variant
+  about: |-
+    Oak pyre logs are used in the Shades of Mort'ton minigame to cremate shade remains. Lighting requires level 20 Firemaking and a tinderbox. Burning oak pyre logs with Loar or Phrin remains grants 70 Firemaking XP plus Prayer XP from the cremated shade. Made by using a dose of sacred oil on oak logs at level 1 Firemaking for 10 XP.
+  market_strategy:
+    notes:
+      - "Demand tied to Shades of Mort'ton activity"
+      - "Margin depends on sacred oil supply"
+      - "Buy limit of 11,000 per 4 hours"
+      - "Bulk profit from oak log + oil arbitrage"
+  history:
+    - date: "2004-10-18"
+      description: "Released as part of the Shades of Mort'ton minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/odium-shard-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/odium-shard-1.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 12400
   highalch: 18600
   limit: 10000
-  about: "Odium shard 1 is a members-only item in Old School RuneScape. High alchemy value: 18,600 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: shield_shard
+    tier: high
+  properties:
+    release_date: "2014-03-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Chaos Fanatic
+        quantity: "1"
+        rarity: 1/256
+  related_items:
+    - item_name: Odium shard 2
+      slug: odium-shard-2
+      relationship: set-piece
+      description: Second shard, combines into Odium ward
+    - item_name: Odium shard 3
+      slug: odium-shard-3
+      relationship: set-piece
+      description: Third shard, combines into Odium ward
+    - item_name: Odium ward
+      slug: odium-ward
+      relationship: product
+      description: Combined ranged shield at Blighted Volcano
+    - item_name: Malediction shard 1
+      slug: malediction-shard-1
+      relationship: alternative
+      description: Magic shield counterpart shard
+  about: |-
+    Odium shard 1 is one of three shards used to forge an Odium ward, a ranged-attack shield. Combine all three Odium shards at the Blighted Volcano in the northeastern Wilderness; no skills or XP required. Dropped exclusively by the Chaos Fanatic at 1/256.
+  market_strategy:
+    notes:
+      - "Supply gated by Wilderness boss kills"
+      - "High alch value supports floor price"
+      - "Demand swings with Odium ward popularity"
+      - "Buy limit of 10,000 per 4 hours"
+  history:
+    - date: "2014-03-13"
+      description: "Released alongside the Odium ward as part of the Wilderness boss expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pearl-dragon-bolts.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 11000
-  about: "Pearl dragon bolts is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: bolts
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 64
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 84
+      xp: 3.2
+      materials:
+        - item_name: Dragon bolts
+          quantity: 1
+        - item_name: Pearl bolt tips
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Pearl dragon bolts (e)
+      slug: pearl-dragon-bolts-e
+      relationship: upgrade
+      description: Enchanted version with Sea Curse proc
+    - item_name: Dragon bolts
+      slug: dragon-bolts
+      relationship: component
+      description: Unfinished dragon bolt base
+    - item_name: Pearl bolt tips
+      slug: pearl-bolt-tips
+      relationship: component
+      description: Tip attached for Fletching
+    - item_name: Pearl bolts
+      slug: pearl-bolts
+      relationship: downgrade
+      description: Mithril-grade pearl variant
+  about: "Pearl dragon bolts are dragon crossbow bolts tipped with pearl, requiring 64 Ranged to wield. They provide +122 ranged strength, the same as base dragon bolts, and can be enchanted into pearl dragon bolts (e) for the Sea Curse passive proc — strong against water-aligned dragons and certain bosses."
+  market_strategy:
+    notes:
+      - "Price floor tracks dragon bolt + pearl tip composite"
+      - "Demand driven by Magic enchanting and PvM consumption"
+      - "Buy limit (11k per 4 hours) allows steady accumulation"
+  trading_tips:
+    - Spread vs unenchanted (e) variant is the key edge
+    - Watch DXP weekends for Fletching-driven dumps
+  history:
+    - date: "2018-01-04"
+      description: "Added alongside Dragon Slayer II content."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-chunks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-chunks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pineapple chunks | OSRS Price Data
-description: "Pineapple chunks: Fresh chunks of pineapple.. High alch: 1 GP, GE limit: 13,000."
+description: "Pineapple chunks: Fresh chunks of pineapple. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 2116
   name: Pineapple chunks
@@ -12,9 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Pineapple chunks is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.12
+    options:
+      - Eat
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 25
+      xp: 70
+      materials:
+        - item_name: Cooking apple
+          quantity: 1
+        - item_name: Orange
+          quantity: 1
+        - item_name: Pineapple chunks
+          quantity: 1
+        - item_name: Batta tin
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Pineapple
+      slug: pineapple
+      relationship: component
+      description: Diced with a knife to produce chunks
+    - item_name: Pineapple ring
+      slug: pineapple-ring
+      relationship: alternative
+      description: Alternative slicing output from the same fruit
+    - item_name: Pineapple pizza
+      slug: pineapple-pizza
+      relationship: product
+      description: Both chunks and rings can top pizzas
+  about: "Pineapple chunks are produced by using a knife on a pineapple or tenti pineapple with the dice option. They're used in pineapple pizza, fruit batta at 25 Cooking, and several gnome cocktails (pineapple punch, wizard blizzard, drunk dragon). Eating restores 2 HP."
+  market_strategy:
+    notes:
+      - "Demand tied to gnome cooking trainers and pizza makers"
+      - "Slicing from raw pineapples can profit when chunk price is high"
+  trading_tips:
+    - Track gnome cooking guide cycles for spikes
+  history:
+    - date: "2002-12-12"
+      description: "Added to OSRS as part of the gnome cooking and pizza updates."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-ring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pineapple ring | OSRS Price Data
-description: "Pineapple ring: Exotic fruit.. High alch: 1 GP, GE limit: 13,000."
+description: "Pineapple ring: Exotic fruit. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 2118
   name: Pineapple ring
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Pineapple ring is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-08-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Eat
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 65
+      xp: 188
+      materials:
+        - item_name: Plain pizza
+          quantity: 1
+        - item_name: Pineapple ring
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Pineapple
+      slug: pineapple
+      relationship: component
+      description: Sliced with a knife to produce 4 rings
+    - item_name: Pineapple chunks
+      slug: pineapple-chunks
+      relationship: alternative
+      description: Alternative dicing output from the same fruit
+    - item_name: Pineapple pizza
+      slug: pineapple-pizza
+      relationship: product
+      description: Created by adding a ring to a plain pizza
+  about: "Pineapple ring is produced by using a knife on a pineapple or tenti pineapple and selecting the slice option, yielding 4 rings per fruit. The primary use is adding to a plain pizza at 65 Cooking to make a pineapple pizza. Heals 2 HP when eaten."
+  market_strategy:
+    notes:
+      - "Profitable to slice from raw pineapples during low-supply windows"
+      - "Demand driven by Cooking trainers making pineapple pizzas"
+  trading_tips:
+    - Compare pineapple cost vs ring price for slicing arbitrage
+  history:
+    - date: "2002-08-15"
+      description: "Released as part of the early fruit and cooking content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-hat-patch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-hat-patch.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 150
-  about: "Pirate hat & patch is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.002
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Big pirate hat
+      slug: big-pirate-hat
+      relationship: component
+      description: One half of the combined cosmetic
+    - item_name: Right eye patch
+      slug: right-eye-patch
+      relationship: component
+      description: Second half of the combined cosmetic
+  about: "Pirate hat & patch is a cosmetic head slot item created by combining a big pirate hat with a right eye patch through Patchy on Mos Le'Harmless for 500 coins. Requires completion of Cabin Fever and offers no combat bonuses. High alchemy value: 1,800 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - "Cosmetic demand limited to fashionscape collectors"
+      - "Supply throttled by Cabin Fever requirement and 500 gp combine fee"
+      - "Storable in costume room treasure chest"
+  trading_tips:
+    - Cheaper to assemble from parts than buy outright when GE is thin
+    - Margin opportunities around pirate-themed holiday events
+  history:
+    - date: "2014-06-12"
+      description: "Item released as a combinable cosmetic via Patchy on Mos Le'Harmless."
+    - date: "2015-07-16"
+      description: "Female model adjusted so the hat now sits in place with a female character's head."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-leggings-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-leggings-brown.mdx
@@ -12,12 +12,95 @@ osrs:
   lowalch: 140
   highalch: 210
   limit: 150
-  about: "Pirate leggings (brown) is a members-only item in Old School RuneScape. High alchemy value: 210 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "31 March 2004"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Dodgy Mike's Second-hand Clothing
+      location: Mos Le'Harmless
+      price: 200
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Pirate leggings (blue)
+      slug: pirate-leggings-blue
+      relationship: variant
+      description: Blue colour variant
+    - item_name: Pirate leggings (beige)
+      slug: pirate-leggings-beige
+      relationship: variant
+      description: Beige colour variant
+    - item_name: Pirate leggings (red)
+      slug: pirate-leggings-red
+      relationship: variant
+      description: Red colour variant
+    - item_name: Pirate bandana (brown)
+      slug: pirate-bandana-brown
+      relationship: set-piece
+      description: Matching brown pirate bandana
+    - item_name: Pirate shirt (brown)
+      slug: pirate-shirt-brown
+      relationship: set-piece
+      description: Matching brown pirate shirt
+  about: "Pirate leggings (brown) are a fashionscape legs slot item sold by Dodgy Mike's Second-hand Clothing on Mos Le'Harmless. They have no combat stats and are worn purely for cosmetic appeal, completing the brown pirate outfit alongside the matching bandana and shirt. One of four colour variants of the pirate leggings."
+  market_strategy:
+    notes:
+      - "Cheap shop-bought fashionscape gear"
+      - "Mos Le'Harmless requires Cabin Fever quest access"
+      - "Limited daily trade volume"
+      - "Demand tied to outfit collectors"
+  trading_tips:
+    - Bulk-purchase from Dodgy Mike for quick GE resale
+    - Track colour variant price gaps
+    - Outfit completion drives bursty demand
+  history:
+    - date: "31 March 2004"
+      description: "Item was added to the game with the Cabin Fever release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pointed-bruise-blue-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pointed-bruise-blue-snelm.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Pointed bruise blue snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: snail-shell
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 6
+      magic: -1
+      ranged: 7
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish blue shell (pointed)
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_name: Round bruise blue snelm
+      slug: round-bruise-blue-snelm
+      relationship: variant
+      description: Rounded shell variant
+    - item_name: Blamish blue shell (pointed)
+      slug: blamish-blue-shell-pointed
+      relationship: component
+      description: Raw shell crafted into the snelm
+    - item_name: Pointed myre snelm
+      slug: pointed-myre-snelm
+      relationship: alternative
+      description: Other pointed snelm variant
+  about: "Pointed bruise blue snelm is a head slot helmet crafted from a Blamish blue shell (pointed) using a chisel at 15 Crafting. It reduces damage taken from snails by 12 and provides surprisingly competitive low-level melee defence. Released with the Morytania Expansion."
+  market_strategy:
+    notes:
+      - "Supply driven by Mort Myre snail kills and crafting alts"
+      - "Buy limit (150) caps flips meaningfully"
+      - "Demand is low outside collection log hunters"
+  trading_tips:
+    - Margin tends to widen during snail farming events
+    - Stockpile during double XP for crafting alt dumps
+  history:
+    - date: "2004-10-14"
+      description: "Released with the Morytania Expansion."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/poison-item.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/poison-item.mdx
@@ -12,18 +12,57 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
+  material:
+    type: quest-utility
+    tier: low
+  properties:
+    release_date: "2001-01-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: true
+    weight: 0.02
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Rasolo the Wandering Merchant
+      location: South of Baxtorian Falls
+      price: 2
+      currency: coins
+      stock: 1
+    - shop_name: The Lighthouse Store
+      location: Lighthouse
+      price: 1
+      currency: coins
+      stock: 1
   related_items:
-    - item_id: 272
-      item_name: Fish food
+    - item_name: Fish food
       slug: fish-food
       relationship: component
-      description: Combined to make poisoned fish food
-  about: |-
-    > _"This stuff looks nasty."_
-
-    Poison is a quest item used in Ernest the Chicken (combined with fish food) and Hazeel Cult. A simple utility item with no combat application.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Combined with poison to make poisoned fish food
+    - item_name: Poisoned fish food
+      slug: poisoned-fish-food
+      relationship: product
+      description: Used in Ernest the Chicken to kill piranhas
+  about: "Poison is a quest item used in Ernest the Chicken — combined with fish food to poison the piranhas in the Draynor Manor fountain — and applied to the Carnillean household's food during Hazeel Cult. Attempting to use it on the sheep in Sheep Herder is refused. Also spawns at Draynor Manor for free-to-play players."
+  market_strategy:
+    notes:
+      - "Almost no flip margin; mostly self-supplied via Draynor spawn"
+      - "Buy limit of 15 caps any speculative play"
+      - "Demand is steady-trickle from quest-grinders"
+  trading_tips:
+    - Just grab a spawn for personal use rather than flipping
+    - Shop refresh at Rasolo gives a thin instant fill if needed
+  history:
+    - date: "2001-01-21"
+      description: "Added with Ernest the Chicken on the original RuneScape release wave."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Prayer mix(1) | OSRS Price Data
-description: "Prayer mix(1): One dose of fishy Prayer potion.. High alch: 45 GP, GE limit: 2,000."
+description: "Prayer mix(1): One dose of fishy Prayer potion. High alch: 45 GP, GE limit: 2,000."
 osrs:
   id: 11467
   name: Prayer mix(1)
@@ -12,9 +12,72 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 2000
-  about: "Prayer mix(1) is a members-only item in Old School RuneScape. High alchemy value: 45 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 7-31 Prayer points (8-33 with a holy wrench equipped) and heals 6 Hitpoints per dose."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 42
+      xp: 29
+      materials:
+        - item_name: Prayer potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Prayer mix(2)
+      slug: prayer-mix-2
+      relationship: variant
+      description: Two-dose version of the same Barbarian Herblore mix.
+    - item_name: Prayer potion(2)
+      slug: prayer-potion-2
+      relationship: component
+      description: Base potion mixed with caviar to create Prayer mix.
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore secondary required for the mix.
+  about: |-
+    Prayer mix(1) is the Barbarian Herblore variant of a Prayer potion - a single dose that restores 7-31 Prayer points and incidentally heals 6 Hitpoints when sipped. With a holy wrench equipped the Prayer restore range becomes 8-33.
+
+    The mix is created by using caviar on a Prayer potion(2) at 42 Herblore, granting 29 Herblore experience and turning the 2-dose into a single-dose Prayer mix. Barbarian Training (Otto Godblessed) must be completed before mixing.
+
+    Requirements: 42 Herblore | Slot: None | Single dose.
+  market_strategy:
+    notes:
+      - "Niche product - mostly an intermediate for those grinding Herblore XP."
+      - "High alch (45 gp) keeps a hard price floor near alch parity."
+      - "GE limit of 2,000 means bulk buyers cap out quickly."
+  trading_tips:
+    - Watch caviar and Prayer potion(2) margins for mix arbitrage.
+    - Best margin moves come during DMM/league prep weeks.
+  history:
+    - date: "2007-07-03"
+      description: "Released with the Barbarian Training update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-2.mdx
@@ -12,46 +12,66 @@ osrs:
   lowalch: 45
   highalch: 68
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   potion:
-    doses: 2
-    herblore_level: 38
-    herblore_xp: 87.5
-    effect: Restores 7-31 Prayer points based on Prayer level
     effects:
-      - stat: Prayer
-        boost_formula: 7 + floor(level / 4)
+      - description: "Restores Prayer points using the formula 7 + floor(Prayer level / 4) per dose."
+        duration: 0
+      - description: "When wearing a Prayer cape, Max cape, or ring of the gods (i), or carrying a Holy wrench: restores 7 + floor(Prayer level * 0.27) per dose."
+        duration: 0
   related_items:
-    - item_id: 2434
-      item_name: Prayer potion(4)
+    - item_name: Prayer potion(4)
       slug: prayer-potion-4
       relationship: variant
-      description: 4-dose version
-    - item_id: 139
-      item_name: Prayer potion(3)
+      description: 4-dose version with the same effect
+    - item_name: Prayer potion(3)
       slug: prayer-potion-3
       relationship: variant
       description: 3-dose version
-    - item_id: 143
-      item_name: Prayer potion(1)
+    - item_name: Prayer potion(1)
       slug: prayer-potion-1
       relationship: variant
       description: 1-dose version
-    - item_id: 3024
-      item_name: Super restore(4)
+    - item_name: Super restore(4)
       slug: super-restore-4
       relationship: upgrade
-      description: Also restores stats
-  about: 2-dose variant of Prayer potion.
+      description: Also restores stats and prayer
+  about: "Prayer potion(2) is a 2-dose Herblore potion that restores Prayer points. Each dose heals 7 + floor(Prayer level / 4) prayer, increased to 7 + floor(Prayer level * 0.27) when wearing a Holy wrench, Prayer cape, Max cape, or ring of the gods (i). Brewed at 38 Herblore by combining a ranarr potion (unf) with snape grass for a Prayer potion(3); doses split or decant to this 2-dose variant."
   market_strategy:
     notes:
-      - Compare to 4-dose price
-      - Decanting can profit
-      - Use decanting NPC in GE
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Compare 2-dose price against 1/2 of a 4-dose for decant arbitrage"
+      - "Decanting NPCs at the Grand Exchange convert doses for profit when ratios diverge"
+      - "Buy limit of 2,000 supports large-scale flipping"
+  trading_tips:
+    - Watch the per-dose spread across all four prayer potion variants
+    - Buy when the per-dose price is below the 4-dose equivalent, then decant up
+  history:
+    - date: "2002-02-27"
+      description: "Released as part of the Herblore skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-choc-s-dy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-choc-s-dy.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Premade choc s'dy is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: Restores 5 Hitpoints.
+        duration: 0
+      - description: Lowers Attack by 2 plus an additional level.
+        duration: 0
+      - description: Boosts Strength by 5% plus 2 levels.
+        duration: 0
+  shops:
+    - shop_name: Blurberry Bar
+      location: Grand Tree
+      price: 30
+      currency: Coins
+      stock: 2
+    - shop_name: Gnome Stronghold cocktail shop
+      location: Gnome Stronghold
+      price: 30
+      currency: Coins
+      stock: 2
+  related_items:
+    - item_name: Chocolate saturday
+      slug: chocolate-saturday
+      relationship: alternative
+      description: Player-crafted equivalent of the premade cocktail.
+    - item_name: Premade fr't crunchies
+      slug: premade-fr-t-crunchies
+      relationship: alternative
+      description: Another premade gnome cuisine from Blurberry Bar.
+  about: "Premade choc s'dy is the shop version of the Chocolate Saturday gnome cocktail, sold at Blurberry Bar in the Grand Tree. It restores 5 Hitpoints while granting a 5% plus 2 level Strength boost in exchange for a small Attack drain. Cannot be used in the Gnome Restaurant minigame."
+  market_strategy:
+    notes:
+      - "Restock-limited supply at 30 coins makes shop-to-GE flips reliable when GE price drifts above 60."
+      - "Demand is steady from low-level pures and skillers wanting Strength boosts."
+  trading_tips:
+    - Hop worlds for Blurberry Bar restocks to maximise per-trip volume.
+    - Note the cocktail before banking to halve trip count.
+  history:
+    - date: "2006-08-07"
+      description: "Renamed from 'Choc saturday' to 'Premade choc s'dy' and graphically updated alongside the Gnome Restaurant overhaul."
+    - date: "2002-12-12"
+      description: "Released with the Gnome Restaurant minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/primordial-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/primordial-crystal.mdx
@@ -12,69 +12,76 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 15
-  item:
-    type: crafting_material
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crystal
+    tier: high
+  properties:
+    release_date: "2015-08-27"
     tradeable: true
-  obtaining:
-    methods:
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
       - source: Cerberus
-        drop_rate: 1/520
-        requirements:
-          slayer: 91
-  creation:
-    creates:
-      item_id: 13239
-      item_name: Primordial boots
-      slug: primordial-boots
-    combine_with:
-      item_id: 11840
-      item_name: Dragon boots
-      slug: dragon-boots
-    requirements:
-      magic: 60
-      runecraft: 60
-    warning: Irreversible process
+        quantity: "1"
+        rarity: 1/520
+  recipes:
+    - skill: magic
+      level: 60
+      xp: 200
+      materials:
+        - item_name: Dragon boots
+          quantity: 1
+        - item_name: Primordial crystal
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 0
-      item_name: Cerberus
+    - item_name: Cerberus
       slug: cerberus
       relationship: component
-      description: Boss drop
-    - item_id: 13239
-      item_name: Primordial boots
+      description: Boss source of the primordial crystal drop
+    - item_name: Primordial boots
       slug: primordial-boots
       relationship: product
-      description: Created item
-    - item_id: 13229
-      item_name: Pegasian crystal
+      description: Boots created by combining the crystal with dragon boots
+    - item_name: Pegasian crystal
       slug: pegasian-crystal
       relationship: alternative
-      description: Ranged version
+      description: Ranged equivalent dropped by Cerberus
+    - item_name: Eternal crystal
+      slug: eternal-crystal
+      relationship: alternative
+      description: Magic equivalent dropped by Cerberus
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Stackable | No |
+    The primordial crystal is a rare drop from Cerberus (1/520) that combines with dragon boots to produce primordial boots, the best-in-slot melee strength boots. The combination requires level 60 Magic and 60 Runecraft (no boosts), grants 200 experience in both skills, and is irreversible.
 
-    Combine with Dragon boots to create Primordial boots.
-
-    | Requirement | Level |
-    |-------------|-------|
-    | Magic | 60 |
-    | Runecraft | 60 |
-
-    Warning: Irreversible process.
+    Cerberus requires 91 Slayer to fight, so most players farm the boss while on a hellhound task to maximise value.
   market_strategy:
     notes:
-      - Most valuable Cerberus crystal
-      - Creates BiS melee boots
-      - Farm Cerberus on task
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Most valuable Cerberus crystal of the three"
+      - "Creates BiS melee strength boots, demand is steady"
+      - "Farm Cerberus on task for compounded slayer xp"
+      - "Buy limit of 15 keeps swing rooms tight"
+  trading_tips:
+    - Hold during boss flips when dragon boots crash
+  history:
+    - date: "2015-08-27"
+      description: "Primordial crystal released as a rare drop from Cerberus."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pumpkin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pumpkin.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 50
-  about: "Pumpkin is a free-to-play item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2001-10-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: Edible
+      description: "Heals 14 Hitpoints when consumed."
+  drop_table:
+    sources:
+      - source: 2001 Halloween event
+        quantity: "1"
+        rarity: Always
+      - source: 2013 Rare Drops event
+        quantity: "1"
+        rarity: Varies
+  related_items:
+    - item_name: Jack lantern mask
+      slug: jack-lantern-mask
+      relationship: set-piece
+      description: Halloween holiday cosmetic
+    - item_name: Scythe
+      slug: scythe
+      relationship: set-piece
+      description: Halloween holiday cosmetic
+    - item_name: Zombie head
+      slug: zombie-head
+      relationship: set-piece
+      description: Halloween holiday cosmetic
+  about: |-
+    > *"Happy Halloween."*
+
+    Holiday food from the 2001 Halloween event. Heals 14 Hitpoints but is far more valuable as a collector's item — note it before listing to avoid the eat-by-accident pitfall.
+  market_strategy:
+    notes:
+      - "Holiday supply is fixed; price drifts upward over time"
+      - "Always note before listing to avoid accidental consumption"
+  trading_tips:
+    - Watch for seasonal spikes around real-world Halloween
+  history:
+    - date: "2001-10-31"
+      description: "Released during the original 2001 Halloween event."
+    - date: "2013-06-10"
+      description: "Reissued via the Rare Drops event."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-hat.mdx
@@ -12,12 +12,91 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Purple hat is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "29 June 2004"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 650
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Grey hat
+      slug: grey-hat
+      relationship: variant
+      description: Alternative colour
+    - item_name: Red hat
+      slug: red-hat
+      relationship: variant
+      description: Alternative colour
+    - item_name: Yellow hat
+      slug: yellow-hat
+      relationship: variant
+      description: Alternative colour
+    - item_name: Teal hat
+      slug: teal-hat
+      relationship: variant
+      description: Alternative colour
+  about: "The purple hat is a fashionscape head slot item sold by Barkers' Haberdashery in Canifis. It provides minor magic bonuses (+3 attack, +3 defence) but no real combat use, primarily worn for cosmetic appeal. Available in five colour variants alongside other Canifis robe pieces."
+  market_strategy:
+    notes:
+      - "Shop-bought from Canifis at 650 coins"
+      - "Pure fashionscape demand"
+      - "Low daily volume around 220 trades"
+      - "Limited upside above shop price"
+  trading_tips:
+    - Buy in bulk from Canifis when stock available
+    - Resell to fashionscape buyers at GE premium
+    - Compare colour variant prices for arbitrage
+  history:
+    - date: "29 June 2004"
+      description: "Item was added to the game as part of the Canifis Haberdashery release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-partyhat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-partyhat.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 5
-  about: "Purple partyhat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: holiday rare
+    tier: high
+  properties:
+    release_date: "2001-12-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.056
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.056
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Christmas cracker
+        quantity: "1"
+        rarity: Random
+  related_items:
+    - item_name: Red partyhat
+      slug: red-partyhat
+      relationship: variant
+      description: Red partyhat colour variant
+    - item_name: Yellow partyhat
+      slug: yellow-partyhat
+      relationship: variant
+      description: Yellow partyhat colour variant
+    - item_name: Blue partyhat
+      slug: blue-partyhat
+      relationship: variant
+      description: Blue partyhat colour variant
+    - item_name: Green partyhat
+      slug: green-partyhat
+      relationship: variant
+      description: Green partyhat colour variant
+    - item_name: White partyhat
+      slug: white-partyhat
+      relationship: variant
+      description: White partyhat colour variant
+  about: |-
+    The purple partyhat is one of the rarest items in Old School RuneScape, originally released during the 2001 Christmas event. Players obtained it by pulling Christmas crackers with other players, which would yield a random partyhat colour. Today it functions purely as a cosmetic status symbol with no combat bonuses, and remains one of the most prestigious wealth markers in the game.
+  market_strategy:
+    notes:
+      - "Top-tier wealth flex with extremely low daily volume"
+      - "Long-term price floor driven by limited supply from 2001 event"
+      - "Price swings track GP inflation and high-end account demand"
+      - "Purple sits mid-range among partyhat colours by historical value"
+      - "Buy limit of 5 means accumulating positions takes weeks"
+  trading_tips:
+    - Use offers around 2-3 percent below GE mid for patient fills
+    - Monitor wealth-tier item indices for macro trend signals
+    - Avoid panic selling during short-term GP inflation pullbacks
+  history:
+    - date: "2001-12-24"
+      description: "Released as a reward from the 2001 Christmas event Christmas cracker."
+    - date: "2013-07-04"
+      description: "Re-released temporarily during the Rare Drops event from July 4 to July 14."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-robe-bottoms.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Purple robe bottoms is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barker's Haberdashery
+      location: Canifis
+      price: 650
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Red robe bottoms
+      slug: red-robe-bottoms
+      relationship: variant
+      description: Red colour variant from Barker's Haberdashery.
+    - item_name: Yellow robe bottoms
+      slug: yellow-robe-bottoms
+      relationship: variant
+      description: Yellow colour variant from Barker's Haberdashery.
+    - item_name: Tan robe bottoms
+      slug: tan-robe-bottoms
+      relationship: variant
+      description: Tan colour variant from Barker's Haberdashery.
+  about: "Purple robe bottoms are cosmetic legs sold by Barker's Haberdashery in Canifis after starting Priest in Peril. They are part of the Canifis townsfolk wardrobe and pair with matching werewolf-themed robe tops."
+  market_strategy:
+    notes:
+      - "Barker shop stock caps profit when GE price drifts above shop restock cost."
+      - "Cosmetic demand is event-driven; expect quiet flat volume otherwise."
+  trading_tips:
+    - Buy from Barker's Haberdashery and flip on the GE when supply runs dry.
+    - Track bond-week cosmetic crazes for short spikes.
+  history:
+    - date: "2014-12-10"
+      description: "Renamed from 'Robe bottoms' to 'Purple robe bottoms' in the Trading Post update."
+    - date: "2004-06-29"
+      description: "Released with the Priest in Peril quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rabbit-snare.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rabbit-snare.mdx
@@ -12,12 +12,74 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 250
-  about: "Rabbit snare is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: hunter-tool
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Lay
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Aleck's Hunter Emporium
+      location: Yanille
+      price: 18
+      currency: Coins
+      stock: 10
+    - shop_name: Nardah Hunter Shop
+      location: Nardah
+      price: 18
+      currency: Coins
+      stock: 10
+    - shop_name: Imia's Supplies
+      location: Hunter Guild
+      price: 18
+      currency: Coins
+      stock: 10
+    - shop_name: Elder Strom's Hunting Stall
+      location: Feldip Hills
+      price: 18
+      currency: Coins
+      stock: 10
+  related_items:
+    - item_name: Ferret
+      slug: ferret
+      relationship: component
+      description: Used to flush rabbits into the snare
+    - item_name: Rabbit foot
+      slug: rabbit-foot
+      relationship: product
+      description: Rare drop while snaring rabbits
+  about: "Rabbit snare is a Hunter tool used to catch white rabbits at level 27 Hunter. Players must complete Eagles' Peak to use the snare. Set on a rabbit path and use a ferret to flush rabbits for 144 Hunter XP per catch."
+  market_strategy:
+    notes:
+      - "Cheaper to buy from Hunter shops than the Grand Exchange in some cases"
+      - "Bulk-purchase target for ironmen training Hunter"
+      - "Now stackable so easy to carry in volume"
+  trading_tips:
+    - Compare shop price vs GE price before buying
+    - Stackable status from 2025 makes long Hunter trips more efficient
+  history:
+    - date: "2006-11-21"
+      description: "Added to the game with the release of the Hunter skill."
+    - date: "2025-08-20"
+      description: "Rabbit snare became stackable."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-relic-hunter-t1-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-relic-hunter-t1-armour-set.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Raging echoes relic hunter (t1) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic-set
+    tier: mid-high
+  properties:
+    release_date: "2024-11-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Raging echoes hood (t1)
+      slug: raging-echoes-hood-t1
+      relationship: set-piece
+      description: Head piece bundled in the set
+    - item_name: Raging echoes top (t1)
+      slug: raging-echoes-top-t1
+      relationship: set-piece
+      description: Body piece bundled in the set
+    - item_name: Raging echoes trousers (t1)
+      slug: raging-echoes-trousers-t1
+      relationship: set-piece
+      description: Legs piece bundled in the set
+    - item_name: Raging echoes boots (t1)
+      slug: raging-echoes-boots-t1
+      relationship: set-piece
+      description: Boots piece bundled in the set
+  about: "Raging echoes relic hunter (t1) armour set bundles all four tier 1 Leagues V cosmetic pieces (hood, top, trousers, boots) into a single tradeable container. Assembled or unpacked through a Grand Exchange clerk's Sets interface for convenient bulk listing."
+  market_strategy:
+    notes:
+      - "Bundle typically trades at a premium over the sum of components"
+      - "Premium reflects GE convenience, not utility — set has no combat stats"
+      - "Not alchemisable; arbitrage is buy-pieces / sell-set"
+  trading_tips:
+    - Watch component vs set spread; flip when premium exceeds GE tax overhead
+    - Demand spikes when Leagues V nostalgia content surfaces
+  history:
+    - date: "2024-11-27"
+      description: "Released as part of Leagues V: Raging Echoes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-spirit-tree-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-spirit-tree-scroll.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Raging echoes spirit tree scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2025-01-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: "Leagues Reward Shop (6,000 League Points)"
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Raging echoes portal frame scroll
+      slug: raging-echoes-portal-frame-scroll
+      relationship: set-piece
+      description: Matching Leagues V POH cosmetic
+    - item_name: Raging echoes portal nexus scroll
+      slug: raging-echoes-portal-nexus-scroll
+      relationship: set-piece
+      description: Matching Leagues V POH cosmetic
+    - item_name: Raging echoes scrying pool scroll
+      slug: raging-echoes-scrying-pool-scroll
+      relationship: set-piece
+      description: Matching Leagues V POH cosmetic
+  about: |-
+    > *"Used on a Spirit Tree inside your Player Owned House to decorate it in the style of Leagues V: Raging Echoes."*
+
+    Redecorates a POH spirit tree (or spirit tree and fairy ring combo) in the Raging Echoes style. Removing the tree refunds the scroll but consumes the original sapling.
+  market_strategy:
+    notes:
+      - "Supply tied to Leagues V participation"
+      - "No GE buy limit recorded; rare flips of multiples possible"
+  history:
+    - date: "2025-01-15"
+      description: "Added as a Leagues V: Raging Echoes reward."
+    - date: "2025-01-22"
+      description: "Became tradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raurg-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raurg-bones.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Raurg bones is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bones
+    tier: mid
+  properties:
+    release_date: "2005-05-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.8
+    options:
+      - Bury
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  passive_effects:
+    - name: Bury
+      description: "Grants 96 Prayer experience when buried."
+    - name: Chaos Temple offering
+      description: "Up to 768 Prayer XP at the Chaos Temple with a 50% chance to preserve the bones."
+  drop_table:
+    sources:
+      - source: Ogre coffin (Thieving, 20 required)
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Blessed raurg bones
+      slug: blessed-raurg-bones
+      relationship: product
+      description: Blessed variant for higher Prayer XP
+    - item_name: Raurg bonemeal
+      slug: raurg-bonemeal
+      relationship: product
+      description: Ground bones for altar offerings
+    - item_name: Zogre bones
+      slug: zogre-bones
+      relationship: alternative
+      description: Other Zogre Flesh Eaters bone drop
+  about: |-
+    > *"Ancient ogre bones from the ogre burial tomb."*
+
+    Looted from ogre coffins after Zogre Flesh Eaters. Buries for 96 Prayer XP or up to 768 at the Chaos Temple altar with the preservation roll.
+  market_strategy:
+    notes:
+      - "Daily volume is low; large flips can move the price"
+      - "Demand fluctuates with Prayer training meta vs. dagannoth/superior bones"
+  history:
+    - date: "2005-05-17"
+      description: "Released with the Zogre Flesh Eaters quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-admiral-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-admiral-pie.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 62
   highalch: 93
   limit: 13000
-  about: "Raw admiral pie is a members-only item in Old School RuneScape. High alchemy value: 93 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 70
+      xp: 210
+      materials:
+        - item_name: Raw admiral pie
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  related_items:
+    - item_name: Admiral pie
+      slug: admiral-pie
+      relationship: product
+      description: Cooked result at level 70 Cooking, granting +5 Fishing boost on consumption.
+    - item_name: Part admiral pie (tuna)
+      slug: part-admiral-pie-tuna
+      relationship: component
+      description: Tuna stage of the pie before adding raw potato to finish the raw admiral pie.
+    - item_name: Pie shell
+      slug: pie-shell
+      relationship: component
+      description: Empty pastry shell used as the base of every admiral pie.
+    - item_name: Burnt pie
+      slug: burnt-pie
+      relationship: variant
+      description: Failure result when cooking the raw admiral pie below sufficient level.
+  about: "Raw admiral pie is the uncooked stage of the admiral pie, requiring a part admiral pie (tuna) topped with a raw potato. It bakes at level 70 Cooking for 210 XP, producing the +5 Fishing-boost admiral pie used by ironmen prepping shark and minnow trips."
+  market_strategy:
+    notes:
+      - "Profit is highest when crafted from raw ingredients rather than flipping pies directly."
+      - "13k buy limit makes high-volume cook-to-flip viable during Fishing skilling events."
+      - "Burn rate at level 70 reduces hourly throughput - 99 Cooking is the practical floor."
+  trading_tips:
+    - Pair admiral pie batches with Fishing competition windows for peak demand.
+    - Buy at GE low when bots dump raw pies overnight.
+    - Track salmon and tuna prices - they drive raw admiral pie cost.
+  history:
+    - date: "2006-02-20"
+      description: "Released with the pie variants expansion that introduced Mort'ton Cooking content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-anchovies.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-anchovies.mdx
@@ -12,18 +12,64 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.12
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw anchovies
+          quantity: 1
+      tools:
+        - Fire or range
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Small fishing net (Net fishing spot)
+        quantity: "1"
+        rarity: Common
   related_items:
-    - item_id: 319
-      item_name: Anchovies
+    - item_name: Anchovies
       slug: anchovies
       relationship: product
-      description: Cooked version
-  about: |-
-    > _"I should try cooking this."_
-
-    Raw anchovies can be cooked at 1 Cooking to make anchovies. Also used as an ingredient in anchovy pizza. Caught at the same spots as raw shrimps.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Cooked result of using raw anchovies on a fire or range.
+    - item_name: Raw shrimps
+      slug: raw-shrimps
+      relationship: alternative
+      description: Caught at the same small net fishing spots.
+    - item_name: Anchovy pizza
+      slug: anchovy-pizza
+      relationship: product
+      description: Uses cooked anchovies as a topping ingredient.
+  about: "Raw anchovies are caught with a small fishing net at 15 Fishing for 40 XP per catch. They cook at 1 Cooking for 30 XP into anchovies, which double as a pizza topping ingredient."
+  market_strategy:
+    notes:
+      - "Steady supply from low-level fishers keeps prices flat near alch value."
+      - "Pizza-makers cause periodic demand spikes when bonus XP weekends hit."
+  trading_tips:
+    - Buy in bulk during late-night EU hours for the best fills.
+    - Cook into anchovies for a minor margin if Cooking XP is also wanted.
+  history:
+    - date: "2024-11-01"
+      description: "Catch message updated from 'You catch some anchovies' to 'You catch some raw anchovies' for clarity."
+    - date: "2001-06-11"
+      description: "Released with the original RuneScape Fishing skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-chompy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-chompy.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw chompy | OSRS Price Data
-description: "Raw chompy: I need to cook this first.. High alch: 51 GP, GE limit: 13,000."
+description: "Raw chompy hunted with ogre bows; cook at 30 Cooking for chompy bird hat progress. High alch: 51 GP, GE limit: 13,000."
 osrs:
   id: 2876
   name: Raw chompy
@@ -12,9 +12,68 @@ osrs:
   lowalch: 34
   highalch: 51
   limit: 13000
-  about: "Raw chompy is a members-only item in Old School RuneScape. High alchemy value: 51 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2004-05-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 30
+      xp: 140
+      materials:
+        - item_name: Raw chompy
+          quantity: 1
+      tools:
+        - Iron spit
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Chompy bird
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Cooked chompy
+      slug: cooked-chompy
+      relationship: product
+      description: Cooked version after iron/ogre spit-roast
+    - item_name: Chompy bird hat
+      slug: chompy-bird-hat
+      relationship: product
+      description: Reward for hunting chompy kill milestones
+    - item_name: Comp ogre bow
+      slug: comp-ogre-bow
+      relationship: alternative
+      description: Bow used to down chompy birds
+  about: |-
+    > _"I need to cook this first."_
+
+    Raw chompy drops from chompy birds (combat level 6) in the Feldip Hills. Hunting them requires completion of Big Chompy Bird Hunting and an ogre/comp ogre bow with brutal arrows. Cook at 30 Cooking on an iron spit for 140 XP.
+  market_strategy:
+    notes:
+      - "Sales are thin — most raw chompies are cooked privately for kill credit."
+      - "Watch GE limits when reselling kill-hunt inventories."
+  trading_tips:
+    - List in stacks of 100+ around weekend hunt clans.
+    - Cook before reselling for the larger cooked chompy spread.
+  history:
+    - date: "2004-05-18"
+      description: "Released with the Big Chompy Bird Hunting quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-larupia.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-larupia.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw larupia | OSRS Price Data
-description: "Raw larupia: I should probably cook this first.. High alch: 1 GP, GE limit: 13,000."
+description: "Raw larupia: I should probably cook this first. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 29122
   name: Raw larupia
@@ -12,12 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw larupia is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Cook
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Spined larupia (Hunter, 31)
+        quantity: "1"
+        rarity: always
+  recipes:
+    - skill: cooking
+      level: 31
+      xp: 92
+      materials:
+        - item_name: Raw larupia
+          quantity: 1
+      tools:
+        - Range
+      output_quantity: 1
+  related_items:
+    - item_name: Cooked larupia
+      slug: cooked-larupia
+      relationship: product
+      description: Cooked version produced at 31 Cooking
+    - item_name: Quetzal whistle
+      slug: quetzal-whistle
+      relationship: alternative
+      description: Exchange raw larupia with Soar Leader Pitri for whistle charges
+  about: "Raw larupia drops from spined larupias caught with 31 Hunter in Varlamore. Cook at 31 Cooking for 92 xp or trade with Soar Leader Pitri to recharge quetzal whistles. Burns to a 'burnt large beast' on cook failure."
+  market_strategy:
+    notes:
+      - "Always-drop from Hunter creature keeps supply abundant"
+      - "High buy limit and low value mean thin per-unit margins"
+  trading_tips:
+    - Buy in bulk for quetzal whistle recharging
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore: The Hunter Update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-mystery-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-mystery-meat.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Raw mystery meat is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2020-06-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw mystery meat
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  shops:
+    - shop_name: Darkmeyer Meat Shop
+      location: Darkmeyer
+      price: 1
+      currency: Coins
+      stock: 25
+  related_items:
+    - item_name: Cooked mystery meat
+      slug: cooked-mystery-meat
+      relationship: product
+      description: Cooked at level 1 Cooking for 30 XP, used to feed Frank the bloodveld in Darkmeyer.
+  about: "Raw mystery meat is a Darkmeyer butcher product introduced with Sins of the Father, sold for one coin at the meat shop. It cooks at level 1 Cooking for 30 XP into cooked mystery meat, which can be fed to Frank the bloodveld inside Darkmeyer."
+  market_strategy:
+    notes:
+      - "GE price often inflates well beyond the 1gp shop price because the Darkmeyer shop is locked behind Sins of the Father."
+      - "Stock restocks every 48 seconds at the Darkmeyer Meat Shop, making it easy to buy out for resale."
+      - "Demand is niche - mostly ironmen and pet hunters needing Frank interactions."
+  trading_tips:
+    - Run Darkmeyer shop runs when GE prices spike above 200gp per meat.
+    - Cooked variant typically sells for more than raw - consider cooking before listing.
+    - Sins of the Father gates access, so flips work best during quest league seasons.
+  history:
+    - date: "2020-06-04"
+      description: "Released with the Sins of the Father quest and the Darkmeyer city expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragon-mask.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Red dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Green dragon mask
+      slug: green-dragon-mask
+      relationship: variant
+      description: Green-coloured dragon mask variant
+    - item_name: Blue dragon mask
+      slug: blue-dragon-mask
+      relationship: variant
+      description: Blue-coloured dragon mask variant
+    - item_name: Black dragon mask
+      slug: black-dragon-mask
+      relationship: variant
+      description: Black-coloured dragon mask variant
+  about: |-
+    The red dragon mask is a cosmetic head slot item obtained as a rare reward from hard Treasure Trail caskets. It provides no combat bonuses and is purely worn for fashion. The mask resembles the head of a red dragon and can be stored in a costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Hard clue rare; supply tied to clue completion rates"
+      - "Pure cosmetic, demand swings with fashion meta"
+      - "Compare against other dragon mask colours for relative pricing"
+  trading_tips:
+    - Stockpile during clue scroll droughts when supply thins
+    - Flip on holiday/event price spikes
+  history:
+    - date: "2014-06-12"
+      description: "Added to the hard Treasure Trails reward table."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-spiders-eggs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-spiders-eggs.mdx
@@ -12,81 +12,110 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: secondary
     tier: mid-high
+  properties:
+    release_date: "2001-02-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Spidine
+        quantity: "1"
+        rarity: Always
+      - source: Temple Spider
+        quantity: "1"
+        rarity: 8/100
+      - source: Araxxor
+        quantity: "1"
+        rarity: 2/115
+      - source: Venenatis
+        quantity: "1"
+        rarity: 3/126
   recipes:
     - skill: herblore
       level: 22
       xp: 62.5
       materials:
         - item_name: Harralander potion (unf)
-          item_id: 97
           quantity: 1
         - item_name: Red spiders' eggs
-          item_id: 223
           quantity: 1
-      product: Restore potion(3)
-      product_id: 127
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
     - skill: herblore
       level: 63
       xp: 142.5
       materials:
         - item_name: Snapdragon potion (unf)
-          item_id: 3004
           quantity: 1
         - item_name: Red spiders' eggs
-          item_id: 223
           quantity: 1
-      product: Super restore(3)
-      product_id: 3026
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
+    - skill: herblore
+      level: 73
+      xp: 190
+      materials:
+        - item_name: Coconut milk
+          quantity: 1
+        - item_name: Cactus spine
+          quantity: 1
+        - item_name: Red spiders' eggs
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 3000
-      item_name: Snapdragon
+    - item_name: Snapdragon
       slug: snapdragon
       relationship: component
-      description: Super restore herb
-    - item_id: 3024
-      item_name: Super restore(4)
+      description: Super restore herb pairing
+    - item_name: Super restore(4)
       slug: super-restore-4
       relationship: product
-      description: Primary end product
-    - item_id: 255
-      item_name: Harralander
+      description: Primary end product driving demand
+    - item_name: Harralander
       slug: harralander
       relationship: component
-      description: Restore potion herb
-    - item_id: 5952
-      item_name: Weapon poison(+)
+      description: Restore potion herb pairing
+    - item_name: Weapon poison(+)
       slug: weapon-poison-plus
       relationship: product
-      description: PvP use
+      description: PvP weapon poison product
   about: |-
-    Secondary ingredient for potions:
-
-    | Potion | Herb | Herblore Level |
-    |--------|------|----------------|
-    | Restore potion | Harralander | 22 |
-    | Super restore | Snapdragon | 63 |
-    | Weapon poison(+) | Cactus spine | 73 |
+    Red spiders' eggs are a key secondary potion ingredient used in Restore potion, Super restore, and Weapon poison(+). Demand is driven by raid consumption of super restores, making this one of the more reliable secondaries to flip. Tower of Life is the best gathering location, with collectors averaging around 1,500 eggs per hour.
   market_strategy:
     notes:
-      - Tower of Life best method
-      - ~1,500/hr manually
-      - Low competition spots
-      - Super restore drives demand
-      - Price tied to snapdragon market
-      - Raid consumption creates sink
-      - Super restore chain drives price
-      - Tower of Life spawns fastest
-      - Ironmen need collection methods
-      - Check restore vs eggs margin
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Tower of Life best method"
+      - "1500 per hour manually"
+      - "Low competition spots"
+      - "Super restore drives demand"
+      - "Price tied to snapdragon market"
+      - "Raid consumption creates sink"
+      - "Super restore chain drives price"
+      - "Tower of Life spawns fastest"
+      - "Ironmen need collection methods"
+      - "Check restore vs eggs margin"
+  trading_tips:
+    - Bulk buy at low alch and resell during raid spikes
+    - Pair-flip with snapdragon for super restore arbitrage
+    - Watch DMM and league seasons for demand surges
+  history:
+    - date: "2001-02-05"
+      description: "Released as a Herblore secondary ingredient."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ribcage-piece.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ribcage-piece.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Ribcage piece is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: material
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Wallasalki
+        quantity: "1"
+        rarity: 2/128
+  related_items:
+    - item_name: Skeletal top
+      slug: skeletal-top
+      relationship: product
+      description: "Crafted using a ribcage piece, dagannoth hides, and coins."
+    - item_name: Fibula piece
+      slug: fibula-piece
+      relationship: set-piece
+      description: Skeletal armour component
+    - item_name: Skull piece
+      slug: skull-piece
+      relationship: set-piece
+      description: Skeletal armour component
+  about: |-
+    > *"A slightly damaged ribcage."*
+
+    Wallasalki drop used to forge the skeletal top via Peer the Seer after completing The Fremennik Trials. Can also be traded to Askeladden for cooked tuna or lobster depending on quest state.
+  market_strategy:
+    notes:
+      - "Demand tied to skeletal armour crafting"
+      - "Ironmen drive Wallasalki kill volume"
+  history:
+    - date: "2005-08-01"
+      description: "Released with the Waterbirth Island and Wallasalki update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-forging.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-forging.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ring of forging | OSRS Price Data
-description: "Ring of forging is a F2P ring slot item. High alch: 1,215 GP, GE limit: 10,000."
+description: "Ring of forging: An enchanted ring. High alch: 1,215 GP, GE limit: 10,000."
 osrs:
   id: 2568
   name: Ring of forging
@@ -12,8 +12,33 @@ osrs:
   lowalch: 810
   highalch: 1215
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ruby
+    tier: mid
+  properties:
+    release_date: "2002-05-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ring
+    weapon_type: null
+    attack_speed: null
+    weight: 0.006
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,60 +56,55 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements: {}
-    weight: 0.006
   recipes:
     - skill: magic
       level: 49
       xp: 59
-      inputs:
+      materials:
         - item_name: Ruby ring
           quantity: 1
         - item_name: Cosmic rune
           quantity: 1
         - item_name: Fire rune
           quantity: 5
+      tools: []
       output_quantity: 1
+  passive_effects:
+    - name: Guaranteed iron smelt
+      description: Forces a 100% success rate when smelting iron ore at a regular furnace; lasts 140 successful smelts before the ring crumbles to dust.
   related_items:
-    - item_id: 2570
-      item_name: Ring of life
+    - item_name: Ruby ring
+      slug: ruby-ring
+      relationship: component
+      description: Base ring required to cast Lvl-4 Enchant.
+    - item_name: Ring of life
       slug: ring-of-life
       relationship: alternative
-      description: Emergency teleport ring
-    - item_id: 2550
-      item_name: Ring of recoil
+      description: Emergency teleport ring at low HP.
+    - item_name: Ring of recoil
       slug: ring-of-recoil
       relationship: alternative
-      description: Damage reflection ring
+      description: Reflects a percentage of damage back at attackers.
   about: |-
-    No combat bonuses. The ring's value is entirely in its skilling effect.
+    The ring of forging grants a 100% iron-smelting success rate at standard furnaces, replacing the usual 50% chance per ore. It carries 140 charges - each successful iron smelt consumes one - before crumbling to dust.
 
-    Requirements: None to wear | Weight: 0.006 kg
+    Charges are tracked per player, not per ring, so swapping rings does not refresh the counter. The ring is created by casting Lvl-4 Enchant on a ruby ring (49 Magic).
 
-    Guarantees 100% success rate when smelting iron ore into iron bars. Without the ring, iron ore normally has only a 50% success rate (each ore has a 50% chance of failing).
-
-    Charges: 140 uses before the ring crumbles to dust. Each iron ore smelted consumes one charge.
-
-    Important: Charges are tracked per player, not per ring — swapping to a new ring does not reset the counter.
-
-    | Method | Iron Bars per Ring | Cost per Ring |
-    |--------|-------------------|---------------|
-    | Without ring | ~70 bars (50% rate) | Free |
-    | With ring | 140 bars (100%) | ~800 GP |
-
-    The ring effectively doubles your iron bar output, saving ~70 iron ores worth of value per ring.
-
-    At the Blast Furnace, iron ore already smelts at 100% — making the ring of forging unnecessary there. The ring is primarily useful at regular furnaces.
-
-    Essential for Ironman accounts producing iron bars at regular furnaces, where the 50% failure rate would waste hard-earned ores. Most ironmen transition to Blast Furnace eventually, but the ring is valuable during early-mid game.
+    Without ring: ~70 iron bars per 140 ore | With ring: 140 iron bars per 140 ore. At the Blast Furnace iron already smelts at 100%, so the ring is unnecessary there - it shines at regular furnaces, especially for ironmen during early- to mid-game iron grinds.
   market_strategy:
     notes:
-      - Cheap to enchant (ruby ring + cosmic + fire runes)
-      - Consumed on use — steady recurring demand
-      - F2P accessible via Murky Matt (250 coins)
-      - Less useful once Blast Furnace is unlocked
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap to enchant (ruby ring + cosmic + fire runes)."
+      - "Consumed on use - steady recurring demand."
+      - "F2P accessible via Murky Matt for 250 coins."
+      - "Less useful once Blast Furnace is unlocked."
+  trading_tips:
+    - Stock up when ruby ring price dips; arbitrage via enchant.
+    - Bulk-supply ironman markets ahead of Blast Furnace minigame downtime.
+  history:
+    - date: "2013-02-22"
+      description: "Item carried over to Old School RuneScape at launch."
+    - date: "2002-05-28"
+      description: "Originally released in RuneScape Classic."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-wealth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-wealth.mdx
@@ -12,9 +12,31 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2004-04-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Rub
+      - Features
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ring
+    weapon_type: null
+    attack_speed: null
     weight: 0.006
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,76 +54,57 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  special_effect:
-    name: Wealth Effect
-    description: Improves rare drop table, auto-collects coins/tokkul, tracks boss kills
-    triggers: passive
   recipes:
     - skill: magic
       level: 68
       xp: 78
-      spell: Lvl-5 Enchant
       materials:
         - item_name: Dragonstone ring
-          item_id: 1645
           quantity: 1
         - item_name: Cosmic rune
-          item_id: 564
           quantity: 1
         - item_name: Earth rune
-          item_id: 557
           quantity: 15
         - item_name: Water rune
-          item_id: 555
           quantity: 15
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Rare drop table boost
+      description: Removes empty rolls from the rare drop table and gem drop table when worn during the killing blow
+    - name: Auto-collect currency
+      description: Automatically picks up coins, Tokkul, and numulites dropped by defeated monsters
   related_items:
-    - item_id: 1645
-      item_name: Dragonstone ring
+    - item_name: Dragonstone ring
       slug: dragonstone-ring
       relationship: component
-      description: Unenchanted version
-    - item_id: 12785
-      item_name: Ring of wealth (i)
+      description: Unenchanted base ring
+    - item_name: Ring of wealth (i)
       slug: ring-of-wealth-i
       relationship: upgrade
-      description: Imbued version
-    - item_id: 1615
-      item_name: Dragonstone
+      description: Imbued version doubles Wilderness clue chances
+    - item_name: Dragonstone
       slug: dragonstone
       relationship: component
-      description: Gem component
-    - item_id: 2357
-      item_name: Gold bar
+      description: Gem used in the base ring
+    - item_name: Gold bar
       slug: gold-bar
       relationship: component
-      description: Crafting material
+      description: Crafting material for the base ring
   about: |-
-    | Effect | Description |
-    |--------|-------------|
-    | Rare drop table | Removes empty rolls |
-    | Coin collection | Auto-pickup coins/tokkul |
-    | Boss log | Tracks boss kills |
-    | Teleports | 5 charges when imbued |
-
-    - Grand Exchange
-    - Miscellania
-    - Falador Park
-    - Dondakan
+    Ring of wealth automatically collects coin/Tokkul/numulite drops and improves the rare drop table by eliminating empty rolls. Charge at the Fountain of Rune for 5 teleport charges to Miscellania, Grand Exchange, Falador Park, or Dondakan. Imbuing the ring doubles clue scroll drop chance in the Wilderness.
   market_strategy:
     notes:
-      - Improves rare drops
-      - Coin collection useful
-      - Teleport charges
-      - Slayer tasks
-      - Bossing
-      - Money making
-      - Clue scrolls
-      - Charge at Fountain of Rune
-      - Imbue for permanent effect
-      - Auto coin pickup saves time
-      - Boss log tracking
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Steady demand from PvM and Slayer players"
+      - "Doubles as utility teleport ring"
+      - "Supply tied to Dragonstone ring enchantment volume"
+      - "Buy limit of 10,000 per 4 hours"
+  trading_tips:
+    - Compare enchant cost vs market price for crafting flips
+    - Imbued version commands premium for Wilderness clues
+  history:
+    - date: "2004-04-20"
+      description: "Released as one of the original Crafting jewellery enchantments."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-helm.mdx
@@ -12,8 +12,34 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rock-shell
+    tier: mid-high
+  properties:
+    release_date: "1 August 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,65 +57,55 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-    weight: 2.721
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dagannoth hide
+          quantity: 1
+        - item_name: Rock-shell chunk
+          quantity: 1
+        - item_name: Coins
+          quantity: 5000
+      tools:
+        - Skulgrimen
+      output_quantity: 1
   related_items:
-    - item_id: 6129
-      item_name: Rock-shell plate
+    - item_name: Rock-shell plate
       slug: rock-shell-plate
       relationship: set-piece
       description: Matching body piece
-    - item_id: 6130
-      item_name: Rock-shell legs
+    - item_name: Rock-shell legs
       slug: rock-shell-legs
       relationship: set-piece
       description: Matching leg piece
-    - item_id: 10828
-      item_name: Helm of neitiznot
+    - item_name: Helm of neitiznot
       slug: helm-of-neitiznot
       relationship: upgrade
-      description: Superior with Strength/Prayer bonus
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +30 |
-    | Slash | +32 |
-    | Crush | +27 |
-    | Ranged | +30 |
-    | Magic | -1 |
-
-    Requirements: 40 Defence
-
-    | Stat | Rock-shell Helm | Rune Full Helm | Berserker Helm |
-    |------|----------------|----------------|----------------|
-    | Stab Def | +30 | +30 | +30 |
-    | Slash Def | +32 | +32 | +32 |
-    | Crush Def | +27 | +27 | +27 |
-    | Ranged Def | +30 | +30 | +30 |
-    | Str Bonus | 0 | 0 | +3 |
-    | Prayer | 0 | 0 | 0 |
-    | Req | 40 Def | 40 Def | 45 Def + quest |
-
-    Identical defensive stats to a rune full helm. The berserker helm (from The Fremennik Trials) is the preferred choice at this tier due to its +3 Strength bonus — making the rock-shell helm largely obsolete.
-
-    The rock-shell set is the melee variant of the three Fremennik armour sets:
-    - Rock-shell — melee (Skulgrimen)
-    - Skeletal — magic (Peer the Seer)
-    - Spined — ranged (Sigli the Huntsman)
-
-    Storable in a Costume Room armour case as part of the complete rock-shell set.
+      description: Superior alternative with Strength and Prayer bonus
+    - item_name: Berserker helm
+      slug: berserker-helm
+      relationship: alternative
+      description: Equivalent defence with strength bonus
+  about: "The rock-shell helm is a member's melee head slot item requiring 40 Defence and completion of The Fremennik Trials. Crafted by Skulgrimen in Rellekka from 1 dagannoth hide, 1 rock-shell chunk, and 5,000 coins. It matches rune full helm and berserker helm defensively but lacks any offensive bonus, making it largely obsolete for combat. Part of the rock-shell melee armour set alongside the skeletal (magic) and spined (ranged) Fremennik sets."
   market_strategy:
     notes:
-      - Rock-shell chunks from Rock crabs (common drop)
-      - Outclassed by berserker helm and Helm of neitiznot
-      - Collector's/fashionscape piece
-      - Low trade volume
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Outclassed by berserker helm and Helm of neitiznot"
+      - "Collector and fashionscape piece"
+      - "Low trade volume with thin order book"
+      - "Rock-shell chunks drop from rock crabs"
+  trading_tips:
+    - Buy when chunk supply is high from rock crab tasks
+    - Resell during Fremennik Trials completion spikes
+    - Sell to costume room collectors at premium
+  history:
+    - date: "1 August 2005"
+      description: "Item was added to the game with the Lunar Diplomacy and Fremennik content expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-amulet-u.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 810
   highalch: 1215
   limit: 10000
-  about: "Ruby amulet (u) is a free-to-play item in Old School RuneScape. High alchemy value: 1,215 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ruby
+    tier: mid
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 50
+      xp: 85
+      materials:
+        - item_name: Gold bar
+          quantity: 1
+        - item_name: Ruby
+          quantity: 1
+        - item_name: Amulet mould
+          quantity: 1
+      tools:
+        - Furnace
+      output_quantity: 1
+  related_items:
+    - item_name: Ruby amulet
+      slug: ruby-amulet
+      relationship: upgrade
+      description: Strung version after applying ball of wool
+    - item_name: Amulet of strength
+      slug: amulet-of-strength
+      relationship: product
+      description: Enchanted via Lvl-3 Enchant
+    - item_name: Sapphire amulet (u)
+      slug: sapphire-amulet-u
+      relationship: downgrade
+      description: Lower tier unstrung amulet
+    - item_name: Emerald amulet (u)
+      slug: emerald-amulet-u
+      relationship: downgrade
+      description: Lower tier unstrung amulet
+  about: "Ruby amulet (u) is the unstrung output of crafting a gold bar plus cut ruby at a furnace with an amulet mould at 50 Crafting (85 XP). Add a ball of wool (or cast Lunar string spell) to string it, then cast Lvl-3 Enchant to produce an Amulet of strength."
+  market_strategy:
+    notes:
+      - "Profit margin tracks ruby and gold bar prices"
+      - "Demand driven by Magic enchanting alts and amulet of strength supply"
+      - "F2P availability widens buyer pool"
+  trading_tips:
+    - Watch ruby vs gold bar spreads — both inputs affect floor
+    - Bulk demand during DXP for Magic and Crafting training
+  history:
+    - date: "2001-05-08"
+      description: "Released as part of the original Crafting jewellery line."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-axe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune axe | OSRS Price Data
-description: "Rune axe: A powerful axe.. High alch: 7,680 GP, GE limit: 40."
+description: "Rune axe: A powerful axe. High alch: 7,680 GP, GE limit: 40."
 osrs:
   id: 1359
   name: Rune axe
@@ -12,24 +12,99 @@ osrs:
   lowalch: 5120
   highalch: 7680
   limit: 40
-  item_id: 1359
-  item_type: equipment
-  slot: weapon
-  type: axe
-  tradeable: true
-  weight: 1.36
-  requirements:
-    attack: 40
-    woodcutting: 41
-  stats:
-    slash_attack: 43
-    crush_attack: 32
-    strength: 41
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2001-08-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: axe
+    attack_speed: 5
+    weight: 1.36
+    requirements:
+      attack: 40
+      woodcutting: 41
+    attack_bonus:
+      stab: -2
+      slash: 26
+      crush: 24
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 29
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 86
+      xp: 75
+      materials:
+        - item_name: Runite bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: "Perry's Chop-chop Shop"
+      location: "Woodcutting Guild"
+      price: 40960
+      currency: "Coins"
+      stock: 2
   related_items:
-    - slug: dragon-axe
-    - slug: runite-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Adamant axe
+      slug: adamant-axe
+      relationship: downgrade
+      description: "Previous tier axe and cheaper trainer."
+    - item_name: Dragon axe
+      slug: dragon-axe
+      relationship: upgrade
+      description: "Members-only upgrade with a special attack."
+    - item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: "Smithing material for crafting a rune axe."
+    - item_name: Gilded axe
+      slug: gilded-axe
+      relationship: alternative
+      description: "Cosmetic clue reward with identical stats."
+  about: "The rune axe is the highest free-to-play woodcutting axe and a budget 40 Attack one-handed slash weapon. It requires 41 Woodcutting to chop and 40 Attack to wield, and can be smithed at 86 Smithing from one runite bar for 75 xp."
+  market_strategy:
+    notes:
+      - "Daily volume is steady from f2p woodcutters; price tracks runite bar more than alch."
+      - "Smithing it for profit is rarely viable - bars usually cost more than the finished axe."
+  trading_tips:
+    - "Buy noted rune axes from new wcers, alch when high alch beats GE price."
+    - "Watch for 99 Smithing grinders dumping stock after runite bar grinds."
+  history:
+    - date: "2001-08-13"
+      description: "Released as the top-tier free-to-play woodcutting axe."
+    - date: "2015-02-26"
+      description: "Added to Perry's Chop-chop Shop stock in the Woodcutting Guild."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-javelin-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune javelin(p) | OSRS Price Data
-description: "Rune javelin(p) is a members weapon slot item requiring 40 Ranged. High alch: 240 GP, GE limit: 7,000."
+description: "Rune javelin(p) is a members poisoned ranged ammunition for ballistae. High alch: 240 GP, GE limit: 7,000."
 osrs:
   id: 836
   name: Rune javelin(p)
@@ -12,21 +12,98 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 6
+    weight: 0
     requirements:
       ranged: 40
     attack_bonus:
-      ranged: 25
-    ranged_strength: 72
-  related_items: []
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 124
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Void Knight Archery Store
+      location: Pest Control Island
+      price: 400
+      currency: coins
+      stock: 0
+    - shop_name: Ranging Guild Ticket Exchange
+      location: Ranging Guild
+      price: 520
+      currency: coins
+      stock: 0
+    - shop_name: Oobapohk's Javelin Store
+      location: Feldip Hills
+      price: 400
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Rune javelin
+      slug: rune-javelin
+      relationship: variant
+      description: Unpoisoned version
+    - item_name: Rune javelin(p+)
+      slug: rune-javelin-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_name: Rune javelin(p++)
+      slug: rune-javelin-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+    - item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: alternative
+      description: Weapon that fires javelins
   about: |-
     > _"A rune tipped javelin with a poisoned tip."_
 
-    A rune javelin tipped with basic weapon poison. Requires 40 Ranged. The highest standard tier of poisoned javelin. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    A rune javelin tipped with basic weapon poison. Used as ammunition for ballistae and requires 40 Ranged to wield. Poison has a chance to deal damage over time.
+  market_strategy:
+    notes:
+      - "Ballista ammunition keeps steady demand from PvP and slayer."
+      - "Poison variant trades at a premium vs the plain javelin for poison-immune content."
+  trading_tips:
+    - Buy plain rune javelins and poison them when the spread justifies it.
+    - Stock up during PvP off-peak windows for resale during weekend tournaments.
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch as poisoned ranged ammunition."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-knife.mdx
@@ -12,55 +12,90 @@ osrs:
   lowalch: 66
   highalch: 100
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: runite
+    tier: mid-high
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 40
-  stats:
-    attack:
+    weight: 0
+    requirements:
+      ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 25
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 24
-  smithing:
-    level: 92
-    xp: 75
-    method: Runite bar at anvil
-    bars: 1
-    quantity: 5
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 92
+      xp: 75
+      materials:
+        - item_name: Runite bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 5
   related_items:
-    - item_id: 2363
-      item_name: Runite bar
+    - item_name: Runite bar
       slug: runite-bar
       relationship: component
       description: Smithing material
-    - item_id: 22804
-      item_name: Dragon knife
+    - item_name: Dragon knife
       slug: dragon-knife
       relationship: upgrade
-      description: Best throwing knife
-    - item_id: 867
-      item_name: Adamant knife
+      description: Best throwing knife tier
+    - item_name: Adamant knife
       slug: adamant-knife
       relationship: downgrade
-      description: Lower tier knife
-    - item_id: 811
-      item_name: Rune dart
+      description: Previous tier throwing knife
+    - item_name: Rune dart
       slug: rune-dart
       relationship: alternative
       description: Alternative thrown weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0.006 kg |
-    | Requirements | 40 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Rune knife is a members-only thrown weapon requiring 40 Ranged. Smith from a runite bar at level 92 Smithing for 75 xp, producing 5 knives per bar. Sometimes preferred over dragon knives in PKing because the throwing animation can be cancelled earlier, keeping the attacker more mobile."
+  market_strategy:
+    notes:
+      - "Smithing cost typically exceeds GE price — net loss to craft"
+      - "PvP demand keeps volume high despite dragon knife dominance in PvM"
+  trading_tips:
+    - Stock up on bars when GE rune knife price spikes during PvP events
+    - Pair with weapon poison variants to flip into the poisoned versions
+  history:
+    - date: "2003-04-14"
+      description: "Released as part of the New Throwing Weapons update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h2.mdx
@@ -5,16 +5,97 @@ osrs:
   id: 7342
   name: Rune shield (h2)
   slug: rune-shield-h2
-  examine: A shield with a heraldic design
+  examine: A shield with a heraldic design.
   members: false
   icon: Rune shield (h2).png
   value: 54400
   lowalch: 21760
   highalch: 32640
   limit: 70
-  about: "Rune shield (h2) is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 47
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: variant
+      description: "Plain undecorated rune kiteshield with identical stats."
+    - item_name: Rune shield (h1)
+      slug: rune-shield-h1
+      relationship: alternative
+      description: "Asgarnia heraldic variant."
+    - item_name: Rune shield (h3)
+      slug: rune-shield-h3
+      relationship: alternative
+      description: "Guthix heraldic variant."
+    - item_name: Rune shield (h4)
+      slug: rune-shield-h4
+      relationship: alternative
+      description: "Zamorak heraldic variant."
+    - item_name: Rune shield (h5)
+      slug: rune-shield-h5
+      relationship: alternative
+      description: "Misthalin heraldic variant."
+  about: "Rune shield (h2) is a Saradomin-heraldic rune kiteshield rewarded from hard Treasure Trails. Stats match the plain rune kiteshield, so demand is largely cosmetic and from Trailblazer/Achievement collectors hunting clue-only heraldry."
+  market_strategy:
+    notes:
+      - "Heraldic clue rewards live and die on clue meta - hard clue volume drives all five variants together."
+      - "Buy limit 70 keeps margins fat but daily volume is thin; flips are slow."
+  trading_tips:
+    - "Compare all five h-variants before listing - cheapest is the easiest cosmetic flip."
+    - "Cleanups during clue scroll events shake out cheap stock from casual cluers."
+  history:
+    - date: "2006-02-20"
+      description: "Released as part of the heraldic rune kiteshield rewards from hard clues."
+    - date: "2021-04"
+      description: "Ranged attack bonus adjusted from -2 to -3."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-armour-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-armour-set-lg.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Saradomin armour set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour-set
+    tier: mid
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Saradomin full helm
+      slug: saradomin-full-helm
+      relationship: set-piece
+      description: Head piece included in set
+    - item_name: Saradomin platebody
+      slug: saradomin-platebody
+      relationship: set-piece
+      description: Body piece included in set
+    - item_name: Saradomin platelegs
+      slug: saradomin-platelegs
+      relationship: set-piece
+      description: Legs piece included in set
+    - item_name: Saradomin kiteshield
+      slug: saradomin-kiteshield
+      relationship: set-piece
+      description: Shield piece included in set
+    - item_name: Saradomin armour set (sk)
+      slug: saradomin-armour-set-sk
+      relationship: variant
+      description: Plateskirt variant of the same set
+  about: |-
+    The Saradomin armour set (lg) is a Grand Exchange convenience bundle containing a Saradomin full helm, platebody, platelegs, and kiteshield. Players use the set primarily as a cheap way to purchase or sell all four pieces at once via the GE Sets tab.
+  market_strategy:
+    notes:
+      - "Price commonly trades at a premium over individual pieces"
+      - "Compare set price to sum of components before flipping"
+      - "Buy limit of 8 lets bulk flippers compound margins"
+  trading_tips:
+    - Buy components and combine when premium exceeds spread
+    - Sell intact to F2P fashion buyers
+  history:
+    - date: "2015-02-26"
+      description: "Added to the Grand Exchange armour sets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-armour-set-sk.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
-  about: "Saradomin armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid-high
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Saradomin full helm
+      slug: saradomin-full-helm
+      relationship: set-piece
+      description: Helm component of the set
+    - item_name: Saradomin platebody
+      slug: saradomin-platebody
+      relationship: set-piece
+      description: Body component of the set
+    - item_name: Saradomin plateskirt
+      slug: saradomin-plateskirt
+      relationship: set-piece
+      description: Legs component of the set
+    - item_name: Saradomin kiteshield
+      slug: saradomin-kiteshield
+      relationship: set-piece
+      description: Shield component of the set
+    - item_name: Saradomin armour set (lg)
+      slug: saradomin-armour-set-lg
+      relationship: variant
+      description: Legs variant using platelegs instead of plateskirt
+  about: "Saradomin armour set (sk) is a free-to-play Grand Exchange set that bundles the Saradomin full helm, platebody, plateskirt and kiteshield into a single tradeable item to save bank space. Players exchange it back into the four individual pieces via any Grand Exchange clerk. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
+  market_strategy:
+    notes:
+      - "Set commonly trades at a small discount versus combined piece prices"
+      - "F2P availability widens the buyer pool versus members-only sets"
+      - "Buy limit of 8 caps single-flip volume but pieces themselves are unlimited"
+  trading_tips:
+    - Compare set price vs combined helm+platebody+plateskirt+kiteshield for arbitrage
+    - Use the set for compact bank storage when banking complete kit
+  history:
+    - date: "2015-02-26"
+      description: "Released as a Grand Exchange convenience set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-d-hide-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-d-hide-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Saradomin d'hide boots | OSRS Price Data
-description: "Saradomin d'hide boots: Saradomin blessed dragonhide boots.. High alch: 5,580 GP, GE limit: 8."
+description: "Saradomin d'hide boots: Saradomin blessed dragonhide boots. High alch: 5,580 GP, GE limit: 8."
 osrs:
   id: 19933
   name: Saradomin d'hide boots
@@ -12,9 +12,82 @@ osrs:
   lowalch: 3720
   highalch: 5580
   limit: 8
-  about: "Saradomin d'hide boots is a members-only item in Old School RuneScape. High alchemy value: 5,580 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.4
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weight: 1.4
+    requirements:
+      defence: 40
+      ranged: 70
+    attack_bonus: {}
+    defence_bonus:
+      stab: 4
+      slash: 4
+      crush: 4
+      magic: 4
+      ranged: 4
+    other_bonus:
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  related_items:
+    - item_name: Guthix d'hide boots
+      slug: guthix-d-hide-boots
+      relationship: alternative
+      description: Guthix-aligned blessed dragonhide boots
+    - item_name: Zamorak d'hide boots
+      slug: zamorak-d-hide-boots
+      relationship: alternative
+      description: Zamorak-aligned blessed dragonhide boots
+    - item_name: Bandos d'hide boots
+      slug: bandos-d-hide-boots
+      relationship: alternative
+      description: Bandos-aligned blessed dragonhide boots
+    - item_name: Armadyl d'hide boots
+      slug: armadyl-d-hide-boots
+      relationship: alternative
+      description: Armadyl-aligned blessed dragonhide boots
+    - item_name: Ancient d'hide boots
+      slug: ancient-d-hide-boots
+      relationship: alternative
+      description: Ancient-aligned blessed dragonhide boots
+  about: "Saradomin d'hide boots are blessed dragonhide boots aligned with Saradomin. They provide Saradominist protection in the God Wars Dungeon and are obtained as a 1/1,625 reward from hard clue caskets. With +1 prayer and balanced defence bonuses, they're a popular choice for prayer-conscious ranged setups."
+  market_strategy:
+    notes:
+      - "Demand spikes with God Wars Dungeon trips"
+      - "Prayer bonus makes these competitive with regular d'hide boots"
+  trading_tips:
+    - Watch for clue scroll meta shifts to time entries
+  history:
+    - date: "2016-07-06"
+      description: "Added to the game with the Treasure Trail rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-mitre.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-mitre.mdx
@@ -12,33 +12,92 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: vestment
+    tier: mid-high
+  properties:
+    release_date: "5 December 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.3
     requirements:
       prayer: 40
       magic: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
+  drop_table:
+    sources:
+      - source: Elite Treasure Trails
+        quantity: "1"
+        rarity: Common
   related_items:
-    - item_id: 10458
-      item_name: Saradomin robe top
+    - item_name: Saradomin robe top
       slug: saradomin-robe-top
       relationship: set-piece
       description: Saradomin vestment body
-    - item_id: 10464
-      item_name: Saradomin robe legs
+    - item_name: Saradomin robe legs
       slug: saradomin-robe-legs
       relationship: set-piece
       description: Saradomin vestment legs
-  about: |-
-    > *"A Saradomin mitre."*
-
-    The Saradomin mitre is a head slot item from the Saradomin vestment set. It provides a +5 Prayer bonus and requires 40 Prayer and 40 Magic to equip. Offers the second-highest prayer bonus for head slot items while matching mystic hat magic bonuses. Counts as a Saradominist item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Saradomin cloak
+      slug: saradomin-cloak
+      relationship: set-piece
+      description: Saradomin vestment cloak
+    - item_name: Saradomin stole
+      slug: saradomin-stole
+      relationship: set-piece
+      description: Saradomin vestment stole
+  about: "The Saradomin mitre is the head piece of the Saradomin vestment set, obtained as a reward from elite Treasure Trails. It provides a +5 Prayer bonus and matches mystic hat magic bonuses, requiring 40 Prayer and 40 Magic to equip. It counts as a Saradominist item in the God Wars Dungeon and is storable in the Costume Room treasure chest."
+  market_strategy:
+    notes:
+      - "Elite clue scroll exclusive"
+      - "Low GE buy limit of 8 makes flips slow"
+      - "Demand from Saradomin GWD trips and ironman alts"
+      - "Price stable with seasonal clue events"
+  trading_tips:
+    - Stock up during clue scroll events when supply spikes
+    - Sell during PvM weekends when GWD activity is high
+    - Compare prices across all four god mitres for arbitrage
+  history:
+    - date: "5 December 2006"
+      description: "Item was added to the game as part of the god vestment sets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/senntisten-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/senntisten-teleport-tablet.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Senntisten teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tablet
+    tier: mid
+  properties:
+    release_date: "2014-09-18"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 60
+      xp: 70
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Soul rune
+          quantity: 1
+      tools:
+        - Ancient lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Required rune for crafting the tablet
+    - item_name: Soul rune
+      slug: soul-rune
+      relationship: component
+      description: Required rune for crafting the tablet
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Base material for any teleport tablet
+  about: "The Senntisten teleport tablet breaks to teleport the player to the Digsite Exam Centre, mirroring the Senntisten teleport spell. Created at an ancient lectern in the Ancient Pyramid using the Ancient Magicks spellbook (60 Magic) from soft clay, 2 law runes and 1 soul rune — granting 70 Magic XP per tablet. Casting the tablet does not award XP and does not require the spellbook to be active."
+  market_strategy:
+    notes:
+      - "Crafted by Magic trainers running soft clay and runes"
+      - "Used by PvMers travelling to Dagannoth Kings and Senntisten dig site"
+      - "High buy limit (10,000) suits bulk supply"
+      - "No alch value — utility-only flips"
+      - "Profit per cast depends on soul rune supply"
+  trading_tips:
+    - Make in bulk at the Ancient Pyramid lectern
+    - Watch soul rune prices — they dominate margin
+    - Demand spikes with DT2 boss and dig site content
+  history:
+    - date: "2014-09-18"
+      description: "Item added to the game alongside Ancient spellbook tablets."
+    - date: "2015-04-01"
+      description: "Graphical update to the tablet sprite."
+    - date: "2016-05-01"
+      description: "Second graphical update applied."
+    - date: "2020-09-01"
+      description: "Ancient spellbook tablet crafting expanded with broader content support."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relic-hunter-t3-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relic-hunter-t3-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shattered relic hunter (t3) armour set | OSRS Price Data
-description: "Shattered relic hunter (t3) armour set is a members-only OSRS item. High alch: 30,000 GP."
+description: "Shattered relic hunter (t3) armour set: A set containing Shattered boots (t3), trousers (t3), top (t3) and hood (t3). High alch: 30,000 GP."
 osrs:
   id: 26560
   name: Shattered relic hunter (t3) armour set
@@ -12,9 +12,62 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Shattered relic hunter (t3) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2022-03-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: "Shattered hood (t3)"
+      slug: shattered-hood-t3
+      relationship: set-piece
+      description: "Hood component of the t3 outfit."
+    - item_name: "Shattered top (t3)"
+      slug: shattered-top-t3
+      relationship: set-piece
+      description: "Top component of the t3 outfit."
+    - item_name: "Shattered trousers (t3)"
+      slug: shattered-trousers-t3
+      relationship: set-piece
+      description: "Trousers component of the t3 outfit."
+    - item_name: "Shattered boots (t3)"
+      slug: shattered-boots-t3
+      relationship: set-piece
+      description: "Boots component of the t3 outfit."
+    - item_name: "Shattered relic hunter (t1) armour set"
+      slug: shattered-relic-hunter-t1-armour-set
+      relationship: downgrade
+      description: "Lower tier cosmetic outfit set."
+    - item_name: "Shattered relic hunter (t2) armour set"
+      slug: shattered-relic-hunter-t2-armour-set
+      relationship: downgrade
+      description: "Mid tier cosmetic outfit set."
+  about: "The Shattered relic hunter (t3) armour set is a Grand Exchange bundle of the four-piece tier-3 Leagues III cosmetic outfit. It is created by exchanging the components with a GE clerk and is mainly used to ship the whole outfit in one slot when listing or merching."
+  market_strategy:
+    notes:
+      - "No GE buy limit; set premium above part sum varies sharply when leagues nostalgia spikes."
+      - "Long-term cosmetic - price floor depends on Jagex never reissuing the outfit."
+  trading_tips:
+    - "Buy individual pieces below set price and merge with the GE clerk for arbitrage."
+    - "List in sets to clear all four parts faster during low cosmetic demand."
+  history:
+    - date: "2022-03-16"
+      description: "Released as a tradeable cosmetic bundle of the Leagues III tier-3 hunter outfit."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-fortune-farmer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-fortune-farmer.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the fortune farmer is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2021-08-25"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to destroy this sigil? You must unattune it before destroying."
+  drop_table:
+    sources:
+      - source: Deadman Mode global drop table
+        quantity: "1"
+        rarity: Rare
+  passive_effects:
+    - name: Stackable Clue Scrolls
+      description: While attuned, newly-dropped clue scrolls become stackable in the inventory.
+  related_items:
+    - item_name: Sigil of the menacing mage
+      slug: sigil-of-the-menacing-mage
+      relationship: alternative
+      description: Another tier 2 utility sigil from Deadman Mode events.
+    - item_name: Sigil of the ranging rogue
+      slug: sigil-of-the-ranging-rogue
+      relationship: alternative
+      description: Combat sigil sibling from the same Deadman drop pool.
+  about: "Sigil of the fortune farmer is a tier 2 utility sigil from temporary Deadman Mode events (Armageddon, Apocalypse, Reborn). When attuned, newly-dropped clue scrolls become stackable. It is currently unobtainable outside of a live Deadman event."
+  market_strategy:
+    notes:
+      - "Static unobtainable supply means price action is driven by collector demand on legacy servers only."
+      - "Effect is highly desired by clue-hunters during Deadman tournaments."
+  trading_tips:
+    - Unattune before destroying; the sigil refuses destruction while bound.
+    - Track Jagex Deadman event announcements for re-availability windows.
+  history:
+    - date: "2021-08-25"
+      description: "Released for the Deadman: Reborn tournament as part of the utility sigil set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-potion-master.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-potion-master.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of the potion master is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sigil
+    tier: high
+  properties:
+    release_date: "2021-08-25"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Unlock
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: false
+    destroy: "You will need to obtain another sigil from the Deadman skull shop."
+  passive_effects:
+    - name: Potion Conservation
+      description: "Once attuned, grants a 20% chance to not consume a dose when drinking a potion, with a 6-second cooldown between activations (5% chance in Deadman: Annihilation, no cooldown)."
+  related_items:
+    - item_name: Sigil of the smith
+      slug: sigil-of-the-smith
+      relationship: alternative
+      description: Smithing-focused Deadman sigil
+    - item_name: Sigil of the chef
+      slug: sigil-of-the-chef
+      relationship: alternative
+      description: Cooking-focused Deadman sigil
+  about: "Sigil of the potion master is a power-enhancing sigil obtained from Deadman Mode events. When attuned via the Unlock option, it grants a permanent 20% chance to not consume a potion dose upon use, with a 6-second cooldown between activations. The sigil is exclusive to temporary Deadman seasons and is generally not obtainable in the standard live game."
+  market_strategy:
+    notes:
+      - "Deadman Mode exclusive — not tradeable on live game GE"
+      - "Originally purchased from the Deadman skull shop"
+      - "Duplicates can be sold back to the skull shop"
+      - "Single attune unlock — multiple sigils can stack effects"
+      - "Value tag of 10,000 coins is informational only"
+  trading_tips:
+    - Cannot be traded — Deadman event reward
+    - High alch not possible
+    - Attune as soon as obtained for permanent buff
+  history:
+    - date: "2021-08-25"
+      description: "Item added to the game as part of Deadman: Reborn season."
+    - date: "Deadman: Annihilation"
+      description: "Earlier event variant featured a 5% chance with no cooldown."
+    - date: "Deadman: Armageddon / Apocalypse / Reborn"
+      description: "Effect rebalanced to 20% chance with a 6-second cooldown between procs."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-enchantment.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-enchantment.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 480
   highalch: 720
   limit: 500
-  about: "Slayer's enchantment is a members-only item in Old School RuneScape. High alchemy value: 720 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2017-04-13"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Wilderness Slayer monsters (Krystilia task)
+        quantity: "1"
+        rarity: Variable by HP
+      - source: Wilderness bosses (on task)
+        quantity: "1"
+        rarity: 1/30
+  related_items:
+    - item_name: Slayer's staff
+      slug: slayer-s-staff
+      relationship: component
+      description: Base staff that gets enchanted
+    - item_name: Slayer's staff (e)
+      slug: slayer-s-staff-e
+      relationship: product
+      description: Enchanted staff with 2500 charges
+  about: |-
+    Slayer's enchantment is a parchment used to enchant a Slayer's staff into a Slayer's staff (e), granting 2,500 charges of an empowered Magic Dart spell. The enchanted staff requires 75 Magic and 55 Slayer to wield. Dropped exclusively by Wilderness Slayer monsters when assigned by Krystilia, with drop rate scaling by monster HP.
+  market_strategy:
+    notes:
+      - "Demand from PvM and Wilderness Slayer training"
+      - "Supply tied to Krystilia task participation"
+      - "Buy limit of 500 per 4 hours"
+      - "Stackable, easy to bank in volume"
+  trading_tips:
+    - Watch for price dips during Wilderness DMM events
+    - Pairs with Slayer's staff supply for combo flipping
+  history:
+    - date: "2017-04-13"
+      description: "Released as part of the Wilderness Slayer expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/small-fishing-net.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/small-fishing-net.mdx
@@ -12,18 +12,73 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 40
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 4.535
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Gerrant's Fishy Business
+      location: Port Sarim
+      price: 5
+      currency: coins
+      stock: 5
+    - shop_name: Harry's Fishing Shop
+      location: Catherby
+      price: 5
+      currency: coins
+      stock: 5
+    - shop_name: Fremennik Fish Monger
+      location: Rellekka
+      price: 6
+      currency: coins
+      stock: 5
+    - shop_name: Fishing Guild Shop
+      location: Fishing Guild
+      price: 5
+      currency: coins
+      stock: 5
+    - shop_name: Arnold's Eclectic Supplies
+      location: Piscatoris Fishing Colony
+      price: 5
+      currency: coins
+      stock: 2
   related_items:
-    - item_id: 305
-      item_name: Big fishing net
+    - item_name: Big fishing net
       slug: big-fishing-net
       relationship: variant
       description: Catches multiple fish at once
+    - item_name: Drift net
+      slug: drift-net
+      relationship: alternative
+      description: Fossil Island net fishing tool
   about: |-
     > _"Useful for catching small fish."_
 
     The small fishing net is used to catch shrimps (1 Fishing) and anchovies (15 Fishing) at net/bait fishing spots. The first fishing tool most players use.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "Shop supply is abundant and cheap — flipping margins are razor-thin"
+      - "Used heavily by low-level Fishing trainers, ironmen craft alternatives"
+  history:
+    - date: "2001-06-11"
+      description: "Released with the original Fishing skill."
+    - date: "2025-08-01"
+      description: "Patched a bug preventing Ironmen from picking up nets in Sunset Coast and Shipwreck Cove."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spined-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spined-chaps.mdx
@@ -12,8 +12,35 @@ osrs:
   lowalch: 1560
   highalch: 2340
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dagannoth-hide
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 40
+      ranged: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -27,75 +54,40 @@ osrs:
       magic: 8
       ranged: 22
     other_bonus:
-      melee_strength: 0
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-      ranged: 40
-    weight: 5.443
   drop_table:
     sources:
       - source: Dagannoth Supreme
-        combat_level: 303
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/128
-        members_only: true
+        rarity: 1/128
   related_items:
-    - item_id: 6131
-      item_name: Spined helm
+    - item_name: Spined helm
       slug: spined-helm
       relationship: set-piece
       description: Matching helm piece
-    - item_id: 6133
-      item_name: Spined body
+    - item_name: Spined body
       slug: spined-body
       relationship: set-piece
       description: Matching body piece
-  about: |-
-    | Ranged | Value |
-    |--------|-------|
-    | Ranged Attack | +8 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +22 |
-    | Slash | +16 |
-    | Crush | +24 |
-    | Magic | +8 |
-    | Ranged | +22 |
-
-    Requirements: 40 Defence, 40 Ranged
-
-    | Stat | Spined Chaps | Green D'hide Chaps |
-    |------|-------------|-------------------|
-    | Ranged Atk | +8 | +8 |
-    | Stab Def | +22 | +22 |
-    | Slash Def | +16 | +16 |
-    | Crush Def | +24 | +20 |
-    | Magic Def | +8 | +8 |
-    | Ranged Def | +22 | +22 |
-    | Req | 40 Def + 40 Rng | 40 Rng |
-
-    Virtually identical to green d'hide chaps with slightly better crush defence (+24 vs +20). The additional 40 Defence requirement makes green d'hide chaps more accessible.
-
-    | Stat | Total |
-    |------|-------|
-    | Ranged Atk | +29 |
-    | Stab Def | +68 |
-    | Slash Def | +54 |
-    | Crush Def | +75 |
-    | Magic Def | +34 |
-    | Total cost | 22,500 coins + hides |
+    - item_name: Green d'hide chaps
+      slug: green-dhide-chaps
+      relationship: alternative
+      description: Accessible alternative with fewer requirements
+  about: "Spined chaps are a Fremennik ranged-armour leg piece dropped by Dagannoth Supreme. Requires The Fremennik Trials plus 40 Defence and 40 Ranged. Sigli the Huntsman can also tailor them from 2 dagannoth hides, 1 stretched hide and 7,500 coins. Defensively very close to green d'hide chaps with +4 crush defence over them."
   market_strategy:
     notes:
-      - Dagannoth Supreme drop (passive from DK farming)
-      - Green d'hide chaps preferred for accessibility
-      - Low trade volume — collector's piece
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Dagannoth Supreme drop (passive supply from DK farming)"
+      - "Green d'hide chaps preferred for accessibility (no 40 Defence req)"
+      - "Low trade volume — collector and Fremennik-set buyers only"
+  trading_tips:
+    - Margin tends to widen around Dagannoth Kings rework patches
+    - Pair with spined helm and body to flip the full set
+  history:
+    - date: "2005-08-01"
+      description: "Released with the Fremennik Isles content rollout."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/splitbark-gauntlets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/splitbark-gauntlets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Splitbark gauntlets | OSRS Price Data
-description: "Splitbark gauntlets: These should keep my hands safe.. High alch: 3,000 GP, GE limit: 70."
+description: "Splitbark gauntlets: These should keep my hands safe. High alch: 3,000 GP, GE limit: 70."
 osrs:
   id: 3391
   name: Splitbark gauntlets
@@ -12,12 +12,97 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 70
-  about: "Splitbark gauntlets is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: splitbark
+    tier: mid
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements:
+      defence: 40
+      magic: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: -1
+    defence_bonus:
+      stab: 3
+      slash: 2
+      crush: 4
+      magic: 2
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Magpie impling
+        quantity: "1"
+        rarity: 1/21
+      - source: Magpie impling jar
+        quantity: "1"
+        rarity: 1/21
+  recipes:
+    - skill: crafting
+      level: 60
+      xp: 32
+      materials:
+        - item_name: Bark
+          quantity: 1
+        - item_name: Fine cloth
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+  related_items:
+    - item_name: Splitbark body
+      slug: splitbark-body
+      relationship: set-piece
+      description: Body of the splitbark mage hybrid set
+    - item_name: Splitbark helm
+      slug: splitbark-helm
+      relationship: set-piece
+      description: Headpiece of the splitbark mage hybrid set
+  about: "Splitbark gauntlets are members-only hybrid hands giving low magic attack with melee defence. Crafted at 60 Crafting from 1 bark, 1 fine cloth, and 1 thread, or commissioned from Wizard Jalarast at Wizards' Tower for 1,000 coins. Magpie implings drop them at a 1/21 rarity."
+  market_strategy:
+    notes:
+      - "Crafting from raw materials usually a small net loss; supply mostly from implings"
+      - "High alch close to GE price gives marginal alch margin"
+  trading_tips:
+    - Stock often thin; place buy offers slightly above GE mid
+  history:
+    - date: "2004-10-18"
+      description: "Released as part of the splitbark armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/statius-s-platelegs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Statius's platelegs | OSRS Price Data
-description: "Statius's platelegs: A powerful pair of platelegs.. High alch: 300,000 GP, GE limit: 10."
+description: "Statius's platelegs: A powerful pair of platelegs. High alch: 300,000 GP, GE limit: 10."
 osrs:
   id: 22631
   name: Statius's platelegs
@@ -12,9 +12,87 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10
-  about: "Statius's platelegs is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2023-05-24"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Uncharge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 1
+      slash: 1
+      crush: 10
+      magic: -30
+      ranged: -12
+    defence_bonus:
+      stab: 73
+      slash: 71
+      crush: 68
+      magic: -14
+      ranged: 95
+    other_bonus:
+      melee_strength: 3
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+  related_items:
+    - item_name: Statius's full helm
+      slug: statius-s-full-helm
+      relationship: set-piece
+      description: Helmet half of the Statius's wargear set.
+    - item_name: Statius's platebody
+      slug: statius-s-platebody
+      relationship: set-piece
+      description: Chest piece of the Statius's wargear set.
+    - item_name: Statius's warhammer
+      slug: statius-s-warhammer
+      relationship: set-piece
+      description: Iconic crush weapon associated with the set's special.
+    - item_name: Corrupted statius's platelegs
+      slug: corrupted-statius-s-platelegs
+      relationship: variant
+      description: Corrupted version with the same role in Bounty Hunter combat.
+  about: |-
+    Statius's platelegs is a high-end pair of legs purchased from the Bounty Hunter Store for 500 Bounty Hunter points, with a 5,000,000 coin activation fee. Worn alongside the matching helm and platebody, it boosts melee special-attack accuracy by 15%.
+
+    Use is restricted to Bounty Hunter-style PvP arenas, Castle Wars, Clan Wars, Soul Wars, the TzHaar Fight Pit and POH combat rings. The item is untradeable and not alchable.
+
+    Requirements: 78 Defence | Slot: Legs | Weight: 9.071 kg
+  market_strategy:
+    notes:
+      - "Untradeable - no Grand Exchange market; value is in BH points spent."
+      - "Set bonus only fires inside the allowed arenas."
+      - "Activation fee of 5m coins is unavoidable on every fresh purchase."
+  trading_tips:
+    - Plan BH point budgets across the full Statius's set instead of one piece at a time.
+    - If only Castle Wars / Soul Wars use is planned, weigh cost vs ZGS/Bandos legs.
+  history:
+    - date: "2023-06-14"
+      description: "Set bonuses adjusted post-release."
+    - date: "2023-05-24"
+      description: "Released as part of the revamped Bounty Hunter Store."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-knife-p-5656.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-knife-p-5656.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 7000
-  about: "Steel knife(p+) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 8
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 7
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Weapon poison(+)
+      description: Has a chance to inflict extra strong poison on hit, dealing 5 damage initially.
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Steel knife
+          quantity: 5
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      output_quantity: 5
+  related_items:
+    - item_name: Steel knife
+      slug: steel-knife
+      relationship: component
+      description: Unpoisoned base knife combined with weapon poison(+).
+    - item_name: Steel knife(p)
+      slug: steel-knife-p
+      relationship: downgrade
+      description: Standard weapon poison variant of the steel knife.
+    - item_name: Steel knife(p++)
+      slug: steel-knife-p-plus-plus
+      relationship: upgrade
+      description: Stronger weapon poison(++) variant.
+  about: "Steel knife(p+) is a thrown weapon crafted by applying weapon poison(+) to five steel knives. It requires 5 Ranged to wield and inflicts extra-strong poison on hit, useful for early-tier ranged pures and PvP setups."
+  market_strategy:
+    notes:
+      - "Cheap stackable throwing weapon; demand pulses with PvP events."
+      - "Crafted in batches of five which can spike supply briefly after Herblore training."
+  trading_tips:
+    - Buy unpoisoned steel knives and apply weapon poison(+) when the spread justifies it.
+    - Stack up for Bounty Hunter events; demand spikes during PvP weekends.
+  history:
+    - date: "2006-09-01"
+      description: "Renamed from 'Steel knife(+)' to 'Steel knife(p+)' to standardise poison suffixes."
+    - date: "2005-07-11"
+      description: "Released alongside the Herblore weapon poison(+) update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-locks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-locks.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 640
   highalch: 960
   limit: 8
-  about: "Steel locks is a members-only item in Old School RuneScape. High alchemy value: 960 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2021-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Steel chest (red)
+        quantity: "1"
+        rarity: 1/63
+      - source: Steel chest (brown)
+        quantity: "1"
+        rarity: 1/62
+      - source: Steel chest (crimson)
+        quantity: "1"
+        rarity: 1/61
+      - source: Steel chest (black)
+        quantity: "1"
+        rarity: 1/60
+      - source: Steel chest (purple)
+        quantity: "1"
+        rarity: 1/59
+  related_items:
+    - item_name: Broken coffin
+      slug: broken-coffin
+      relationship: component
+      description: Base coffin Dampe needs alongside steel locks to assemble a steel coffin.
+    - item_name: Steel coffin
+      slug: steel-coffin
+      relationship: product
+      description: Result of bringing the steel locks and broken coffin to NPC Dampe.
+    - item_name: Bronze locks
+      slug: bronze-locks
+      relationship: downgrade
+      description: Lower-tier lock from the same Shades of Mort'ton chest reward pool.
+    - item_name: Black locks
+      slug: black-locks
+      relationship: upgrade
+      description: Next-tier lock used to assemble a black coffin.
+  about: "Steel locks are a Shades of Mort'ton chest reward obtained from steel-tier chests during the minigame. Players take the locks and a broken coffin to Dampe, who attaches them to forge a steel coffin used in the minigame's burning loop."
+  market_strategy:
+    notes:
+      - "Supply is gated by the steel-tier chest rotation, so listing volume is low."
+      - "GE buy limit of 8 per 4 hours keeps the spread wide; ironmen are the largest buyer pool."
+      - "Demand spikes during Shades of Mort'ton skilling events and Pyromancer pet hunts."
+  trading_tips:
+    - Stockpile during minigame community events to capture peak demand.
+    - Compare lock tier prices before deciding which coffin to assemble.
+    - List slightly under high alch to ensure consistent flips.
+  history:
+    - date: "2021-01-27"
+      description: "Added with the Shades of Mort'ton rework which expanded the minigame's reward chests."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-nails.mdx
@@ -12,86 +12,81 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: nails
-    tier: steel
-  smithing:
-    level: 34
-    xp: 37.5
-    bars: 1
-    nails_per_bar: 15
-  construction:
-    bend_rate: Medium
-    min_level: 1
+    tier: mid
+  properties:
+    release_date: "23 September 2001"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Sawmill operator
+      location: Varrock Lumber Yard
+      price: 3
+      currency: Coins
+      stock: 1000
   recipes:
     - skill: smithing
       level: 34
       xp: 37.5
       materials:
         - item_name: Steel bar
-          item_id: 2353
           quantity: 1
-      product: Steel nails
-      product_id: 1539
-      product_quantity: 15
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 15
   related_items:
-    - item_id: 2353
-      item_name: Steel bar
+    - item_name: Steel bar
       slug: steel-bar
       relationship: component
-      description: Smelting material
-    - item_id: 4820
-      item_name: Iron nails
+      description: Smithing material for nails
+    - item_name: Iron nails
       slug: iron-nails
       relationship: downgrade
-      description: Higher bend rate
-    - item_id: 4822
-      item_name: Mithril nails
+      description: Higher bend rate, cheaper alternative
+    - item_name: Mithril nails
       slug: mithril-nails
       relationship: upgrade
       description: Lower bend rate
-    - item_id: 960
-      item_name: Plank
+    - item_name: Plank
       slug: plank
-      relationship: component
-      description: Used with planks
-    - item_id: 8778
-      item_name: Oak plank
+      relationship: product
+      description: Used with regular planks in Construction
+    - item_name: Oak plank
       slug: oak-plank
-      relationship: component
-      description: Construction material
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Bend rate | Medium |
-    | Construction level | 1+ |
-    | Used with | Planks |
-
-    Most common nails for Construction training. Reasonable bend rate with affordable cost.
-
-    Required for:
-    - Furniture using regular planks
-    - Some quest builds (e.g., Priest in Peril bridge)
-
-    | Nails | Bend Rate | Shop Price |
-    |-------|-----------|------------|
-    | Bronze | Highest | 1 GP |
-    | Iron | High | 2 GP |
-    | Steel | Medium | 5 GP |
-    | Mithril | Low | 10 GP |
-    | Adamantite | Very Low | 25 GP |
-    | Rune | Never bends | 100 GP |
+      relationship: product
+      description: Used with oak planks in Construction
+  about: "Steel nails are a stackable Construction reagent smithed from steel bars at level 34 Smithing (15 nails per bar, 37.5 XP). Used together with planks to build a variety of furniture and quest constructions, including the Priest in Peril bridge. Offer a medium bend rate — a balance between the cheaper iron nails and the more reliable mithril and adamantite versions. Also sold by the Sawmill operator at the Varrock Lumber Yard."
   market_strategy:
     notes:
-      - Best value nails for Construction
-      - Good balance of cost and bend rate
-      - Popular for early Construction training
-      - Required for various quests
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Best value nails for Construction training"
+      - "High daily GE volume keeps prices liquid"
+      - "Shop floor at 3 coins from Sawmill operator"
+      - "Smithing recipe loses money pre-tax"
+  trading_tips:
+    - Buy from Sawmill operator for arbitrage to GE
+    - Watch Construction event weekends for demand spikes
+    - Stockpile during Smithing events when steel bars dip
+  history:
+    - date: "23 September 2001"
+      description: "Item was added to the game alongside the original nails set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-pickaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-pickaxe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel pickaxe | OSRS Price Data
-description: "Steel pickaxe: Used for mining.. High alch: 300 GP, GE limit: 40."
+description: "Steel pickaxe mines on a 6-tick cycle and requires 6 Mining. High alch: 300 GP, GE limit: 40."
 osrs:
   id: 1269
   name: Steel pickaxe
@@ -12,9 +12,89 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 40
-  about: "Steel pickaxe is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2003-05-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: pickaxe
+    attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 5
+      mining: 6
+    attack_bonus:
+      stab: 8
+      slash: -2
+      crush: 6
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 9
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Nurmof's Pickaxe Shop
+      location: Dwarven Mine
+      price: 500
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Iron pickaxe
+      slug: iron-pickaxe
+      relationship: downgrade
+      description: One tier below; 7-tick cycle
+    - item_name: Mithril pickaxe
+      slug: mithril-pickaxe
+      relationship: upgrade
+      description: One tier above; faster mining
+    - item_name: Black pickaxe
+      slug: black-pickaxe
+      relationship: alternative
+      description: Cosmetic-tier alternative
+    - item_name: Rune pickaxe
+      slug: rune-pickaxe
+      relationship: upgrade
+      description: High-tier free-to-play pickaxe
+  about: |-
+    > _"Used for mining."_
+
+    Steel pickaxe mines on a 6-tick cycle, one tick faster than iron. Requires 6 Mining to use and 5 Attack to wield. Bought from Nurmof's in the Dwarven Mine — cannot be smithed.
+  market_strategy:
+    notes:
+      - "Demand is limited by 40 GE limit and Nurmof's shop floor."
+      - "Useful as a cheap melee/strength training tool because of +9 strength bonus."
+  trading_tips:
+    - Sell pickaxes in pairs during big mining rework events.
+    - Buy directly from Nurmof when GE flips below shop price.
+  history:
+    - date: "2003-05-27"
+      description: "Released with the original RuneScape 2 mining suite."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-warhammer.mdx
@@ -12,41 +12,80 @@ osrs:
   lowalch: 256
   highalch: 384
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: warhammer
-    tradeable: true
+    weapon_type: warhammer
+    attack_speed: 6
     weight: 1.814
     requirements:
       attack: 5
-    stats:
-      attack_stab: -4
-      attack_slash: -4
-      attack_crush: 18
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 18
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 16
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: smithing
+      level: 39
+      xp: 112.5
+      materials:
+        - item_name: Steel bar
+          quantity: 3
+      tools:
+        - Hammer
+      output_quantity: 1
   related_items:
-    - item_id: 1341
-      item_name: Black warhammer
+    - item_name: Black warhammer
       slug: black-warhammer
       relationship: upgrade
       description: Higher tier warhammer
-    - item_id: 1424
-      item_name: Steel mace
+    - item_name: Steel mace
       slug: steel-mace
       relationship: alternative
       description: Alternative crush weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Steel warhammer is an F2P one-handed crush weapon required for the In Search of the Myreque quest. Smith from 3 steel bars at level 39 Smithing for 112.5 xp. Also substitutes for a regular hammer at the Bandos' Stronghold entrance."
+  market_strategy:
+    notes:
+      - "Smithing input cost typically exceeds GE price (loss to craft for profit)"
+      - "Demand driven mainly by quest requirement spikes"
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch."
+    - date: "2021-04-21"
+      description: "Requirement changed from 5 Attack to 5 Strength; strength bonus raised from 16 to 18 in live game."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sulphur-blades.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sulphur-blades.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 15
-  about: "Sulphur blades is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: weapon
+    tier: high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: slash_weapon
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 55
+    attack_bonus:
+      stab: 0
+      slash: 72
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 64
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Sulphur Nagua
+        quantity: "1"
+        rarity: 1/450
+  related_items:
+    - item_name: Glacial temotli
+      slug: glacial-temotli
+      relationship: alternative
+      description: Crush variant of the multi-hit Varlamore weapon trio
+    - item_name: Earthbound tecpatl
+      slug: earthbound-tecpatl
+      relationship: alternative
+      description: Stab variant of the multi-hit Varlamore weapon trio
+    - item_name: Dragon scimitar
+      slug: dragon-scimitar
+      relationship: alternative
+      description: Conventional slash benchmark
+  about: |-
+    > *"Are these explosive?"*
+
+    Two-handed slash weapon that rolls two independent hits per swing. Requires 55 Attack and drops from Sulphur Nagua at 1/450.
+  market_strategy:
+    notes:
+      - "Supply gated by Sulphur Nagua drop rate"
+      - "Multi-hit mechanic keeps demand among slayer/AFK trainers"
+  trading_tips:
+    - Watch for price dips after each new Varlamore content patch
+  history:
+    - date: "2024-03-20"
+      description: "Added with Varlamore: Part One."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-2.mdx
@@ -12,70 +12,84 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 2000
-  potion:
-    doses: 2
-    type: restore
-    effect: Restores all stats (except Hitpoints) and Prayer
-    effects:
-      - stat: All stats
-        boost_formula: 8 + floor(level / 4)
-      - stat: Prayer
-        boost_formula: 8 + floor(level / 4)
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
   properties:
+    release_date: "2004-07-27"
     tradeable: true
-    tradeable_ge: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores all stats except Hitpoints by 8 + 25% of base level per dose."
+        duration: 0
+      - description: "Restores Prayer points by 8 + 25% of Prayer level per dose."
+        duration: 0
   recipes:
     - skill: herblore
       level: 63
       xp: 142.5
       materials:
         - item_name: Snapdragon potion (unf)
-          item_id: 3004
           quantity: 1
         - item_name: Red spiders' eggs
-          item_id: 223
           quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 3024
-      item_name: Super restore(4)
+    - item_name: Super restore(4)
       slug: super-restore-4
       relationship: variant
-      description: Full dose variant
-    - item_id: 3026
-      item_name: Super restore(3)
+      description: Full 4-dose variant of the same potion.
+    - item_name: Super restore(3)
       slug: super-restore-3
       relationship: variant
-      description: 3-dose variant
-    - item_id: 6685
-      item_name: Saradomin brew(4)
+      description: 3-dose variant.
+    - item_name: Super restore(1)
+      slug: super-restore-1
+      relationship: variant
+      description: 1-dose variant.
+    - item_name: Sanfew serum(4)
+      slug: sanfew-serum-4
+      relationship: upgrade
+      description: Upgraded potion with poison and disease cure.
+    - item_name: Saradomin brew(4)
       slug: saradomin-brew-4
       relationship: alternative
-      description: Paired consumable (3:1 ratio)
-  about: |-
-    2-dose variant of Super restore(4).
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 63 |
-    | XP gained | 142.5 (when making 3-dose) |
-
-    Per dose restores:
-    - All stats except Hitpoints
-    - Prayer points: 8 + 25% of level
-    - Other stats: 8 + 25% of level
-
-    At 99 Prayer: Restores 32 prayer points per dose.
-
-    Used with Saradomin brew at 3:1 brew-to-restore ratio.
-
-    Note: Decants to/from 4-dose version at Bob Barter (GE).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Paired consumable used at a 3:1 brew-to-restore ratio.
+  about: "Super restore(2) is the 2-dose form of the super restore potion. Each dose restores all stats except Hitpoints and refills Prayer points, making it the standard staple at bossing and PvM."
+  market_strategy:
+    notes:
+      - "Decants directly to and from 4-dose at Bob Barter at the Grand Exchange."
+      - "Demand tied to PvM and Prayer-heavy content."
+  trading_tips:
+    - Convert 2-dose into 4-dose via decanting for better stack efficiency.
+    - Buy during off-peak hours for cheaper bulk supply.
+  history:
+    - date: "2004-07-27"
+      description: "Super restore potions added to the game."
+    - date: "2004-09-01"
+      description: "Update note: \"Super restore potions will now restore non-combat skills.\""
+    - date: "2004-10-26"
+      description: "\"Empty\" option added to the potion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/supercompost.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/supercompost.mdx
@@ -1,6 +1,6 @@
 ---
 title: Supercompost | OSRS Price Data
-description: "Supercompost: Super-good for the smallest or largest of plants.. High alch: 51 GP, GE limit: 2,000."
+description: "Supercompost reduces disease 4/5 per stage and raises minimum herb yield to 5. High alch: 51 GP, GE limit: 2,000."
 osrs:
   id: 6034
   name: Supercompost
@@ -12,51 +12,76 @@ osrs:
   lowalch: 34
   highalch: 51
   limit: 2000
-  item_id: 6034
-  type: farming_material
-  tradeable: true
-  weight: 3
-  buy_limit: 2000
-  requirements:
-    skills: []
-  obtaining:
-    primary:
-      method: Compost Bin
-      details: Fill with 15 suitable items (watermelons, herbs)
-    upgrade:
-      method: Compost Potion
-      details: Upgrade regular compost
-    shop:
-      name: Farmer Gricoller's Rewards
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: farming
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: Disease reduction
+      description: Reduces crop disease chance by 4/5 per growth stage versus normal compost.
+    - name: Yield boost
+      description: Raises minimum herb yield to 5 and provides 26 Farming XP per bucket applied.
+  recipes:
+    - skill: farming
+      level: 1
+      xp: 26
+      materials:
+        - item_name: Compost
+          quantity: 1
+        - item_name: Saltpetre
+          quantity: 3
+      tools:
+        - Compost bin
+      output_quantity: 1
+  shops:
+    - shop_name: Farmer Gricoller's Rewards
+      location: Hosidius
       price: 5
-    drops:
-      - Zygomites
-      - Wilderness bosses
-  usage:
-    farming:
-      disease_reduction: 5/128
-      yield_increase: true
+      currency: Farming Reward Points
+      stock: 0
   related_items:
-    - slug: ultracompost
-      name: Ultracompost
-      relation: higher_tier
-    - slug: compost-potion
-      name: Compost potion
-      relation: upgrade_method
+    - item_name: Compost
+      slug: compost
+      relationship: downgrade
+      description: Base tier compost
+    - item_name: Ultracompost
+      slug: ultracompost
+      relationship: upgrade
+      description: Higher tier compost using volcanic ash
+    - item_name: Compost potion
+      slug: compost-potion
+      relationship: alternative
+      description: Upgrade method for regular compost
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Farming Material |
-    | Tradeable | Yes |
-    | Weight | 3 kg |
-    | Requirements | None |
+    > _"Super-good for the smallest or largest of plants."_
 
-    Reduces crop disease rate to 5/128.
-
-    Increases herb yield compared to regular compost.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Supercompost is made by filling a compost bin with 15 high-tier produce (watermelons, pineapples, herbs, oranges, papayas) or by combining 3 saltpetre with regular compost. Applying it requires only level 1 Farming and grants 26 XP per bucket.
+  market_strategy:
+    notes:
+      - "Demand follows farm-run cadence; bulk listings move quickly during herb XP events."
+      - "Watermelon farming pipelines feed into supercompost crafting."
+  trading_tips:
+    - Buy from Farmer Gricoller for 5 points and resell when GE prints above 75 gp.
+    - Stockpile during weekday lulls for weekend bot-buyer demand.
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming skill expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-helm.mdx
@@ -12,12 +12,103 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Swampbark helm is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bark
+    tier: mid-high
+  properties:
+    release_date: "27 January 2021"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements:
+      magic: 50
+      defence: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 13
+      slash: 11
+      crush: 14
+      magic: 5
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: runecraft
+      level: 46
+      xp: 12.5
+      materials:
+        - item_name: Splitbark helm
+          quantity: 1
+        - item_name: Nature rune
+          quantity: 250
+      tools:
+        - Nature altar
+        - Runescroll of swampbark
+      output_quantity: 1
+  passive_effects:
+    - name: Bind extension
+      description: "Worn alongside swampbark body and legs, increases bind, snare, and entangle durations by a combined 6 ticks."
+  related_items:
+    - item_name: Splitbark helm
+      slug: splitbark-helm
+      relationship: downgrade
+      description: Base helm consumed to craft the swampbark variant
+    - item_name: Swampbark body
+      slug: swampbark-body
+      relationship: set-piece
+      description: Matching swampbark body
+    - item_name: Swampbark legs
+      slug: swampbark-legs
+      relationship: set-piece
+      description: Matching swampbark legs
+    - item_name: Runescroll of swampbark
+      slug: runescroll-of-swampbark
+      relationship: component
+      description: Unlocks the swampbark crafting recipe
+  about: "The swampbark helm is an upgraded magic helmet crafted from a splitbark helm and 250 nature runes at the Nature Altar, requiring 46 Runecraft. It requires 50 Magic and 50 Defence to wear. When worn with the matching body and legs, the set extends bind, snare, and entangle spell durations by 6 ticks total, giving Bind 14 ticks, Snare 22 ticks, and Entangle 30 ticks. Useful for PvP setups that rely on freezes."
+  market_strategy:
+    notes:
+      - "Skilling-gated supply through Runecraft + Nature Altar"
+      - "Niche PvP and PvM utility (freeze extension)"
+      - "No GE buy limit cap published"
+      - "Demand spikes during PvP-focused content updates"
+  trading_tips:
+    - Track splitbark helm prices for crafting margin
+    - Buy during quieter content lulls
+    - Sell during Wilderness or LMS events
+  history:
+    - date: "27 January 2021"
+      description: "Item was added to the game alongside the Mage Arena 2 rework and Runescroll of swampbark unlock."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swift-blade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swift-blade.mdx
@@ -12,12 +12,81 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: null
-  about: "Swift blade is a free-to-play item in Old School RuneScape. High alchemy value: 900 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: mid-high
+  properties:
+    release_date: "2019-08-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 3
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
+      ranged_strength: 0
+      magic_damage: 0
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Ferox Enclave
+      price: 350
+      currency: Last Man Standing points
+      stock: 1
+  related_items:
+    - item_name: Granite hammer
+      slug: granite-hammer
+      relationship: alternative
+      description: Other Last Man Standing reward weapon
+    - item_name: Ham joint
+      slug: ham-joint
+      relationship: alternative
+      description: Joke LMS reward weapon
+  about: "Swift blade is a Last Man Standing reward weapon. With no combat bonuses but a 3 tick attack speed and stab plus slash styles, it is used for Defence pures and Theatre of Blood's Nylocas room because it does not conflict with the dragon warhammer's crush style."
+  market_strategy:
+    notes:
+      - "Supply is gated by Last Man Standing point grinding"
+      - "Niche demand from ToB and pure builds keeps the floor elevated"
+      - "No buy limit so volume traders can move large stacks"
+  trading_tips:
+    - Watch ToB meta shifts that change Nylocas weapon preference
+    - LMS point grinders often dump multiple swift blades after streaks
+  history:
+    - date: "2019-08-29"
+      description: "Added to Justine's reward shop with the Last Man Standing rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/target-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/target-teleport.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Target teleport is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport_tablet
+    tier: low
+  properties:
+    release_date: "7 November 2019"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Justine's stuff for the Last Shopper Standing"
+      location: Last Man Standing lobby
+      price: 1
+      currency: Last Man Standing points
+      stock: 1000
+  drop_table:
+    sources:
+      - source: Wilderness Slayer Cave creatures
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Target teleport scroll
+      slug: target-teleport-scroll
+      relationship: component
+      description: "Unlock scroll that enables the Teleport to Target spell"
+  about: |-
+    Target teleport is a tablet that breaks to cast Teleport to Target, instantly bringing the player to their current Bounty Hunter target. The unlock scroll for the spellbook entry must have been read for the tablet to function.
+
+    Originally introduced as 'Bounty target teleport' during the 2019 Bounty Hunter Rework, the tablet was renamed in 2020.
+  market_strategy:
+    notes:
+      - "Demand driven by Bounty Hunter PKers"
+      - "Last Man Standing point sink for shop-bought supply"
+  trading_tips:
+    - Bulk-buy from Justine for cheap arbitrage when GE price spikes
+  history:
+    - date: "7 November 2019"
+      description: "Released with the Bounty Hunter rework."
+    - date: "6 August 2020"
+      description: "Renamed from 'Bounty target teleport' to 'Target teleport.'"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-armour-case-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-armour-case-flatpack.mdx
@@ -12,12 +12,65 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak armour case (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teak
+    tier: low
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 64
+      xp: 270
+      materials:
+        - item_name: Teak plank
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Required material to flatpack the armour case
+    - item_name: Armour case
+      slug: armour-case
+      relationship: product
+      description: Costume room furniture built from this flatpack
+    - item_name: Mahogany armour case (flatpack)
+      slug: mahogany-armour-case-flatpack
+      relationship: upgrade
+      description: Higher tier armour case flatpack
+  about: "Teak armour case (flatpack) is built at a bench with a vice in the workshop of a player owned house, requiring level 64 Construction, 3 teak planks, and granting 270 Construction XP. The flatpack version can be sold on the Grand Exchange or moved between houses, where it builds the costume room teak armour case for armour storage."
+  market_strategy:
+    notes:
+      - "Common XP farm for Construction trainers selling planks worth of XP"
+      - "500 buy limit makes it easy to flip in volume at thin margins"
+      - "Demand driven by mid-game costume room builders"
+  trading_tips:
+    - Buy when teak plank price spikes drive flatpack price up
+    - Sell rather than build personally if low Construction is the bottleneck
+  history:
+    - date: "2006-10-18"
+      description: "Added with the launch of the Construction skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teleport-anchoring-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teleport-anchoring-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teleport anchoring scroll | OSRS Price Data
-description: "Teleport anchoring scroll: A formidable magic spell which prevents unwanted teleportation.. High alch: 30,000 GP, GE limit: 5."
+description: "Teleport anchoring scroll: A formidable magic spell which prevents unwanted teleportation. High alch: 30,000 GP, GE limit: 5."
 osrs:
   id: 29455
   name: Teleport anchoring scroll
@@ -12,12 +12,60 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 5
-  about: "Teleport anchoring scroll is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2024-04-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.015
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Zombie Pirate's Locker
+        quantity: "1"
+        rarity: 1/275
+      - source: Zombie pirate (rare)
+        quantity: "1"
+        rarity: 3/200000
+      - source: Zombie pirate diary
+        quantity: "1"
+        rarity: 1/20000
+  passive_effects:
+    - name: Teleport anchoring
+      description: Reading the scroll permanently grants the player immunity to teleportation attacks from abyssal demons and elder chaos druids.
+  related_items:
+    - item_name: Royal seed pod
+      slug: royal-seed-pod
+      relationship: alternative
+      description: Traveller's reward used for fast teleports
+    - item_name: Zombie pirate key
+      slug: zombie-pirate-key
+      relationship: alternative
+      description: Opens zombie pirate's locker drop source
+  about: "Teleport anchoring scroll is a consumable read-once unlock from zombie pirate content. After reading, the player can never again be teleported by abyssal demons or elder chaos druids. The effect does not protect against Abyssal Sire, Chaos Elemental Confusion, or Tele Block."
+  market_strategy:
+    notes:
+      - "Demand limited to players farming abyssal demons or elder chaos druids"
+      - "1/275 locker rarity caps supply"
+  trading_tips:
+    - Buy limit of 5 makes bulk flipping slow
+  history:
+    - date: "2024-04-10"
+      description: "Released with the Forestry Update Part 2 and Zombie Pirate content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/the-dogsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/the-dogsword.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: The dogsword is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2024-11-27"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: two-handed
+    weapon_type: godsword
+    attack_speed: 6
+    weight: 10
+    requirements:
+      attack: 75
+    attack_bonus:
+      stab: 0
+      slash: 132
+      crush: 80
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 132
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 8
+  drop_table:
+    sources:
+      - source: Echo Cerberus
+        quantity: "1"
+        rarity: 1/25
+  related_items:
+    - item_name: Armadyl godsword
+      slug: armadyl-godsword
+      relationship: alternative
+      description: One of the five canonical godswords whose special attack effect is mirrored by the dogsword's Echo slash.
+    - item_name: Bandos godsword
+      slug: bandos-godsword
+      relationship: alternative
+      description: Bandos special is part of the combined effect on the dogsword Echo slash.
+    - item_name: Saradomin godsword
+      slug: saradomin-godsword
+      relationship: alternative
+      description: Saradomin restore portion of the dogsword's special attack.
+    - item_name: Zamorak godsword
+      slug: zamorak-godsword
+      relationship: alternative
+      description: Zamorak freeze effect bundled into the dogsword's Echo slash.
+    - item_name: Ancient godsword
+      slug: ancient-godsword
+      relationship: alternative
+      description: Ancient blood-staining effect combined into the dogsword special.
+  about: "The dogsword is a two-handed godsword variant from Raging Echoes League and the Grid Master event, requiring 75 Attack to wield. Its Echo slash special attack costs 50% energy and bundles every standard godsword effect into a single swing."
+  market_strategy:
+    notes:
+      - "Untradeable cosmetic-grade godsword - cannot be flipped on the Grand Exchange."
+      - "Only obtainable through league and event windows, so account access is gated behind completed unlocks."
+      - "As a discontinued item it will not return through normal gameplay outside future commemorative events."
+  trading_tips:
+    - Plan league grinds around Echo Cerberus access to secure the drop before the league ends.
+    - Complete Grid Master column 1 tasks during event windows to lock in the reward.
+    - Treat the dogsword as a trophy rather than a flip target; supply is fixed.
+  history:
+    - date: "2024-11-27"
+      description: "Released as a Raging Echoes League reward and Grid Master event unlock."
+    - date: "2025-11-12"
+      description: "Item discontinued after the closing event window."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toadflax-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toadflax-seed.mdx
@@ -12,68 +12,71 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 600
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: seed
+    tier: mid
+  properties:
+    release_date: "2005-06-06"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0
-  farming:
-    level: 38
-    growth_time: 80
-    plant_xp: 34
-    harvest_xp: 38.5
-    patch_type: herb
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 38
+      xp: 38.5
+      materials:
+        - item_name: Toadflax seed
+          quantity: 1
+      tools:
+        - Seed dibber
+        - Rake
+      output_quantity: 1
   related_items:
-    - item_id: 2998
-      item_name: Toadflax
+    - item_name: Toadflax
       slug: toadflax
       relationship: product
-      description: Harvested herb
-    - item_id: 6687
-      item_name: Saradomin brew(4)
+      description: Harvested herb used in Saradomin brews
+    - item_name: Saradomin brew(4)
       slug: saradomin-brew-4
       relationship: alternative
-      description: End product potion
-    - item_id: 21483
-      item_name: Ultracompost
+      description: End-product potion driving toadflax demand
+    - item_name: Ultracompost
       slug: ultracompost
-      relationship: alternative
-      description: Best compost for yield
-    - item_id: 7409
-      item_name: Magic secateurs
+      relationship: component
+      description: Best compost for higher yield and disease resistance
+    - item_name: Magic secateurs
       slug: magic-secateurs
-      relationship: alternative
-      description: Yield boost tool
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Farming Level | 38 |
-    | Growth Time | 80 minutes |
-    | Plant XP | 34 |
-    | Harvest XP | 38.5 per herb |
-
-    | Compost Type | Min Harvest | Avg at 99 |
-    |--------------|-------------|-----------|
-    | None | 3 | ~5 herbs |
-    | Compost | 4 | ~6 herbs |
-    | Supercompost | 5 | ~7.5 herbs |
-    | Ultracompost | 6 | ~9.2 herbs |
-
-    Tip: Use magic secateurs and attas plant for maximum yield.
-
-    Toadflax is used to create:
-    - Saradomin brew(4) - Essential PvM potion
-    - Agility potion(4) - Run restoration
+      relationship: component
+      description: Yield boost tool from Fairy Tale Part I
+  about: "Toadflax seed is a herb seed planted in a herb patch at 38 Farming. Each seed grows into toadflax over 80 minutes (four 20 minute stages) and yields at least 3 herbs per patch, more with compost. Toadflax is the primary herb for Saradomin brews and is a major PvM economy driver."
   market_strategy:
     notes:
-      - Profitable herb to farm
-      - Saradomin brew demand drives price
-      - Often farmed alongside other valuable herbs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Profitable herb to farm thanks to Saradomin brew demand"
+      - "Stack across multiple herb patches for compounding runs"
+      - "Magic secateurs and attas plant maximise per-patch yield"
+  trading_tips:
+    - Buy seeds in bulk during Wintertodt seed pack waves
+    - Sell harvested toadflax over the seed for higher margin
+  history:
+    - date: "2005-06-06"
+      description: "Added with the Farming skill release."
+    - date: "2020-04-23"
+      description: "Experience moved from planting to harvesting to prevent click-spam farming."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-necklace.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 570
   highalch: 855
   limit: 10000
-  about: "Topaz necklace is a members-only item in Old School RuneScape. High alchemy value: 855 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: jewellery
+    tier: low
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 32
+      xp: 70
+      materials:
+        - item_name: Red topaz
+          quantity: 1
+        - item_name: Silver bar
+          quantity: 1
+      tools:
+        - Necklace mould
+      output_quantity: 1
+  related_items:
+    - item_name: Necklace of faith
+      slug: necklace-of-faith
+      relationship: product
+      description: Enchanted via Lvl-3 Enchant
+    - item_name: Red topaz
+      slug: red-topaz
+      relationship: component
+      description: Cut gem used in crafting
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Bar used in crafting
+  about: |-
+    > *"I wonder if this is valuable."*
+
+    Crafted from a silver bar and a red topaz at 32 Crafting for 70 XP. Primarily made as a stepping stone to the Necklace of faith via the Lvl-3 Enchant spell.
+  market_strategy:
+    notes:
+      - "Crafting yields a net loss at typical material prices"
+      - "Demand driven by Magic XP enchanters chasing the faith necklace"
+  history:
+    - date: "2017-02-02"
+      description: "Released alongside the rest of the topaz jewellery line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platelegs.mdx
@@ -12,86 +12,93 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: torva
+    tier: high
+  properties:
+    release_date: "2022-01-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: melee_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
     requirements:
       defence: 80
-    stats:
-      defence_stab: 87
-      defence_slash: 78
-      defence_crush: 79
-      defence_magic: -9
-      defence_ranged: 102
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 87
+      slash: 78
+      crush: 79
+      magic: -9
+      ranged: 102
+    other_bonus:
       strength: 4
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 1
   recipes:
     - skill: smithing
       level: 90
-      xp: 500
+      xp: 2250
       materials:
         - item_name: Torva platelegs (damaged)
-          item_id: 26380
           quantity: 1
         - item_name: Bandosian components
-          item_id: 26348
-          quantity: 1
-      product: Torva platelegs
-      product_id: 26386
-      product_quantity: 1
-      facility: Anvil
-      members_only: true
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
   related_items:
-    - item_id: 26382
-      item_name: Torva full helm
+    - item_name: Torva full helm
       slug: torva-full-helm
       relationship: set-piece
-      description: Head slot
-    - item_id: 26384
-      item_name: Torva platebody
+      description: Matching head piece
+    - item_name: Torva platebody
       slug: torva-platebody
       relationship: set-piece
-      description: Body slot
-    - item_id: 11834
-      item_name: Bandos tassets
+      description: Matching body piece
+    - item_name: Bandos tassets
       slug: bandos-tassets
       relationship: alternative
-      description: Budget option
-  about: |-
-    Repair Torva platelegs (damaged) with Bandosian components at an anvil.
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Torva platelegs (damaged) | Nex | ~260M gp |
-    | Bandosian components | Disassemble Bandos armour | N/A |
-
-    | Stat | Value |
-    |------|-------|
-    | Stab defence | +87 |
-    | Slash defence | +78 |
-    | Crush defence | +79 |
-    | Ranged defence | +102 |
-    | Magic defence | -9 |
-    | Strength bonus | +4 |
-    | Prayer bonus | +1 |
-    | Requirements | 80 Defence |
-
-    PvM:
-    - Best-in-slot strength legs
-    - Highest melee defence legs
-    - All high-level melee content
-
-    Best For:
-    - Max melee setups
-    - Solo bossing
-    - Slayer
+      description: Budget BiS alternative
+    - item_name: Sanguine torva platelegs
+      slug: sanguine-torva-platelegs
+      relationship: upgrade
+      description: Cosmetic recolour upgrade via Magic
+  about: "Torva platelegs are the best-in-slot melee legs for both strength bonus and stab/slash/crush defence. Repair Torva platelegs (damaged) from Nex with 2 Bandosian components at an anvil: 90 Smithing for 2,250 xp. Also grants Zarosian-faction protection inside the God Wars Dungeon."
   market_strategy:
     notes:
-      - Nex kills affect supply
-      - BiS melee legs
-      - +2 str over Bandos tassets
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Nex kill rate drives damaged-leg supply"
+      - "Bandosian components bottleneck the repair, sustaining premium"
+      - "Used in nearly every high-end melee setup"
+  trading_tips:
+    - Buy damaged + components separately during raid resets, repair for a margin
+    - Sanguine recolour offers no stat gain — value is purely cosmetic
+  history:
+    - date: "2022-01-05"
+      description: "Released as a repaired-Nex drop in the Nex boss update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toy-soldier-wound.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toy-soldier-wound.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 150
-  about: "Toy soldier (wound) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: clockwork_toy
+    tier: low
+  properties:
+    release_date: "31 May 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Release
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Toy soldier
+      slug: toy-soldier
+      relationship: variant
+      description: "Unwound version of this clockwork toy"
+    - item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: "Crafting component used to assemble the toy soldier"
+  about: |-
+    Toy soldier (wound) is the wound-up form of the toy soldier, a clockwork toy crafted at a crafting table in a player-owned house from a plank and a clockwork.
+
+    Once wound, releasing the toy lets it walk around the immediate area. The item is otherwise a cosmetic / collection log target with negligible alchemy value.
+  market_strategy:
+    notes:
+      - "Cosmetic clockwork toy with very thin liquidity"
+      - "Often relisted by POH builders who craft them for amusement"
+  trading_tips:
+    - Buy from crafters in bulk near construction worlds
+  history:
+    - date: "31 May 2006"
+      description: "Released alongside the clockwork toy family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-cane.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-cane.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 5
-  about: "Trailblazer cane is a members-only item in Old School RuneScape. High alchemy value: 90,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Trailblazer Relic Emote
+      - Trailblazer Area Emote
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spiked
+    attack_speed: 4
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer relic hunter (t3) outfit
+      slug: trailblazer-relic-hunter-t3-outfit
+      relationship: set-piece
+      description: Outfit awarded alongside the cane
+  about: "Trailblazer cane is a cosmetic one-handed crush weapon awarded with the tier 3 Trailblazer Relic Hunter outfit from the Leagues Reward Shop (15,000 League points). Provides no combat bonuses; its real value is two equipped emotes: Trailblazer Relic Emote and Trailblazer Area Emote."
+  market_strategy:
+    notes:
+      - "Supply gated by League points, not gameplay loops"
+      - "Demand driven by collectors and emote unlocks"
+  passive_effects:
+    - name: Trailblazer Relic Emote
+      description: "Equipped emote unlocked while the cane is wielded."
+    - name: Trailblazer Area Emote
+      description: "Second equipped emote added in the 2021 graphical update."
+  history:
+    - date: "2021-01-06"
+      description: "Received a graphical update; value raised from 1,000 to 150,000 coins and the Trailblazer Area Emote option was added."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-buckler.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-buckler.mdx
@@ -1,6 +1,6 @@
 ---
 title: Twisted buckler | OSRS Price Data
-description: "Twisted buckler is a members shield slot item requiring 75 Defence. High alch: 54,000 GP, GE limit: 8."
+description: "Twisted buckler is a members shield slot item requiring 75 Ranged and 75 Defence. High alch: 54,000 GP, GE limit: 8."
 osrs:
   id: 21000
   name: Twisted buckler
@@ -12,73 +12,86 @@ osrs:
   lowalch: 36000
   highalch: 54000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: olm-bone
+    tier: high
+  properties:
+    release_date: "2017-01-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: ranged_shield
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 5.443
     requirements:
       ranged: 75
       defence: 75
-    stats:
-      ranged_attack: 18
-      stab_def: 22
-      slash_def: 24
-      crush_def: 22
-      magic_def: 26
-      ranged_def: 58
+    attack_bonus:
+      stab: -8
+      slash: -10
+      crush: -7
+      magic: -8
+      ranged: 18
+    defence_bonus:
+      stab: 22
+      slash: 24
+      crush: 22
+      magic: 26
+      ranged: 58
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 10
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
-      - source: Chambers of Xeric
-        rate: Rare
-  truemarket:
-    buy_limit: 8
-    price_estimate: 4500000
+      - source: Chambers of Xeric (rare unique)
+        quantity: "1"
+        rarity: rare
   related_items:
-    - item_id: 22002
-      item_name: Dragonfire ward
+    - item_name: Dragonfire ward
       slug: dragonfire-ward
       relationship: alternative
-      description: Dragon content
-    - item_id: 11926
-      item_name: Odium ward
+      description: Specialised dragon-content shield
+    - item_name: Odium ward
       slug: odium-ward
       relationship: downgrade
-      description: Budget option
-    - item_id: 11785
-      item_name: Armadyl crossbow
+      description: Budget ranged shield alternative
+    - item_name: Armadyl crossbow
       slug: armadyl-crossbow
       relationship: alternative
-      description: Pairs well
+      description: Common ranged weapon pairing
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +18 |
+    The twisted buckler is the best-in-slot ranged shield for general ranged combat, awarded as a rare unique from Chambers of Xeric. It offers the highest ranged attack and ranged strength bonus available in the shield slot, plus strong magic defence.
 
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +22 |
-    | Slash | +24 |
-    | Crush | +22 |
-    | Magic | +26 |
-    | Ranged | +58 |
-
-    Requirements: 75 Ranged, 75 Defence
-
-    BiS ranged shield for:
-    - All ranged combat (non-dragon)
-    - Raids
-    - Bossing
-    - Slayer
-
-    Best ranged attack bonus from shield slot.
+    Requires 75 Ranged and 75 Defence to wield. It is favoured for raids, slayer, and bossing whenever a dragonfire ward is not strictly required.
   market_strategy:
     notes:
-      - CoX is only source
-      - Best offensive ranged shield
-      - Use DFW for dragons
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Chambers of Xeric is the only source"
+      - "Best offensive ranged shield in the game"
+      - "Use Dragonfire ward over Twisted buckler against dragonfire content"
+      - "Price strongly tracks raid popularity and team meta"
+  trading_tips:
+    - Buy after CoX participation spikes (drop-table dilution)
+    - Hold through PvM updates that buff ranged content
+  history:
+    - date: "2017-01-05"
+      description: "Released alongside Chambers of Xeric."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-hat-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-hat-t2.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 5
-  about: "Twisted hat (t2) is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "16 January 2020"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Twisted League hub
+      price: 2500
+      currency: League points
+      stock: 1
+  related_items:
+    - item_name: Twisted coat (t2)
+      slug: twisted-coat-t2
+      relationship: set-piece
+      description: "Body piece of the Twisted Relic Hunter (t2) outfit"
+    - item_name: Twisted trousers (t2)
+      slug: twisted-trousers-t2
+      relationship: set-piece
+      description: "Leg piece of the Twisted Relic Hunter (t2) outfit"
+    - item_name: Twisted boots (t2)
+      slug: twisted-boots-t2
+      relationship: set-piece
+      description: "Foot piece of the Twisted Relic Hunter (t2) outfit"
+    - item_name: Twisted hat (t1)
+      slug: twisted-hat-t1
+      relationship: downgrade
+      description: "Lower-tier Twisted Relic Hunter hat variant"
+    - item_name: Twisted hat (t3)
+      slug: twisted-hat-t3
+      relationship: upgrade
+      description: "Higher-tier Twisted Relic Hunter hat variant"
+  about: |-
+    Twisted hat (t2) is the head piece of the tier-2 Twisted Relic Hunter outfit, awarded for finishing the Twisted League with a qualifying point total and purchased from the Leagues Reward Shop.
+
+    Purely cosmetic with all combat bonuses at zero; can be stored in a costume room's armour case as part of the full set.
+  market_strategy:
+    notes:
+      - "Capped supply from a one-off league event"
+      - "Long-term appreciation play on retired league cosmetics"
+  trading_tips:
+    - Demand spikes during new league announcements
+    - Pair flips with the matching coat/trousers/boots set
+  history:
+    - date: "16 January 2020"
+      description: "Released with the Twisted League rewards shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-teleport-scroll.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Twisted teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic unlock
+    tier: high
+  properties:
+    release_date: "2020-01-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Lumbridge Castle
+      price: 750
+      currency: League Points
+      stock: 1
+  related_items:
+    - item_name: Trailblazer teleport scroll
+      slug: trailblazer-teleport-scroll
+      relationship: alternative
+      description: Trailblazer League cosmetic teleport variant
+    - item_name: Shattered teleport scroll
+      slug: shattered-teleport-scroll
+      relationship: alternative
+      description: Shattered Relics League cosmetic teleport variant
+  about: |-
+    The twisted teleport scroll is a one-time-use cosmetic unlock released alongside the Twisted League reward shop in January 2020. Reading the scroll unlocks the twisted home teleport animation, consuming the scroll in the process. It is one of the original league-themed home teleport animation rewards and remains a popular cosmetic flex.
+  market_strategy:
+    notes:
+      - "Fixed supply with no in-game rerelease since 2020"
+      - "Buy limit of 5 caps speculation positions"
+      - "Demand driven by collectors and high-end cosmetic builds"
+      - "Long-term price floor rises with rare cosmetic index"
+      - "Volume is low and price discovery is volatile"
+  trading_tips:
+    - Use patient offers a few percent below GE mid
+    - Avoid timing entries around cosmetic update news
+    - Hold through league announcements for demand spikes
+  history:
+    - date: "2020-01-16"
+      description: "Released in the Twisted League reward shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-trousers-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-trousers-t1.mdx
@@ -12,12 +12,88 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 5
-  about: "Twisted trousers (t1) is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2020-01-16"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: League hall
+      price: 1000
+      currency: League points
+      stock: 1
+  related_items:
+    - item_name: Twisted hat (t1)
+      slug: twisted-hat-t1
+      relationship: set-piece
+      description: Head slot of the tier 1 Twisted Relic Hunter outfit
+    - item_name: Twisted coat (t1)
+      slug: twisted-coat-t1
+      relationship: set-piece
+      description: Body slot of the tier 1 Twisted Relic Hunter outfit
+    - item_name: Twisted boots (t1)
+      slug: twisted-boots-t1
+      relationship: set-piece
+      description: Feet slot of the tier 1 Twisted Relic Hunter outfit
+    - item_name: Twisted trousers (t2)
+      slug: twisted-trousers-t2
+      relationship: upgrade
+      description: Tier 2 cosmetic upgrade of the same outfit
+  about: |-
+    Twisted trousers (t1) is the tier 1 leg slot piece of the Twisted Relic Hunter outfit set, a cosmetic reward from the Twisted League. It can be purchased from the Leagues Reward Shop for 1,000 League points and provides no combat bonuses.
+
+    The outfit can be stored in costume room armour cases or displayed on League hall outfit stands. Available for both male and female character models.
+  market_strategy:
+    notes:
+      - "Pure cosmetic with zero combat stats"
+      - "Buy limit of 5 keeps supply tight relative to demand"
+      - "Often paired with the rest of the t1 set for collectors"
+  history:
+    - date: "2020-01-16"
+      description: "Twisted trousers (t1) added to the Twisted League Reward Shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-toxic-trident-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-toxic-trident-e.mdx
@@ -12,9 +12,97 @@ osrs:
   lowalch: 43200
   highalch: 64800
   limit: 8
-  about: "Uncharged toxic trident (e) is a members-only item in Old School RuneScape. High alchemy value: 64,800 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic weapon
+    tier: high
+  properties:
+    release_date: "2018-02-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Check
+      - Dismantle
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: powered_staff
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      magic: 78
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 25
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 15
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Venomous strike
+      description: Has a 25 percent chance to inflict venom on the target when attacking with a charged trident.
+  recipes:
+    - skill: crafting
+      level: 59
+      xp: 100
+      materials:
+        - item_name: Uncharged trident (e)
+          quantity: 1
+        - item_name: Magic fang
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_name: Trident of the swamp (e)
+      slug: trident-of-the-swamp-e
+      relationship: upgrade
+      description: Charged form with death runes, chaos runes, fire runes, and Zulrah scales
+    - item_name: Uncharged trident (e)
+      slug: uncharged-trident-e
+      relationship: downgrade
+      description: Pre-fang enhanced trident base
+    - item_name: Magic fang
+      slug: magic-fang
+      relationship: component
+      description: Zulrah-only upgrade material
+  about: |-
+    The uncharged toxic trident (e) is the dormant form of the trident of the swamp (e), released in February 2018 as part of the enhanced trident update. Created at level 59 Crafting by combining an uncharged trident (e) with a magic fang, it serves as the storage form when discharged. Charging it requires death runes, chaos runes, fire runes, and Zulrah scales, and the charged variant has a 25 percent chance to inflict venom.
+  market_strategy:
+    notes:
+      - "Buy limit of 8 caps speculative inventory size"
+      - "Demand driven by Zulrah farmers and CoX teams"
+      - "Magic fang price is the dominant cost component"
+      - "Price typically tracks Zulrah scale supply trends"
+      - "Charging margin is the primary flip signal"
+  trading_tips:
+    - Watch magic fang price as a leading indicator
+    - Flip into Magic XP event windows for demand bursts
+    - Hold during scale shortage cycles for upside
+  history:
+    - date: "2018-02-08"
+      description: "Released alongside the enhanced trident update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uri-s-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uri-s-hat.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Uri's hat is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Elite Treasure Trails reward casket
+        quantity: "1"
+        rarity: 1/1275
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_name: Uri's gloves
+      slug: uri-s-gloves
+      relationship: set-piece
+      description: Matching elite clue cosmetic
+    - item_name: Elite clue scroll
+      slug: clue-scroll-elite
+      relationship: component
+      description: Source of the reward casket
+  about: |-
+    > *"This is top secret comrade..."*
+
+    Cosmetic head slot reward from elite clue caskets at 1/1,275. Worn by NPC Uri and Watson; stat profile is purely cosmetic.
+  market_strategy:
+    notes:
+      - "Supply tied directly to elite clue completion volume"
+      - "Buy limit of 4 keeps short-term flips thin"
+  history:
+    - date: "2019-04-11"
+      description: "Added as an elite clue scroll reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vegetable-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vegetable-batta.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Vegetable batta is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 30
+      xp: 156
+      materials:
+        - item_name: Unfinished batta (vegetable)
+          quantity: 1
+        - item_name: Equa leaves
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  shops:
+    - shop_name: Gnome Waiters
+      location: Grand Tree
+      price: 120
+      currency: coins
+      stock: 3
+  related_items:
+    - item_name: Unfinished batta (vegetable)
+      slug: unfinished-batta-vegetable
+      relationship: component
+      description: Cooked into vegetable batta
+    - item_name: Gianne dough
+      slug: gianne-dough
+      relationship: component
+      description: Base dough used in batta preparation
+  about: "Vegetable batta is a members-only gnome cooking food cooked from an unfinished vegetable batta and equa leaves on a cooking range at level 30 Cooking for 156 xp. Stops burning at level 38. Premade copies are sold by gnome waiters at the Grand Tree for 120 coins each."
+  market_strategy:
+    notes:
+      - "Used primarily for gnome cooking training and Gnome Restaurant runs"
+      - "High GE limit (6,000) supports bulk training material flips"
+  trading_tips:
+    - Watch for cooking-bonus event spikes that drain stock
+    - Margin opportunities right after Gnome Restaurant minigame patches
+  history:
+    - date: "2002-12-12"
+      description: "Released as part of the Agility skill update."
+    - date: "2006-08-07"
+      description: "Graphically updated during the Gnome Restaurant overhaul."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-armband-pink.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-armband-pink.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 150
-  about: "Villager armband (pink) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.68
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.68
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 60
+      currency: Trading sticks
+      stock: 0
+  about: "Villager armband (pink) is a members-only hands-slot cosmetic from Tai Bwo Wannai. Despite the pink set name the armband appears white; bought with trading sticks at Gabooty's Cooperative. High alchemy value: 90 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - "Cosmetic with no combat bonuses, demand is roleplay-driven"
+      - "Buyable directly from Gabooty's with trading sticks, capping GE price ceiling"
+      - "Magic wardrobe storage frees bank slots for hoarders"
+  trading_tips:
+    - Check Gabooty's stock for cheap arbitrage versus Grand Exchange
+    - Pair with other pink set pieces for full Tai Bwo Wannai look
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Clean-Up update."
+    - date: "2005-09-19"
+      description: "Examine text updated from 'A brightly coloured purple arm band.' to 'A white armband, as worn by the Tai Bwo Wannai locals.'"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vyrewatch-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vyrewatch-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vyrewatch top | OSRS Price Data
-description: "Vyrewatch top: Dress like the powerful vyrewatch!. High alch: 300 GP, GE limit: 150."
+description: "Vyrewatch top: Dress like the powerful vyrewatch! High alch: 300 GP, GE limit: 150."
 osrs:
   id: 9634
   name: Vyrewatch top
@@ -12,9 +12,82 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Vyrewatch top is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-09-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Trader Sven's Black Market Goods"
+      location: "Meiyerditch"
+      price: 650
+      currency: "Coins"
+      stock: 10
+  related_items:
+    - item_name: Vyrewatch legs
+      slug: vyrewatch-legs
+      relationship: set-piece
+      description: "Matching legs for the Vyrewatch disguise."
+    - item_name: Vyrewatch shoes
+      slug: vyrewatch-shoes
+      relationship: set-piece
+      description: "Matching shoes that complete the outfit."
+    - item_name: Vyre noble top
+      slug: vyre-noble-top
+      relationship: upgrade
+      description: "Upgraded during Sins of the Father by Polmafi Ferdygris."
+  about: "The vyrewatch top is the chest piece of the vyrewatch disguise, sold by Trader Sven in Meiyerditch after Darkness of Hallowvale. Worn with the matching legs and shoes, it lets players walk freely past vyrewatch patrols and is the precursor to the vyre noble top from Sins of the Father."
+  market_strategy:
+    notes:
+      - "Constantly restocked from Sven's shop, so the GE rarely outpaces shop price."
+      - "Demand bumps every time Sins of the Father grinders need disguise pieces."
+  trading_tips:
+    - "Bulk-buy from Sven for 650 gp and flip on GE for the small spread."
+    - "Pair with vyrewatch legs and shoes for a one-bag disguise resell."
+  history:
+    - date: "2006-09-04"
+      description: "Released with Darkness of Hallowvale."
+    - date: "2019-09-25"
+      description: "Sins of the Father added the vyre noble top upgrade path."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/webweaver-bow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/webweaver-bow-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Webweaver bow (u) | OSRS Price Data
-description: "Webweaver bow (u): A bow of a follower of Armadyl, corrupted by the power of Venenatis.. High alch: 105,000 GP."
+description: "Webweaver bow (u): A bow of a follower of Armadyl, corrupted by the power of Venenatis. High alch: 105,000 GP."
 osrs:
   id: 27652
   name: Webweaver bow (u)
@@ -12,12 +12,99 @@ osrs:
   lowalch: 70000
   highalch: 105000
   limit: null
-  about: "Webweaver bow (u) is a members-only item in Old School RuneScape. High alchemy value: 105,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: corrupted
+    tier: high
+  properties:
+    release_date: "2023-01-25"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Charge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: bow
+    attack_speed: 4
+    weight: 3.175
+    requirements:
+      ranged: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 85
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 65
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Venenatis
+        quantity: "1"
+        rarity: 1/256
+      - source: Spindel
+        quantity: "1"
+        rarity: 1/384
+  recipes:
+    - skill: fletching
+      level: 85
+      xp: 1000
+      materials:
+        - item_name: Craw's bow (u)
+          quantity: 1
+        - item_name: Fangs of Venenatis
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Wilderness damage boost
+      description: Grants a 50% accuracy and damage boost against NPCs while in the Wilderness.
+    - name: Swarm special attack
+      description: For 50% special energy, fires four arrows in rapid succession with doubled accuracy.
+  related_items:
+    - item_name: Craw's bow (u)
+      slug: craws-bow-u
+      relationship: component
+      description: Base bow combined with fangs of Venenatis to create webweaver
+    - item_name: Webweaver bow
+      slug: webweaver-bow
+      relationship: variant
+      description: Charged form usable for the special attack
+  about: "Webweaver bow (u) is the uncharged form of the corrupted ranged weapon obtained from Venenatis or by combining Craw's bow (u) with Fangs of Venenatis at 85 Fletching (or 500,000 coins to Derse Venator). It uses revenant ether, requires 1,000 to charge, and holds up to 17,000."
+  market_strategy:
+    notes:
+      - "Supply tied to Venenatis kill rate; price tracks wilderness boss meta"
+      - "Untradeable charged form means uncharged is the only GE liquidity"
+  trading_tips:
+    - Uncharge before sale to convert from the charged variant
+  history:
+    - date: "2023-01-25"
+      description: "Released with the Wilderness Boss Rework update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-boater.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "White boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Red boater
+      slug: red-boater
+      relationship: variant
+      description: Red colour variant of the boater hat.
+    - item_name: Black boater
+      slug: black-boater
+      relationship: variant
+      description: Black colour variant of the boater hat.
+    - item_name: Blue boater
+      slug: blue-boater
+      relationship: variant
+      description: Blue colour variant of the boater hat.
+    - item_name: Green boater
+      slug: green-boater
+      relationship: variant
+      description: Green colour variant of the boater hat.
+    - item_name: Orange boater
+      slug: orange-boater
+      relationship: variant
+      description: Orange colour variant of the boater hat.
+    - item_name: Pink boater
+      slug: pink-boater
+      relationship: variant
+      description: Pink colour variant of the boater hat.
+  about: "White boater is a cosmetic head item rewarded from the Master emote clue at Castle Drakan's northern wall. It carries no combat stats and serves purely as a fashion piece."
+  market_strategy:
+    notes:
+      - "Tight 4-item buy limit forces patient flips for stock builds."
+      - "Master clue supply trickles slowly, keeping floor price elevated relative to alch."
+  trading_tips:
+    - Place GE offers at the 5-minute swing low during off-peak hours.
+    - Avoid alching; high alch value is far below market price.
+  history:
+    - date: "2014-06-12"
+      description: "Released as a master emote clue reward in the Treasure Trails expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-elegant-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-elegant-skirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: White elegant skirt | OSRS Price Data
-description: "White elegant skirt is a members legs slot item. High alch: 1,200 GP, GE limit: 4."
+description: "White elegant skirt is a cosmetic medium clue legs reward. High alch: 1,200 GP, GE limit: 4."
 osrs:
   id: 10422
   name: White elegant skirt
@@ -12,21 +12,86 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 10420
-      item_name: White elegant blouse
+    - item_name: White elegant blouse
       slug: white-elegant-blouse
       relationship: set-piece
-      description: Matching elegant blouse
+      description: Matching elegant top
+    - item_name: Black elegant skirt
+      slug: black-elegant-skirt
+      relationship: variant
+      description: Black colour variant
+    - item_name: Red elegant skirt
+      slug: red-elegant-skirt
+      relationship: variant
+      description: Red colour variant
+    - item_name: Blue elegant skirt
+      slug: blue-elegant-skirt
+      relationship: variant
+      description: Blue colour variant
   about: |-
-    > *"A rather elegant white skirt."*
+    > _"A rather elegant white skirt."_
 
-    Purely cosmetic treasure trail reward with no combat stats. Part of the white elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Purely cosmetic medium Treasure Trail reward (drop rate 8/18,128 from medium reward caskets). Part of the white elegant clothing set and storable in costume rooms.
+  market_strategy:
+    notes:
+      - "Buy limit of 4 makes the item a low-volume cosmetic flip."
+      - "Set completion drives outsized demand for matching blouse + skirt."
+  trading_tips:
+    - List blouse and skirt as a set to hit the costume-set premium.
+    - Avoid overstocking; thin liquidity means single high-margin sales beat bulk.
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the elegant clothing set reward pool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-plateskirt.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 125
-  about: "White plateskirt is a members-only item in Old School RuneScape. High alchemy value: 1,152 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: white
+    tier: low
+  properties:
+    release_date: "2005-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 8.164
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 21
+      slash: 20
+      crush: 19
+      magic: -4
+      ranged: 20
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: Sir Vyvin's Armour Shop
+      location: Falador Castle
+      price: 1920
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: White platelegs
+      slug: white-platelegs
+      relationship: variant
+      description: Trouser variant with identical stats
+    - item_name: White full helm
+      slug: white-full-helm
+      relationship: set-piece
+      description: Matching head piece
+    - item_name: White platebody
+      slug: white-platebody
+      relationship: set-piece
+      description: Matching body piece
+  about: |-
+    The white plateskirt is a members-only leg piece purchased from Sir Vyvin in Falador after reaching Page rank with the White Knights (300 black knight kills) and completing the Wanted! quest. It offers a small prayer bonus and solid melee defence, making it a niche prayer-tank option for low-level players.
+  market_strategy:
+    notes:
+      - "Prayer bonus is the main draw over standard plateskirts"
+      - "Supply hinges on White Knight rank grinders"
+      - "Wanted! quest gate keeps the buyer pool narrow"
+  trading_tips:
+    - Buy when fashionscape collectors are quiet
+    - Sell to ironmen unlocks via shop arbitrage when allowed
+  history:
+    - date: "2005-10-17"
+      description: "Released with the Wanted! quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-blackjack-d.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-blackjack-d.mdx
@@ -12,12 +12,93 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 125
-  about: "Willow blackjack(d) is a members-only item in Old School RuneScape. High alchemy value: 480 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "15 August 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: blackjack
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      defence: 20
+      thieving: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 8
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 8
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Martin Thwait's Lost and Found
+      location: Rogues' Den
+      price: 800
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Willow blackjack
+      slug: willow-blackjack
+      relationship: variant
+      description: Base willow blackjack
+    - item_name: Willow blackjack(o)
+      slug: willow-blackjack-o
+      relationship: variant
+      description: Offensive willow blackjack variant
+    - item_name: Oak blackjack(d)
+      slug: oak-blackjack-d
+      relationship: downgrade
+      description: Lower-tier defensive blackjack
+    - item_name: Maple blackjack(d)
+      slug: maple-blackjack-d
+      relationship: upgrade
+      description: Higher-tier defensive blackjack
+  about: "The willow blackjack(d) is the defensive variant of the willow blackjack, used in the Thieving minigame at Pollnivneach to knock out and pickpocket bandits. It requires 30 Thieving and 20 Defence to wield. The defensive variant lowers the chance of failed knockouts compared to the offensive variant, making it the safer choice for early blackjack training. Purchased from Martin Thwait's Lost and Found in the Rogues' Den."
+  market_strategy:
+    notes:
+      - "Rogues' Den shop floor at 800 coins"
+      - "Demand tied to Thieving training routes"
+      - "Low daily volume"
+      - "Stable price near shop value"
+  trading_tips:
+    - Buy when shop restocks during low-activity hours
+    - Resell during Thieving event weekends
+    - Compare with maple blackjack(d) upgrade timing
+  history:
+    - date: "15 August 2005"
+      description: "Item was added to the game alongside the blackjack thieving rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-shield.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 18000
-  about: "Willow shield is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2018-02-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 3.175
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 6
+      slash: 7
+      crush: 5
+      magic: 2
+      ranged: 6
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 42
+      xp: 83
+      materials:
+        - item_name: Willow logs
+          quantity: 2
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Willow logs
+      slug: willow-logs
+      relationship: component
+      description: Required material for fletching the shield
+    - item_name: Snakeskin shield
+      slug: snakeskin-shield
+      relationship: upgrade
+      description: Crafted from willow shield at Crafting 56
+    - item_name: Oak shield
+      slug: oak-shield
+      relationship: downgrade
+      description: Lower-tier wooden shield
+    - item_name: Maple shield
+      slug: maple-shield
+      relationship: upgrade
+      description: Higher-tier wooden shield
+  about: |-
+    The willow shield is a mid-tier wooden shield introduced with the wooden shield expansion in 2018. Fletched from 2 willow logs at level 42 Fletching, it requires 30 Defence to equip and serves as a component for the snakeskin shield at Crafting 56. While stats are modest, it remains a popular leveling option for low-defence pures and skillers.
+  market_strategy:
+    notes:
+      - "Low-margin item with high volume and 18k buy limit"
+      - "Demand driven by Fletching trainers and snakeskin shield crafters"
+      - "Price often hovers near or below low alch value"
+      - "Watch for Fletching XP event spikes"
+      - "Consider it as raw stock for snakeskin upgrade flips"
+  trading_tips:
+    - Buy at low alch as a price floor for safe holds
+    - Bulk flip into snakeskin shield demand cycles
+    - Avoid overpaying above 80 percent of high alch
+  history:
+    - date: "2018-02-01"
+      description: "Added with the wooden shields expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wizard-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wizard-hat.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 125
-  about: "Wizard hat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Betty's Magic Emporium
+      location: Port Sarim
+      price: 2
+      currency: Coins
+      stock: 5
+    - shop_name: Regath's Wares
+      location: Arceuus
+      price: 2
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Wizard robe
+      slug: wizard-robe
+      relationship: set-piece
+      description: Matching wizard robe top
+    - item_name: Wizard hat (g)
+      slug: wizard-hat-g
+      relationship: variant
+      description: Gold trimmed variant
+  about: "Wizard hat is a free-to-play head-slot item that grants a small +2 Magic defence bonus and acts as a cosmetic starter for new mages. Sold cheaply at Betty's Magic Emporium and Regath's Wares. High alchemy value: 1 coin. Grand Exchange buy limit: 125 per 4 hours."
+  market_strategy:
+    notes:
+      - "Shops provide a price floor that keeps GE prices low"
+      - "Demand driven by cosmetic and ironman early-game mage gear"
+      - "High alch value of 1 coin means it is not worth alching"
+  trading_tips:
+    - Buy at shops in bulk if GE price spikes above 2 coins
+    - Pair with Wizard robe and Blue skirt for the classic mage look
+  history:
+    - date: "2001-01-04"
+      description: "Released as part of RuneScape's original launch content."
+    - date: "2005-06-22"
+      description: "Renamed from 'Wizard's hat' to its current 'Wizard hat'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-partyhat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-partyhat.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 5
-  about: "Yellow partyhat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: holiday rare
+    tier: high
+  properties:
+    release_date: "2001-12-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.056
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.056
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Christmas cracker
+        quantity: "1"
+        rarity: Random
+  related_items:
+    - item_name: Red partyhat
+      slug: red-partyhat
+      relationship: variant
+      description: Red partyhat colour variant
+    - item_name: Purple partyhat
+      slug: purple-partyhat
+      relationship: variant
+      description: Purple partyhat colour variant
+    - item_name: Blue partyhat
+      slug: blue-partyhat
+      relationship: variant
+      description: Blue partyhat colour variant
+    - item_name: Green partyhat
+      slug: green-partyhat
+      relationship: variant
+      description: Green partyhat colour variant
+    - item_name: White partyhat
+      slug: white-partyhat
+      relationship: variant
+      description: White partyhat colour variant
+  about: |-
+    The yellow partyhat is one of six original partyhat colours released during the 2001 Christmas event. Like its peers, it offers no combat bonuses and exists purely as a cosmetic status symbol. Yellow has historically traded near the lower end of the partyhat colour spectrum, making it a relatively accessible entry into rare wealth ownership.
+  market_strategy:
+    notes:
+      - "Lowest-priced partyhat colour in most market cycles"
+      - "Acts as floor reference for the partyhat index"
+      - "Volume is consistently the highest of all colours"
+      - "GP inflation lifts the whole partyhat set together"
+      - "Use it as a hedge into rare items without top-tier capital"
+  trading_tips:
+    - Stagger offers within 1 percent of GE mid for clean fills
+    - Track partyhat ratio spreads for relative-value flips
+    - Watch holiday seasons for demand-driven price spikes
+  history:
+    - date: "2001-12-24"
+      description: "Released as a reward from the 2001 Christmas event Christmas cracker."
+    - date: "2013-07-04"
+      description: "Re-released temporarily during the Rare Drops event from July 4 to July 14."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-robe-bottoms.mdx
@@ -12,12 +12,86 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Yellow robe bottoms is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 650
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Yellow robe top
+      slug: yellow-robe-top
+      relationship: set-piece
+      description: Matching upper robe from Barkers' Haberdashery
+    - item_name: Blue robe bottoms
+      slug: blue-robe-bottoms
+      relationship: variant
+      description: Blue-colored variant of the Canifis robes
+    - item_name: Green robe bottoms
+      slug: green-robe-bottoms
+      relationship: variant
+      description: Green-colored variant of the Canifis robes
+  about: |-
+    Yellow robe bottoms are a cosmetic leg slot item sold by Barker at Barkers' Haberdashery in Canifis. They were introduced alongside the Priest in Peril quest in 2004 and provide no combat bonuses.
+
+    They were renamed from "Robe bottoms" to "Yellow robe bottoms" in December 2014 to distinguish them from other coloured variants in the Canifis robes collection.
+  market_strategy:
+    notes:
+      - "Pure cosmetic, often used for fashionscape outfits"
+      - "Cheap to alch or restock from Canifis when needed"
+      - "Low daily volume but stable price"
+  history:
+    - date: "2004-06-29"
+      description: "Yellow robe bottoms (then called \"Robe bottoms\") released with the Priest in Peril quest update."
+    - date: "2014-12-10"
+      description: "Renamed from \"Robe bottoms\" to \"Yellow robe bottoms\" to disambiguate the Canifis colour variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-shortbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-shortbow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Yew shortbow | OSRS Price Data
-description: "Yew shortbow is a members two-handed weapon. High alch: 480 GP, GE limit: 18,000."
+description: "Yew shortbow is a 40 Ranged two-handed bow with 4-tick attack speed. High alch: 480 GP, GE limit: 18,000."
 osrs:
   id: 857
   name: Yew shortbow
@@ -12,50 +12,103 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 18000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: yew
+    tier: mid
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
-    slot: 2h
-    type: shortbow
-    attack_style: ranged
+    slot: weapon
+    weapon_type: shortbow
     attack_speed: 4
-  requirements:
-    ranged: 40
-  stats:
-    attack:
+    weight: 1.36
+    requirements:
+      ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 47
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-    range: 7
-  fletching:
-    level: 65
-    xp: 67.5
-    method: Yew shortbow (u) + bowstring
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 65
+      xp: 67.5
+      materials:
+        - item_name: Yew shortbow (u)
+          quantity: 1
+        - item_name: Bow string
+          quantity: 1
+      tools: []
+      output_quantity: 1
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
       price: 800
+      currency: coins
+      stock: 0
   related_items:
-    - item_id: 861
-      item_name: Magic shortbow
-      slug: magic-shortbow
-      relationship: upgrade
-      description: P2P upgrade with spec
-    - item_id: 855
-      item_name: Yew longbow
+    - item_name: Yew longbow
       slug: yew-longbow
       relationship: alternative
-      description: More attack range
-    - item_id: 68
-      item_name: Yew shortbow (u)
+      description: Slower attack speed, longer attack range
+    - item_name: Magic shortbow
+      slug: magic-shortbow
+      relationship: upgrade
+      description: Higher tier shortbow with special attack
+    - item_name: Maple shortbow
+      slug: maple-shortbow
+      relationship: downgrade
+      description: One tier below yew shortbow
+    - item_name: Yew shortbow (u)
       slug: yew-shortbow-u
       relationship: component
-      description: Unstrung version
-    - item_id: 1777
-      item_name: Bow string
+      description: Unstrung shortbow component
+    - item_name: Bow string
       slug: bow-string
       relationship: component
       description: Stringing material
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: |-
+    > _"A shortbow made out of yew, still effective."_
+
+    Yew shortbow is a 40 Ranged two-handed shortbow firing up to rune arrows on a 4-tick attack speed. Fletched from a yew shortbow (u) plus bow string at 65 Fletching for 67.5 XP. Sold by Lowe's Archery in Varrock.
+  market_strategy:
+    notes:
+      - "Demand follows mid-game ranged training and Scurrius/Barrows setups."
+      - "Combined with Scurrius' spine to create the bone shortbow upgrade."
+  trading_tips:
+    - Buy yew shortbow (u) and bow strings during weekend lulls and string in bulk.
+    - Watch GE buy limit cycles; 18,000 lets you build large positions quickly.
+  history:
+    - date: "2002-03-25"
+      description: "Released with the original Ranged skill content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-godsword-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-godsword-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zamorak godsword ornament kit | OSRS Price Data
-description: "Zamorak godsword ornament kit: Use on a Zamorak godsword to make it look fancier!. High alch: 3,000 GP, GE limit: 4."
+description: "Zamorak godsword ornament kit: Use on a Zamorak godsword to make it look fancier! High alch: 3,000 GP, GE limit: 4."
 osrs:
   id: 20077
   name: Zamorak godsword ornament kit
@@ -12,12 +12,59 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Zamorak godsword ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/3404
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  passive_effects:
+    - name: Cosmetic recolour
+      description: When used on a Zamorak godsword, creates the Zamorak godsword (or). Cosmetic only with no stat changes. Combined sword becomes untradeable but the kit can be removed and resold.
+  related_items:
+    - item_name: Zamorak godsword
+      slug: zamorak-godsword
+      relationship: component
+      description: Base weapon required to apply the ornament kit
+    - item_name: Zamorak godsword (or)
+      slug: zamorak-godsword-or
+      relationship: product
+      description: Ornamented variant produced by combining the kit with the godsword
+  about: "Zamorak godsword ornament kit is a cosmetic upgrade obtained exclusively from master Treasure Trail reward caskets at a 1/3,404 rarity. Applies to a Zamorak godsword to produce the (or) variant; reversible by detaching the kit."
+  market_strategy:
+    notes:
+      - "Master clue scroll supply caps daily volume around 31 trades"
+      - "Demand driven by cosmetic collectors and end-game showoff builds"
+  trading_tips:
+    - Buy limit of 4 per 4 hours makes mass flipping slow
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-monk-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-monk-bottom.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zamorak monk bottom | OSRS Price Data
-description: "Zamorak monk bottom: A robe worn by worshippers of Zamorak.. High alch: 18 GP, GE limit: 15."
+description: "Zamorak monk bottom: A robe worn by worshippers of Zamorak. High alch: 18 GP, GE limit: 15."
 osrs:
   id: 1033
   name: Zamorak monk bottom
@@ -12,23 +12,77 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 15
-  item_id: 1033
-  item_type: equipment
-  slot: legs
-  type: robes
-  tradeable: true
-  weight: 0.907
-  requirements:
-    defence: 0
-  stats:
-    magic_attack: 2
-    magic_defence: 3
-    prayer: 3
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2002-05-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
   related_items:
-    - slug: zamorak-monk-top
-    - slug: chaos-fanatic
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Zamorak monk top
+      slug: zamorak-monk-top
+      relationship: set-piece
+      description: Matching top to complete the Zamorak monk robe set.
+  about: |-
+    Zamorak monk bottom is a free-to-play leg slot robe worn by Zamorakian monks. It is one of the very few F2P leg items that grants a Magic attack bonus, making it useful for budget mages.
+
+    The robe drops from Zamorak monks at the Chaos Temple south of Varrock, and is also occasionally a clue scroll reward. It pairs with the Zamorak monk top to complete the set.
+
+    Weight: 0.907 kg | Requirements: None | Slot: Legs
+  market_strategy:
+    notes:
+      - "Modest +2 Magic attack bonus is unusual for an F2P legs item."
+      - "Cheap drop from low-level Zamorak monks; supply is steady."
+      - "Demand spikes when free players gear up for early magic training."
+  trading_tips:
+    - Buy in bulk when GE price is near the alch threshold.
+    - Pair sales with the Zamorak monk top for set buyers.
+  history:
+    - date: "2018-06-28"
+      description: "Renamed from \"Zamorak robe\" to \"Zamorak monk bottom\"."
+    - date: "2017-07-20"
+      description: "Made available to free-to-play players."
+    - date: "2005-06-22"
+      description: "Renamed from \"Robe of zamorak\"."
+    - date: "2002-05-28"
+      description: "Item released to Old School RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-hood.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-hood.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zuriel's hood | OSRS Price Data
-description: "Zuriel's hood: A powerful hood.. High alch: 150,000 GP, GE limit: 10."
+description: "Zuriel's hood: A powerful hood. High alch: 150,000 GP, GE limit: 10."
 osrs:
   id: 22650
   name: Zuriel's hood
@@ -12,12 +12,91 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 10
-  about: "Zuriel's hood is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ancient
+    tier: high
+  properties:
+    release_date: "2023-05-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Charge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements:
+      defence: 78
+      magic: 78
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 18
+      ranged: -2
+    defence_bonus:
+      stab: 20
+      slash: 16
+      crush: 22
+      magic: 8
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 0
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Edgeville
+      price: 300
+      currency: Bounty points
+      stock: 1
+  passive_effects:
+    - name: PvP-only set bonus
+      description: When worn with Zuriel's robe top and bottom, grants a 25% magic accuracy bonus inside designated PvP areas (Daimon's Crater, Castle Wars, Clan Wars, Soul Wars, TzHaar Fight Pit, POH or Clan Hall combat rings).
+    - name: Charge cost
+      description: Must be charged with 5,000,000 coins before use; uncharges after combat exposure.
+  related_items:
+    - item_name: Zuriel's robe top
+      slug: zuriel-s-robe-top
+      relationship: set-piece
+      description: Body piece of the Zuriel's set
+    - item_name: Zuriel's robe bottom
+      slug: zuriel-s-robe-bottom
+      relationship: set-piece
+      description: Leg piece of the Zuriel's set
+    - item_name: Zuriel's staff
+      slug: zuriel-s-staff
+      relationship: set-piece
+      description: Weapon piece of the Zuriel's set
+  about: "Zuriel's hood is the PvP-restricted head slot of the Zuriel's ancient set, purchased from the Bounty Hunter Store for 300 points and charged with 5M coins to activate. Inside designated PvP areas the full set grants 25% magic accuracy."
+  market_strategy:
+    notes:
+      - "Supply tied to Bounty Hunter activity"
+      - "5M activation fee compresses the price floor"
+  trading_tips:
+    - PvP-area restriction limits buyer pool to PKers
+  history:
+    - date: "2023-05-24"
+      description: "Released with the 'Bounty Hunter is Back!' update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-robe-top.mdx
@@ -12,12 +12,83 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10
-  about: "Zuriel's robe top is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ancient-magicks
+    tier: high
+  properties:
+    release_date: "8 February 2017"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 4.535
+    requirements:
+      magic: 78
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 28
+      ranged: -10
+    defence_bonus:
+      stab: 63
+      slash: 45
+      crush: 74
+      magic: 35
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 3
+      prayer: 0
+  related_items:
+    - item_name: Zuriel's hood
+      slug: zuriel-s-hood
+      relationship: set-piece
+      description: Matching ancient magicks hood
+    - item_name: Zuriel's robe bottom
+      slug: zuriel-s-robe-bottom
+      relationship: set-piece
+      description: Matching ancient magicks legs
+    - item_name: Zuriel's staff
+      slug: zuriel-s-staff
+      relationship: set-piece
+      description: Matching ancient magicks staff
+  about: "Zuriel's robe top is the body piece of the Zuriel's set, dropped by revenants in the Revenant Caves and Wilderness. It requires 78 Magic and 70 Defence to wear, providing strong magic attack bonuses alongside solid melee defence. When worn with the full set, it grants a 25% damage boost to magic spell special attacks. Highly sought after by PvP and Wilderness players."
+  market_strategy:
+    notes:
+      - "Wilderness revenant drop, scarce in supply"
+      - "Demand driven by Wilderness PvP and bossing"
+      - "Price volatile with PK meta shifts"
+      - "Low GE buy limit of 10 per 4 hours"
+  trading_tips:
+    - Monitor revenant population events and Wilderness updates
+    - Buy during off-meta lulls for resale during PK trends
+    - Pair with hood and bottom for full-set arbitrage
+  history:
+    - date: "8 February 2017"
+      description: "Item was added to the game as a revenant drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />


### PR DESCRIPTION
## Summary
- Random sample of 200 OSRS item MDX files migrated from `mdx_version: 2` to `3`
- WebFetch-verified wiki stats, drops, recipes, history
- Schema normalization: market_strategy.notes array, materials[].item_name, passive_effects[].name, treasure_trail.tier filled where missing

## Local CI mirror
- `npx astro sync` — clean
- `npx astro build` — 7688 pages in 288.45s, no errors

## Test plan
- [ ] CI manifest guard passes
- [ ] CI build passes
- [ ] Spot-check a couple of pages in preview