### PR TITLE
perf(grafana-dashboard): compact cards + sticky nav + hover tooltips

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroGrafanaDashboard.astro
@@ -17,16 +17,31 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 					<ReactGrafanaHeader client:only="react" />
 				</div>
 
-				<div id="grafana-alerts">
-					<ReactGrafanaAlerts client:only="react" />
-				</div>
+				<nav class="kbve-dash-nav" aria-label="Dashboard sections">
+					<a href="#grafana-alerts">Alerts</a>
+					<a href="#grafana-nodes">Nodes</a>
+					<a href="#grafana-k8s">Kubernetes</a>
+				</nav>
 
-				<section id="grafana-nodes" class="kbve-dash-section">
+				<section
+					id="grafana-alerts"
+					class="kbve-dash-section"
+					aria-label="Alerts">
+					<ReactGrafanaAlerts client:only="react" />
+				</section>
+
+				<section
+					id="grafana-nodes"
+					class="kbve-dash-section"
+					aria-label="Nodes">
 					<h2 class="kbve-dash-section-title">Nodes</h2>
 					<ReactGrafanaNodes client:only="react" />
 				</section>
 
-				<section id="grafana-k8s" class="kbve-dash-section">
+				<section
+					id="grafana-k8s"
+					class="kbve-dash-section"
+					aria-label="Kubernetes">
 					<h2 class="kbve-dash-section-title">Kubernetes</h2>
 					<ReactGrafanaK8s client:only="react" />
 				</section>
