### PR TITLE
fix(osrs): rows un-tappable on iOS Safari + e2e to catch regression

### DIFF
--- a/apps/kbve/astro-kbve/e2e/osrs.spec.ts
+++ b/apps/kbve/astro-kbve/e2e/osrs.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test';
+
+const OSRS_URL = '/osrs/';
+const ROW_SEL = '[data-osrs-row]';
+
+test.describe('osrs item browser — list loads', () => {
+	test('virtualized list renders rows', async ({ page }) => {
+		await page.goto(OSRS_URL, { waitUntil: 'load' });
+		const firstRow = page.locator(ROW_SEL).first();
+		await expect(firstRow).toBeVisible({ timeout: 30_000 });
+		const count = await page.locator(ROW_SEL).count();
+		expect(count).toBeGreaterThan(0);
+	});
+
+	test('search input filters the list', async ({ page }) => {
+		await page.goto(OSRS_URL, { waitUntil: 'load' });
+		await expect(page.locator(ROW_SEL).first()).toBeVisible({
+			timeout: 30_000,
+		});
+
+		const search = page.getByPlaceholder(/Search by name/i);
+		await expect(search).toBeVisible();
+		await search.fill('whip');
+		// At least one whip-named row should still be present; the
+		// counter line says "N of M items".
+		await expect(page.locator(ROW_SEL).first()).toBeVisible({
+			timeout: 10_000,
+		});
+		const text = await page.locator(ROW_SEL).first().innerText();
+		expect(text.toLowerCase()).toContain('whip');
+	});
+});
+
+test.describe('osrs item browser — tap navigates (Safari regression)', () => {
+	test('tapping a row navigates to its detail page', async ({ page }) => {
+		await page.goto(OSRS_URL, { waitUntil: 'load' });
+		const firstRow = page.locator(ROW_SEL).first();
+		await expect(firstRow).toBeVisible({ timeout: 30_000 });
+
+		const slug = await firstRow.getAttribute('data-osrs-slug');
+		expect(slug).toBeTruthy();
+		const expectedPath = `/osrs/${slug}/`;
+
+		// `click()` in Playwright dispatches a real touch event on the
+		// mobile-safari / mobile-chrome projects, so this is the same
+		// failure mode the user reported on iPhone Safari.
+		await Promise.all([
+			page.waitForURL(`**${expectedPath}`, { timeout: 15_000 }),
+			firstRow.click(),
+		]);
+
+		expect(page.url()).toContain(expectedPath);
+	});
+
+	test('row has touchAction=manipulation + cursor=pointer (Safari tap fix)', async ({
+		page,
+	}) => {
+		await page.goto(OSRS_URL, { waitUntil: 'load' });
+		const firstRow = page.locator(ROW_SEL).first();
+		await expect(firstRow).toBeVisible({ timeout: 30_000 });
+
+		const styles = await firstRow.evaluate((el) => {
+			const cs = getComputedStyle(el as HTMLElement);
+			return {
+				touchAction: cs.touchAction,
+				cursor: cs.cursor,
+			};
+		});
+		expect(styles.touchAction).toBe('manipulation');
+		expect(styles.cursor).toBe('pointer');
+	});
+
+	test('row anchor has a non-empty href (Safari requires real href to tap)', async ({
+		page,
+	}) => {
+		await page.goto(OSRS_URL, { waitUntil: 'load' });
+		const firstRow = page.locator(ROW_SEL).first();
+		await expect(firstRow).toBeVisible({ timeout: 30_000 });
+
+		const href = await firstRow.getAttribute('href');
+		expect(href).toMatch(/^\/osrs\/.+\/$/);
+		const tag = await firstRow.evaluate((el) => el.tagName);
+		expect(tag).toBe('A');
+	});
+});
+
+test.describe('osrs item browser — filter UI', () => {
+	test('changing tag filter updates the rendered rows', async ({ page }) => {
+		await page.goto(OSRS_URL, { waitUntil: 'load' });
+		await expect(page.locator(ROW_SEL).first()).toBeVisible({
+			timeout: 30_000,
+		});
+
+		const tagSelect = page
+			.locator('select')
+			.filter({ has: page.locator('option', { hasText: 'All' }) })
+			.first();
+		await tagSelect.selectOption('food');
+		await expect(page.locator(ROW_SEL).first()).toBeVisible({
+			timeout: 10_000,
+		});
+	});
+});

