### PR TITLE
feat(astro-kbve,axum-kbve): staff RCON gameops panel for Velocity + Lobby + Survival

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactMcDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactMcDashboard.tsx
@@ -1,19 +1,11 @@
 import { useStore } from '@nanostores/react';
-import {
-	Pickaxe,
-	ShieldOff,
-	Github,
-	ExternalLink,
-	Container,
-	Server,
-	Boxes,
-} from 'lucide-react';
+import { ExternalLink, Github, Pickaxe, ShieldOff } from 'lucide-react';
+import ServerCard from './mc/ServerCard';
 import { homeService } from './homeService';
 
-const VELOCITY_IMAGE = 'ghcr.io/kbve/mc-velocity';
-const LOBBY_IMAGE = 'ghcr.io/kbve/mc-lobby';
-const MANIFESTS_PATH = '/docs/project/mc-velocity/';
 const REPO_PATH = 'https://github.com/KBVE/kbve/tree/main/apps/kube/agones/mc';
+const VELOCITY_DOCS = '/docs/project/mc-velocity/';
+const LOBBY_DOCS = '/docs/project/mc-lobby/';
 
 const styles = {
 	centered: {
@@ -39,59 +31,22 @@ const styles = {
 		display: 'flex',
 		alignItems: 'center',
 		gap: '0.75rem',
-		marginBottom: '1rem',
+		marginBottom: '0.5rem',
 	},
-	statusRow: {
-		display: 'inline-flex',
-		alignItems: 'center',
-		gap: '0.5rem',
-		padding: '0.35rem 0.75rem',
-		borderRadius: '999px',
-		fontSize: '0.85rem',
-		fontWeight: 500,
-		background: 'rgba(139, 148, 158, 0.15)',
+	subTitle: {
+		margin: '0 0 1.25rem 0',
 		color: 'var(--sl-color-gray-3, #8b949e)',
-		border: '1px solid rgba(139, 148, 158, 0.4)',
-	},
-	statusDot: {
-		width: '0.5rem',
-		height: '0.5rem',
-		borderRadius: '50%',
-		background: 'var(--sl-color-gray-3, #8b949e)',
+		fontSize: '0.95rem',
 	},
 	grid: {
 		display: 'grid',
-		gap: '1rem',
-		gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
-		marginTop: '1.5rem',
-	},
-	card: {
-		display: 'flex',
-		flexDirection: 'column' as const,
-		gap: '0.5rem',
-		padding: '1rem 1.25rem',
-		borderRadius: '0.75rem',
-		border: '1px solid var(--sl-color-gray-5, #30363d)',
-		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
-	},
-	cardLabel: {
-		display: 'flex',
-		alignItems: 'center',
-		gap: '0.5rem',
-		fontSize: '0.85rem',
-		color: 'var(--sl-color-gray-3, #8b949e)',
-	},
-	cardValue: {
-		margin: 0,
-		fontSize: '1rem',
-		fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
-		color: 'var(--sl-color-text, #e6edf3)',
-		wordBreak: 'break-all' as const,
+		gridTemplateColumns: 'repeat(auto-fit, minmax(22rem, 1fr))',
+		gap: '1.25rem',
 	},
 	links: {
 		display: 'flex',
-		gap: '0.75rem',
 		flexWrap: 'wrap' as const,
+		gap: '0.75rem',
 		marginTop: '1.5rem',
 	},
 	linkButton: {
@@ -127,44 +82,30 @@ export default function ReactMcDashboard() {
 		<div>
 			<div style={styles.header}>
 				<Pickaxe size={28} color="var(--sl-color-accent, #2f81f7)" />
-				<h1 style={styles.heading}>Minecraft</h1>
+				<h1 style={styles.heading}>Minecraft Gameops</h1>
 			</div>
-			<span style={styles.statusRow}>
-				<span style={styles.statusDot} />
-				Deployed in cluster · Live dashboard wiring planned
-			</span>
+			<p style={styles.subTitle}>
+				Velocity proxy + Paper backends. Per-server status, live player
+				roster, and staff-only RCON consoles routed through{' '}
+				<code>POST /api/v1/rcon/mc/&#123;server&#125;/exec</code>.
+			</p>
 
 			<div style={styles.grid}>
-				<div style={styles.card}>
-					<div style={styles.cardLabel}>
-						<Container size={16} />
-						Velocity proxy image
-					</div>
-					<p style={styles.cardValue}>{VELOCITY_IMAGE}</p>
-				</div>
-				<div style={styles.card}>
-					<div style={styles.cardLabel}>
-						<Container size={16} />
-						Lobby image
-					</div>
-					<p style={styles.cardValue}>{LOBBY_IMAGE}</p>
-				</div>
-				<div style={styles.card}>
-					<div style={styles.cardLabel}>
-						<Server size={16} />
-						Cluster manifests
-					</div>
-					<p style={styles.cardValue}>apps/kube/agones/mc/</p>
-				</div>
-				<div style={styles.card}>
-					<div style={styles.cardLabel}>
-						<Boxes size={16} />
-						Live RCON / player count
-					</div>
-					<p style={styles.cardValue}>
-						not yet wired into this dashboard
-					</p>
-				</div>
+				<ServerCard
+					server="velocity"
+					label="Velocity Proxy"
+					role="Network edge — routes /glist, /alert, /send across backends."
+				/>
+				<ServerCard
+					server="lobby"
+					label="Lobby Backend"
+					role="Spawn world. List, kick, gamemode, broadcast."
+				/>
+				<ServerCard
+					server="survival"
+					label="Survival Backend"
+					role="Main play world. Whitelist, bans, world ops."
+				/>
 			</div>
 
 			<div style={styles.links}>
@@ -176,9 +117,11 @@ export default function ReactMcDashboard() {
 					<Github size={16} /> Manifests on GitHub
 					<ExternalLink size={14} />
 				</a>
-				<a href={MANIFESTS_PATH} style={styles.linkButton}>
-					<Container size={16} /> mc-velocity project docs
-					<ExternalLink size={14} />
+				<a href={VELOCITY_DOCS} style={styles.linkButton}>
+					mc-velocity docs <ExternalLink size={14} />
+				</a>
+				<a href={LOBBY_DOCS} style={styles.linkButton}>
+					mc-lobby docs <ExternalLink size={14} />
 				</a>
 			</div>
 		</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/mc/RconConsole.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/mc/RconConsole.tsx
@@ -1,0 +1,416 @@
+import { useMemo, useState } from 'react';
+import { AlertTriangle, Play, Terminal, Trash2 } from 'lucide-react';
+import { execRcon } from '@/lib/rcon-client';
+import { commandsForServer, type CommandDef, type Tier } from './commands';
+
+export type McServer = 'velocity' | 'lobby' | 'survival';
+
+interface LogEntry {
+	id: number;
+	ts: number;
+	command: string;
+	args: string[];
+	ok: boolean;
+	output: string;
+	error?: string;
+	latency_ms: number;
+}
+
+const TIER_TINT: Record<Tier, { bg: string; fg: string; border: string }> = {
+	read: {
+		bg: 'rgba(63, 185, 80, 0.10)',
+		fg: 'var(--sl-color-green, #3fb950)',
+		border: 'rgba(63, 185, 80, 0.35)',
+	},
+	write: {
+		bg: 'rgba(47, 129, 247, 0.10)',
+		fg: 'var(--sl-color-accent, #2f81f7)',
+		border: 'rgba(47, 129, 247, 0.35)',
+	},
+	destructive: {
+		bg: 'rgba(248, 81, 73, 0.10)',
+		fg: 'var(--sl-color-red, #f85149)',
+		border: 'rgba(248, 81, 73, 0.4)',
+	},
+};
+
+const TIERS: Tier[] = ['read', 'write', 'destructive'];
+const TIER_LABEL: Record<Tier, string> = {
+	read: 'Read',
+	write: 'Write',
+	destructive: 'Destructive',
+};
+
+const styles = {
+	root: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.75rem',
+		padding: '1rem',
+		borderRadius: '0.75rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-sidebar, rgba(13, 17, 23, 0.4))',
+	},
+	headerRow: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		fontSize: '0.85rem',
+		fontWeight: 600,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+	tabs: {
+		display: 'flex',
+		gap: '0.25rem',
+		padding: '0.25rem',
+		borderRadius: '0.5rem',
+		background: 'rgba(13, 17, 23, 0.4)',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+	},
+	tab: (active: boolean, tier: Tier): React.CSSProperties => ({
+		flex: 1,
+		padding: '0.35rem 0.6rem',
+		borderRadius: '0.35rem',
+		border: 'none',
+		fontSize: '0.8rem',
+		fontWeight: 600,
+		cursor: 'pointer',
+		background: active ? TIER_TINT[tier].bg : 'transparent',
+		color: active ? TIER_TINT[tier].fg : 'var(--sl-color-gray-3, #8b949e)',
+	}),
+	commandSelect: {
+		width: '100%',
+		padding: '0.4rem 0.6rem',
+		borderRadius: '0.4rem',
+		background: 'var(--sl-color-bg, #0d1117)',
+		color: 'var(--sl-color-text, #e6edf3)',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		fontSize: '0.85rem',
+	},
+	description: {
+		margin: 0,
+		fontSize: '0.78rem',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+	argRow: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.25rem',
+	},
+	argLabel: {
+		fontSize: '0.72rem',
+		fontWeight: 600,
+		textTransform: 'uppercase' as const,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		letterSpacing: '0.04em',
+	},
+	argInput: {
+		padding: '0.4rem 0.55rem',
+		borderRadius: '0.35rem',
+		background: 'var(--sl-color-bg, #0d1117)',
+		color: 'var(--sl-color-text, #e6edf3)',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		fontSize: '0.85rem',
+		fontFamily: 'var(--sl-font-mono, monospace)',
+	},
+	actions: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		gap: '0.5rem',
+	},
+	runBtn: (tier: Tier, disabled: boolean): React.CSSProperties => ({
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+		padding: '0.4rem 0.85rem',
+		borderRadius: '0.4rem',
+		border: `1px solid ${TIER_TINT[tier].border}`,
+		background: disabled ? 'rgba(48, 54, 61, 0.4)' : TIER_TINT[tier].bg,
+		color: disabled
+			? 'var(--sl-color-gray-3, #8b949e)'
+			: TIER_TINT[tier].fg,
+		fontWeight: 600,
+		fontSize: '0.85rem',
+		cursor: disabled ? 'not-allowed' : 'pointer',
+	}),
+	clearBtn: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.3rem 0.6rem',
+		borderRadius: '0.4rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'transparent',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		fontSize: '0.78rem',
+		cursor: 'pointer',
+	},
+	log: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.4rem',
+		maxHeight: '18rem',
+		overflowY: 'auto' as const,
+		padding: '0.6rem',
+		borderRadius: '0.5rem',
+		background: 'rgba(0, 0, 0, 0.35)',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		fontFamily: 'var(--sl-font-mono, monospace)',
+		fontSize: '0.8rem',
+	},
+	logEmpty: {
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		fontStyle: 'italic' as const,
+		textAlign: 'center' as const,
+		padding: '0.5rem',
+	},
+	logEntry: (ok: boolean): React.CSSProperties => ({
+		display: 'flex',
+		flexDirection: 'column',
+		gap: '0.2rem',
+		paddingLeft: '0.5rem',
+		borderLeft: `2px solid ${
+			ok ? 'rgba(63, 185, 80, 0.5)' : 'rgba(248, 81, 73, 0.5)'
+		}`,
+	}),
+	logMeta: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		gap: '0.5rem',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+		fontSize: '0.7rem',
+	},
+	logCmd: {
+		color: 'var(--sl-color-text, #e6edf3)',
+		whiteSpace: 'pre-wrap' as const,
+	},
+	logOutput: (ok: boolean): React.CSSProperties => ({
+		whiteSpace: 'pre-wrap',
+		color: ok
+			? 'var(--sl-color-text, #e6edf3)'
+			: 'var(--sl-color-red, #f85149)',
+	}),
+};
+
+interface Props {
+	server: McServer;
+}
+
+let entryId = 0;
+
+export default function RconConsole({ server }: Props) {
+	const commands = useMemo(() => commandsForServer(server), [server]);
+	const [tier, setTier] = useState<Tier>('read');
+	const visible = useMemo(
+		() => commands.filter((c) => c.tier === tier),
+		[commands, tier],
+	);
+	const [selectedName, setSelectedName] = useState<string>(
+		visible[0]?.name ?? '',
+	);
+	const selected: CommandDef | undefined =
+		visible.find((c) => c.name === selectedName) ?? visible[0];
+	const [args, setArgs] = useState<string[]>([]);
+	const [pending, setPending] = useState(false);
+	const [log, setLog] = useState<LogEntry[]>([]);
+
+	function pickTier(next: Tier) {
+		setTier(next);
+		const first = commands.find((c) => c.tier === next);
+		setSelectedName(first?.name ?? '');
+		setArgs([]);
+	}
+
+	function pickCommand(name: string) {
+		setSelectedName(name);
+		setArgs([]);
+	}
+
+	function updateArg(index: number, value: string) {
+		setArgs((prev) => {
+			const next = prev.slice();
+			while (next.length <= index) next.push('');
+			next[index] = value;
+			return next;
+		});
+	}
+
+	async function run() {
+		if (!selected) return;
+		const fullArgs = selected.args.map((_, i) => args[i] ?? '');
+		if (selected.tier === 'destructive') {
+			const summary = [selected.label, ...fullArgs.filter(Boolean)].join(
+				' ',
+			);
+			const ok = window.confirm(
+				`Run ${summary} on ${server}? This is a destructive command.`,
+			);
+			if (!ok) return;
+		}
+		setPending(true);
+		const ts = Date.now();
+		try {
+			const res = await execRcon('mc', server, {
+				command: selected.name,
+				args: fullArgs,
+			});
+			setLog((prev) =>
+				[
+					{
+						id: ++entryId,
+						ts,
+						command: selected.name,
+						args: fullArgs,
+						ok: res.ok,
+						output: res.output,
+						error: res.error,
+						latency_ms: res.latency_ms,
+					},
+					...prev,
+				].slice(0, 50),
+			);
+		} catch (e: unknown) {
+			const err = e as Error;
+			setLog((prev) =>
+				[
+					{
+						id: ++entryId,
+						ts,
+						command: selected.name,
+						args: fullArgs,
+						ok: false,
+						output: '',
+						error: err?.message ?? 'request failed',
+						latency_ms: 0,
+					},
+					...prev,
+				].slice(0, 50),
+			);
+		} finally {
+			setPending(false);
+		}
+	}
+
+	return (
+		<div style={styles.root}>
+			<div style={styles.headerRow}>
+				<Terminal size={14} />
+				RCON · {server}
+			</div>
+
+			<div style={styles.tabs}>
+				{TIERS.map((t) => {
+					const has = commands.some((c) => c.tier === t);
+					if (!has) return null;
+					return (
+						<button
+							key={t}
+							type="button"
+							style={styles.tab(tier === t, t)}
+							onClick={() => pickTier(t)}>
+							{TIER_LABEL[t]}
+						</button>
+					);
+				})}
+			</div>
+
+			{visible.length === 0 ? (
+				<p style={styles.description}>
+					No {TIER_LABEL[tier].toLowerCase()} commands available for{' '}
+					{server}.
+				</p>
+			) : (
+				<>
+					<select
+						style={styles.commandSelect}
+						value={selectedName}
+						onChange={(e) => pickCommand(e.target.value)}>
+						{visible.map((c) => (
+							<option key={c.name} value={c.name}>
+								{c.label} ({c.name})
+							</option>
+						))}
+					</select>
+
+					{selected && (
+						<p style={styles.description}>{selected.description}</p>
+					)}
+
+					{selected?.args.map((arg, i) => (
+						<div key={i} style={styles.argRow}>
+							<span style={styles.argLabel}>{arg.label}</span>
+							<input
+								style={styles.argInput}
+								type="text"
+								placeholder={arg.placeholder}
+								value={args[i] ?? ''}
+								onChange={(e) => updateArg(i, e.target.value)}
+							/>
+						</div>
+					))}
+
+					<div style={styles.actions}>
+						<button
+							type="button"
+							style={styles.runBtn(tier, pending || !selected)}
+							onClick={run}
+							disabled={pending || !selected}>
+							{tier === 'destructive' && (
+								<AlertTriangle size={14} />
+							)}
+							{tier !== 'destructive' && <Play size={14} />}
+							{pending
+								? 'Running…'
+								: `Run ${selected?.label ?? ''}`}
+						</button>
+						{log.length > 0 && (
+							<button
+								type="button"
+								style={styles.clearBtn}
+								onClick={() => setLog([])}>
+								<Trash2 size={12} /> Clear log
+							</button>
+						)}
+					</div>
+				</>
+			)}
+
+			<div style={styles.log}>
+				{log.length === 0 ? (
+					<div style={styles.logEmpty}>No commands run yet.</div>
+				) : (
+					log.map((entry) => (
+						<div key={entry.id} style={styles.logEntry(entry.ok)}>
+							<div style={styles.logMeta}>
+								<span>
+									{new Date(entry.ts).toLocaleTimeString()} ·{' '}
+									{entry.command}
+								</span>
+								<span>
+									{entry.ok
+										? `${entry.latency_ms}ms`
+										: 'failed'}
+								</span>
+							</div>
+							{entry.args.length > 0 && (
+								<div style={styles.logCmd}>
+									args: [
+									{entry.args
+										.map((a) => JSON.stringify(a))
+										.join(', ')}
+									]
+								</div>
+							)}
+							<div style={styles.logOutput(entry.ok)}>
+								{entry.ok
+									? entry.output || '(empty)'
+									: (entry.error ?? 'failed')}
+							</div>
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/mc/ServerCard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/mc/ServerCard.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useState } from 'react';
+import { Network, Server, Users } from 'lucide-react';
+import RconConsole, { type McServer } from './RconConsole';
+
+interface McPlayer {
+	name: string;
+	uuid: string | null;
+	skin_url: string | null;
+	server: string;
+}
+
+interface McServerStatus {
+	server: string;
+	online: number;
+	max: number;
+	reachable: boolean;
+}
+
+interface McPlayerListData {
+	online: number;
+	max: number;
+	players: McPlayer[];
+	servers: McServerStatus[];
+	cached_at: number;
+}
+
+interface Props {
+	server: McServer;
+	label: string;
+	role: string;
+	refreshInterval?: number;
+}
+
+const styles = {
+	card: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '1rem',
+		padding: '1.25rem',
+		borderRadius: '0.75rem',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
+	},
+	header: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'flex-start',
+		gap: '0.75rem',
+	},
+	titleBlock: {
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.25rem',
+	},
+	title: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.5rem',
+		margin: 0,
+		fontSize: '1.1rem',
+		fontWeight: 700,
+		color: 'var(--sl-color-text, #e6edf3)',
+	},
+	role: {
+		margin: 0,
+		fontSize: '0.78rem',
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+	statusPill: (reachable: boolean): React.CSSProperties => ({
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.25rem 0.6rem',
+		borderRadius: '999px',
+		fontSize: '0.72rem',
+		fontWeight: 600,
+		background: reachable
+			? 'rgba(63, 185, 80, 0.15)'
+			: 'rgba(248, 81, 73, 0.15)',
+		color: reachable
+			? 'var(--sl-color-green, #3fb950)'
+			: 'var(--sl-color-red, #f85149)',
+		border: `1px solid ${
+			reachable ? 'rgba(63, 185, 80, 0.4)' : 'rgba(248, 81, 73, 0.4)'
+		}`,
+	}),
+	statusDot: (reachable: boolean): React.CSSProperties => ({
+		width: '0.45rem',
+		height: '0.45rem',
+		borderRadius: '50%',
+		background: reachable
+			? 'var(--sl-color-green, #3fb950)'
+			: 'var(--sl-color-red, #f85149)',
+	}),
+	metricsRow: {
+		display: 'flex',
+		gap: '0.75rem',
+		flexWrap: 'wrap' as const,
+	},
+	metric: {
+		flex: '1 1 8rem',
+		display: 'flex',
+		flexDirection: 'column' as const,
+		gap: '0.15rem',
+		padding: '0.6rem 0.75rem',
+		borderRadius: '0.5rem',
+		background: 'rgba(13, 17, 23, 0.4)',
+		border: '1px solid var(--sl-color-gray-5, #30363d)',
+	},
+	metricLabel: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		fontSize: '0.7rem',
+		fontWeight: 600,
+		letterSpacing: '0.04em',
+		textTransform: 'uppercase' as const,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+	metricValue: {
+		fontSize: '1.1rem',
+		fontWeight: 700,
+		color: 'var(--sl-color-text, #e6edf3)',
+	},
+	players: {
+		display: 'flex',
+		flexWrap: 'wrap' as const,
+		gap: '0.35rem',
+	},
+	playerChip: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.3rem',
+		padding: '0.2rem 0.55rem',
+		borderRadius: '999px',
+		fontSize: '0.75rem',
+		background: 'rgba(47, 129, 247, 0.1)',
+		color: 'var(--sl-color-accent, #2f81f7)',
+		border: '1px solid rgba(47, 129, 247, 0.3)',
+	},
+	playersEmpty: {
+		margin: 0,
+		fontSize: '0.78rem',
+		fontStyle: 'italic' as const,
+		color: 'var(--sl-color-gray-3, #8b949e)',
+	},
+};
+
+export default function ServerCard({
+	server,
+	label,
+	role,
+	refreshInterval = 15_000,
+}: Props) {
+	const [data, setData] = useState<McPlayerListData | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		async function poll() {
+			try {
+				const res = await fetch('/api/v1/mc/players');
+				if (!res.ok) return;
+				const json = (await res.json()) as McPlayerListData;
+				if (!cancelled) setData(json);
+			} catch {
+				/* ignore — keep last known good */
+			}
+		}
+		poll();
+		const id = window.setInterval(poll, refreshInterval);
+		return () => {
+			cancelled = true;
+			window.clearInterval(id);
+		};
+	}, [refreshInterval]);
+
+	const status = data?.servers.find((s) => s.server === server);
+	const players = (data?.players ?? []).filter((p) => p.server === server);
+	const reachable = status?.reachable ?? false;
+
+	const showsPlayers = server !== 'velocity';
+
+	return (
+		<div style={styles.card}>
+			<div style={styles.header}>
+				<div style={styles.titleBlock}>
+					<h3 style={styles.title}>
+						<Server size={18} /> {label}
+					</h3>
+					<p style={styles.role}>{role}</p>
+				</div>
+				<span style={styles.statusPill(reachable)}>
+					<span style={styles.statusDot(reachable)} />
+					{reachable ? 'online' : 'unreachable'}
+				</span>
+			</div>
+
+			<div style={styles.metricsRow}>
+				<div style={styles.metric}>
+					<span style={styles.metricLabel}>
+						<Users size={12} /> Online
+					</span>
+					<span style={styles.metricValue}>
+						{status ? `${status.online} / ${status.max}` : '—'}
+					</span>
+				</div>
+				<div style={styles.metric}>
+					<span style={styles.metricLabel}>
+						<Network size={12} /> Endpoint
+					</span>
+					<span
+						style={{
+							...styles.metricValue,
+							fontSize: '0.85rem',
+							fontFamily: 'var(--sl-font-mono, monospace)',
+						}}>
+						RCON_MC_{server.toUpperCase()}
+					</span>
+				</div>
+			</div>
+
+			{showsPlayers && (
+				<div>
+					<div
+						style={{
+							...styles.metricLabel,
+							marginBottom: '0.35rem',
+						}}>
+						<Users size={12} /> Players ({players.length})
+					</div>
+					{players.length === 0 ? (
+						<p style={styles.playersEmpty}>No players online.</p>
+					) : (
+						<div style={styles.players}>
+							{players.map((p) => (
+								<span
+									key={p.uuid ?? p.name}
+									style={styles.playerChip}>
+									{p.name}
+								</span>
+							))}
+						</div>
+					)}
+				</div>
+			)}
+
+			<RconConsole server={server} />
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/mc/commands.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/mc/commands.ts
@@ -1,0 +1,218 @@
+export type Tier = 'read' | 'write' | 'destructive';
+export type Scope = 'velocity' | 'backend' | 'shared';
+
+export interface CommandDef {
+	name: string;
+	label: string;
+	template: string;
+	args: { label: string; placeholder?: string }[];
+	tier: Tier;
+	scope: Scope;
+	description: string;
+}
+
+export const MC_COMMANDS: CommandDef[] = [
+	{
+		name: 'list',
+		label: 'List players',
+		template: 'list',
+		args: [],
+		tier: 'read',
+		scope: 'backend',
+		description: 'Paper /list — online players on this backend.',
+	},
+	{
+		name: 'tps',
+		label: 'Server TPS',
+		template: 'tps',
+		args: [],
+		tier: 'read',
+		scope: 'backend',
+		description: 'Paper-only — last 1m/5m/15m TPS averages.',
+	},
+	{
+		name: 'save_all',
+		label: 'Save world',
+		template: 'save-all',
+		args: [],
+		tier: 'read',
+		scope: 'backend',
+		description: 'Flush world state to disk now.',
+	},
+	{
+		name: 'glist',
+		label: 'Global player list',
+		template: 'glist',
+		args: [],
+		tier: 'read',
+		scope: 'velocity',
+		description: 'Velocity /glist — players across every proxied backend.',
+	},
+	{
+		name: 'find',
+		label: 'Find player',
+		template: 'find {0}',
+		args: [{ label: 'player', placeholder: 'name' }],
+		tier: 'read',
+		scope: 'velocity',
+		description: 'Velocity /find — locate which backend a player is on.',
+	},
+	{
+		name: 'server_info',
+		label: 'Server info',
+		template: 'server {0}',
+		args: [{ label: 'server', placeholder: 'lobby | survival' }],
+		tier: 'read',
+		scope: 'velocity',
+		description: 'Velocity /server — details about a registered backend.',
+	},
+
+	{
+		name: 'say',
+		label: 'Broadcast (this server)',
+		template: 'say {0}',
+		args: [{ label: 'message' }],
+		tier: 'write',
+		scope: 'backend',
+		description: 'Broadcast a chat message on this backend.',
+	},
+	{
+		name: 'alert',
+		label: 'Broadcast (network)',
+		template: 'alert {0}',
+		args: [{ label: 'message' }],
+		tier: 'write',
+		scope: 'velocity',
+		description:
+			'Velocity /alert — broadcast across every proxied backend.',
+	},
+	{
+		name: 'tp',
+		label: 'Teleport',
+		template: 'tp {0} {1}',
+		args: [
+			{ label: 'source', placeholder: 'player' },
+			{ label: 'target', placeholder: 'player or x y z' },
+		],
+		tier: 'write',
+		scope: 'backend',
+		description: 'Paper /tp — teleport source to target.',
+	},
+	{
+		name: 'send',
+		label: 'Send player',
+		template: 'send {0} {1}',
+		args: [
+			{ label: 'player' },
+			{ label: 'target server', placeholder: 'lobby | survival' },
+		],
+		tier: 'write',
+		scope: 'velocity',
+		description: 'Velocity /send — move a player to another backend.',
+	},
+	{
+		name: 'gamemode',
+		label: 'Set gamemode',
+		template: 'gamemode {0} {1}',
+		args: [
+			{ label: 'gamemode', placeholder: 'survival | creative | ...' },
+			{ label: 'player' },
+		],
+		tier: 'write',
+		scope: 'backend',
+		description: 'Paper /gamemode <mode> <player>.',
+	},
+	{
+		name: 'time_set',
+		label: 'Set time',
+		template: 'time set {0}',
+		args: [{ label: 'value', placeholder: 'day | night | 6000' }],
+		tier: 'write',
+		scope: 'backend',
+		description: 'Paper /time set.',
+	},
+	{
+		name: 'weather',
+		label: 'Set weather',
+		template: 'weather {0}',
+		args: [{ label: 'weather', placeholder: 'clear | rain | thunder' }],
+		tier: 'write',
+		scope: 'backend',
+		description: 'Paper /weather.',
+	},
+
+	{
+		name: 'kick',
+		label: 'Kick player',
+		template: 'kick {0} {1}',
+		args: [{ label: 'player' }, { label: 'reason' }],
+		tier: 'destructive',
+		scope: 'backend',
+		description: 'Paper /kick <player> <reason>.',
+	},
+	{
+		name: 'op',
+		label: 'Grant op',
+		template: 'op {0}',
+		args: [{ label: 'player' }],
+		tier: 'destructive',
+		scope: 'backend',
+		description: 'Paper /op <player>. Persists across restarts.',
+	},
+	{
+		name: 'deop',
+		label: 'Revoke op',
+		template: 'deop {0}',
+		args: [{ label: 'player' }],
+		tier: 'destructive',
+		scope: 'backend',
+		description: 'Paper /deop <player>.',
+	},
+	{
+		name: 'ban',
+		label: 'Ban player',
+		template: 'ban {0} {1}',
+		args: [{ label: 'player' }, { label: 'reason' }],
+		tier: 'destructive',
+		scope: 'backend',
+		description: 'Paper /ban <player> <reason>.',
+	},
+	{
+		name: 'pardon',
+		label: 'Pardon player',
+		template: 'pardon {0}',
+		args: [{ label: 'player' }],
+		tier: 'destructive',
+		scope: 'backend',
+		description: 'Paper /pardon <player>.',
+	},
+	{
+		name: 'whitelist_add',
+		label: 'Whitelist add',
+		template: 'whitelist add {0}',
+		args: [{ label: 'player' }],
+		tier: 'destructive',
+		scope: 'backend',
+		description: 'Paper /whitelist add <player>.',
+	},
+	{
+		name: 'whitelist_remove',
+		label: 'Whitelist remove',
+		template: 'whitelist remove {0}',
+		args: [{ label: 'player' }],
+		tier: 'destructive',
+		scope: 'backend',
+		description: 'Paper /whitelist remove <player>.',
+	},
+];
+
+export function commandsForServer(
+	server: 'velocity' | 'lobby' | 'survival',
+): CommandDef[] {
+	const matches = (c: CommandDef): boolean => {
+		if (c.scope === 'shared') return true;
+		if (server === 'velocity') return c.scope === 'velocity';
+		return c.scope === 'backend';
+	};
+	return MC_COMMANDS.filter(matches);
+}

--- a/apps/kbve/astro-kbve/src/lib/rcon-client.ts
+++ b/apps/kbve/astro-kbve/src/lib/rcon-client.ts
@@ -1,0 +1,77 @@
+import { initSupa, getSupa } from './supa';
+
+export type Game = 'mc' | 'factorio';
+
+export interface RconExecRequest {
+	command: string;
+	args?: string[];
+}
+
+export interface RconExecResponse {
+	ok: boolean;
+	output: string;
+	latency_ms: number;
+	error?: string;
+}
+
+const API_BASE = '/api/v1/rcon';
+
+async function bearerToken(): Promise<string | null> {
+	await initSupa();
+	const supa = getSupa();
+	const result = await supa.getSession().catch(() => null);
+	return (result?.session?.access_token as string | undefined) ?? null;
+}
+
+export async function execRcon(
+	game: Game,
+	server: string,
+	body: RconExecRequest,
+): Promise<RconExecResponse> {
+	const token = await bearerToken();
+	if (!token) {
+		throw new Error('Not signed in');
+	}
+	const res = await fetch(
+		`${API_BASE}/${encodeURIComponent(game)}/${encodeURIComponent(server)}/exec`,
+		{
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${token}`,
+			},
+			body: JSON.stringify(body),
+		},
+	);
+
+	const text = await res.text();
+	let parsed: RconExecResponse | undefined;
+	try {
+		parsed = text ? (JSON.parse(text) as RconExecResponse) : undefined;
+	} catch {
+		parsed = undefined;
+	}
+
+	if (!res.ok) {
+		const message =
+			parsed?.error ??
+			(typeof parsed?.output === 'string' ? parsed.output : undefined) ??
+			text ??
+			`HTTP ${res.status}`;
+		return {
+			ok: false,
+			output: '',
+			latency_ms: 0,
+			error: message,
+		};
+	}
+
+	return (
+		parsed ?? {
+			ok: false,
+			output: '',
+			latency_ms: 0,
+			error: 'empty response',
+		}
+	);
+}

--- a/apps/kbve/axum-kbve/src/rcon/registry.rs
+++ b/apps/kbve/axum-kbve/src/rcon/registry.rs
@@ -43,7 +43,7 @@ impl Game {
 
     fn well_known_servers(self) -> &'static [&'static str] {
         match self {
-            Game::Mc => &["LOBBY", "SURVIVAL"],
+            Game::Mc => &["VELOCITY", "LOBBY", "SURVIVAL"],
             Game::Factorio => &["MAIN"],
         }
     }

--- a/packages/data/rcon/commands.yaml
+++ b/packages/data/rcon/commands.yaml
@@ -13,13 +13,33 @@
 #   template         — wire command rendered with positional {N} args
 #   arg_validators   — per-arg validator names; resolved by the server
 #                       (currently: "string", "int", "lua_snippet")
+#
+# UI tiers (front-end groups commands by name, NOT a server-side concept):
+#   read:        list, glist, find, server_info, tps, save_all
+#   write:       say, alert, tp, send, gamemode, time_set, weather
+#   destructive: kick, op, deop, ban, pardon, whitelist_add, whitelist_remove
 
 commands:
-    # ---- Minecraft (vanilla / Fabric) ----
+    # =========================================================================
+    # Minecraft — Paper / Fabric backends (lobby, survival)
+    # =========================================================================
+
     - game: mc
       name: list
-      staff_only: false
+      staff_only: true
       template: list
+      arg_validators: []
+
+    - game: mc
+      name: tps
+      staff_only: true
+      template: tps
+      arg_validators: []
+
+    - game: mc
+      name: save_all
+      staff_only: true
+      template: save-all
       arg_validators: []
 
     - game: mc
@@ -37,17 +57,128 @@ commands:
           - string
           - string
 
-    # ---- Factorio (vanilla) ----
-    # `players online` — read-only, safe for everyone signed in.
+    - game: mc
+      name: gamemode
+      staff_only: true
+      template: 'gamemode {0} {1}'
+      arg_validators:
+          - string
+          - string
+
+    - game: mc
+      name: time_set
+      staff_only: true
+      template: 'time set {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: weather
+      staff_only: true
+      template: 'weather {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: kick
+      staff_only: true
+      template: 'kick {0} {1}'
+      arg_validators:
+          - string
+          - string
+
+    - game: mc
+      name: op
+      staff_only: true
+      template: 'op {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: deop
+      staff_only: true
+      template: 'deop {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: ban
+      staff_only: true
+      template: 'ban {0} {1}'
+      arg_validators:
+          - string
+          - string
+
+    - game: mc
+      name: pardon
+      staff_only: true
+      template: 'pardon {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: whitelist_add
+      staff_only: true
+      template: 'whitelist add {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: whitelist_remove
+      staff_only: true
+      template: 'whitelist remove {0}'
+      arg_validators:
+          - string
+
+    # =========================================================================
+    # Minecraft — Velocity proxy
+    # =========================================================================
+
+    - game: mc
+      name: glist
+      staff_only: true
+      template: glist
+      arg_validators: []
+
+    - game: mc
+      name: find
+      staff_only: true
+      template: 'find {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: server_info
+      staff_only: true
+      template: 'server {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: alert
+      staff_only: true
+      template: 'alert {0}'
+      arg_validators:
+          - string
+
+    - game: mc
+      name: send
+      staff_only: true
+      template: 'send {0} {1}'
+      arg_validators:
+          - string
+          - string
+
+    # =========================================================================
+    # Factorio (vanilla)
+    # =========================================================================
+
     - game: factorio
       name: players_online
       staff_only: false
       template: '/players online'
       arg_validators: []
 
-    # `/silent-command` runs arbitrary Lua. Staff only, validator forces a
-    # plain Lua snippet (no length limit here — Source RCON enforces 4096B
-    # at the wire layer in jedi::rcon).
     - game: factorio
       name: silent_command
       staff_only: true


### PR DESCRIPTION
## Summary
Wires the existing \`POST /api/v1/rcon/mc/{server}/exec\` endpoint into the \`/dashboard/gameops/mc/\` page so staff drive Velocity + Paper backends from one console.

## Backend
- \`apps/kbve/axum-kbve/src/rcon/registry.rs\` — extend \`Game::Mc.well_known_servers()\` with \`VELOCITY\` so \`RCON_MC_VELOCITY_HOST/PORT/PASSWORD\` becomes a first-class endpoint alongside \`LOBBY\` / \`SURVIVAL\`.
- \`packages/data/rcon/commands.yaml\` — expand the allowlist (all entries \`staff_only: true\`):
  - **Paper backends:** \`list\`, \`tps\`, \`save_all\`, \`say\`, \`tp\`, \`gamemode\`, \`time_set\`, \`weather\`, \`kick\`, \`op\`, \`deop\`, \`ban\`, \`pardon\`, \`whitelist_add\`, \`whitelist_remove\`.
  - **Velocity proxy:** \`glist\`, \`find\`, \`server_info\`, \`alert\`, \`send\`.
- YAML is baked via \`include_str!\` so adding commands stays a PR-gated change.

## Frontend
- **\`src/lib/rcon-client.ts\`** — fetch wrapper that pulls the Supabase access_token via the existing \`supa\` gateway, POSTs to the exec endpoint, normalises ok/error into a single \`RconExecResponse\`.
- **\`components/dashboard/mc/commands.ts\`** — front-end mirror of the YAML, broken out by tier (read / write / destructive) and scope (velocity / backend) so the UI shows the right palette per server.
- **\`components/dashboard/mc/RconConsole.tsx\`** — per-server console: tier tabs, command picker, args inputs, run button, in-memory scrollback (50 entries with latency, success/failure colour, rendered args). Destructive commands gated behind \`window.confirm\`.
- **\`components/dashboard/mc/ServerCard.tsx\`** — per-server card: polls \`/api/v1/mc/players\` every 15s for reachable + online/max + player chips, embeds \`RconConsole\` for that server.
- **\`ReactMcDashboard.tsx\`** — refactor previous static placeholder into the three-card grid (velocity / lobby / survival) under the existing \`is_staff\` gate.

## Auth + audit
- Every exec goes through the existing JWT cache; \`staff_only: true\` means non-staff get 403 before RCON sees the command.
- Audit is the same \`tracing!(target = "rcon_audit", source = "axum", …)\` line per request — already piped to Vector → ClickHouse.

## Validation
- [x] \`cargo check -p axum-kbve\` — clean.
- [x] \`nx run astro-kbve:build\` — clean, 7689 pages built.

## Required runtime config (post-merge)
Set on axum-kbve runtime:
\`\`\`
RCON_MC_VELOCITY_HOST=…   RCON_MC_VELOCITY_PORT=25575   RCON_MC_VELOCITY_PASSWORD=…
RCON_MC_LOBBY_HOST=…      RCON_MC_LOBBY_PORT=25575      RCON_MC_LOBBY_PASSWORD=…
RCON_MC_SURVIVAL_HOST=…   RCON_MC_SURVIVAL_PORT=25575   RCON_MC_SURVIVAL_PASSWORD=…
\`\`\`
(Coexists with the legacy \`MC_RCON_*\` scheme that drives the read-only player poller in \`src/db/mc.rs\`.)

## Test plan
- [ ] Sign in as staff, hit \`/dashboard/gameops/mc/\`, confirm three cards render with reachable status.
- [ ] Run \`list\` on lobby → returns player names.
- [ ] Run \`glist\` on velocity → returns proxy roster.
- [ ] Run \`say "hello"\` on lobby → broadcast visible in client.
- [ ] Destructive command (\`kick\`) opens confirm before firing.
- [ ] Non-staff user → "Staff Access Required" gate.
- [ ] Vector picks up \`target=rcon_audit\` lines with \`source=axum\`.

## Follow-up
- Time-series player chart from \`mc.player_snapshots_distributed\` (ClickHouse).
- Velocity-side TPS/MSPT collection (Paper exposes via \`tps\`; Velocity doesn't).
- Activity feed from Vector → ClickHouse for chat / joins / commands.
- Slice C of the rcon plan: Deno edge \`rcon/\` forwarder backing the same UI for Path-A redundancy.