### PR TITLE
refactor(rareicon): split ProfessionDispatchSystem into 3 pipeline phases (#11)

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
@@ -9,11 +9,10 @@ using Unity.Transforms;
 
 namespace RareIcon
 {
-    /// <summary>Picks the highest-priority profession with nearby work for each Player unit; writes ProfessionIntent. If no scored offer wins, assigns ProfessionKind.Default and rolls a Wander MovementGoal so units never sit idle. Reads the dispatch context + TaskOffer pool from ProfessionOffersSingleton (rebuilt on cadence by ProfessionOfferBuildSystem). Emits ProfessionChangedMessage via ProfessionEventSink on any kind/target change — coalesced + published by ProfessionMessagePipeBridgeSystem. Per-unit scoring runs as a [BurstCompile] IJobEntity parallel job — the main thread builds the snapshot inputs (occupancy / activePerKind / reservedPerKind / WriteBuffer capacity), schedules ScheduleParallel, and publishes the handle through ProfessionsDBSingleton.PipelineHandle so downstream consumers chain on it instead of forcing a sync.</summary>
+    /// <summary>Third phase of the split dispatcher pipeline (#11 from #11716) — runs after ProfessionTaskReconcileSystem and ProfessionPreemptSystem. Only acts on units left with an empty task queue, no controlled-unit override, and a doFullDispatch tick: scores TaskOffers against per-unit priorities, picks a best, writes ProfessionIntent + task head, and emits Assigned / Retargeted / Fallback events. Units that Reconcile committed (Active head) or Preempt re-targeted are skipped via the tasks.Length check — no chunk-level filtering needed. Pre-pass jobs (Clear / BuildActive / BuildReserved / Reduce) populate the singleton accumulators on worker threads before the scoring job starts.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
-    [UpdateAfter(typeof(ReliefSystem))]
-    [UpdateAfter(typeof(ProfessionsDomainSystem))]
+    [UpdateAfter(typeof(ProfessionPreemptSystem))]
     [UpdateAfter(typeof(ProfessionOfferBuildSystem))]
     [UpdateAfter(typeof(CombatThreatScanSystem))]
     public partial struct ProfessionDispatchSystem : ISystem
@@ -145,18 +144,8 @@ namespace RareIcon
                     JobHandle.CombineDependencies(activeHandle, reservedHandle));
             }
 