--- a/apps/kbve/astro-kbve/src/components/osrs/OSRSItemBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/osrs/OSRSItemBrowser.tsx
@@ -50,24 +50,37 @@ type RowExtra = { items: OSRSIndexEntry[] };
 
 function Row({ index, style, items }: RowComponentProps<RowExtra>) {
 	const item = items[index];
+	const rowStyle: React.CSSProperties = {
+		...style,
+		// iOS Safari swallows taps on <a> elements that live inside a
+		// momentum-scrolling virtualized container (react-window 2) unless
+		// touchAction is set to `manipulation`; otherwise the browser
+		// queues the tap as a possible scroll-start and never fires the
+		// click. cursor + tap-highlight keep the affordance honest.
+		touchAction: 'manipulation',
+		WebkitTapHighlightColor: 'rgba(56, 189, 248, 0.18)',
+		cursor: 'pointer',
+	};
 	return (
 		<a
 			href={`/osrs/${item.slug}/`}
-			style={style}
-			className="flex items-center gap-3 border-b border-white/5 px-3 hover:bg-white/5 transition-colors">
+			data-osrs-row
+			data-osrs-slug={item.slug}
+			style={rowStyle}
+			className="flex items-center gap-3 border-b border-white/5 px-3 hover:bg-white/5 active:bg-white/10 transition-colors">
 			<img
 				src={iconUrl(item.icon)}
 				alt=""
 				loading="lazy"
 				width={32}
 				height={32}
-				className="h-8 w-8 flex-shrink-0 object-contain"
+				className="h-8 w-8 flex-shrink-0 object-contain pointer-events-none"
 				onError={(e) => {
 					(e.currentTarget as HTMLImageElement).style.visibility =
 						'hidden';
 				}}
 			/>
-			<div className="min-w-0 flex-1">
+			<div className="min-w-0 flex-1 pointer-events-none">
 				<div className="flex items-center gap-2">
 					<span className="truncate font-medium text-sm">
 						{item.name}


### PR DESCRIPTION
## Report
User on iPhone Safari at https://kbve.com/osrs/ — tapping any row did nothing. Item detail pages were unreachable from the index.

## Root cause
`OSRSItemBrowser.tsx` is a `react-window 2` virtualized list (migrated 1.8.11 → 2.2.7 in #11616). iOS Safari, inside a momentum-scrolling container, queues taps on positioned `<a>` elements as possible scroll starts; without an explicit `touch-action` hint the click never fires. Same failure mode as PR #11578 (Argo dashboard row), different surface.

## Fix
`OSRSItemBrowser.tsx` row link:
- `touchAction: 'manipulation'` — kills the 300ms iOS tap delay + tells Safari it's a tap not a scroll start.
- `cursor: 'pointer'` + `WebkitTapHighlightColor` — visual affordance + native iOS tap-highlight.
- Inner `<img>` + content `<div>` get `pointer-events-none` so taps that land on a child element bubble cleanly to the `<a>`.
- `active:bg-white/10` for touch feedback.
- `data-osrs-row` + `data-osrs-slug` attributes for stable e2e selectors.

## e2e coverage
New `apps/kbve/astro-kbve/e2e/osrs.spec.ts` runs across `chromium / webkit / mobile-chrome / mobile-safari` (added in #11584), so the Safari-only break is now CI-visible:

| Test | Asserts |
|---|---|
| Virtualized list renders rows | rows mount, count > 0 |
| Search input filters | typing `whip` narrows to whip rows |
| **Tapping a row navigates to detail page** | the exact regression — fails on the OLD code under mobile-safari |
| Row has `touchAction=manipulation` + `cursor=pointer` | computed-style canary, fails fast if a future refactor strips the fix |
| Row is `<a>` with valid `href` | defends against a `<div onClick>` refactor that would re-break a11y + touch |
| Tag filter changes set | dropdown UX |

## Test plan
- [ ] CI `ci-e2e` (Monday cron) runs the new spec across all 4 projects
- [ ] Manual: load `/osrs/` on iPhone Safari, tap any row → navigates