### PR TITLE
chore(rareicon): dispatch hygiene bundle — #7 + #8 + #9 from #11716

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
@@ -186,7 +186,7 @@ namespace RareIcon
                 CapitalHasFood   = offersDB.CapitalHasFood,
                 AnyHostile       = combatDB.Threats.Length > 0,
                 DoFullDispatch   = doFullDispatch,
-                NowTick          = (uint)SystemAPI.Time.ElapsedTime,
+                NowTick          = (uint)(SystemAPI.Time.ElapsedTime * 1000d),
             };
 
             state.Dependency = job.ScheduleParallel(state.Dependency);
@@ -398,7 +398,7 @@ namespace RareIcon
                         && head.Kind != ProfessionKind.Guard
                         && priorities.Guard >= GuardPreemptThreshold
                         && TryFindClosestThreat(Threats, transform.Position,
-                                                out var preemptHex, out var preemptHostile, out _))
+                                                out var preemptHex, out var preemptHostile))
                     {
                         tasks.Clear();
                         var preemptedIntent = intent;
@@ -519,20 +519,20 @@ namespace RareIcon
                 {
                     int2   hostileHex    = default;
                     Entity hostileEntity = Entity.Null;
-                    int    hostileDist   = int.MaxValue;
                     bool   foundHostile  = false;
                     if (AnyHostile && p.Guard >= GuardPreemptThreshold)
                     {
                         foundHostile = TryFindClosestThreat(
                             Threats, transform.Position,
-                            out hostileHex, out hostileEntity, out hostileDist);
+                            out hostileHex, out hostileEntity);
                     }
 
                     int guardReservationShortfall = math.max(0, ReservedPerKind[ProfessionKind.Guard] - ActivePerKind[ProfessionKind.Guard]);
 
                     if (foundHostile)
                     {
-                        long gScore = (long)p.Guard * PriorityWeight - (long)hostileDist;
+                        int hostileHexDist = HexDistance(currentHex, hostileHex);
+                        long gScore = (long)p.Guard * PriorityWeight - (long)hostileHexDist;
                         if (hostileEntity != Entity.Null && hostileEntity == currentTarget)
                             gScore += HysteresisBonus;
                         if (guardReservationShortfall > 0)
@@ -553,6 +553,18 @@ namespace RareIcon
                         int dq = (int)(rng % (uint)span) - e.Radius;
                         rng ^= rng >> 7; rng *= 0x27D4EB2Fu;
                         int dr = (int)(rng % (uint)span) - e.Radius;
+
+                        // Axial dq/dr in a square overshoots the hex disc at
+                        // the corners. Walk back toward origin one step at a
+                        // time until the point is inside e.Radius — preserves
+                        // the rng-seeded direction while keeping patrol within
+                        // the emitter's actual territory.
+                        while (AxialDistance(dq, dr) > e.Radius)
+                        {
+                            if (math.abs(dq) > math.abs(dr)) dq -= (int)math.sign(dq);
+                            else                             dr -= (int)math.sign(dr);
+                        }
+
                         int2 patrolHex = new int2(e.Center.x + dq, e.Center.y + dr);
                         int patrolDist = HexDistance(currentHex, patrolHex);
 
@@ -692,10 +704,15 @@ namespace RareIcon
                      || variant == OfferVariant.LooterDropPickup));
         }
 
+        // Picks the nearest threat by world distance for in-territory
+        // selection (Euclidean is the correct shape for the scan radius
+        // gate), but emits only hex + entity — callers convert to
+        // HexDistance for scoring so guard scoring scales the same way
+        // as the rest of the dispatcher.
         static bool TryFindClosestThreat(
             NativeArray<ThreatRecord> threats,
             float3 originWorld,
-            out int2 outHex, out Entity outEntity, out int outDist)
+            out int2 outHex, out Entity outEntity)
         {
             const float ScanRadiusSq = 6f * 6f;
 
@@ -725,19 +742,17 @@ namespace RareIcon
             {
                 outHex    = inBestHex;
                 outEntity = inBestEntity;
-                outDist   = (int)math.round(math.sqrt(inBestSq));
                 return true;
             }
 
             if (bestEntity == Entity.Null)
             {
-                outHex = default; outEntity = Entity.Null; outDist = int.MaxValue;
+                outHex = default; outEntity = Entity.Null;
                 return false;
             }
 
             outHex    = bestHex;
             outEntity = bestEntity;
-            outDist   = (int)math.round(math.sqrt(bestSq));
             return true;
         }
 