@@ -58,13 +73,69 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 	.grafana-dashboard {
 		display: flex;
 		flex-direction: column;
-		gap: 1.5rem;
+		gap: 1.25rem;
+	}
+
+	.kbve-dash-nav {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		display: flex;
+		gap: 0.25rem;
+		padding: 0.4rem;
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-radius: 10px;
+		background: color-mix(
+			in srgb,
+			var(--sl-color-bg-nav, #111) 92%,
+			transparent
+		);
+		backdrop-filter: saturate(140%) blur(8px);
+		-webkit-backdrop-filter: saturate(140%) blur(8px);
+		overflow-x: auto;
+	}
+
+	.kbve-dash-nav a {
+		flex: 0 0 auto;
+		padding: 0.35rem 0.85rem;
+		border-radius: 6px;
+		color: var(--sl-color-gray-2, #c9d1d9);
+		font-size: 0.8rem;
+		font-weight: 500;
+		text-decoration: none;
+		transition:
+			background-color 0.15s,
+			color 0.15s,
+			border-color 0.15s;
+		border: 1px solid transparent;
+	}
+
+	.kbve-dash-nav a:hover {
+		background: var(--sl-color-gray-6, #1c1c1c);
+		color: var(--sl-color-text, #e6edf3);
+		border-color: var(--sl-color-gray-5, #262626);
+	}
+
+	.kbve-dash-nav a:target,
+	.kbve-dash-nav a.is-active {
+		background: color-mix(
+			in srgb,
+			var(--sl-color-accent, #06b6d4) 18%,
+			transparent
+		);
+		color: var(--sl-color-accent-high, #67e8f9);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent, #06b6d4) 40%,
+			transparent
+		);
 	}
 
 	.kbve-dash-section {
 		display: flex;
 		flex-direction: column;
 		gap: 0.75rem;
+		scroll-margin-top: 72px;
 	}
 
 	.kbve-dash-section-title {
@@ -82,14 +153,96 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 		}
 	}
 
+	:global(.kbve-card-grid) {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(168px, 1fr));
+		gap: 0.6rem;
+	}
+
+	:global(.kbve-stat-card) {
+		position: relative;
+		display: flex;
+		flex-direction: column;
+		justify-content: space-between;
+		gap: 0.35rem;
+		padding: 0.65rem 0.8rem 1.1rem;
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-top-width: 2px;
+		border-radius: 9px;
+		background: var(--sl-color-bg-nav, #111);
+		min-height: 96px;
+		overflow: hidden;
+		transition:
+			border-color 0.18s,
+			transform 0.15s,
+			box-shadow 0.18s;
+	}
+
+	:global(.kbve-stat-card__header) {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.65rem;
+		font-weight: 600;
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+		color: var(--sl-color-gray-3, #8b949e);
+	}
+
+	:global(.kbve-stat-card__header svg) {
+		flex: 0 0 auto;
+	}
+
+	:global(.kbve-stat-card__value) {
+		display: flex;
+		align-items: baseline;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		font-size: 1.45rem;
+		font-weight: 700;
+		font-variant-numeric: tabular-nums;
+		line-height: 1.05;
+		color: var(--sl-color-text, #e6edf3);
+	}
+
+	:global(.kbve-stat-card__trend) {
+		font-size: 0.7rem;
+		font-weight: 500;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	:global(.kbve-stat-card__spark) {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		height: 18px;
+		opacity: 0.65;
+		pointer-events: none;
+	}
+
 	:global(.kbve-stat-card.is-clickable) {
+		cursor: pointer;
 		-webkit-tap-highlight-color: transparent;
 	}
 
 	:global(.kbve-stat-card.is-clickable:hover) {
-		border-color: var(--sl-color-gray-4, #6b7280);
+		border-color: color-mix(
+			in srgb,
+			var(--sl-color-accent, #06b6d4) 55%,
+			var(--sl-color-gray-4, #6b7280)
+		);
 		transform: translateY(-2px);
-		box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+		box-shadow:
+			0 6px 18px -8px rgba(0, 0, 0, 0.55),
+			0 0 0 1px
+				color-mix(
+					in srgb,
+					var(--sl-color-accent, #06b6d4) 20%,
+					transparent
+				);
 	}
 
 	@media (hover: none) {
@@ -103,11 +256,55 @@ import ReactGrafanaAlerts from './ReactGrafanaAlerts';
 		}
 	}
 
+	:global(.kbve-stat-card[data-tip]:hover::after) {
+		content: attr(data-tip);
+		position: absolute;
+		bottom: calc(100% + 6px);
+		left: 50%;
+		transform: translateX(-50%);
+		padding: 0.35rem 0.55rem;
+		border-radius: 6px;
+		background: var(--sl-color-bg-inline-code, #0f1115);
+		color: var(--sl-color-text, #e6edf3);
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		font-size: 0.7rem;
+		font-weight: 400;
+		letter-spacing: 0;
+		text-transform: none;
+		white-space: nowrap;
+		max-width: 220px;
+		z-index: 10;
+		pointer-events: none;
+		box-shadow: 0 8px 20px -10px rgba(0, 0, 0, 0.6);
+	}
+
+	@media (hover: none) {
+		:global(.kbve-stat-card[data-tip]:hover::after) {
+			display: none;
+		}
+	}
+
 	:global(.kbve-chart-panel) {
-		padding: clamp(0.75rem, 3vw, 1.5rem) !important;
+		padding: clamp(0.75rem, 3vw, 1.25rem) !important;
 	}
 
 	:global(.kbve-chart-panel h3) {
-		font-size: clamp(0.95rem, 2.4vw, 1.1rem) !important;
+		font-size: clamp(0.95rem, 2.4vw, 1.05rem) !important;
 	}
 </style>
+
+<script>
+	const setActive = () => {
+		const hash = window.location.hash || '#grafana-alerts';
+		document
+			.querySelectorAll<HTMLAnchorElement>('.kbve-dash-nav a')
+			.forEach((a) => {
+				a.classList.toggle(
+					'is-active',
+					a.getAttribute('href') === hash,
+				);
+			});
+	};
+	setActive();
+	window.addEventListener('hashchange', setActive);
+</script>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaK8s.tsx
@@ -86,41 +86,40 @@ function TrendIndicator({ trend }: { trend: TrendInfo }) {
 	const sign = isUp ? '+' : '';
 
 	return (
-		<div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-			<Icon size={12} style={{ color }} />
-			<span style={{ color, fontSize: '0.75rem', fontWeight: 500 }}>
+		<span className="kbve-stat-card__trend" style={{ color }}>
+			<Icon size={11} style={{ color }} />
+			<span style={{ color, fontSize: '0.7rem', fontWeight: 500 }}>
 				{sign}
 				{trend.percentChange.toFixed(1)}%
 			</span>
-		</div>
+		</span>
 	);
 }
 
-function SparklineSlot({
+function SparklineBg({
 	data,
 	color,
 }: {
 	data?: SparklinePoint[];
 	color: string;
 }) {
-	// Slot is always rendered to reserve 36px in the card layout — keeps
-	// StatCard at a stable height while sparkline data hydrates.
+	if (!data || data.length < 2) return null;
 	return (
-		<div style={{ width: '100%', height: 36, marginTop: 'auto' }}>
-			{data && data.length >= 2 && (
-				<ResponsiveContainer width="100%" height={36}>
-					<LineChart data={data}>
-						<Line
-							type="monotone"
-							dataKey="v"
-							stroke={color}
-							strokeWidth={1.5}
-							dot={false}
-							isAnimationActive={false}
-						/>
-					</LineChart>
-				</ResponsiveContainer>
-			)}
+		<div className="kbve-stat-card__spark">
+			<ResponsiveContainer width="100%" height="100%">
+				<LineChart
+					data={data}
+					margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+					<Line
+						type="monotone"
+						dataKey="v"
+						stroke={color}
+						strokeWidth={1.5}
+						dot={false}
+						isAnimationActive={false}
+					/>
+				</LineChart>
+			</ResponsiveContainer>
 		</div>
 	);
 }
@@ -132,6 +131,7 @@ function StatCard({
 	trend,
 	sparkline,
 	onClick,
+	tip,
 }: {
 	icon: React.ReactNode;
 	label: string;
@@ -139,65 +139,30 @@ function StatCard({
 	trend?: TrendInfo;
 	sparkline?: SparklinePoint[];
 	onClick?: () => void;
+	tip?: string;
 }) {
+	const accentColor = 'var(--sl-color-accent, #06b6d4)';
+	const valueText =
+		value != null
+			? Number.isInteger(value)
+				? value
+				: value.toFixed(1)
+			: '--';
 	return (
 		<div
-			className={
-				onClick ? 'kbve-stat-card is-clickable' : 'kbve-stat-card'
-			}
-			style={{
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'flex-start',
-				gap: '0.5rem',
-				padding: '1rem 1.25rem',
-				borderRadius: '10px',
-				border: '1px solid var(--sl-color-gray-5, #262626)',
-				background: 'var(--sl-color-bg-nav, #111)',
-				transition:
-					'border-color 0.2s, transform 0.15s, box-shadow 0.15s',
-				minHeight: 156,
-				cursor: onClick ? 'pointer' : 'default',
-				borderTop: '2px solid var(--sl-color-accent, #06b6d4)',
-			}}
-			onClick={onClick}>
-			<div
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-					gap: '0.5rem',
-					width: '100%',
-				}}>
-				<span style={{ color: 'var(--sl-color-accent, #06b6d4)' }}>
-					{icon}
-				</span>
-				<span
-					style={{
-						color: 'var(--sl-color-gray-3, #8b949e)',
-						fontSize: '0.75rem',
-						fontWeight: 500,
-						textTransform: 'uppercase' as const,
-						letterSpacing: '0.06em',
-					}}>
-					{label}
-				</span>
+			className={`kbve-stat-card${onClick ? ' is-clickable' : ''}`}
+			style={{ borderTopColor: accentColor }}
+			onClick={onClick}
+			data-tip={tip}>
+			<div className="kbve-stat-card__header">
+				<span style={{ color: accentColor }}>{icon}</span>
+				<span>{label}</span>
 			</div>
-			<div
-				style={{
-					fontSize: '1.75rem',
-					fontWeight: 700,
-					color: 'var(--sl-color-text, #e6edf3)',
-					fontVariantNumeric: 'tabular-nums',
-					whiteSpace: 'nowrap' as const,
-				}}>
-				{value != null
-					? Number.isInteger(value)
-						? value
-						: value.toFixed(1)
-					: '--'}
+			<div className="kbve-stat-card__value">
+				{valueText}
+				{trend && <TrendIndicator trend={trend} />}
 			</div>
-			{trend && <TrendIndicator trend={trend} />}
-			<SparklineSlot data={sparkline} color="#06b6d4" />
+			<SparklineBg data={sparkline} color={accentColor} />
 		</div>
 	);
 }
@@ -287,47 +252,47 @@ export default function ReactGrafanaK8s() {
 
 	return (
 		<>
-			<div
-				className="kbve-card-grid"
-				style={{
-					display: 'grid',
-					gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
-					gap: '0.75rem',
-				}}>
+			<div className="kbve-card-grid">
 				<StatCard
-					icon={<Activity size={20} />}
+					icon={<Activity size={16} />}
 					label="Running Pods"
 					value={snapshot.pods}
 					trend={trends.pods}
 					sparkline={sparklines.pods}
 					onClick={() => grafanaService.toggleCard('pods')}
+					tip="Pods currently in Running phase. Click for namespace breakdown."
 				/>
 				<StatCard
-					icon={<Clock size={20} />}
+					icon={<Clock size={16} />}
 					label="Pending Pods"
 					value={snapshot.pendingPods}
+					tip="Pods in Pending phase — likely waiting on scheduling or images."
 				/>
 				<StatCard
-					icon={<AlertTriangle size={20} />}
+					icon={<AlertTriangle size={16} />}
 					label="Failed Pods"
 					value={snapshot.failedPods}
+					tip="Pods in Failed phase — non-zero exit + restartPolicy=Never."
 				/>
 				<StatCard
-					icon={<Box size={20} />}
+					icon={<Box size={16} />}
 					label="Containers"
 					value={snapshot.containers}
 					trend={trends.containers}
+					tip="Container instances running across all pods."
 				/>
 				<StatCard
-					icon={<RotateCcw size={20} />}
+					icon={<RotateCcw size={16} />}
 					label={`Restarts (${timeRange})`}
 					value={snapshot.podRestarts}
+					tip="Container restart count over the selected window."
 				/>
 				<StatCard
-					icon={<Layers size={20} />}
+					icon={<Layers size={16} />}
 					label="Deployments"
 					value={snapshot.deployments}
 					trend={trends.deployments}
+					tip="Total Deployment objects across all namespaces."
 				/>
 			</div>
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactGrafanaNodes.tsx
@@ -102,41 +102,40 @@ function TrendIndicator({
 	const sign = isUp ? '+' : '';
 
 	return (
-		<div style={{ display: 'flex', alignItems: 'center', gap: '0.25rem' }}>
-			<Icon size={12} style={{ color }} />
-			<span style={{ color, fontSize: '0.75rem', fontWeight: 500 }}>
+		<span className="kbve-stat-card__trend" style={{ color }}>
+			<Icon size={11} style={{ color }} />
+			<span style={{ color, fontSize: '0.7rem', fontWeight: 500 }}>
 				{sign}
 				{trend.percentChange.toFixed(1)}%
 			</span>
-		</div>
+		</span>
 	);
 }
 
-function SparklineSlot({
+function SparklineBg({
 	data,
 	color,
 }: {
 	data?: SparklinePoint[];
 	color: string;
 }) {
-	// Slot is always rendered to reserve 36px in the card layout — keeps
-	// EnhancedStatCard at a stable height while sparkline data hydrates.
+	if (!data || data.length < 2) return null;
 	return (
-		<div style={{ width: '100%', height: 36, marginTop: 'auto' }}>
-			{data && data.length >= 2 && (
-				<ResponsiveContainer width="100%" height={36}>
-					<LineChart data={data}>
-						<Line
-							type="monotone"
-							dataKey="v"
-							stroke={color}
-							strokeWidth={1.5}
-							dot={false}
-							isAnimationActive={false}
-						/>
-					</LineChart>
-				</ResponsiveContainer>
-			)}
+		<div className="kbve-stat-card__spark">
+			<ResponsiveContainer width="100%" height="100%">
+				<LineChart
+					data={data}
+					margin={{ top: 0, right: 0, bottom: 0, left: 0 }}>
+					<Line
+						type="monotone"
+						dataKey="v"
+						stroke={color}
+						strokeWidth={1.5}
+						dot={false}
+						isAnimationActive={false}
+					/>
+				</LineChart>
+			</ResponsiveContainer>
 		</div>
 	);
 }
@@ -152,6 +151,7 @@ function EnhancedStatCard({
 	thresholds,
 	invertTrend,
 	onClick,
+	tip,
 }: {
 	icon: React.ReactNode;
 	label: string;
@@ -163,73 +163,37 @@ function EnhancedStatCard({
 	thresholds?: { warn: number; crit: number };
 	invertTrend?: boolean;
 	onClick?: () => void;
+	tip?: string;
 }) {
 	const hasThreshold = thresholds && value != null;
 	const thresholdColor = hasThreshold
 		? getThresholdColor(value, thresholds)
 		: undefined;
-	const valueColor = thresholdColor ?? 'var(--sl-color-text, #e6edf3)';
-	const sparkColor = thresholdColor ?? '#06b6d4';
 	const accentColor = thresholdColor ?? 'var(--sl-color-accent, #06b6d4)';
-
+	const valueText = displayValue
+		? displayValue
+		: value != null
+			? `${Number.isInteger(value) ? value : value.toFixed(1)}${unit || ''}`
+			: '--';
 	return (
 		<div
-			className={
-				onClick ? 'kbve-stat-card is-clickable' : 'kbve-stat-card'
-			}
-			style={{
-				display: 'flex',
-				flexDirection: 'column',
-				alignItems: 'flex-start',
-				gap: '0.5rem',
-				padding: '1rem 1.25rem',
-				borderRadius: '10px',
-				border: '1px solid var(--sl-color-gray-5, #262626)',
-				background: 'var(--sl-color-bg-nav, #111)',
-				transition:
-					'border-color 0.2s, transform 0.15s, box-shadow 0.15s',
-				minHeight: 156,
-				cursor: onClick ? 'pointer' : 'default',
-				borderTop: `2px solid ${accentColor}`,
-			}}
-			onClick={onClick}>
-			<div
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-					gap: '0.5rem',
-					width: '100%',
-				}}>
+			className={`kbve-stat-card${onClick ? ' is-clickable' : ''}`}
+			style={{ borderTopColor: accentColor }}
+			onClick={onClick}
+			data-tip={tip}>
+			<div className="kbve-stat-card__header">
 				<span style={{ color: accentColor }}>{icon}</span>
-				<span
-					style={{
-						color: 'var(--sl-color-gray-3, #8b949e)',
-						fontSize: '0.75rem',
-						fontWeight: 500,
-						textTransform: 'uppercase' as const,
-						letterSpacing: '0.06em',
-					}}>
-					{label}
-				</span>
+				<span>{label}</span>
 			</div>
 			<div
-				style={{
-					fontSize: '1.75rem',
-					fontWeight: 700,
-					color: valueColor,
-					fontVariantNumeric: 'tabular-nums',
-					whiteSpace: 'nowrap' as const,
-				}}>
-				{displayValue
-					? displayValue
-					: value != null
-						? `${Number.isInteger(value) ? value : value.toFixed(1)}${unit || ''}`
-						: '--'}
+				className="kbve-stat-card__value"
+				style={thresholdColor ? { color: thresholdColor } : undefined}>
+				{valueText}
+				{trend && (
+					<TrendIndicator trend={trend} invertColors={invertTrend} />
+				)}
 			</div>
-			{trend && (
-				<TrendIndicator trend={trend} invertColors={invertTrend} />
-			)}
-			<SparklineSlot data={sparkline} color={sparkColor} />
+			<SparklineBg data={sparkline} color={accentColor} />
 		</div>
 	);
 }
@@ -334,15 +298,9 @@ export default function ReactGrafanaNodes() {
 
 	return (
 		<>
-			<div
-				className="kbve-card-grid"
-				style={{
-					display: 'grid',
-					gridTemplateColumns: 'repeat(auto-fit, minmax(190px, 1fr))',
-					gap: '0.75rem',
-				}}>
+			<div className="kbve-card-grid">
 				<EnhancedStatCard
-					icon={<Cpu size={20} />}
+					icon={<Cpu size={16} />}
 					label="CPU Usage"
 					value={snapshot.cpu}
 					unit="%"
@@ -351,9 +309,10 @@ export default function ReactGrafanaNodes() {
 					invertTrend
 					sparkline={sparklines.cpu}
 					onClick={() => grafanaService.toggleCard('cpu')}
+					tip="Cluster-wide CPU utilization (avg, 5m). Click for per-node breakdown."
 				/>
 				<EnhancedStatCard
-					icon={<HardDrive size={20} />}
+					icon={<HardDrive size={16} />}
 					label="Memory"
 					value={snapshot.memory}
 					unit="%"
@@ -362,9 +321,10 @@ export default function ReactGrafanaNodes() {
 					invertTrend
 					sparkline={sparklines.memory}
 					onClick={() => grafanaService.toggleCard('memory')}
+					tip="Cluster memory used vs total. Click for per-node breakdown."
 				/>
 				<EnhancedStatCard
-					icon={<HardDrive size={20} />}
+					icon={<HardDrive size={16} />}
 					label="Disk"
 					value={snapshot.disk}
 					unit="%"
@@ -373,30 +333,35 @@ export default function ReactGrafanaNodes() {
 					invertTrend
 					sparkline={sparklines.disk}
 					onClick={() => grafanaService.toggleCard('disk')}
+					tip="Root filesystem usage. Click for per-node breakdown."
 				/>
 				<EnhancedStatCard
-					icon={<Network size={20} />}
+					icon={<Network size={16} />}
 					label="Net RX"
 					value={snapshot.networkRx}
 					displayValue={formatBytes(snapshot.networkRx)}
+					tip="Inbound network throughput (excludes lo / veth / cni)."
 				/>
 				<EnhancedStatCard
-					icon={<Network size={20} />}
+					icon={<Network size={16} />}
 					label="Net TX"
 					value={snapshot.networkTx}
 					displayValue={formatBytes(snapshot.networkTx)}
+					tip="Outbound network throughput (excludes lo / veth / cni)."
 				/>
 				<EnhancedStatCard
-					icon={<Server size={20} />}
+					icon={<Server size={16} />}
 					label="Nodes"
 					value={snapshot.nodes}
+					tip="Total nodes registered with the kubelet."
 				/>
 				<EnhancedStatCard
-					icon={<Database size={20} />}
+					icon={<Database size={16} />}
 					label="PVC Usage"
 					value={snapshot.pvcUsage}
 					unit="%"
 					thresholds={RESOURCE_THRESHOLDS}
+					tip="Aggregate persistent volume claim utilization."
 				/>
 			</div>
 


### PR DESCRIPTION
## Summary

Visual polish pass — screenshot review showed too much vertical dead space, no tab/section nav, no per-card context, lots of inline styles. This refactor pushes the cards into a tighter, more professional rhythm and adds the nav/tooltip surfaces the user asked for.

### Card redesign

- \`minHeight\` 156 → 96, padding 1rem/1.25rem → 0.65rem/0.8rem
- Two-row layout: header (icon + label) + value-with-inline-trend
- Sparkline now an absolute-positioned 18 px bottom strip — no longer reserves layout space
- Grid \`minmax(190px, 1fr)\` → \`minmax(168px, 1fr)\` — seven cards fit two rows on common viewports without giant gaps
- Inline grid styles dropped; \`.kbve-card-grid\` CSS owns layout
- Icon size 20 → 16
- Hover lift uses \`color-mix\` against \`--sl-color-accent\` for the glow ring

### Sticky section nav

- Astro-rendered \`<nav>\` with anchor links to \`#grafana-alerts\` / \`#grafana-nodes\` / \`#grafana-k8s\`
- Sticky, glassy backdrop (\`backdrop-filter: blur\`) so it reads as a tab strip without hiding content
- Tiny inline script syncs \`.is-active\` on hashchange; \`:target\` provides the styling baseline so SSG cold-paint already shows the right tab if URL has a hash
- \`scroll-margin-top: 72px\` on sections so anchored jumps clear the nav
- Alerts now wrapped in its own anchorable \`<section>\`

### Hover tooltips

- Every card gets a \`tip\` prop with a one-sentence description
- CSS-only \`.kbve-stat-card[data-tip]:hover::after\` renders the tooltip above the card, styled with Starlight vars
- Hidden under \`@media (hover: none)\` so it doesn't stick on touch

### Theming

- All accents resolve through \`--sl-color-*\`; hover ring + nav active state use \`color-mix\` so theme switches stay consistent

## Verification

- [x] \`nx run astro-kbve:build\` clean

## Test plan

- [ ] Cards render at ~96 px instead of 156 px — less scroll, no \`--\` floating in dead space
- [ ] Hover any card → tooltip appears above with description
- [ ] Click \`Nodes\` / \`Kubernetes\` in nav → page scrolls to section with title clearing the sticky bar
- [ ] Active tab pill highlights based on URL hash
- [ ] Touch device: no sticky hover after tap, no tooltip on touch
- [ ] Sparklines render as bottom strip, no layout shift when they hydrate

## Stacks on

#11688 + #11699 (both merged).