### PR TITLE
content(osrs): migrate batch 19 (200 items) v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-platebody.mdx
@@ -12,58 +12,99 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: 3rd-age
+    tier: high
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: melee armour
-    attack_style: melee
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
     requirements:
       defence: 65
-    stats:
-      defence_stab: 107
-      defence_slash: 105
-      defence_crush: 98
-      defence_magic: -6
-      defence_ranged: 107
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -20
+      ranged: 0
+    defence_bonus:
+      stab: 96
+      slash: 108
+      crush: 113
+      magic: -4
+      ranged: 97
+    other_bonus:
       melee_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Treasure Trail reward casket
+        quantity: "1"
+        rarity: 1/211250
+      - source: Elite Treasure Trail reward casket
+        quantity: "1"
+        rarity: 1/249262
+      - source: Master Treasure Trail reward casket
+        quantity: "1"
+        rarity: 1/313168
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 10350
-      item_name: 3rd age full helmet
+    - item_name: 3rd age full helmet
       slug: 3rd-age-full-helmet
       relationship: set-piece
-      description: Head slot of 3rd age melee set
-    - item_id: 10346
-      item_name: 3rd age platelegs
+      description: Head slot of the 3rd age melee set
+    - item_name: 3rd age platelegs
       slug: 3rd-age-platelegs
       relationship: set-piece
-      description: Leg slot of 3rd age melee set
-    - item_id: 10352
-      item_name: 3rd age kiteshield
+      description: Leg slot of the 3rd age melee set
+    - item_name: 3rd age kiteshield
       slug: 3rd-age-kiteshield
       relationship: set-piece
-      description: Shield slot of 3rd age melee set
+      description: Shield slot of the 3rd age melee set
   about: |-
-    The 3rd age platebody is part of the 3rd age melee set, one of the rarest and most prestigious armour sets in Old School RuneScape. It requires 65 Defence to wear and provides stats comparable to a rune platebody but with superior aesthetics.
+    The 3rd age platebody is part of the 3rd age melee set, one of the rarest and most prestigious armour sets in Old School RuneScape. It requires 65 Defence to wear and provides crush-focused defensive stats similar to chainbodies while retrieving ammunition with Ava's devices.
 
-    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trail reward caskets at exceptionally low drop rates, with master clues offering the highest chance per casket.
   market_strategy:
-    title: Investment Notes
     notes:
-      - One of the most valuable items in OSRS
-      - Price driven by collector demand
-      - Often used as currency for high-value trades
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "One of the most valuable items in OSRS"
+      - "Price driven by collector and fashionscape demand"
+      - "Often used as currency for high-value trades"
+      - "Verify authenticity when trading high-value items"
+      - "Use Grand Exchange for secure settlement"
+      - "Monitor price trends before purchasing"
+  trading_tips:
+    - Buy on dips during update lulls; sell into hype cycles
+    - Cross-reference GE limit of 8 with bond trades
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the Treasure Trails 3rd age reward pool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-range-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-range-coif.mdx
@@ -12,60 +12,103 @@ osrs:
   lowalch: 20160
   highalch: 30240
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "5 December 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements:
       ranged: 65
       defence: 45
-    stats:
-      attack_ranged: 8
-      defence_stab: 6
-      defence_slash: 9
-      defence_crush: 12
-      defence_magic: 8
-      defence_ranged: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 9
+    defence_bonus:
+      stab: 4
+      slash: 7
+      crush: 10
+      magic: 5
+      ranged: 8
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/211250
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/249262
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/313168
+      - source: The Mimic
+        quantity: "1"
+        rarity: Very rare
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 10330
-      item_name: 3rd age range top
+    - item_name: 3rd age range top
       slug: 3rd-age-range-top
       relationship: set-piece
-      description: Body slot of 3rd age range set
-    - item_id: 10332
-      item_name: 3rd age range legs
+      description: Body slot of the 3rd age ranged set
+    - item_name: 3rd age range legs
       slug: 3rd-age-range-legs
       relationship: set-piece
-      description: Leg slot of 3rd age range set
-    - item_id: 10336
-      item_name: 3rd age vambraces
+      description: Leg slot of the 3rd age ranged set
+    - item_name: 3rd age vambraces
       slug: 3rd-age-vambraces
       relationship: set-piece
-      description: Hands slot of 3rd age range set
+      description: Hands slot of the 3rd age ranged set
   about: |-
-    The 3rd age range coif is part of the 3rd age ranged set, one of the rarest and most prestigious armour sets in Old School RuneScape. It requires 65 Ranged and 45 Defence to wear.
-
-    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+    The 3rd age range coif is part of the 3rd age ranged set, one of the rarest and most prestigious armour sets in Old School RuneScape. It requires 65 Ranged and 45 Defence to wear and is only obtained as an exceptionally rare reward from hard, elite, and master Treasure Trails caskets or from defeating The Mimic.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Extremely valuable due to rarity
-      - Price fluctuates based on collector demand
-      - Consider set value vs individual pieces
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Extremely valuable due to rarity"
+      - "Price fluctuates based on collector demand"
+      - "Consider full set value vs individual pieces"
+      - "Buy limit 8 per 4 hours - thin liquidity"
+  trading_tips:
+    - Verify authenticity through Grand Exchange to avoid scams
+    - Monitor master clue completion rates for supply trends
+    - Pair with the rest of the 3rd age ranged set for maximum resale prestige
+  history:
+    - date: "5 December 2006"
+      description: "3rd age range coif added with the Treasure Trails expansion."
+    - date: "June 2014"
+      description: "Store value raised from 10,000 to 50,400 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/abyssal-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/abyssal-dagger.mdx
@@ -12,74 +12,93 @@ osrs:
   lowalch: 46000
   highalch: 69000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: abyssal
+    tier: high
+  properties:
+    release_date: "2015-10-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: dagger
-    attack_style: melee
+    weapon_type: dagger
     attack_speed: 4
+    weight: 0.453
     requirements:
       attack: 70
-    stats:
-      attack_stab: 75
-      attack_slash: 40
-      attack_crush: -4
-      attack_magic: 1
+    attack_bonus:
+      stab: 75
+      slash: 40
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
       strength: 75
-  special_attack:
-    name: Abyssal Puncture
-    energy: 25
-    description: Hits twice in rapid succession with +25% accuracy per hit and -15% damage per hit
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Abyssal Sire (via Unsired)
+        quantity: "1"
+        rarity: "~1/5"
+      - source: Abyssal demon
+        quantity: "1"
+        rarity: 1/32000
+      - source: Greater abyssal demon
+        quantity: "1"
+        rarity: 3/32000
+  passive_effects:
+    - name: Abyssal Puncture
+      description: "Special attack: consumes 25% energy, hits twice with +25% accuracy and -15% damage per hit; both hits share a single accuracy roll."
   related_items:
-    - item_id: 13263
-      item_name: Abyssal bludgeon
+    - item_name: Abyssal bludgeon
       slug: abyssal-bludgeon
       relationship: alternative
-      description: Crush weapon from Sire
-    - item_id: 4151
-      item_name: Abyssal whip
+      description: Crush weapon from the Abyssal Sire.
+    - item_name: Abyssal whip
       slug: abyssal-whip
       relationship: alternative
-      description: Slash weapon
-    - item_id: 22324
-      item_name: Ghrazi rapier
+      description: Standard slash training weapon.
+    - item_name: Ghrazi rapier
       slug: ghrazi-rapier
       relationship: upgrade
-      description: BiS stab upgrade
+      description: Best-in-slot stab upgrade from Theatre of Blood.
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +75 |
-    | Slash | +40 |
-    | Crush | -4 |
-    | Magic | +1 |
-    | Strength | +75 |
+    The abyssal dagger is the dagger-class drop from the Abyssal Sire, sitting between the whip and the rapier as a stab option with a useful spec.
 
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 70 Attack
-
-    Abyssal Puncture (25% energy):
-    - Hits twice in rapid succession
-    - +25% accuracy per hit
-    - -15% damage per hit
-    - Max hit: 44-44 (PvP)
-
-    Popular for:
-    - PvP (double hit spec)
-    - Abyssal Sire
-    - Cerberus
-    - Budget stab weapon
-
-    Strong spec weapon with guaranteed double hit.
+    Its Abyssal Puncture special attack costs 25% energy, lands two hits in rapid succession, and pairs a +25% accuracy boost with a -15% damage cut per hit, making it a strong stack-pusher in PvP and a workable burst tool against Sire, Cerberus, and other stab-weak bosses.
   market_strategy:
     notes:
-      - Sire is best source
-      - Good for PvP combos
-      - Cheaper than rapier alternatives
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Abyssal Sire's Unsired pet shop is the main supply path; supply tracks Sire popularity."
+      - "Spec utility keeps PvP demand steady even as PvM users push toward the rapier."
+      - "Prices below rapier alternatives, which sustains budget stab buyers."
+  trading_tips:
+    - Watch Sire drop-rate adjustments and Unsired sink changes for supply shocks.
+    - Compare spec value vs dragon dagger before listing in PvP-heavy windows.
+  history:
+    - date: "2015-10-01"
+      description: "Released alongside the Abyssal Sire boss."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-knife-p-5659.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-knife-p-5659.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 7000
-  about: "Adamant knife(p+) is a members-only item in Old School RuneScape. High alchemy value: 39 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 15
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 14
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Adamant knife
+      slug: adamant-knife
+      relationship: variant
+      description: Base non-poisoned variant
+    - item_name: Adamant knife(p)
+      slug: adamant-knife-p
+      relationship: variant
+      description: Weak poison variant
+    - item_name: Adamant knife(p++)
+      slug: adamant-knife-p
+      relationship: upgrade
+      description: Strongest poison variant
+    - item_name: Rune knife(p+)
+      slug: rune-knife-p
+      relationship: upgrade
+      description: Stronger ranged knife with extra-strong poison
+  about: "Adamant knife(p+) is a poisoned throwing knife with +15 ranged attack and +14 ranged strength, requiring 30 Ranged. The (p+) variant applies extra-strength poison. Adamant knives are made via Smithing 77 from adamantite bars."
+  market_strategy:
+    notes:
+      - "Niche demand for poisoned variants"
+      - "Stackable; bulk trades common"
+      - "Ironmen craft from adamantite bars"
+  trading_tips:
+    - Compare base knife price plus poison cost
+    - Sell into PvP demand windows for slight margin
+  history:
+    - date: "2003-04-14"
+      description: "Item released with adamant throwing knives."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-2.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 2000
-  about: "Agility potion(2) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2004-07-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily raises the Agility level by 3 stages, allowing access to shortcuts above the player's base level until the boost decays."
+        duration: 60
+  recipes:
+    - skill: herblore
+      level: 34
+      xp: 80
+      materials:
+        - item_name: Toadflax potion (unf)
+          quantity: 1
+        - item_name: "Toad's legs"
+          quantity: 1
+      tools: []
+      output_quantity: 3
+  drop_table:
+    sources:
+      - source: "Skeleton (Tarn's Lair)"
+        quantity: "1"
+        rarity: "5/128"
+  related_items:
+    - item_name: Agility potion(1)
+      slug: agility-potion-1
+      relationship: variant
+      description: "1-dose variant of the same Agility potion."
+    - item_name: Agility potion(3)
+      slug: agility-potion-3
+      relationship: variant
+      description: "3-dose variant brewed directly via Herblore."
+    - item_name: Agility potion(4)
+      slug: agility-potion-4
+      relationship: variant
+      description: "4-dose variant produced from a full Herblore flask."
+  about: |-
+    > _"2 doses of Agility potion."_
+
+    The 2-dose Agility potion is the middle-decant tier of the toadflax-and-toad's-legs brew. Each sip raises Agility by 3 levels, unlocking shortcuts (e.g. the Wilderness lava maze step or 71 Agility shortcut tricks) for players just below the threshold.
+  market_strategy:
+    notes:
+      - "Thin daily volume (~15) means a single decanter can move the price; treat it as a low-liquidity flip."
+      - "Demand spikes during diary completion events where Agility shortcut access matters."
+      - "Toad's legs supply caps production — Slayer task volume on swamp toads sets the floor."
+  trading_tips:
+    - "Use the per-dose spread between (1)/(2)/(3)/(4) to spot decanter arbitrage opportunities."
+    - "Skeletons in Tarn's Lair drop the (2) variant directly, so price tracks Slayer task popularity for that monster."
+  history:
+    - date: "2004-07-27"
+      description: "Released in the Agility, Potions and Parties update as part of the Herblore expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/air-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/air-tiara.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 40
-  about: "Air tiara is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: silver
+    tier: low
+  properties:
+    release_date: "2005-06-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 25
+      materials:
+        - item_name: Tiara
+          quantity: 1
+        - item_name: Air talisman
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: emote clue
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers: ["easy"]
+  about: "Air tiara is a free-to-play head item that allows direct left-click entry to the Air Altar without carrying an air talisman, freeing inventory space during Runecrafting. Created by using an air talisman on the Air Altar with a tiara equipped (1 Runecraft, 25 XP). Also drops as an emote clue reward from easy Treasure Trails. Crafting at the altar during Guardians of the Rift prevents imbuement. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
+  market_strategy:
+    notes:
+      - "Crafting is unprofitable — materials cost more than the finished tiara"
+      - "Demand from F2P runecrafters and clue-scroll outfit collectors"
+      - "Easy-clue casket supply keeps GE prices low and stable"
+  trading_tips:
+    - Buy off GE rather than crafting — the talisman alone outprices the finished tiara
+    - Stock alongside other elemental tiaras for runecrafting bundle resellers
+  related_items:
+    - item_name: Tiara
+      slug: tiara
+      relationship: component
+      description: Base item infused with the talisman to create the air tiara
+    - item_name: Air talisman
+      slug: air-talisman
+      relationship: component
+      description: Talisman consumed when crafting the air tiara at the altar
+    - item_name: Water tiara
+      slug: water-tiara
+      relationship: alternative
+      description: Elemental tiara variant for the Water Altar
+    - item_name: Earth tiara
+      slug: earth-tiara
+      relationship: alternative
+      description: Elemental tiara variant for the Earth Altar
+    - item_name: Fire tiara
+      slug: fire-tiara
+      relationship: alternative
+      description: Elemental tiara variant for the Fire Altar
+  history:
+    - date: "2005-06-13"
+      description: "Added to the game with the introduction of tiaras as Runecrafting convenience items."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-accuracy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-accuracy.mdx
@@ -12,39 +12,74 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 5
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: amulet
+    tier: low
+  properties:
+    release_date: "2001-02-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: true
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: amulet
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 0.01
-    stats:
-      attack_stab: 4
-      attack_slash: 4
-      attack_crush: 4
-      attack_magic: 4
-      attack_ranged: 4
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    requirements: {}
+    attack_bonus:
+      stab: 4
+      slash: 4
+      crush: 4
+      magic: 4
+      ranged: 4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
   related_items:
-    - item_id: 1731
-      item_name: Amulet of power
+    - item_name: Amulet of power
       slug: amulet-of-power
       relationship: upgrade
-      description: Better stats
-    - item_id: 1712
-      item_name: Amulet of glory
+      description: Stronger neck amulet with higher bonuses
+    - item_name: Amulet of glory
       slug: amulet-of-glory
       relationship: upgrade
-      description: P2P upgrade
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Members upgrade with teleports
+  about: |-
+    Amulet of accuracy is a free-to-play neck amulet introduced 16 February 2001 that grants a flat +4 to every attack style. It is awarded as part of the Imp Catcher quest and remains a low-cost option for newer players covering melee, magic, and ranged training.
+
+    Crafting requirements are modest, and the amulet trades in low volumes on the Grand Exchange thanks to its niche role as a stepping stone item.
+  market_strategy:
+    notes:
+      - "F2P accessible neck slot upgrade for early combat training"
+      - "Buy limit of 5 makes flips slow; rely on patient bids"
+      - "High alch value of 60 GP is below GE price, so do not alch"
+  trading_tips:
+    - Pair with cheap weapons when leveling on free worlds
+    - Replace with Amulet of power once 30 Hitpoints and basic gear is reached
+  history:
+    - date: "2001-02-16"
+      description: "Introduced with the Imp Catcher quest"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-chemistry.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-chemistry.mdx
@@ -12,81 +12,90 @@ osrs:
   lowalch: 420
   highalch: 630
   limit: 15000
+  material:
+    type: jewellery
+    tier: mid
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: skilling_amulet
-    tradeable: true
-    weight: 0.015
-    charges: 5
-  creation:
-    method: Enchant Jade amulet with Lvl-2 Enchant
-    requirements:
-      magic: 27
-    runes:
-      - rune: Cosmic
-        quantity: "1"
-      - rune: Air
-        quantity: "3"
-  special_effect:
-    name: Extra Dose
-    description: 5% chance to create 4-dose potion instead of 3-dose
-    charges: 5
-    notes:
-      - No extra XP granted
-      - ~100 potions per amulet
-  market:
-    buy_limit: 15000
-    price_estimate: 1500
+    weapon_type: null
+    attack_speed: null
+    weight: 0.007
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Extra Dose
+      description: "5% chance to create a 4-dose potion instead of a 3-dose potion when brewing. No extra Herblore XP is awarded. The amulet has 5 charges; on average ~100 potions are brewed before it crumbles to dust."
+  recipes:
+    - skill: magic
+      level: 27
+      xp: 37
+      materials:
+        - item_name: Jade amulet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 3
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 1658
-      item_name: Jade amulet
+    - item_name: Jade amulet
       slug: jade-amulet
       relationship: component
-      description: Base item
-    - item_id: 7178
-      item_name: Botanical pie
-      slug: botanical-pie
-      relationship: alternative
-      description: Herblore boost
-    - item_id: 21160
-      item_name: Amulet of bounty
+      description: Base item enchanted with Lvl-2 Enchant
+    - item_name: Alchemist's amulet
+      slug: alchemist-s-amulet
+      relationship: upgrade
+      description: Upgraded version of the amulet
+    - item_name: Amulet of bounty
       slug: amulet-of-bounty
       relationship: alternative
-      description: Farming equivalent
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Neck |
-    | Type | Skilling Amulet |
-    | Tradeable | Yes |
-    | Weight | 0.015 kg |
-
-    Enchant Jade amulet with Lvl-2 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 27 |
-    | Cosmic rune | 1 |
-    | Air rune | 3 |
-
-    Extra Dose:
-    - 5% chance to create 4-dose
-    - No extra XP
-    - 5 charges (~100 potions)
-
-    Great for:
-    - Herblore training
-    - Potion making profit
-    - Ironman efficiency
-
-    Effectively 5% more potions.
+      description: Farming-focused equivalent jewellery
+  about: "The Amulet of chemistry grants a 5% chance to brew a 4-dose potion instead of a 3-dose when worn. Made by enchanting a Jade amulet with Lvl-2 Enchant at Magic 27. Holds 5 charges before crumbling."
   market_strategy:
     notes:
-      - Very cheap
-      - Works on all potions
-      - ~5% profit increase
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap consumable; demand scales with Herblore activity"
+      - "Ironmen craft directly from jade amulets"
+      - "Effective ~5% boost to potion output value"
+  trading_tips:
+    - Stockpile during Herblore double XP events
+    - Compare against Alchemist's amulet upgrade cost
+  history:
+    - date: "2017-02-02"
+      description: "Item released alongside the dragonstone jewellery rework."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-brew-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-brew-1.mdx
@@ -12,10 +12,27 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 2000
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: potion
+    tier: mid
+  properties:
+    release_date: "2022-01-05"
     tradeable: true
-    doses: 1
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: herblore
       level: 85
@@ -25,58 +42,44 @@ osrs:
           quantity: 1
         - item_name: Nihil dust
           quantity: 1
-  effect:
-    boost:
-      - skill: magic
-        amount: +2 + 5%
-      - skill: prayer
-        amount: +2 + 10%
-    drain:
-      - skill: attack
-        amount: -2 - 10%
-      - skill: strength
-        amount: -2 - 10%
-      - skill: defence
-        amount: -2 - 10%
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Magic boost: +2 + 5% of base Magic level."
+        duration: 0
+      - description: "Prayer restore: +2 + 10% of base Prayer level."
+        duration: 0
+      - description: "Drains Attack, Strength, and Defence by 2 + 10% of current level each."
+        duration: 0
   related_items:
-    - item_id: 26229
-      item_name: Nihil dust
+    - item_name: Nihil dust
       slug: nihil-dust
       relationship: component
-      description: From Nihil shards
-    - item_id: 26348
-      item_name: Forgotten brew
-      slug: forgotten-brew
+      description: "Crafted from Nihil shards dropped by Nex"
+    - item_name: Dwarf weed potion (unf)
+      slug: dwarf-weed-potion-unf
+      relationship: component
+      description: "Unfinished base potion"
+    - item_name: Ancient brew(4)
+      slug: ancient-brew-4
+      relationship: variant
+      description: "Full 4-dose vial"
+    - item_name: Forgotten brew(4)
+      slug: forgotten-brew-4
       relationship: upgrade
-      description: Enhanced version
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Potion |
-    | Tradeable | Yes |
-    | Stackable | No |
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore | 85 |
-    | XP | 190 |
-
-    Ingredients:
-    - Dwarf weed potion (unf)
-    - Nihil dust
-
-    Magic Boost: +2 + 5% of Magic level.
-
-    Prayer Restore: +2 + 10% of Prayer level.
-
-    Stat Drain: -2 - 10% to Attack, Strength, Defence.
+      description: "Enhanced version made with ancient essence"
+  about: "Ancient brew(1) is a single-dose magic and prayer boosting potion designed for magic-only content. The Magic and Prayer gains come at the cost of melee defensive stats."
   market_strategy:
     notes:
-      - Nihil dust from Nex
-      - Good for magic-only content
-      - Can upgrade to Forgotten brew
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Useful for Nex, ToB mage rooms, and other magic-only encounters"
+      - "Nihil dust supply tied to Nex drop rates"
+      - "Upgrade to Forgotten brew with ancient essence for stronger boost"
+  history:
+    - date: "2022-01-05"
+      description: "Released alongside Nex: The Fifth General."
+    - date: "2021-12-16"
+      description: "Added to the game as unobtainable in preparation for release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-essence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-essence.mdx
@@ -12,58 +12,67 @@ osrs:
   lowalch: 11
   highalch: 16
   limit: 300000
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: currency
+    tier: mid
+  properties:
+    release_date: "11 January 2023"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Phantom Muspah
-        rate: 60/100
-      - source: Mining crystals (75 Mining)
-  obtaining:
-    - method: Venator shard breakdown
-      amount: 50000
-    - method: Ancient icon breakdown
-      amount: 5000
-  uses:
-    - item: Venator bow charges
-    - item: Forgotten brew (91 Herblore)
-      amount: 20-80 per dose
-    - item: Saturated heart
-      amount: 150000
+        quantity: "1"
+        rarity: 60/100
+      - source: Phantom Muspah
+        quantity: "1"
+        rarity: 23/100
+      - source: Phantom Muspah
+        quantity: "1"
+        rarity: 10/100
+      - source: Frozen cache
+        quantity: "1"
+        rarity: 60/496
+      - source: Mining ancient essence crystals (75 Mining)
+        quantity: "1"
+        rarity: Always
   related_items:
-    - item_id: 27610
-      item_name: Venator bow
+    - item_name: Venator bow
       slug: venator-bow
       relationship: alternative
-      description: Charging use
-    - item_id: 27638
-      item_name: Forgotten brew
+      description: Charged with ancient essence
+    - item_name: Forgotten brew
       slug: forgotten-brew
-      relationship: alternative
-      description: Herblore use
-    - item_id: 24514
-      item_name: Saturated heart
+      relationship: product
+      description: Created with ancient essence at 91 Herblore
+    - item_name: Saturated heart
       slug: saturated-heart
-      relationship: alternative
-      description: Magic use - 150,000 essence
+      relationship: product
+      description: Requires 150,000 ancient essence
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Currency |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    | Use | Amount |
-    |-----|--------|
-    | Venator bow charges | Various |
-    | Forgotten brew (91 Herblore) | 20-80 per dose |
-    | Saturated heart | 150,000 |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Ancient essence is pure magical energy harvested from the Phantom Muspah and ancient essence crystals in Ghorrock Dungeon. It powers high-end Herblore and Magic upgrades.
+  market_strategy:
+    notes:
+      - "Demand driven by Venator bow charging cost"
+      - "Saturated heart consumes 150,000 essence per upgrade"
+      - "Phantom Muspah killers flood supply"
+  trading_tips:
+    - Buy in bulk before Herblore content drops
+    - Monitor Phantom Muspah popularity for supply shifts
+  history:
+    - date: "11 January 2023"
+      description: "Ancient essence added with the Phantom Muspah boss."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-plateskirt.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Ancient plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: "1/1,625"
+  related_items:
+    - item_name: Ancient full helm
+      slug: ancient-full-helm
+      relationship: set-piece
+      description: "Matching helm in the ancient god armour set"
+    - item_name: Ancient platebody
+      slug: ancient-platebody
+      relationship: set-piece
+      description: "Matching platebody in the ancient god armour set"
+    - item_name: Ancient platelegs
+      slug: ancient-platelegs
+      relationship: alternative
+      description: "Platelegs variant of the ancient leg armour"
+    - item_name: Ancient kiteshield
+      slug: ancient-kiteshield
+      relationship: set-piece
+      description: "Matching kiteshield in the ancient god armour set"
+  about: |-
+    "Rune plateskirt in the colours of a long-forgotten god."
+
+    The Ancient plateskirt is a cosmetic recolour of the rune plateskirt awarded from hard clue scroll caskets at a rate of 1/1,625. It shares identical combat stats with the standard rune plateskirt and other god-themed variants (Saradomin, Zamorak, Guthix, Armadyl, Bandos), so the choice between them is purely aesthetic or tied to the matching armour set look.
+
+    The plateskirt requires 40 Defence to wear and provides solid defensive bonuses (+51 stab, +49 slash, +47 crush, +49 ranged) along with a +1 prayer bonus. It became available to free-to-play players on 7 April 2016, making it one of the few god-aligned cosmetics F2P can show off.
+  market_strategy:
+    notes:
+      - "1/1,625 hard clue rate keeps supply thin but steady"
+      - "F2P-tradeable since 2016 broadens the buyer pool versus members-only god variants"
+      - "Buy limit of 8 per 4 hours discourages large speculative positions"
+      - "Price tracks Saradomin/Zamorak/Guthix/Armadyl/Bandos variants closely; pick the cheapest god skirt for the same stats"
+  trading_tips:
+    - Watch for double-clue events that flood the market with hard rewards
+    - Compare against the full ancient set price before flipping the skirt alone
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trails reward expansion."
+    - date: "2016-04-07"
+      description: "Made tradeable and equippable in free-to-play worlds."
+    - date: "2021-04-21"
+      description: "Magic ranged attack penalty adjusted from minus 7 to minus 11 to align with rune plateskirt."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-poison-supermix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-poison-supermix-1.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 2000
-  about: "Anti-poison supermix(1) is a members-only item in Old School RuneScape. High alchemy value: 86 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "3 July 2007"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and grants full poison immunity"
+        duration: 360
+      - description: "Restores 6 Hitpoints on drink"
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 51
+      xp: 35
+      materials:
+        - item_name: Superantipoison(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Superantipoison(4)
+      slug: superantipoison-4
+      relationship: component
+      description: Base potion for the supermix
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Secondary ingredient
+    - item_name: Anti-poison supermix(2)
+      slug: anti-poison-supermix-2
+      relationship: variant
+      description: Two-dose variant
+  about: |-
+    Anti-poison supermix(1) is a Barbarian Herblore mix that grants poison immunity for 6 minutes and heals 6 Hitpoints on drink. Requires Barbarian Herblore training unlocked.
+  market_strategy:
+    notes:
+      - "Barbarian Herblore prerequisite limits the producer pool"
+      - "Demand spikes around poison-heavy bosses"
+      - "Caviar supply cap pressures availability"
+  trading_tips:
+    - Stockpile when caviar prices dip
+    - Sell into peak boss meta windows
+  history:
+    - date: "3 July 2007"
+      description: "Released alongside the Barbarian Training update."
+    - date: "April 2015"
+      description: "Renamed from Anti-p supermix to Anti-poison supermix."
+    - date: "April 2016"
+      description: "Bank placeholder support enabled for half-full mixes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-plateskirt.mdx
@@ -12,9 +12,100 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Armadyl plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune plateskirt
+      slug: rune-plateskirt
+      relationship: variant
+      description: "Plain rune plateskirt; same combat stats but no prayer bonus."
+    - item_name: Saradomin plateskirt
+      slug: saradomin-plateskirt
+      relationship: alternative
+      description: "Saradomin god-aligned variant from hard clue rewards."
+    - item_name: Zamorak plateskirt
+      slug: zamorak-plateskirt
+      relationship: alternative
+      description: "Zamorak god-aligned variant from hard clue rewards."
+    - item_name: Bandos plateskirt
+      slug: bandos-plateskirt
+      relationship: alternative
+      description: "Bandos god-aligned variant from hard clue rewards."
+    - item_name: Guthix plateskirt
+      slug: guthix-plateskirt
+      relationship: alternative
+      description: "Guthix god-aligned variant from hard clue rewards."
+    - item_name: Ancient plateskirt
+      slug: ancient-plateskirt
+      relationship: alternative
+      description: "Zarosian god-aligned variant from hard clue rewards."
+  about: |-
+    > _"Rune plateskirt in the colours of Armadyl."_
+
+    The Armadyl plateskirt is a Treasure Trails recolour of the standard rune plateskirt. It keeps the same melee defence profile while adding a +1 prayer bonus, making it a cosmetic prayer-flick favourite for f2p PKers and god-armour collectors.
+  market_strategy:
+    notes:
+      - "Hard clue 1/1,625 drop rate keeps supply tight; price hinges on clue scroll completion volume."
+      - "Free-to-play accessibility (since April 2016) widens the buyer pool beyond members."
+      - "The April 2021 ranged-bonus nerf (-7 → -11) marginally reduced hybrid PvP appeal but barely moved cosmetic demand."
+  trading_tips:
+    - "Pair flips with the matching Armadyl helm and chestplate for set-piece premiums."
+    - "Limit of 8 every 4 hours rewards patient buy-in during clue droughts."
+  history:
+    - date: "2014-06-12"
+      description: "Introduced as a hard Treasure Trails reward alongside the god-aligned rune armour recolours."
+    - date: "2016-04-07"
+      description: "Made tradeable on free-to-play worlds following the F2P clue rework."
+    - date: "2021-04-01"
+      description: "Ranged attack bonus adjusted from -7 to -11 to align with standard rune plateskirt penalties."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale-4.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Asgarnian ale(4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "11 July 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 24
+      xp: 248
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Asgarnian hops
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Calquat keg
+          quantity: 2
+      tools: []
+      output_quantity: 2
+  potion:
+    effects:
+      - description: "Temporarily boosts Strength by 2 levels."
+        duration: 180
+      - description: "Reduces Attack by 4 levels."
+        duration: 180
+  related_items:
+    - item_name: Asgarnian ale(1)
+      slug: asgarnian-ale-1
+      relationship: variant
+      description: One-dose keg variant
+    - item_name: Asgarnian hops
+      slug: asgarnian-hops
+      relationship: component
+      description: Primary brewing ingredient
+  about: |-
+    Asgarnian ale(4) is a four-pint keg of Asgarnian Ale brewed at the Keldagrim brewery with level 24 Cooking, granting 248 brewing XP per batch. Drinking a dose temporarily raises Strength by 2 while lowering Attack by 4. Partially consumed kegs cannot be traded on the Grand Exchange following the 26 February 2015 update.
+  market_strategy:
+    notes:
+      - "Not alchable - alch values display as 1 gp placeholder"
+      - "Brewery output makes high-volume profit when hop prices are low"
+      - "Buy limit 2,000 supports bulk brewing flips"
+  trading_tips:
+    - Watch Asgarnian hops prices - they drive brewing margin
+    - Sell full 4-pint kegs only; partial kegs cannot be GE listed
+  history:
+    - date: "11 July 2005"
+      description: "Released as part of the Farming/brewing update."
+    - date: "26 February 2015"
+      description: "Partially consumed kegs became untradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/assorted-flowers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/assorted-flowers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Assorted flowers | OSRS Price Data
-description: "Assorted flowers: A posy of flowers.. High alch: 60 GP, GE limit: 150."
+description: "Assorted flowers are a novelty wieldable harvested from mithril/adamant seeds, used to craft imp repellent. High alch: 60 GP, GE limit: 150."
 osrs:
   id: 2460
   name: Assorted flowers
@@ -12,9 +12,96 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Assorted flowers is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: herblore-secondary
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: novelty
+    attack_speed: 4
+    weight: 0.028
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Mithril seed (planted)
+        quantity: "1"
+        rarity: random
+      - source: Adamant seed (planted)
+        quantity: "1"
+        rarity: random
+  related_items:
+    - item_name: Mithril seed
+      slug: mithril-seed
+      relationship: component
+      description: Primary source when planted
+    - item_name: Adamant seed
+      slug: adamant-seed
+      relationship: component
+      description: Alternate planted source
+    - item_name: Imp repellent
+      slug: imp-repellent
+      relationship: product
+      description: Herblore output that uses assorted flowers
+    - item_name: Mixed flowers
+      slug: mixed-flowers
+      relationship: variant
+      description: Other planted flower outcome
+  about: |-
+    Assorted flowers are a posy harvested from planting mithril or adamant seeds and watering them with a watering can. A player only has one chance to pick the flowers; refusing the option does not return.
+
+    They are wieldable in the weapon slot as a joke weapon with strictly negative combat bonuses, but their practical use is as a Herblore ingredient for imp repellent. They are also a popular cosmetic gift among players.
+  market_strategy:
+    notes:
+      - "Supply driven by mithril seed gambling and Wintertodt cracker prizes"
+      - "Imp repellent and novelty demand keep a floor under price"
+      - "Buy limit makes it a slow flip"
+      - "Seasonal events and joke meta drive small bumps"
+  trading_tips:
+    - Flip when seed gambling streamers go viral
+    - Buy during slow weekday lulls
+    - Sell when novelty wieldable meta trends spike
+  history:
+    - date: "2004-03-29"
+      description: "Released with the RuneScape 2 launch."
+    - date: "2014-12-04"
+      description: "Renamed from 'Flowers' to 'Assorted flowers'."
+    - date: "2024-04-17"
+      description: "Adamant seeds added as an alternative source."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/attack-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Attack potion(3) | OSRS Price Data
-description: "Attack potion(3): 3 doses of Attack potion.. High alch: 7 GP, GE limit: 2,000."
+description: "Attack potion(3): 3 doses of Attack potion. High alch: 7 GP, GE limit: 2,000."
 osrs:
   id: 121
   name: Attack potion(3)
@@ -12,23 +12,67 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options: ["Drink", "Empty", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 3
+      xp: 25
+      materials:
+        - item_name: Guam potion (unf)
+          quantity: 1
+        - item_name: Eye of newt
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Boosts Attack by 3 + 10% of current Attack level (rounded down)"
+        duration: 60
   related_items:
-    - item_id: 123
-      item_name: Attack potion(2)
+    - item_name: Attack potion(2)
       slug: attack-potion-2
       relationship: variant
       description: 2-dose version
-    - item_id: 125
-      item_name: Attack potion(1)
+    - item_name: Attack potion(1)
       slug: attack-potion-1
       relationship: variant
       description: 1-dose version
+    - item_name: Super attack(3)
+      slug: super-attack-3
+      relationship: upgrade
+      description: Stronger Attack boost
   about: |-
     > _"3 doses of Attack potion."_
 
-    The attack potion boosts Attack by 3 + 10% of current level (rounded down). The lowest-level potion brewable with Herblore.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The lowest-level Herblore potion. Boosts Attack by 3 + 10% of current level (rounded down); the boost decays at 1 level per minute (90 seconds with Preserve prayer).
+  market_strategy:
+    notes:
+      - "Low-level Herblore product"
+      - "High GE limit supports bulk flipping"
+      - "Useful for early Herblore XP"
+  trading_tips:
+    - Buy unfinished guam potions for cheap conversion XP
+    - Demand spikes during bonus XP weekends
+  history:
+    - date: "2002-02-27"
+      description: "Released with the Herblore skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-dead-tree.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-dead-tree.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 10000
-  about: "Bagged dead tree is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: organic
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Bagged dead tree is a members-only Construction and Farming decoration in Old School RuneScape. Plant it in a player-owned house garden (requires Construction 5+ and a watering can) for 31 Construction and Farming XP, or combine with 2 compost in a menagerie grassland habitat (Construction 37+) for 37 Construction XP. High alchemy value: 600 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Bulk demand comes from Construction and Farming training in player-owned house gardens"
+      - "Stable shop-restocked supply keeps GE prices close to spawn cost"
+      - "Higher value than other bagged plants due to slower restock and dead aesthetic for haunted-themed POHs"
+  trading_tips:
+    - Buy in bulk when training Construction tea-stalls or POH garden layouts
+    - Cheaper than buying individual seeds + waiting for growth cycles
+  related_items:
+    - item_name: Bagged nice tree
+      slug: bagged-nice-tree
+      relationship: alternative
+      description: Cheaper bagged tree variant for POH gardens
+    - item_name: Bagged oak tree
+      slug: bagged-oak-tree
+      relationship: alternative
+      description: Oak variant for higher-tier garden decoration
+    - item_name: Bagged willow tree
+      slug: bagged-willow-tree
+      relationship: alternative
+      description: Willow variant for POH gardens
+  history:
+    - date: "2006-05-31"
+      description: "Added to the game with the Player-Owned Houses update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-roses.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-roses.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 10000
-  about: "Bagged roses is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: construction
+    tier: high
+  properties:
+    release_date: "31 May 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Garden Supplier
+      location: Falador Park
+      price: 15000
+      currency: coins
+      stock: 20
+    - shop_name: Garden Supplier
+      location: Farming Guild
+      price: 15000
+      currency: coins
+      stock: 20
+  related_items:
+    - item_name: Bagged plant 1
+      slug: bagged-plant-1
+      relationship: alternative
+      description: Cheaper formal garden flower
+    - item_name: Bagged nice tree
+      slug: bagged-nice-tree
+      relationship: alternative
+      description: Tree variant for formal gardens
+    - item_name: Watering can
+      slug: watering-can
+      relationship: component
+      description: Filled watering can required when planting
+  about: |-
+    Bagged roses are a formal-garden Construction item planted at 76 Construction for 122 XP in both Construction and Farming. Purely decorative.
+  market_strategy:
+    notes:
+      - "Shop floor at 15,000 coins anchors price"
+      - "Demand driven by player-owned house decoration sprees"
+      - "Low daily volume amplifies swings"
+  trading_tips:
+    - Bulk buy from Garden Supplier when GE price spikes
+    - List at slight premium during PoH update cycles
+  history:
+    - date: "31 May 2006"
+      description: "Released with the Construction skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ball-of-wool.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ball-of-wool.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Ball of wool is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.012
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 2.5
+      materials:
+        - item_name: Wool
+          quantity: 1
+      tools:
+        - Spinning wheel
+      output_quantity: 1
+  shops:
+    - shop_name: Neitiznot Supplies
+      location: Neitiznot
+      price: 14
+      currency: coins
+      stock: 100
+    - shop_name: Hamab's Crafting Emporium
+      location: Ape Atoll
+      price: 14
+      currency: coins
+      stock: 100
+  about: "Ball of wool is a free-to-play Crafting material spun from wool on a spinning wheel (1 Crafting, 2.5 XP per ball). Primarily used to string unstrung amulets (sapphire, emerald, ruby, diamond, gold, holy symbol, etc.). Required by Sheep Shearer (20), Prince Ali Rescue (3) and Regicide (4). High alchemy value: 1 coin. Grand Exchange buy limit: 13,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Steady demand from amulet stringers training Crafting at all levels"
+      - "F2P availability + shop spawns keep prices anchored near shop value"
+      - "Bulk reliable supply makes it ideal for high-volume low-margin flipping"
+  trading_tips:
+    - Spin wool yourself when shop supply runs out to capture small margins on amulet stringers
+    - Stock alongside unstrung amulets for Crafting bundle resellers
+  related_items:
+    - item_name: Wool
+      slug: wool
+      relationship: component
+      description: Raw material spun on a spinning wheel to produce ball of wool
+    - item_name: Holy symbol
+      slug: holy-symbol
+      relationship: product
+      description: Strung with a ball of wool to complete the holy symbol
+    - item_name: Gold amulet (u)
+      slug: gold-amulet-u
+      relationship: product
+      description: Common unstrung amulet completed with ball of wool
+  history:
+    - date: "2001-01-04"
+      description: "Added to the game at RuneScape's launch as a basic Crafting material."
+    - date: "2024-01-01"
+      description: "Examine text updated to reflect alpaca-sourced wool variations."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-full-helm.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 8
-  about: "Bandos full helm is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: variant
+      description: Base rune full helm before Bandos colouring
+    - item_name: Bandos platebody
+      slug: bandos-platebody
+      relationship: set-piece
+      description: Matching Bandos-coloured platebody
+    - item_name: Bandos plateskirt
+      slug: bandos-plateskirt
+      relationship: set-piece
+      description: Matching Bandos-coloured plateskirt
+    - item_name: Bandos kiteshield
+      slug: bandos-kiteshield
+      relationship: set-piece
+      description: Matching Bandos-coloured kiteshield
+  about: |-
+    Bandos full helm is a cosmetic rune full helm in Bandos colours, obtained as a hard Treasure Trails reward casket drop at roughly 1/1,625. It shares stats with the standard rune full helm and grants a +1 Prayer bonus, requiring 40 Defence to wear.
+  market_strategy:
+    notes:
+      - "Cosmetic premium over the base rune full helm"
+      - "Demand tied to fashionscape and Bandos sets"
+      - "Tiny 8 buy limit makes the market thin"
+  trading_tips:
+    - Pair with the full Bandos set for higher resale margin
+  history:
+    - date: "2014-06-12"
+      description: "Item added to the game as a hard clue reward."
+    - date: "2016-04-07"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/barnacle-blaster.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/barnacle-blaster.mdx
@@ -1,6 +1,6 @@
 ---
 title: Barnacle blaster | OSRS Price Data
-description: "Barnacle blaster: Rum, lemon and... crushed barnacles?. High alch: 12 GP."
+description: "Barnacle blaster is a Sailing-era cocktail that boosts Fishing while draining Sailing, Attack, Strength, and Defence. High alch: 12 GP."
 osrs:
   id: 31255
   name: Barnacle blaster
@@ -12,9 +12,64 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Barnacle blaster is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: consumable
+    tier: low
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: The Pandemonium pub
+      location: Pandemonium
+      price: 20
+      currency: coins
+      stock: 10
+  potion:
+    effects:
+      - description: Boosts Fishing by 1
+        duration: 0
+      - description: "Drains Sailing, Attack, Strength, and Defence by 2% plus 2"
+        duration: 0
+  related_items:
+    - item_name: Tuna potato
+      slug: tuna-potato
+      relationship: alternative
+      description: Common Fishing boost food alternative
+    - item_name: Admiral pie
+      slug: admiral-pie
+      relationship: alternative
+      description: Pie that boosts Fishing
+  about: |-
+    The barnacle blaster is a cocktail introduced with the Sailing expansion, sold by Squawking Steve Beanie at The Pandemonium pub for 20 coins. Drinking it boosts Fishing by 1 while penalising Sailing, Attack, Strength, and Defence by 2 percent plus 2.
+
+    It mostly fills a flavour niche for the Sailing rollout and offers a cheap Fishing boost when running cocktails between other content. The drain on Sailing and combat stats limits its usefulness outside fishing trips.
+  market_strategy:
+    notes:
+      - "Shop-bought, so GE price is anchored by shop cost"
+      - "Demand is light, mostly novelty and milestone hunters"
+      - "No buy limit makes it easy to volume flip on small margins"
+      - "Watch for Sailing diary or achievement updates that drive demand"
+  trading_tips:
+    - Buy from the shop and resell to the GE when prices float
+    - Avoid hoarding; demand is narrow
+    - Flip alongside Sailing release hype windows
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the Sailing skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/barrows-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/barrows-teleport-tablet.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Barrows teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2016-05-12"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 83
+      xp: 90
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Blood rune
+          quantity: 1
+        - item_name: Dark essence block
+          quantity: 1
+      tools:
+        - Arceuus lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Magic tablet
+      slug: magic-tablet
+      relationship: variant
+      description: "Family of teleport tablets created via lecterns across all spellbooks."
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: "Substrate used to imprint the teleport spell on a lectern."
+    - item_name: Dark essence block
+      slug: dark-essence-block
+      relationship: component
+      description: "Arceuus-only material consumed when creating the tablet."
+  about: "Barrows teleport (tablet) is an Arceuus spellbook teleport tablet that drops players at the Barrows minigame entrance. Requires Priest in Peril completion to use but has no Magic level requirement when breaking the tablet. High alchemy value: 1 coin. Grand Exchange buy limit: 10,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Volume is driven by Barrows runners who prefer one-tick teleports over spellbook swaps."
+      - "Margins fluctuate with law and blood rune prices plus dark essence block supply."
+  trading_tips:
+    - "Crafting at the Arceuus lectern often nets several thousand gp per tablet once rune costs are accounted for."
+  history:
+    - date: "2016-05-12"
+      description: "Released with the Arceuus spellbook tablet support."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/belladonna-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/belladonna-seed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Belladonna seed | OSRS Price Data
-description: "Belladonna seed: Also known as Deadly Nightshade - plant in a belladonna patch.. High alch: 106 GP, GE limit: 200."
+description: "Belladonna seed is a members farming seed requiring 63 Farming. High alch: 106 GP, GE limit: 200."
 osrs:
   id: 5281
   name: Belladonna seed
@@ -12,9 +12,64 @@ osrs:
   lowalch: 70
   highalch: 106
   limit: 200
-  about: "Belladonna seed is a members-only item in Old School RuneScape. High alchemy value: 106 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: farming-seed
+    tier: mid
+  properties:
+    release_date: "2005-06-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Nature impling jar
+        quantity: "1"
+        rarity: 1/10
+      - source: Aberrant spectre
+        quantity: "1"
+        rarity: 1/51.4
+      - source: Turoth
+        quantity: "1"
+        rarity: 1/54.2
+      - source: Kurask
+        quantity: "1"
+        rarity: 1/63
+      - source: Master Farmer
+        quantity: "1"
+        rarity: 1/820
+  related_items:
+    - item_name: Cadava berries
+      slug: cadava-berries
+      relationship: alternative
+      description: Other Farming product harvested from a nightshade patch type
+  about: |-
+    Belladonna seed grows into the Deadly Nightshade crop used to obtain nightshade, a secondary ingredient for the weapon poison++ and combat potion brews. Released 6 June 2005, the seed requires 63 Farming to plant in the dedicated belladonna patch at Draynor Manor or Auburnvale.
+
+    Each seed yields 91 XP on planting and 512 XP per harvest, with a growth time of roughly 5.3 hours. Yield scales with Farming level, reaching a maximum of 18 nightshades at level 99.
+  market_strategy:
+    notes:
+      - "Demand follows weapon poison++ usage in PvM rotations"
+      - "200 buy limit allows steady restocking for daily Farming runs"
+      - "Slayer drops from aberrant spectres and kurask seed the supply"
+  trading_tips:
+    - Stock seeds before raids meta shifts that favour poison weapons
+    - Use nature impling jars to capture the cheapest direct drop source
+  history:
+    - date: "2005-06-06"
+      description: "Introduced with the original Farming skill release"
+    - date: "2023-02-15"
+      description: "Nightshade harvest converted into an untradeable, stackable item"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bird-nest-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bird-nest-empty.mdx
@@ -12,79 +12,85 @@ osrs:
   lowalch: 181
   highalch: 271
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: nest
-    tier: processed
+    tier: mid
+  properties:
+    release_date: "6 June 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Search
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: herblore
       level: 81
       xp: 180
       materials:
         - item_name: Toadflax
-          item_id: 2998
           quantity: 1
         - item_name: Crushed nest
-          item_id: 5075
           quantity: 1
-      product: Saradomin brew(3)
-      product_id: 6687
-      product_quantity: 1
-      members_only: true
+      tools:
+        - Vial of water
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Bird house trap
+        quantity: "1"
+        rarity: 65/100
+      - source: Wyson the gardener (mole skins)
+        quantity: "1"
+        rarity: 8/100
+      - source: Woodcutting (random event)
+        quantity: "1"
+        rarity: Varies
   related_items:
-    - item_id: 5070
-      item_name: Bird nest (empty)
-      slug: bird-nest-empty
-      relationship: component
-      description: Source material
-    - item_id: 2998
-      item_name: Toadflax
+    - item_name: Crushed nest
+      slug: crushed-nest
+      relationship: product
+      description: Made by crushing with pestle and mortar
+    - item_name: Toadflax
       slug: toadflax
       relationship: component
-      description: Paired ingredient
-    - item_id: 6685
-      item_name: Saradomin brew(4)
+      description: Paired Herblore ingredient
+    - item_name: Saradomin brew(4)
       slug: saradomin-brew-4
       relationship: product
-      description: End product
-    - item_id: 233
-      item_name: Pestle and mortar
+      description: End Herblore product
+    - item_name: Pestle and mortar
       slug: pestle-and-mortar
       relationship: component
-      description: Tool required
+      description: Required to crush the nest
   about: |-
-    Use Pestle and mortar on an empty Bird nest.
-
-    | Method | Cost |
-    |--------|------|
-    | Manual | Free |
-    | Wesley (Nardah) | 50 GP each |
-
-    | Potion | Herblore Level | Primary Herb |
-    |--------|----------------|--------------|
-    | Saradomin brew | 81 | Toadflax |
+    Empty bird nests are crushed with a pestle and mortar to create crushed nests, the Saradomin brew secondary. Drops from bird houses, Wyson, and woodcutting random events.
   market_strategy:
-    title: |-
-      - Buy empty nests → Crush → Sell
-      - Calculate: `Crushed nest - Bird nest (empty) = Profit`
-      - Wesley for bulk processing
-    profit_formulas:
-      - Crushed nest - Bird nest (empty) = Profit
     notes:
-      - Buy empty nests → Crush → Sell
-      - "Calculate:"
-      - Wesley for bulk processing
-      - Essential secondary ingredient
-      - Price follows Sara brew demand
-      - Raid consumption drives prices
-      - Woodcutting (random chance)
-      - Wyson the Gardener (mole skins)
-      - Kingdom of Miscellania
-      - Price tied to Sara brew market
-      - Giant Mole farms produce nests
-      - Check ring/seed nest values too
-      - Bulk crush at Wesley
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Saradomin brew demand is the price driver"
+      - "Bird house runs flood supply daily"
+      - "Wesley in Nardah bulk-crushes for 50 GP each"
+  trading_tips:
+    - Buy nest, crush, flip the crushed nest spread for profit
+    - Track raid roster popularity for brew demand
+  history:
+    - date: "6 June 2005"
+      description: "Bird nests added to OSRS."
+    - date: "14 April 2016"
+      description: "Notification color changed to red when nests fall during woodcutting."
+    - date: "27 October 2016"
+      description: "Made tradeable and bank-noteable."
+    - date: "22 June 2022"
+      description: "Ground despawn time raised from 30 seconds to 2 minutes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-claws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black claws | OSRS Price Data
-description: "Black claws: A set of fighting claws.. High alch: 216 GP, GE limit: 125."
+description: "Black claws: A set of fighting claws. High alch: 216 GP, GE limit: 125."
 osrs:
   id: 3098
   name: Black claws
@@ -12,9 +12,81 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 125
-  about: "Black claws is a members-only item in Old School RuneScape. High alchemy value: 216 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2004-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: claws
+    attack_speed: 4
+    weight: 0.907
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 10
+      slash: 14
+      crush: -4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 4
+      slash: 7
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 14
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Steel claws
+      slug: steel-claws
+      relationship: downgrade
+      description: Lower tier claws available to free-to-play.
+    - item_name: Mithril claws
+      slug: mithril-claws
+      relationship: alternative
+      description: Lighter-weight mid-tier alternative.
+    - item_name: Adamant claws
+      slug: adamant-claws
+      relationship: upgrade
+      description: Stronger members' claws sitting one tier above black.
+  about: |-
+    > *"A set of fighting claws."*
+
+    Black claws are a members-only two-handed slash weapon requiring 10 Attack, sitting in the black tier of the claws progression. They cannot be smithed and only enter the game via monster drops.
+
+    Speed-4 attack with +14 slash and +14 strength makes them a viable budget low-level option in early member training.
+  market_strategy:
+    notes:
+      - "Cannot be smithed, so supply depends entirely on monster drop activity."
+      - "125 GE limit absorbs most low-level training demand without price pressure."
+      - "High alch floor sits well under GE price, keeping speculation muted."
+  trading_tips:
+    - Stocks tend to refresh around new account waves; flip during early-game streamer pushes.
+    - Pair with steel/mithril/adamant claws when scouting the full ladder for arbitrage.
+  history:
+    - date: "2004-08-09"
+      description: "Released as part of the claws weapon family expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-desert-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-desert-shirt.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15
-  about: "Black desert shirt is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2005-11-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Desert shirt
+      slug: desert-shirt
+      relationship: variant
+      description: "Undyed base shirt"
+    - item_name: Black dye
+      slug: black-dye
+      relationship: component
+      description: "Dye used to stain the shirt"
+    - item_name: Black desert robe
+      slug: black-desert-robe
+      relationship: set-piece
+      description: "Matching desert robe variant"
+  about: "Black desert shirt is a black-dyed variant of the regular desert shirt. It is worn in the body slot and is used during the Shadow of the Storm quest to appear evil."
+  market_strategy:
+    notes:
+      - "Cheap cosmetic body slot item"
+      - "Dyed from regular desert shirt with black dye"
+      - "Used in Shadow of the Storm quest"
+  history:
+    - date: "2005-11-14"
+      description: "Item released to the game."
+    - date: "2022-02-09"
+      description: "Examine text simplified to: \"A desert shirt stained black.\""
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-toy-horsey.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-toy-horsey.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Black toy horsey is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2004-04-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.05
+    options: ["Play-with", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Diango's Toy Store
+      location: Draynor Village
+      price: 150
+      currency: coins
+      stock: 5
+    - shop_name: Rasolo the Wandering Merchant
+      location: South of Baxtorian Falls
+      price: 200
+      currency: coins
+      stock: 10
+  about: "Black toy horsey is a free-to-play novelty toy sold by Diango in Draynor Village. When played-with, the character announces \"Just say neigh to gambling!\" — a Jagex anti-real-world-trading message added in 2013. Originally released as a 2004 April Fool's joke (renamed from \"Toy horsey\" in 2014 when the color variants launched). High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is purely collector / fashionscape — daily volume is low"
+      - "Diango's 150 gp shop price puts a soft floor under GE prices"
+      - "Rare during April Fool's anniversary content when promo demand spikes"
+  trading_tips:
+    - Buy from Diango at 150 gp when GE price climbs above shop spawn
+    - Stock the full toy horsey color set for collectors
+  related_items:
+    - item_name: White toy horsey
+      slug: white-toy-horsey
+      relationship: alternative
+      description: White color variant from Diango's Toy Store
+    - item_name: Brown toy horsey
+      slug: brown-toy-horsey
+      relationship: alternative
+      description: Brown color variant from Diango's Toy Store
+    - item_name: Grey toy horsey
+      slug: grey-toy-horsey
+      relationship: alternative
+      description: Grey color variant from Diango's Toy Store
+  history:
+    - date: "2004-04-01"
+      description: "Added to the game as an April Fool's novelty originally named \"Toy horsey\"."
+    - date: "2013-03-18"
+      description: "Play-with action changed to always say \"Just say neigh to gambling!\" replacing the previous random phrases."
+    - date: "2014-12-10"
+      description: "Renamed from \"Toy horsey\" to \"Black toy horsey\" when the white, brown and grey color variants were added."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-wizard-robe-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-wizard-robe-g.mdx
@@ -12,25 +12,84 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic-robe
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options: ["Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
     requirements: {}
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 3
+      ranged: 0
     defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 3
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers: ["easy"]
   related_items:
-    - item_id: 12453
-      item_name: Black wizard hat (g)
+    - item_name: Black wizard hat (g)
       slug: black-wizard-hat-g
       relationship: set-piece
       description: Matching gold-trimmed wizard hat
+    - item_name: Black wizard robe
+      slug: black-wizard-robe
+      relationship: variant
+      description: Untrimmed standard variant
+    - item_name: Blue wizard robe (g)
+      slug: blue-wizard-robe-g
+      relationship: alternative
+      description: Blue gold-trimmed alternative
   about: |-
     > *"I can do magic better in this."*
 
-    The black wizard robe (g) is a gold-trimmed cosmetic variant of the black wizard robe. It provides +3 magic attack and defence with no requirements. Significantly rarer and more expensive than the blue variant. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Gold-trimmed cosmetic variant of the black wizard robe. Provides +3 magic attack and defence with no requirements; significantly rarer and pricier than the blue trim. Free-to-play equippable.
+  market_strategy:
+    notes:
+      - "Easy clue exclusive cosmetic"
+      - "F2P-equippable rare wizard recolour"
+      - "Low buy limit (4) keeps supply thin"
+  trading_tips:
+    - Premium over blue (g) is the fashionscape margin
+    - Demand spikes during clue release events
+  history:
+    - date: "2014-06-12"
+      description: "Added to Treasure Trails as a Easy clue cosmetic reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blackbird-red.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blackbird-red.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blackbird red | OSRS Price Data
-description: "Blackbird red: A smooth and rich Aldarin Red that's said to flutter on the tongue.. High alch: 180 GP."
+description: "Blackbird red: A smooth and rich Aldarin Red that's said to flutter on the tongue. High alch: 180 GP."
 osrs:
   id: 29944
   name: Blackbird red
@@ -12,9 +12,64 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: null
-  about: "Blackbird red is a members-only item in Old School RuneScape. High alchemy value: 180 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wine
+    tier: low
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Moonrise Wines
+      location: Moonrise Brewery and Winery
+      price: 300
+      currency: Coins
+      stock: 20
+    - shop_name: The Flaming Arrow
+      location: Civitas illa Fortis
+      price: 300
+      currency: Coins
+      stock: 0
+    - shop_name: Sunlight's Sanctum
+      location: Aldarin
+      price: 300
+      currency: Coins
+      stock: 0
+    - shop_name: The King's Inn
+      location: Tal Teklan
+      price: 300
+      currency: Coins
+      stock: 0
+  passive_effects:
+    - name: Aldarin Red
+      description: "Drinking restores 16 Hitpoints and boosts Hunter by 1, but drains Attack by 5 and Slayer by 1."
+  about: |-
+    > *"A smooth and rich Aldarin Red that's said to flutter on the tongue."*
+
+    Blackbird red is an Aldarin wine introduced in the Varlamore: The Rising Darkness update. It restores 16 Hitpoints with a Hunter boost, at the cost of light Attack and Slayer drains — flavour notes of redberry, dwellberry, chocolate, and cinnamon are referenced in its tasting profile.
+  market_strategy:
+    notes:
+      - "Shops at Moonrise, Civitas illa Fortis, Aldarin, and Tal Teklan supply unlimited inventory at 300 coins."
+      - "GE price hovers slightly above shop value, leaving thin arbitrage margins."
+  trading_tips:
+    - Buy from unlimited shops at 300 and high alch for 180 to recover most of the cost via Magic XP.
+    - Hunter content runners may stockpile these for the +1 boost ahead of trips.
+  history:
+    - date: "2024-09-25"
+      description: "Added with the Varlamore: The Rising Darkness update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-gauntlets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-gauntlets.mdx
@@ -12,9 +12,99 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 70
-  about: "Bloodbark gauntlets is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bloodbark
+    tier: high
+  properties:
+    release_date: "2021-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options:
+      - Wear
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements:
+      magic: 60
+      defence: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 5
+      slash: 4
+      crush: 6
+      magic: 5
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: runecraft
+      level: 77
+      xp: 0
+      materials:
+        - item_name: Splitbark gauntlets
+          quantity: 1
+        - item_name: Blood rune
+          quantity: 100
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Blood spell healing
+      description: Each equipped bloodbark piece increases blood spell healing by 2 percent; the full set converts 35 percent of damage dealt by blood spells into healing.
+  related_items:
+    - item_name: Splitbark gauntlets
+      slug: splitbark-gauntlets
+      relationship: component
+      description: Base armour infused at the Blood Altar to create bloodbark gauntlets.
+    - item_name: Bloodbark helm
+      slug: bloodbark-helm
+      relationship: set-piece
+      description: Matching head slot piece of the bloodbark set.
+    - item_name: Bloodbark body
+      slug: bloodbark-body
+      relationship: set-piece
+      description: Matching body slot piece of the bloodbark set.
+    - item_name: Bloodbark legs
+      slug: bloodbark-legs
+      relationship: set-piece
+      description: Matching legs slot piece of the bloodbark set.
+    - item_name: Bloodbark boots
+      slug: bloodbark-boots
+      relationship: set-piece
+      description: Matching feet slot piece of the bloodbark set.
+  about: |-
+    Bloodbark gauntlets are the hands slot piece of the bloodbark armour set, created by infusing splitbark gauntlets with 100 blood runes at the Blood Altar after learning the secret of infusion. They require 60 Magic and 60 Defence to wear.
+  market_strategy:
+    notes:
+      - "Demand tracks Magic and Defence pures levelling at the Blood Altar."
+      - "Limited supply because crafting consumes 100 blood runes and a splitbark base."
+  trading_tips:
+    - Buy splitbark gauntlets cheap and craft when blood rune prices dip.
+    - Sell during clue scroll or PvM gear meta shifts toward magic defence.
+  history:
+    - date: "2021-01-27"
+      description: "Bloodbark gauntlets released alongside the Bloodbark armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-elegant-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-elegant-shirt.mdx
@@ -12,21 +12,76 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: clothing
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options: ["Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/2808
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers: ["easy"]
   related_items:
-    - item_id: 10410
-      item_name: Blue elegant legs
+    - item_name: Blue elegant legs
       slug: blue-elegant-legs
       relationship: set-piece
       description: Matching elegant legs
   about: |-
     > *"A well made elegant men's blue shirt."*
 
-    Purely cosmetic treasure trail reward with no combat stats. Part of the blue elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Purely cosmetic easy treasure trail reward with no combat stats. Part of the blue elegant clothing set; can be stored in a costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Easy clue exclusive cosmetic"
+      - "Low GE buy limit (4) keeps supply tight"
+      - "Demand driven by fashionscape collectors"
+  trading_tips:
+    - Stock up during easy clue saturation events
+    - Pair sales with matching blue elegant legs
+  history:
+    - date: "2006-12-05"
+      description: "Added with the Treasure Trails update as an easy clue reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-skirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-skirt.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 150
-  about: "Blue skirt is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Thessalia's Fine Clothes
+      location: Varrock
+      price: 2
+      currency: coins
+      stock: 5
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 2
+      currency: coins
+      stock: 5
+    - shop_name: Shayzien Styles
+      location: Shayzien
+      price: 2
+      currency: coins
+      stock: 5
+    - shop_name: Floria's Fashion
+      location: Civitas illa Fortis
+      price: 2
+      currency: coins
+      stock: 5
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Blue wizard robe
+      slug: blue-wizard-robe
+      relationship: set-piece
+      description: Matching top for the blue wizard outfit
+  about: |-
+    Blue skirt is a free-to-play cosmetic legs slot item with no combat bonuses. It can be purchased cheaply from clothing shops in Varrock, Shayzien, and Civitas illa Fortis, or received as an emote clue step reward from easy Treasure Trails. The buy limit of 150 keeps it as a low-volume novelty item on the Grand Exchange.
+  market_strategy:
+    notes:
+      - "Effectively cosmetic - no combat utility"
+      - "GE price floats well above shop price due to convenience"
+      - "Easy clue scroll demand keeps supply steady"
+  trading_tips:
+    - Buy from Thessalia's Fine Clothes for 2 gp and flip on the GE
+    - Pair with the matching blue wizard robe for a complete cosmetic outfit
+  history:
+    - date: "4 January 2001"
+      description: "Item released with the launch of RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/body-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/body-tiara.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 40
-  about: "Body tiara is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "13 June 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 37.5
+      materials:
+        - item_name: Tiara
+          quantity: 1
+        - item_name: Body talisman
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Body talisman
+      slug: body-talisman
+      relationship: component
+      description: Required to imbue the tiara at the Body Altar
+    - item_name: Tiara
+      slug: tiara
+      relationship: component
+      description: Base silver tiara used in the runecrafting process
+  about: |-
+    Body tiara is a free-to-play runecrafting tiara created by using a body talisman on a tiara while standing on the Body Altar pedestal, yielding 37.5 Runecrafting XP. When worn it allows left-click entry to the Body Altar ruins, freeing the inventory slot otherwise needed for a body talisman.
+  market_strategy:
+    notes:
+      - "Limited demand from body rune runners"
+      - "Buy limit is only 40 per 4 hours"
+      - "More valuable as a convenience item than for alch"
+  trading_tips:
+    - Compare price against a tiara + body talisman crafted yourself
+    - Useful for ironmen training low-level runecrafting
+  history:
+    - date: "13 June 2005"
+      description: "Body tiara released as part of the tiara update for Runecrafting."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-mould.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 40
-  about: "Bolt mould is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Dommik's Crafting Store
+      location: Al Kharid
+      price: 25
+      currency: coins
+      stock: 10
+    - shop_name: Rommik's Crafty Supplies
+      location: Rimmington
+      price: 25
+      currency: coins
+      stock: 10
+    - shop_name: Artima's Crafting Supplies
+      location: Civitas illa Fortis
+      price: 25
+      currency: coins
+      stock: 4
+  related_items:
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: "Used with the bolt mould to cast unfinished silver bolts."
+    - item_name: Silver bolts (unf)
+      slug: silver-bolts-unf
+      relationship: product
+      description: "Ten unfinished silver bolts produced per silver bar."
+  about: "Bolt mould is a Crafting tool used to cast unfinished silver crossbow bolts. Requires 61 Crafting to use a silver bar in a furnace, granting 50 experience per bar and producing 10 unfinished silver bolts. High alchemy value: 15 coins. Grand Exchange buy limit: 40 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is one-and-done; most Fletchers buy a single mould and keep it forever."
+      - "Shop stock at 25 gp keeps the GE price tightly anchored."
+  trading_tips:
+    - "Buy directly from Dommik or Rommik instead of paying GE markup."
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside silver bolt Smithing and Fletching support."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broad-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broad-bolts.mdx
@@ -12,41 +12,100 @@ osrs:
   lowalch: 22
   highalch: 33
   limit: 7000
-  equipment:
-    slot: ammo
+  material:
     type: ammunition
+    tier: mid
+  properties:
+    release_date: "2014-01-06"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: null
+    attack_speed: null
     weight: 0
     requirements:
       slayer: 55
       ranged: 61
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 100
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 55
+      xp: 30
+      materials:
+        - item_name: Unfinished broad bolts
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      output_quantity: 10
+  shops:
+    - shop_name: Slayer Reward Shop
+      location: Various Slayer masters
+      price: 35
+      currency: Slayer reward points
+      stock: 250
   related_items:
-    - item_id: 21316
-      item_name: Amethyst broad bolts
+    - item_name: Amethyst broad bolts
       slug: amethyst-broad-bolts
       relationship: upgrade
-      description: Higher tier broad bolts
+      description: "Higher tier amethyst-tipped broad bolts unlocked at 76 Fletching"
+    - item_name: Unfinished broad bolts
+      slug: unfinished-broad-bolts
+      relationship: component
+      description: "Unfeathered shaft used in the fletching recipe"
+    - item_name: Broad arrows
+      slug: broad-arrows
+      relationship: alternative
+      description: "Bow-fired equivalent for Slayer-locked Turoth/Kurask kills"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 55 Slayer, 61 Ranged |
+    "Crossbow bolts with broad tips."
 
-    | Stat | Bonus |
-    |------|-------|
-    | Ranged strength | +100 |
+    Broad bolts are the standard Slayer-locked crossbow ammunition needed to kill Turoth and Kurask with ranged. They require 55 Slayer and 61 Ranged to wield and fire from the rune, dragon hunter, dragon, Armadyl, and Zaryte crossbows. With plus 100 ranged strength they hit roughly as hard as adamant bolts at a fraction of the price, making them popular budget training ammo even outside their Slayer use case.
 
-    Slayer: Required for killing Turoth and Kurask with ranged.
-
-    Compatible Crossbows: Rune, Dragon hunter, Dragon, Armadyl, Zaryte.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Players obtain broad bolts from Slayer masters at 35 reward points per 250 bolts, or fletch them at 55 Fletching from unfinished broad bolts and feathers for 30 XP per 10. The fletching path requires the "Broader fletching" unlock from any Slayer master at 300 reward points. At 76 Fletching they can be upgraded into amethyst broad bolts for higher damage.
+  market_strategy:
+    notes:
+      - "7,000 buy limit per 4 hours allows large positions for Slayer prep"
+      - "High alch of 33 gp sets a hard floor that often underprices fletching margins"
+      - "Demand spikes with Turoth/Kurask task popularity and Slayer point sinks"
+      - "Supply from Slayer masters caps abuse but rewards point hoarders who flip"
+  trading_tips:
+    - Compare current GE price against feather plus unfinished broad bolt cost before fletching
+    - Bulk-buy on Slayer point payout weeks when supply floods the market
+  history:
+    - date: "2014-01-06"
+      description: "Released as the OSRS broad bolts ammunition for Slayer Turoth/Kurask kills."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broken-antler.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broken-antler.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 20
   highalch: 31
   limit: null
-  about: "Broken antler is a members-only item in Old School RuneScape. High alchemy value: 31 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bone
+    tier: mid
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Fletch
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Juvenile stalker
+        quantity: "1"
+        rarity: 1/15
+      - source: Mature stalker
+        quantity: "1"
+        rarity: 6.6875/107
+      - source: Elder stalker
+        quantity: "1"
+        rarity: 4/124
+      - source: Ancient Custodian
+        quantity: "3"
+        rarity: 4/124
+      - source: Strange creature (Shadows of Custodia)
+        quantity: "1"
+        rarity: 11/160
+  recipes:
+    - skill: fletching
+      level: 74
+      xp: 10
+      materials:
+        - item_name: Broken antler
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 100
+  related_items:
+    - item_name: Atlatl dart tip
+      slug: atlatl-dart-tip
+      relationship: product
+      description: Produced by chiseling the antler
+    - item_name: Atlatl dart
+      slug: atlatl-dart
+      relationship: product
+      description: Fletched ranged ammunition
+    - item_name: Custodian stalker
+      slug: custodian-stalker
+      relationship: alternative
+      description: Source creature family
+  about: "Broken antler is fletched into 100 atlatl dart tips with a chisel at Fletching 74, granting 10 XP per antler. The atlatl darts produced are the main use, feeding the Stalker Den slayer task drop pipeline introduced with Varlamore: The Final Dawn."
+  market_strategy:
+    notes:
+      - "Supply driven by Stalker Den slayer tasks"
+      - "No buy limit makes bulk plays easier"
+      - "Atlatl dart demand sets the floor price"
+  trading_tips:
+    - Convert to dart tips for processing margin if Fletching 74+
+    - Track slayer task popularity for supply swings
+  history:
+    - date: "2025-07-23"
+      description: "Released with the Varlamore: The Final Dawn update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-boots.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 125
-  about: "Bronze boots is a members-only item in Old School RuneScape. High alchemy value: 14 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2005-01-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 1.36
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 1
+      slash: 2
+      crush: 3
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Cave crawler
+        quantity: "1"
+        rarity: 1/128
+      - source: Chasm crawler
+        quantity: "1"
+        rarity: 3/128
+  related_items:
+    - item_name: Fighting boots
+      slug: fighting-boots
+      relationship: alternative
+      description: Identical defence stats
+    - item_name: Fancy boots
+      slug: fancy-boots
+      relationship: alternative
+      description: Identical defence stats
+    - item_name: Iron boots
+      slug: iron-boots
+      relationship: upgrade
+      description: Stronger metal tier boots
+  about: "Bronze boots are entry-tier feet armour dropped by cave and chasm crawlers. They cannot be smithed and instead match the defence profile of fighting boots and fancy boots, making them mostly a cosmetic or starter option."
+  market_strategy:
+    notes:
+      - "Niche slayer and ironman-only demand"
+      - "Buy limit only 125 per 4 hours"
+      - "High-alch loss makes alching unprofitable"
+  trading_tips:
+    - Most useful as a low-volume flip target
+    - Watch for slayer task spikes on cave crawlers
+  history:
+    - date: "2005-01-26"
+      description: "Released as part of an early armour expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin-p-5648.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin-p-5648.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 7000
-  about: "Bronze javelin(p++) is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammunition
+    weapon_type: javelin
+    attack_speed: null
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 25
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Bronze javelin
+      slug: bronze-javelin
+      relationship: variant
+      description: "Unpoisoned base javelin."
+    - item_name: Bronze javelin(p)
+      slug: bronze-javelin-p-825
+      relationship: variant
+      description: "Standard poison-tipped variant."
+    - item_name: Bronze javelin(p+)
+      slug: bronze-javelin-p-5642
+      relationship: variant
+      description: "Extra-strong poison variant."
+  about: "Bronze javelin(p++) is the strongest poisoned variant of the bronze javelin, used as Ranged ammunition for one-handed throwing weapons. High alchemy value: 2 coins. Grand Exchange buy limit: 7,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Volume is thin compared to the unpoisoned base; expect choppy spreads."
+      - "Super-strong poison adds little practical value at low tiers, keeping demand niche."
+  trading_tips:
+    - "Buy the unpoisoned base and apply weapon poison++ yourself if the (p++) spread is unfavourable."
+  history:
+    - date: "2004-03-29"
+      description: "Added with the RS2 launch as part of the javelin family."
+    - date: "2016-10-06"
+      description: "Ranged Strength bonus reduced from +30 to +25."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife-p-5661.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-knife-p-5661.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Bronze knife(p++) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 3
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Bronze knife
+      slug: bronze-knife
+      relationship: variant
+      description: "Unpoisoned base variant."
+    - item_name: Bronze knife(p)
+      slug: bronze-knife-p
+      relationship: variant
+      description: "Standard poison applied via weapon poison."
+    - item_name: Bronze knife(p+)
+      slug: bronze-knife-p-5654
+      relationship: variant
+      description: "Stronger poison applied via weapon poison(+)."
+  about: |-
+    > _"A finely balanced throwing knife."_
+
+    Bronze knife(p++) is the most heavily poisoned tier of the bronze throwing knife. It delivers identical combat stats to the unpoisoned version while inflicting +6 damage poison hits, but the bronze body keeps damage output low compared to higher-metal knives.
+  market_strategy:
+    notes:
+      - "Niche demand: most rangers skip straight to iron/steel knives, so volume is thin."
+      - "Buy limit of 7,000 lets PvP pranksters stack large piles quickly when listings show up."
+  trading_tips:
+    - "Watch for accidental decant-style listings — poisoned and unpoisoned variants are often confused."
+    - "Cross-check the (p) and (p+) tiers for arbitrage; weapon poison(++) input cost sets the price floor."
+  history:
+    - date: "2005-07-11"
+      description: "Released as part of the Farming update."
+    - date: "2006-01-01"
+      description: 'Renamed from "Bronze knife(s)" to "Bronze knife(p++)" to align with the new poison-tier suffix system.'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-limbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-limbs.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 10000
-  about: "Bronze limbs is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 6
+      xp: 12.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+  shops:
+    - shop_name: Crossbow Shop
+      location: Dwarven Mine
+      price: 72
+      currency: coins
+      stock: 5
+    - shop_name: Crossbow Shop
+      location: White Wolf Mountain
+      price: 72
+      currency: coins
+      stock: 5
+    - shop_name: Crossbow Shop
+      location: Keldagrim
+      price: 60
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: "Smithed into bronze limbs at a Smithing level of 6."
+    - item_name: Bronze crossbow (u)
+      slug: bronze-crossbow-u
+      relationship: product
+      description: "Combined with a wooden stock via Fletching to produce an unstrung bronze crossbow."
+  about: "Bronze limbs is a members-only item in Old School RuneScape used in the Fletching of bronze crossbows. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is driven almost entirely by Fletchers training bronze crossbows from scratch."
+      - "Smithing them from bronze bars usually loses money once GE tax is included; check spreads before mass production."
+  trading_tips:
+    - "Compare the bronze bar + Smithing XP path against buying limbs directly when training Fletching."
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside the introduction of crossbow Smithing."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-spear.mdx
@@ -12,9 +12,115 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 125
-  about: "Bronze spear is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Goblin
+        quantity: "1"
+        rarity: 3/128
+      - source: Hobgoblin
+        quantity: "1"
+        rarity: 3/128
+      - source: Minotaur
+        quantity: "1"
+        rarity: 3/128
+      - source: Dagannoth
+        quantity: "1"
+        rarity: Uncommon
+      - source: Jogre
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Fortis Blacksmith
+      location: Fortis
+      price: 26
+      currency: Coins
+      stock: 5
+    - shop_name: Elder Blunn's Spear and Shield Stall
+      location: Land's End
+      price: 26
+      currency: Coins
+      stock: 5
+  recipes:
+    - skill: smithing
+      level: 5
+      xp: 25
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+        - item_name: Logs
+          quantity: 1
+      tools:
+        - Barbarian Smithing
+      output_quantity: 1
+  related_items:
+    - item_name: Iron spear
+      slug: iron-spear
+      relationship: upgrade
+      description: Next tier in the metallic spear chain.
+    - item_name: Bronze hasta
+      slug: bronze-hasta
+      relationship: variant
+      description: One-handed Fremennik counterpart.
+  about: |-
+    The bronze spear is the entry-tier metallic spear, made via Barbarian Smithing at level 5 from a bronze bar and a log. It is the weakest spear in the game but provides the spear weapon class's all-style attack from level 1.
+
+    Players generally pick it up as a Smithing training output or pull it from low-tier goblin drop tables rather than buying it directly.
+  market_strategy:
+    notes:
+      - "Buy limit and alch margin are tight; volume comes from Smithing training spillover."
+      - "Demand is mostly from scarecrow crafting (Farming) and ironmen filling spear slots."
+      - "Price hugs the Grand Exchange floor with minimal flip headroom."
+  trading_tips:
+    - Source from Barbarian Smithing producers rather than GE for bulk.
+    - Compare alch margin against nature rune cost before mass alching.
+  history:
+    - date: "2003-04-14"
+      description: "Released with the New Throwing Weapons update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/calcite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/calcite.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 13000
-  about: "Calcite is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mineral
+    tier: low
+  properties:
+    release_date: "2017-09-07"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Spitting wyvern
+        quantity: "2"
+        rarity: 2/123
+      - source: Ancient zygomite
+        quantity: "1"
+        rarity: 18/118
+      - source: Ammonite Crab
+        quantity: "1"
+        rarity: 1/128
+      - source: Volcanic Mine boulder
+        quantity: "1-4"
+        rarity: 1/20
+  shops:
+    - shop_name: Petrified Pete's Ore Shop
+      location: Volcanic Mine
+      price: 70
+      currency: numulite
+      stock: 0
+  related_items:
+    - item_name: Pyrophosphite
+      slug: pyrophosphite
+      relationship: alternative
+      description: Other mineral used to recalcify fossils
+    - item_name: Numulite
+      slug: numulite
+      relationship: alternative
+      description: Fossil Island shop currency
+    - item_name: Volcanic ash
+      slug: volcanic-ash
+      relationship: alternative
+      description: Fossil Island farming resource
+  about: "Calcite is a Fossil Island mineral combined with pyrophosphite at the mycelium pool to recalcify fossils into enriched bones. The enriched bones are then offered at the eastern strange machine in the House on the Hill for Prayer experience. Stack of 1-4 also drops while mining Volcanic Mine boulders."
+  market_strategy:
+    notes:
+      - "Demand tied to Fossil Island Prayer training"
+      - "Volcanic Mine bulk supply caps price ceiling"
+      - "Petrified Pete's shop sells at 70 numulite each"
+  trading_tips:
+    - Buy bulk before double XP weekends
+    - Watch supply during Volcanic Mine clue events
+  history:
+    - date: "2017-09-07"
+      description: "Released with the Fossil Island update."
+    - date: "2019-01-10"
+      description: "Examine text fixed: cabonate corrected to carbonate."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-repair-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-repair-kit.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1400
   highalch: 2100
   limit: 13000
-  about: "Camphor repair kit is a members-only item in Old School RuneScape. High alchemy value: 2,100 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Apply
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Orca
+        quantity: "1"
+        rarity: uncommon
+      - source: Armoured kraken
+        quantity: "1"
+        rarity: uncommon
+  recipes:
+    - skill: construction
+      level: 66
+      xp: 0
+      materials:
+        - item_name: Camphor plank
+          quantity: 2
+        - item_name: Adamantite nails
+          quantity: 10
+        - item_name: Swamp paste
+          quantity: 5
+      tools:
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Mahogany repair kit
+      slug: mahogany-repair-kit
+      relationship: alternative
+      description: Alternative repair kit tier
+    - item_name: Camphor plank
+      slug: camphor-plank
+      relationship: component
+      description: Material used to craft the kit
+    - item_name: Adamantite nails
+      slug: adamantite-nails
+      relationship: component
+      description: Material used to craft the kit
+    - item_name: Swamp paste
+      slug: swamp-paste
+      relationship: component
+      description: Material used to craft the kit
+  passive_effects:
+    - name: Boat repair
+      description: Heals 40 health to a boat during ship combat; higher Deckhandiness on crewmates can restore additional health per kit.
+  about: |-
+    Camphor repair kit is a sailing-tier consumable used during ship combat to restore 40 health to a boat. Players craft it at a shipwrights' workbench with 66 Construction from camphor planks, adamantite nails, and swamp paste, and the kit also drops from orcas and armoured krakens.
+  market_strategy:
+    notes:
+      - "Consumable with steady ship-combat demand"
+      - "Buy limit 13,000 makes scale flipping viable"
+      - "Supply driven by Construction crafters and PvM drops"
+  trading_tips:
+    - Watch shipwright update cadence for price spikes
+  history:
+    - date: "2025-11-19"
+      description: "Item added to the game with the Sailing expansion repair kit tier."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chilli-potato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chilli-potato.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 13000
-  about: "Chilli potato is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "30 January 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 41
+      xp: 15
+      materials:
+        - item_name: Potato with butter
+          quantity: 1
+        - item_name: Bowl of chilli con carne
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Potato with butter
+      slug: potato-with-butter
+      relationship: component
+      description: Base ingredient before adding chilli con carne
+    - item_name: Bowl of chilli con carne
+      slug: bowl-of-chilli-con-carne
+      relationship: component
+      description: Chilli filling combined with the buttered potato
+  about: |-
+    Chilli potato is a members-only food made by combining a potato with butter and a bowl of chilli con carne at level 41 Cooking, granting 15 Cooking experience. Eating it heals 14 hitpoints, slightly less than eating the two ingredients separately.
+  market_strategy:
+    notes:
+      - "Component ingredients usually cost more than the finished potato"
+      - "Demand driven by Cooking XP grinders rather than food consumption"
+      - "High alch only 7 gp - not worth alching"
+  trading_tips:
+    - Compare Grand Exchange price vs ingredient sum before cooking for profit
+    - Useful filler food for low-budget members accounts
+  history:
+    - date: "30 January 2006"
+      description: "Chilli potato released alongside other stuffed potato variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-onion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-onion.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Chopped onion is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food-ingredient
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Onion
+          quantity: 1
+        - item_name: Bowl
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Onion
+      slug: onion
+      relationship: component
+      description: Raw onion sliced into the bowl
+    - item_name: Bowl
+      slug: bowl
+      relationship: component
+      description: Container holding the chopped onion
+    - item_name: Ugthanki kebab
+      slug: ugthanki-kebab
+      relationship: product
+      description: Cooking product requiring chopped onion
+  about: |-
+    Chopped onion is a members ingredient created by using a knife on an onion held in a bowl. Each chop takes 2 game ticks (1.2 seconds) and produces a single chopped onion.
+
+    Eating chopped onion restores only 1 hitpoint and displays "It's always sad to see a grown person cry." Its primary use is as a cooking ingredient for higher-tier dishes such as ugthanki kebab (58 Cooking) and mushroom potato (64 Cooking).
+  market_strategy:
+    notes:
+      - "Bulk supplier for Gnome Cooking and Mahjarrah Restaurant"
+      - "Steady demand from cooking trainers chasing mid-level XP"
+      - "Buy raw onions + bowls and chop for profit margin"
+  trading_tips:
+    - Note onions before chopping to reduce inventory swaps
+    - Watch for arbitrage versus raw onion + bowl combined price
+  history:
+    - date: "2003-04-14"
+      description: "Item released."
+    - date: "2006-01-30"
+      description: "Graphical update applied and \"Eat\" option added."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cider.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cider.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cider | OSRS Price Data
-description: "Cider: A glass of cider.. High alch: 1 GP, GE limit: 2,000."
+description: "Cider is a members brewed beverage with a temporary Farming boost. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5763
   name: Cider
@@ -12,9 +12,83 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Cider is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: beverage
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: The Golden Field
+      location: Hosidius
+      price: 2
+      currency: coins
+      stock: 10
+    - shop_name: Hefin Inn
+      location: Prifddinas
+      price: 2
+      currency: coins
+      stock: 10
+    - shop_name: The Lost Pickaxe
+      location: Cam Torum
+      price: 2
+      currency: coins
+      stock: 10
+  recipes:
+    - skill: cooking
+      level: 14
+      xp: 182
+      materials:
+        - item_name: Apple mush
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Beer glass
+          quantity: 8
+      tools: []
+      output_quantity: 8
+  related_items:
+    - item_name: Apple mush
+      slug: apple-mush
+      relationship: component
+      description: Crushed cooking apples used in the brew
+    - item_name: Ale yeast
+      slug: ale-yeast
+      relationship: component
+      description: Fermenting agent required by every brewed drink
+    - item_name: Beer glass
+      slug: beer-glass
+      relationship: component
+      description: Glass that holds the final cider serving
+  about: |-
+    Cider is a brewed beverage available across members shops in Hosidius, Prifddinas, Cam Torum, and other Varlamore-area inns. Drinking grants +1 Hitpoints and a temporary +1 Farming boost while draining 2 Attack and 2 Strength.
+
+    Players can also brew cider with the Cooking skill at level 14 by combining 4 apple mush, 1 ale yeast, and 8 beer glasses in a brewing vat, then waiting for the fermentation period to finish. The shop price of 2 coins per glass keeps it the go-to cheap Farming boost.
+  market_strategy:
+    notes:
+      - "Shops stock cider at 2 GP, capping the realistic ceiling price"
+      - "Buy limit of 2,000 covers most personal use cases"
+      - "High alch yields 1 GP which is below shop value; never alch"
+  trading_tips:
+    - Stock up before farming contracts that benefit from Farming boosts
+    - Hosidius shops are the most reliable bulk source thanks to favour
+  history:
+    - date: "2005-07-11"
+      description: "Added with the cooking skill brewing rework"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/citizen-trousers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/citizen-trousers.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
-  about: "Citizen trousers is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-09-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    weight: 0.907
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Trader Sven's Black-market Goods
+      location: Meiyerditch
+      price: 6
+      currency: coins
+      stock: 10
+  about: "Citizen trousers is a members disguise leg piece introduced with Darkness of Hallowvale (Myreque Pt III). Required to blend in around Meiyerditch as part of the citizen outfit (top, trousers, shoes). Offers negligible combat defence (+2 slash, +2 crush). High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand spikes when players begin Darkness of Hallowvale or related Morytania content"
+      - "Trader Sven's shop in Meiyerditch keeps shop prices low; GE markup driven by convenience"
+      - "Useful for fashionscape disguise outfits in clue scroll outfit collections"
+  trading_tips:
+    - Buy directly from Trader Sven in Meiyerditch for the cheapest source
+    - Stock all three citizen pieces together when reselling on the GE
+  related_items:
+    - item_name: Citizen top
+      slug: citizen-top
+      relationship: set-piece
+      description: Body piece of the citizen disguise outfit
+    - item_name: Citizen shoes
+      slug: citizen-shoes
+      relationship: set-piece
+      description: Footwear piece of the citizen disguise outfit
+  history:
+    - date: "2006-09-04"
+      description: "Added with the Darkness of Hallowvale (Myreque Pt III) quest update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-slimy-eel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-slimy-eel.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Cooked slimy eel is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 28
+      xp: 95
+      materials:
+        - item_name: Raw slimy eel
+          quantity: 1
+      tools:
+        - Cooking range or fire
+      output_quantity: 1
+  passive_effects:
+    - name: Heal
+      description: "Eat to restore 6 to 10 Hitpoints depending on Cooking level."
+  related_items:
+    - item_name: Raw slimy eel
+      slug: raw-slimy-eel
+      relationship: component
+      description: Raw fish required to cook the slimy eel.
+    - item_name: Cooked karambwan
+      slug: cooked-karambwan
+      relationship: alternative
+      description: Higher-heal combo eat used over slimy eel.
+  about: |-
+    Cooked slimy eel is the cooked form of the raw slimy eel from Morytania, requiring 28 Cooking and granting 95 XP per success. It heals between 6 and 10 Hitpoints with the actual amount scaling slightly with Cooking level.
+
+    Burn rate stops entirely at level 61 Cooking, but the modest heal pushes most players toward sharks or karambwans well before that.
+  market_strategy:
+    notes:
+      - "Pure Cooking-training output; demand mostly from F2P/ironman snack fillers."
+      - "Buy limit is high; bulk movement requires patience."
+      - "High alch value of 1 gp means no alch margin."
+  trading_tips:
+    - Profitable mainly when sold in bulk to ironmen who skip karambwans.
+    - Stockpile during fishing/cooking Bingo events and clue food demand spikes.
+  history:
+    - date: "2004-10-14"
+      description: "Released with the Morytania Expansion update."
+    - date: "2005-07-04"
+      description: "Renamed from 'Cooked slimey eel' to 'Cooked slimy eel' with examine text corrected."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cow-slippers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cow-slippers.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Cow slippers is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2026-02-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.2
+    options:
+      - Wear
+      - Swap
+      - Drop
+    worn_options:
+      - Swap
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.2
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Brutus
+        quantity: "1"
+        rarity: rare
+  related_items:
+    - item_name: Wintertodt
+      slug: wintertodt
+      relationship: alternative
+      description: Wintertodt warm-clothing slot equivalent
+  passive_effects:
+    - name: Warm clothing
+      description: Counts as warm clothing for the Wintertodt minigame.
+  about: |-
+    Cow slippers are a cosmetic feet-slot item dropped by Brutus after completing the related quest, offering no combat bonuses but counting as warm clothing for the Wintertodt. The drop carries a small chance to swap to a fourth Isle of Souls color variant and can be stored in a costume room magic wardrobe.
+  market_strategy:
+    notes:
+      - "Purely cosmetic with a tiny 4 buy limit"
+      - "Tight supply keeps the price elevated versus alch value"
+      - "Useful as a Wintertodt warm-clothing piece"
+  trading_tips:
+    - Watch for swap-variant pumps that can spike the price
+  history:
+    - date: "2026-02-25"
+      description: "Item added to the game with the Brutus quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crushed-nest.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crushed-nest.mdx
@@ -1,6 +1,6 @@
 ---
 title: Crushed nest | OSRS Price Data
-description: "Crushed nest: A crushed bird's nest.. High alch: 120 GP, GE limit: 11,000."
+description: "Crushed nest: A crushed bird's nest. High alch: 120 GP, GE limit: 11,000."
 osrs:
   id: 6693
   name: Crushed nest
@@ -12,66 +12,83 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: secondary
     tier: high
+  properties:
+    release_date: "2005-10-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: herblore
       level: 81
       xp: 180
       materials:
         - item_name: Toadflax potion (unf)
-          item_id: 3002
           quantity: 1
         - item_name: Crushed nest
-          item_id: 6693
           quantity: 1
-      product: Saradomin brew(3)
-      product_id: 6687
-      product_quantity: 1
-      facility: None
-      members_only: true
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Flight Kilisa
+        quantity: "1"
+        rarity: 8/127
+      - source: Wingman Skree
+        quantity: "1"
+        rarity: 8/127
+      - source: Flockleader Geerin
+        quantity: "1"
+        rarity: 8/127
   related_items:
-    - item_id: 6687
-      item_name: Saradomin brew(3)
+    - item_name: Saradomin brew(3)
       slug: saradomin-brew-3
       relationship: product
-      description: Main product
-    - item_id: 2998
-      item_name: Toadflax
+      description: Main product crafted with crushed nest
+    - item_name: Toadflax
       slug: toadflax
       relationship: component
-      description: Partner herb
-    - item_id: 5070
-      item_name: Bird nest
+      description: Partner herb for Saradomin brews
+    - item_name: Bird nest
       slug: bird-nest
       relationship: component
-      description: Source item
-    - item_id: 233
-      item_name: Pestle and mortar
+      description: Source item — crush with pestle and mortar
+    - item_name: Pestle and mortar
       slug: pestle-and-mortar
       relationship: component
-      description: Tool
+      description: Tool used to crush bird nests
   about: |-
     | Method | Requirements |
     |--------|--------------|
     | Pestle and mortar | Empty bird nest |
-    | No skill required | - |
+    | Wesley in Nardah | 50 gp per nest |
+
+    The crushed bird's nest is the secondary ingredient for Saradomin brews — a staple high-end PvM consumable. Produced by crushing empty bird nests with a pestle and mortar, or noted via Wesley in Nardah for 50 coins each.
   market_strategy:
     notes:
-      - Essential for Saradomin brews
-      - High demand consumable
-      - Woodcutting byproduct
-      - Saradomin brew production
-      - PvM consumable demand
-      - Raids preparation
-      - Bossing supplies
-      - Crush empty nests
-      - Woodcutting provides nests
-      - Birdhouse runs supply
-      - High volume trading
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Essential for Saradomin brews"
+      - "High GE limit supports bulk PvM demand"
+      - "Supply driven by woodcutting and birdhouse runs"
+  trading_tips:
+    - Buy bird nests during Woodcutting events for bonus margin
+    - Crush in bulk before bossing weekends
+  history:
+    - date: "2005-10-24"
+      description: "Released with the Saradomin brew Herblore recipe."
+    - date: "2018-11-22"
+      description: "Removed from Vorkath, Zulrah, and Callisto drop tables to stabilise Saradomin brew pricing."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dagon-hai-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dagon-hai-robe-top.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 56000
   highalch: 84000
   limit: null
-  about: "Dagon'hai robe top is a members-only item in Old School RuneScape. High alchemy value: 84,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: mid-high
+  properties:
+    release_date: "2019-10-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements:
+      magic: 70
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 25
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 21
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 2
+  drop_table:
+    sources:
+      - source: Larran's big chest
+        quantity: "1"
+        rarity: 1/256
+  about: "Dagon'hai robe top is a mid-high tier magic body slot item requiring 70 Magic and 40 Defence. Drops as rare loot from Larran's big chest (1/256). Provides +25 magic attack, +21 magic defence, +1% magic damage and +2 prayer bonus — strong PvM/PvP magic gear for the Defence requirement. Pairs with the Dagon'hai hat and robe bottom; storable in a magic wardrobe. High alchemy value: 84,000 coins."
+  market_strategy:
+    notes:
+      - "Larran's chest drop rate (1/256) gates supply; PKers stocking the chest drive trickle availability"
+      - "Demand from mid-game mages who want the 40 Defence requirement instead of 70 Defence ahrim's"
+      - "+1% magic damage and +2 prayer bonus distinguish it from cheaper mystic robe tops"
+  trading_tips:
+    - Watch Larran's chest meta — bounty hunter / chest content shifts directly move supply
+    - Resell full Dagon'hai set (hat + top + robe) for collector premium
+  related_items:
+    - item_name: Dagon'hai hat
+      slug: dagon-hai-hat
+      relationship: set-piece
+      description: Head piece of the Dagon'hai robes set
+    - item_name: Dagon'hai robe bottom
+      slug: dagon-hai-robe-bottom
+      relationship: set-piece
+      description: Legs piece of the Dagon'hai robes set
+    - item_name: Mystic robe top
+      slug: mystic-robe-top
+      relationship: alternative
+      description: Cheaper magic body alternative without the magic damage and prayer bonuses
+    - item_name: Ahrim's robetop
+      slug: ahrims-robetop
+      relationship: upgrade
+      description: Higher-tier magic body requiring 70 Defence
+  history:
+    - date: "2019-10-24"
+      description: "Added to the game as a rare drop from Larran's big chest."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-2.mdx
@@ -12,23 +12,62 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
+  potion:
+    effects:
+      - description: "Boosts Defence by 3 + 10% of current level for two doses."
+        duration: 60
   related_items:
-    - item_id: 133
-      item_name: Defence potion(3)
+    - item_name: Defence potion(3)
       slug: defence-potion-3
       relationship: variant
-      description: 3-dose version
-    - item_id: 137
-      item_name: Defence potion(1)
+      description: Three-dose variant
+    - item_name: Defence potion(1)
       slug: defence-potion-1
       relationship: variant
-      description: 1-dose version
-  about: |-
-    > _"2 doses of Defence potion."_
-
-    A 2-dose defence potion. Boosts Defence by 3 + 10% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: One-dose variant
+    - item_name: Defence potion(4)
+      slug: defence-potion-4
+      relationship: variant
+      description: Four-dose variant
+    - item_name: Defence mix(2)
+      slug: defence-mix-2
+      relationship: upgrade
+      description: Barbarian Herblore upgrade adding healing
+  about: "Defence potion(2) is a two-dose Herblore potion boosting Defence by 3 + 10% of the player's current level. It can be combined with other doses or made into Defence mix."
+  market_strategy:
+    notes:
+      - "Cheap entry-level Defence boost"
+      - "Often produced as a by-product of decanting four-dose potions"
+      - "Buy limit of 2,000 per 4 hours"
+  trading_tips:
+    - Two-dose flips often track four-dose spreads
+    - Decanting can quickly normalise stock between dose sizes
+  history:
+    - date: "2002-02-27"
+      description: "Released alongside the Herblore skill expansion."
+    - date: "2004-10-26"
+      description: "Empty option added for vial recovery."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platebody-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platebody-0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dharok's platebody 0 | OSRS Price Data
-description: "Dharok's platebody 0: Dharok the Wretched's platebody armour.. High alch: 168,000 GP, GE limit: 15."
+description: "Dharok's platebody 0 is a members fully degraded Barrows body requiring 70 Defence. High alch: 168,000 GP, GE limit: 15."
 osrs:
   id: 4896
   name: Dharok's platebody 0
@@ -12,9 +12,96 @@ osrs:
   lowalch: 112000
   highalch: 168000
   limit: 15
-  about: "Dharok's platebody 0 is a members-only item in Old School RuneScape. High alchemy value: 168,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: barrows-armour
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
+    requirements:
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -10
+    defence_bonus:
+      stab: 122
+      slash: 120
+      crush: 107
+      magic: -6
+      ranged: 132
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Dharok's platebody
+      slug: dharok-s-platebody
+      relationship: variant
+      description: Fully charged version with 100 combat hours of durability
+    - item_name: Dharok's platebody 25
+      slug: dharok-s-platebody-25
+      relationship: variant
+      description: Partially degraded charge state
+    - item_name: Dharok's platebody 50
+      slug: dharok-s-platebody-50
+      relationship: variant
+      description: Half-degraded charge state
+    - item_name: Dharok's platebody 75
+      slug: dharok-s-platebody-75
+      relationship: variant
+      description: Lightly used charge state
+    - item_name: Dharok's helm 0
+      slug: dharok-s-helm-0
+      relationship: set-piece
+      description: Matching head slot armour in degraded state
+    - item_name: Dharok's greataxe 0
+      slug: dharok-s-greataxe-0
+      relationship: set-piece
+      description: Matching two-handed weapon in degraded state
+    - item_name: Dharok's platelegs 0
+      slug: dharok-s-platelegs-0
+      relationship: set-piece
+      description: Matching legs slot armour in degraded state
+  about: |-
+    Dharok's platebody 0 is the fully degraded form of the Barrows brother Dharok the Wretched's chest piece. It cannot be worn in this state and must be repaired before equipping. Released 9 May 2005 with the Barrows minigame, the armour requires 70 Defence to wield once restored.
+
+    Repairs cost up to 90,000 GP at an NPC, dropping as low as 45,450 GP at a player-owned house armour stand with 99 Smithing. The fully degraded form is the cheapest way to acquire the platebody on the Grand Exchange before repairing it for use.
+  market_strategy:
+    notes:
+      - "Degraded 0 charge price floors the platebody market"
+      - "Repair to 100 charges captures the premium price spread"
+      - "Buy limit of 15 keeps short-term flips niche"
+  trading_tips:
+    - Maintain a POH armour stand at high Smithing to maximise repair savings
+    - Compare repaired listings vs degraded plus repair cost before flipping
+  history:
+    - date: "2005-05-09"
+      description: "Released with the Barrows minigame"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-dragon-bolts-e.mdx
@@ -12,82 +12,98 @@ osrs:
   lowalch: 352
   highalch: 528
   limit: 11000
-  ammunition:
-    type: enchanted_bolt
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: null
+    attack_speed: null
     weight: 0
     requirements:
       ranged: 64
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 122
-  creation:
-    method: Enchant Diamond dragon bolts
-    spell: Enchant Crossbow Bolt
-    requirements:
-      magic: 57
-    runes:
-      - 1 Cosmic
-      - 2 Law
-      - 10 Earth
-  special_effect:
-    name: Armour Piercing
-    description: Guaranteed hit with +15% max hit
-    proc_rate_pvm: 10%
-    proc_rate_pvp: 5%
-    damage_range: 0-115% of max
-  market:
-    buy_limit: 11000
-    price_estimate: 3815
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: magic
+      level: 57
+      xp: 0
+      materials:
+        - item_name: Diamond dragon bolts
+          quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Earth rune
+          quantity: 10
+      tools: []
+      output_quantity: 10
+  passive_effects:
+    - name: Armour piercing
+      description: 10% chance (5% in PvP) to guarantee the hit and deal up to +15% max damage; with Zaryte crossbow the boost rises to +26%. Hard Kandarin Diary raises the trigger chance by 10%.
   related_items:
-    - item_id: 21944
-      item_name: Ruby dragon bolts (e)
-      slug: ruby-dragon-bolts-e
-      relationship: alternative
-      description: High HP switch
-    - item_id: 21948
-      item_name: Diamond dragon bolts
+    - item_name: Diamond dragon bolts
       slug: diamond-dragon-bolts
       relationship: downgrade
-      description: Unenchanted
-    - item_id: 21950
-      item_name: Dragonstone dragon bolts (e)
+      description: Unenchanted variant
+    - item_name: Ruby dragon bolts (e)
+      slug: ruby-dragon-bolts-e
+      relationship: alternative
+      description: High HP target switch
+    - item_name: Dragonstone dragon bolts (e)
       slug: dragonstone-dragon-bolts-e
       relationship: alternative
-      description: Alternative
-  about: |-
-    Enchant Diamond dragon bolts with Enchant Crossbow Bolt.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 57 |
-    | Cosmic rune | 1 |
-    | Law rune | 2 |
-    | Earth rune | 10 |
-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged Strength | +122 |
-
-    Armour Piercing:
-    - +15% max hit
-    - Guaranteed to hit
-    - 10% proc (PvM), 5% proc (PvP)
-    - Damage: 0-115% of max
-
-    BiS for:
-    - Low HP finishers
-    - General crossbow use
-    - After ruby switches
-
-    Best bolts for consistent damage.
+      description: Magic-defence ignoring variant
+    - item_name: Dragon crossbow
+      slug: dragon-crossbow
+      relationship: alternative
+      description: Required crossbow tier
+  about: "Diamond dragon bolts (e) are enchanted dragon bolts with a 10% Armour Piercing proc (5% in PvP) that guarantees the hit and adds 15% to maximum damage (26% on Zaryte crossbow). With the hard Kandarin Diary the proc rate rises to 11%. Common best-in-slot consistency bolt for crossbow setups, especially after ruby HP threshold switches."
   market_strategy:
     notes:
-      - Switch from ruby at low HP
-      - Ignores defence on proc
-      - Great all-around bolt
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Strong steady demand from PvM crossbow users"
+      - "Enchanting margin frequently negative; manual flips preferred"
+      - "Watch ruby and dragonstone bolt spreads for tier swaps"
+  trading_tips:
+    - Switch from ruby bolts when target HP drops below threshold
+    - Stockpile before raids and high-level slayer content updates
+  history:
+    - date: "2018-01-04"
+      description: "Released with the Dragon Slayer II update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-dragon-bolts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Diamond dragon bolts | OSRS Price Data
-description: "Diamond dragon bolts: Dragon crossbow bolts, tipped with diamond.. High alch: 510 GP, GE limit: 11,000."
+description: "Diamond dragon bolts are 64 Ranged crossbow ammunition fletched from dragon bolts and diamond bolt tips. High alch: 510 GP, GE limit: 11,000."
 osrs:
   id: 21969
   name: Diamond dragon bolts
@@ -12,9 +12,96 @@ osrs:
   lowalch: 340
   highalch: 510
   limit: 11000
-  about: "Diamond dragon bolts is a members-only item in Old School RuneScape. High alchemy value: 510 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ammunition
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: crossbow-ammo
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 64
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 84
+      xp: 7
+      materials:
+        - item_name: Dragon bolts
+          quantity: 1
+        - item_name: Diamond bolt tips
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Dragon bolts
+      slug: dragon-bolts
+      relationship: component
+      description: Untipped dragon crossbow bolts
+    - item_name: Diamond bolt tips
+      slug: diamond-bolt-tips
+      relationship: component
+      description: Tip applied via Fletching
+    - item_name: Diamond dragon bolts (e)
+      slug: diamond-dragon-bolts-e
+      relationship: upgrade
+      description: Enchanted version with Armour Piercing effect
+    - item_name: Ruby dragon bolts
+      slug: ruby-dragon-bolts
+      relationship: alternative
+      description: Comparable dragon bolt variant
+  about: |-
+    Diamond dragon bolts are crossbow ammunition created by tipping dragon bolts with diamond bolt tips at 84 Fletching for 7 experience per bolt. They require 64 Ranged to wield and provide +122 ranged strength.
+
+    Their primary purpose is the enchanted form, diamond dragon bolts (e), unlocked at 57 Magic via Enchant Crossbow Bolt (Diamond). The enchanted bolts grant the Armour Piercing special effect, which ignores a portion of the target's defensive bonuses on a successful proc.
+  market_strategy:
+    notes:
+      - "Margin depends on dragon bolt and diamond bolt tip spread"
+      - "Demand spikes during late-game raid metas using enchanted variants"
+      - "84 Fletching gate keeps supply consistent"
+      - "Money-making guides quote ~729k/hr fletch profit"
+  trading_tips:
+    - Buy bolts and tips, resell as fletched product when margins clear 1-2gp
+    - Watch raid meta shifts that pull bolt (e) demand
+    - Flip near bond price changes that affect bolt feedstock
+  history:
+    - date: "2018-01-04"
+      description: "Released as part of the dragon bolts and dragon crossbow content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-attack-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-attack-potion-4.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 2000
-  about: "Divine super attack potion(4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Attack by 5 plus 15 percent of the player's Attack level, and prevents Attack from draining below the maximum boost for the duration. Drinking the potion costs 10 Hitpoints, so the player must have more than 10 HP to use it."
+        duration: 300
+  recipes:
+    - skill: herblore
+      level: 70
+      xp: 2
+      materials:
+        - item_name: Super attack(4)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 4
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Super attack(4)
+      slug: super-attack-4
+      relationship: component
+      description: Base potion infused with crystal dust to create the divine variant.
+    - item_name: Crystal dust
+      slug: crystal-dust
+      relationship: component
+      description: Reagent obtained by crushing crystal shards.
+    - item_name: Divine super attack potion(3)
+      slug: divine-super-attack-potion-3
+      relationship: variant
+      description: Three-dose version of the same potion.
+  about: |-
+    Divine super attack potion(4) is a four-dose combat potion created with Herblore that grants a sustained Attack boost at the cost of 10 Hitpoints per dose. Unlocked after Song of the Elves, it is favoured for long PvM trips because the buff does not drain.
+  market_strategy:
+    notes:
+      - "Profit is tied to the spread between Super attack(4) and crystal dust costs."
+      - "PvM bossing demand tends to lift price after raids meta shifts."
+  trading_tips:
+    - Buy crystal shards in bulk when Prifddinas events flood supply.
+    - Sell decanted divine doses when high-tier PvM content rotates in.
+  history:
+    - date: "2019-07-25"
+      description: "Divine super attack potion released with the Song of the Elves expansion."
+    - date: "2020-07-02"
+      description: "Inventory icon updated graphically to match the look of normal potions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dagger-p-5680.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dagger-p-5680.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon dagger(p+) | OSRS Price Data
-description: "Dragon dagger(p+): A powerful dagger.. High alch: 14,400 GP, GE limit: 70."
+description: "Dragon dagger(p+): A powerful dagger. High alch: 14,400 GP, GE limit: 70."
 osrs:
   id: 5680
   name: Dragon dagger(p+)
@@ -12,9 +12,100 @@ osrs:
   lowalch: 9600
   highalch: 14400
   limit: 70
-  about: "Dragon dagger(p+) is a members-only item in Old School RuneScape. High alchemy value: 14,400 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon-weapon
+    tier: high
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 40
+      slash: 25
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 40
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Dragon dagger
+          quantity: 1
+        - item_name: Weapon poison++
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Puncture (special attack)
+      description: "Consumes 25% special attack energy to deal two hits with +15% accuracy and +15% damage per hit"
+    - name: Weapon poison++
+      description: "Has a chance to inflict the stronger weapon poison++ effect on hit"
+  related_items:
+    - item_name: Dragon dagger
+      slug: dragon-dagger
+      relationship: variant
+      description: Unpoisoned base dagger
+    - item_name: Dragon dagger(p)
+      slug: dragon-dagger-p
+      relationship: variant
+      description: Standard poisoned variant
+    - item_name: Dragon dagger(p++)
+      slug: dragon-dagger-pp
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_name: Weapon poison+
+      slug: weapon-poison-plus
+      relationship: component
+      description: Poison used to upgrade the dagger
+  about: |-
+    | Bonus | Value |
+    |-------|-------|
+    | Stab attack | +40 |
+    | Strength | +40 |
+    | Attack speed | 4 ticks |
+
+    Requires 60 Attack and Lost City completion. Carries the iconic Puncture special — two hits at 25% spec, with +15% accuracy and damage per hit — and applies the upgraded weapon poison+ effect.
+  market_strategy:
+    notes:
+      - "Classic PKing and PvM special-attack weapon"
+      - "Poison variants priced by tier of weapon poison applied"
+      - "Members-only post-Lost City quest"
+  trading_tips:
+    - Track price gap vs unpoisoned dragon dagger to spot arbitrage on weapon poison+
+    - Demand spikes during bossing weeks and Wilderness events
+  history:
+    - date: "2004-03-29"
+      description: "Released as part of the RuneScape 2 launch alongside the dragon dagger."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta-p-22740.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta-p-22740.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 24960
   highalch: 37440
   limit: 70
-  about: "Dragon hasta(p++) is a members-only item in Old School RuneScape. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 55
+      slash: 55
+      crush: 55
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -15
+      slash: -15
+      crush: -12
+      magic: 0
+      ranged: -15
+    other_bonus:
+      strength: 60
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Dragon hasta
+      slug: dragon-hasta
+      relationship: variant
+      description: "Unpoisoned base variant."
+    - item_name: Dragon hasta(p)
+      slug: dragon-hasta-p-22736
+      relationship: variant
+      description: "Standard weapon poison variant."
+    - item_name: Dragon hasta(p+)
+      slug: dragon-hasta-p-22738
+      relationship: variant
+      description: "Weapon poison+ variant."
+  about: "Dragon hasta(p++) is the super-strong poison variant of the dragon hasta, a one-handed spear unlocked via Barbarian Training Smithing. It requires 60 Attack to wield and uses the Unleash special attack, which ignores 40% of Protect from Melee damage reduction. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
+  market_strategy:
+    notes:
+      - "Niche pick for short specs and slayer tasks where Protect from Melee bypass matters."
+      - "Spread is wider than the unpoisoned version because of poison++ ingredient cost."
+  trading_tips:
+    - "If poison++ is cheap, poisoning the base hasta yourself often beats the (p++) GE price."
+  history:
+    - date: "2019-01-10"
+      description: "Added with the Kebos Lowlands update via the Barbarian Training Smithing extension."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-kiteshield.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 640000
   highalch: 960000
   limit: 70
-  about: "Dragon kiteshield is a members-only item in Old School RuneScape. High alchemy value: 960,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
+    requirements:
+      defence: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 56
+      slash: 60
+      crush: 58
+      magic: -1
+      ranged: 58
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 75
+      xp: 1000
+      materials:
+        - item_name: Dragon sq shield
+          quantity: 1
+        - item_name: Dragon metal slice
+          quantity: 1
+        - item_name: Dragon metal shard
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+  about: "Dragon kiteshield is a high-tier members shield introduced with Dragon Slayer II. Forged at the Dragon Forge from a dragon sq shield, dragon metal slice and dragon metal shard at 75 Smithing (1,000 XP). Requires 60 Defence to wield and provides best-in-slot melee defensive bonuses for non-degradable shields, though it does NOT protect against dragonfire. High alchemy value: 960,000 coins. Grand Exchange buy limit: 70 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand driven by 60 Defence pures and PvM mid-game builds wanting a strong tradeable shield"
+      - "Supply throttled by Dragon Slayer II completion and Dragon Forge access"
+      - "Cosmetic upgradable with the dragon kiteshield ornament kit"
+  trading_tips:
+    - Pair smithing cost vs GE arbitrage when dragon metal slice/shard prices dip
+    - Watch for content updates that introduce new shields (can suppress demand)
+  related_items:
+    - item_name: Dragon sq shield
+      slug: dragon-sq-shield
+      relationship: component
+      description: Base shield needed to forge the kiteshield
+    - item_name: Dragon metal slice
+      slug: dragon-metal-slice
+      relationship: component
+      description: Smithing material from Dragon Slayer II
+    - item_name: Dragon metal shard
+      slug: dragon-metal-shard
+      relationship: component
+      description: Smithing material from Dragon Slayer II
+    - item_name: Dragon kiteshield ornament kit
+      slug: dragon-kiteshield-ornament-kit
+      relationship: upgrade
+      description: Cosmetic recolor for the dragon kiteshield
+  history:
+    - date: "2018-01-04"
+      description: "Added with the Dragon Slayer II update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-scale-dust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-scale-dust.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon scale dust | OSRS Price Data
-description: "Dragon scale dust: Finely ground scale of Dragon.. High alch: 31 GP, GE limit: 13,000."
+description: "Dragon scale dust is a Herblore secondary made by crushing blue dragon scales, used in antifire and weapon poison potions. High alch: 31 GP, GE limit: 13,000."
 osrs:
   id: 241
   name: Dragon scale dust
@@ -12,94 +12,90 @@ osrs:
   lowalch: 20
   highalch: 31
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
-    type: secondary
+    type: herblore-secondary
     tier: mid
-  processing:
-    method: Crush blue dragon scale with pestle and mortar
-    source_id: 243
-    source_name: Blue dragon scale
-    npc_service: Wesley in Nardah (50 gp per item)
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
-      - source: Blue dragon
-        source_id: 264
-        combat_level: 111
+      - source: Blue dragon scale (pestle and mortar)
         quantity: "1"
         rarity: always
-      - source: Brutal blue dragon
-        source_id: 7273
-        combat_level: 271
-        quantity: "2"
+      - source: Wesley (Nardah, 50 gp per item)
+        quantity: "1"
         rarity: always
-        members_only: true
   recipes:
     - skill: herblore
       level: 60
       xp: 137.5
       materials:
         - item_name: Kwuarm potion (unf)
-          item_id: 105
           quantity: 1
         - item_name: Dragon scale dust
-          item_id: 241
           quantity: 1
-      product: Weapon poison(3)
-      product_id: 187
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
     - skill: herblore
       level: 69
       xp: 157.5
       materials:
         - item_name: Lantadyme potion (unf)
-          item_id: 2483
           quantity: 1
         - item_name: Dragon scale dust
-          item_id: 241
           quantity: 1
-      product: Antifire potion(3)
-      product_id: 2454
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 243
-      item_name: Blue dragon scale
+    - item_name: Blue dragon scale
       slug: blue-dragon-scale
       relationship: component
-      description: Raw material
-    - item_id: 2454
-      item_name: Antifire potion(3)
+      description: Raw material crushed for dust
+    - item_name: Antifire potion(3)
       slug: antifire-potion-3
       relationship: product
-      description: Primary end product
-    - item_id: 187
-      item_name: Weapon poison(3)
+      description: Primary end product at 69 Herblore
+    - item_name: Weapon poison(3)
       slug: weapon-poison-3
       relationship: product
-      description: Combat product
-    - item_id: 233
-      item_name: Pestle and mortar
+      description: Combat product at 60 Herblore
+    - item_name: Pestle and mortar
       slug: pestle-and-mortar
       relationship: component
-      description: Processing tool
+      description: Tool used to grind blue dragon scales
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
+    Dragon scale dust is the Herblore secondary made by using a pestle and mortar on a blue dragon scale. Players who want to skip the grinding can pay Wesley in Nardah 50 coins per scale to do it for them.
 
-    Secondary ingredient for:
-    - Weapon poison (with kwuarm potion unf)
-    - Weapon poison+ (with cactus spine)
-    - Antifire (with lantadyme potion unf)
-    - Extended antifire (with lava scale shard)
-
-    Essential for antifire potion production.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    It feeds two core potions: weapon poison at 60 Herblore (with kwuarm potion unf) and antifire potion at 69 Herblore (with lantadyme potion unf). The antifire chain is the largest sink, making dust price track antifire and extended antifire demand.
+  market_strategy:
+    notes:
+      - "Demand is tied to antifire and weapon poison production"
+      - "Supply scales with blue dragon and brutal blue dragon farming"
+      - "Wesley service caps practical labour cost"
+      - "Watch for slayer task updates that affect blue dragon throughput"
+  trading_tips:
+    - Buy scales, grind, and sell dust when spread covers Wesley's 50 gp fee
+    - Stockpile ahead of antifire-heavy boss release windows
+    - Note remap removals from reward shops that historically lowered supply
+  history:
+    - date: "2002-02-27"
+      description: "Released as a Herblore secondary."
+    - date: "2023-08-30"
+      description: "Removed from Dom Onion's reward shop, reducing alternate supply."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfire-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonfire-shield.mdx
@@ -12,34 +12,100 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "18 June 2007"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 7.257
+    options:
+      - Wield
+      - Inspect
+      - Drop
+    worn_options:
+      - Activate
+      - Check
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: dragonfire shield
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 7.257
     requirements:
       defence: 75
-    stats:
-      defence_stab: 20
-      defence_slash: 25
-      defence_crush: 22
-      defence_magic: 10
-      defence_ranged: 22
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: -5
+    defence_bonus:
+      stab: 20
+      slash: 25
+      crush: 22
+      magic: 10
+      ranged: 22
+    other_bonus:
       strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 90
+      xp: 2000
+      materials:
+        - item_name: Anti-dragon shield
+          quantity: 1
+        - item_name: Draconic visage
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  passive_effects:
+    - name: Dragonfire protection
+      description: "Provides full protection against dragonfire equivalent to an anti-dragon shield, plus partial protection against icy breath from wyverns."
+    - name: Charged special attack
+      description: "When charged with up to 50 charges, the shield can be activated to unleash a dragonfire blast dealing up to 25 damage with a roughly 1:56 cooldown."
   related_items:
-    - item_id: 11286
-      item_name: Draconic visage
+    - item_name: Draconic visage
       slug: draconic-visage
       relationship: component
-      description: Required to create dragonfire shield
-    - item_id: 1540
-      item_name: Anti-dragon shield
+      description: Required component obtained from steel and higher dragons
+    - item_name: Anti-dragon shield
       slug: anti-dragon-shield
       relationship: component
-      description: Base shield for creating dragonfire shield
-  about: Absorbs dragonfire. Charges increase defence bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Base shield combined with the visage at level 90 Smithing
+    - item_name: Ancient wyvern shield
+      slug: ancient-wyvern-shield
+      relationship: alternative
+      description: Higher tier magic-leaning dragonfire shield alternative
+  about: |-
+    Dragonfire shield is a high-tier shield created at level 90 Smithing by combining an anti-dragon shield with a draconic visage on an anvil, requiring completion of Dragon Slayer I. The shield offers strong defensive bonuses, a passive dragonfire protection equivalent to the anti-dragon shield, and a charged dragonfire blast special attack.
+  market_strategy:
+    notes:
+      - "High alch 1.2M gp - frequently sustained above alch price"
+      - "Visage drop scarcity sets the floor price"
+      - "Buy limit 8 every 4 hours - thin liquidity"
+  trading_tips:
+    - Track draconic visage GE price as the leading indicator
+    - Uncharged version only is tradeable - empty charges before listing
+  history:
+    - date: "18 June 2007"
+      description: "Dragonfire shield released alongside the draconic visage drop."
+    - date: "26 February 2014"
+      description: "Released in Old School RuneScape after a developer poll."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/drake-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/drake-bones.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 7500
-  about: "Drake bones is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: bones
+    tier: mid-high
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.8
+    options:
+      - Bury
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Drake
+        quantity: "1"
+        rarity: Always
+      - source: Guardian drake
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Blessed drake bones
+      slug: blessed-drake-bones
+      relationship: product
+      description: Blessed variant with higher prayer XP
+    - item_name: Drake bonemeal
+      slug: drake-bonemeal
+      relationship: product
+      description: Crushed form for Ectofuntus
+    - item_name: Wyrm bones
+      slug: wyrm-bones
+      relationship: downgrade
+      description: Lower tier slayer dungeon bones
+    - item_name: Hydra bones
+      slug: hydra-bones
+      relationship: upgrade
+      description: Higher tier slayer dungeon bones
+  about: "Drake bones grant 80 Prayer XP when buried, 280 XP at a gilded altar with two burners, 320 XP via Ectofuntus drake bonemeal, 335 XP at a libation bowl with level 30 Prayer, and 240 XP plus 180 Magic XP via Sinister Offering. Always dropped by drakes and guardian drakes in the Karuulm Slayer Dungeon."
+  market_strategy:
+    notes:
+      - "Steady prayer training supply tied to drake slayer tasks"
+      - "Price moves with gilded altar Prayer training demand"
+      - "Bonemeal conversion adds processing margin"
+  trading_tips:
+    - Track demand against wyrm and hydra bone alternatives
+    - Bulk buy during ironman flooding events drops price
+  history:
+    - date: "2019-01-10"
+      description: "Released with The Kebos Lowlands and Karuulm Slayer Dungeon."
+    - date: "2019-02-13"
+      description: "Prayer XP rebalanced: bury 60 to 80, altar 210 to 280, Ectofuntus 240 to 320."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-cannon-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarf-cannon-set.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 240000
   highalch: 360000
   limit: 40
-  about: "Dwarf cannon set is a members-only item in Old School RuneScape. High alchemy value: 360,000 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: equipment-set
+    tier: high
+  properties:
+    release_date: "2014-12-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Cannon barrels
+      slug: cannon-barrels
+      relationship: set-piece
+      description: "Top section of the Dwarf Multicannon"
+    - item_name: Cannon base
+      slug: cannon-base
+      relationship: set-piece
+      description: "Bottom base of the Dwarf Multicannon"
+    - item_name: Cannon furnace
+      slug: cannon-furnace
+      relationship: set-piece
+      description: "Furnace section of the Dwarf Multicannon"
+    - item_name: Cannon stand
+      slug: cannon-stand
+      relationship: set-piece
+      description: "Stand section of the Dwarf Multicannon"
+  about: "Dwarf cannon set bundles the four parts of the Dwarf Multicannon (barrels, base, furnace, stand) for one-click Grand Exchange trading. Players who complete Dwarf Cannon can buy and assemble the set into a functional multicannon."
+  market_strategy:
+    notes:
+      - "Trade the set instead of four separate pieces to save time"
+      - "Compare set price to component sum before buying"
+      - "Requires Dwarf Cannon quest to deploy the assembled cannon"
+  history:
+    - date: "2014-12-10"
+      description: "Set added to the Grand Exchange Sets interface."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-stout.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dwarven stout | OSRS Price Data
-description: "Dwarven stout: A pint of thick dark beer.. High alch: 1 GP, GE limit: 2,000."
+description: "Dwarven stout: A pint of thick dark beer. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 1913
   name: Dwarven stout
@@ -12,9 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Dwarven stout is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2001-04-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 1 Hitpoint"
+        duration: 0
+      - description: "Boosts Mining and Smithing by +1 level"
+        duration: 0
+      - description: "Drains Attack, Strength, and Defence by 4% +2 levels"
+        duration: 0
+  drop_table:
+    sources:
+      - source: Rockslug
+        quantity: "1"
+        rarity: 13/128
+      - source: Rock golem
+        quantity: "1"
+        rarity: 13/78
+  shops:
+    - shop_name: The Toad and Chicken
+      location: Burthorpe
+      price: 2
+      currency: Coins
+      stock: 10
+    - shop_name: Rising Sun Inn
+      location: Falador
+      price: 2
+      currency: Coins
+      stock: 10
+    - shop_name: The Lighthouse Store
+      location: Lighthouse
+      price: 2
+      currency: Coins
+      stock: 10
+  related_items:
+    - item_name: Asgarnian ale
+      slug: asgarnian-ale
+      relationship: alternative
+      description: Another beer with stat-altering effects
+    - item_name: Wizard's mind bomb
+      slug: wizards-mind-bomb
+      relationship: alternative
+      description: Magic-boosting beer
+  about: "Dwarven stout is a free-to-play beer that temporarily boosts Mining and Smithing by 1 level while reducing Attack, Strength, and Defence. Useful for hitting Mining/Smithing level milestones."
+  market_strategy:
+    notes:
+      - "Cheap stat-boost potion alternative"
+      - "Often bought in bulk for Mining/Smithing level-up tasks"
+      - "Shop-bought is cheaper than GE"
+  trading_tips:
+    - Buy from Burthorpe or Falador inns at 2 gp each
+    - GE limit of 2,000 makes flipping low-margin
+  history:
+    - date: "2001-04-06"
+      description: "Released alongside RuneScape's launch as a tavern drink."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-yellow-vest.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-yellow-vest.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Elven top (yellow vest) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Lliann's Wares
+      location: Prifddinas
+      price: 5000
+      currency: Coins
+      stock: 100
+  related_items:
+    - item_name: Elven top (white vest)
+      slug: elven-top-white-vest
+      relationship: variant
+      description: White vest variant
+    - item_name: Elven legwear
+      slug: elven-legwear
+      relationship: set-piece
+      description: Legs piece of the elven outfit
+    - item_name: Elven boots
+      slug: elven-boots
+      relationship: set-piece
+      description: Feet piece of the elven outfit
+  about: "Elven top (yellow vest) is a cosmetic body slot item available from Lliann's Wares in Prifddinas after Song of the Elves. Provides no combat bonuses; part of the broader elven outfit collection."
+  market_strategy:
+    notes:
+      - "Sourced directly from Lliann's Wares shop"
+      - "Fashionscape and outfit collection demand"
+      - "Quest gate (Song of the Elves) limits supply"
+  trading_tips:
+    - Buy from shop at 5,000 coins and sell on GE for higher
+    - Demand spikes when new fashionscape promotions launch
+  history:
+    - date: "2019-07-25"
+      description: "Item released with the Song of the Elves quest."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald.mdx
@@ -12,124 +12,145 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: gem
-    tier: low-mid
-  crafting:
-    level: 27
-    xp: 67.5
+    tier: mid
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: crafting
       level: 27
       xp: 55
       materials:
         - item_name: Emerald
-          item_id: 1605
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Emerald ring
-      product_id: 1639
-      product_quantity: 1
-      facility: Furnace
+      tools:
+        - Ring mould
+      output_quantity: 1
     - skill: crafting
       level: 29
       xp: 60
       materials:
         - item_name: Emerald
-          item_id: 1605
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Emerald necklace
-      product_id: 1658
-      product_quantity: 1
-      facility: Furnace
+      tools:
+        - Necklace mould
+      output_quantity: 1
     - skill: crafting
       level: 31
       xp: 70
       materials:
         - item_name: Emerald
-          item_id: 1605
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Emerald amulet (u)
-      product_id: 1677
-      product_quantity: 1
-      facility: Furnace
+      tools:
+        - Amulet mould
+      output_quantity: 1
     - skill: crafting
       level: 30
       xp: 65
       materials:
         - item_name: Emerald
-          item_id: 1605
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Emerald bracelet
-      product_id: 11076
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
+      tools:
+        - Bracelet mould
+      output_quantity: 1
     - skill: fletching
       level: 58
       xp: 5.5
       materials:
         - item_name: Emerald
-          item_id: 1605
           quantity: 1
-      product: Emerald bolt tips
-      product_id: 9190
-      product_quantity: 12
-      members_only: true
+      tools:
+        - Chisel
+      output_quantity: 12
+  drop_table:
+    sources:
+      - source: Earth impling
+        quantity: "2"
+        rarity: 1/100
+      - source: Duke Sucellus
+        quantity: "28-42 (noted)"
+        rarity: 1/100
+      - source: Vardorvis
+        quantity: "17-25 (noted)"
+        rarity: 1/100
+      - source: Tombs of Amascut chest
+        quantity: "4-205 (noted)"
+        rarity: 3/27
+  shops:
+    - shop_name: Gem Merchant
+      location: Al Kharid
+      price: 750
+      currency: coins
+      stock: 0
+    - shop_name: Gem Trader
+      location: Falador
+      price: 750
+      currency: coins
+      stock: 0
+    - shop_name: Herquin's Gems
+      location: Falador
+      price: 750
+      currency: coins
+      stock: 0
   related_items:
-    - item_id: 1621
-      item_name: Uncut emerald
+    - item_name: Uncut emerald
       slug: uncut-emerald
       relationship: component
-      description: Raw gem
-    - item_id: 2552
-      item_name: Ring of dueling
+      description: Raw gem cut into emerald
+    - item_name: Ring of dueling
       slug: ring-of-dueling
       relationship: product
-      description: Enchanted ring
-    - item_id: 5521
-      item_name: Binding necklace
+      description: Enchanted teleport ring
+    - item_name: Binding necklace
       slug: binding-necklace
       relationship: product
-      description: Enchanted necklace
-    - item_id: 1607
-      item_name: Sapphire
+      description: Enchanted combine runes necklace
+    - item_name: Sapphire
       slug: sapphire
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier gem
-    - item_id: 1603
-      item_name: Ruby
+    - item_name: Ruby
       slug: ruby
-      relationship: alternative
+      relationship: upgrade
       description: Higher tier gem
-  about: |-
-    | Item | Effect |
-    |------|--------|
-    | Ring of dueling | Duel Arena teleports |
-    | Binding necklace | Combine rune crafting |
-    | Castle wars bracelet | Castle Wars boost |
-    | Amulet of nature | Farming status |
+  about: "Emeralds are F2P precious gems cut from uncut emeralds at Crafting 27. They feed jewellery production (ring of dueling, binding necklace, amulet of nature, castle wars bracelet) and Fletching emerald bolt tips at level 58. Best ROI typically comes from ring of dueling and binding necklace pipelines."
   market_strategy:
     notes:
-      - Ring of dueling production
-      - Binding necklace for runecrafting
-      - Crafting training
-      - Popular for ring of dueling
-      - Binding necklace essential for RC
-      - Good XP for level
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Ring of dueling demand drives steady throughput"
+      - "Binding necklace essential for combination runecrafting"
+      - "Crafting training method for many accounts"
+      - "Fletching bolt tips at 58 adds secondary demand"
+  trading_tips:
+    - Watch uncut emerald spreads for crafting margin
+    - Bulk crafters move large volumes during double XP weekends
+  history:
+    - date: "2001-05-08"
+      description: "Released in early RuneScape as a base gem."
+    - date: "2002-03-25"
+      description: "Added to jewellery crafting pipelines."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-sapphire-or-opal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enchant-sapphire-or-opal.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Enchant sapphire or opal is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: tablet
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 7
+      xp: 13.2
+      materials:
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 1
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Oak lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Enchant emerald or jade
+      slug: enchant-emerald-or-jade
+      relationship: variant
+      description: Tablet for Lvl-2 enchant
+    - item_name: Enchant ruby or topaz
+      slug: enchant-ruby-or-topaz
+      relationship: variant
+      description: Tablet for Lvl-3 enchant
+    - item_name: Enchant diamond
+      slug: enchant-diamond
+      relationship: variant
+      description: Tablet for Lvl-4 enchant
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Required to make the tablet
+  about: "Enchant sapphire or opal is a Magic tablet that casts Lvl-1 Enchant on the user's behalf. Made at Magic 7 on an Oak lectern using 1 cosmic rune, 1 water rune, and soft clay for 13.2 XP."
+  market_strategy:
+    notes:
+      - "Player-made supply from Construction houses"
+      - "Low value; mostly POH convenience trade"
+      - "Buy limit of 10,000 supports bulk transactions"
+  trading_tips:
+    - Bulk craft if soft clay and water runes are cheap
+    - Sell to ironmen alternatives via shop turnover
+  history:
+    - date: "2006-05-31"
+      description: "Item released with Construction lecterns."
+    - date: "2017-02-16"
+      description: "Tablet renamed from \"Enchant sapphire\" to \"Enchant sapphire or opal\" after opal was added."
+    - date: "2018-03-01"
+      description: "\"Break\" option removed and \"Info\" option added."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enchanted-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enchanted-hat.mdx
@@ -12,8 +12,30 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 8
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements:
+      magic: 40
+      defence: 20
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,60 +53,43 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 40
-      defence: 20
-  related_items:
-    - item_id: 7399
-      item_name: Enchanted top
-      slug: enchanted-top
-      relationship: set-piece
-      description: Enchanted set body
-    - item_id: 7398
-      item_name: Enchanted robe
-      slug: enchanted-robe
-      relationship: set-piece
-      description: Enchanted set legs
-    - item_id: 4089
-      item_name: Mystic hat
-      slug: mystic-hat
-      relationship: alternative
-      description: Same stats, easier to obtain
-  about: |-
-    > *"A three pointed hat of magic."*
-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +4 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +4 |
-
-    Requirements: 40 Magic, 20 Defence
-
-    Weight: 0.453 kg
-
-    | Stat | Enchanted Hat | Mystic Hat | Farseer Helm |
-    |------|--------------|-----------|--------------|
-    | Magic Atk | +4 | +4 | +6 |
-    | Magic Def | +4 | +4 | +8 |
-    | Req | 40 Mage/20 Def | 40 Mage/20 Def | 45 Mage/45 Def |
-
-    The enchanted hat is statistically identical to the mystic hat. The only difference is the visual appearance and source. It is valued primarily as a fashionscape item from Treasure Trails.
-
-    - Cosmetic alternative to the mystic hat
-    - Treasure Trails fashionscape outfit
-    - Can be stored in POH costume room
-    - Same combat utility as mystic hat in every scenario
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers: ["hard"]
+  about: "Enchanted hat is a hard Treasure Trails reward statistically identical to the mystic hat (+4 magic attack, +4 magic defence) but distinguished by its three-pointed wizard hat aesthetic. Requires 40 Magic and 20 Defence to wear. Part of the enchanted robes set (hat, top, robe) and storable in a POH costume room. High alchemy value: 9,000 coins. Grand Exchange buy limit: 8 per 4 hours."
   market_strategy:
     notes:
-      - Rarity from hard clues gives it some collector value
-      - Price may fluctuate above mystic hat due to cosmetic demand
-      - Storable in costume room for outfit collectors
-      - Part of the complete enchanted robes set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Rarity from hard clues gives it some collector value above mystic hat"
+      - "Price may fluctuate above mystic hat due to cosmetic demand"
+      - "Storable in costume room for outfit collectors"
+      - "Part of the complete enchanted robes set"
+  trading_tips:
+    - Demand spikes when clue-scroll content drops; trickle in supply makes the 8-unit limit easy to fill
+    - Pair with enchanted top and enchanted robe when reselling set collectors
+  related_items:
+    - item_name: Enchanted top
+      slug: enchanted-top
+      relationship: set-piece
+      description: Body piece of the enchanted robes set
+    - item_name: Enchanted robe
+      slug: enchanted-robe
+      relationship: set-piece
+      description: Legs piece of the enchanted robes set
+    - item_name: Mystic hat
+      slug: mystic-hat
+      relationship: alternative
+      description: Same combat stats, easier to obtain
+  history:
+    - date: "2006-02-20"
+      description: "Added to the game as a hard Treasure Trails reward."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/enchanted-robe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/enchanted-robe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enchanted robe | OSRS Price Data
-description: "Enchanted robe is a members legs slot item requiring 20 Defence. High alch: 48,000 GP, GE limit: 8."
+description: "Enchanted robe is a hard clue scroll reward legs slot piece with mystic robe bottom stats. High alch: 48,000 GP, GE limit: 8."
 osrs:
   id: 7398
   name: Enchanted robe
@@ -12,8 +12,35 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: clue-reward
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements:
+      magic: 40
+      defence: 20
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,60 +58,50 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      magic: 40
-      defence: 20
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 7400
-      item_name: Enchanted hat
+    - item_name: Enchanted hat
       slug: enchanted-hat
       relationship: set-piece
       description: Enchanted set hat
-    - item_id: 7399
-      item_name: Enchanted top
+    - item_name: Enchanted top
       slug: enchanted-top
       relationship: set-piece
       description: Enchanted set body
-    - item_id: 4093
-      item_name: Mystic robe bottom
+    - item_name: Mystic robe bottom
       slug: mystic-robe-bottom
       relationship: alternative
-      description: Same stats, easier to obtain
+      description: Same stats and requirements, easier to obtain
+    - item_name: Ahrim's robeskirt
+      slug: ahrim-s-robeskirt
+      relationship: upgrade
+      description: Stronger Barrows magic legs alternative
   about: |-
-    > *"Enchanted Wizards robes."*
+    The enchanted robe is the legs slot of the enchanted robes set, a hard clue scroll reward. It mirrors the mystic robe bottom statistically, requiring 40 Magic and 20 Defence and giving +15 magic attack and +15 magic defence with no other bonuses.
 
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +15 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +15 |
-
-    Requirements: 40 Magic, 20 Defence
-
-    Weight: 1.814 kg
-
-    | Stat | Enchanted Robe | Mystic Robe Bottom | Ahrim's Robeskirt | Infinity Bottoms |
-    |------|---------------|--------------------|--------------------|------------------|
-    | Magic Atk | +15 | +15 | +22 | +17 |
-    | Magic Def | +15 | +15 | +22 | +17 |
-    | Req | 40 Mage/20 Def | 40 Mage/20 Def | 70 Mage/70 Def | 50 Mage/25 Def |
-
-    The enchanted robe is statistically identical to the mystic robe bottom. The only difference is the visual appearance and source. It trades at a different price due to its rarity from Treasure Trails.
-
-    - Cosmetic alternative to the mystic robe bottom
-    - Treasure Trails fashionscape outfit
-    - Can be stored in POH costume room
-    - Same combat utility as mystic robe bottom in every scenario
+    Practical combat value is identical to a mystic robe bottom, so the enchanted robe is collected for its rarity, the matching fashionscape set, and player-owned house costume room storage. It rolls at 1/1,625 from a hard reward casket.
   market_strategy:
     notes:
-      - Hard clue rarity gives it collector value
-      - Typically trades near or above mystic robe bottom
-      - Storable in costume room for outfit collectors
-      - Part of the complete enchanted robes set (hat, top, robe)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Hard clue rarity gives it collector value"
+      - "Typically trades near or above mystic robe bottom"
+      - "Storable in costume room for outfit collectors"
+      - "Part of the complete enchanted robes set (hat, top, robe)"
+  trading_tips:
+    - Watch hard clue meta updates that change drop pool weighting
+    - Hold while completionists chase set listings
+    - Flip against mystic robe bottom price when premium gaps widen
+  history:
+    - date: "2006-02-20"
+      description: "Released as a hard Treasure Trails reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-3.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 133
   highalch: 199
   limit: 2000
-  about: "Extended anti-venom+(3) is a members-only item in Old School RuneScape. High alchemy value: 199 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2024-08-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and venom on consumption."
+        duration: 0
+      - description: "Grants immunity to poison for approximately 17.7 minutes."
+        duration: 1062
+      - description: "Grants immunity to venom for approximately 6.3 minutes."
+        duration: 378
+  recipes:
+    - skill: herblore
+      level: 94
+      xp: 20
+      materials:
+        - item_name: Anti-venom+(4)
+          quantity: 1
+        - item_name: Araxyte venom sack
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Extended anti-venom+(4)
+      slug: extended-anti-venom-4
+      relationship: variant
+      description: 4-dose version
+    - item_name: Extended anti-venom+(2)
+      slug: extended-anti-venom-2
+      relationship: variant
+      description: 2-dose version
+    - item_name: Extended anti-venom+(1)
+      slug: extended-anti-venom-1
+      relationship: variant
+      description: 1-dose version
+    - item_name: Anti-venom+(4)
+      slug: anti-venom-4
+      relationship: component
+      description: Base potion required for creation
+  about: "Extended anti-venom+(3) is a 3-dose members potion that cures poison and venom, granting extended immunity. Made with Herblore 94 by combining Anti-venom+ with Araxyte venom sack."
+  market_strategy:
+    notes:
+      - "High Herblore requirement keeps supply tight"
+      - "Demand from PvM at Araxxor and other venom encounters"
+      - "4-dose splits into lower doses if profitable"
+  trading_tips:
+    - Compare per-dose price against 4-dose and 1-dose variants
+    - Best alch profit is low; sell on GE
+  history:
+    - date: "2024-08-28"
+      description: "Item released alongside Araxxor content."
+    - date: "2024-09-04"
+      description: "Recolored for distinction from Anti-venom+ and gained priority for auto-cure via health orb."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/flax-seed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/flax-seed.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 2000
-  about: "Flax seed is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: seed
+    tier: low
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 18
+      xp: 16
+      materials:
+        - item_name: Flax seed
+          quantity: 3
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Albatross
+        quantity: "1"
+        rarity: Common
+      - source: Osprey
+        quantity: "1"
+        rarity: Common
+      - source: Frigatebird
+        quantity: "1"
+        rarity: Common
+      - source: Dolphin
+        quantity: "1"
+        rarity: Uncommon
+      - source: Narwhal
+        quantity: "1"
+        rarity: Uncommon
+      - source: Tern
+        quantity: "1"
+        rarity: Common
+      - source: Orca
+        quantity: "1"
+        rarity: Rare
+  related_items:
+    - item_name: Flax
+      slug: flax
+      relationship: product
+      description: Harvested crop from a fully grown flax plant
+  about: |-
+    Flax seed is a members-only farming seed planted in hops patches at level 18 Farming. It grows in 60 minutes (3 cycles of 20 minutes) and yields harvestable flax used for crafting bowstrings.
+
+    Introduced with the Sailing update on 19 November 2025, flax seeds drop from a wide variety of sea creatures encountered while sailing including albatrosses, ospreys, dolphins, narwhals and orcas.
+  market_strategy:
+    notes:
+      - "Cheap entry-level Farming seed"
+      - "High GE limit (2,000) makes bulk runs viable"
+      - "Sailing drops keep supply healthy"
+  trading_tips:
+    - Run multiple hops patches for hourly farming XP
+    - Combine with bowstring crafting for double-skill profit
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the Sailing update."
+    - date: "2025-08-14"
+      description: "Item appearance updated during Sailing beta."
+    - date: "2025-06-26"
+      description: "Initially added during Sailing beta testing."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/forgotten-brew-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/forgotten-brew-3.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: null
-  about: "Forgotten brew(3) is a members-only item in Old School RuneScape. High alchemy value: 90 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2023-01-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 91
+      xp: 108
+      materials:
+        - item_name: Ancient brew(3)
+          quantity: 1
+        - item_name: Ancient essence
+          quantity: 60
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Magic boost: +3 + 8% of base Magic level."
+        duration: 0
+      - description: "Prayer restore: +2 + 10% of base Prayer level."
+        duration: 0
+      - description: "Drains Attack, Strength, and Defence by 2 + 10% of current level each."
+        duration: 0
+  related_items:
+    - item_name: Ancient brew(3)
+      slug: ancient-brew-3
+      relationship: component
+      description: "Base potion upgraded with ancient essence"
+    - item_name: Ancient essence
+      slug: ancient-essence
+      relationship: component
+      description: "20 essence per dose required for upgrade"
+    - item_name: Forgotten brew(4)
+      slug: forgotten-brew-4
+      relationship: variant
+      description: "Full 4-dose vial"
+    - item_name: Forgotten brew(2)
+      slug: forgotten-brew-2
+      relationship: variant
+      description: "2-dose vial"
+  about: "Forgotten brew(3) is the upgraded version of ancient brew, providing a stronger Magic boost than its base. It is the go-to magic accuracy potion for content that bans non-magic stat boosts."
+  market_strategy:
+    notes:
+      - "Upgrade from ancient brew at 91 Herblore with ancient essence"
+      - "Best magic-only boosting potion for Nex and ToB mage rooms"
+      - "Ancient essence supply comes from Phantom Muspah and Leviathan"
+  history:
+    - date: "2023-01-11"
+      description: "Released with the Secrets of the North quest update."
+    - date: "2022-11-19"
+      description: "Originally polled as Magister's brew before the quest name was finalised."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/four-poster-bed-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/four-poster-bed-flatpack.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Four-poster bed (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
+  recipes:
+    - skill: construction
+      level: 53
+      xp: 450
+      materials:
+        - item_name: Mahogany plank
+          quantity: 3
+        - item_name: Bolt of cloth
+          quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: Primary material for the flatpack
+    - item_name: Bolt of cloth
+      slug: bolt-of-cloth
+      relationship: component
+      description: Cloth used in construction
+  about: "Four-poster bed (flatpack) is a members-only Construction flatpack created at a steel framed workbench at level 53 Construction for 450 experience. It is placed in the bedroom of a player-owned house."
+  market_strategy:
+    notes:
+      - "Crafted from mahogany planks and cloth at a steel framed workbench"
+      - "Sold to players building POH bedrooms"
+      - "Buy limit 500 per 4 hours"
+  trading_tips:
+    - Watch mahogany plank prices to gauge profitability
+    - Bulk buying for construction training is common
+  history:
+    - date: "2006-05-31"
+      description: "Introduced with the release of Player-Owned Houses."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-red-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-red-shirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fremennik red shirt | OSRS Price Data
-description: "Fremennik red shirt: The latest in Fremennik fashion.. High alch: 150 GP, GE limit: 150."
+description: "Fremennik red shirt: The latest in Fremennik fashion. High alch: 150 GP, GE limit: 150."
 osrs:
   id: 3773
   name: Fremennik red shirt
@@ -12,9 +12,94 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik red shirt is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      price: 325
+      currency: Coins
+      stock: 5
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania
+      price: 250
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Fremennik blue shirt
+      slug: fremennik-blue-shirt
+      relationship: variant
+      description: Blue color variant
+    - item_name: Fremennik brown shirt
+      slug: fremennik-brown-shirt
+      relationship: variant
+      description: Brown color variant
+    - item_name: Fremennik beige shirt
+      slug: fremennik-beige-shirt
+      relationship: variant
+      description: Beige color variant
+    - item_name: Fremennik grey shirt
+      slug: fremennik-grey-shirt
+      relationship: variant
+      description: Grey color variant
+  about: "Fremennik red shirt is a cosmetic body slot item sold at Fremennik clothing shops. Available in five colors and frequently used in fashionscape sets."
+  market_strategy:
+    notes:
+      - "Shop price in Miscellania is lower than the GE for resellers"
+      - "Low GE volume keeps daily flips limited"
+      - "Fashionscape and clue-themed outfits drive demand"
+  trading_tips:
+    - Buy from Miscellanian Clothes Shop at 250 gp for the best entry
+    - Resell on GE when fashion threads pump the price
+  history:
+    - date: "2004-11-02"
+      description: "Released as part of The Fremennik Trials update."
+    - date: "2005-01-17"
+      description: "Graphically updated."
+    - date: "2014-12-10"
+      description: "Renamed from \"Fremennik shirt\" to \"Fremennik red shirt\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fury-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fury-ornament-kit.mdx
@@ -12,60 +12,59 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: ornament_kit
+    tier: high
+  properties:
+    release_date: "12 June 2014"
     tradeable: true
-    target_item: Amulet of fury
-    target_id: 6585
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Elite
-        drop_rate: Rare from reward casket
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/1275
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
   related_items:
-    - item_id: 6585
-      item_name: Amulet of fury
+    - item_name: Amulet of fury
       slug: amulet-of-fury
-      relationship: product
-      description: Base item to upgrade
-    - item_id: 12436
-      item_name: Amulet of fury (or)
+      relationship: component
+      description: Base amulet that receives the ornament
+    - item_name: Amulet of fury (or)
       slug: amulet-of-fury-or
       relationship: product
-      description: Ornamented version
+      description: Ornamented result
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ornament Kit |
-    | Target | Amulet of fury |
-    | Tradeable | Yes |
-
-    Use on an Amulet of fury to create an Amulet of fury (or).
-
-    The ornament kit:
-    - Adds gold decoration to the amulet
-    - Purely cosmetic change
-    - Does not affect stats
-    - Can be reverted
-
-    Materials:
-    - Amulet of fury
-    - Fury ornament kit
-
-    Result:
-    - Amulet of fury (or) - ornamented version
-
-    The ornamented amulet can be reverted to return:
-    - Amulet of fury
-    - Fury ornament kit
+    Fury ornament kit is an elite Treasure Trails cosmetic that converts an Amulet of fury into the (or) variant. The kit can be detached at any time.
   market_strategy:
     notes:
-      - Elite clue exclusive
-      - Popular amulet upgrade
-      - Prestigious fashionscape item
-      - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Elite clue exclusivity holds the floor"
+      - "Buy limit of 4 amplifies short-term swings"
+      - "Collection log demand drives long-tail value"
+  trading_tips:
+    - Buy during clue droughts when supply thins
+    - Sell when fashionscape and ornament hype is trending
+  history:
+    - date: "12 June 2014"
+      description: "Released with the Treasure Trail Expansion update."
+    - date: "25 January 2018"
+      description: "Graphical update applied alongside other ornament kits."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-d-hide-body.mdx
@@ -12,95 +12,96 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 6
     requirements:
       ranged: 40
       defence: 40
-      quest: Dragon Slayer I
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 15
-      defence_stab: 40
-      defence_slash: 32
-      defence_crush: 45
-      defence_magic: 20
-      defence_ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 15
+    defence_bonus:
+      stab: 40
+      slash: 32
+      crush: 45
+      magic: 20
+      ranged: 40
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 6
-  obtaining:
-    methods:
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+      - master
+  drop_table:
+    sources:
       - source: Reward casket (elite)
-        drop_rate: 1/14,662.5
+        quantity: "1"
+        rarity: 1/14662.5
       - source: Reward casket (master)
-        drop_rate: 1/13,616
+        quantity: "1"
+        rarity: 1/13616
   related_items:
-    - item_id: 2503
-      item_name: Black d'hide body
+    - item_name: Black d'hide body
       slug: black-dhide-body
       relationship: alternative
-      description: Same stats, non-gilded
-    - item_id: 23267
-      item_name: Gilded d'hide chaps
+      description: Same stats, crafted at 84 Crafting
+    - item_name: Gilded d'hide chaps
       slug: gilded-dhide-chaps
-      relationship: alternative
+      relationship: set-piece
       description: Matching gilded legs
-    - item_id: 23261
-      item_name: Gilded d'hide vambraces
+    - item_name: Gilded d'hide vambraces
       slug: gilded-dhide-vambraces
-      relationship: alternative
+      relationship: set-piece
       description: Matching gilded gloves
-    - item_id: 23258
-      item_name: Gilded coif
+    - item_name: Gilded coif
       slug: gilded-coif
-      relationship: alternative
-      description: Matching gilded helm
-  about: |-
-    "Made with 100% golden dragonhide."
-
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -15 |
-    | Ranged Attack | +15 |
-    | Stab Defence | +40 |
-    | Slash Defence | +32 |
-    | Crush Defence | +45 |
-    | Magic Defence | +20 |
-    | Ranged Defence | +40 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 40 Ranged, 40 Defence, Dragon Slayer I
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Gilded d'hide body | +15 | +40 | +20 | Elite/Master clues |
-    | Black d'hide body | +15 | +40 | +20 | Crafting (84) |
-
-    Stats are identical to the black d'hide body. The gilded version is purely cosmetic and significantly more expensive due to its rarity from Treasure Trails.
+      relationship: set-piece
+      description: Matching gilded coif
+  about: "Gilded d'hide body is a cosmetic gilded variant of the black dragonhide body, sharing identical combat stats. It is obtained as a rare reward from elite and master Treasure Trails."
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Elite clue reward rarity
-      - Collection log completionists
-      - Identical stats to black d'hide body
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Fashionscape and collection log demand"
+      - "Identical stats to black d'hide body — value is purely cosmetic rarity"
+      - "Price fluctuates with clue scroll completion activity"
+      - "Low trade volume and small buy limit can amplify manipulation"
+  trading_tips:
+    - Watch GE during clue popularity events
+    - Track average price over weeks given the thin order book
+  history:
+    - date: "2019-04-11"
+      description: "Added as a reward from elite and master Treasure Trails."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gnomish-firelighter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gnomish-firelighter.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 40
-  about: "Gnomish firelighter is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Check
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Medium Treasure Trail reward casket
+        quantity: "1"
+        rarity: 10/3410
+      - source: Reward casket (Entrana variant)
+        quantity: "1"
+        rarity: 1/170
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  passive_effects:
+    - name: Charged firelighter
+      description: "Holds up to 1,000 charges of a chosen colour; consumes one charge per log lit to produce a coloured fire similar to a tinderbox."
+  related_items:
+    - item_name: Red firelighter
+      slug: red-firelighter
+      relationship: component
+      description: One of the coloured firelighters that can be loaded into the device.
+    - item_name: Reward casket (medium)
+      slug: reward-casket-medium
+      relationship: alternative
+      description: Source casket that drops the gnomish firelighter.
+  about: |-
+    The gnomish firelighter is a medium-clue cosmetic from the 2016 Treasure Trail Expansion. Charge it with up to 1,000 coloured firelighters of a single colour and it functions as a reusable tinderbox that produces matching coloured fires.
+
+    The casket drop rate from medium clues is around 10 in 3,410, with the Entrana variant raising it to roughly 1 in 170.
+  market_strategy:
+    notes:
+      - "Cosmetic; demand driven by medium clue popularity and colour-themed events."
+      - "Buy limit of 40 keeps unit liquidity low - thin order book."
+      - "Spikes during treasure trail content updates and rare-cosmetic videos."
+  trading_tips:
+    - Stockpile during clue droughts; release into clue meta updates.
+    - Watch known charge-loss bug status; an official fix could shift demand.
+  history:
+    - date: "2016-07-06"
+      description: "Released with the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-elegant-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-elegant-shirt.mdx
@@ -12,21 +12,79 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 12349
-      item_name: Gold elegant legs
+    - item_name: Gold elegant legs
       slug: gold-elegant-legs
       relationship: set-piece
-      description: Matching elegant legs
-  about: |-
-    > *"A well made elegant men's gold shirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the gold elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching gold elegant legs for the men's set."
+    - item_name: Gold elegant blouse
+      slug: gold-elegant-blouse
+      relationship: variant
+      description: "Women's variant of the elegant gold top."
+    - item_name: Gold elegant skirt
+      slug: gold-elegant-skirt
+      relationship: variant
+      description: "Women's variant of the elegant gold legs."
+  about: "Cosmetic body slot item from medium clue rewards. The gold elegant shirt provides zero combat bonuses and serves as part of the gold elegant men's set. Storable in a costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Cosmetic-only with thin liquidity due to low buy limit (4)."
+      - "Collector demand for the full elegant set drives most volume."
+  trading_tips:
+    - "Pair with gold elegant legs for set-buyer premiums."
+    - "Long hold strategy works better than flipping due to slow turnover."
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-2kg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-2kg.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 100
-  about: "Granite (2kg) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: stone
+    tier: low
+  properties:
+    release_date: "2006-01-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Granite (500g)
+      slug: granite-500g
+      relationship: variant
+      description: "Smaller 500 gram chunk yielding less Mining XP"
+    - item_name: Granite (5kg)
+      slug: granite-5kg
+      relationship: variant
+      description: "Larger 5 kilogram chunk yielding more Mining XP"
+  about: |-
+    "A small chunk of granite."
+
+    Granite (2kg) is the mid-size chunk mined from granite rocks at 45 Mining for 60 experience per ore. The most common training spots are the Bandit Camp Quarry in the Kharidian Desert, the Necropolis mine, and the Cape Conch mine. Each rock respawns after 5 seconds, making granite one of the fastest XP/hour mining methods in the mid-game once the player can carry the weight efficiently.
+
+    Beyond Mining XP, granite is used in the Enakhra's Lament and King's Ransom quests, as a Construction material for the volcanic habitat in player-owned houses, and to recolour the Rock Golem pet. The 2kg chunk is the standard size most players default to because it balances XP per ore against inventory weight.
+  market_strategy:
+    notes:
+      - "High alch is 1 gp so the floor is effectively zero"
+      - "Granite is rarely traded as players mine it themselves; thin volume makes flipping unreliable"
+      - "Ironmen drive most of the marginal demand for construction projects"
+  trading_tips:
+    - Treat the GE listing as a convenience tax rather than a real market
+    - If you actually need granite at scale, mine it yourself
+  history:
+    - date: "2006-01-23"
+      description: "Granite introduced with the Enakhra's Lament quest update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-5kg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-5kg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Granite (5kg) | OSRS Price Data
-description: "Granite (5kg): A medium-sized chunk of granite.. High alch: 1 GP, GE limit: 100."
+description: "Granite (5kg) is a heavy mining drop used for Construction, quests, and house theme upgrades. GE limit: 100."
 osrs:
   id: 6983
   name: Granite (5kg)
@@ -9,12 +9,71 @@ osrs:
   members: true
   icon: Granite (5kg).png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 100
-  about: "Granite (5kg) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mining-resource
+    tier: mid
+  properties:
+    release_date: "2006-01-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Granite rock (Bandit Camp Quarry)
+        quantity: "1"
+        rarity: always
+      - source: Granite rock (Necropolis mine)
+        quantity: "1"
+        rarity: always
+      - source: Granite rock (Cape Conch mine)
+        quantity: "1"
+        rarity: always
+  related_items:
+    - item_name: Granite (500g)
+      slug: granite-500g
+      relationship: variant
+      description: Smaller granite chunk variant
+    - item_name: Granite (2kg)
+      slug: granite-2kg
+      relationship: variant
+      description: Medium granite chunk variant
+    - item_name: Sandstone (10kg)
+      slug: sandstone-10kg
+      relationship: alternative
+      description: Comparable Desert mining drop
+  about: |-
+    Granite (5kg) is the largest of the three granite chunks mined from granite rocks at the Bandit Camp Quarry, Necropolis mine, and Cape Conch mine. It requires 45 Mining and is members-only. Unlike sandstone, granite cannot be chiselled down into smaller sizes.
+
+    Five 5kg pieces are required to upgrade a player-owned house to the volcanic habitat and two pieces are required for the volcanic theme. The 5kg variant is also consumed during Enakhra's Lament and is used as the dye source when recolouring the Rock golem pet.
+  market_strategy:
+    notes:
+      - "Demand is driven by POH theme upgrades and pet recolours"
+      - "Heavy weight discourages bank-running without weight reduction"
+      - "Price tied to mining bot supply at Bandit Camp Quarry"
+      - "Spikes possible around any POH or pet-related update"
+  trading_tips:
+    - Buy in bulk when mining bot activity floods supply
+    - Sell during POH update hype windows
+    - Pair with stamina potions when collecting personally
+  history:
+    - date: "2006-01-23"
+      description: "Released alongside granite rocks south of the Bandit Camp."
+    - date: "2006-02-06"
+      description: "Renamed from 'Granite (medium)' to 'Granite (5kg)'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-boater.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "Green boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options:
+      - Wear
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Medium Treasure Trail reward casket
+        quantity: "1"
+        rarity: Rare
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Red boater
+      slug: red-boater
+      relationship: variant
+      description: Red colour variant of the boater hat from medium clues.
+    - item_name: Blue boater
+      slug: blue-boater
+      relationship: variant
+      description: Blue colour variant of the boater hat from medium clues.
+    - item_name: Black boater
+      slug: black-boater
+      relationship: variant
+      description: Black colour variant of the boater hat from medium clues.
+    - item_name: Orange boater
+      slug: orange-boater
+      relationship: variant
+      description: Orange colour variant of the boater hat from medium clues.
+    - item_name: Pink boater
+      slug: pink-boater
+      relationship: variant
+      description: Pink colour variant of the boater hat from medium clues.
+  about: |-
+    The green boater is a cosmetic head slot hat awarded from medium Treasure Trail caskets. It provides no combat bonuses and is purely fashionscape, with several colour variants in the same clue pool.
+  market_strategy:
+    notes:
+      - "GE buy limit of 4 keeps the price thin and easy to manipulate."
+      - "Fashionscape demand swells whenever Castle Drakan emote clues rotate in."
+  trading_tips:
+    - Snap up cheap boaters during clue scroll meta declines.
+    - Bundle with splitbark body and dragon sq shield for emote clue ready sets.
+  history:
+    - date: "2006-02-20"
+      description: "Green boater released alongside the original boater hat clue rewards."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-d-hide-vambraces.mdx
@@ -12,87 +12,106 @@ osrs:
   lowalch: 1000
   highalch: 1500
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dragonhide
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
-    type: ranged_armour
-    ranged_requirement: 40
-    defence_requirement: 0
-  attack_bonuses:
-    ranged: 8
-  defence_bonuses:
-    ranged: 6
-    magic: 4
-  crafting:
-    level: 57
-    xp: 62
+    weapon_type: null
+    attack_speed: null
+    weight: 0.283
+    requirements:
+      ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 8
+    defence_bonus:
+      stab: 1
+      slash: 2
+      crush: 2
+      magic: 2
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 57
       xp: 62
       materials:
         - item_name: Green dragon leather
-          item_id: 1745
           quantity: 1
         - item_name: Thread
-          item_id: 1734
           quantity: 1
-      product: Green d'hide vambraces
-      product_id: 1065
-      product_quantity: 1
-      facility: Needle and thread
+      tools:
+        - Needle
+      output_quantity: 1
   related_items:
-    - item_id: 1753
-      item_name: Green dragonhide
+    - item_name: Green dragonhide
       slug: green-dragonhide
       relationship: component
-      description: Raw material
-    - item_id: 1745
-      item_name: Green dragon leather
+      description: Raw hide tanned into leather
+    - item_name: Green dragon leather
       slug: green-dragon-leather
       relationship: component
-      description: Tanned hide
-    - item_id: 1135
-      item_name: Green d'hide body
+      description: Tanned crafting material
+    - item_name: Green d'hide body
       slug: green-dhide-body
-      relationship: alternative
-      description: Matching body
-    - item_id: 1099
-      item_name: Green d'hide chaps
+      relationship: set-piece
+      description: Matching torso slot armour
+    - item_name: Green d'hide chaps
       slug: green-dhide-chaps
-      relationship: alternative
-      description: Matching legs
-    - item_id: 2487
-      item_name: Blue d'hide vambraces
+      relationship: set-piece
+      description: Matching legs slot armour
+    - item_name: Blue d'hide vambraces
       slug: blue-dhide-vambraces
-      relationship: alternative
-      description: Higher tier vambraces
+      relationship: upgrade
+      description: Higher tier vambraces requiring 50 Ranged
   about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Crafting | 57 | 1 Green dragon leather |
-    | XP | 62 | - |
+    Green d'hide vambraces are the lowest tier of dragonhide hand wraps and the cheapest free-to-play ranged glove option. Released 29 March 2004, they require 40 Ranged to wield and grant +8 Ranged attack alongside modest defence.
 
-    | Stat | Value |
-    |------|-------|
-    | Ranged requirement | 40 |
-    | Defence requirement | None |
-    | Ranged attack | +8 |
-    | Ranged defence | +6 |
-    | Magic defence | +4 |
+    Crafters can fashion them at level 57 Crafting for 62 XP using green dragon leather, thread, and a needle. They are a staple early Crafting target due to fast tick speed and reliable demand.
   market_strategy:
     notes:
-      - First dragonhide glove tier
-      - F2P accessible
-      - Budget ranged gear
-      - Crafting training (62 XP)
-      - F2P ranged armor
-      - Budget gear
-      - Best F2P ranged gloves
-      - 1 leather per vambraces
-      - Lowest crafting level in set
-      - Fast crafting method
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "First dragonhide glove tier and the only F2P option"
+      - "1 leather plus thread per craft keeps margins thin but steady"
+      - "Watch leather prices to time bulk crafting flips"
+      - "Crafting at 57 yields 62 XP per pair"
+  trading_tips:
+    - Crafters list large stacks during double XP weekends
+    - Pair flips with green dragon leather to capture the spread
+  history:
+    - date: "2004-03-29"
+      description: "Released alongside the original dragonhide armour set"
+    - date: "2006-01-23"
+      description: "Renamed from Dragon vambraces to Green d'hide vamb"
+    - date: "2020-04-08"
+      description: "Display name expanded to Green d'hide vambraces"
+    - date: "2021-09-22"
+      description: "Stab defence reduced from +3 to +1; crush defence reduced from +4 to +2"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-firelighter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-firelighter.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 250
-  about: "Green firelighter is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: consumable
+    tier: low
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  related_items:
+    - item_name: Red firelighter
+      slug: red-firelighter
+      relationship: variant
+      description: "Red-colored firelighter variant."
+    - item_name: Blue firelighter
+      slug: blue-firelighter
+      relationship: variant
+      description: "Blue-colored firelighter variant."
+    - item_name: Purple firelighter
+      slug: purple-firelighter
+      relationship: variant
+      description: "Purple-colored firelighter variant."
+    - item_name: White firelighter
+      slug: white-firelighter
+      relationship: variant
+      description: "White-colored firelighter variant."
+  about: "Green firelighters are obtained from Treasure Trails reward caskets across all difficulty tiers and combine with logs to create green-colored fires. 250 green firelighters can be used to recolor a Phoenix pet to green; the recolor mechanic prompted the GE buy limit to be raised from 150 to 250."
+  market_strategy:
+    notes:
+      - "Demand spikes around Phoenix pet recolor projects (250-unit bulk consumption)."
+      - "Master tier supply (20-38 per drop, 1/151.6) is the dominant source."
+  trading_tips:
+    - "Stockpile during clue-event weekends when supply increases."
+    - "Sell into Phoenix recolor demand for short bursts of premium pricing."
+  history:
+    - date: "2006-02-20"
+      description: "Released as treasure trail rewards alongside other firelighter colors."
+    - date: "2020-01-29"
+      description: "Phoenix pet recolor mechanic added; GE buy limit raised from 150 to 250."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-huasca.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-huasca.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: null
-  about: "Grimy huasca is a members-only item in Old School RuneScape. High alchemy value: 15 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: herb
+    tier: low
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 58
+      xp: 11.8
+      materials:
+        - item_name: Grimy huasca
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Huasca
+      slug: huasca
+      relationship: product
+      description: "Clean herb produced by cleaning grimy huasca."
+    - item_name: Huasca seed
+      slug: huasca-seed
+      relationship: component
+      description: "Seed used to grow huasca herbs via Farming."
+  about: "Grimy huasca is a members-only herb introduced with the Varlamore update. Players clean it at Herblore level 58 for 11.8 experience, or use the Degrime spell (Magic 70, Herblore 58) for 83 Magic and 5.9 Herblore XP. Grown from huasca seeds at Farming 65."
+  market_strategy:
+    notes:
+      - "High trading volume averaging ~23k units daily makes flipping viable."
+      - "Cleaning yields lower XP than higher-tier herbs but offers a cheap entry point for Herblore training."
+  trading_tips:
+    - "Buy in bulk during peak hours when supply spikes from farm runs."
+    - "Clean grimy huasca into huasca herb if margin between grimy and clean is positive."
+  history:
+    - date: "2024-09-25"
+      description: "Added to the game with the Varlamore expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-chainskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthan-s-chainskirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthan's chainskirt | OSRS Price Data
-description: "Guthan's chainskirt: Guthan the Infested's chainskirt.. High alch: 165,000 GP, GE limit: 15."
+description: "Guthan's chainskirt is a members legs slot item requiring 70 Defence, part of Guthan the Infested's Barrows set. High alch: 165,000 GP, GE limit: 15."
 osrs:
   id: 4730
   name: Guthan's chainskirt
@@ -12,9 +12,90 @@ osrs:
   lowalch: 110000
   highalch: 165000
   limit: 15
-  about: "Guthan's chainskirt is a members-only item in Old School RuneScape. High alchemy value: 165,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: barrows-equipment
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 8.164
+    requirements:
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -14
+      ranged: -11
+    defence_bonus:
+      stab: 75
+      slash: 72
+      crush: 73
+      magic: 0
+      ranged: 82
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Barrows chest
+        quantity: "1"
+        rarity: "7 x 1/2,448"
+  related_items:
+    - item_name: Guthan's helm
+      slug: guthan-s-helm
+      relationship: set-piece
+      description: Helmet slot of the Guthan set
+    - item_name: Guthan's platebody
+      slug: guthan-s-platebody
+      relationship: set-piece
+      description: Body slot of the Guthan set
+    - item_name: Guthan's warspear
+      slug: guthan-s-warspear
+      relationship: set-piece
+      description: Weapon slot of the Guthan set
+    - item_name: Verac's plateskirt
+      slug: verac-s-plateskirt
+      relationship: alternative
+      description: Comparable Barrows legs piece with prayer bonus
+  about: |-
+    Guthan's chainskirt is the legs slot piece of Guthan the Infested's Barrows equipment, offering very strong melee defensive bonuses behind only a small set of late-game alternatives. Worn alongside the helm, platebody, and warspear it activates the Guthan set effect, granting successful melee attacks a 25 percent chance to heal the user for damage dealt.
+
+    The chainskirt degrades over 15 hours of combat and must be either fully repaired or fully degraded to be tradeable. Players commonly slot it for sustainable PvM training, especially in slayer tasks where consumables would otherwise dominate cost.
+  market_strategy:
+    notes:
+      - "Price tracks the full Guthan set demand and Barrows rune-pack values"
+      - "Fully repaired and fully degraded states only on the Grand Exchange"
+      - "Healing set effect keeps demand sticky among mid-game slayer accounts"
+      - "Watch for Barrows minigame buffs or new set effect interactions"
+  trading_tips:
+    - Compare Barrows chest profitability before buying off the GE
+    - Hold during weekend slayer demand and DMM-style events
+    - Sell into hype around new Barrows-related updates
+  history:
+    - date: "2005-05-09"
+      description: "Released with the Barrows minigame as part of Guthan the Infested's set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-platebody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix platebody | OSRS Price Data
-description: "Guthix platebody: Rune platebody in the colours of Guthix.. High alch: 39,000 GP, GE limit: 8."
+description: "Guthix platebody: Rune platebody in the colours of Guthix. High alch: 39,000 GP, GE limit: 8."
 osrs:
   id: 2669
   name: Guthix platebody
@@ -12,9 +12,93 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
-  about: "Guthix platebody is a free-to-play item in Old School RuneScape. High alchemy value: 39,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune-armour
+    tier: high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options: ["Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers: ["hard"]
+  related_items:
+    - item_name: Rune platebody
+      slug: rune-platebody
+      relationship: variant
+      description: Base rune platebody
+    - item_name: Guthix platelegs
+      slug: guthix-platelegs
+      relationship: set-piece
+      description: Matching platelegs
+    - item_name: Guthix full helm
+      slug: guthix-full-helm
+      relationship: set-piece
+      description: Matching helm
+    - item_name: Guthix kiteshield
+      slug: guthix-kiteshield
+      relationship: set-piece
+      description: Matching kiteshield
+  about: |-
+    | Bonus | Value |
+    |-------|-------|
+    | Stab defence | +82 |
+    | Slash defence | +80 |
+    | Prayer | +1 |
+
+    Hard clue cosmetic recolour of the rune platebody with identical defensive stats plus the iconic +1 prayer bonus from the god-aligned set. Requires 40 Defence and Dragon Slayer I to equip.
+  market_strategy:
+    notes:
+      - "Hard clue exclusive god-aligned recolour"
+      - "+1 prayer bonus when paired with full set"
+      - "F2P-equippable cosmetic upgrade"
+  trading_tips:
+    - Demand scales with Hard clue popularity events
+    - Sell as a set with other Guthix pieces for fashionscape premium
+  history:
+    - date: "2004-05-05"
+      description: "Released as a Treasure Trails reward alongside other god-aligned rune armour."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/icy-basalt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/icy-basalt.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 10000
-  about: "Icy basalt is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rock
+    tier: low
+  properties:
+    release_date: "2018-09-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Rub
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Basalt
+          quantity: 1
+        - item_name: Efh salt
+          quantity: 3
+        - item_name: Te salt
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  related_items:
+    - item_name: Basalt
+      slug: basalt
+      relationship: component
+      description: Base rock used in creation
+    - item_name: Efh salt
+      slug: efh-salt
+      relationship: component
+      description: Required salt ingredient
+    - item_name: Te salt
+      slug: te-salt
+      relationship: component
+      description: Required salt ingredient
+    - item_name: Stony basalt
+      slug: stony-basalt
+      relationship: alternative
+      description: Teleport to My Arm's home
+    - item_name: Sandy basalt
+      slug: sandy-basalt
+      relationship: alternative
+      description: Teleport to Lassar Undercity
+  about: "Icy basalt teleports the player to Weiss, north of the herb patches. Requires completion of Making Friends with My Arm to use. Consumed on use, providing a single one-way teleport ideal for herb runs and ice troll content."
+  market_strategy:
+    notes:
+      - "Created at slight loss; profit comes from teleport utility"
+      - "Bulk crafted by herb runners for Weiss patch access"
+      - "Demand tied to Weiss herb patch popularity"
+  trading_tips:
+    - Buy in bulk for herb run efficiency
+    - Compare price vs raw salts plus basalt to spot crafting margin
+  history:
+    - date: "2018-09-06"
+      description: "Released with the Making Friends with My Arm update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/imbued-heart.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/imbued-heart.mdx
@@ -12,69 +12,71 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 8
-  item:
-    type: magic_boost
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic-boost
+    tier: high
+  properties:
+    release_date: "2016-09-15"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.35
-  effect:
-    invigorate:
-      base_boost: 1
-      percent_boost: 10
-      max_boost_at_99: 10
-      cooldown_minutes: 7
-      resets_on_death: true
+    options:
+      - Invigorate
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Nuclear smoke devil
-        rate: 1/200
-      - source: Other superiors
-        rate: 1/200 - 1/1,376
-  market:
-    buy_limit: 8
-    price_estimate: 29000000
+        quantity: "1"
+        rarity: 1/200
+      - source: Colossal Hydra
+        quantity: "1"
+        rarity: 1/160
+      - source: Guardian drake
+        quantity: "1"
+        rarity: 1/368
+      - source: Greater abyssal demon
+        quantity: "1"
+        rarity: 1/352
+  passive_effects:
+    - name: Invigorate
+      description: "Boosts Magic by 1 + 10% of the player's Magic level (rounded down); 7-minute cooldown shared across all hearts owned, resets on death."
   related_items:
-    - item_id: 27277
-      item_name: Saturated heart
+    - item_name: Saturated heart
       slug: saturated-heart
       relationship: upgrade
-      description: Upgraded version
-    - item_id: 3040
-      item_name: Magic potion
+      description: Upgraded heart with +3 stronger boost and 5-minute cooldown.
+    - item_name: Magic potion
       slug: magic-potion
       relationship: alternative
-      description: Alternative boost
-    - item_id: 27616
-      item_name: Ancient essence
+      description: Common alternative magic boost.
+    - item_name: Ancient essence
       slug: ancient-essence
       relationship: component
-      description: Upgrade material
+      description: 150,000 essence consumed to upgrade into a saturated heart.
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Magic Boost |
-    | Tradeable | Yes |
-    | Weight | 0.35 kg |
+    The imbued heart is a rare drop from superior slayer monsters, providing a reusable Invigorate option that boosts Magic by 1 + 10% of the player's Magic level (10 at level 99) on a 7-minute cooldown shared across all hearts.
 
-    Invigorate:
-    - Boosts Magic by 1 + 10% of level
-    - At 99 Magic: +10 levels
-    - Cooldown: 7 minutes
-    - Resets on death
-
-    Essential for:
-    - Magic bossing
-    - Raids
-    - Any high-level magic content
-    - Unlimited uses
-
-    Best magic boost item in the game.
+    With 150,000 ancient essence it can be upgraded irreversibly into a saturated heart for a stronger boost without gradual drain and a 5-minute cooldown.
   market_strategy:
     notes:
-      - Farm superiors for drop
-      - Unlimited uses
-      - Upgrade to saturated
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply tracks superior slayer popularity (Nuclear smoke devil, Colossal Hydra)."
+      - "Long-term demand from raids, ToA, and TzKal-Zuk attempts keeps a strong floor."
+      - "Saturated heart upgrade sinks supply over time."
+  trading_tips:
+    - Track ancient essence prices to gauge saturated heart upgrade pressure.
+    - Watch superior slayer balance changes; rare-drop tweaks shift supply quickly.
+  history:
+    - date: "2016-09-15"
+      description: "Released as a rare drop from superior variants of slayer monsters."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/inquisitor-s-mace.mdx
@@ -12,112 +12,101 @@ osrs:
   lowalch: 2000000
   highalch: 3000000
   limit: 8
+  material:
+    type: mace
+    tier: high
+  properties:
+    release_date: "2020-02-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: mace
-    attack_style: crush
+    weapon_type: mace
     attack_speed: 4
-    tradeable: true
-    weight: 2.267
+    weight: 1.814
     requirements:
       attack: 75
-    stats:
-      attack_stab: 52
-      attack_crush: 95
+    attack_bonus:
+      stab: 52
+      slash: -4
+      crush: 95
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 89
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 2
-  set_bonus:
-    set_name: Inquisitor's
-    bonus_per_piece: 0.5
-    bonus_per_piece_with_mace: 2.5
-    full_set_bonus: 2.5
-    full_set_bonus_with_mace: 7.5
-    applies_to: crush accuracy and damage
+  passive_effects:
+    - name: Inquisitor's set synergy
+      description: "Each piece of Inquisitor's armour grants a 0.5% crush accuracy and damage bonus on its own, but wearing the mace alongside any piece scales each piece to 2.5% and the full four-piece set to 7.5%."
   drop_table:
     sources:
       - source: The Nightmare
-        source_id: 9425
-        combat_level: 814
         quantity: "1"
-        rarity: Very rare
-        drop_rate: 1/750 to 1/428
-        members_only: true
+        rarity: "1/750 to 1/428"
       - source: Phosani's Nightmare
-        source_id: 9416
-        combat_level: 814
         quantity: "1"
-        rarity: Very rare
-        drop_rate: 1/1,250
-        members_only: true
-  market:
-    buy_limit: 8
-    price_estimate: 550000000
+        rarity: "1/1,250"
   related_items:
-    - item_id: 24668
-      item_name: Inquisitor's great helm
+    - item_name: Inquisitor's great helm
       slug: inquisitors-great-helm
       relationship: set-piece
-      description: Set helm
-    - item_id: 24670
-      item_name: Inquisitor's hauberk
+      description: "Set helm contributing to the Inquisitor crush bonus"
+    - item_name: Inquisitor's hauberk
       slug: inquisitors-hauberk
       relationship: set-piece
-      description: Set body armor
-    - item_id: 24672
-      item_name: Inquisitor's plateskirt
+      description: "Set body contributing to the Inquisitor crush bonus"
+    - item_name: Inquisitor's plateskirt
       slug: inquisitors-plateskirt
       relationship: set-piece
-      description: Set leg armor
-    - item_id: 22324
-      item_name: Ghrazi rapier
+      description: "Set legs contributing to the Inquisitor crush bonus"
+    - item_name: Ghrazi rapier
       slug: ghrazi-rapier
       relationship: alternative
-      description: Stab equivalent
+      description: "Best-in-slot stab equivalent from Theatre of Blood"
+    - item_name: Blade of saeldor
+      slug: blade-of-saeldor
+      relationship: alternative
+      description: "Slash equivalent from the Gauntlet"
   about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +52 |
-    | Crush | +95 |
-    | Strength | +89 |
+    "A powerful mace once wielded by the turncloak Justiciar."
 
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +2 |
+    Inquisitor's mace is the crush-style counterpart to the Ghrazi rapier and blade of saeldor, dropped by The Nightmare and Phosani's Nightmare. It hits at a 4-tick speed with plus 95 crush, plus 52 stab and plus 89 strength, plus 2 prayer for sustainability at long boss trips.
 
-    Requirements: 75 Attack
-
-    With Inquisitor's Armour:
-
-    | Pieces | Bonus (without mace) | Bonus (with mace) |
-    |--------|---------------------|-------------------|
-    | Each piece | +0.5% | +2.5% |
-    | Full set | +2.5% | +7.5% |
-
-    Bonus applies to crush accuracy and damage.
-
-    The mace dramatically increases the set bonus from 2.5% to 7.5%.
-
-    BiS for crush-weak enemies:
-    - The Nightmare
-    - Kalphite Queen
-    - Cerberus
-    - Tekton (Chambers of Xeric)
-    - Corporeal Beast (spec switching)
-    - Sarachnis
-
-    | Weapon | Attack | Strength | Special |
-    |--------|--------|----------|---------|
-    | Inquisitor's mace | +95 crush | +89 | Set bonus |
-    | Ghrazi rapier | +94 stab | +89 | None |
-    | Blade of saeldor | +94 slash | +89 | None |
+    The mace's real value is the Inquisitor armour set synergy: each piece on its own grants 0.5% crush accuracy and damage, but combined with the mace each piece scales to 2.5% and the full four-piece set reaches 7.5%. That bonus makes the mace the best-in-slot crush option against crush-weak targets like The Nightmare itself, Tekton in Chambers of Xeric, Kalphite Queen and Cerberus.
   market_strategy:
     notes:
-      - Most expensive Nightmare unique
-      - Best with full Inquisitor set
-      - 7.5% set bonus is substantial
-      - Nightmare/Phosani grind
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Most expensive Nightmare unique with limited drop sources keeping supply tight"
+      - "Buy limit of 8 per 4 hours discourages whales from snapping the float fast"
+      - "Price is heavily tied to Inquisitor set demand because the mace shines with armour"
+      - "Watch for Tombs of Amascut and Tekton-meta shifts which spike crush gear demand"
+  trading_tips:
+    - Track Nightmare team kill rates; supply spikes after community events
+    - Pair-buy with armour pieces if the set bonus is what you actually want
+  history:
+    - date: "2020-02-06"
+      description: "Released alongside The Nightmare boss."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/insulated-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/insulated-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Insulated boots | OSRS Price Data
-description: "Insulated boots: They're heavily insulated wellies.. High alch: 120 GP, GE limit: 70."
+description: "Insulated boots: They're heavily insulated wellies. High alch: 120 GP, GE limit: 70."
 osrs:
   id: 7159
   name: Insulated boots
@@ -12,9 +12,82 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 70
-  about: "Insulated boots is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 1.36
+    requirements:
+      slayer: 37
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 1
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Electric damage reduction
+      description: Reduces damage taken from Killerwatts, rune dragons' electric strikes, and Verzik Vitur's electric ball attacks. Negates shock damage in Darkness of Hallowvale.
+  shops:
+    - shop_name: Slayer Equipment
+      location: Any Slayer Master
+      price: 200
+      currency: Coins
+      stock: 50
+  related_items:
+    - item_name: Spiny helmet
+      slug: spiny-helmet
+      relationship: alternative
+      description: Slayer-required gear for sea snakes
+    - item_name: Earmuffs
+      slug: earmuffs
+      relationship: alternative
+      description: Slayer-required gear against banshees
+    - item_name: Mirror shield
+      slug: mirror-shield
+      relationship: alternative
+      description: Slayer-required gear for cockatrices
+  about: "Insulated boots are Slayer-required boots that reduce electric damage from Killerwatts, rune dragons, and Verzik Vitur. Purchased from any Slayer Master for 200 coins."
+  market_strategy:
+    notes:
+      - "Shop-bought infinite supply caps GE price near 200 gp baseline"
+      - "Demand spikes for rune dragon and ToB content"
+      - "Flipping margin minimal due to shop availability"
+  trading_tips:
+    - Buy directly from a Slayer Master for the cheapest copy
+    - Keep one in your bank for rune dragon trips and ToB Verzik
+  history:
+    - date: "2006-02-20"
+      description: "Released alongside the Killerwatt Plane Slayer update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-axe.mdx
@@ -12,9 +12,106 @@ osrs:
   lowalch: 22
   highalch: 33
   limit: 40
-  about: "Iron axe is a free-to-play item in Old School RuneScape. High alchemy value: 33 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: axe
+    attack_speed: 5
+    weight: 1.36
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: -2
+      slash: 5
+      crush: 3
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 16
+      xp: 25
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Bob's Brilliant Axes
+      location: Lumbridge
+      price: 56
+      currency: coins
+      stock: 5
+    - shop_name: Aemad's Adventuring Supplies
+      location: East Ardougne
+      price: 72
+      currency: coins
+      stock: 2
+    - shop_name: Perry's Chop-chop Shop
+      location: Woodcutting Guild
+      price: 179
+      currency: coins
+      stock: 3
+  related_items:
+    - item_name: Bronze axe
+      slug: bronze-axe
+      relationship: downgrade
+      description: Lower-tier woodcutting axe
+    - item_name: Steel axe
+      slug: steel-axe
+      relationship: upgrade
+      description: Higher-tier woodcutting axe
+    - item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Smithing material
+  about: |-
+    Iron axe is an early-game woodcutting and combat tool. Doubles as a 2H-style weapon with notable Strength bonus for its tier.
+  market_strategy:
+    notes:
+      - "Free-to-play accessibility caps the ceiling"
+      - "New accounts and ironmen drive baseline demand"
+      - "Shop floor limits dump potential"
+  trading_tips:
+    - High alch only profitable when GE under 33 coins
+    - Smith from bars when bar prices crash
+  history:
+    - date: "22 June 2005"
+      description: "Examine text corrected to A woodcutter's axe."
+    - date: "11 September 2014"
+      description: "Axes can no longer be broken during woodcutting."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-javelin-tips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron javelin tips | OSRS Price Data
-description: "Iron javelin tips: Needs a shaft.. High alch: 21 GP, GE limit: 10,000."
+description: "Iron javelin tips are smithed from iron bars and combined with javelin shafts to fletch iron javelins. High alch: 21 GP, GE limit: 10,000."
 osrs:
   id: 19572
   name: Iron javelin tips
@@ -12,9 +12,82 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 10000
-  about: "Iron javelin tips is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ammunition-component
+    tier: low
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 21
+      xp: 25
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 5
+    - skill: fletching
+      level: 17
+      xp: 30
+      materials:
+        - item_name: Iron javelin tips
+          quantity: 15
+        - item_name: Javelin shaft
+          quantity: 15
+      tools: []
+      output_quantity: 15
+  related_items:
+    - item_name: Iron javelin
+      slug: iron-javelin
+      relationship: product
+      description: Finished ranged ammunition
+    - item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Smithing input that produces five tips
+    - item_name: Javelin shaft
+      slug: javelin-shaft
+      relationship: component
+      description: Fletching partner that creates iron javelins
+    - item_name: Steel javelin tips
+      slug: steel-javelin-tips
+      relationship: upgrade
+      description: Next-tier javelin tip
+  about: |-
+    Iron javelin tips are smithed from a single iron bar on an anvil at 21 Smithing, producing five tips and granting 25 Smithing experience. They are members-only and used exclusively as a Fletching component.
+
+    At 17 Fletching, players combine 15 iron javelin tips with 15 javelin shafts to produce 15 iron javelins for 30 Fletching experience. The pipeline is a popular low-level Fletching skilling method when shaft and bar prices line up.
+  market_strategy:
+    notes:
+      - "Price tracks iron bar and javelin shaft supply"
+      - "Low-level fletchers create steady GE volume"
+      - "Margins thin so flips work best in bulk near the buy limit"
+      - "Sensitive to bond pricing and bot waves on iron rocks"
+  trading_tips:
+    - Compare iron bar vs tip price for smithing arbitrage
+    - Buy when iron bars dip from mining bot waves
+    - Stockpile for double XP weekends
+  history:
+    - date: "2016-05-06"
+      description: "Released as part of the Monkey Madness II update."
+    - date: "2025-11-19"
+      description: "Renamed from 'Iron javelin heads' to 'Iron javelin tips'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-nails.mdx
@@ -12,73 +12,97 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: nails
-    tier: iron
-  smithing:
-    level: 19
-    xp: 25
-    bars: 1
-    nails_per_bar: 15
-  construction:
-    bend_rate: High
-    min_level: 1
+    tier: low
+  properties:
+    release_date: "2005-05-17"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: smithing
       level: 19
       xp: 25
       materials:
         - item_name: Iron bar
-          item_id: 2351
           quantity: 1
-      product: Iron nails
-      product_id: 4820
-      product_quantity: 15
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 15
+  shops:
+    - shop_name: Sawmill
+      location: Sawmill
+      price: 5
+      currency: coins
+      stock: 1000
+    - shop_name: Woodcutting Guild Shop
+      location: Woodcutting Guild
+      price: 5
+      currency: coins
+      stock: 1000
+    - shop_name: Prifddinas Construction Shop
+      location: Prifddinas
+      price: 5
+      currency: coins
+      stock: 1000
+    - shop_name: Auburnvale Construction Shop
+      location: Auburnvale
+      price: 5
+      currency: coins
+      stock: 1000
+    - shop_name: Port Piscarilius Construction Shop
+      location: Port Piscarilius
+      price: 4
+      currency: coins
+      stock: 500
+    - shop_name: Shipyard Construction Shop
+      location: Shipyard
+      price: 5
+      currency: coins
+      stock: 1000
   related_items:
-    - item_id: 2351
-      item_name: Iron bar
+    - item_name: Iron bar
       slug: iron-bar
       relationship: component
-      description: Smelting material
-    - item_id: 4819
-      item_name: Bronze nails
+      description: "Smelted to make 15 nails per bar"
+    - item_name: Bronze nails
       slug: bronze-nails
       relationship: downgrade
-      description: Higher bend rate
-    - item_id: 1539
-      item_name: Steel nails
+      description: "Highest bend rate, cheaper tier"
+    - item_name: Steel nails
       slug: steel-nails
       relationship: upgrade
-      description: Most common nails
-    - item_id: 960
-      item_name: Plank
+      description: "Medium bend rate, recommended Construction nail"
+    - item_name: Plank
       slug: plank
       relationship: component
-      description: Used with planks
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Bend rate | High |
-    | Construction level | 1+ |
-    | Used with | Planks |
-
-    Note: Iron nails still have a high bend rate. Consider steel nails instead.
-
-    | Nails | Bend Rate |
-    |-------|-----------|
-    | Bronze | Highest |
-    | Iron | High |
-    | Steel | Medium |
-    | Mithril | Low |
-    | Adamantite | Very Low |
-    | Rune | Never bends |
+      description: "Used together with planks for Construction builds"
+  about: "Iron nails are used in Construction to attach planks. They have a high bend rate compared to steel, mithril, and higher tier nails, so most builders skip them in favour of steel."
   market_strategy:
     notes:
-      - Slightly better than bronze nails
-      - Still bends frequently
-      - Steel nails recommended for training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheap nails but bend frequently when hammered into planks"
+      - "Steel nails are the standard pick for serious Construction training"
+      - "Buyable in bulk from Sawmill and other Construction shops"
+  history:
+    - date: "2026-05-27"
+      description: "Item graphically updated to better match other iron items."
+    - date: "2005-07-05"
+      description: "Item value increased from 0 to 4 coins."
+    - date: "2005-05-17"
+      description: "Item released to the game."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-plateskirt.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 125
-  about: "Iron plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2001-02-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.164
+    options:
+      - Drop
+    worn_options:
+      - Wear
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 8.164
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: -4
+      ranged: 10
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 31
+      xp: 75
+      materials:
+        - item_name: Iron bar
+          quantity: 3
+      tools:
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Iron platelegs
+      slug: iron-platelegs
+      relationship: alternative
+      description: Heavy legs alternative for the same defensive slot.
+    - item_name: Iron platebody
+      slug: iron-platebody
+      relationship: set-piece
+      description: Matching body slot piece smithed from iron bars.
+    - item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: set-piece
+      description: Matching head slot piece in the iron armour set.
+  about: |-
+    Iron plateskirts are smithed from 3 iron bars at level 31 Smithing for 75 XP and provide identical bonuses to iron platelegs at a cosmetic alternative. They are members and F2P safe.
+  market_strategy:
+    notes:
+      - "Profit is sensitive to iron bar price volatility."
+      - "High alch arbitrage rarely beats nature rune costs at this tier."
+  trading_tips:
+    - Buy iron bars at Varrock when 2t powermining floods supply.
+    - Resell smithed plateskirts to clue scroll cosmetic collectors.
+  history:
+    - date: "2001-02-13"
+      description: "Iron plateskirt released with the original RuneScape armour roster."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus decreased from -7 to -11."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-spear.mdx
@@ -12,9 +12,110 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 125
-  about: "Iron spear is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 8
+      slash: 8
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 10
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 20
+      xp: 50
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+        - item_name: Oak logs
+          quantity: 1
+      tools:
+        - Barbarian anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Fortis Blacksmith
+      location: Fortis
+      price: 91
+      currency: coins
+      stock: 0
+    - shop_name: Elder Blunn's Spear and Shield Stall
+      location: Land's End
+      price: 91
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Iron spear(p)
+      slug: iron-spear-p
+      relationship: variant
+      description: "Poisoned variant of the iron spear."
+    - item_name: Iron spear(p+)
+      slug: iron-spear-p-plus
+      relationship: variant
+      description: "Iron spear poisoned with weapon poison+."
+    - item_name: Iron spear(p++)
+      slug: iron-spear-p-plus-plus
+      relationship: variant
+      description: "Iron spear poisoned with weapon poison++."
+    - item_name: Iron spear(kp)
+      slug: iron-spear-kp
+      relationship: variant
+      description: "Karambwan paste poisoned variant."
+    - item_name: Bronze spear
+      slug: bronze-spear
+      relationship: downgrade
+      description: "Lower-tier bronze spear with weaker bonuses."
+    - item_name: Steel spear
+      slug: steel-spear
+      relationship: upgrade
+      description: "Higher-tier steel spear with stronger bonuses."
+  about: "The iron spear is an early-tier two-handed melee weapon released with the introduction of spears in 2003. Craftable at level 20 Smithing via Barbarian Smithing using an iron bar and oak logs at a barbarian anvil. Used as a low-level spear option and required for several PvM niches such as bone spear use at Dagannoth Kings."
+  market_strategy:
+    notes:
+      - "Cheap entry-tier spear; high GE buy limit (125) supports flipping."
+      - "Demand from new players starting Barbarian Smithing or low-level PvM."
+  trading_tips:
+    - "Buy at shop value (91 gp) during empty restocks and resell on GE for margin."
+    - "Pair with weapon poison vials to flip poisoned variants for additional profit."
+  history:
+    - date: "2003-04-14"
+      description: "Released alongside the introduction of spear-type weapons."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-darkness.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-darkness.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jar of darkness | OSRS Price Data
-description: "Jar of darkness: It smells like it's been where the sun doesn't shine.. High alch: 1 GP, GE limit: 4."
+description: "Jar of darkness: It smells like it's been where the sun doesn't shine. High alch: 1 GP, GE limit: 4."
 osrs:
   id: 19701
   name: Jar of darkness
@@ -12,45 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  item:
-    type: jar
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: collectible
+    tier: high
+  properties:
+    release_date: "2016-06-16"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.04
-  obtaining:
-    methods:
+    options: ["View", "Drop"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
       - source: Skotizo
-        drop_rate: 1/200
-  usage:
-    description: Decoration for Achievement Gallery boss lair display
-    requirements: Defeating Skotizo at least once to place
-    cosmetic: true
+        quantity: "1"
+        rarity: 1/200
   related_items:
-    - item_id: 0
-      item_name: Jar of souls
+    - item_name: Jar of souls
       slug: jar-of-souls
       relationship: alternative
-      description: Similar jar drop
-    - item_id: 19685
-      item_name: Dark totem
+      description: Similar boss jar drop
+    - item_name: Dark totem
       slug: dark-totem
+      relationship: component
+      description: Required to summon Skotizo
+    - item_name: Skotizo's club
+      slug: skotos
       relationship: alternative
-      description: Used to fight Skotizo
+      description: Other unique drop from Skotizo
   about: |-
     | Property | Value |
     |----------|-------|
     | Slot | N/A |
-    | Type | Jar |
+    | Type | Boss jar |
     | Tradeable | Yes |
     | Weight | 0.04 kg |
-    | Requirements | None |
+    | Source | Skotizo |
+    | Drop rate | 1/200 |
 
-    Decoration for Achievement Gallery boss lair display.
-
-    Requires defeating Skotizo at least once to place.
-
-    Cosmetic/collectible item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Collectible jar drop from Skotizo. Viewing it briefly blacks the screen with "You view the darkness." Can be displayed in the Achievement Gallery boss lair after defeating Skotizo at least once.
+  market_strategy:
+    notes:
+      - "Skotizo collectible — low buy limit (4)"
+      - "Drop rate buffed from 1/2,500 to 1/200 in November 2022"
+      - "Demand driven by Achievement Gallery completionists"
+  trading_tips:
+    - Supply rises in tandem with Dark totem trade volume
+    - Price floor follows nostalgia / completionist cycles
+  history:
+    - date: "2016-06-16"
+      description: "Released as a rare Skotizo drop with the Catacombs of Kourend update."
+    - date: "2022-11-30"
+      description: "Drop rate buffed from 1/2,500 to 1/200 after community poll."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-decay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-decay.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Jar of decay is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: jar
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.04
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Vorkath (post-quest)
+        quantity: "1"
+        rarity: 1/3000
+  related_items:
+    - item_name: Vorkath's head
+      slug: vorkaths-head
+      relationship: alternative
+      description: Other rare Vorkath collectible
+    - item_name: Jar of dirt
+      slug: jar-of-dirt
+      relationship: alternative
+      description: Zulrah boss jar
+    - item_name: Jar of swamp
+      slug: jar-of-swamp
+      relationship: alternative
+      description: Zulrah boss jar
+    - item_name: Jar of smoke
+      slug: jar-of-smoke
+      relationship: alternative
+      description: Thermonuclear smoke devil jar
+  about: "Jar of decay is an ultra-rare 1 in 3,000 drop from post-quest Vorkath. It can be placed on a boss lair display in the player's achievement gallery to commemorate the kill. Using most bone types on the jar destroys them with the message that they decay into nothingness."
+  market_strategy:
+    notes:
+      - "Buy limit of only 4 makes flipping near-impossible"
+      - "Price driven entirely by collection and trophy demand"
+      - "Vorkath uptime and supply both heavily restricted"
+  trading_tips:
+    - Collectors should buy during Vorkath efficiency content waves
+    - Watch GE for cleared offers; supply dries up quickly
+  history:
+    - date: "2018-01-04"
+      description: "Released with the Dragon Slayer II quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leathertop-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leathertop-0.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 15
-  about: "Karil's leathertop 0 is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: barrows
+    tier: high
+  properties:
+    release_date: "9 May 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Check
+      - Remove
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
+    requirements:
+      defence: 70
+      ranged: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 47
+      slash: 42
+      crush: 50
+      magic: 65
+      ranged: 57
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Barrows reward chest
+        quantity: "1"
+        rarity: 7/2448
+  related_items:
+    - item_name: Karil's leathertop
+      slug: karil-s-leathertop
+      relationship: variant
+      description: Fully charged version
+    - item_name: Karil's leathertop 25
+      slug: karil-s-leathertop-25
+      relationship: variant
+      description: Partially charged variant
+    - item_name: Karil's leathertop 100
+      slug: karil-s-leathertop-100
+      relationship: variant
+      description: Fully repaired variant
+    - item_name: Karil's crossbow
+      slug: karil-s-crossbow
+      relationship: set-piece
+      description: Matching Karil's set weapon
+  about: |-
+    Karil's leathertop 0 is the broken state of Karil the Tainted's ranged body armour, requiring repair before further use. Provides best-in-slot ranged defence within the Barrows set.
+  market_strategy:
+    notes:
+      - "Repaired versions retain charge value, raising margin potential"
+      - "Broken stock floods after Barrows mass spins"
+      - "Ranged tank meta drives off-cycle demand"
+  trading_tips:
+    - Buy broken, repair at NPC for spread profit
+    - Sell into Barrows set demand windows
+  history:
+    - date: "9 May 2005"
+      description: "Released as part of the Barrows update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/king-worm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/king-worm.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "King worm is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.12
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: King worm scenery (Tree Gnome Stronghold, Taverley, Molch Island)
+        quantity: "1"
+        rarity: Always
+      - source: Gnome (thieving)
+        quantity: "1"
+        rarity: 3/128
+      - source: Gnome child (thieving)
+        quantity: "1"
+        rarity: 3/128
+      - source: Gnome woman (thieving)
+        quantity: "1"
+        rarity: 3/128
+  related_items:
+    - item_name: Druid pouch
+      slug: druid-pouch
+      relationship: alternative
+      description: Aerial fishing also uses worms but druid pouch is a separate ghast tool.
+    - item_name: Bird snare
+      slug: bird-snare
+      relationship: alternative
+      description: King worms bait aerial fishing spots alongside hunter trap items.
+  about: |-
+    King worms are a members-only food item gathered from worm spawns across the Tree Gnome Stronghold, Taverley, and Molch Island, or pickpocketed from gnomes. They heal 2 Hitpoints when eaten and act as bait for Molch Island aerial fishing.
+  market_strategy:
+    notes:
+      - "Aerial fishing demand sets a steady floor on the price."
+      - "Supply spikes when gnome thieving methods are popular."
+  trading_tips:
+    - Stack purchases in advance of aerial fishing meta updates.
+    - Resell in noted form to aerial fishers who hop banks in Prifddinas.
+  history:
+    - date: "2002-12-12"
+      description: "King worm released as a gnome delicacy and aerial fishing bait precursor."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kodai-wand.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kodai-wand.mdx
@@ -12,90 +12,97 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: kodai
+    tier: high
+  properties:
+    release_date: "2017-01-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.198
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: wand
-    attack_style: magic
-    attack_speed: 4
+    weapon_type: wand
+    attack_speed: 5
+    weight: 0.198
     requirements:
       magic: 80
-    stats:
-      attack_magic: 28
-      magic_damage_percent: 15
-  effect:
-    unlimited_water_runes: true
-    rune_save_chance: 15
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 28
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 3
+      magic: 20
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 15
+      prayer: 0
   recipes:
     - skill: none
       level: 0
       xp: 0
       materials:
         - item_name: Master wand
-          item_id: 6914
           quantity: 1
         - item_name: Kodai insignia
-          item_id: 21043
           quantity: 1
-      product: Kodai wand
-      product_id: 21006
-      product_quantity: 1
-      facility: None
-      members_only: true
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Unlimited water runes
+      description: "Acts as an infinite water rune source when equipped; combines with the tome of water for accuracy and damage on water spells."
+    - name: Rune conservation
+      description: "15% chance to negate rune costs when casting an offensive spell."
   related_items:
-    - item_id: 6914
-      item_name: Master wand
+    - item_name: Master wand
       slug: master-wand
       relationship: component
-      description: Base wand
-    - item_id: 21043
-      item_name: Kodai insignia
+      description: Base wand obtained from Mage Training Arena.
+    - item_name: Kodai insignia
       slug: kodai-insignia
       relationship: component
-      description: From Chambers of Xeric
-    - item_id: 24423
-      item_name: Harmonised nightmare staff
+      description: Rare drop from Chambers of Xeric used to upgrade the wand.
+    - item_name: Harmonised nightmare staff
       slug: harmonised-nightmare-staff
       relationship: alternative
-      description: Faster casting
+      description: Faster cast speed on the standard spellbook.
   about: |-
-    Attach Kodai insignia to Master wand.
+    The kodai wand is the best-in-slot magic damage one-handed at 80 Magic, built by attaching a Kodai insignia from the Chambers of Xeric to a master wand. The process is irreversible.
 
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Master wand | Mage Training Arena | ~1.5M gp |
-    | Kodai insignia | Chambers of Xeric | ~75M gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +28 |
-    | Magic damage | +15% |
-    | Attack speed | 4 tick (2.4s) |
-    | Requirements | 80 Magic |
-
-    Unlimited Water Runes:
-    - Acts as infinite water rune source
-    - Great for ice spells
-
-    Rune Saving:
-    - 15% chance to not consume runes
-    - Works with all offensive spells
-
-    PvM:
-    - Best-in-slot for ice barrage
-    - Bursting/barraging slayer
-    - Chambers of Xeric
-    - Inferno
-
-    PvP:
-    - Ice barrage in tribrid fights
-    - Saves runes over time
+    Combined with the tome of water it dominates Ice Barrage bursting, raids, and tribrid PvP, while the 15% rune save and infinite water runes meaningfully cut the cost of long magic sessions.
   market_strategy:
     notes:
-      - Insignia from CoX drives price
-      - Essential for mage setups
-      - Always strong demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Insignia supply from Chambers of Xeric raid throughput sets the floor."
+      - "Demand tracks CoX team usage and ice-barrage slayer popularity."
+      - "Stable best-in-slot since release; no direct replacement on standard spellbook."
+  trading_tips:
+    - Watch CoX scaling/loot changes for supply shifts.
+    - Compare against shadow staff for raids spend decisions before flipping volume.
+  history:
+    - date: "2017-01-05"
+      description: "Kodai insignia released as a CoX drop; players upgrade master wand into the kodai wand."
+    - date: "2022-05-04"
+      description: "Magic requirement raised from 75 to 80."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-oak-bed-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-oak-bed-flatpack.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Large oak bed (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 34
+      xp: 330
+      materials:
+        - item_name: Oak plank
+          quantity: 5
+        - item_name: Bolt of cloth
+          quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: "Primary plank material for the flatpack"
+    - item_name: Bolt of cloth
+      slug: bolt-of-cloth
+      relationship: component
+      description: "Cloth material for the bed"
+    - item_name: Large teak bed (flatpack)
+      slug: large-teak-bed-flatpack
+      relationship: upgrade
+      description: "Higher-tier teak variant"
+  about: |-
+    "How does it all fit in there?"
+
+    Large oak bed (flatpack) is a construction item built at the oak workbench in a player-owned house at 34 Construction for 330 experience. It takes 5 oak planks and 2 bolts of cloth per flatpack, and lets a builder ship a complete bed to a friend's house without bringing the workbench themselves.
+
+    Flatpacks are how most players actually pay for Construction XP at scale, but the large oak bed runs at a loss versus raw materials at current GE prices. It exists primarily for ironmen building bedrooms in their own house or for high-level players powering through quick last-XP construction goals where convenience beats break-even economics.
+  market_strategy:
+    notes:
+      - "Net loss per flatpack at current GE prices makes profitable flipping rare"
+      - "500 buy limit caps supply manipulation"
+      - "Real demand is from POH builders shortcutting Construction progress"
+  trading_tips:
+    - Compare against raw plank plus cloth cost before crafting for resale
+    - Watch for double-XP weekends, when flatpack demand spikes briefly
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Player-Owned Houses Construction skill update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-oak-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-oak-hull-parts.mdx
@@ -5,16 +5,64 @@ osrs:
   id: 32065
   name: Large oak hull parts
   slug: large-oak-hull-parts
-  examine: Parts for creating an oak hull for larger boats.
+  examine: Large parts for creating an oak hull for a large boat.
   members: true
   icon: Large oak hull parts.png
   value: 3125
   lowalch: 1250
   highalch: 1875
   limit: null
-  about: "Large oak hull parts is a members-only item in Old School RuneScape. High alchemy value: 1,875 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: shipwright_component
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
+  recipes:
+    - skill: construction
+      level: 8
+      xp: 2.5
+      materials:
+        - item_name: Oak hull parts
+          quantity: 5
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Oak hull parts
+      slug: oak-hull-parts
+      relationship: component
+      description: Combined into large oak hull parts at the Shipwrights' workbench
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Upstream material for oak hull parts
+  about: "Large oak hull parts are crafted at the Shipwrights' workbench by combining five oak hull parts. Sixteen large oak hull parts are required to complete a full oak sloop hull."
+  market_strategy:
+    notes:
+      - "Created from oak hull parts (and ultimately oak planks)"
+      - "Used in bulk for sloop hull construction"
+      - "No buy limit listed on the Grand Exchange"
+  trading_tips:
+    - Track oak plank pricing to estimate margin
+    - Demand scales with shipwright training popularity
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Shipwrighting expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-leaves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-leaves.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Magic leaves is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: leaves
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Magic tree (Forestry kit chance)
+        quantity: "1"
+        rarity: 1/4
+      - source: Curing a diseased magic tree (Farming)
+        quantity: "1"
+        rarity: Always
+      - source: Forestry events (Struggling sapling, Friendly ent)
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Magic logs
+      slug: magic-logs
+      relationship: alternative
+      description: Primary woodcutting yield from a magic tree.
+    - item_name: Cooked chicken
+      slug: cooked-chicken
+      relationship: component
+      description: Combined with magic leaves to make forester's rations.
+    - item_name: Forester's ration
+      slug: foresters-ration
+      relationship: product
+      description: Cooking product that grants extra logs while woodcutting.
+  about: |-
+    Magic leaves are gathered while chopping magic trees with a Forestry kit or curing diseased magic trees. They stack in the inventory and feed into forester's rations or compost bins.
+  market_strategy:
+    notes:
+      - "Forestry-meta drives most of the demand for magic leaves."
+      - "Stackable + zero weight makes it easy to bulk for crafters."
+  trading_tips:
+    - Buy when Forestry events rotate out of the spotlight.
+    - Bulk to forester's ration producers ahead of woodcutting double XP events.
+  history:
+    - date: "2005-07-11"
+      description: "Magic leaves introduced with the magic tree Farming and Woodcutting rework."
+    - date: "2023-06-01"
+      description: "Magic leaves became tradeable on the Grand Exchange following Forestry release."
+    - date: "2023-10-01"
+      description: "Magic leaves were made stackable in the inventory."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magic sapling | OSRS Price Data
-description: "Magic sapling: This sapling is ready to be replanted in a tree patch.. High alch: 1 GP, GE limit: 200."
+description: "Magic sapling: This sapling is ready to be replanted in a tree patch. High alch: 1 GP, GE limit: 200."
 osrs:
   id: 5374
   name: Magic sapling
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Magic sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Plant
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 75
+      xp: 145.5
+      materials:
+        - item_name: Magic sapling
+          quantity: 1
+      tools:
+        - Spade
+      output_quantity: 1
+  related_items:
+    - item_name: Magic seed
+      slug: magic-seed
+      relationship: component
+      description: Seed required to grow the seedling
+    - item_name: Magic seedling
+      slug: magic-seedling
+      relationship: component
+      description: Seedling stage prior to becoming a sapling
+    - item_name: Magic tree
+      slug: magic-tree
+      relationship: product
+      description: Fully grown tree from the sapling
+    - item_name: Magic logs
+      slug: magic-logs
+      relationship: product
+      description: Harvested from a fully grown magic tree
+  about: "Magic sapling is the planted stage of the magic tree, created by watering a magic seedling in a filled plant pot. Planting requires 75 Farming and the tree takes 8 hours to mature, granting 13,768.3 experience on check-health."
+  market_strategy:
+    notes:
+      - "Saplings sell at premium vs raw seeds due to planted XP timing"
+      - "Buy limit of 200 caps daily volume for bulk planters"
+      - "Price tracks magic seed availability and farming bot bans"
+  trading_tips:
+    - Cheaper than raising your own seedling if time is limited
+    - Always pay gardeners 25 coconuts to protect during 8h grow time
+  history:
+    - date: "2005-07-11"
+      description: "Released alongside the Farming skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magpie-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magpie-impling-jar.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magpie impling jar | OSRS Price Data
-description: "Magpie impling jar: Magpie impling in a jar.. High alch: 30 GP, GE limit: 18,000."
+description: "Magpie impling jar is a members Hunter loot jar requiring 65 Hunter. High alch: 30 GP, GE limit: 18,000."
 osrs:
   id: 11252
   name: Magpie impling jar
@@ -12,9 +12,60 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  about: "Magpie impling jar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: impling-jar
+    tier: mid
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "If you drop this it will disappear. Are you sure you want to do this?"
+  related_items:
+    - item_name: Magpie impling
+      slug: magpie-impling
+      relationship: component
+      description: Wild impling captured to create the jar
+    - item_name: Empty impling jar
+      slug: empty-impling-jar
+      relationship: component
+      description: Holds the impling; can be reused after looting
+    - item_name: Nature impling jar
+      slug: nature-impling-jar
+      relationship: alternative
+      description: Lower tier impling jar with seed-focused loot
+  about: |-
+    Magpie impling jar contains a captured Magpie impling, the fourth tier impling caught with 65 Hunter. Released 11 June 2007 with Impetuous Impulses, the jar can be looted for valuable rewards including gems, hard clue scrolls, and rings of recoil.
+
+    Looting destroys the impling and returns an empty impling jar 90% of the time. Players can also trade three jars to Elnock Inquisitor for additional empty jars, making bulk hunting profitable on the Grand Exchange.
+  market_strategy:
+    notes:
+      - "Loot table refresh in 2023 added rings of recoil to the rewards"
+      - "18,000 buy limit supports bulk loot flips"
+      - "Empty impling jar return rate is roughly 90% per loot action"
+  trading_tips:
+    - Open in bulk to convert into rare clue and ring of recoil loot
+    - Track Hunter task popularity to time GE flip windows
+  history:
+    - date: "2007-06-11"
+      description: "Released with the Impetuous Impulses minigame"
+    - date: "2015-03-05"
+      description: "Made tradeable on the Grand Exchange"
+    - date: "2016-04-21"
+      description: "Hard clue scrolls added to the loot table"
+    - date: "2023-03-09"
+      description: "Rings of recoil added to the loot table"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-bird-house.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-bird-house.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 250
-  about: "Mahogany bird house is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: hunter_trap
+    tier: mid
+  properties:
+    release_date: "18 January 2018"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 50
+      xp: 40
+      materials:
+        - item_name: Mahogany logs
+          quantity: 1
+        - item_name: Clockwork
+          quantity: 1
+      tools:
+        - Chisel
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Mahogany logs
+      slug: mahogany-logs
+      relationship: component
+      description: Required log material
+    - item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: Required mechanism
+    - item_name: Yew bird house
+      slug: yew-bird-house
+      relationship: downgrade
+      description: Lower-tier bird house variant
+    - item_name: Redwood bird house
+      slug: redwood-bird-house
+      relationship: upgrade
+      description: Higher-tier bird house variant
+  about: |-
+    Mahogany bird house is a Hunter trap placed on Fossil Island. Requires 49 Hunter to deploy and yields 960 Hunter XP per cycle.
+  market_strategy:
+    notes:
+      - "Demand follows Fossil Island bird house run popularity"
+      - "Clockwork cost dictates floor price"
+      - "Bulk crafters supply the GE in batches"
+  trading_tips:
+    - Buy clockworks and mahogany logs separately when assembled price is high
+    - Watch for Hunter XP method meta shifts
+  history:
+    - date: "18 January 2018"
+      description: "Added with the Fossil Island Improvements update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Menaphite purple top | OSRS Price Data
-description: "Menaphite purple top: Colourful.. High alch: 12 GP, GE limit: 150."
+description: "Menaphite purple top: Colourful. High alch: 12 GP, GE limit: 150."
 osrs:
   id: 6394
   name: Menaphite purple top
@@ -12,9 +12,90 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 150
-  about: "Menaphite purple top is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-08-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.005
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Desert heat delay
+      description: Wearing the Menaphite purple top delays the onset of desert heat damage by 12 seconds.
+  shops:
+    - shop_name: Ali's Discount Wares
+      location: Al Kharid
+      price: 20
+      currency: Coins
+      stock: 25
+  related_items:
+    - item_name: Menaphite purple hat
+      slug: menaphite-purple-hat
+      relationship: set-piece
+      description: Hat of the purple Menaphite outfit
+    - item_name: Menaphite purple robe
+      slug: menaphite-purple-robe
+      relationship: set-piece
+      description: Robe of the purple Menaphite outfit
+    - item_name: Menaphite purple kilt
+      slug: menaphite-purple-kilt
+      relationship: set-piece
+      description: Kilt of the purple Menaphite outfit
+    - item_name: Menaphite red top
+      slug: menaphite-red-top
+      relationship: variant
+      description: Red color variant of the top
+  about: "Menaphite purple top is a cosmetic body slot item sold by Ali's Discount Wares in Al Kharid. Part of the purple Menaphite outfit, it grants a 12-second delay to desert heat damage."
+  market_strategy:
+    notes:
+      - "Shop is essentially infinite supply, GE flips are minimal"
+      - "Light desert-heat utility keeps a small demand floor"
+      - "Fashionscape demand spikes around desert content updates"
+  trading_tips:
+    - Buy directly from Ali's Discount Wares for the cheapest entry
+    - Stack with full Menaphite set for the largest heat delay
+  history:
+    - date: "2005-08-15"
+      description: "Released as part of the Rogue Trader update."
+    - date: "2023-03-22"
+      description: "Added desert heat delay effect to all Menaphite outfits."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-remedy-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-remedy-4.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Menaphite remedy(4) is a members-only item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2022-08-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.14
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 6 + 16% of the player's combat stats (excluding Prayer) every 15 seconds, over the course of five minutes; counteracts the stat-draining effect of Saradomin brews."
+        duration: 300
+  recipes:
+    - skill: herblore
+      level: 88
+      xp: 200
+      materials:
+        - item_name: Dwarf weed potion (unf)
+          quantity: 1
+        - item_name: Lily of the sands
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Menaphite remedy(3)
+      slug: menaphite-remedy-3
+      relationship: variant
+      description: "3-dose variant of the Menaphite remedy."
+    - item_name: Menaphite remedy(2)
+      slug: menaphite-remedy-2
+      relationship: variant
+      description: "2-dose variant of the Menaphite remedy."
+    - item_name: Menaphite remedy(1)
+      slug: menaphite-remedy-1
+      relationship: variant
+      description: "1-dose variant of the Menaphite remedy."
+  about: |-
+    > _"4 doses of Menaphite remedy."_
+
+    Menaphite remedy is a herblore potion introduced with the Tombs of Amascut. The 4-dose flask restores 6 + 16% of combat stats (Prayer excluded) every 15 seconds for five minutes, making it the standard counter to Saradomin brew drains in PvM.
+  market_strategy:
+    notes:
+      - "Highly liquid: daily volume hovers near 28k units, so flips fill quickly even at tight margins."
+      - "Per-dose price closely tracks dwarf weed potion (unf) + lily of the sands; spikes when Herblore inputs gap up."
+      - "Demand pulses around new ToA challenge mode rotations and group raid resets."
+  trading_tips:
+    - "Cross-check with the (1)/(2)/(3) variants — decanting flips can extract value when 4-dose trades at a discount per dose."
+    - "Stockpile during Herblore double-XP events when grinders dump excess output."
+  history:
+    - date: "2022-08-24"
+      description: "Released alongside the Tombs of Amascut update as a Saradomin-brew counter."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platebody-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platebody-g.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 2080
   highalch: 3120
   limit: 8
-  about: "Mithril platebody (g) is a free-to-play item in Old School RuneScape. High alchemy value: 3,120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 46
+      slash: 44
+      crush: 38
+      magic: -6
+      ranged: 44
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: variant
+      description: "Standard untrimmed mithril platebody with identical combat stats."
+    - item_name: Mithril platebody (t)
+      slug: mithril-platebody-t
+      relationship: variant
+      description: "Silver-trimmed cosmetic variant from medium clue rewards."
+    - item_name: Mithril platelegs (g)
+      slug: mithril-platelegs-g
+      relationship: set-piece
+      description: "Matching gold-trimmed legs for the set."
+    - item_name: Mithril full helm (g)
+      slug: mithril-full-helm-g
+      relationship: set-piece
+      description: "Matching gold-trimmed helm for the set."
+    - item_name: Mithril kiteshield (g)
+      slug: mithril-kiteshield-g
+      relationship: set-piece
+      description: "Matching gold-trimmed kiteshield for the set."
+  about: "Mithril platebody (g) is a cosmetic gold-trimmed variant of the standard mithril platebody obtained from medium clue scroll caskets at a rarity of 1/1,133. It shares identical defensive stats with the standard mithril platebody and requires level 20 Defence to equip."
+  market_strategy:
+    notes:
+      - "Cosmetic-only premium over standard mithril platebody; collector-driven price."
+      - "Free-to-play tradeable, broadening the buyer pool."
+  trading_tips:
+    - "Hold over time as clue supply is steady but demand from set-collectors trickles in."
+    - "Complete the full gold trim set for resale at a premium versus piecemeal selling."
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-base.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-base.mdx
@@ -12,9 +12,116 @@ osrs:
   lowalch: 3600
   highalch: 5400
   limit: null
-  about: "Mixed hide base is a members-only item in Old School RuneScape. High alchemy value: 5,400 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crafting-material
+    tier: mid-high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Pellem's Fur Store"
+      location: "Hunter Guild"
+      price: 11700
+      currency: "coins"
+      stock: 10
+  recipes:
+    - skill: crafting
+      level: 69
+      xp: 75
+      materials:
+        - item_name: Mixed hide base
+          quantity: 1
+        - item_name: Sunlight antelope fur
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+    - skill: crafting
+      level: 68
+      xp: 62
+      materials:
+        - item_name: Mixed hide base
+          quantity: 1
+        - item_name: Fox fur
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+    - skill: crafting
+      level: 71
+      xp: 210
+      materials:
+        - item_name: Mixed hide base
+          quantity: 1
+        - item_name: Sunlight antelope fur
+          quantity: 2
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+    - skill: crafting
+      level: 72
+      xp: 150
+      materials:
+        - item_name: Mixed hide base
+          quantity: 1
+        - item_name: Jaguar fur
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools:
+        - Needle
+      output_quantity: 1
+  related_items:
+    - item_name: Mixed hide boots
+      slug: mixed-hide-boots
+      relationship: product
+      description: "Crafted from a mixed hide base and sunlight antelope fur."
+    - item_name: Mixed hide cape
+      slug: mixed-hide-cape
+      relationship: product
+      description: "Crafted from a mixed hide base and fox fur."
+    - item_name: Mixed hide legs
+      slug: mixed-hide-legs
+      relationship: product
+      description: "Crafted from a mixed hide base and two sunlight antelope furs."
+    - item_name: Mixed hide top
+      slug: mixed-hide-top
+      relationship: product
+      description: "Crafted from a mixed hide base and jaguar fur."
+  about: |-
+    > _"I need this to make mixed hide armour."_
+
+    The mixed hide base is the crafting backbone for the Hunters' Loot Sack II armour suite added with Varlamore. Each base pairs with a specific fur to tailor into one of four mixed hide pieces, and the only reliable supply is Pellem at the Hunter Guild.
+  market_strategy:
+    notes:
+      - "No GE limit, but trades thin volume — bulk orders from crafting flippers can move the spread sharply."
+      - "Shop price (11.7k) sits well below GE; fast-restock farming Pellem is the steady production path."
+      - "Demand spikes whenever a high-tier Hunter rework or BiS update points back at the mixed hide suite."
+  trading_tips:
+    - "Run Pellem's restock loop with multiple alts to bank cheap bases, then list against the GE buyout for a clean margin."
+    - "Pair listings with the matching fur (sunlight antelope, jaguar, fox) to corner the assembled armour market."
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore Part Two update as the shared crafting input for the mixed hide armour suite."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mole-claw.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mole-claw.mdx
@@ -12,47 +12,67 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 50
-  item_id: 7416
-  type: boss_drop
-  tradeable: true
-  weight: 0.001
-  buy_limit: 50
-  obtaining:
-    primary:
-      source: Giant Mole
-      location: Beneath Falador Park
-    other_sources:
-      - Molanisks
-      - Experiment No.2
-  usage:
-    exchange:
-      npc: Wyson the gardener
-      location: Falador Park
-      product: Bird nest
-      rate: 1:1
+  material:
+    type: boss_drop
+    tier: mid-high
+  properties:
+    release_date: "2006-03-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Giant Mole
+        quantity: "1"
+        rarity: Always
+      - source: Molanisk
+        quantity: "1"
+        rarity: 1/128
+      - source: Experiment No.2
+        quantity: "1"
+        rarity: 1/128
   related_items:
-    - slug: mole-skin
-      name: Mole skin
-      relation: also_dropped
-    - slug: bird-nest
-      name: Bird nest
-      relation: exchange_reward
-    - slug: giant-mole
-      name: Giant Mole
-      relation: drop_source
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Boss Drop |
-    | Tradeable | Yes |
-    | Weight | 0.001 kg |
-
-    Trade to Wyson the gardener (Falador Park) for bird nests.
-
-    Exchange rate: 1 mole claw = 1 bird nest
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Mole skin
+      slug: mole-skin
+      relationship: alternative
+      description: Other Giant Mole drop traded to Wyson
+    - item_name: Bird nest
+      slug: bird-nest
+      relationship: product
+      description: Received from Wyson in exchange for mole claws
+    - item_name: Baby mole
+      slug: baby-mole
+      relationship: alternative
+      description: Pet from Giant Mole; can transform into baby mole-rat using claws
+  about: "Mole claw is a guaranteed Giant Mole drop traded to Wyson the gardener in Falador Park for bird nests at a 1:1 rate. Also drops rarely from Molanisks and Experiment No.2."
+  market_strategy:
+    notes:
+      - "Tight buy limit of 50 limits bulk flipping"
+      - "Demand driven by bird nest seed money-makers"
+      - "Daily volume is high relative to buy limit"
+  trading_tips:
+    - Stock daily and resell into bird nest crash windows
+    - Pair with mole skin trades for max output
+  history:
+    - date: "2006-03-07"
+      description: "Item released with Giant Mole boss."
+    - date: "2015-03-25"
+      description: "Giant Mole began dropping noted claws after Falador Hard Diary completion."
+    - date: "2016-02-25"
+      description: "Bird nests from Wyson updated to contain more valuable seeds."
+    - date: "2021-04-14"
+      description: "Baby mole transformation into baby mole-rat using mole claws added."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-moth-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-moth-mix-1.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: null
-  about: "Moonlight moth mix (1) is a members-only item in Old School RuneScape. High alchemy value: 18 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 22 Prayer points per dose; in multicombat areas, up to three nearby players with Accept Aid enabled receive the same benefit."
+        duration: 0
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Moonlight moth (jarred)
+          quantity: 1
+        - item_name: Hunter meat
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  related_items:
+    - item_name: Moonlight moth mix (2)
+      slug: moonlight-moth-mix-2
+      relationship: variant
+      description: "Two-dose variant of the same Prayer-restoring mix."
+    - item_name: Moonlight moth
+      slug: moonlight-moth
+      relationship: component
+      description: "Jarred moth combined with hunter meat to produce the mix."
+  about: "Moonlight moth mix (1) is a single-dose Prayer restore introduced with Varlamore: Part One. It does not require Herblore to create and benefits nearby teammates in multicombat areas. High alchemy value: 18 coins."
+  market_strategy:
+    notes:
+      - "Demand rises with Varlamore Hunter content and group PvM where Accept Aid sharing is useful."
+      - "Profit margin versus crafting depends heavily on the chosen hunter meat ingredient."
+  trading_tips:
+    - "Track the jarred moth + hunter meat spread before buying mixes outright."
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore: Part One update as a no-Herblore Prayer alternative."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mort-myre-pear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mort-myre-pear.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Mort myre pear is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: quest
+    tier: low
+  properties:
+    release_date: "2004-07-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.113
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Bloom on small bush, Mort Myre Swamp (silver sickle (b))
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - item_name: Mort myre fungus
+      slug: mort-myre-fungus
+      relationship: alternative
+      description: More common bloom drop used for druid pouch charges.
+    - item_name: Mort myre stem
+      slug: mort-myre-stem
+      relationship: alternative
+      description: Bloom drop used for druid pouch and Nature Spirit progress.
+    - item_name: Silver sickle (b)
+      slug: silver-sickle-b
+      relationship: component
+      description: Blessed sickle required to cast Bloom in Mort Myre.
+    - item_name: Druid pouch
+      slug: druid-pouch
+      relationship: product
+      description: Pear adds three charges, protecting against ghasts in Mort Myre.
+  about: |-
+    Mort myre pears are a Bloom drop from small bushes in Mort Myre Swamp. They charge druid pouches and are a possible material for Fairytale I - Growing Pains.
+  market_strategy:
+    notes:
+      - "Bloom RNG keeps supply low and demand collector-driven."
+      - "Demand spikes during quest pushes that require Mort Myre exploration."
+  trading_tips:
+    - Stack pears alongside fungus and stems for druid pouch resale bundles.
+    - Watch for player events that route through the Theatre of Blood path.
+  history:
+    - date: "2004-07-13"
+      description: "Mort myre pear released with the Nature Spirit quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-body.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Mummy's body is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/12,765
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Mummy's head
+      slug: mummy-s-head
+      relationship: set-piece
+      description: Head piece of the mummy outfit
+    - item_name: Mummy's legs
+      slug: mummy-s-legs
+      relationship: set-piece
+      description: Legs piece of the mummy outfit
+    - item_name: Mummy's hands
+      slug: mummy-s-hands
+      relationship: set-piece
+      description: Hands piece of the mummy outfit
+    - item_name: Mummy's feet
+      slug: mummy-s-feet
+      relationship: set-piece
+      description: Feet piece of the mummy outfit
+  about: "Mummy's body is a cosmetic body slot item that is part of the mummy outfit, obtained as a rare reward from master clue caskets at a 1/12,765 chance."
+  market_strategy:
+    notes:
+      - "Extremely rare master clue reward"
+      - "Fashionscape demand drives high price"
+      - "Buy limit of 4 keeps liquidity thin"
+  trading_tips:
+    - Watch master clue completion trends to time buys
+    - Sell into hype windows for cosmetic outfits
+  history:
+    - date: "2016-07-06"
+      description: "Item released with master clue scrolls."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/musketeer-tabard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/musketeer-tabard.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 752
   highalch: 1128
   limit: 4
-  about: "Musketeer tabard is a members-only item in Old School RuneScape. High alchemy value: 1,128 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_name: Musketeer hat
+      slug: musketeer-hat
+      relationship: set-piece
+      description: "Head piece of the Musketeer cosmetic outfit."
+    - item_name: Musketeer pants
+      slug: musketeer-pants
+      relationship: set-piece
+      description: "Legs piece of the Musketeer cosmetic outfit."
+  about: |-
+    > _"All for one!"_
+
+    The Musketeer tabard is the body slot piece of the three-part Musketeer cosmetic outfit, dropped exclusively from elite clue caskets. It offers no combat bonuses and is purely a fashionscape statement piece.
+  market_strategy:
+    notes:
+      - "1/1,275 from elite caskets — supply is tied to elite clue completion volume."
+      - "Buy limit of 4 every 4 hours plus low daily volume creates wide bid/ask spreads."
+      - "Demand jumps when popular streamers cycle elite cosmetic transmogs into rotation."
+  trading_tips:
+    - "Cross-list with the hat and pants — full-set listings command a premium over loose pieces."
+    - "Costume room storage cycles supply back into the market sporadically; watch for outlier dumps after collection-log clearouts."
+  history:
+    - date: "2014-06-12"
+      description: "Released alongside the elite Treasure Trails expansion as the body slot of the Musketeer outfit."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-set-dusk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-set-dusk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic set (dusk) | OSRS Price Data
-description: "Mystic set (dusk): A set containing dusk mystic hat, robe top and bottom, gloves and boots.. High alch: 141,000 GP, GE limit: 70."
+description: "Mystic set (dusk): A set containing dusk mystic hat, robe top and bottom, gloves and boots. High alch: 141,000 GP, GE limit: 70."
 osrs:
   id: 23119
   name: Mystic set (dusk)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 94000
   highalch: 141000
   limit: 70
-  about: "Mystic set (dusk) is a members-only item in Old School RuneScape. High alchemy value: 141,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour-set
+    tier: high
+  properties:
+    release_date: "2019-03-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Mystic hat (dusk)
+      slug: mystic-hat-dusk
+      relationship: set-piece
+      description: Head slot piece included in the dusk set.
+    - item_name: Mystic robe top (dusk)
+      slug: mystic-robe-top-dusk
+      relationship: set-piece
+      description: Body slot piece included in the dusk set.
+    - item_name: Mystic robe bottom (dusk)
+      slug: mystic-robe-bottom-dusk
+      relationship: set-piece
+      description: Legs slot piece included in the dusk set.
+    - item_name: Mystic gloves (dusk)
+      slug: mystic-gloves-dusk
+      relationship: set-piece
+      description: Hands slot piece included in the dusk set.
+    - item_name: Mystic boots (dusk)
+      slug: mystic-boots-dusk
+      relationship: set-piece
+      description: Feet slot piece included in the dusk set.
+  about: |-
+    > *"A set containing dusk mystic hat, robe top and bottom, gloves and boots."*
+
+    Mystic set (dusk) is a Grand Exchange convenience bundle for the dusk-coloured mystic robes. Players assemble it through a Grand Exchange clerk to trade all five pieces in a single listing.
+  market_strategy:
+    notes:
+      - "Compare the GE set price against the sum of the five component prices for arbitrage opportunities."
+      - "Sets are typically used by sellers to clear inventory quickly rather than buyers seeking discounts."
+      - "GE limit of 70 sets every 4 hours allows steady wholesale flipping."
+  trading_tips:
+    - Break the set with a GE clerk to sell pieces individually when the component sum exceeds the set price.
+    - Build sets to consolidate stock when set price runs above component sum.
+  history:
+    - date: "2019-03-14"
+      description: "Added with the Mystic robes (dusk) cosmetic recolour update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-platelegs.mdx
@@ -12,86 +12,90 @@ osrs:
   lowalch: 26800
   highalch: 40200
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: obsidian
+    tier: high
+  properties:
+    release_date: "2017-06-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: melee_armor
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 9.071
     requirements:
       defence: 60
-    stats:
-      strength: 1
-      stab_def: 46
-      slash_def: 43
-      crush_def: 41
-      magic_def: -10
-      ranged_def: 40
-  set_bonus:
-    set_name: Obsidian
-    requirement: Full set + Obsidian weapon
-    damage_bonus: +10%
-    accuracy_bonus: +10%
-    stacks_with:
-      - item_id: 11128
-        item_name: Berserker necklace
-        additional_bonus: +20%
-  shop:
-    npc: TzHaar-Hur-Zal
-    location: Mor Ul Rek
-    price: 100500
-    currency: Tokkul
-  market:
-    buy_limit: 70
-    price_estimate: 830000
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 46
+      slash: 43
+      crush: 41
+      magic: -10
+      ranged: 40
+    other_bonus:
+      melee_strength: 1
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Obsidian set bonus
+      description: When worn with the obsidian helmet and platebody, all obsidian weapons receive +10% melee accuracy and +10% melee strength. Stacks with the berserker necklace (+20%).
+  drop_table:
+    sources:
+      - source: TzHaar-Ket (level 221)
+        quantity: "1"
+        rarity: 1/2000
+  shops:
+    - shop_name: TzHaar-Hur-Zal's Equipment Store
+      location: Mor Ul Rek
+      price: 100500
+      currency: Tokkul
+      stock: 1
   related_items:
-    - item_id: 21298
-      item_name: Obsidian helmet
+    - item_name: Obsidian helmet
       slug: obsidian-helmet
       relationship: set-piece
-      description: Helm slot
-    - item_id: 21301
-      item_name: Obsidian platebody
+      description: Helm slot of the Obsidian set
+    - item_name: Obsidian platebody
       slug: obsidian-platebody
       relationship: set-piece
-      description: Body armor
-    - item_id: 6525
-      item_name: Toktz-xil-ek
-      slug: toktz-xil-ek
-      relationship: alternative
-      description: Obsidian dagger
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Strength | +1 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +46 |
-    | Slash | +43 |
-    | Crush | +41 |
-    | Magic | -10 |
-    | Ranged | +40 |
-
-    Requirements: 60 Defence
-
-    Full Obsidian Set + Obsidian Weapon:
-    - +10% damage bonus
-    - +10% accuracy bonus
-    - Stacks with Berserker necklace (+20%)
-
-    Popular for:
-    - Training at TzHaar
-    - Budget melee training
-    - Fight Caves
-
-    Part of the Obsidian training set.
+      description: Body slot of the Obsidian set
+    - item_name: Berserker necklace
+      slug: berserker-necklace
+      relationship: component
+      description: Stacks +20% with the obsidian set bonus
+  about: "Obsidian platelegs are part of the Obsidian armour set. When combined with the obsidian helmet, platebody, and an obsidian weapon, players gain +10% melee accuracy and damage, stacking further with the berserker necklace."
   market_strategy:
     notes:
-      - Buy with Tokkul or GE
-      - Set bonus is powerful
-      - Good for training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Tokkul price (100,500) is cheaper than GE in many cases"
+      - "Karamja gloves reduce Tokkul cost to 87,100"
+      - "Demand spikes with TzHaar/Inferno content updates"
+  trading_tips:
+    - Farm Tokkul in Fight Caves or Inferno for the shop alternative
+    - Watch for armor set deals on the Grand Exchange
+  history:
+    - date: "2017-06-01"
+      description: "Released alongside The Inferno update as part of the Obsidian armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ogre-arrow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ogre arrow | OSRS Price Data
-description: "Ogre arrow: A large ogre arrow with a bone tip.. High alch: 15 GP, GE limit: 7,000."
+description: "Ogre arrow: A large ogre arrow with a bone tip. High alch: 15 GP, GE limit: 7,000."
 osrs:
   id: 2866
   name: Ogre arrow
@@ -12,9 +12,93 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 7000
-  about: "Ogre arrow is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ammunition
+    tier: low
+  properties:
+    release_date: "2004-05-18"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: arrow
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 22
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 5
+      xp: 6
+      materials:
+        - item_name: Flighted ogre arrow
+          quantity: 6
+        - item_name: Wolfbone arrowtips
+          quantity: 6
+      tools: []
+      output_quantity: 6
+  related_items:
+    - item_name: Flighted ogre arrow
+      slug: flighted-ogre-arrow
+      relationship: component
+      description: Pre-tipped arrow shaft
+    - item_name: Wolfbone arrowtips
+      slug: wolfbone-arrowtips
+      relationship: component
+      description: Arrow tip used to finish ogre arrows
+    - item_name: Ogre bow
+      slug: ogre-bow
+      relationship: alternative
+      description: Bow used to fire these arrows
+    - item_name: Ogre composite bow
+      slug: ogre-composite-bow
+      relationship: alternative
+      description: Stronger composite bow firing ogre arrows
+  about: |-
+    | Bonus | Value |
+    |-------|-------|
+    | Ranged strength | +22 |
+
+    Bone-tipped ogre arrows used with the ogre bow and ogre composite bow — required ammunition for hunting Chompy birds during and after Big Chompy Bird Hunting. Made at Fletching 5 by tipping flighted ogre arrows with wolfbone arrowtips.
+  market_strategy:
+    notes:
+      - "Required for Chompy bird hunting"
+      - "High GE limit for bulk Chompy farmers"
+      - "Cheap Fletching XP route at low levels"
+  trading_tips:
+    - Stock surges during Chompy-related diary tasks
+    - Cross-list with wolfbone arrowtips to capture full chain
+  history:
+    - date: "2004-05-18"
+      description: "Released with Big Chompy Bird Hunting as ammunition for ogre bows."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oil-lamp.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oil-lamp.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 11
   highalch: 16
   limit: 40
-  about: "Oil lamp is a members-only item in Old School RuneScape. High alchemy value: 16 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2005-03-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Light
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Miltog's Lamps
+      location: Dorgesh-Kaan
+      price: 42
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Empty oil lamp
+      slug: empty-oil-lamp
+      relationship: component
+      description: "Filled with lamp oil to produce a usable Oil lamp."
+    - item_name: Lamp oil
+      slug: lamp-oil
+      relationship: component
+      description: "Fuel used to fill the empty oil lamp."
+    - item_name: Oil lantern
+      slug: oil-lantern
+      relationship: upgrade
+      description: "Brighter light source crafted from the Oil lamp body."
+    - item_name: Tinderbox
+      slug: tinderbox
+      relationship: component
+      description: "Required to light the oil lamp once filled."
+  about: "Oil lamp is a low-tier light source used for cave exploration, requiring level 12 Firemaking to ignite and a tinderbox to light. It is dangerous in gas-filled areas such as Lumbridge Swamp Caves, where it can trigger explosions. High alchemy value: 16 coins. Grand Exchange buy limit: 40 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is one-off; players rarely need more than a single lamp."
+      - "Shop stock at 42 gp in Dorgesh-Kaan keeps the GE price soft."
+  trading_tips:
+    - "Buy from Miltog's Lamps if any GE markup pushes above ~50 gp."
+  history:
+    - date: "2005-03-14"
+      description: "Released as a low-tier cave light source alongside the Lumbridge Swamp Caves."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-ring.mdx
@@ -12,9 +12,95 @@ osrs:
   lowalch: 420
   highalch: 630
   limit: 10000
-  about: "Opal ring is a members-only item in Old School RuneScape. High alchemy value: 630 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: silver
+    tier: mid
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ring
+    weapon_type: null
+    attack_speed: null
+    weight: 0.006
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 10
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+        - item_name: Opal
+          quantity: 1
+      tools:
+        - Ring mould
+      output_quantity: 1
+  related_items:
+    - item_name: Opal
+      slug: opal
+      relationship: component
+      description: Gem set into the ring
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Base metal for the ring
+    - item_name: Ring of pursuit
+      slug: ring-of-pursuit
+      relationship: product
+      description: Enchanted form via Lvl-1 Enchant
+    - item_name: Jade ring
+      slug: jade-ring
+      relationship: upgrade
+      description: Next tier silver gem ring
+    - item_name: Sapphire ring
+      slug: sapphire-ring
+      relationship: alternative
+      description: Gold-bar gem ring tier
+  about: "Opal ring is crafted at Crafting 1 using 1 silver bar, 1 opal, and a ring mould at a furnace, granting 10 XP. The ring is most often used as a midstep toward enchanting it into a ring of pursuit via the Lvl-1 Enchant spell at Magic 7 for 17.5 XP."
+  market_strategy:
+    notes:
+      - "Crafting margin depends on silver bar plus opal spread"
+      - "Ring of pursuit enchant demand sets demand floor"
+      - "Buy limit 10,000 allows bulk flips"
+  trading_tips:
+    - Bulk craft during low silver bar prices
+    - Enchant in batches for steady Magic XP plus margin
+  history:
+    - date: "2017-02-02"
+      description: "Released with the Lunar Diplomacy gem ring update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ornate-maul-handle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ornate-maul-handle.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 50
-  about: "Ornate maul handle is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2019-09-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Apply
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "The handle is destroyed if the ornate modification is removed from the weapon."
+  shops:
+    - shop_name: Justine's stuff for the Last Man Standing
+      location: Ferox Enclave
+      price: 15
+      currency: LMS points
+      stock: 0
+  related_items:
+    - item_name: Granite maul
+      slug: granite-maul
+      relationship: component
+      description: Base weapon the handle is applied to
+    - item_name: Granite maul (clamp)
+      slug: granite-maul-clamp
+      relationship: alternative
+      description: Alternate granite maul cosmetic upgrade
+    - item_name: Granite maul (or)
+      slug: granite-maul-or
+      relationship: product
+      description: Ornate granite maul produced by combining the handle
+  passive_effects:
+    - name: Special attack discount
+      description: Reduces the granite maul's special attack energy cost from 60 percent to 50 percent when applied.
+  about: |-
+    Ornate maul handle is a cosmetic upgrade purchased from Justine's Last Man Standing shop for 15 LMS points. Applied to a granite maul, it produces the ornate variant which reduces the weapon's special attack cost from 60 percent to 50 percent; removing the modification destroys the handle.
+  market_strategy:
+    notes:
+      - "Direct sink from LMS points to GP for active LMS players"
+      - "Demand from PvPers seeking the reduced special cost"
+      - "Tiny 50 buy limit keeps the market thin"
+  trading_tips:
+    - LMS activity spikes can flood supply briefly
+  history:
+    - date: "2019-09-05"
+      description: "Item added to the game with the Last Man Standing rewards expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pantaloons.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pantaloons.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
-  about: "Pantaloons is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Flared trousers
+      slug: flared-trousers
+      relationship: alternative
+      description: "Easy clue cosmetic leg slot from the same reward pool."
+    - item_name: Pantaloons (enhanced)
+      slug: pantaloons-enhanced
+      relationship: upgrade
+      description: "Treasure Trails enhanced emote variant added with the 2025 emote enhancer rework."
+  about: |-
+    > _"Alas, someone has slashed my pantaloons."_
+
+    Pantaloons are an easy Treasure Trails cosmetic leg piece introduced in late 2006. They provide no combat stats but unlock the enhanced Bow emote when worn as part of the emote enhancer suite.
+  market_strategy:
+    notes:
+      - "1/1,404 from easy clue caskets — supply scales with low-level clue throughput."
+      - "Demand jumped after the March 2025 emote enhancer update reignited cosmetic collecting."
+      - "Buy limit of 4 every 4 hours keeps single-bidder corner attempts slow but feasible."
+  trading_tips:
+    - "Bundle with related easy-clue cosmetics for collector lots on Discord trade channels."
+    - "Costume room storage means displaced supply often returns to the market in waves; watch for outlier dumps."
+  history:
+    - date: "2006-12-05"
+      description: "Released as a tradeable easy Treasure Trails reward."
+    - date: "2025-03-26"
+      description: "Added to the emote enhancer set, gaining an enhanced Bow emote loop when worn."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pegasian-crystal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pegasian-crystal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pegasian crystal | OSRS Price Data
-description: "Pegasian crystal: A powerful crystal of flight.. High alch: 27,000 GP, GE limit: 15."
+description: "Pegasian crystal is a members Cerberus drop used to craft Pegasian boots. High alch: 27,000 GP, GE limit: 15."
 osrs:
   id: 13229
   name: Pegasian crystal
@@ -12,66 +12,62 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 15
-  item:
-    type: crafting_material
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: upgrade-crystal
+    tier: high
+  properties:
+    release_date: "2015-08-27"
     tradeable: true
-  obtaining:
-    methods:
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
       - source: Cerberus
-        drop_rate: 1/520
-        requirements:
-          slayer: 91
-  creation:
-    creates:
-      item_id: 13237
-      item_name: Pegasian boots
-      slug: pegasian-boots
-    combine_with:
-      item_id: 2577
-      item_name: Ranger boots
-      slug: ranger-boots
-    requirements:
-      magic: 60
-      runecraft: 60
-    warning: Irreversible process
+        quantity: "1"
+        rarity: 1/520
   related_items:
-    - item_id: 0
-      item_name: Cerberus
-      slug: cerberus
-      relationship: component
-      description: Boss drop
-    - item_id: 13237
-      item_name: Pegasian boots
+    - item_name: Pegasian boots
       slug: pegasian-boots
       relationship: product
-      description: Created item
-    - item_id: 13231
-      item_name: Primordial crystal
+      description: Created by combining the crystal with ranger boots
+    - item_name: Ranger boots
+      slug: ranger-boots
+      relationship: component
+      description: Required base footwear for the upgrade
+    - item_name: Primordial crystal
       slug: primordial-crystal
       relationship: alternative
-      description: Melee version
+      description: Melee variant dropped by Cerberus
+    - item_name: Eternal crystal
+      slug: eternal-crystal
+      relationship: alternative
+      description: Magic variant dropped by Cerberus
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Stackable | No |
+    Pegasian crystal is the ranged-focused crystal dropped by Cerberus at a 1/520 rate. Released 27 August 2015, it requires 91 Slayer to encounter the boss and combines with ranger boots to create the Pegasian boots, the best-in-slot ranged footwear in OSRS.
 
-    Combine with Ranger boots to create Pegasian boots.
-
-    | Requirement | Level |
-    |-------------|-------|
-    | Magic | 60 |
-    | Runecraft | 60 |
-
-    Warning: Irreversible process.
+    The combining process requires 60 Magic and 60 Runecraft, grants 200 XP in both skills, and cannot be reversed. The crystal is the cheapest of the three Cerberus crystals due to ranger boots being the most accessible base item.
   market_strategy:
     notes:
-      - Cheapest Cerberus crystal
-      - Limited by ranger boots supply
-      - Farm Cerberus on task
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheapest Cerberus crystal of the three primordial/eternal options"
+      - "Price closely tracks Cerberus task popularity and ranger boots supply"
+      - "15 buy limit makes this a slow but high-value flip"
+  trading_tips:
+    - Stack Cerberus Slayer tasks to farm crystals while gaining points
+    - Pair flips with ranger boots to time the boot creation arbitrage
+  history:
+    - date: "2015-08-27"
+      description: "Released as a Cerberus boss drop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pie-dish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pie-dish.mdx
@@ -12,66 +12,86 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 500
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: pottery
-    tier: fired
-  crafting:
-    level: 1
-    xp: 10
+    tier: low
+  properties:
+    release_date: "2001-03-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: crafting
       level: 1
       xp: 10
       materials:
         - item_name: Unfired pie dish
-          item_id: 1789
           quantity: 1
-      product: Pie dish
-      product_id: 2313
-      product_quantity: 1
-      facility: Pottery oven
+      tools:
+        - Pottery oven
+      output_quantity: 1
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle cellar
+      price: 3
+      currency: Coins
+      stock: 10
+    - shop_name: Frenita's Cookery Shop
+      location: Yanille
+      price: 3
+      currency: Coins
+      stock: 10
+    - shop_name: Logava Gricoller's Cooking Supplies
+      location: Zanaris
+      price: 3
+      currency: Coins
+      stock: 10
+    - shop_name: Cam Torum General Store
+      location: Cam Torum
+      price: 3
+      currency: Coins
+      stock: 5
   related_items:
-    - item_id: 1789
-      item_name: Unfired pie dish
+    - item_name: Unfired pie dish
       slug: unfired-pie-dish
       relationship: component
-      description: Unfired version
-    - item_id: 1761
-      item_name: Soft clay
+      description: Unfired clay version, baked into a finished pie dish
+    - item_name: Soft clay
       slug: soft-clay
       relationship: component
-      description: Raw material
-    - item_id: 2327
-      item_name: Meat pie
+      description: Raw material used to mould an unfired pie dish
+    - item_name: Meat pie
       slug: meat-pie
       relationship: product
-      description: Cooking product
+      description: Common cooking product made with a pie dish
   about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Pottery oven | 1 | 1 Unfired pie dish |
-    | XP | 10 | - |
+    The Pie dish is a free-to-play pottery item used to cook pies. Each dish is crafted at level 1 Crafting from an unfired pie dish baked in a pottery oven for 10 Crafting experience. Players with 13 Crafting or higher always succeed at firing the dish.
 
-    | Use | Cooking Level | Product |
-    |-----|---------------|---------|
-    | Redberry pie | 10 | Redberry pie |
-    | Meat pie | 20 | Meat pie |
-    | Apple pie | 30 | Apple pie |
-    | Garden pie | 34 | Garden pie |
-    | Fish pie | 47 | Fish pie |
-    | Wild pie | 85 | Wild pie |
-    | Summer pie | 95 | Summer pie |
+    Pie dishes accept pastry dough to form pie shells, which combine with various fillings to make pies ranging from redberry pie (10 Cooking) all the way up to summer pie (95 Cooking). They can also be bought cheaply from cooking-supply shops across Gielinor.
   market_strategy:
     notes:
-      - Pie making
-      - Cooking training
-      - Summer pie production
-      - Essential for pie cooking
-      - Summer pie very popular
-      - F2P accessible
-      - Buy from shops
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Pie making and Cooking training staple"
+      - "Summer pie demand keeps consumption high"
+      - "Essential for pie cooking"
+      - "F2P accessible"
+      - "Shop-bought floor keeps GE price low"
+  trading_tips:
+    - Bulk-buy from Frenita or Logava and resell on GE
+    - Pair with pastry dough for one-step pie shell production
+  history:
+    - date: "2001-03-17"
+      description: "Released with the initial RuneScape Classic Cooking and Crafting content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-boater.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "Pink boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "12 June 2014"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Red boater
+      slug: red-boater
+      relationship: variant
+      description: Color variant
+    - item_name: Orange boater
+      slug: orange-boater
+      relationship: variant
+      description: Color variant
+    - item_name: Green boater
+      slug: green-boater
+      relationship: variant
+      description: Color variant
+    - item_name: Blue boater
+      slug: blue-boater
+      relationship: variant
+      description: Color variant
+  about: |-
+    Pink boater is a purely cosmetic head slot hat from medium Treasure Trails. Storable in the costume room.
+  market_strategy:
+    notes:
+      - "Buy limit of 4 amplifies price swings"
+      - "Cosmetic demand follows fashionscape trends"
+      - "Medium clue grinder supply is steady but thin"
+  trading_tips:
+    - Buy after large clue grind streams
+    - Sell during fashionscape competitions and events
+  history:
+    - date: "12 June 2014"
+      description: "Added with the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-legs.mdx
@@ -12,21 +12,82 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 8/18128
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 12315
-      item_name: Pink elegant shirt
+    - item_name: Pink elegant shirt
       slug: pink-elegant-shirt
       relationship: set-piece
-      description: Matching elegant shirt
+      description: Matching elegant shirt for the pink elegant outfit.
   about: |-
     > *"A rather elegant pair of men's pink pantaloons."*
 
-    Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Pink elegant legs are a purely cosmetic medium clue scroll reward with no combat stats. They form the bottom half of the men's pink elegant clothing set.
+  market_strategy:
+    notes:
+      - "Demand is driven by fashionscape collectors completing the elegant outfit."
+      - "Low GE buy limit of 4 per 4 hours can sustain price spikes."
+      - "Supply scales with medium clue completion activity."
+  trading_tips:
+    - Pair flips with the pink elegant shirt for set arbitrage on the GE.
+    - Check both elegant shirt and legs prices to identify mispriced set pieces.
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion as a medium clue reward."
+    - date: "2014-12-10"
+      description: "Renamed from \"Pink ele' legs\" to \"Pink elegant legs\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-top-equipped.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/polar-camo-top-equipped.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Polar camo top (equipped) is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Remove
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.226
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 15
+      crush: 19
+      magic: 0
+      ranged: 12
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Polar camo top
+      slug: polar-camo-top
+      relationship: variant
+      description: Unequipped (inventory) variant
+    - item_name: Polar camo legs
+      slug: polar-camo-legs
+      relationship: set-piece
+      description: Matching legs piece for the polar camouflage set
+    - item_name: Polar kebbit fur
+      slug: polar-kebbit-fur
+      relationship: component
+      description: Material used to craft the top at the Fancy Clothes Store
+  about: |-
+    Polar camo top (equipped) is the worn state of the Polar camo top, used by hunters to make polar kebbits and other polar creatures less likely to detect the player. It is crafted at the Fancy Clothes Store in Varrock, the Hunter Guild, or Prifddinas' Seamstress from 2 polar kebbit fur and 20 coins per piece.
+  market_strategy:
+    notes:
+      - "Untradeable in its equipped state; players must craft from polar kebbit fur"
+      - "Pair with the matching legs for the full camo set"
+  trading_tips:
+    - Stock polar kebbit fur to keep crafting cost low
+  history:
+    - date: "2006-11-21"
+      description: "Item added with the Hunter skill release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pure-essence.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pure-essence.mdx
@@ -12,65 +12,64 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 30000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: essence
-    tier: standard
-  mining:
-    level: 30
-    xp: 5
-    locations:
-      - Rune Essence Mine
-    rate: ~2,100/hour
-    quest_required: Rune Mysteries
+    tier: low
+  properties:
+    release_date: "20 April 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   related_items:
-    - item_id: 1436
-      item_name: Rune essence
+    - item_name: Rune essence
       slug: rune-essence
       relationship: alternative
-      description: Basic runes only
-    - item_id: 561
-      item_name: Nature rune
+      description: F2P essence that only crafts basic runes
+    - item_name: Nature rune
       slug: nature-rune
       relationship: product
-      description: Popular crafted rune
-    - item_id: 560
-      item_name: Death rune
+      description: Popular crafted rune from pure essence
+    - item_name: Death rune
       slug: death-rune
       relationship: product
-      description: High-level rune
-    - item_id: 565
-      item_name: Blood rune
+      description: High-level rune crafted from pure essence
+    - item_name: Blood rune
       slug: blood-rune
       relationship: product
-      description: End-game rune
-    - item_id: 564
-      item_name: Cosmic rune
+      description: End-game rune crafted from pure essence
+    - item_name: Cosmic rune
       slug: cosmic-rune
       relationship: product
-      description: Mid-level rune
+      description: Mid-level rune crafted from pure essence
   about: |-
-    Pure essence can craft ALL runes. Required for:
-    - Cosmic rune (27 RC)
-    - Chaos rune (35 RC)
-    - Astral rune (40 RC)
-    - Nature rune (44 RC)
-    - Law rune (54 RC)
-    - Death rune (65 RC)
-    - Blood rune (77 RC)
-    - Wrath rune (95 RC)
-
-    Rune essence can only craft basic runes (air, mind, water, earth, fire, body).
+    Pure essence is the unimbued form of essence used to craft all runes above the basic tier. Members with 30+ Mining can mine it from the Rune Essence Mine after Rune Mysteries; rates reach roughly 2,100 per hour with optimal setup, and far higher in the Scar essence mine. It is the universal feedstock for Runecrafting training and a constant low-margin Grand Exchange staple.
   market_strategy:
     notes:
-      - Trade essence to runecrafters at altars
-      - They craft runes and give you a cut
-      - Popular at Nature and Law altars
-      - Very cheap (~2 GP each)
-      - Massive volume
-      - Essential for Runecrafting training
-      - Price tied to rune prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Trade essence to runecrafters at altars for a cut of crafted runes"
+      - "Very high daily volume - tight bid/ask spread"
+      - "Price is tied to nature and law rune profitability"
+      - "Buy limit 30,000 supports large-scale Runecrafting accounts"
+  trading_tips:
+    - Stockpile when nature rune prices dip to ride the next spike
+    - Sell at busy altars in F2P worlds for premium over GE price
+  history:
+    - date: "20 April 2006"
+      description: "Pure essence introduced; existing rune essence was retroactively converted for members."
+    - date: "September 2020"
+      description: "Grand Exchange buy limit raised from 20,000 to 30,000 per 4 hours."
+    - date: "March 2023"
+      description: 'Examine text updated to "An unimbued rune of extra capability".'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-relic-hunter-t2-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-relic-hunter-t2-armour-set.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Raging echoes relic hunter (t2) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour-set
+    tier: mid
+  properties:
+    release_date: "2024-11-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Raging echoes hat (t2)
+      slug: raging-echoes-hat-t2
+      relationship: set-piece
+      description: Head slot piece included in the bundle
+    - item_name: Raging echoes top (t2)
+      slug: raging-echoes-top-t2
+      relationship: set-piece
+      description: Body slot piece included in the bundle
+    - item_name: Raging echoes robeskirt (t2)
+      slug: raging-echoes-robeskirt-t2
+      relationship: set-piece
+      description: Leg slot piece included in the bundle
+    - item_name: Raging echoes boots (t2)
+      slug: raging-echoes-boots-t2
+      relationship: set-piece
+      description: Feet slot piece included in the bundle
+  about: |-
+    The Raging echoes relic hunter (t2) armour set bundles four pieces of the t2 Raging Echoes cosmetic outfit: the hat, top, robeskirt and boots. Players combine the four individual pieces at a Grand Exchange clerk using the "Sets" option to create the bundle for convenient single-line trading.
+
+    Released alongside the Raging Echoes content on 27 November 2024, the bundle is intended purely for trade convenience and provides no equipment bonuses on its own — the individual pieces must be unpacked to wear them.
+  market_strategy:
+    notes:
+      - "Bundle exists only for single-listing GE trades"
+      - "Compare bundle price versus sum of individual pieces"
+      - "Outfit cosmetic demand sets the price floor"
+  trading_tips:
+    - Pack or unpack at the Sets clerk to arbitrage piece spreads
+    - No GE buy limit makes bulk flipping viable
+  history:
+    - date: "2024-11-27"
+      description: "Released alongside the Raging Echoes relic hunter outfit."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-top-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-top-t3.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
-  about: "Raging echoes top (t3) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2025-01-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Raging echoes top (t1)
+      slug: raging-echoes-top-t1
+      relationship: downgrade
+      description: "Tier 1 cosmetic of the Raging Echoes relic hunter outfit."
+    - item_name: Raging echoes top (t2)
+      slug: raging-echoes-top-t2
+      relationship: downgrade
+      description: "Tier 2 cosmetic of the Raging Echoes relic hunter outfit."
+    - item_name: Raging echoes cane
+      slug: raging-echoes-cane
+      relationship: alternative
+      description: "Companion cosmetic from the same Leagues V reward shop."
+  about: "Raging echoes top (t3) is the tier 3 body slot cosmetic from the Leagues V: Raging Echoes reward shop, awarded for 20,000 League points. It provides no combat bonuses and is storable in the costume room armour case. High alchemy value: 60,000 coins."
+  market_strategy:
+    notes:
+      - "Pure cosmetic; price tracks Leagues nostalgia rather than utility."
+      - "Limited mint window means supply is fixed once Leagues V closes."
+  trading_tips:
+    - "Long-hold cosmetic; expect slow but trending appreciation post-league."
+  history:
+    - date: "2024-11-27"
+      description: "Added to the game files alongside the Leagues V rewards data."
+    - date: "2025-01-15"
+      description: "Became obtainable when the Raging Echoes reward shop opened."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranger-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranger-gloves.mdx
@@ -12,72 +12,92 @@ osrs:
   lowalch: 1360
   highalch: 2040
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ranged-armour
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options: ["Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
-    type: ranged_gloves
-    tradeable: true
-    weight: 0.05
+    weapon_type: null
+    attack_speed: null
+    weight: 0.226
     requirements:
       ranged: 40
-    stats:
-      attack_ranged: 11
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Master
-        drop_rate: Rare from reward casket
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 11
+    defence_bonus:
+      stab: 1
+      slash: 2
+      crush: 1
+      magic: 2
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/1275
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers: ["elite"]
   related_items:
-    - item_id: 2581
-      item_name: Robin hood hat
+    - item_name: Robin hood hat
       slug: robin-hood-hat
       relationship: set-piece
       description: Matching headgear
-    - item_id: 12596
-      item_name: Rangers' tunic
+    - item_name: Rangers' tunic
       slug: rangers-tunic
       relationship: set-piece
       description: Matching body armour
-    - item_id: 2577
-      item_name: Ranger boots
+    - item_name: Ranger boots
       slug: ranger-boots
       relationship: set-piece
       description: Matching boots
-    - item_id: 22981
-      item_name: Barrows gloves
+    - item_name: Barrows gloves
       slug: barrows-gloves
       relationship: alternative
-      description: Higher ranged bonus gloves
+      description: Higher ranged attack bonus gloves
   about: |-
     | Offense | Value |
     |---------|-------|
     | Ranged attack | +11 |
 
-    Requirements: 40 Ranged
-
-    Master clue ranged gloves:
-    - +11 ranged attack bonus
-    - Fashionscape with ranger set
-    - Master clue exclusive
-
-    | Item | Ranged attack | Notes |
-    |------|---------------|-------|
-    | Ranger gloves | +11 | Master clue |
-    | Barrows gloves | +12 | Quest reward |
-    | Black d'hide vambs | +8 | Budget option |
-
-    Complete the ranger set with:
-    - Robin hood hat (hard clue)
-    - Rangers' tunic (hard clue)
-    - Ranger boots (medium clue)
-    - Rangers' tights (elite clue)
+    Requires 40 Ranged. Elite clue exclusive gloves with +11 ranged attack — slightly weaker than Barrows gloves but iconic fashionscape for the ranger set.
   market_strategy:
     notes:
-      - Master clue exclusive
-      - Fashionscape value
-      - Slightly weaker than Barrows gloves
-      - Part of ranger outfit
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Elite clue exclusive"
+      - "Fashionscape demand"
+      - "Slightly weaker than Barrows gloves"
+      - "Part of full ranger outfit"
+  trading_tips:
+    - List with matching ranger set pieces for bundled appeal
+    - Price spikes during elite clue droughts
+  history:
+    - date: "2016-07-06"
+      description: "Added as an Elite Treasure Trails reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranging-potion-1.mdx
@@ -12,23 +12,74 @@ osrs:
   lowalch: 57
   highalch: 86
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts the Ranged level by 4 + 10% of the player's current Ranged level (rounded down). Decays by 1 level every 60 seconds, or every 90 seconds with the Preserve prayer active."
+        duration: 60
+  recipes:
+    - skill: herblore
+      level: 72
+      xp: 162
+      materials:
+        - item_name: Dwarf weed potion (unf)
+          quantity: 1
+        - item_name: Wine of Zamorak
+          quantity: 1
+      tools: []
+      output_quantity: 3
   related_items:
-    - item_id: 169
-      item_name: Ranging potion(3)
-      slug: ranging-potion-3
-      relationship: variant
-      description: 3-dose version
-    - item_id: 171
-      item_name: Ranging potion(2)
+    - item_name: Ranging potion(2)
       slug: ranging-potion-2
       relationship: variant
-      description: 2-dose version
+      description: "2-dose variant of the same potion."
+    - item_name: Ranging potion(3)
+      slug: ranging-potion-3
+      relationship: variant
+      description: "3-dose variant brewed directly via Herblore."
+    - item_name: Ranging potion(4)
+      slug: ranging-potion-4
+      relationship: variant
+      description: "4-dose variant produced from a full Herblore flask."
+    - item_name: Bastion potion(1)
+      slug: bastion-potion-1
+      relationship: alternative
+      description: "Combination potion that bundles Ranging with a Defence boost."
   about: |-
     > _"1 dose of ranging potion."_
 
-    A 1-dose ranging potion. Boosts Ranged by 4 + 10% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The 1-dose Ranging potion is the leftover dreg of a Herblore brew, mostly used to top up doses or fulfil decanting orders. It still grants the full Ranging boost (4 + 10% of Ranged level) for a single sip.
+  market_strategy:
+    notes:
+      - "Decanter arbitrage drives volume: traders combine 1-dose stacks into 4-dose flasks for resale."
+      - "Spikes around Inferno/CoX competitive grind windows where rangers chain doses."
+      - "Lower base price means slippage costs hit harder; tight margins reward bulk orders."
+  trading_tips:
+    - "Watch the per-dose spread between (1), (2), (3), and (4) variants; a wide gap signals a decanting flip."
+    - "Pair with Wine of Zamorak supply tracking — a Wine spike pushes all four dose tiers up together."
+  history:
+    - date: "2002-02-27"
+      description: "Released as part of the original Herblore release with the dwarf weed branch of potions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bluefin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bluefin.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 15000
-  about: "Raw bluefin is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "19 November 2025"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.7
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 87
+      xp: 215
+      materials:
+        - item_name: Raw bluefin
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Veiled kraken
+        quantity: "1"
+        rarity: 5/272
+  related_items:
+    - item_name: Bluefin
+      slug: bluefin
+      relationship: product
+      description: Cooked form of the raw bluefin
+  about: |-
+    Raw bluefin is a high-level Sailing-skill fish caught at bluefin shoals with level 87 Fishing, yielding 220.5 XP per catch with a trawling net or 44.1 XP with a fishing rod. It is also a rare drop from the veiled kraken. Cooking it requires level 87 Cooking and grants 215 XP per successful cook.
+  market_strategy:
+    notes:
+      - "High-level Sailing/Fishing supply with strong cooking demand"
+      - "Daily volume ~308k - liquid market"
+      - "Buy limit 15,000 supports bulk Cooking trainers"
+  trading_tips:
+    - Cook to bluefin for Cooking XP and resale margin
+    - Track Sailing engagement spikes for price movement
+  history:
+    - date: "20 March 2025"
+      description: "Raw bluefin added during Sailing Alpha testing."
+    - date: "26 June 2025"
+      description: "Adjusted during Sailing Beta."
+    - date: "3 July 2025"
+      description: "Final Sailing Beta tuning."
+    - date: "19 November 2025"
+      description: "Released to live game with the Sailing skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-elegant-blouse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-elegant-blouse.mdx
@@ -12,21 +12,87 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 10426
-      item_name: Red elegant skirt
+    - item_name: Red elegant skirt
       slug: red-elegant-skirt
       relationship: set-piece
-      description: Matching elegant skirt
+      description: Matching skirt of the women's red elegant set.
+    - item_name: Red elegant shirt
+      slug: red-elegant-shirt
+      relationship: variant
+      description: Men's red elegant variant.
+    - item_name: Red elegant legs
+      slug: red-elegant-legs
+      relationship: set-piece
+      description: Men's red elegant lower garment.
   about: |-
-    > *"A well made elegant ladies' red blouse."*
+    The red elegant blouse is the women's red blouse from the elegant clothing line, awarded as an easy Treasure Trail clue reward.
 
-    Purely cosmetic treasure trail reward with no combat stats. Part of the red elegant clothing set (women's variant). Pairs with the red elegant skirt.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    It has no combat stats and is purely cosmetic, pairing with the red elegant skirt to complete the women's red elegant outfit and qualifying for storage in the costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Tight buy limit of 4 keeps daily volume thin."
+      - "Cosmetic demand spikes during clue-related updates and seasonal events."
+      - "Easy clue reward floor caps the upside vs harder-tier outfits."
+  trading_tips:
+    - Pair with red elegant skirt for set listings to lift margin.
+    - Track easy clue droprate changes and clue-update news for entry timing.
+  history:
+    - date: "2006-12-05"
+      description: "Released with the Treasure Trails update."
+    - date: "2007-01-01"
+      description: "Renamed from 'Elegant blouse' to 'Red ele' blouse'."
+    - date: "2014-12-04"
+      description: "Renamed from 'Red ele' blouse' to 'Red elegant blouse'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-hat.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Red hat is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Barkers' Haberdashery
+      location: Canifis
+      price: 650
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Grey hat
+      slug: grey-hat
+      relationship: variant
+      description: "Grey-colored variant of the Canifis pointed hat."
+    - item_name: Yellow hat
+      slug: yellow-hat
+      relationship: variant
+      description: "Yellow-colored variant of the Canifis pointed hat."
+    - item_name: Teal hat
+      slug: teal-hat
+      relationship: variant
+      description: "Teal-colored variant of the Canifis pointed hat."
+    - item_name: Purple hat
+      slug: purple-hat
+      relationship: variant
+      description: "Purple-colored variant of the Canifis pointed hat."
+  about: "The red hat is a cosmetic head slot item sold by Barkers' Haberdashery in Canifis after completing the Priest in Peril quest. Provides +3 Magic attack and +3 Magic defence. Part of a coordinated five-color Canifis robe set."
+  market_strategy:
+    notes:
+      - "Shop-stocked item with bottomless supply, so GE arbitrage requires buyer urgency."
+      - "Modest Magic bonuses make this a budget low-level mage hat."
+  trading_tips:
+    - "Restock from Canifis at 650 gp and flip to the GE when prices spike."
+    - "Watch event timing; cosmetic demand from new players keeps a steady floor."
+  history:
+    - date: "2004-06-29"
+      description: "Released with the Priest in Peril quest update."
+    - date: "2014-12-10"
+      description: "Renamed from \"Hat\" to \"Red hat\" to distinguish color variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/redwood-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/redwood-shield.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 512
   highalch: 768
   limit: 18000
-  about: "Redwood shield is a members-only item in Old School RuneScape. High alchemy value: 768 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: wooden-shield
+    tier: mid
+  properties:
+    release_date: "2018-02-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 3.175
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 12
+      slash: 15
+      crush: 11
+      magic: 4
+      ranged: 10
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 92
+      xp: 216
+      materials:
+        - item_name: Redwood logs
+          quantity: 2
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Redwood logs
+      slug: redwood-logs
+      relationship: component
+      description: "Logs fletched with a knife"
+    - item_name: Black d'hide shield
+      slug: black-dhide-shield
+      relationship: upgrade
+      description: "Crafted by adding black dragon leather and rune nails at 83 Crafting"
+    - item_name: Mahogany shield
+      slug: mahogany-shield
+      relationship: downgrade
+      description: "Lower tier fletched shield"
+  about: "Redwood shield is a high-Fletching shield wielded in the shield slot. It is a popular base for the black d'hide shield upgrade and offers solid all-round defensive stats for a level 40 Defence shield."
+  market_strategy:
+    notes:
+      - "Made at 92 Fletching from 2 redwood logs for 216 XP"
+      - "Can be crafted into black d'hide shield at 83 Crafting"
+      - "Buy limit raised to 18,000 in July 2025"
+  history:
+    - date: "2018-02-01"
+      description: "Released alongside the Woodcutting Guild."
+    - date: "2025-07-09"
+      description: "Grand Exchange buy limit increased from 125 to 18,000."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ritual-mulch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ritual-mulch.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
-  about: "Ritual mulch is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: forestry
+    tier: mid
+  properties:
+    release_date: "2023-06-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Forestry Shop
+      location: Multiple Forestry camps
+      price: "150 anima-infused bark + 10 noted maple logs"
+      currency: anima-infused bark
+      stock: 0
+  related_items:
+    - item_name: Anima-infused bark
+      slug: anima-infused-bark
+      relationship: component
+      description: "Forestry currency required to buy ritual mulch"
+    - item_name: Nature offering
+      slug: nature-offering
+      relationship: product
+      description: "Made by combining ritual mulch with herbs"
+  about: "Ritual mulch is a Forestry resource purchased from the Forestry Shop. Combine it with selected herbs (avantoe, kwuarm, snapdragon, cadantine, lantadyme, dwarf weed, or torstol) to produce nature offerings used in tree spirit rituals."
+  market_strategy:
+    notes:
+      - "Bought from Forestry Shop with anima-infused bark and maple logs"
+      - "Each combination yields 40 nature offerings, no XP reward"
+      - "Requires level 68 Woodcutting and 50 Farming to use"
+  history:
+    - date: "2023-06-28"
+      description: "Released with the Forestry: The Way of the Forester update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/robin-hood-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/robin-hood-hat.mdx
@@ -12,69 +12,87 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 8
+  material:
+    type: ranged_armour
+    tier: high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: ranged_helm
+    weapon_type: null
+    attack_speed: null
+    weight: 0.283
     requirements:
       ranged: 40
-    stats:
-      attack_ranged: 8
-      defence_stab: 4
-      defence_slash: 6
-      defence_crush: 8
-      defence_magic: 4
-      defence_ranged: 4
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 8
+    defence_bonus:
+      stab: 4
+      slash: 6
+      crush: 8
+      magic: 4
+      ranged: 4
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
-      - source: Hard clue casket
-        source_id: 0
-        combat_level: 0
+      - source: Reward casket (hard)
         quantity: "1"
         rarity: 1/1,625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 11826
-      item_name: Armadyl helmet
+    - item_name: Armadyl helmet
       slug: armadyl-helmet
       relationship: upgrade
       description: BiS ranged helm
-    - item_id: 19925
-      item_name: Blessed coif
+    - item_name: Blessed coif
       slug: blessed-coif
       relationship: alternative
       description: Prayer bonus option
-    - item_id: 3751
-      item_name: Archer helm
+    - item_name: Archer helm
       slug: archer-helm
       relationship: alternative
       description: Fremennik alternative
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged attack | +8 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +4 |
-    | Slash | +6 |
-    | Crush | +8 |
-    | Magic | +4 |
-    | Ranged | +4 |
-
-    Requirements: 40 Ranged
-
-    Popular for:
-    - 1 Defence pures (no def req)
-    - Fashion
-    - Mid-game ranged
-
-    Best ranged helm with no Defence requirement.
+  about: "Robin hood hat is a hard clue scroll reward providing the highest ranged attack bonus on headgear that has no Defence requirement, making it the go-to head slot piece for 1 Defence pures."
   market_strategy:
     notes:
-      - Popular with pures
-      - Farm hard clues
-      - Fashionscape value
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Hard clue casket only at 1/1,625 keeps supply tight"
+      - "Popular with 1 Def pures"
+      - "Buy limit of 8 amplifies price volatility"
+  trading_tips:
+    - Watch hard clue grind activity for supply waves
+    - Premium versus generic ranged helms due to pure demand
+  history:
+    - date: "2004-05-05"
+      description: "Item released as a clue scroll reward."
+    - date: "2015-07-30"
+      description: "Robin hood hat no longer clips with a certain hairstyle."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-boots.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 125
-  about: "Rock-shell boots is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rock-shell
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 3.175
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Giant Rock Crab
+        quantity: "1"
+        rarity: 2/128
+      - source: King Sand Crab
+        quantity: "1"
+        rarity: 2/128
+  related_items:
+    - item_name: Rock-shell helm
+      slug: rock-shell-helm
+      relationship: set-piece
+      description: Head slot of the rock-shell armour set.
+    - item_name: Rock-shell plate
+      slug: rock-shell-plate
+      relationship: set-piece
+      description: Body slot of the rock-shell armour set.
+    - item_name: Rock-shell legs
+      slug: rock-shell-legs
+      relationship: set-piece
+      description: Legs slot of the rock-shell armour set.
+  about: |-
+    Rock-shell boots are the boot slot of the Fremennik rock-shell armour set, dropped from the Giant Rock Crab and King Sand Crab. They equip with no stat or quest requirement, granting modest slash and crush defence and pairing with the rest of the rock-shell pieces stored in the costume room armour case.
+  market_strategy:
+    notes:
+      - "Steady but thin demand from rock-shell collectors and set fillers."
+      - "GE price tracks the alch floor; volume is modest."
+      - "Drop supply from crab grinders keeps the floor in place."
+  trading_tips:
+    - Buy when crab Slayer tasks spike and dump rock-shell drops.
+    - Set bundles (helm/plate/legs/boots) flip better than the boots alone.
+  history:
+    - date: "2005-08-01"
+      description: "Released with the Waterbirth Island update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/roe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/roe.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 13000
-  about: "Roe is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: organic
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: ["Eat", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Roe is a members ingredient harvested by cutting open leaping trout or leaping salmon with a knife during Barbarian fishing. Heals 3 hitpoints when eaten and is the primary ingredient for five Barbarian-mix potions (Attack, Strength, Restore, Antipoison, Relicym's). Roe yield scales with Cooking level. High alchemy value: 12 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand driven by Barbarian-mix potion crafters and Herblore training"
+      - "Reagent pouch and prescription goggles (Oct 2024) reduced consumption per mix"
+      - "Supply tied to Barbarian fishing throughput — volatile during fishing meta shifts"
+  trading_tips:
+    - Bulk-buy when Barbarian fishing is unpopular for cheap Herblore-mix supply
+    - Sell into demand spikes when new Barbarian potion content launches
+  related_items:
+    - item_name: Caviar
+      slug: caviar
+      relationship: alternative
+      description: Higher-tier sturgeon roe used for the other Barbarian mixes
+    - item_name: Leaping salmon
+      slug: leaping-salmon
+      relationship: component
+      description: Fish that yields roe when cut with a knife
+    - item_name: Leaping trout
+      slug: leaping-trout
+      relationship: component
+      description: Fish that yields roe when cut with a knife
+  history:
+    - date: "2007-07-03"
+      description: "Added to the game with the introduction of Barbarian Training fishing."
+    - date: "2024-10-16"
+      description: "Added reagent pouch compatibility and prescription goggles interaction to save roe during Barbarian potion-making."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-armour-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-armour-set-sk.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 30000
   highalch: 45000
   limit: 8
-  about: "Rune armour set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 45,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6.0
+    options:
+      - Exchange
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: set-piece
+      description: Head slot piece included in the set
+    - item_name: Rune platebody
+      slug: rune-platebody
+      relationship: set-piece
+      description: Body slot piece included in the set
+    - item_name: Rune plateskirt
+      slug: rune-plateskirt
+      relationship: set-piece
+      description: Legs slot piece (skirt variant) included in the set
+    - item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: set-piece
+      description: Shield slot piece included in the set
+    - item_name: Rune armour set (lg)
+      slug: rune-armour-set-lg
+      relationship: alternative
+      description: Plate legs variant of the set
+  about: |-
+    Rune armour set (sk) is the skirt variant of the packaged rune armour set, containing a rune full helm, platebody, plateskirt, and kiteshield. Players assemble or break down the set via the Grand Exchange clerk's "Sets" tab to save bank space when buying or selling the complete kit.
+  market_strategy:
+    notes:
+      - "Useful for flipping versus the four individual components"
+      - "Saves bank slots for ironmen-style stash or muling"
+      - "Demand peaks around midgame Defence training"
+  trading_tips:
+    - Compare set price against component sum before buying or splitting
+    - Buy when set trades at a discount to components and break for profit
+  history:
+    - date: "2015-02-26"
+      description: "Item added to the game alongside other armour set packages."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow-p.mdx
@@ -12,16 +12,87 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
   equipment:
     slot: ammo
-    ranged_strength: 49
-  related_items: []
-  about: |-
-    > _"Rune arrows with a poisoned tip."_
-
-    Rune arrows tipped with basic weapon poison. The highest standard tier of poisoned arrow. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    weapon_type: arrow
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 49
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 75
+      xp: 187.5
+      materials:
+        - item_name: Headless arrow
+          quantity: 15
+        - item_name: Rune arrowtips
+          quantity: 15
+      tools: []
+      output_quantity: 15
+  related_items:
+    - item_name: Rune arrow
+      slug: rune-arrow
+      relationship: variant
+      description: Unpoisoned baseline arrow
+    - item_name: Rune arrow(p+)
+      slug: rune-arrow-p-plus
+      relationship: upgrade
+      description: Stronger poison variant
+    - item_name: Rune arrow(p++)
+      slug: rune-arrow-p-plus-plus
+      relationship: upgrade
+      description: Strongest poison variant
+  about: "Rune arrow(p) is the lightly poisoned variant of rune arrows, made by applying weapon poison to standard rune arrows. The poison deals up to 4 damage on hit."
+  market_strategy:
+    notes:
+      - "Made from rune arrows and weapon poison"
+      - "Demand tracks high-level Ranged training"
+      - "Buy limit 11,000 per 4 hours"
+  trading_tips:
+    - Compare poisoned spread against base rune arrow + poison cost
+    - Stacks well for long Ranged sessions
+  history:
+    - date: "2002-03-25"
+      description: "Released as part of the rune-tier ammunition lineup."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-hasta-p.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Rune hasta(p) is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 36
+      slash: 36
+      crush: 36
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -10
+      slash: -10
+      crush: -9
+      magic: 0
+      ranged: -10
+    other_bonus:
+      strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Rune hasta
+      slug: rune-hasta
+      relationship: variant
+      description: Unpoisoned rune hasta
+    - item_name: Rune spear(p)
+      slug: rune-spear-p
+      relationship: alternative
+      description: Two-handed poisoned spear equivalent
+    - item_name: Dragon hasta(p)
+      slug: dragon-hasta-p
+      relationship: upgrade
+      description: Higher tier poisoned hasta
+  passive_effects:
+    - name: Weapon poison
+      description: Hits have a chance to apply weapon poison damage on attack.
+  about: |-
+    Rune hasta(p) is the weapon poison-coated variant of the rune hasta, a one-handed spear unlocked via the Barbarian Training Smithing miniquest. It requires 40 Attack to wield and is forged at the Barbarian anvil from a runite bar and magic logs at 90 Smithing for 150 XP.
+  market_strategy:
+    notes:
+      - "Niche use cases versus the unpoisoned variant"
+      - "Stab-based with strong strength bonus for spear training"
+      - "Limited demand keeps margins thin"
+  trading_tips:
+    - Coat unpoisoned hastas with weapon poison for the spread
+  history:
+    - date: "2007-07-03"
+      description: "Item added to the game with the Barbarian Training miniquest expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h1.mdx
@@ -5,16 +5,104 @@ osrs:
   id: 7336
   name: Rune shield (h1)
   slug: rune-shield-h1
-  examine: A shield with a heraldic design
+  examine: A shield with a heraldic design.
   members: false
   icon: Rune shield (h1).png
   value: 54400
   lowalch: 21760
   highalch: 32640
   limit: 70
-  about: "Rune shield (h1) is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: Rare
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: alternative
+      description: Standard rune kiteshield with identical combat bonuses.
+    - item_name: Rune shield (h2)
+      slug: rune-shield-h2
+      relationship: variant
+      description: Alternate heraldic colour scheme from the same hard clue pool.
+    - item_name: Rune shield (h3)
+      slug: rune-shield-h3
+      relationship: variant
+      description: Alternate heraldic colour scheme from the same hard clue pool.
+  about: |-
+    > *"A shield with a heraldic design."*
+
+    Mechanically identical to the standard rune kiteshield with a cosmetic heraldic emblem. A hard clue scroll reward, tied to the Beckon (Kharazi Jungle) and Cheer (Agility Pyramid) emote clues.
+  market_strategy:
+    notes:
+      - "Hard clue supply keeps prices well above the equivalent kiteshield."
+      - "F2P availability since 2006 means demand spans both game modes."
+      - "Daily volume is modest — large flips need patience."
+  trading_tips:
+    - Compare against h2/h3 variants — the cheapest pattern is often the easiest flip target.
+    - Holiday/event recolour buzz lifts heraldic gear prices broadly.
+  history:
+    - date: "2006-02-20"
+      description: "Released as a hard treasure trail reward."
+    - date: "2006-03-15"
+      description: "Made available to free-to-play players."
+    - date: "2006-03-28"
+      description: "Graphical update applied to the heraldic shield model."
+    - date: "2006-05-31"
+      description: "Renamed from \"Rune kiteshield(h)\" to \"Rune shield(h1)\"."
+    - date: "2021-04-21"
+      description: "Ranged defence bonus tuned during shield rebalance."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-spear-p-5728.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-spear-p-5728.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 8320
   highalch: 12480
   limit: 70
-  about: "Rune spear(p++) is a members-only item in Old School RuneScape. High alchemy value: 12,480 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 36
+      slash: 36
+      crush: 36
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 42
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Rune spear
+      slug: rune-spear
+      relationship: variant
+      description: "Unpoisoned base variant of the rune spear."
+    - item_name: Rune spear(p)
+      slug: rune-spear-p-5722
+      relationship: variant
+      description: "Standard poisoned rune spear."
+    - item_name: Rune spear(p+)
+      slug: rune-spear-p-5725
+      relationship: variant
+      description: "Rune spear poisoned with weapon poison+."
+    - item_name: Rune spear(kp)
+      slug: rune-spear-kp
+      relationship: variant
+      description: "Karambwan paste poisoned variant from Tai Bwo Wannai Trio."
+  about: "Rune spear(p++) is the strongest poisoned variant of the rune spear, dealing damage-over-time poison hits while wielded. Crafted by applying weapon poison++ to a rune spear. Spears are required for certain hard clue steps and bone spear runs."
+  market_strategy:
+    notes:
+      - "Premium poisoned variant carries a price premium over the unpoisoned spear."
+      - "Demand stems from PvM niche use and clue scroll requirements."
+  trading_tips:
+    - "Apply weapon poison++ to unpoisoned rune spears bought during low-volume hours for margin."
+    - "Watch for hard clue scroll-related demand spikes."
+  history:
+    - date: "2003-04-14"
+      description: "Rune spear variants released with the introduction of spears."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-glacialis-item.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-glacialis-item.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 125
-  about: "Sapphire glacialis (item) is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: hunter-creature
+    tier: mid
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Release
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: "Released boost"
+      description: "Releasing the butterfly boosts the player's Defence level by 4 + 15% of their current Defence level (rounded down). In multi-combat zones, the effect can be shared with up to three nearby players within a 5x5 tile area who have Accept Aid toggled on."
+  related_items:
+    - item_name: Ruby harvest (item)
+      slug: ruby-harvest-item
+      relationship: alternative
+      description: "Hunter butterfly that grants a temporary Attack boost on release."
+    - item_name: Snowy knight (item)
+      slug: snowy-knight-item
+      relationship: alternative
+      description: "Hunter butterfly that grants a temporary Hitpoints restore on release."
+    - item_name: Black warlock (item)
+      slug: black-warlock-item
+      relationship: alternative
+      description: "Hunter butterfly that grants a temporary Strength boost on release."
+    - item_name: Sapphire glacialis mix
+      slug: sapphire-glacialis-mix
+      relationship: product
+      description: "Crafted by combining the butterfly with raw hunter meat using a pestle and mortar."
+  about: |-
+    > _"There's a sapphire glacialis butterfly in here."_
+
+    The sapphire glacialis is one of the four Hunter butterflies introduced with the Hunter expansion. Caught in a butterfly jar at the Rellekka Hunter area, outside the Farming Guild, or in Mons Gratia, releasing one grants a 4 + 15% Defence boost shareable with nearby teammates in multi-combat.
+  market_strategy:
+    notes:
+      - "GE limit of 125 every 4 hours combined with low alch keeps speculation tame."
+      - "Demand rises during PvM team events where shared Defence boosts matter for low-level alts."
+      - "Sapphire glacialis mix consumption sets a floor on raw butterfly demand."
+  trading_tips:
+    - "Track Hunter task rotations — Slayer-style Hunter contracts pump supply when active."
+    - "Pair with raw hunter meat tracking; mix-crafters bundle inputs simultaneously."
+  history:
+    - date: "2006-11-21"
+      description: "Released as part of the Hunter skill launch with the butterfly catching mechanic."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-dragonhide-set.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 3600
   highalch: 5400
   limit: 8
-  about: "Saradomin dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 5,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour-set
+    tier: high
+  properties:
+    release_date: "2015-03-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Saradomin coif
+      slug: saradomin-coif
+      relationship: set-piece
+      description: "Head slot piece bundled in the set."
+    - item_name: Saradomin d'hide body
+      slug: saradomin-dhide-body
+      relationship: set-piece
+      description: "Torso slot piece bundled in the set."
+    - item_name: Saradomin chaps
+      slug: saradomin-chaps
+      relationship: set-piece
+      description: "Legs slot piece bundled in the set."
+    - item_name: Saradomin bracers
+      slug: saradomin-bracers
+      relationship: set-piece
+      description: "Hands slot piece bundled in the set."
+    - item_name: Zamorak dragonhide set
+      slug: zamorak-dragonhide-set
+      relationship: alternative
+      description: "Zamorak god-aligned dragonhide set sibling."
+    - item_name: Guthix dragonhide set
+      slug: guthix-dragonhide-set
+      relationship: alternative
+      description: "Guthix god-aligned dragonhide set sibling."
+    - item_name: Ancient dragonhide set
+      slug: ancient-dragonhide-set
+      relationship: alternative
+      description: "Zarosian god-aligned dragonhide set sibling."
+    - item_name: Armadyl dragonhide set
+      slug: armadyl-dragonhide-set
+      relationship: alternative
+      description: "Armadyl god-aligned dragonhide set sibling."
+    - item_name: Bandos dragonhide set
+      slug: bandos-dragonhide-set
+      relationship: alternative
+      description: "Bandos god-aligned dragonhide set sibling."
+  about: |-
+    > _"A set containing a Saradomin dragonhide coif, body, chaps and vambraces."_
+
+    The Saradomin dragonhide set is a Grand Exchange convenience bundle containing the coif, body, chaps, and vambraces in Saradomin trim. Exchanging the set unpacks the four pieces into the inventory; combining them via the GE clerk repacks them.
+  market_strategy:
+    notes:
+      - "Set markup of ~57k coins over component total — high enough to attract repackers when spreads widen."
+      - "Component prices are driven by hard clue scroll volume; demand spikes during clue grinding events."
+      - "Buy limit of 8 every 4 hours keeps single-account corner attempts slow."
+  trading_tips:
+    - "Watch component-vs-set spread; profitable arbitrage swings both directions as collectors and rangers consume pieces."
+    - "Pair flips with the other god dragonhide sets to spread risk across the same cosmetic demand pool."
+  history:
+    - date: "2015-03-19"
+      description: "Released as a Grand Exchange convenience bundle for the Saradomin dragonhide armour pieces."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-robe-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-robe-legs.mdx
@@ -12,24 +12,85 @@ osrs:
   lowalch: 2800
   highalch: 4200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.7
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 2.7
     requirements:
       prayer: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 10458
-      item_name: Saradomin robe top
+    - item_name: Saradomin robe top
       slug: saradomin-robe-top
       relationship: set-piece
-      description: Saradomin vestment body
+      description: Saradomin vestment body piece
+    - item_name: Saradomin mitre
+      slug: saradomin-mitre
+      relationship: set-piece
+      description: Saradomin vestment headwear
+    - item_name: Saradomin stole
+      slug: saradomin-stole
+      relationship: set-piece
+      description: Saradomin vestment cape piece
+    - item_name: Zamorak robe legs
+      slug: zamorak-robe-legs
+      relationship: alternative
+      description: Opposing god vestment leg piece
   about: |-
-    > *"Leggings from the Saradomin Vestments."*
-
-    The Saradomin robe legs are the legs piece of the Saradomin vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as a Saradominist item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Saradomin robe legs are the leg piece of the Saradomin vestment set, a +5 Prayer bonus item that requires 20 Prayer to wear. They count as a Saradominist item in the God Wars Dungeon and drop from easy Treasure Trails reward caskets at roughly 1/1,404.
+  market_strategy:
+    notes:
+      - "Easy clue reward with steady supply"
+      - "Demand from prayer-bonus and fashionscape buyers"
+      - "Low buy limit keeps the GE thin"
+  trading_tips:
+    - Combine with the full vestment set for resale upside
+  history:
+    - date: "2006-12-05"
+      description: "Item added to the game with the Treasure Trails reward update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-1.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 2000
-  about: "Serum 207 (1) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily cures afflicted villagers in Mort'ton during the Shades of Mort'ton minigame."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 15
+      xp: 50
+      materials:
+        - item_name: Tarromin potion (unf)
+          quantity: 1
+        - item_name: Ashes
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Serum 207 (2)
+      slug: serum-207-2
+      relationship: variant
+      description: "2-dose version of serum 207"
+    - item_name: Serum 207 (3)
+      slug: serum-207-3
+      relationship: variant
+      description: "3-dose version of serum 207"
+    - item_name: Serum 207 (4)
+      slug: serum-207-4
+      relationship: variant
+      description: "4-dose version of serum 207"
+    - item_name: Serum 208 (1)
+      slug: serum-208-1
+      relationship: upgrade
+      description: "Sanctified form created at the fire altar with 5% sanctity per dose"
+  about: |-
+    "1 dose serum 207 as described in Herbi Flax's diary."
+
+    Serum 207 (1) is a single dose of the herbal serum used during the Shades of Mort'ton minigame to temporarily cure afflicted villagers. Players brew the potion using a tarromin potion (unf) and ashes at 15 Herblore for 50 experience. Unlike most potions, Serum 207 has no make-X interface; the player keeps producing doses until reagents are exhausted.
+
+    A single dose can be upgraded to Serum 208 at the fire altar by spending 5% sanctity per dose, providing better minigame rewards. Players typically carry the 4-dose flask for efficiency and decant down to single doses only when topping off small leftovers from the brewing process.
+  market_strategy:
+    notes:
+      - "Demand follows Shades of Mort'ton activity, which is bursty"
+      - "Single doses are mostly leftovers from decanting; bulk supply often spikes after group runs"
+      - "Cheap to flip at scale due to the 2,000 buy limit and tight bid-ask spread"
+      - "Compare margins against the 3-dose to find which dose is mispriced"
+  trading_tips:
+    - Buy when minigame interest drops and decant to higher doses to relist
+    - Track high alch as a floor (6 gp) before bidding
+  history:
+    - date: "2004-10-18"
+      description: "Item released alongside Shades of Mort'ton."
+    - date: "2024-07-31"
+      description: "Sanctification was changed to consume 5% sanctity per dose."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-boots-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-boots-t3.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered boots (t3) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2022-03-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.34
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Shattered hood (t3)
+      slug: shattered-hood-t3
+      relationship: set-piece
+      description: "Matching hood in the tier 3 Shattered Relic Hunter outfit"
+    - item_name: Shattered top (t3)
+      slug: shattered-top-t3
+      relationship: set-piece
+      description: "Matching top in the tier 3 Shattered Relic Hunter outfit"
+    - item_name: Shattered trousers (t3)
+      slug: shattered-trousers-t3
+      relationship: set-piece
+      description: "Matching trousers in the tier 3 Shattered Relic Hunter outfit"
+    - item_name: Shattered gloves (t3)
+      slug: shattered-gloves-t3
+      relationship: set-piece
+      description: "Matching gloves in the tier 3 Shattered Relic Hunter outfit"
+  about: |-
+    "The boots of a Shattered Relic Hunter."
+
+    Shattered boots (t3) are a purely cosmetic feet-slot item from the Shattered Relics League rewards, originally purchasable from the Leagues Reward Shop for League points as the boots half of the tier 3 Shattered Relic Hunter outfit. They provide no combat bonuses and exist purely as a status symbol commemorating League participation.
+
+    Because the Shattered Relics League ended on 16 March 2022, no new copies enter the game from the shop. The boots can still be traded, stored in a costume room's armour case, or displayed via a League hall outfit stand. Long-term supply only shrinks as boots are alched or destroyed, which underpins the slow upward drift in price.
+  market_strategy:
+    notes:
+      - "Fixed supply since the League ended in 2022; only buyers above current floor can drive price"
+      - "No GE buy limit makes large positions possible but illiquid to exit"
+      - "Cosmetic-only demand is mostly collectors and clout-flexers"
+      - "High alch of 9,000 gp is well below market price, so alch losses do not anchor floor"
+  trading_tips:
+    - Track sales over weeks not hours; spreads are wide and fills slow
+    - Pair with other Shattered Relic Hunter pieces for a set-bundle premium
+  history:
+    - date: "2022-03-16"
+      description: "Released as part of the Shattered Relics League reward shop."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relics-mystic-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-relics-mystic-ornament-kit.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Shattered relics mystic ornament kit is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic-kit
+    tier: mid-high
+  properties:
+    release_date: "2022-03-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Lumbridge Castle
+      price: 1000
+      currency: League points
+      stock: 0
+  related_items:
+    - item_name: Mystic hat
+      slug: mystic-hat
+      relationship: component
+      description: Compatible blue mystic piece for ornament kit application.
+    - item_name: Mystic robe top
+      slug: mystic-robe-top
+      relationship: component
+      description: Compatible blue mystic piece for ornament kit application.
+    - item_name: Mystic robe bottom
+      slug: mystic-robe-bottom
+      relationship: component
+      description: Compatible blue mystic piece for ornament kit application.
+    - item_name: Mystic gloves
+      slug: mystic-gloves
+      relationship: component
+      description: Compatible blue mystic piece for ornament kit application.
+    - item_name: Mystic boots
+      slug: mystic-boots
+      relationship: component
+      description: Compatible blue mystic piece for ornament kit application.
+  about: |-
+    > *"A kit that can be used to apply a Leagues III - Shattered Relics theme to a blue Mystic robe piece."*
+
+    Applies a Leagues III - Shattered Relics cosmetic recolour to any of the five blue mystic robe pieces. The transformation is reversible, returning both the base piece and the kit.
+
+    Originally purchased from the Leagues Reward Shop in bundles of 5 for 1,000 League Points; tradeable so non-League players can equip the look via the GE.
+  market_strategy:
+    notes:
+      - "Supply is fixed at the Shattered Relics reward pool — no new kits enter circulation."
+      - "GE buy limit of 5 per 4 hours keeps prices defensive against dump events."
+      - "Demand is collector-driven; price tends to climb on League anniversary buzz."
+  trading_tips:
+    - Reversibility means high alch is the floor — players can always recover the kit and base item.
+    - Long-hold flips during quiet content gaps frequently pay off ahead of new League launches.
+  history:
+    - date: "2022-01-19"
+      description: "Added to the game ahead of Leagues III - Shattered Relics."
+    - date: "2022-03-16"
+      description: "Made obtainable from the Leagues Reward Shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-fletcher.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-fletcher.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of the fletcher is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sigil
+    tier: mid
+  properties:
+    release_date: "2021-08-25"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: true
+    destroy: "Destroy"
+  passive_effects:
+    - name: Instant Fletching
+      description: When attuned, processes all logs or bolt tips at once when fletching, effectively giving instant batch completion.
+  drop_table:
+    sources:
+      - source: Most monsters (Deadman Mode drop table)
+        quantity: "1"
+        rarity: Very Rare
+  related_items:
+    - item_name: Sigil of the smith
+      slug: sigil-of-the-smith
+      relationship: alternative
+      description: Tier 1 skilling sigil for Smithing
+    - item_name: Sigil of the cook
+      slug: sigil-of-the-cook
+      relationship: alternative
+      description: Tier 1 skilling sigil for Cooking
+  about: |-
+    The Sigil of the fletcher is a Tier 1 skilling sigil exclusive to Deadman: Reborn seasonal events. The un-attuned version is tradeable on the Grand Exchange while the attuned version is permanently bound to the player.
+
+    Once attuned, the sigil causes all logs or bolt tips in a player's inventory to be processed at once when fletching, dramatically accelerating bulk Fletching training during a Deadman season.
+  market_strategy:
+    notes:
+      - "Only obtainable during Deadman: Reborn events"
+      - "Low GE buy limit (10) and small Deadman supply keep price volatile"
+      - "Attune locks the sigil permanently — verify before binding"
+  trading_tips:
+    - Track Deadman season schedule for supply spikes
+    - Sell un-attuned during the event when demand peaks
+  history:
+    - date: "2021-08-25"
+      description: "Released as part of the Deadman: Reborn update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-formidable-fighter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-formidable-fighter.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of the formidable fighter is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sigil
+    tier: high
+  properties:
+    release_date: "2021-08-25"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Inspect
+      - Destroy
+    worn_options: []
+    alchable: false
+    destroy: "You must unattune the Sigil before you can destroy it."
+  passive_effects:
+    - name: Formidable accuracy
+      description: "Grants +30 melee accuracy across stab, slash, and crush styles."
+    - name: Formidable strike
+      description: "On a successful melee hit, 30% chance for the next successful strike to deal +10 bonus damage; 10-second cooldown; does not work with special attacks."
+  related_items:
+    - item_name: Deadman's skull
+      slug: deadmans-skull
+      relationship: component
+      description: "Used to sell duplicate sigils back to the skull shop"
+  about: "Sigil of the formidable fighter is a Deadman Mode melee sigil purchased from the skull shop. It boosts melee accuracy and grants a chance-based +10 damage proc on successful strikes."
+  market_strategy:
+    notes:
+      - "Only obtainable during active Deadman Mode events"
+      - "Untradeable through the Grand Exchange"
+      - "Duplicates can be sold back via Deadman's skull for points"
+  history:
+    - date: "2021-08-25"
+      description: "Released for the Deadman: Reborn event."
+    - date: "2026-01-22"
+      description: "Examine text updated to display the full passive effect description."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-sickle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-sickle.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 70
   highalch: 105
   limit: 15
-  about: "Silver sickle is a members-only item in Old School RuneScape. High alchemy value: 105 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: silver
+    tier: low
+  properties:
+    release_date: "2004-07-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.587
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: slash
+    attack_speed: 5
+    weight: 1.587
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 1
+      ranged: 1
+    other_bonus:
+      strength: 1
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 18
+      xp: 50
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+        - item_name: Sickle mould
+          quantity: 1
+      tools:
+        - Furnace
+      output_quantity: 1
+  related_items:
+    - item_name: Silver sickle (b)
+      slug: silver-sickle-b
+      relationship: upgrade
+      description: "Blessed silver sickle obtained during Nature Spirit; enables Bloom."
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: "Smelted silver used to craft the sickle."
+  about: "The silver sickle is introduced during the Nature Spirit quest and can be blessed by Filliman Tarlock to enable the Bloom spell in Mort Myre Swamp for gathering snakes, branches and fungi. Craftable at level 18 Crafting from a silver bar and sickle mould."
+  market_strategy:
+    notes:
+      - "Low GE volume but cheap entry item; demand tracks new players starting Nature Spirit."
+      - "Crafting from silver bars at level 18 yields a small profit if silver prices stay low."
+  trading_tips:
+    - "Stock 1 sickle for the Nature Spirit quest; bless it for the upgraded version."
+    - "Useful for Mort Myre resource runs after blessing."
+  history:
+    - date: "2004-07-13"
+      description: "Added to the game with the Nature Spirit quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/smouldering-stone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/smouldering-stone.mdx
@@ -1,6 +1,6 @@
 ---
 title: Smouldering stone | OSRS Price Data
-description: "Smouldering stone: A smouldering stone from the depths of Hell.. High alch: 27,000 GP, GE limit: 5."
+description: "Smouldering stone: A smouldering stone from the depths of Hell. High alch: 27,000 GP, GE limit: 5."
 osrs:
   id: 13233
   name: Smouldering stone
@@ -12,90 +12,97 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 5
-  item:
-    type: upgrade_material
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: upgrade-material
+    tier: high
+  properties:
+    release_date: "2015-08-27"
     tradeable: true
-  effect:
-    creates_infernal_tools: true
-    auto_process_chance: 33
-    secondary_xp_percent: 50
-    charges_per_tool: 5000
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Cerberus
-        source_id: 5862
-        combat_level: 318
         quantity: "1"
         rarity: 1/520
-        members_only: true
-      - source: Hellhound (Wildy Slayer)
-        source_id: 0
-        combat_level: 0
+      - source: Hellhound (Wilderness Slayer Cave)
         quantity: "1"
-        rarity: 1/16,384
-        members_only: true
-      - source: Hellhound (regular)
-        source_id: 0
-        combat_level: 0
+        rarity: 1/16384
+      - source: Hellhound
         quantity: "1"
-        rarity: 1/32,768
-        members_only: true
-  recipes_creates:
-    - product_id: 13241
-      product_name: Infernal axe
-      requirements: 85 FM, 61 WC
-    - product_id: 13243
-      product_name: Infernal pickaxe
-      requirements: 85 Smith, 61 Mining
-    - product_id: 21031
-      product_name: Infernal harpoon
-      requirements: 85 Cook, 75 Fishing
+        rarity: 1/32768
+  recipes:
+    - skill: firemaking
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Dragon axe
+          quantity: 1
+        - item_name: Smouldering stone
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - skill: smithing
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Dragon pickaxe
+          quantity: 1
+        - item_name: Smouldering stone
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - skill: cooking
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Dragon harpoon
+          quantity: 1
+        - item_name: Smouldering stone
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 13241
-      item_name: Infernal axe
+    - item_name: Infernal axe
       slug: infernal-axe
       relationship: product
-      description: Created tool
-    - item_id: 13243
-      item_name: Infernal pickaxe
+      description: Created by combining a smouldering stone with a dragon axe at 85 Firemaking.
+    - item_name: Infernal pickaxe
       slug: infernal-pickaxe
       relationship: product
-      description: Created tool
+      description: Created by combining a smouldering stone with a dragon pickaxe at 85 Smithing.
+    - item_name: Infernal harpoon
+      slug: infernal-harpoon
+      relationship: product
+      description: Created by combining a smouldering stone with a dragon harpoon at 85 Cooking.
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Upgrade Material |
-    | Tradeable | Yes |
-    | Weight | 0.05 kg |
+    > *"A smouldering stone from the depths of Hell."*
 
-    Creates infernal tools:
+    The smouldering stone is the upgrade catalyst behind every infernal skilling tool. Combine it with a Dragon axe, pickaxe, or harpoon to forge the untradeable infernal variant, each granting a 33% auto-process chance with bonus secondary skill XP and 5,000 charges before reverting.
 
-    | Base Tool | Result | Requirements |
-    |-----------|--------|--------------|
-    | Dragon axe | Infernal axe | 85 FM, 61 WC |
-    | Dragon pickaxe | Infernal pickaxe | 85 Smith, 61 Mining |
-    | Dragon harpoon | Infernal harpoon | 85 Cook, 75 Fishing |
-
-    All infernal tools have 5,000 charges.
-
-    Auto-Process:
-    - 33% chance to instantly process resource
-    - Grants ~50% of secondary skill XP
-    - Destroys the resource
-
-    Essential for:
-    - Creating infernal tools
-    - Recharging infernal tools
-    - Ironman progression
-
-    Key drop from Cerberus.
+    Best obtained from Cerberus at 1/520, which requires 91 Slayer to access.
   market_strategy:
     notes:
-      - Cerberus is best source
-      - 91 Slayer required
-      - Used for all infernal tools
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cerberus is by far the most efficient source; hellhound rolls are negligible."
+      - "91 Slayer gate on Cerberus restricts supply, supporting price stability."
+      - "Demand is driven by Ironman progression and high-level skiller QoL upgrades."
+  trading_tips:
+    - Pair flips with dragon axe/pickaxe/harpoon margins to time set purchases.
+    - GE buy limit of 5 makes accumulating stock for long-term holds slow but reliable.
+  history:
+    - date: "2015-08-27"
+      description: "Added as a Cerberus drop with the Cerberus boss release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/soda-ash.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/soda-ash.mdx
@@ -12,49 +12,71 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: material
+    tier: low
+  properties:
+    release_date: "2002-03-18"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: crafting
       level: 1
       xp: 10
       materials:
-        - item_id: 1781
-          item_name: Soda ash
+        - item_name: Soda ash
           quantity: 1
-        - item_id: 1783
-          item_name: Bucket of sand
+        - item_name: Bucket of sand
           quantity: 1
-      product: Molten glass
-      product_id: 1775
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Trader Stan's Trading Post
+      location: Charter ships
+      price: 5
+      currency: Coins
+      stock: 0
   related_items:
-    - item_id: 401
-      item_name: Seaweed
+    - item_name: Seaweed
       slug: seaweed
       relationship: component
-      description: Raw material
-    - item_id: 21504
-      item_name: Giant seaweed
+      description: Cook on a range or fire to produce a single soda ash.
+    - item_name: Giant seaweed
       slug: giant-seaweed
       relationship: component
-      description: Higher yield option
-    - item_id: 1775
-      item_name: Molten glass
+      description: Cooks into six soda ash per successful action.
+    - item_name: Bucket of sand
+      slug: bucket-of-sand
+      relationship: component
+      description: Smelted with soda ash to make molten glass.
+    - item_name: Molten glass
       slug: molten-glass
       relationship: product
-      description: Crafted product
+      description: Furnace product made by combining soda ash with sand.
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-
-    Combine with bucket of sand at furnace to create molten glass.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Soda ash is the cooked product of seaweeds and a core Crafting ingredient. Combined with a bucket of sand in a furnace it produces molten glass for vials, lanterns, lenses, and Superglass Make.
+  market_strategy:
+    notes:
+      - "Sea-weed underwater agility farms control supply elasticity."
+      - "Demand is steady from Crafting trainers funnelling into molten glass."
+  trading_tips:
+    - Stack soda ash from giant seaweed for the best yield-per-buy.
+    - Pair with bucket of sand orders to keep furnace runs uninterrupted.
+  history:
+    - date: "2002-03-18"
+      description: "Soda ash released alongside the original glass crafting flow."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spined-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spined-armour-set.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 58000
   highalch: 87000
   limit: null
-  about: "Spined armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dagannoth hide
+    tier: mid
+  properties:
+    release_date: "2025-08-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Grand Exchange Sets
+      location: Grand Exchange
+      price: 0
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Spined helm
+      slug: spined-helm
+      relationship: set-piece
+      description: "Head slot piece of the Spined Ranged armour set."
+    - item_name: Spined body
+      slug: spined-body
+      relationship: set-piece
+      description: "Body slot piece of the Spined Ranged armour set."
+    - item_name: Spined chaps
+      slug: spined-chaps
+      relationship: set-piece
+      description: "Legs slot piece of the Spined Ranged armour set."
+    - item_name: Spined boots
+      slug: spined-boots
+      relationship: set-piece
+      description: "Boots slot piece of the Spined Ranged armour set."
+    - item_name: Spined gloves
+      slug: spined-gloves
+      relationship: set-piece
+      description: "Hands slot piece of the Spined Ranged armour set."
+  about: "Spined armour set bundles the full five-piece Spined Ranged armour into a single tradeable item via the Grand Exchange sets exchange. High alchemy value: 87,000 coins."
+  market_strategy:
+    notes:
+      - "Convenient single-trade purchase for Fremennik Ranged kits before Dagannoth Kings."
+      - "Set premium fluctuates with the lower-volume pieces, especially the Spined helm."
+  trading_tips:
+    - "Compare the set price to the sum of individual components before buying; the set frequently trades above intrinsic value."
+  history:
+    - date: "2025-08-20"
+      description: "Added as a Grand Exchange item set bundling all five Spined armour pieces."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spined-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spined-helm.mdx
@@ -12,8 +12,34 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: dagannoth-hide
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      defence: 40
+      ranged: 40
     attack_bonus:
       stab: -6
       slash: -6
@@ -31,57 +57,34 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 40
-      ranged: 40
-    weight: 2.721
   related_items:
-    - item_id: 6133
-      item_name: Spined body
+    - item_name: Spined body
       slug: spined-body
       relationship: set-piece
-      description: Matching body piece
-    - item_id: 6135
-      item_name: Spined chaps
+      description: Matching body piece in the spined armour set
+    - item_name: Spined chaps
       slug: spined-chaps
       relationship: set-piece
-      description: Matching leg piece
+      description: Matching leg piece in the spined armour set
+    - item_name: Archer helm
+      slug: archer-helm
+      relationship: alternative
+      description: Comparable ranged head slot with the same +6 ranged attack bonus
   about: |-
-    | Ranged | Value |
-    |--------|-------|
-    | Ranged Attack | +6 |
+    The Spined helm is the head piece of the spined armour set, the ranged-focused variant of the three Fremennik armour sets (rock-shell, skeletal and spined). It requires 40 Defence and 40 Ranged to equip along with completion of The Fremennik Trials.
 
-    | Defence | Value |
-    |---------|-------|
-    | All melee | +6 |
-    | Magic | +6 |
-
-    Requirements: 40 Defence, 40 Ranged
-
-    The spined set is the ranged variant of the three Fremennik armour sets:
-    - Rock-shell — melee (Skulgrimen)
-    - Skeletal — magic (Peer the Seer)
-    - Spined — ranged (Sigli the Huntsman)
-
-    All require The Fremennik Trials and dagannoth hides.
-
-    | Stat | Spined Helm | Coif |
-    |------|------------|------|
-    | Ranged Atk | +6 | +4 |
-    | Melee Def | +6 each | +4/+6/+8 |
-    | Magic Def | +6 | +4 |
-    | Req | 40 Def/Rng | 40 Rng |
-
-    Slightly better than the coif in ranged attack and more consistent defence, but requires 40 Defence.
-
-    Storable in a Costume Room armour case as part of the complete spined set.
+    Players obtain a spined helm by bringing 1 dagannoth hide, 1 circular hide and 5,000 coins to Sigli the Huntsman in Rellekka. The helm offers +6 ranged attack matching the Archer helm but provides more consistent all-around defence in exchange for the higher Defence requirement.
   market_strategy:
     notes:
-      - Circular hides from Dagannoths on Waterbirth Island
-      - Low demand — green d'hide is easier to obtain
-      - Collector's/fashionscape piece
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Circular hides drop from Dagannoths on Waterbirth Island"
+      - "Low demand — green d'hide coif is easier to obtain"
+      - "Collector and fashionscape piece for full Fremennik sets"
+  trading_tips:
+    - Stock up after Fremennik Trials revisits or skilling events
+    - Bundle with spined body and chaps for set sales
+  history:
+    - date: "2005-08-01"
+      description: "Released with the Fremennik armour expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spork.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spork.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 50
-  about: "Spork is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "15 March 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: sword
+    attack_speed: 5
+    weight: 1.814
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 11
+      slash: 8
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle basement
+      price: 325
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Steel sword
+      slug: steel-sword
+      relationship: alternative
+      description: Identical combat stats
+    - item_name: Spatula
+      slug: spatula
+      relationship: alternative
+      description: Other Recipe for Disaster cosmetic weapon
+  about: |-
+    Spork is a Recipe for Disaster cosmetic weapon mirroring Steel sword stats. Sold by the Culinaromancer's Chest after three RFD subquest unlocks.
+  market_strategy:
+    notes:
+      - "Quest gating limits the supplier pool"
+      - "Buy limit of 50 keeps the spread tight"
+      - "Novelty fashion demand sustains premium pricing"
+  trading_tips:
+    - Buy at shop price when GE spread is wide
+    - Unload during meme weapon trends and fashion events
+  history:
+    - date: "15 March 2006"
+      description: "Released as part of the Recipe for Disaster quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-earth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-earth.mdx
@@ -12,25 +12,83 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: 125
-  item_id: 1385
-  item_type: equipment
-  slot: weapon
-  type: staff
-  tradeable: true
-  weight: 2.267
-  requirements:
-    magic: 0
-  stats:
-    magic_attack: 10
-    magic_defence: 10
-  effect:
-    description: Provides unlimited earth runes when equipped.
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: staff
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    attack_speed: 5
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 1
+      slash: -1
+      crush: 9
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Unlimited Earth Runes
+      description: Provides unlimited amounts of earth runes when equipped, removing the need to carry earth runes for any spell.
+  shops:
+    - shop_name: Zaff's Superior Staffs
+      location: Varrock
+      price: 1500
+      currency: Coins
+      stock: 5
   related_items:
-    - slug: earth-battlestaff
-    - slug: mystic-earth-staff
-  about: Provides unlimited earth runes when equipped.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Earth battlestaff
+      slug: earth-battlestaff
+      relationship: upgrade
+      description: Higher-tier earth staff with better stats
+    - item_name: Mystic earth staff
+      slug: mystic-earth-staff
+      relationship: upgrade
+      description: Mystic-tier upgrade of the earth battlestaff
+  about: |-
+    The Staff of earth is a free-to-play one-handed magic staff that provides an unlimited supply of earth runes while equipped. It can be autocast with Standard spellbook spells and offers a +10 magic attack bonus.
+
+    Sold by Zaff's Superior Staffs in Varrock for 1,500 coins or traded on the Grand Exchange. Players with 42 Construction can modify it using a crystal ball in their player-owned house to swap the elemental type to fire, water or air.
+  market_strategy:
+    notes:
+      - "Cheap budget option for earth-based spells"
+      - "F2P accessible and shop-bought floor keeps price stable"
+      - "Outclassed by earth battlestaff for higher Magic levels"
+  trading_tips:
+    - Useful for low-level Magic training without rune costs
+    - Hold for Construction-related crystal ball flips
+  history:
+    - date: "2001-01-04"
+      description: "Released in RuneScape Classic as part of the original elemental staves."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-2h-sword.mdx
@@ -12,41 +12,88 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: 2h
-    type: two-handed sword
-    tradeable: true
+    weapon_type: two-handed sword
+    attack_speed: 7
     weight: 3.628
     requirements:
       attack: 5
-    stats:
-      attack_stab: -4
-      attack_slash: 21
-      attack_crush: 16
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: -4
+      slash: 21
+      crush: 16
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
       strength: 22
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: smithing
+      level: 44
+      xp: 112.5
+      materials:
+        - item_name: Steel bar
+          quantity: 3
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
   related_items:
-    - item_id: 1313
-      item_name: Black 2h sword
+    - item_name: Black 2h sword
       slug: black-2h-sword
       relationship: upgrade
       description: Higher tier 2h sword
-    - item_id: 1295
-      item_name: Steel longsword
+    - item_name: Steel longsword
       slug: steel-longsword
       relationship: alternative
       description: One-handed alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: |-
+    Steel 2h sword is a free-to-play two-handed weapon requiring 5 Attack to wield. It is smithed from 3 steel bars at level 44 Smithing for 112.5 XP. The high strength bonus makes it a budget choice for low-level slash training despite the slow 7-tick attack speed.
+  market_strategy:
+    notes:
+      - "High alch 600 gp - can be profitable when bought below alch + nature rune cost"
+      - "Demand from F2P Smithing trainers buying steel bars"
+      - "Slow attack speed limits PvM viability"
+  trading_tips:
+    - Check GE price vs 3 steel bars + 35 XP value before crafting to sell
+    - Pair with strength amulet for early-game strength training
+  history:
+    - date: "4 January 2001"
+      description: "Item released with the launch of RuneScape."
+    - date: "31 May 2005"
+      description: "Item graphically updated."
+    - date: "23 August 2005"
+      description: "Equip animation changed."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dagger.mdx
@@ -12,26 +12,90 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 125
-  item_id: 1207
-  item_type: equipment
-  slot: weapon
-  type: dagger
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 0.453
-  requirements:
-    attack: 5
-  stats:
-    stab_attack: 8
-    slash_attack: 4
-    crush_attack: -4
-    strength: 7
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 8
+      slash: 4
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 30
+      xp: 37.5
+      materials:
+        - item_name: Steel bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Varrock Swordshop
+      location: Varrock
+      price: 125
+      currency: coins
+      stock: 5
   related_items:
-    - slug: black-dagger
-    - slug: steel-sword
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Black dagger
+      slug: black-dagger
+      relationship: upgrade
+      description: Higher tier dagger
+    - item_name: Steel sword
+      slug: steel-sword
+      relationship: alternative
+      description: One-handed slash alternative
+  about: |-
+    Steel dagger is a free-to-play stab weapon requiring level 5 Attack to wield. It is smithed from a single steel bar at level 30 Smithing for 37.5 XP and is commonly used by low-level players for stab-weak monsters.
+  market_strategy:
+    notes:
+      - "Cheap entry-level stab weapon"
+      - "Stable demand from F2P Smithing trainers"
+      - "High alch only 75 gp - not profitable to alch"
+  trading_tips:
+    - Buy steel bars and smith for Smithing XP rather than profit
+    - Useful for low-level stab training against monsters weak to stab
+  history:
+    - date: "4 January 2001"
+      description: "Item released with the launch of RuneScape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-halberd.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
-  about: "Steel halberd is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2004-09-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
+  equipment:
+    slot: weapon
+    weapon_type: halberd
+    attack_speed: 7
+    weight: 3.175
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 14
+      slash: 19
+      crush: 0
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 20
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Quartermaster's halberd store
+      location: Tyras Camp
+      price: 1300
+      currency: Coins
+      stock: 5
+    - shop_name: Fortis Blacksmith
+      location: Civitas illa Fortis
+      price: 1000
+      currency: Coins
+      stock: 0
+  related_items:
+    - item_name: Mithril halberd
+      slug: mithril-halberd
+      relationship: upgrade
+      description: Higher tier halberd
+    - item_name: Iron halberd
+      slug: iron-halberd
+      relationship: downgrade
+      description: Lower tier halberd
+    - item_name: Adamant halberd
+      slug: adamant-halberd
+      relationship: upgrade
+      description: Stronger adamant tier
+  passive_effects:
+    - name: Two-tile reach
+      description: All halberds have a two-square attack range, allowing safespotting on melee monsters.
+  about: "Steel halberd is the steel-tier halberd available from Tyras Camp and Civitas illa Fortis. Like other halberds it strikes from two tiles away, enabling safe melee training and PvM."
+  market_strategy:
+    notes:
+      - "Available cheap from shop NPCs"
+      - "Niche use for safespot melee setups"
+      - "Buy limit 125 per 4 hours"
+  trading_tips:
+    - Shop floor at Tyras and Fortis sets the upper bound
+    - Demand spikes during quests featuring slayer-style bosses
+  history:
+    - date: "2004-09-20"
+      description: "Released alongside the halberd category in Regicide."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-knife.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-knife.mdx
@@ -12,55 +12,97 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: thrown
-    attack_style: ranged
+    weapon_type: thrown
     attack_speed: 3
-  requirements:
-    ranged: 5
-  stats:
-    attack:
+    weight: 0
+    requirements:
+      ranged: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
       ranged: 8
-    other:
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 7
-  smithing:
-    level: 37
-    xp: 37.5
-    method: Steel bar at anvil
-    bars: 1
-    quantity: 5
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 37
+      xp: 37.5
+      materials:
+        - item_name: Steel bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 5
+  shops:
+    - shop_name: Martin Thwait's Lost and Found
+      location: Rogues' Den
+      price: 41
+      currency: Coins
+      stock: 50
   related_items:
-    - item_id: 2353
-      item_name: Steel bar
+    - item_name: Steel bar
       slug: steel-bar
       relationship: component
-      description: Smithing material
-    - item_id: 866
-      item_name: Mithril knife
+      description: Smithing material for crafting steel knives
+    - item_name: Mithril knife
       slug: mithril-knife
       relationship: upgrade
-      description: Higher tier knife
-    - item_id: 863
-      item_name: Iron knife
+      description: Next tier thrown knife
+    - item_name: Iron knife
       slug: iron-knife
       relationship: downgrade
-      description: Lower tier knife
-    - item_id: 808
-      item_name: Steel dart
+      description: Previous tier thrown knife
+    - item_name: Steel dart
       slug: steel-dart
       relationship: alternative
-      description: Alternative thrown weapon
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Weapon |
-    | Type | Thrown |
-    | Tradeable | Yes |
-    | Weight | 0.006 kg |
-    | Requirements | 5 Ranged |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Alternative thrown weapon at the same tier
+  about: "Steel knife is a thrown ranged weapon requiring 5 Ranged to wield. It can be smithed at level 37 Smithing from a steel bar (5 knives per bar) or bought from Martin Thwait's Lost and Found at the Rogues' Den."
+  market_strategy:
+    notes:
+      - "7,000 buy limit allows bulk flipping"
+      - "Smithing margin is thin against bar costs"
+      - "Low-tier ranged knife with stable demand from training accounts"
+  trading_tips:
+    - Compare Steel bar prices before smithing for profit
+    - Buy in bulk for cheap low-level ranged training
+  history:
+    - date: "2003-04-14"
+      description: "Released as part of the New Throwing Weapons update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platelegs-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-platelegs-g.mdx
@@ -12,22 +12,88 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Drop
+    worn_options:
+      - Wear
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 17
+      slash: 16
+      crush: 15
+      magic: -4
+      ranged: 16
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Easy Treasure Trail reward casket
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 20169
-      item_name: Steel platebody (g)
+    - item_name: Steel platelegs
+      slug: steel-platelegs
+      relationship: variant
+      description: Untrimmed base version with identical stats.
+    - item_name: Steel platebody (g)
       slug: steel-platebody-g
       relationship: set-piece
-      description: Matching gold-trimmed platebody
+      description: Matching gold-trimmed platebody from the same clue tier.
+    - item_name: Steel plateskirt (g)
+      slug: steel-plateskirt-g
+      relationship: alternative
+      description: Gold-trimmed skirt alternative for the legs slot.
   about: |-
-    > *"Steel platelegs with gold trim."*
-
-    The steel platelegs (g) are a gold-trimmed cosmetic variant of standard steel platelegs. Identical stats, requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Steel platelegs (g) are a cosmetic gold-trimmed variant of the standard steel platelegs, awarded from easy Treasure Trail caskets. Stats are identical to the untrimmed version and only 5 Defence is required to wear them.
+  market_strategy:
+    notes:
+      - "Supply is gated entirely by easy clue scroll completion."
+      - "Demand is collector and fashionscape driven, not combat driven."
+  trading_tips:
+    - Pick up cheap during clue scroll giveaway events.
+    - List in costume room sets to capture the matching premium.
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of the Treasure Trail Expansion update."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus decreased from -7 to -11."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-spear-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-spear-p.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  about: "Steel spear(p) is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    weight: 2.267
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Steel spear
+      slug: steel-spear
+      relationship: variant
+      description: "Unpoisoned base variant of the steel spear."
+    - item_name: Steel spear(p+)
+      slug: steel-spear-p-plus
+      relationship: variant
+      description: "Steel spear poisoned with weapon poison+."
+    - item_name: Steel spear(p++)
+      slug: steel-spear-p-plus-plus
+      relationship: variant
+      description: "Steel spear poisoned with weapon poison++."
+  about: "The steel spear(p) is a poisoned variant of the steel spear, applying poison damage on hit while wielded. Created by applying weapon poison to a steel spear. Useful for low-level PvM where poison damage compounds with weak hits."
+  market_strategy:
+    notes:
+      - "Niche entry-tier spear with low margin but consistent demand from new accounts."
+      - "Premium over the unpoisoned variant tracks weapon poison vial prices."
+  trading_tips:
+    - "Apply weapon poison to unpoisoned spears bought cheap; sell at a small margin."
+    - "Avoid bulk holding; volume is limited."
+  history:
+    - date: "2003-04-14"
+      description: "Steel spear variants released with the introduction of spears."
+    - date: "2021-04-21"
+      description: "Attack speed improved from 5 ticks to 4 ticks, improving combat efficiency."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stone-seal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stone-seal.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 13000
-  about: "Stone seal is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: artefact
+    tier: low
+  properties:
+    release_date: "2006-07-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
+  drop_table:
+    sources:
+      - source: Grand gold chest (Pyramid Plunder, room 1)
+        quantity: "1"
+        rarity: 1/4
+      - source: Sarcophagus (Pyramid Plunder, room 1)
+        quantity: "1"
+        rarity: 1/4
+      - source: Sarcophagus (Pyramid Plunder, room 2)
+        quantity: "1"
+        rarity: 1/2
+      - source: Sarcophagus (Pyramid Plunder, room 3)
+        quantity: "1"
+        rarity: 1/2
+      - source: Sarcophagus (Pyramid Plunder, room 4)
+        quantity: "1"
+        rarity: 1/2
+      - source: Sarcophagus (Pyramid Plunder, room 5)
+        quantity: "1"
+        rarity: 1/4
+      - source: Urn (Pyramid Plunder)
+        quantity: "1"
+        rarity: Unknown
+  related_items:
+    - item_name: Ivory comb
+      slug: ivory-comb
+      relationship: alternative
+      description: Another Pyramid Plunder artefact
+    - item_name: Pottery scarab
+      slug: pottery-scarab
+      relationship: alternative
+      description: Another Pyramid Plunder artefact
+    - item_name: Gold seal
+      slug: gold-seal
+      relationship: variant
+      description: Higher-tier seal artefact
+  about: "Stone seal is a low-tier Pyramid Plunder artefact looted from urns, chests, and sarcophagi in the Jalsavrah pyramid. It can be sold to Simon Templeton for coins."
+  market_strategy:
+    notes:
+      - "Looted from Pyramid Plunder containers"
+      - "Sold to Simon Templeton or on the Grand Exchange"
+      - "Generated in large volumes during thieving training"
+  trading_tips:
+    - Prices fluctuate with Pyramid Plunder popularity
+    - Bulk buyers often resell to Simon Templeton for coins
+  history:
+    - date: "2006-07-17"
+      description: "Released alongside Pyramid Plunder."
+    - date: "2015-02-26"
+      description: "Made tradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stone-statuette.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stone-statuette.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 13000
-  about: "Stone statuette is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: stone
+    tier: low
+  properties:
+    release_date: "2006-07-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Simon Templeton's Trade
+      location: Sophanem
+      price: 200
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Golden statuette
+      slug: golden-statuette
+      relationship: upgrade
+      description: "Higher-value Pyramid Plunder artifact."
+    - item_name: Stone seal
+      slug: stone-seal
+      relationship: alternative
+      description: "Another stone-tier Pyramid Plunder reward."
+    - item_name: Ivory comb
+      slug: ivory-comb
+      relationship: alternative
+      description: "Lower-tier Pyramid Plunder artifact."
+    - item_name: Pharaoh's sceptre
+      slug: pharaohs-sceptre
+      relationship: product
+      description: "Recharged using 12 stone statuettes."
+  about: "The stone statuette is a Pyramid Plunder reward obtained at Thieving 31+ in Sophanem. It can be sold to Simon Templeton for 200 coins each, and 12 statuettes are used to recharge the Pharaoh's sceptre."
+  market_strategy:
+    notes:
+      - "Floor price near vendor sale value (200 gp to Simon Templeton) creates a natural price anchor."
+      - "Used in Pharaoh's sceptre recharges, providing steady demand."
+  trading_tips:
+    - "If GE price drops below 200, buy and vendor to Simon for risk-free profit."
+    - "Stockpile for Pharaoh's sceptre owners (12 statuettes per full recharge)."
+  history:
+    - date: "2006-07-17"
+      description: "Added with the Pyramid Plunder minigame update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-combat-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-combat-potion-3.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 2000
-  about: "Super combat potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2014-08-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 90
+      xp: 150
+      materials:
+        - item_name: Super attack(4)
+          quantity: 1
+        - item_name: Super strength(4)
+          quantity: 1
+        - item_name: Super defence(4)
+          quantity: 1
+        - item_name: Torstol
+          quantity: 1
+      tools:
+        - Vial
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Boosts Attack, Strength, and Defence by floor(SkillLevel * 15 / 100) + 5 (+19 at level 99 in each stat)."
+        duration: 300
+      - description: "Boosted stats decay at 1 level per minute (or every 90 seconds with the Preserve prayer)."
+        duration: 300
+  related_items:
+    - item_name: Super combat potion(4)
+      slug: super-combat-potion-4
+      relationship: variant
+      description: Four-dose variant of the same potion.
+    - item_name: Super combat potion(2)
+      slug: super-combat-potion-2
+      relationship: variant
+      description: Two-dose variant of the same potion.
+    - item_name: Super combat potion(1)
+      slug: super-combat-potion-1
+      relationship: variant
+      description: One-dose variant of the same potion.
+    - item_name: Divine super combat potion(4)
+      slug: divine-super-combat-potion-4
+      relationship: upgrade
+      description: Divine variant with a fixed 5-minute boost.
+  about: |-
+    Super combat potion(3) is a three-dose version of the super combat potion, boosting Attack, Strength, and Defence at the standard 5 + 15% formula.
+
+    Brewed at 90 Herblore for 150 XP per dose set by combining a super attack(4), super strength(4), super defence(4), and a torstol, or by drinking down from a four-dose.
+  market_strategy:
+    notes:
+      - "Supply driven by Herblore training, with most output sold as (4) doses."
+      - "Three-dose variants accumulate from PvM partial usage."
+      - "GE flip room is narrow; alch margin is negative without nature savings."
+  trading_tips:
+    - "Decant chains: buy (3) cheap, decant up to (4) for resale on demand."
+    - Watch torstol and super attack/strength/defence cost shifts for production margin.
+  history:
+    - date: "2014-08-14"
+      description: "Released with the super combat potion update."
+    - date: "2019-02-14"
+      description: "Update allowed unfinished torstol potions to substitute for clean torstol when brewing."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tangled-toad-s-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tangled-toad-s-legs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tangled toad's legs | OSRS Price Data
-description: "Tangled toad's legs: It actually smells quite good.. High alch: 1 GP, GE limit: 6,000."
+description: "Tangled toad's legs: It actually smells quite good. High alch: 1 GP, GE limit: 6,000."
 osrs:
   id: 2187
   name: Tangled toad's legs
@@ -12,9 +12,49 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Tangled toad's legs is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: herblore-secondary
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Mutated Tortoise
+        quantity: "1"
+        rarity: Common
+      - source: Warped Tortoise
+        quantity: "1"
+        rarity: Common
+  about: |-
+    > *"It actually smells quite good."*
+
+    Tangled toad's legs are a gnome cuisine ingredient and Herblore secondary used in higher-level potion recipes. They drop in stacks from mutated and warped tortoises and serve as a delivery item during The Path of Glouphrie quest.
+  market_strategy:
+    notes:
+      - "Generous 6,000/4hr buy limit means bulk orders rarely move price."
+      - "Cheap floor near alch value keeps margins thin but consistent."
+      - "Demand spikes when high-level Herblore potions trend on streamer content."
+  trading_tips:
+    - Stock up during quest-prep cycles when newcomers need bulk for Path of Glouphrie.
+    - Treat as a volume play rather than a flip target given the 1 gp alch floor.
+  history:
+    - date: "2002-12-12"
+      description: "Introduced as a gnome cooking ingredient at 40 Cooking."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tarromin-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tarromin-potion-unf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tarromin potion (unf) | OSRS Price Data
-description: "Tarromin potion (unf) is a 4-dose members potion. High alch: 6 GP, GE limit: 10,000."
+description: "Tarromin potion (unf) is a members unfinished potion. High alch: 6 GP, GE limit: 10,000."
 osrs:
   id: 95
   name: Tarromin potion (unf)
@@ -12,65 +12,68 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  potion:
-    type: unfinished
-    tier: basic
-  herblore:
-    level: 12
-    xp: 0
-    method: Add tarromin to vial of water
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: unfinished-potion
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: herblore
       level: 12
       xp: 0
       materials:
         - item_name: Vial of water
-          item_id: 227
           quantity: 1
         - item_name: Tarromin
-          item_id: 253
           quantity: 1
-      product: Tarromin potion (unf)
-      product_id: 95
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 253
-      item_name: Tarromin
+    - item_name: Tarromin
       slug: tarromin
       relationship: component
-      description: Herb ingredient
-    - item_id: 227
-      item_name: Vial of water
+      description: Clean herb added to the vial of water
+    - item_name: Vial of water
       slug: vial-of-water
       relationship: component
-      description: Base liquid
-    - item_id: 225
-      item_name: Limpwurt root
+      description: Base liquid for any unfinished potion
+    - item_name: Limpwurt root
       slug: limpwurt-root
       relationship: component
-      description: Secondary for strength potion
-    - item_id: 115
-      item_name: Strength potion(3)
+      description: Secondary used to finish a Strength potion
+    - item_name: Strength potion(3)
       slug: strength-potion-3
       relationship: product
-      description: Boosts strength
+      description: Finished potion that boosts Strength
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 12 Herblore |
+    Tarromin potion (unf) is the unfinished base used to craft Strength potions, Serum 207, and Shrink-me-quick. It is made at level 12 Herblore by adding a clean tarromin to a vial of water for 0 XP.
 
-    Add secondary ingredient to create:
-    - Strength potion (+ limpwurt root)
-    - Serum 207 (+ ashes)
-
-    Strength potions popular for combat training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Bulk crafters buy these to skip the cleaning step when working toward Strength potions, which remain a popular low-level combat boost.
+  market_strategy:
+    notes:
+      - "Demand driven by Strength potion production for combat training"
+      - "10,000 buy limit allows high-volume potion makers to stock up"
+      - "0 XP recipe means margins, not training, dictate price"
+  trading_tips:
+    - Buy when tarromin spikes to lock in unfinished stock
+    - Sell finished Strength potions back into the market for better profit
+  history:
+    - date: "2002-02-27"
+      description: "Released with the Herblore skill rework"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teak sapling | OSRS Price Data
-description: "Teak sapling: This sapling is ready to be replanted in a hardwood tree patch.. High alch: 1 GP, GE limit: 200."
+description: "Teak sapling: This sapling is ready to be replanted in a hardwood tree patch. High alch: 1 GP, GE limit: 200."
 osrs:
   id: 21477
   name: Teak sapling
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Teak sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: sapling
+    tier: mid
+  properties:
+    release_date: "2017-09-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options: ["Drop"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 35
+      xp: 35
+      materials:
+        - item_name: Teak seedling (w)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Teak seed
+      slug: teak-seed
+      relationship: component
+      description: Plant in a filled plant pot to start the sapling chain
+    - item_name: Teak seedling
+      slug: teak-seedling
+      relationship: component
+      description: Pre-water seedling stage
+    - item_name: Teak seedling (w)
+      slug: teak-seedling-w
+      relationship: component
+      description: Watered seedling — matures into the sapling
+    - item_name: Teak logs
+      slug: teak-logs
+      relationship: product
+      description: Eventual woodcutting output after full growth
+  about: |-
+    | Stage | Action |
+    |-------|--------|
+    | Teak seed → seedling | Plant in plant pot (35 Farming) |
+    | Seedling → watered | Watering can or Humidify |
+    | Watered → sapling | Wait one crop cycle (0–5 min) |
+    | Sapling planted | 35 Farming XP, 7,290 check-health XP |
+
+    Hardwood tree sapling grown from a teak seedling. Plant in a hardwood tree patch (Fossil Island, Karamja, Hosidius) — full growth takes ~3 days 3 hours. Pay 15 limpwurt roots per patch for disease protection.
+  market_strategy:
+    notes:
+      - "Required for hardwood tree farming runs"
+      - "Low GE limit (200) keeps supply rationed"
+      - "Demand stable with daily farming rotations"
+  trading_tips:
+    - Sapling spawn rate is fixed per seed — pricing follows teak seed cost
+    - Stock up before bonus XP weekends
+  history:
+    - date: "2017-09-07"
+      description: "Released alongside hardwood tree patches and the teak seed Farming chain."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teal-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teal-gloves.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Teal gloves is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Crawling Hand
+        quantity: "1"
+        rarity: 2/128
+      - source: Crushing Hand
+        quantity: "1"
+        rarity: 6/128
+  shops:
+    - shop_name: Barker's Haberdashery
+      location: Canifis
+      price: 650
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Red gloves
+      slug: red-gloves
+      relationship: variant
+      description: Red colour variant sold at Barker's Haberdashery
+    - item_name: Blue gloves
+      slug: blue-gloves
+      relationship: variant
+      description: Blue colour variant sold at Barker's Haberdashery
+    - item_name: Yellow gloves
+      slug: yellow-gloves
+      relationship: variant
+      description: Yellow colour variant sold at Barker's Haberdashery
+  about: |-
+    Teal gloves are a free-to-play hand slot cosmetic offering minor slash and crush defence bonuses. They are purchased from Barker's Haberdashery in Canifis for 650 coins or dropped by Crawling Hands and Crushing Hands during Slayer tasks.
+
+    Originally simply called "Gloves" when released alongside the Priest in Peril quest, they were renamed "Teal gloves" on 10 December 2014 to distinguish them from other coloured glove variants.
+  market_strategy:
+    notes:
+      - "Shop-bought floor at 650 coins limits margin"
+      - "Slayer drops keep GE supply liquid"
+      - "Cosmetic and fashionscape piece"
+  trading_tips:
+    - Watch for cosmetic outfit hype around holiday events
+    - Flip colour variant spreads when one colour spikes
+  history:
+    - date: "2004-06-29"
+      description: "Released alongside the Priest in Peril quest under the original name \"Gloves\"."
+    - date: "2014-12-10"
+      description: "Renamed from \"Gloves\" to \"Teal gloves\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-13-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-13-cape.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-13 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Larry's Wilderness Cape Shop
+      location: Bone Yard
+      price: 50
+      currency: coins
+      stock: 50
+  related_items:
+    - item_name: Team-12 cape
+      slug: team-12-cape
+      relationship: variant
+      description: "Sequential team cape variant with identical stats."
+    - item_name: Team-14 cape
+      slug: team-14-cape
+      relationship: variant
+      description: "Sequential team cape variant with identical stats."
+  about: "Team-13 cape is one of fifty numbered team capes used to mark allies on the minimap and through right-click attack options. Free-to-play since 23 May 2013. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
+  market_strategy:
+    notes:
+      - "Demand is driven by clan or event coordination rather than combat performance."
+      - "Numbered variants generally trade close to one another; uncommon numbers occasionally spike."
+  trading_tips:
+    - "Buying directly from Larry at 50 gp usually beats any GE premium."
+  history:
+    - date: "2005-02-22"
+      description: "Released as part of the team cape family for PvP and clan identification."
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-15-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-15-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-15 cape | OSRS Price Data
-description: "Team-15 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-15 cape: Ooohhh look at the pretty colours. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4343
   name: Team-15 cape
@@ -12,9 +12,73 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-15 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Edward's Wilderness Cape Shop
+      location: Around the Rogues' Castle
+      price: 50
+      currency: Coins
+      stock: 100
+  about: |-
+    > *"Ooohhh look at the pretty colours..."*
+
+    Team-15 capes are part of the team cape series used to identify clans in PvP encounters. Players wearing the same team number appear as blue dots on each other's minimaps rather than the usual white.
+  market_strategy:
+    notes:
+      - "Shop restock at 50 coins anchors the GE price near vendor cost."
+      - "Demand cycles with PK group activity at the Rogues' Castle."
+      - "F2P availability since 2013 keeps the supply pool large."
+  trading_tips:
+    - Buy from Edward's shop for guaranteed 50 gp pricing when GE is overpriced.
+    - Stockpile during low-demand periods for resale during PK event weekends.
+  history:
+    - date: "2005-02-22"
+      description: "Released as part of the Wilderness team capes update."
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-ket-xil.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-ket-xil.mdx
@@ -12,8 +12,34 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: obsidian
+    tier: mid-high
+  properties:
+    release_date: "2005-09-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 3.628
+    requirements:
+      defence: 60
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,63 +57,45 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 60
-    weight: 3.628
+  drop_table:
+    sources:
+      - source: TzHaar-Ket (level 149)
+        quantity: "1"
+        rarity: 1/512
+      - source: TzHaar-Ket (level 221)
+        quantity: "1"
+        rarity: 1/512
+  shops:
+    - shop_name: TzHaar-Hur-Tel's Equipment Store
+      location: Mor Ul Rek
+      price: 67500
+      currency: Tokkul
+      stock: 1
   related_items:
-    - item_id: 3122
-      item_name: Granite shield
+    - item_name: Granite shield
       slug: granite-shield
       relationship: alternative
-      description: Same defence stats, no Strength bonus
-    - item_id: 12954
-      item_name: Dragon defender
+      description: Same defence stats but no Strength bonus
+    - item_name: Dragon defender
       slug: dragon-defender
       relationship: alternative
-      description: Offensive alternative with accuracy bonuses
-    - item_id: 6522
-      item_name: Toktz-xil-ul
+      description: Offensive shield-slot option with attack bonuses
+    - item_name: Toktz-xil-ul
       slug: toktz-xil-ul
       relationship: set-piece
-      description: Obsidian throwing rings
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +40 |
-    | Slash | +42 |
-    | Crush | +38 |
-    | Ranged | +65 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +5 |
-
-    Requirements: 60 Defence | Weight: 3.6 kg
-
-    The Toktz-ket-xil is unique among shields — it provides +5 melee Strength while maintaining strong defensive stats. No other shield in the game offers this combination of Strength and defence.
-
-    | Stat | Toktz-ket-xil | Granite Shield | Dragon Defender | Rune Kiteshield |
-    |------|--------------|----------------|-----------------|-----------------|
-    | Stab Def | +40 | +40 | +25 | +44 |
-    | Slash Def | +42 | +42 | +24 | +48 |
-    | Crush Def | +38 | +38 | +23 | +42 |
-    | Ranged Def | +65 | +65 | +23 | +46 |
-    | Str Bonus | +5 | 0 | +5 | 0 |
-    | Atk Bonus | 0 | 0 | +20 stab/slash | 0 |
-    | Req | 60 Def | 50 Def/Str | 60 Def + quest | 40 Def |
-
-    The dragon defender trades defensive stats for offensive accuracy bonuses. The Toktz-ket-xil is the tanky alternative with the same +5 Strength.
-
-    - Defender — better for DPS (accuracy bonuses speed up kills)
-    - Toktz-ket-xil — better for tanking (superior defence with same Strength)
-    - Use the obsidian shield when survivability matters more than kill speed
+      description: Obsidian throwing rings, paired ranged option
+  about: "Toktz-ket-xil is a unique obsidian shield that offers +5 melee Strength alongside strong defensive stats. It is the only shield in the game to combine melee Strength with high defensive bonuses, making it a tanky alternative to the dragon defender."
   market_strategy:
     notes:
-      - Shop price is 67,500 Tokkul (farm Fight Caves/Inferno for Tokkul)
-      - Karamja gloves reduce shop cost to 58,500
-      - GE price significantly above alch value due to +5 Strength utility
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Shop price (67,500 Tokkul) is well below GE; Karamja gloves drop the price to 58,500"
+      - "+5 melee Strength keeps demand steady from TzHaar tank setups"
+      - "Drop rate from TzHaar-Ket bosses is 1/512, so supply is steady"
+  trading_tips:
+    - Farm Tokkul during Fight Caves or Inferno runs to offset GE cost
+    - Watch for restock cycles in the obsidian shop
+  history:
+    - date: "2005-09-19"
+      description: "Released alongside the TzHaar City update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tome-of-earth-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tome-of-earth-empty.mdx
@@ -11,74 +11,94 @@ osrs:
   value: 20000
   lowalch: 8000
   highalch: 12000
-  limit: null
+  limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: magic-tome
+    tier: high
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wield
+      - Pages
+      - Drop
+    worn_options:
+      - Pages
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: magic_book
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 1
     requirements:
       magic: 50
-    stats:
-      attack_magic: 8
-      defence_magic: 8
-  charging:
-    material_name: Soiled page
-    max_charges: 20000
-    charged_version_id: 30064
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 8
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 8
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
       - source: The Hueycoatl
-        rate: 1/90
-  market:
-    buy_limit: 8
-    price_estimate: 366115
+        quantity: "1"
+        rarity: 1/90
   related_items:
-    - item_id: 30064
-      item_name: Tome of earth
+    - item_name: Tome of earth
       slug: tome-of-earth
       relationship: variant
-      description: Charged version
-    - item_id: 25574
-      item_name: Tome of water
+      description: Charged variant that grants the earth magic boost
+    - item_name: Soiled page
+      slug: soiled-page
+      relationship: component
+      description: Charging material; each page adds 20 charges
+    - item_name: Tome of water
       slug: tome-of-water
       relationship: alternative
-      description: Water tome variant
-    - item_id: 20714
-      item_name: Tome of fire
+      description: Water spell counterpart tome
+    - item_name: Tome of fire
       slug: tome-of-fire
       relationship: alternative
-      description: Fire tome variant
+      description: Fire spell counterpart tome
   about: |-
-    | Stat | Bonus |
-    |------|-------|
-    | Magic Attack | +8 |
-    | Magic Defence | +8 |
+    Tome of earth (empty) is the uncharged form of the earth spell tome released 25 September 2024. It is dropped by The Hueycoatl at a 1/90 rate and requires 50 Magic to wield in the shield slot.
 
-    Note: The empty tome provides only the base stats. To gain the earth spell damage bonus and infinite earth runes effect, you must charge it with Soiled pages.
-
-    To activate the tome's full potential, you need to charge it:
-
-    - Charging Material: Soiled page
-    - Maximum Charges: 20,000
-    - Charged Version: Tome of earth (ID: 30064)
-
-    Each Soiled page adds charges to the tome. When charged, the tome transforms into the active Tome of earth.
-
-    The empty tome is primarily used as:
-    - A stepping stone to the charged Tome of earth
-    - Budget magic off-hand for players who cannot afford pages
-    - Investment item for charging and reselling
-
-    Recommendation: Charge the tome with Soiled pages to unlock the 10% earth spell damage boost and infinite earth runes effect.
+    The empty tome provides +8 Magic attack and +8 Magic defence but offers no spellcasting bonuses until charged. Players add Soiled pages, with each page contributing 20 charges up to a 1,000-charge cap, transforming the empty tome into the active Tome of earth.
   market_strategy:
     notes:
-      - Price gap between empty and charged version indicates page value
-      - Consider buying empty tomes when Hueycoatl is heavily farmed
-      - Empty tomes are more liquid than charged versions
-      - Compare cost of charging vs buying pre-charged
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Price tracks Hueycoatl drop supply and Soiled page demand"
+      - "Empty tomes liquidate faster than charged variants on the GE"
+      - "Buy limit of 8 keeps short-term flipping tight"
+  trading_tips:
+    - Watch Hueycoatl popularity during DMM or new content droughts
+    - Compare empty tome price plus pages versus pre-charged listings
+  history:
+    - date: "2024-09-25"
+      description: "Released alongside The Hueycoatl boss"
+    - date: "2024-10-09"
+      description: "Empty and charged variants now share a bank placeholder"
+    - date: "2025-03-05"
+      description: "Bank interface gained a charge configuration option"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-relic-hunter-t2-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-relic-hunter-t2-armour-set.mdx
@@ -12,9 +12,53 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Trailblazer relic hunter (t2) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: ["Exchange", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Trailblazer relic hunter (t2) armour set is a bundled cosmetic outfit container holding the Trailblazer hood, top, trousers and boots (t2). Originally rewarded during the Trailblazer League (Leagues II, 2020), the set is traded via the Grand Exchange clerk's item sets interface for convenient bulk exchange. Held the record for longest item name in OSRS at release (40 characters). High alchemy value: 30,000 coins."
+  market_strategy:
+    notes:
+      - "Set bundle typically trades above the sum of individual pieces due to Exchange clerk convenience"
+      - "No GE buy limit — useful for arbitrage between set and components"
+      - "Demand from cosmetic collectors and costume room completionists"
+  trading_tips:
+    - Buy the set then unpack at the GE clerk when individual pieces sell for more
+    - Pack the set when bundling individual pieces is cheaper than the set price
+  related_items:
+    - item_name: Trailblazer hood (t2)
+      slug: trailblazer-hood-t2
+      relationship: component
+      description: Head piece of the set
+    - item_name: Trailblazer top (t2)
+      slug: trailblazer-top-t2
+      relationship: component
+      description: Body piece of the set
+    - item_name: Trailblazer trousers (t2)
+      slug: trailblazer-trousers-t2
+      relationship: component
+      description: Legs piece of the set
+    - item_name: Trailblazer boots (t2)
+      slug: trailblazer-boots-t2
+      relationship: component
+      description: Feet piece of the set
+  history:
+    - date: "2021-01-06"
+      description: "Added with the Soul Wars and 20th Anniversary Event update as a Trailblazer League reward bundle."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-trousers-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-trousers-t2.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded trousers (t2) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Are you sure you want to drop this?"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues hub
+      price: 5000
+      currency: League points
+      stock: Unlimited
+  related_items:
+    - item_name: Trailblazer reloaded hood (t2)
+      slug: trailblazer-reloaded-hood-t2
+      relationship: set-piece
+      description: Matching head slot piece
+    - item_name: Trailblazer reloaded top (t2)
+      slug: trailblazer-reloaded-top-t2
+      relationship: set-piece
+      description: Matching body slot piece
+    - item_name: Trailblazer reloaded boots (t2)
+      slug: trailblazer-reloaded-boots-t2
+      relationship: set-piece
+      description: Matching feet slot piece
+    - item_name: Trailblazer reloaded trousers (t1)
+      slug: trailblazer-reloaded-trousers-t1
+      relationship: downgrade
+      description: Lower-tier cosmetic variant
+    - item_name: Trailblazer reloaded trousers (t3)
+      slug: trailblazer-reloaded-trousers-t3
+      relationship: upgrade
+      description: Higher-tier cosmetic variant
+  about: "Trailblazer reloaded trousers (t2) is the tier 2 legs piece of the Trailblazer Reloaded Relic Hunter outfit, purchased from the Leagues Reward Shop for 5,000 league points."
+  market_strategy:
+    notes:
+      - "Cosmetic-only with no combat bonuses"
+      - "Cannot be alchemised"
+      - "Supply controlled by Leagues participation"
+  trading_tips:
+    - Set-piece pricing tends to rise post-League season
+    - Stored as part of the full outfit in costume rooms
+  history:
+    - date: "2023-11-29"
+      description: "Released as a Leagues IV \"Trailblazer Reloaded\" reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-trousers-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-trousers-t3.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded trousers (t3) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer reloaded headband (t3)
+      slug: trailblazer-reloaded-headband-t3
+      relationship: set-piece
+      description: "Matching headband in the tier 3 Trailblazer Reloaded outfit"
+    - item_name: Trailblazer reloaded tunic (t3)
+      slug: trailblazer-reloaded-tunic-t3
+      relationship: set-piece
+      description: "Matching tunic in the tier 3 Trailblazer Reloaded outfit"
+    - item_name: Trailblazer reloaded boots (t3)
+      slug: trailblazer-reloaded-boots-t3
+      relationship: set-piece
+      description: "Matching boots in the tier 3 Trailblazer Reloaded outfit"
+    - item_name: Trailblazer reloaded gloves (t3)
+      slug: trailblazer-reloaded-gloves-t3
+      relationship: set-piece
+      description: "Matching gloves in the tier 3 Trailblazer Reloaded outfit"
+  about: |-
+    "The trousers of a Trailblazer Reloaded Relic Hunter."
+
+    Trailblazer reloaded trousers (t3) are a cosmetic legs slot reward from the Trailblazer Reloaded League rewards shop, originally bought as part of the tier 3 Trailblazer Reloaded Relic Hunter outfit. They provide no combat bonuses and serve only as a status piece worn to commemorate participation in that League.
+
+    Since the Trailblazer Reloaded League ended in early 2024, no new copies enter the game from the shop. The trousers remain tradeable on the Grand Exchange, can be stored in a costume room armour case, and displayed on League hall outfit furniture. Ultimate ironmen cannot withdraw individual pieces from the case once the full outfit is stored.
+  market_strategy:
+    notes:
+      - "Fixed supply since the league ended; price drifts upward with cosmetic demand"
+      - "No GE buy limit makes accumulation possible but reduces flip liquidity"
+      - "High alch of 9,000 gp sits far below market and only acts as a destruction floor"
+      - "Bundle premium exists with matching tier 3 pieces, especially the headband"
+  trading_tips:
+    - Look for full-set sellers offloading inventory at a discount per piece
+    - Watch League re-runs or rebroadcasts which can briefly suppress demand
+  history:
+    - date: "2023-11-29"
+      description: "Released with the Trailblazer Reloaded League rewards."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-pink.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-pink.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Tribal top (pink) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 360
+      currency: trading sticks
+      stock: 5
+  related_items:
+    - item_name: Tribal top (blue)
+      slug: tribal-top-blue
+      relationship: variant
+      description: "Blue colour variant of the tribal top"
+    - item_name: Tribal top (brown)
+      slug: tribal-top-brown
+      relationship: variant
+      description: "Brown colour variant of the tribal top"
+    - item_name: Tribal top (yellow)
+      slug: tribal-top-yellow
+      relationship: variant
+      description: "Yellow colour variant of the tribal top"
+  about: |-
+    "Local dress."
+
+    The Tribal top (pink) is a cosmetic body slot item purchased from Gabooty's Tai Bwo Wannai Cooperative for 360 trading sticks (300 with Karamja gloves 1 or better). It is part of the villager clothing set sold by Gabooty alongside matching hats, robes, armbands, and sandals in multiple colours.
+
+    The top has no combat bonuses and exists purely as roleplay or Karamja-themed fashionscape. Players typically only own a copy to round out a costume room villager outfit or to fit in during Tai Bwo Wannai Cleanup activity.
+  market_strategy:
+    notes:
+      - "Tradeable sticks cap keeps shop supply available but inconvenient to obtain at scale"
+      - "GE volume is thin; price drifts with fashion trends not real demand"
+      - "Karamja gloves discount makes self-supply far cheaper than buying from GE"
+  trading_tips:
+    - Bulk supply usually comes from sticks farmers, watch for Cleanup updates
+    - Compare colour variants since pricing reflects cosmetic preference only
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Clean-Up update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-fairies.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-fairies.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: null
-  about: "Trinket of fairies is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: teleport
+    tier: high
+  properties:
+    release_date: "2023-08-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Fairy-ring
+      - Spirit-tree
+      - Tool-leprechauns
+      - Last-destination
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Breach monsters (Deadman Mode)
+        quantity: "1"
+        rarity: 20/9576
+  passive_effects:
+    - name: Remote fairy ring access
+      description: "Use to open the fairy ring network from anywhere outside level 30 Wilderness."
+    - name: Remote spirit tree access
+      description: "Use to open the spirit tree teleport menu outside level 30 Wilderness."
+    - name: Remote tool leprechaun access
+      description: "Use to summon a tool leprechaun interface for fast tool/produce management outside level 30 Wilderness."
+  related_items:
+    - item_name: Fairy ring
+      slug: fairy-ring
+      relationship: alternative
+      description: "Static fairy ring network this trinket can call remotely"
+    - item_name: Spirit tree
+      slug: spirit-tree
+      relationship: alternative
+      description: "Static spirit tree network this trinket can call remotely"
+  about: "Trinket of fairies is a Deadman Mode reward dropped by Breach monsters. It lets a player invoke the fairy ring, spirit tree, and tool leprechaun networks from anywhere outside level 30 Wilderness."
+  market_strategy:
+    notes:
+      - "Only available during active Deadman Mode events"
+      - "Drop rate is 20/9576 from Breach monsters"
+      - "Value bumped to 100,000 with tool leprechaun rework"
+  trading_tips:
+    - "Stockpile during Deadman events when supply spikes"
+    - "Long-term value depends on Jagex's future Deadman cadence"
+  history:
+    - date: "2023-08-23"
+      description: "Released for Deadman: Apocalypse."
+    - date: "2026-01-22"
+      description: "Tool leprechaun access added and value raised from 10,000 to 100,000 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trouver-parchment.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trouver-parchment.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trouver parchment | OSRS Price Data
-description: "Trouver parchment: Take it to Perdu to help you avoid losing certain items.. High alch: 120 GP, GE limit: 500."
+description: "Trouver parchment: Take it to Perdu to help you avoid losing certain items. High alch: 120 GP, GE limit: 500."
 osrs:
   id: 24187
   name: Trouver parchment
@@ -12,9 +12,58 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 500
-  about: "Trouver parchment is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: utility-consumable
+    tier: high
+  properties:
+    release_date: "2019-08-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Last Man Standing lobby
+      price: 18
+      currency: Last Man Standing points
+      stock: 0
+  drop_table:
+    sources:
+      - source: Wilderness Slayer Cave monsters
+        quantity: "1"
+        rarity: 1/1219
+  about: |-
+    > *"Take it to Perdu to help you avoid losing certain items."*
+
+    Trouver parchments lock select untradeable items so they survive PvP death when prayer-protected. Combined with Perdu, players pay 500,000 coins per item (50,000 for bronze–adamant defenders) to attach the "(l)" tag.
+
+    Sourced from Justine's LMS shop or as Wilderness Slayer Cave drops.
+  market_strategy:
+    notes:
+      - "Stackable and lightweight, ideal for bulk holding."
+      - "LMS supply at 18 points each anchors the long-term floor."
+      - "500 GE limit means flips scale fast for buyers staging Wilderness gear."
+  trading_tips:
+    - Watch Wilderness boss meta shifts — new lockable items spike parchment demand.
+    - Players doing Wilderness Slayer can sell drops directly to capitalize on PvM uptake.
+  history:
+    - date: "2019-08-29"
+      description: "Released alongside Perdu's expanded item-locking service."
+    - date: "2022-03-30"
+      description: "LMS purchase price reduced from 30 to 18 points."
+    - date: "2023-05-31"
+      description: "Wilderness Slayer Cave drops adjusted to drop two parchments per roll."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-relic-hunter-t3-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-relic-hunter-t3-armour-set.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 5
-  about: "Twisted relic hunter (t3) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: armour-set
+    tier: high
+  properties:
+    release_date: "2020-01-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Twisted boots (t3)
+      slug: twisted-boots-t3
+      relationship: set-piece
+      description: "Set component"
+    - item_name: Twisted trousers (t3)
+      slug: twisted-trousers-t3
+      relationship: set-piece
+      description: "Set component"
+    - item_name: Twisted coat (t3)
+      slug: twisted-coat-t3
+      relationship: set-piece
+      description: "Set component"
+    - item_name: Twisted hat (t3)
+      slug: twisted-hat-t3
+      relationship: set-piece
+      description: "Set component"
+  about: "Twisted relic hunter (t3) armour set bundles the four tier 3 Twisted League cosmetic pieces for convenient Grand Exchange trading. The components are cosmetic-only and grant no combat stats."
+  market_strategy:
+    notes:
+      - "Bundled via Grand Exchange Sets interface"
+      - "Cosmetic League III reward, purely visual"
+      - "Compare set price to individual pieces before buying"
+  history:
+    - date: "2020-01-23"
+      description: "Set released with the Twisted League reward shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-trousers-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-trousers-t2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Twisted trousers (t2) | OSRS Price Data
-description: "Twisted trousers (t2): The trousers of a twisted relic hunter.. High alch: 6,000 GP, GE limit: 5."
+description: "Twisted trousers (t2): The trousers of a twisted relic hunter. High alch: 6,000 GP, GE limit: 5."
 osrs:
   id: 24401
   name: Twisted trousers (t2)
@@ -12,9 +12,74 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 5
-  about: "Twisted trousers (t2) is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  properties:
+    release_date: "2020-01-16"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Twisted hat (t2)
+      slug: twisted-hat-t2
+      relationship: set-piece
+      description: Tier 2 hat of the Twisted Relic Hunter outfit
+    - item_name: Twisted coat (t2)
+      slug: twisted-coat-t2
+      relationship: set-piece
+      description: Tier 2 coat of the Twisted Relic Hunter outfit
+    - item_name: Twisted boots (t2)
+      slug: twisted-boots-t2
+      relationship: set-piece
+      description: Tier 2 boots of the Twisted Relic Hunter outfit
+  about: "Twisted trousers (t2) are part of the Tier 2 Twisted Relic Hunter cosmetic outfit, originally awarded to players who reached the second tier of rewards in the Twisted League."
+  market_strategy:
+    notes:
+      - "Cosmetic-only item, value driven by collection log and fashionscape"
+      - "Very low buy limit (5) restricts flipping volume"
+      - "Price tracks League nostalgia and announcements"
+  trading_tips:
+    - Buy slowly due to 5/4hr limit
+    - Watch GE during off-peak seasons for cheaper entries
+  history:
+    - date: "2019-11-23"
+      description: "Initially awarded during the Twisted League as a cosmetic reward at the second tier."
+    - date: "2020-01-16"
+      description: "Made tradeable on the Grand Exchange with value increased to 10,000 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tyrannical-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tyrannical-ring.mdx
@@ -12,78 +12,89 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: ring
+    tier: high
+  properties:
+    release_date: "2014-06-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
   equipment:
     slot: ring
-    type: crush_ring
-    stats:
-      attack_crush: 4
-      defence_crush: 4
-    imbued_stats:
-      attack_crush: 8
-      defence_crush: 8
-  effect:
-    imbue_cost:
-      nmz_points: 650000
-      nmz_points_with_ca: 325000
-      soul_wars_zeal: 260
-      emirs_arena_points: 200
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 4
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   drop_table:
     sources:
       - source: Callisto
-        source_id: 6609
-        combat_level: 470
         quantity: "1"
         rarity: 1/512
-        members_only: true
       - source: Artio
-        source_id: 11992
-        combat_level: 337
         quantity: "1"
         rarity: 1/716
-        members_only: true
   related_items:
-    - item_id: 12605
-      item_name: Treasonous ring
+    - item_name: Tyrannical ring (i)
+      slug: tyrannical-ring-i
+      relationship: upgrade
+      description: Imbued version doubling crush bonuses
+    - item_name: Treasonous ring
       slug: treasonous-ring
       relationship: alternative
-      description: Stab version
-    - item_id: 6737
-      item_name: Berserker ring
+      description: Stab-focused counterpart
+    - item_name: Berserker ring
       slug: berserker-ring
       relationship: alternative
-      description: Strength focus
-    - item_id: 13576
-      item_name: Dragon warhammer
+      description: Strength-focused alternative
+    - item_name: Dragon warhammer
       slug: dragon-warhammer
       relationship: alternative
-      description: Pairs well
-  about: |-
-    | Stat | Regular | Imbued |
-    |------|---------|--------|
-    | Crush attack | +4 | +8 |
-    | Crush defence | +4 | +8 |
-
-    Requirements: None
-
-    | Method | Cost |
-    |--------|------|
-    | NMZ | 650K points (325K with hard CA) |
-    | Soul Wars | 260 zeal |
-    | Scroll | 200 Emir's Arena points |
-
-    BiS crush ring for:
-    - Dragon warhammer specs
-    - Crush-focused combat
-    - Wilderness PvM
-
-    Accuracy boost for DWH specs.
+      description: Pairs well thanks to crush accuracy
+  about: "Tyrannical ring is a crush-focused ring dropped by Callisto and Artio in the Wilderness. It can be imbued via Nightmare Zone, Soul Wars, or Emir's Arena rewards to double its bonuses."
   market_strategy:
     notes:
-      - Wilderness boss drop
-      - Good for DWH accuracy
-      - Niche use case
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Wilderness boss drop with low buy limit"
+      - "Imbue cost factors into resale value"
+      - "Frequently used for dragon warhammer special accuracy"
+  trading_tips:
+    - Imbued versions trade at a premium
+    - Track Wilderness boss popularity for supply swings
+  history:
+    - date: "2014-06-26"
+      description: "Released with the Wilderness Boss rework, dropped by Callisto."
+    - date: "2023-02-22"
+      description: "Artio added as a singles-only alternative source."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/umbral-frag.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/umbral-frag.mdx
@@ -1,6 +1,6 @@
 ---
 title: Umbral frag | OSRS Price Data
-description: "Umbral frag: This can be propagated in a coral nursery.. High alch: 46 GP, GE limit: 200."
+description: "Umbral frag is a members coral fragment used in coral nurseries. High alch: 46 GP, GE limit: 200."
 osrs:
   id: 31515
   name: Umbral frag
@@ -12,9 +12,62 @@ osrs:
   lowalch: 31
   highalch: 46
   limit: 200
-  about: "Umbral frag is a members-only item in Old School RuneScape. High alchemy value: 46 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: coral-fragment
+    tier: low
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Orca
+        quantity: "1"
+        rarity: 2/92
+      - source: Aquanite
+        quantity: "1"
+        rarity: 6/128
+      - source: Narwhal
+        quantity: "1-2"
+        rarity: 1/200
+      - source: Stingray
+        quantity: "1-2"
+        rarity: 3/500
+      - source: Albatross
+        quantity: "1"
+        rarity: 4/500
+      - source: Pygmy kraken
+        quantity: "1"
+        rarity: 1/540
+  related_items:
+    - item_name: Umbral coral
+      slug: umbral-coral
+      relationship: product
+      description: Mature coral grown from a propagated frag
+  about: |-
+    Umbral frag is a stackable coral fragment introduced 19 November 2025 with the coral nursery farming content. Each frag can be propagated in a nursery to grow into umbral coral.
+
+    Drops come primarily from aquatic Slayer creatures such as aquanites, orcas, narwhals, and pygmy krakens. The 200 buy limit and consistent drop rates make these frags a steady passive income for Slayer players.
+  market_strategy:
+    notes:
+      - "Supply tied to aquatic Slayer task popularity"
+      - "Orca and aquanite drops anchor the bulk of GE liquidity"
+      - "Stackable nature simplifies long-term storage in the bank"
+  trading_tips:
+    - Bank umbral frags during high-demand farming spikes
+    - Cross-reference orca drop rates with umbral coral prices to size positions
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-trident.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-trident.mdx
@@ -12,30 +12,81 @@ osrs:
   lowalch: 27200
   highalch: 40800
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: powered_staff
+    tier: high
+  properties:
+    release_date: "2014-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
   equipment:
     slot: weapon
-    type: powered staff
-    tradeable: true
+    weapon_type: powered_staff
+    attack_speed: 4
     weight: 1.814
     requirements:
       magic: 75
-    stats:
-      attack_magic: 15
-      defence_magic: 15
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 15
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Cave kraken
+        quantity: "1"
+        rarity: 1/200
   related_items:
-    - item_id: 12899
-      item_name: Trident of the swamp
+    - item_name: Trident of the seas
+      slug: trident-of-the-seas
+      relationship: upgrade
+      description: Charged form of the uncharged trident
+    - item_name: Trident of the swamp
       slug: trident-of-the-swamp
       relationship: upgrade
-      description: Upgraded version with venom effect
-    - item_id: 12004
-      item_name: Kraken tentacle
+      description: Magic Fang upgrade granting venom
+    - item_name: Kraken tentacle
       slug: kraken-tentacle
       relationship: alternative
-      description: Upgrade component for swamp trident
-  about: Built-in spell. Charges with runes and coins (212 gp per cast).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Used to attach to abyssal whip for slash weapon
+  about: "Uncharged trident is a powered staff dropped by cave krakens at 1/200. Charging costs 1 death rune, 1 chaos rune, 5 fire runes, and 10 coins per shot, up to 2,500 charges."
+  market_strategy:
+    notes:
+      - "Tradeable only when fully uncharged or fully charged"
+      - "Cave kraken drop powers supply"
+      - "Charge cost is roughly 321 coins per cast"
+  trading_tips:
+    - Compare uncharged vs charged spread to choose the cheaper buy
+    - Bulk Magic training drives demand spikes
+  history:
+    - date: "2014-01-30"
+      description: "Released with Cave krakens and the Trident of the seas."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-emerald.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-emerald.mdx
@@ -12,90 +12,100 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
   material:
     type: gem
     tier: mid
-  crafting:
-    cutting_level: 27
-    cutting_xp: 67.5
-    uncut: true
+  properties:
+    release_date: "2001-03-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.003
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Gem rocks
-        source_id: 0
         quantity: "1"
         rarity: common
-        members_only: true
+      - source: Kalphite Queen
+        quantity: "1"
+        rarity: uncommon
+      - source: TzHaar creatures
+        quantity: "1"
+        rarity: uncommon
+  shops:
+    - shop_name: Herquin's Gems
+      location: Falador
+      price: 50
+      currency: coins
+      stock: 0
+    - shop_name: Gem Trader
+      location: Al Kharid
+      price: 50
+      currency: coins
+      stock: 0
+    - shop_name: Toci's Gem Store
+      location: Aldarin
+      price: 50
+      currency: coins
+      stock: 0
+    - shop_name: TzHaar-Hur-Lek's Ore and Gem Store
+      location: Mor Ul Rek
+      price: 75
+      currency: Tokkul
+      stock: 0
   recipes:
     - skill: crafting
       level: 27
       xp: 67.5
       materials:
         - item_name: Uncut emerald
-          item_id: 1621
           quantity: 1
-      product: Emerald
-      product_id: 1605
-      product_quantity: 1
-    - skill: fletching
-      level: 58
-      xp: 5.5
-      materials:
-        - item_name: Emerald
-          item_id: 1605
-          quantity: 1
-      product: Emerald bolt tips
-      product_id: 9190
-      product_quantity: 12
-      members_only: true
+      tools:
+        - Chisel
+      output_quantity: 1
   related_items:
-    - item_id: 1619
-      item_name: Uncut ruby
-      slug: uncut-ruby
-      relationship: alternative
-      description: Higher tier gem
-    - item_id: 1623
-      item_name: Uncut sapphire
-      slug: uncut-sapphire
-      relationship: alternative
-      description: Lower tier gem
-    - item_id: 1605
-      item_name: Emerald
+    - item_name: Emerald
       slug: emerald
       relationship: product
-      description: Cut version
-    - item_id: 2552
-      item_name: Ring of dueling
-      slug: ring-of-dueling
-      relationship: product
-      description: Popular teleport
-    - item_id: 1755
-      item_name: Chisel
+      description: Cut version of the gem
+    - item_name: Uncut sapphire
+      slug: uncut-sapphire
+      relationship: alternative
+      description: Lower tier uncut gem
+    - item_name: Uncut ruby
+      slug: uncut-ruby
+      relationship: alternative
+      description: Higher tier uncut gem
+    - item_name: Chisel
       slug: chisel
       relationship: component
-      description: For cutting
+      description: Tool used to cut the gem
   about: |-
-    | Item | Enchantment | Effect |
-    |------|-------------|--------|
-    | Emerald ring | Ring of dueling | Castle Wars/Ferox teleport |
-    | Emerald necklace | Binding necklace | RC combo runes |
-    | Emerald amulet | Amulet of defence | +7 Defence |
-    | Emerald bolts | Emerald bolts (e) | Poison effect |
+    Uncut emerald is a common gem found across Old School RuneScape. Cutting it with a chisel at 27 Crafting yields an emerald and 67.5 Crafting XP.
+
+    The cut emerald is used in jewelry such as the ring of dueling, binding necklace, and emerald amulet, and to enchant emerald bolts (e) for poison effects.
   market_strategy:
     notes:
-      - Good Crafting XP for level
-      - Buy uncut → Cut → Sell
-      - Lower margins but high volume
-      - Ring of dueling (teleports)
-      - Games necklace
-      - Emerald bolt tips
-      - Crafting training
-      - Most common cut gem
-      - Ring of dueling always needed
-      - Games necklace for minigames
-      - High volume, low margins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy uncut and cut for Crafting XP and resale margin"
+      - "High volume gem due to ring of dueling demand"
+      - "Lower margins than rubies/diamonds but reliable flow"
+      - "Useful for emerald bolt tips fletching at 58 Fletching"
+  trading_tips:
+    - Cut and resell to capture the gem cutting margin
+    - Stack uncut and offload during Crafting XP events
+  history:
+    - date: "2001-03-17"
+      description: "Item added to the game with the gem mining system."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-onyx.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-onyx.mdx
@@ -12,56 +12,89 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 11000
-  item_id: 6571
-  type: gem
-  tradeable: true
-  weight: 0.003
-  buy_limit: 11000
-  requirements:
-    skills:
-      - skill: crafting
-        level: 67
-        context: to cut
-  obtaining:
-    shop:
-      name: TzHaar shops
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: gem
+    tier: high
+  properties:
+    release_date: "2005-10-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.003
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Zulrah
+        quantity: "1"
+        rarity: 1/512
+      - source: Skotizo
+        quantity: "1"
+        rarity: 1/1000
+      - source: Zalcano
+        quantity: "1"
+        rarity: 1/8000
+      - source: Elven Crystal Chest
+        quantity: "1"
+        rarity: 1/10000
+      - source: Gem stall (Thieving, Mor Ul Rek)
+        quantity: "1"
+        rarity: 1/75000
+  shops:
+    - shop_name: TzHaar-Hur-Lek's Ore and Gem Store
+      location: Mor Ul Rek
       price: 300000
       currency: Tokkul
-      discount_price: 260000
-      discount_requirement: Karamja gloves
-    drops:
-      - source: Zulrah
-        rate: 1/512
-      - source: Skotizo
-        rate: 1/1,000
-    thieving:
-      source: Gem shop counter
-      rate: 1/75,000
-  crafting:
-    product: Onyx
-    level: 67
-    xp: 167.5
+      stock: 0
+    - shop_name: TzHaar-Hur-Rin's Ore and Gem Store
+      location: Mor Ul Rek
+      price: 300000
+      currency: Tokkul
+      stock: 0
+  recipes:
+    - skill: crafting
+      level: 67
+      xp: 167.5
+      materials:
+        - item_name: Uncut onyx
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
   related_items:
-    - slug: onyx
-      name: Onyx
-      relation: cut_form
-    - slug: uncut-zenyte
-      name: Uncut zenyte
-      relation: higher_tier
+    - item_name: Onyx
+      slug: onyx
+      relationship: product
+      description: Cut form used in onyx jewellery and zenyte crafting.
+    - item_name: Uncut zenyte
+      slug: uncut-zenyte
+      relationship: upgrade
+      description: Higher-tier gem above onyx.
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Gem |
-    | Tradeable | Yes |
-    | Weight | 0.003 kg |
-    | Requirements | 67 Crafting (to cut) |
+    Uncut onyx is the second-highest-tier gem in the standard cutting chain, gated behind 67 Crafting and used to cut into onyx for jewellery or onyx bolt tips.
 
-    Cut into onyx (67 Crafting, 167.5 XP).
-
-    Used for onyx jewelry and zenyte crafting.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Most supply trickles from Tokkul exchanges at the TzHaar gem stores and rare boss drops from Zulrah, Skotizo, and Zalcano, with high Thieving from the Mor Ul Rek gem stall as a niche source.
+  market_strategy:
+    notes:
+      - "Tokkul exchange caps the natural floor; bulk supply depends on TzHaar Fight Cave runs."
+      - "Zulrah and Skotizo PvM activity drives most tradeable supply."
+      - "Zenyte jewellery demand from Onyx (cut) and amulet of torture pulls uncut prices."
+  trading_tips:
+    - Track jewellery demand (necklace of anguish, amulet of torture) for downstream pull.
+    - Compare uncut vs cut margins before deciding to convert at 67 Crafting.
+  history:
+    - date: "2005-10-04"
+      description: "Released with the TzHaar Fight Caves update."
+    - date: "2007-08-06"
+      description: "Received a graphical update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-zenyte.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-zenyte.mdx
@@ -12,51 +12,69 @@ osrs:
   lowalch: 30000
   highalch: 45000
   limit: 10000
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
     type: gem
+    tier: high
+  properties:
+    release_date: "2016-05-06"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.003
-  obtaining:
-    methods:
-      - source: Ape Atoll flame
-        method: Combine onyx with zenyte shard
-        requirements:
-          quest: Monkey Madness II
-          item: zombie monkey greegree
-  creation:
-    crafting_level: 70
-    cutting:
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
       level: 89
       xp: 200
-      result: Zenyte
-  usage:
-    description: Used for best-in-slot jewelry
-    note: Highest tier gem
+      materials:
+        - item_name: Uncut zenyte
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
   related_items:
-    - item_id: 19529
-      item_name: Zenyte shard
-      slug: zenyte-shard
-      relationship: component
-      description: Component
-    - item_id: 19493
-      item_name: Zenyte
+    - item_name: Zenyte
       slug: zenyte
       relationship: product
-      description: Cut form
+      description: Cut zenyte gem
+    - item_name: Zenyte shard
+      slug: zenyte-shard
+      relationship: component
+      description: Shard combined with an onyx to form the uncut gem
+    - item_name: Onyx
+      slug: onyx
+      relationship: component
+      description: Cut onyx required to fuse with the zenyte shard
+    - item_name: Amulet of torture
+      slug: amulet-of-torture
+      relationship: product
+      description: End-game zenyte enchanted jewellery
+    - item_name: Necklace of anguish
+      slug: necklace-of-anguish
+      relationship: product
+      description: End-game zenyte ranged amulet equivalent
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Gem |
-    | Tradeable | Yes |
-    | Weight | 0.003 kg |
-    | Requirements | 70 Crafting (to create), 89 (to cut) |
-
-    Cut into zenyte (89 Crafting, 200 XP).
-
-    Used for best-in-slot jewelry.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Uncut zenyte is the rarest gem in Old School RuneScape, created by combining a cut onyx with a zenyte shard at the wall of flame beneath the Temple of Marimbo on Ape Atoll while wearing a zombie monkey greegree. The process requires Monkey Madness II completion and 70 Crafting (15 XP). Cutting the gem at 89 Crafting yields a zenyte and 200 XP, which is used to craft the most powerful jewellery in the game.
+  market_strategy:
+    notes:
+      - "End-game jewellery component with consistent demand"
+      - "Expensive single-item flip but high margins"
+      - "Supply is gated by zenyte shard drop rates"
+  trading_tips:
+    - Buy uncut when shard prices fall and cut for Crafting XP plus margin
+    - Watch GE limit since 10k limit allows aggressive accumulation
+  history:
+    - date: "2016-05-06"
+      description: "Item added to the game with Monkey Madness II."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/veg-ball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/veg-ball.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Veg ball is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 35
+      xp: 175
+      materials:
+        - item_name: Unfinished bowl (veg ball)
+          quantity: 1
+        - item_name: Equa leaves
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Unfinished bowl
+      slug: unfinished-bowl
+      relationship: component
+      description: Intermediate Gnome Cooking item
+    - item_name: Equa leaves
+      slug: equa-leaves
+      relationship: component
+      description: Gnome cooking ingredient
+    - item_name: Worm hole
+      slug: worm-hole
+      relationship: alternative
+      description: Other gnome ball food
+  about: "Veg ball is a members Gnome Cooking food that heals 12 hitpoints in one bite. Made by completing the gnome bowl recipe with equa leaves at Cooking 35 for 175 XP."
+  market_strategy:
+    notes:
+      - "Limited demand; mostly used as Aleck shop turn-in"
+      - "Cooking XP rate makes it niche for training"
+      - "6,000 buy limit and low value reduce flipping potential"
+  trading_tips:
+    - Buy from Aleck's Hunter Emporium to flip for small margin
+    - Useful as low-cost healing food for ironmen
+  history:
+    - date: "2002-12-12"
+      description: "Item released with the Gnome Restaurant minigame."
+    - date: "2006-08-07"
+      description: "Graphically updated during Gnome Restaurant rework."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-pink.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-pink.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
-  about: "Villager hat (pink) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 240
+      currency: Trading sticks
+      stock: 1
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative (Karamja gloves)
+      location: Tai Bwo Wannai
+      price: 200
+      currency: Trading sticks
+      stock: 1
+  related_items:
+    - item_name: Villager robe (pink)
+      slug: villager-robe-pink
+      relationship: set-piece
+      description: Matching pink villager robe
+    - item_name: Villager sandals (pink)
+      slug: villager-sandals-pink
+      relationship: set-piece
+      description: Matching pink villager sandals
+  about: |-
+    The Villager hat (pink) is a cosmetic head piece sold by Gabooty's Tai Bwo Wannai Cooperative in Tai Bwo Wannai for 240 trading sticks (or 200 with Karamja gloves 1 or better). It provides no combat bonuses and is intended purely for fashionscape.
+
+    The hat can be stored in the magic wardrobe of a player-owned house Costume Room and forms part of the broader pink villager outfit available through the same shop.
+  market_strategy:
+    notes:
+      - "Fashionscape piece with limited combat utility"
+      - "Trading-sticks gate keeps supply modest"
+      - "Costume Room storage adds collector demand"
+  trading_tips:
+    - Stack trading sticks from Tai Bwo Wannai Cleanup before buying
+    - Karamja gloves 1+ saves 40 sticks per hat
+  history:
+    - date: "2005-08-09"
+      description: "Released as part of the Tai Bwo Wannai cosmetic outfits."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-flowers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-flowers.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "White flowers is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: misc
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Hold
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Mithril seed (harvest)
+        quantity: "1"
+        rarity: 1/1,001
+      - source: Adamant seed (harvest)
+        quantity: "1"
+        rarity: 1/1,001
+  related_items:
+    - item_name: Mithril seed
+      slug: mithril-seed
+      relationship: component
+      description: Source seed for harvesting white flowers
+    - item_name: Adamant seed
+      slug: adamant-seed
+      relationship: component
+      description: Alternative source seed for harvesting
+    - item_name: Red flowers
+      slug: red-flowers
+      relationship: variant
+      description: Differently colored flower variant
+    - item_name: Yellow flowers
+      slug: yellow-flowers
+      relationship: variant
+      description: Differently colored flower variant
+  about: "White flowers are a rare 1/1,001 harvest from mithril or adamant seeds planted via Farming. Part of the broader flower family with multiple color variants."
+  market_strategy:
+    notes:
+      - "150 buy limit suppresses bulk flipping"
+      - "Niche cosmetic and quest demand"
+      - "Supply depends on mithril/adamant seed usage"
+  trading_tips:
+    - List near high alch value for slow sells
+    - Useful for outfit collectors and cosmetic flips
+  history:
+    - date: "2004-03-29"
+      description: "Item released with the RS2 launch."
+    - date: "2014-12-10"
+      description: "Item renamed from \"Flowers\" to \"White flowers\"."
+    - date: "2024-04-10"
+      description: "Adamant seeds gained ability to drop white flowers when harvested."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-branch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-branch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Willow branch | OSRS Price Data
-description: "Willow branch: A branch from a willow tree.. High alch: 1 GP, GE limit: 11,000."
+description: "Willow branch is a farming/crafting material harvested from grown willow trees, used for baskets and Enlightened Journey. GE limit: 11,000."
 osrs:
   id: 5933
   name: Willow branch
@@ -9,12 +9,77 @@ osrs:
   members: true
   icon: Willow branch.png
   value: 2
-  lowalch: 1
+  lowalch: null
   highalch: 1
   limit: 11000
-  about: "Willow branch is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: crafting-material
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Willow tree (secateurs harvest)
+        quantity: "1"
+        rarity: always
+  recipes:
+    - skill: crafting
+      level: 36
+      xp: 56
+      materials:
+        - item_name: Willow branch
+          quantity: 6
+      tools:
+        - Loom
+      output_quantity: 1
+  related_items:
+    - item_name: Basket
+      slug: basket
+      relationship: product
+      description: Crafted from willow branches on a loom
+    - item_name: Secateurs
+      slug: secateurs
+      relationship: component
+      description: Harvest tool required to obtain branches
+    - item_name: Willow seed
+      slug: willow-seed
+      relationship: component
+      description: Plants the willow tree the branches come from
+    - item_name: Willow roots
+      slug: willow-roots
+      relationship: alternative
+      description: Other harvest product of fully grown willow trees
+  about: |-
+    Willow branches are obtained by using secateurs on a fully grown willow tree, which requires 30 Farming. A willow tree produces one branch every five minutes up to a stockpile of six, so disciplined trips through trained farming patches generate steady supply.
+
+    The primary sink is baskets, which require six branches per loom craft at 36 Crafting. Branches are also consumed during Enlightened Journey, where twelve are required, and are part of the medium Falador Diary.
+  market_strategy:
+    notes:
+      - "Supply hinges on dedicated farming runs"
+      - "Demand is consistent from basket crafters"
+      - "Diary and quest tasks set a price floor"
+      - "Watch for any new construction or balloon-related sinks"
+  trading_tips:
+    - Stack into the buy limit for steady margin flips
+    - Sell into basket-driven crafting events
+    - Hold when farming patches see seed price spikes
+  history:
+    - date: "2005-07-11"
+      description: "Released alongside the willow tree farming patch update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-stock.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 21
   highalch: 31
   limit: 10000
-  about: "Willow stock is a members-only item in Old School RuneScape. High alchemy value: 31 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: willow
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 39
+      xp: 22
+      materials:
+        - item_name: Willow logs
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Willow logs
+      slug: willow-logs
+      relationship: component
+      description: Carved with a knife to produce the willow stock.
+    - item_name: Iron crossbow (u)
+      slug: iron-crossbow-u
+      relationship: product
+      description: Attach iron limbs to a willow stock to produce the unstrung iron crossbow.
+    - item_name: Iron crossbow
+      slug: iron-crossbow
+      relationship: product
+      description: Final crossbow built on the willow stock once strung.
+  about: |-
+    The willow stock is a Fletching ingredient created by carving willow logs with a knife at level 39 Fletching for 22 XP. It is the base for the iron crossbow, accepting iron limbs to form the unstrung weapon.
+  market_strategy:
+    notes:
+      - "Profit per stock is thin because supply comes from cheap willow logs."
+      - "Demand follows F2P-to-Members Fletching levelling meta."
+  trading_tips:
+    - Buy willow logs in dips and fletch stocks during weekend price spikes.
+    - Sell to crossbow chain crafters who prefer pre-cut stocks.
+  history:
+    - date: "2006-07-31"
+      description: "Willow stock released as part of the Crossbows expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-chair-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-chair-flatpack.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Wooden chair (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Are you sure you want to drop this?"
+  recipes:
+    - skill: construction
+      level: 8
+      xp: 87
+      materials:
+        - item_name: Plank
+          quantity: 3
+        - item_name: Steel nails
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Plank
+      slug: plank
+      relationship: component
+      description: Wood used to build the chair
+    - item_name: Steel nails
+      slug: steel-nails
+      relationship: component
+      description: Required fasteners
+  about: "Wooden chair (flatpack) is an entry-level Construction flatpack built at a wooden workbench at level 8 Construction for 87 experience. It is placed on a chair space in a player-owned house."
+  market_strategy:
+    notes:
+      - "Crafted cheaply from planks and steel nails"
+      - "Common low-level POH furnishing"
+      - "Buy limit 500 per 4 hours"
+  trading_tips:
+    - Plank prices drive margin
+    - Demand is steady from new POH owners
+  history:
+    - date: "2006-05-31"
+      description: "Introduced with the release of Player-Owned Houses."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-d-hide-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-d-hide-boots.mdx
@@ -12,80 +12,113 @@ osrs:
   lowalch: 3720
   highalch: 5580
   limit: 8
+  material:
+    type: dragonhide
+    tier: mid-high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 1.4
     requirements:
       ranged: 70
       defence: 40
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -10
-      attack_ranged: 7
-      defence_stab: 4
-      defence_slash: 4
-      defence_crush: 4
-      defence_magic: 4
-      defence_ranged: 4
-      melee_strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 7
+    defence_bonus:
+      stab: 4
+      slash: 4
+      crush: 4
+      magic: 4
+      ranged: 4
+    other_bonus:
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: Rare
-        description: Reward from hard clue scroll caskets (1/1,625)
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: "1/1,625"
   related_items:
-    - item_id: 19933
-      item_name: Saradomin d'hide boots
+    - item_name: Saradomin d'hide boots
       slug: saradomin-d-hide-boots
       relationship: variant
-      description: Saradomin variant of blessed d'hide boots
-    - item_id: 19927
-      item_name: Guthix d'hide boots
+      description: "Saradomin-aligned blessed dragonhide boots variant"
+    - item_name: Guthix d'hide boots
       slug: guthix-d-hide-boots
       relationship: variant
-      description: Guthix variant of blessed d'hide boots
-    - item_id: 19930
-      item_name: Armadyl d'hide boots
+      description: "Guthix-aligned blessed dragonhide boots variant"
+    - item_name: Armadyl d'hide boots
       slug: armadyl-d-hide-boots
       relationship: variant
-      description: Armadyl variant of blessed d'hide boots
-    - item_id: 19924
-      item_name: Bandos d'hide boots
+      description: "Armadyl-aligned blessed dragonhide boots variant"
+    - item_name: Bandos d'hide boots
       slug: bandos-d-hide-boots
       relationship: variant
-      description: Bandos variant of blessed d'hide boots
-    - item_id: 19921
-      item_name: Ancient d'hide boots
+      description: "Bandos-aligned blessed dragonhide boots variant"
+    - item_name: Ancient d'hide boots
       slug: ancient-d-hide-boots
       relationship: variant
-      description: Ancient variant of blessed d'hide boots
+      description: "Ancient-aligned blessed dragonhide boots variant"
+    - item_name: Ranger boots
+      slug: ranger-boots
+      relationship: alternative
+      description: "Same plus 7 ranged attack but no prayer bonus"
+    - item_name: Pegasian boots
+      slug: pegasian-boots
+      relationship: upgrade
+      description: "Direct upgrade with stronger ranged stats"
   about: |-
     "Zamorak blessed dragonhide boots."
 
-    The Zamorak d'hide boots are blessed dragonhide boots aligned with the god Zamorak. They require 70 Ranged and 40 Defence to equip and occupy the feet slot. Like all blessed d'hide boots, they offer a +7 ranged attack bonus and a +1 prayer bonus, making them a direct upgrade over regular snakeskin boots for players on a budget.
+    The Zamorak d'hide boots are blessed dragonhide boots aligned with the god Zamorak, awarded from hard clue scroll caskets at a 1/1,625 rate. They require 70 Ranged and 40 Defence to equip and occupy the feet slot. Like all blessed d'hide boots, they offer a plus 7 ranged attack bonus and a plus 1 prayer bonus, making them a direct upgrade over snakeskin boots for ranged setups on a budget.
 
     All six god d'hide boots share identical combat stats, so the choice between them is purely cosmetic or based on God Wars Dungeon faction protection. The Zamorak d'hide boots provide protection from Zamorak-aligned NPCs in the God Wars Dungeon, making them useful for K'ril Tsutsaroth trips.
 
-    Blessed d'hide boots are the best ranged boots available that also provide a prayer bonus, aside from the much more expensive pegasian boots. They share the same +7 ranged attack bonus as ranger boots but add a +1 prayer bonus on top. For players who cannot afford ranger boots or pegasian boots, blessed d'hide boots are the go-to choice for the feet slot in ranged setups.
+    Blessed d'hide boots are the best ranged boots available that also provide a prayer bonus, aside from the much more expensive pegasian boots. They share the plus 7 ranged attack bonus of ranger boots but add a prayer bonus on top. For players who cannot afford ranger boots or pegasian boots, blessed d'hide boots are the go-to choice for the feet slot in ranged setups.
   market_strategy:
-    title: Investment Notes
     notes:
-      - All god d'hide boot variants share the same stats, so price differences are driven by cosmetic demand
-      - Zamorak variants are popular due to the recognizable red-and-black aesthetic
-      - Strong demand from mid-level players building ranged gear sets
-      - Compare prices across all six god variants before buying since stats are identical
-      - Particularly useful for Zamorak protection in the God Wars Dungeon
-      - Buy limit of 8 per 4 hours on the Grand Exchange
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "All god d'hide boot variants share the same stats, so price differences are driven by cosmetic demand"
+      - "Zamorak variants are popular due to the recognizable red-and-black aesthetic"
+      - "Strong demand from mid-level players building ranged gear sets"
+      - "Compare prices across all six god variants before buying since stats are identical"
+      - "Particularly useful for Zamorak protection in the God Wars Dungeon"
+      - "Buy limit of 8 per 4 hours on the Grand Exchange"
+  trading_tips:
+    - Cross-check Saradomin/Guthix prices first when buying for stats only
+    - Spikes during clue-scroll events from boosted hard casket throughput
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of the Treasure Trails expansion update."
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-platelegs.mdx
@@ -12,9 +12,97 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Zamorak platelegs is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  passive_effects:
+    - name: Zamorak protection
+      description: Worn in the God Wars Dungeon, Zamorakian followers will not attack the player.
+  related_items:
+    - item_name: Rune platelegs
+      slug: rune-platelegs
+      relationship: alternative
+      description: Base rune platelegs variant
+    - item_name: Saradomin platelegs
+      slug: saradomin-platelegs
+      relationship: alternative
+      description: Saradomin god alignment
+    - item_name: Guthix platelegs
+      slug: guthix-platelegs
+      relationship: alternative
+      description: Guthix god alignment
+    - item_name: Zamorak plateskirt
+      slug: zamorak-plateskirt
+      relationship: variant
+      description: Skirt variant of Zamorak legs
+    - item_name: Zamorak platebody
+      slug: zamorak-platebody
+      relationship: set-piece
+      description: Matching body in the Zamorak set
+  about: "Zamorak platelegs are rune platelegs styled in Zamorakian colours, requiring 40 Defence to wear. Stats match rune platelegs plus a +1 Prayer bonus. Worn in the God Wars Dungeon they keep Zamorakian followers non-aggressive. Primary source is hard clue reward caskets at 1/1625."
+  market_strategy:
+    notes:
+      - "Tiny buy limit of 8 restricts flipping"
+      - "Demand driven by GWD Zamorak boss prep and clue cosmetics"
+      - "High alch close to break-even via nature rune cost"
+  trading_tips:
+    - Stock during hard clue patches and event spikes
+    - Compare against plateskirt for GWD camp setups
+  history:
+    - date: "2004-05-05"
+      description: "Released as part of the god armour cosmetic rune sets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zombie-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zombie-axe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zombie axe | OSRS Price Data
-description: "Zombie axe: A rusty yet powerful axe.. High alch: 96,000 GP."
+description: "Zombie axe is a members one-handed battleaxe requiring 65 Attack with the highest slash bonus of any 1H weapon. High alch: 96,000 GP."
 osrs:
   id: 28810
   name: Zombie axe
@@ -12,9 +12,84 @@ osrs:
   lowalch: 64000
   highalch: 96000
   limit: null
-  about: "Zombie axe is a members-only item in Old School RuneScape. High alchemy value: 96,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-03"
+  material:
+    type: weapon
+    tier: high
+  properties:
+    release_date: "2024-02-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: battleaxe
+    attack_speed: 5
+    weight: 2.721
+    requirements:
+      attack: 65
+    attack_bonus:
+      stab: -3
+      slash: 105
+      crush: 90
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 107
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Web slicer
+      description: The slash bonus is high enough to slash spider webs automatically without rolling, similar to the Wilderness sword 1.
+  related_items:
+    - item_name: Broken zombie axe
+      slug: broken-zombie-axe
+      relationship: component
+      description: Repair source obtained from armoured zombies
+    - item_name: Saradomin sword
+      slug: saradomin-sword
+      relationship: alternative
+      description: Comparable mid-game one-handed slash weapon
+    - item_name: Abyssal dagger
+      slug: abyssal-dagger
+      relationship: alternative
+      description: Higher-tier one-handed slash alternative
+  about: |-
+    The zombie axe is a one-handed battleaxe obtained by repairing a broken zombie axe at an anvil with 70 Smithing. The broken version itself drops from armoured zombies inside the Forthos Dungeon ruins. Once repaired the axe requires 65 Attack to wield.
+
+    Its +105 slash bonus is the highest of any one-handed weapon in the game, which makes it especially effective at Sarachnis where its slash bonus automatically severs webs in the boss arena. The weapon swings on a 5-tick speed, comparable to other battleaxes.
+  market_strategy:
+    notes:
+      - "Tied to armoured zombie drop rates and Sarachnis efficiency demand"
+      - "Best one-handed slash bonus locks in collector value"
+      - "Watch for nerfs or buffs to Sarachnis loot tables"
+      - "Repair gate makes broken vs repaired pricing diverge"
+  trading_tips:
+    - Compare broken vs repaired price minus smithing cost before flipping
+    - Sell on Sarachnis hype after streamer content drops
+    - Buy after big Forthos crash dumps from armoured zombies
+  history:
+    - date: "2024-02-21"
+      description: "Released alongside the armoured zombies update with broken zombie axes as a drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
- Random sample of 200 OSRS item MDX files migrated from `mdx_version: 2` to `3`
- WebFetch-verified wiki stats, drops, recipes, history
- Schema normalization: market_strategy.notes array, materials[].item_name, passive_effects[].name, shops null → 0, list-item colon quoting

## Local CI mirror
- `npx astro sync` — clean
- `npx astro build` — 7689 pages in 304.64s, no errors

## Test plan
- [ ] CI manifest guard passes
- [ ] CI build passes
- [ ] Spot-check a couple of pages in preview