### PR DESCRIPTION
Closes the hygiene section of the dispatch optimization roadmap (#11716). Three small correctness fixes in one PR, all in [ProfessionDispatchSystem.cs](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs).

## #7 — Guard scoring distance metric

`TryFindClosestThreat` returned a world-space Euclidean distance, but the guard scoring path then mixed that with hex-distance-scaled costs from every other kind:

```csharp
long gScore = (long)p.Guard * PriorityWeight - (long)hostileDist;
//                                              ^^ world units

// vs other kinds:
int dist = HexDistance(currentHex, offer.Hex);
long score = (long)prio * PriorityWeight - (long)dist;
//                                          ^^ axial steps
```

At grid corners those metrics diverge by up to √2, so guard scoring under- or over-valued threats compared to harvest jobs at the same hex-step distance.

**Fix**: drop the world-distance `out` parameter, compute `HexDistance(currentHex, hostileHex)` at the call site. Both preempt and patrol scoring now use axial steps, matching the rest of the dispatcher.

Side effect: `TryFindClosestThreat` no longer carries the `sqrt + round` to convert distance-sq, since neither caller uses it. The `ScanRadiusSq` Euclidean gate stays (it's the right shape for "is this threat in the player's scan disc").

## #8 — Patrol axial radius clamp

The patrol fallback rolled `dq` and `dr` independently in a square of side `2 * Radius + 1` and treated the result as the new patrol hex. For axial coordinates that square overshoots the actual hex disc at the corners — `AxialDistance(dq, dr) > Radius` for ~25% of the square. Guards on patrol could be sent **outside** the friendly emitter's territory entirely, the opposite of the intent.

After the rng roll, walk back toward the origin one axial step at a time until the point is inside `e.Radius`, biasing whichever of `dq` / `dr` is larger:

```csharp
while (AxialDistance(dq, dr) > e.Radius)
{
    if (math.abs(dq) > math.abs(dr)) dq -= (int)math.sign(dq);
    else                             dr -= (int)math.sign(dr);
}
```

Preserves the seeded direction, just trims overshoot. Bounded iterations ≈ corner overflow (≤ `Radius`).

## #9 — `NowTick` resolution

`(uint)SystemAPI.Time.ElapsedTime` rounded to whole seconds, so every event emitted within the same one-second window carried the same `IssuedTick` / `Frame` field. The rest of the rareicon codebase uses ms resolution via `(uint)(ElapsedTime * 1000d)`:

- `ShelterSystem`
- `BanditCampSpawnerSystem`
- `HunterSystems`
- `StorageConsolidatorSystem`
- `ProductionSystem`
- `BuilderDepositSystem`
- `PirateCoveRaidSystem`
- `BanditCampRaidSystem`

Bring `ProfessionDispatchSystem` in line so event ordering + retargeted-within-same-second cases can be told apart by `ProfessionMessagePipeBridgeSystem` and any downstream tick-window analytics.

## Test plan

- [ ] Burst still compiles `ProfessionDispatchSystem` + `DispatchJob` clean.
- [ ] Guard preempt + patrol scoring scale comparably to harvest scoring at the same hex-step distance.
- [ ] Patrol targets never appear outside the friendly emitter's territory.
- [ ] `ProfessionChangedMessage.Frame` values are now distinguishable across events within the same second.

## Roadmap status

✅ #10 #3 #5 #2 (#11719) · ✅ #4 (#11723) · ✅ pre-pass parallelization (#11728) · ✅ #7 #8 #9 (this PR)

Remaining open: **#1** (spatial hash — marginal at current offer scale), **#11** (coordinator split — pure refactor, sets up cleaner future jobs), **#6** (head-index task queue — parked).

Refs #11716.