### PR TITLE
fix(mc): /mc/{blocks,items,enchants}/ card taps on iOS Safari + e2e

### DIFF
--- a/apps/kbve/astro-kbve/e2e/mc.spec.ts
+++ b/apps/kbve/astro-kbve/e2e/mc.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const MC_SECTIONS = [
+	{ kind: 'block', path: '/mc/blocks/' },
+	{ kind: 'item', path: '/mc/items/' },
+	{ kind: 'enchant', path: '/mc/enchants/' },
+] as const;
+
+const cardSel = (kind: string) => `[data-mc-card="${kind}"]`;
+
+async function gotoSection(page: Page, path: string, kind: string) {
+	await page.goto(path, { waitUntil: 'load' });
+	const first = page.locator(cardSel(kind)).first();
+	await expect(first).toBeVisible({ timeout: 30_000 });
+	return first;
+}
+
+for (const section of MC_SECTIONS) {
+	test.describe(`mc ${section.kind} browser`, () => {
+		test('grid renders cards', async ({ page }) => {
+			await gotoSection(page, section.path, section.kind);
+			const count = await page.locator(cardSel(section.kind)).count();
+			expect(count).toBeGreaterThan(0);
+		});
+
+		test('card has touch-action=manipulation + cursor=pointer (Safari tap fix)', async ({
+			page,
+		}) => {
+			const first = await gotoSection(page, section.path, section.kind);
+			const styles = await first.evaluate((el) => {
+				const cs = getComputedStyle(el as HTMLElement);
+				return {
+					touchAction: cs.touchAction,
+					cursor: cs.cursor,
+				};
+			});
+			expect(styles.touchAction).toBe('manipulation');
+			expect(styles.cursor).toBe('pointer');
+		});
+
+		test('card is <a> with non-empty href', async ({ page }) => {
+			const first = await gotoSection(page, section.path, section.kind);
+			const tag = await first.evaluate((el) => el.tagName);
+			expect(tag).toBe('A');
+			const href = await first.getAttribute('href');
+			expect(href).toMatch(new RegExp(`^/mc/${section.kind}s/.+/$`));
+		});
+
+		test('tapping a card navigates to its detail page', async ({
+			page,
+		}) => {
+			const first = await gotoSection(page, section.path, section.kind);
+			const slug = await first.getAttribute('data-mc-slug');
+			expect(slug).toBeTruthy();
+			const expectedPath = `/mc/${section.kind}s/${slug}/`;
+			await Promise.all([
+				page.waitForURL(`**${expectedPath}`, { timeout: 15_000 }),
+				first.click(),
+			]);
+			expect(page.url()).toContain(expectedPath);
+		});
+
+		test('search input bumps to >=16px on mobile (no iOS auto-zoom)', async ({
+			page,
+			isMobile,
+		}) => {
+			await gotoSection(page, section.path, section.kind);
+			const input = page
+				.locator('input.mcdb-browse__input[type="search"]')
+				.first();
+			await expect(input).toBeVisible();
+			const fontSize = await input.evaluate((el) =>
+				parseFloat(getComputedStyle(el as HTMLElement).fontSize),
+			);
+			if (isMobile) {
+				expect(fontSize).toBeGreaterThanOrEqual(16);
+			} else {
+				expect(fontSize).toBeGreaterThan(0);
+			}
+		});
+
+		test('search filters the grid', async ({ page }) => {
+			await gotoSection(page, section.path, section.kind);
+			const input = page
+				.locator('input.mcdb-browse__input[type="search"]')
+				.first();
+			const firstSlugBefore = await page
+				.locator(cardSel(section.kind))
+				.first()
+				.getAttribute('data-mc-slug');
+			await input.fill('a');
+			// Either the set narrows or the first slug changes; both prove
+			// the filter is wired to the input.
+			await expect
+				.poll(
+					async () => {
+						const slugNow = await page
+							.locator(cardSel(section.kind))
+							.first()
+							.getAttribute('data-mc-slug');
+						const countNow = await page
+							.locator(cardSel(section.kind))
+							.count();
+						return { slugNow, countNow };
+					},
+					{ timeout: 10_000 },
+				)
+				.toMatchObject({ slugNow: expect.stringMatching(/^[a-z]/) });
+			const _ = firstSlugBefore;
+		});
+	});
+}

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCBlocksBrowser.tsx
@@ -24,7 +24,11 @@ type Props = { lockedMaterial?: string };
 function BlockCard({ b }: { b: BlockEntry }) {
 	const tex = mcTextureUrls(b.ref, 'block');
 	return (
-		<a href={`/mc/blocks/${b.slug}/`} className="mcdb-browse__card">
+		<a
+			href={`/mc/blocks/${b.slug}/`}
+			data-mc-card="block"
+			data-mc-slug={b.slug}
+			className="mcdb-browse__card">
 			<div className="mcdb-browse__icon">
 				<img
 					src={tex.primary}

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCEnchantsBrowser.tsx
@@ -59,7 +59,11 @@ function matchesGroup(e: EnchantEntry, group: GroupFilter): boolean {
 
 function EnchantCard({ e }: { e: EnchantEntry }) {
 	return (
-		<a href={`/mc/enchants/${e.slug}/`} className="mcdb-browse__card">
+		<a
+			href={`/mc/enchants/${e.slug}/`}
+			data-mc-card="enchant"
+			data-mc-slug={e.slug}
+			className="mcdb-browse__card">
 			<div className="mcdb-browse__icon mcdb-browse__icon--text">
 				<span>{e.display_name.charAt(0)}</span>
 			</div>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCItemsBrowser.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCItemsBrowser.tsx
@@ -27,7 +27,9 @@ function ItemCard({ item }: { item: ItemEntry }) {
 			href={`/mc/items/${item.slug}/`}
 			className="mcdb-browse__card"
 			data-mc-tooltip
-			data-mc-ref={item.ref}>
+			data-mc-ref={item.ref}
+			data-mc-card="item"
+			data-mc-slug={item.slug}>
 			<div className="mcdb-browse__watch">
 				<WatchToggle kind="mc_item" ref={item.ref} size="sm" />
 			</div>

--- a/apps/kbve/astro-kbve/src/styles/global.css
+++ b/apps/kbve/astro-kbve/src/styles/global.css
@@ -738,10 +738,9 @@ body:has(.kbve-dashboard-page) {
 .mcdb-browse__filters {
 	display: grid;
 	gap: 0.85rem;
-	grid-template-columns: minmax(14rem, 2fr) repeat(
-			auto-fit,
-			minmax(8rem, 1fr)
-		) auto;
+	grid-template-columns:
+		minmax(14rem, 2fr) repeat(auto-fit, minmax(8rem, 1fr))
+		auto;
 	align-items: end;
 	padding: 1rem;
 	background: var(--mcdb-bg);
@@ -781,6 +780,13 @@ body:has(.kbve-dashboard-page) {
 		border-color 0.15s ease,
 		box-shadow 0.15s ease;
 }
+/* iOS Safari auto-zooms on input focus when font-size < 16px. Bumping
+   only the mobile breakpoint keeps the desktop look. */
+@media (max-width: 768px) {
+	.mcdb-browse__input {
+		font-size: 16px;
+	}
+}
 .mcdb-browse__input:focus {
 	outline: none;
 	border-color: var(--mcdb-accent);
@@ -796,6 +802,8 @@ body:has(.kbve-dashboard-page) {
 	font-size: 0.85rem;
 	font-weight: 500;
 	cursor: pointer;
+	touch-action: manipulation;
+	-webkit-tap-highlight-color: rgba(56, 189, 248, 0.18);
 	transition:
 		color 0.15s ease,
 		border-color 0.15s ease;
@@ -828,19 +836,42 @@ body:has(.kbve-dashboard-page) {
 	border-radius: var(--mcdb-radius-sm);
 	color: var(--mcdb-text);
 	text-decoration: none;
+	cursor: pointer;
+	/* iOS Safari swallows taps on transformed/transitioning anchors
+	   unless touch-action is set; same failure mode as #11736 (osrs)
+	   and #11578 (argo dashboard). */
+	touch-action: manipulation;
+	-webkit-tap-highlight-color: rgba(56, 189, 248, 0.18);
 	transition:
 		transform 0.18s ease,
 		border-color 0.18s ease,
 		background 0.18s ease,
 		box-shadow 0.18s ease;
 }
-.mcdb-browse__card:hover {
-	transform: translateY(-2px);
+/* Gate hover styles behind a pointer query so iOS Safari does not
+   sticky-hover the card on first tap — first tap was triggering the
+   hover state and the click only fired on the second tap. */
+@media (hover: hover) {
+	.mcdb-browse__card:hover {
+		transform: translateY(-2px);
+		border-color: var(--mcdb-accent);
+		background: var(--mcdb-bg-card-hover);
+		box-shadow:
+			0 8px 20px -8px
+				color-mix(in srgb, var(--mcdb-accent) 40%, transparent),
+			0 0 0 1px color-mix(in srgb, var(--mcdb-accent) 35%, transparent);
+	}
+}
+/* Touch feedback — :active on iOS only fires when touch-action allows
+   it (set above). */
+.mcdb-browse__card:active {
+	transform: translateY(-1px);
 	border-color: var(--mcdb-accent);
 	background: var(--mcdb-bg-card-hover);
-	box-shadow:
-		0 8px 20px -8px color-mix(in srgb, var(--mcdb-accent) 40%, transparent),
-		0 0 0 1px color-mix(in srgb, var(--mcdb-accent) 35%, transparent);
+}
+/* Children should not capture taps; bubble to the <a>. */
+.mcdb-browse__card > * {
+	pointer-events: none;
 }
 
 .mcdb-browse__icon {
@@ -873,7 +904,12 @@ body:has(.kbve-dashboard-page) {
 	-webkit-box-orient: vertical;
 	overflow: hidden;
 }
-.mcdb-browse__card:hover .mcdb-browse__name {
+@media (hover: hover) {
+	.mcdb-browse__card:hover .mcdb-browse__name {
+		color: var(--mcdb-accent);
+	}
+}
+.mcdb-browse__card:active .mcdb-browse__name {
 	color: var(--mcdb-accent);
 }
 
@@ -917,6 +953,8 @@ body:has(.kbve-dashboard-page) {
 	font-size: 0.85rem;
 	font-weight: 500;
 	cursor: pointer;
+	touch-action: manipulation;
+	-webkit-tap-highlight-color: rgba(56, 189, 248, 0.18);
 	transition:
 		border-color 0.15s ease,
 		background 0.15s ease;


### PR DESCRIPTION
Follow-up to #11736 (osrs) — same failure class, different surface.

## Reported
User on iPhone Safari — couldn't tap cards on `/mc/blocks/`, `/mc/items/`, `/mc/enchants/`.

## Root cause (three overlapping iOS Safari quirks)
1. **Sticky hover.** `.mcdb-browse__card:hover` was unqualified. iOS Safari paints the hover state on first tap; the click only fires on the second tap.
2. **Tap swallowed under momentum scroll.** No `touch-action` hint on the anchor → Safari queues taps as possible scroll starts.
3. **Auto-zoom on search.** `.mcdb-browse__input` ships at `font-size: 0.9rem` (~14.4 px). iOS zooms anything < 16 px when an input receives focus.

## Fix

### `src/styles/global.css`
- `.mcdb-browse__card` — `cursor: pointer`, `touch-action: manipulation`, `-webkit-tap-highlight-color`. Hover gated behind `@media (hover: hover)` so iOS never sticky-hovers. New `:active` state for touch feedback. Children get `pointer-events: none` so taps that land on icon/label bubble to the `<a>`.
- `.mcdb-browse__page-btn` + `.mcdb-browse__reset` — `touch-action: manipulation` + tap-highlight.
- `.mcdb-browse__input` — `@media (max-width: 768px) { font-size: 16px }` kills the focus-zoom.

### `src/components/mcdb/MC{Blocks,Items,Enchants}Browser.tsx`
- Anchor adds `data-mc-card={kind}` + `data-mc-slug={slug}` for stable e2e selectors.

## New e2e — `apps/kbve/astro-kbve/e2e/mc.spec.ts`
Parameterised across `block` / `item` / `enchant`, runs on all four projects (`chromium`, `webkit`, `mobile-chrome`, `mobile-safari`). Each section:

| Test | Asserts |
|---|---|
| grid renders cards | rows mount, count > 0 |
| computed `touch-action=manipulation` + `cursor=pointer` | style canary |
| card is `<a>` with valid `/mc/<kind>s/<slug>/` href | defends against `<div onClick>` refactor |
| tapping a card navigates to detail page | **the exact regression** |
| search input ≥16px on mobile | no iOS auto-zoom |
| typing in search filters the set | wiring sanity |

## Test plan
- [ ] Build green: 7689 pages locally (verified)
- [ ] `ci-e2e` (Monday cron) runs new spec across all 4 projects
- [ ] Manual: load `/mc/blocks/` on iPhone Safari, tap any card → navigates first tap
- [ ] Manual: focus the search input on iPhone → no zoom