-            // Pre-allocate WriteBuffer headroom so AddNoResize is safe under
-            // ParallelWriter contention. Worst case = one event per unit per
-            // dispatch tick (Relief / Manual / Preempt / Retarget / Fallback
-            // are exclusive paths). The query count is an upper bound; we
-            // never trim, the bridge consumes the buffer next frame.
-            var unitQuery = SystemAPI.QueryBuilder()
-                .WithAll<ProfessionPriorities, ReliefIntent, ProfessionIntent, UnitMovement, LocalTransform, MovementGoal, TaskMemory>()
-                .Build();
-            int unitCount = unitQuery.CalculateEntityCount();
-            int requiredCapacity = writeBuffer.Length + unitCount;
-            if (writeBuffer.Capacity < requiredCapacity)
-                writeBuffer.SetCapacity(math.max(requiredCapacity, writeBuffer.Capacity * 2));
+            // ProfessionTaskReconcileSystem pre-grows WriteBuffer for the
+            // whole pipeline this tick, so no capacity grow needed here.
 
             var job = new DispatchJob
             {
@@ -339,92 +328,15 @@ namespace RareIcon
                 ref MovementGoal goal,
                 DynamicBuffer<TaskMemory> tasks)
             {
-                if (reliefIntent.Kind != ReliefKind.None)
-                {
-                    if (tasks.Length > 0)
-                    {
-                        var head = tasks[0];
-                        if (head.State == TaskState.Active)
-                        {
-                            head.State = TaskState.Pending;
-                            tasks[0]   = head;
-                        }
-                    }
-                    var prev = intent;
-                    if (prev.Kind != ProfessionKind.None)
-                    {
-                        intent = default;
-                        ProfessionEventSink.Add(ref Events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, NowTick, ProfessionChangeReason.ReliefOverride);
-                    }
-                    return;
-                }
-
-                if (ControlledLookup.HasComponent(entity))
-                {
-                    if (tasks.Length > 0) tasks.Clear();
-                    var prev = intent;
-                    if (prev.Kind != ProfessionKind.None)
-                    {
-                        intent = default;
-                        ProfessionEventSink.Add(ref Events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, NowTick, ProfessionChangeReason.ManualOverride);
-                    }
-                    return;
-                }
-
-                while (tasks.Length > 0 &&
-                       (tasks[0].State == TaskState.Invalidated ||
-                        tasks[0].State == TaskState.Completed))
-                {
-                    tasks.RemoveAt(0);
-                }
-
-                if (tasks.Length > 0)
-                {
-                    var head = tasks[0];
-                    if (head.State == TaskState.Pending)
-                    {
-                        head.State = TaskState.Active;
-                        tasks[0]   = head;
-                        intent = new ProfessionIntent
-                        {
-                            Kind         = head.Kind,
-                            TargetHex    = head.TargetHex,
-                            TargetEntity = head.TargetEntity,
-                        };
-                        return;
-                    }
-                    if (AnyHostile
-                        && head.State == TaskState.Active
-                        && head.Kind != ProfessionKind.Guard
-                        && priorities.Guard >= GuardPreemptThreshold
-                        && TryFindClosestThreat(Threats, transform.Position,
-                                                out var preemptHex, out var preemptHostile))
-                    {
-                        tasks.Clear();
-                        var preemptedIntent = intent;
-                        intent = new ProfessionIntent
-                        {
-                            Kind         = ProfessionKind.Guard,
-                            TargetHex    = preemptHex,
-                            TargetEntity = preemptHostile,
-                        };
-                        tasks.Add(new TaskMemory
-                        {
-                            Kind         = ProfessionKind.Guard,
-                            TargetHex    = preemptHex,
-                            TargetEntity = preemptHostile,
-                            State        = TaskState.Active,
-                            IssuedTick   = NowTick,
-                        });
-                        if (preemptedIntent.Kind != ProfessionKind.Guard)
-                            ProfessionEventSink.Add(ref Events, entity, preemptedIntent.Kind, ProfessionKind.Guard, preemptHex, preemptHostile, NowTick, ProfessionChangeReason.Preempted);
-                        return;
-                    }
-                    if (head.State == TaskState.Active)
-                        return;
-                }
-
-                if (!DoFullDispatch) return;
+                // Reconcile + Preempt ran first this tick. If they left
+                // anything on the queue (Pending under relief, Active
+                // committed, or Guard from preempt), or if the unit is
+                // under relief / manual control, skip — only a healthy
+                // empty queue means this unit needs fresh scoring.
+                if (reliefIntent.Kind != ReliefKind.None)   return;
+                if (tasks.Length > 0)                       return;
+                if (ControlledLookup.HasComponent(entity))  return;
+                if (!DoFullDispatch)                        return;
 
                 var p = priorities;
                 var currentHex = movement.CurrentHex;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionPreemptSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionPreemptSystem.cs
@@ -1,0 +1,139 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+namespace RareIcon
+{
+    /// <summary>Second phase of the split dispatcher pipeline (#11 from #11716). Runs after ProfessionTaskReconcileSystem, before ProfessionDispatchSystem. Yanks the current task off any unit whose Guard priority is past the preempt threshold and an in-territory threat is nearby; writes a Guard ProfessionIntent + emits a Preempted event. System-level skip when CombatDBSingleton.Threats is empty — no chunk iteration on quiet ticks. Splits out of the prior monolithic ProfessionDispatchSystem so this scan is a focused job that only runs when threats are actually present.</summary>
+    [BurstCompile]
+    [UpdateInGroup(typeof(BehaviorSystemGroup))]
+    [UpdateAfter(typeof(ProfessionTaskReconcileSystem))]
+    [UpdateAfter(typeof(CombatThreatScanSystem))]
+    public partial struct ProfessionPreemptSystem : ISystem
+    {
+        const byte GuardPreemptThreshold = 3;
+
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<ProfessionsDBSingleton>();
+            state.RequireForUpdate<CombatDBSingleton>();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            var combatDB = SystemAPI.GetSingleton<CombatDBSingleton>();
+            state.Dependency = Unity.Jobs.JobHandle.CombineDependencies(state.Dependency, combatDB.PipelineHandle);
+
+            if (combatDB.Threats.Length == 0)
+                return;
+
+            ref var dbRef       = ref SystemAPI.GetSingletonRW<ProfessionsDBSingleton>().ValueRW;
+            var     writeBuffer = dbRef.WriteBuffer;
+
+            var job = new PreemptJob
+            {
+                Threats = combatDB.Threats.AsArray(),
+                Events  = writeBuffer.AsParallelWriter(),
+                NowTick = (uint)(SystemAPI.Time.ElapsedTime * 1000d),
+            };
+
+            state.Dependency      = job.ScheduleParallel(state.Dependency);
+            dbRef.PipelineHandle  = state.Dependency;
+        }
+
+        [BurstCompile]
+        partial struct PreemptJob : IJobEntity
+        {
+            [ReadOnly] public NativeArray<ThreatRecord>                       Threats;
+            public           NativeList<ProfessionChangedMessage>.ParallelWriter Events;
+            public           uint                                               NowTick;
+
+            public void Execute(
+                Entity entity,
+                in ProfessionPriorities priorities,
+                in LocalTransform transform,
+                ref ProfessionIntent intent,
+                DynamicBuffer<TaskMemory> tasks)
+            {
+                if (priorities.Guard < GuardPreemptThreshold) return;
+                if (tasks.Length == 0)                        return;
+
+                var head = tasks[0];
+                if (head.State != TaskState.Active) return;
+                if (head.Kind  == ProfessionKind.Guard) return;
+
+                if (!TryFindClosestThreat(Threats, transform.Position, out var hex, out var hostile))
+                    return;
+
+                tasks.Clear();
+                var preemptedIntent = intent;
+                intent = new ProfessionIntent
+                {
+                    Kind         = ProfessionKind.Guard,
+                    TargetHex    = hex,
+                    TargetEntity = hostile,
+                };
+                tasks.Add(new TaskMemory
+                {
+                    Kind         = ProfessionKind.Guard,
+                    TargetHex    = hex,
+                    TargetEntity = hostile,
+                    State        = TaskState.Active,
+                    IssuedTick   = NowTick,
+                });
+                if (preemptedIntent.Kind != ProfessionKind.Guard)
+                    ProfessionEventSink.Add(ref Events, entity, preemptedIntent.Kind, ProfessionKind.Guard, hex, hostile, NowTick, ProfessionChangeReason.Preempted);
+            }
+        }
+
+        static bool TryFindClosestThreat(
+            NativeArray<ThreatRecord> threats,
+            float3 originWorld,
+            out int2 outHex, out Entity outEntity)
+        {
+            const float ScanRadiusSq = 6f * 6f;
+
+            Entity bestEntity = Entity.Null, inBestEntity = Entity.Null;
+            int2   bestHex    = default,     inBestHex    = default;
+            float  bestSq     = float.MaxValue, inBestSq   = float.MaxValue;
+
+            var origin = new float2(originWorld.x, originWorld.y);
+
+            for (int i = 0; i < threats.Length; i++)
+            {
+                var t = threats[i];
+                float d2 = math.distancesq(origin, t.Position);
+                if (d2 > ScanRadiusSq) continue;
+
+                if (d2 < bestSq)
+                {
+                    bestSq = d2; bestHex = t.Hex; bestEntity = t.Entity;
+                }
+                if (t.InsideFriendlyTerritory && d2 < inBestSq)
+                {
+                    inBestSq = d2; inBestHex = t.Hex; inBestEntity = t.Entity;
+                }
+            }
+
+            if (inBestEntity != Entity.Null)
+            {
+                outHex    = inBestHex;
+                outEntity = inBestEntity;
+                return true;
+            }
+
+            if (bestEntity == Entity.Null)
+            {
+                outHex = default; outEntity = Entity.Null;
+                return false;
+            }
+
+            outHex    = bestHex;
+            outEntity = bestEntity;
+            return true;
+        }
+    }
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionTaskReconcileSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionTaskReconcileSystem.cs
@@ -1,0 +1,123 @@
+using Unity.Burst;
+using Unity.Collections;
+using Unity.Entities;
+using Unity.Jobs;
+using Unity.Mathematics;
+
+namespace RareIcon
+{
+    /// <summary>First phase of the split dispatcher pipeline (#11 from #11716). Runs every tick: handles ReliefIntent + ControlledUnitTag overrides, pops drained or invalidated task heads, and promotes Pending → Active. Splits out of the prior monolithic ProfessionDispatchSystem so the override / queue-reconcile path is a small, focused job that runs every frame regardless of full-dispatch cadence; ProfessionPreemptSystem + ProfessionDispatchSystem run after this and only act on units this phase didn't already commit. Emits ReliefOverride / ManualOverride events via the parallel ProfessionEventSink overload; pre-grows ProfessionsDBSingleton.WriteBuffer capacity on the main thread to keep AddNoResize safe across worker threads.</summary>
+    [BurstCompile]
+    [UpdateInGroup(typeof(BehaviorSystemGroup))]
+    [UpdateAfter(typeof(ReliefSystem))]
+    [UpdateAfter(typeof(ProfessionsDomainSystem))]
+    public partial struct ProfessionTaskReconcileSystem : ISystem
+    {
+        public void OnCreate(ref SystemState state)
+        {
+            state.RequireForUpdate<ProfessionsDBSingleton>();
+        }
+
+        [BurstCompile]
+        public void OnUpdate(ref SystemState state)
+        {
+            ref var dbRef       = ref SystemAPI.GetSingletonRW<ProfessionsDBSingleton>().ValueRW;
+            var     writeBuffer = dbRef.WriteBuffer;
+
+            // Capacity headroom for the worst case where every unit emits a
+            // ReliefOverride / ManualOverride this tick. Reconcile is the
+            // first profession system to write into WriteBuffer each frame,
+            // so we grow once here on behalf of Preempt + Dispatch too — all
+            // three then AddNoResize without contention.
+            var unitQuery = SystemAPI.QueryBuilder()
+                .WithAll<ProfessionPriorities, ReliefIntent, ProfessionIntent, TaskMemory>()
+                .Build();
+            int unitCount        = unitQuery.CalculateEntityCount();
+            int requiredCapacity = writeBuffer.Length + unitCount;
+            if (writeBuffer.Capacity < requiredCapacity)
+                writeBuffer.SetCapacity(math.max(requiredCapacity, writeBuffer.Capacity * 2));
+
+            var job = new ReconcileJob
+            {
+                ControlledLookup = SystemAPI.GetComponentLookup<ControlledUnitTag>(true),
+                Events           = writeBuffer.AsParallelWriter(),
+                NowTick          = (uint)(SystemAPI.Time.ElapsedTime * 1000d),
+            };
+
+            state.Dependency      = job.ScheduleParallel(state.Dependency);
+            dbRef.PipelineHandle  = state.Dependency;
+        }
+
+        [BurstCompile]
+        partial struct ReconcileJob : IJobEntity
+        {
+            [ReadOnly] public ComponentLookup<ControlledUnitTag>             ControlledLookup;
+            public           NativeList<ProfessionChangedMessage>.ParallelWriter Events;
+            public           uint                                               NowTick;
+
+            public void Execute(
+                Entity entity,
+                in ReliefIntent reliefIntent,
+                ref ProfessionIntent intent,
+                DynamicBuffer<TaskMemory> tasks)
+            {
+                if (reliefIntent.Kind != ReliefKind.None)
+                {
+                    if (tasks.Length > 0)
+                    {
+                        var head = tasks[0];
+                        if (head.State == TaskState.Active)
+                        {
+                            head.State = TaskState.Pending;
+                            tasks[0]   = head;
+                        }
+                    }
+                    var prev = intent;
+                    if (prev.Kind != ProfessionKind.None)
+                    {
+                        intent = default;
+                        ProfessionEventSink.Add(ref Events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, NowTick, ProfessionChangeReason.ReliefOverride);
+                    }
+                    return;
+                }
+
+                if (ControlledLookup.HasComponent(entity))
+                {
+                    if (tasks.Length > 0) tasks.Clear();
+                    var prev = intent;
+                    if (prev.Kind != ProfessionKind.None)
+                    {
+                        intent = default;
+                        ProfessionEventSink.Add(ref Events, entity, prev.Kind, ProfessionKind.None, default, Entity.Null, NowTick, ProfessionChangeReason.ManualOverride);
+                    }
+                    return;
+                }
+
+                // Pop drained / invalidated heads so Preempt + Dispatch see
+                // the next live task (or an empty queue).
+                while (tasks.Length > 0 &&
+                       (tasks[0].State == TaskState.Invalidated ||
+                        tasks[0].State == TaskState.Completed))
+                {
+                    tasks.RemoveAt(0);
+                }
+
+                if (tasks.Length > 0)
+                {
+                    var head = tasks[0];
+                    if (head.State == TaskState.Pending)
+                    {
+                        head.State = TaskState.Active;
+                        tasks[0]   = head;
+                        intent = new ProfessionIntent
+                        {
+                            Kind         = head.Kind,
+                            TargetHex    = head.TargetHex,
+                            TargetEntity = head.TargetEntity,
+                        };
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes roadmap item **#11** from #11716.

## Was

One monolithic `IJobEntity` that walked every Player unit and ran inline:

```
relief override → manual override → queue cleanup →
Pending→Active promotion → guard preempt → scoring →
wander fallback → intent write → event emit
```

…gated by an internal `if (!DoFullDispatch) return;` per unit. Cost: every Player unit's chunk got iterated every tick even on idle frames.

## Now

Three Burst ISystems with their own jobs, each focused on one phase. Update order set by `[UpdateAfter]`.

### [ProfessionTaskReconcileSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionTaskReconcileSystem.cs) — every tick

Reads `ReliefIntent` / `ControlledUnitTag` / `TaskMemory` head. Applies Relief / Manual overrides, pops drained/invalidated heads, promotes `Pending` → `Active`. Pre-grows `WriteBuffer` capacity for the whole pipeline this tick so Preempt + Dispatch `AddNoResize` without contention.

### [ProfessionPreemptSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionPreemptSystem.cs) — every tick, system-level skip when no threats

```csharp
if (combatDB.Threats.Length == 0) return;
```

Guard preempt scan. Only runs the IJobEntity when threats are present — **quiet ticks pay nothing**. Yanks the Active head off any unit with `Guard ≥ GuardPreemptThreshold` + nearby in-territory threat, writes Guard intent, emits `Preempted` event.

### [ProfessionDispatchSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs) — cadence-gated full dispatch

Pre-pass (`Clear` / `BuildActive` / `BuildReserved` / `Reduce`) still owns the occupancy + activePerKind + reservedPerKind build on workers. `DispatchJob` now only acts on units with a **healthy empty queue**:

```csharp
if (reliefIntent.Kind != ReliefKind.None)   return;
if (tasks.Length > 0)                       return;
if (ControlledLookup.HasComponent(entity))  return;
if (!DoFullDispatch)                        return;
// score TaskOffers, write intent, emit Assigned/Retargeted/Fallback
```

Skips committed / pre-empted / relief / controlled / non-dispatch-tick units via three early checks — no chunk-level filtering needed.

## Idle-tick win

On a frame with no threats and no full-dispatch cadence bump, **only Reconcile actually does per-unit work**:
- Preempt returns at the system level (`Threats.Length == 0`)
- Dispatch schedules its pre-pass only when `doFullDispatch`
- DispatchJob falls out at the third early check

Far less wasted chunk iteration on quiet ticks. Hot ticks (combat + full dispatch) pay roughly the same as before — same total work, distributed across three systems instead of one.

## Behaviour preserved

- All five event reasons fire from the same code paths they used to:
  - `ReliefOverride` (Reconcile)
  - `ManualOverride` (Reconcile)
  - `Preempted` (Preempt)
  - `Retargeted` / `Assigned` / `Fallback` (Dispatch)
- `ProfessionEventSink.Add(ref NativeList<>.ParallelWriter, …)` is the single emission API across all three systems.
- `WriteBuffer` capacity grow + `AsParallelWriter()` pattern from #11723 / #11728 stays — Reconcile owns it now since it runs first.
- `ProfessionsDBSingleton.PipelineHandle` is updated by each system to the latest chained handle, so downstream bridge / domain readers still get a single `.Complete()` target covering all three jobs.

Pre-pass jobs from #11728 (`ClearPrePassJob` / `BuildActiveAndOccupancyJob` / `BuildReservedJob` / `ReducePrePassJob`) stay in `ProfessionDispatchSystem` since they feed only its scoring loop.

## Test plan

- [ ] Burst compiles all three systems clean (no BC1xxx / EA0006).
- [ ] All five event reasons fire correctly under their respective trigger conditions:
  - Set ReliefIntent → expect `ReliefOverride`
  - Tag a unit Controlled → expect `ManualOverride`
  - Spawn threat near Guard-priority unit → expect `Preempted`
  - Full dispatch with new offer → expect `Assigned`
  - Full dispatch with same kind, different hex → expect `Retargeted`
  - Full dispatch with no scoring win → expect `Fallback`
- [ ] Idle tick CPU smoke: with `Threats.Length == 0` and `BuildVersion` unchanged, Preempt + Dispatch should show ~no per-unit work in the profiler.
- [ ] No race or safety errors with `ENABLE_UNITY_COLLECTIONS_CHECKS`.
- [ ] ProfessionMessagePipeBridgeSystem still drains WriteBuffer cleanly across the three writers.

## Roadmap status

✅ #10 #3 #5 #2 (#11719) · ✅ #4 (#11723) · ✅ pre-pass parallelization (#11728) · ✅ #7 #8 #9 (#11733) · ✅ #11 (this PR)

Remaining: **#1** spatial hash (marginal at current offer pool), **#6** head-index task queue (parked, only matters at chain length > 5).

Refs #11716.