### PR TITLE
content(osrs): migrate batch 21 (200 items) v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-range-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-range-legs.mdx
@@ -1,6 +1,6 @@
 ---
 title: 3rd age range legs | OSRS Price Data
-description: "3rd age range legs is a members legs slot item requiring 45 Defence. High alch: 30,360 GP, GE limit: 8."
+description: "3rd age range legs is a members legs slot item requiring 45 Defence and 65 Ranged. High alch: 30,360 GP, GE limit: 8."
 osrs:
   id: 10332
   name: 3rd age range legs
@@ -12,60 +12,107 @@ osrs:
   lowalch: 20240
   highalch: 30360
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 3
     requirements:
       ranged: 65
       defence: 45
-    stats:
-      attack_ranged: 17
-      defence_stab: 31
-      defence_slash: 25
-      defence_crush: 33
-      defence_magic: 28
-      defence_ranged: 33
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 17
+    defence_bonus:
+      stab: 31
+      slash: 25
+      crush: 33
+      magic: 30
+      ranged: 33
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails reward casket
+        quantity: "1"
+        rarity: "1/211,250"
+      - source: Elite Treasure Trails reward casket
+        quantity: "1"
+        rarity: "1/249,262"
+      - source: Master Treasure Trails reward casket
+        quantity: "1"
+        rarity: "1/313,168"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 10334
-      item_name: 3rd age range coif
+    - item_name: 3rd age range coif
       slug: 3rd-age-range-coif
       relationship: set-piece
-      description: Head slot of 3rd age range set
-    - item_id: 10330
-      item_name: 3rd age range top
+      description: "Head slot piece of the 3rd age ranged set"
+    - item_name: 3rd age range top
       slug: 3rd-age-range-top
       relationship: set-piece
-      description: Body slot of 3rd age range set
-    - item_id: 10336
-      item_name: 3rd age vambraces
+      description: "Body slot piece of the 3rd age ranged set"
+    - item_name: 3rd age vambraces
       slug: 3rd-age-vambraces
       relationship: set-piece
-      description: Hands slot of 3rd age range set
+      description: "Hands slot piece of the 3rd age ranged set"
+    - item_name: 3rd age bow
+      slug: 3rd-age-bow
+      relationship: set-piece
+      description: "Two-handed bow that completes the 3rd age ranged loadout"
+    - item_name: Armadyl chainskirt
+      slug: armadyl-chainskirt
+      relationship: alternative
+      description: "Practical ranged legs alternative"
   about: |-
-    The 3rd age range legs are part of the 3rd age ranged set, one of the rarest and most prestigious armour sets in Old School RuneScape. They require 65 Ranged and 45 Defence to wear.
+    The 3rd age range legs are the legs slot piece of the prestigious 3rd age ranged armour set, requiring 65 Ranged and 45 Defence to wear. They share the same defensive profile as karil's leatherskirt while adding ranged attack and slight magic defence.
 
-    3rd age equipment is highly sought after due to its extreme rarity and status symbol value. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
+    3rd age equipment is overwhelmingly cosmetic at the top end of the market — players buy it for the look and the rarity badge, not the marginal stat upgrade over Armadyl. Supply enters the economy only through hard, elite, and master Treasure Trails caskets at vanishingly low rates.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Extremely valuable due to rarity
-      - Price fluctuates based on collector demand
-      - Consider set value vs individual pieces
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Extremely valuable due to rarity — collector-driven price"
+      - "Buy limit of 8 caps flips to a few units per cycle"
+      - "Set value vs individual piece value can diverge significantly"
+      - "Use Grand Exchange for secure trades on high-value items"
+  trading_tips:
+    - "Monitor price trend before committing the bulk of a bank to it"
+    - "Watch clue scroll updates — drop table tweaks shift floor price"
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the 3rd age ranged armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin.mdx
@@ -12,26 +12,108 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: adamantite
+    tier: mid
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
-    slot: weapon
-    attack_speed: 6
+    slot: ammo
+    weapon_type: thrown
+    attack_speed: null
+    weight: 0
     requirements:
       ranged: 30
     attack_bonus:
-      ranged: 20
-    ranged_strength: 59
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 102
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 62
+      xp: 10
+      materials:
+        - item_name: Adamant javelin heads
+          quantity: 1
+        - item_name: Javelin shaft
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Ranging Guild
+      location: Ranging Guild
+      price: 208
+      currency: coins
+      stock: 500
+    - shop_name: Void Knight Archery Store
+      location: Void Knights' Outpost
+      price: 160
+      currency: coins
+      stock: 5
+    - shop_name: Oobapohk's Javelin Store
+      location: Marim
+      price: 160
+      currency: coins
+      stock: 500
   related_items:
-    - item_id: 828
-      item_name: Mithril javelin
+    - item_name: Mithril javelin
       slug: mithril-javelin
-      relationship: variant
-      description: Lower tier javelin
+      relationship: downgrade
+      description: "Lower tier javelin (Ranged 20)"
+    - item_name: Rune javelin
+      slug: rune-javelin
+      relationship: upgrade
+      description: "Higher tier javelin (Ranged 40)"
+    - item_name: Adamant javelin heads
+      slug: adamant-javelin-heads
+      relationship: component
+      description: "Fletched onto a javelin shaft to make this javelin"
   about: |-
     > _"An adamant tipped javelin."_
 
-    The adamant javelin requires 30 Ranged. Commonly used as affordable heavy ballista ammunition.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The adamant javelin is a members-only thrown weapon requiring 30 Ranged. Commonly loaded into heavy ballistae as affordable ranged ammunition with a strong +102 Ranged strength bonus.
+  market_strategy:
+    notes:
+      - "Fletching: 15 javelin heads + 15 shafts at level 62 yields 150 XP"
+      - "Stack with heavy ballista for budget Wilderness PKing"
+      - "Buy limit 11,000 per 4 hours"
+  trading_tips:
+    - "Check fletching margins vs raw javelin price"
+    - "Shop restocks at 208 GP from Ranging Guild can flip to GE"
+  history:
+    - date: "2004-03-29"
+      description: "Released alongside thrown weapons rework"
+    - date: "2016-05-05"
+      description: "Converted from weapon slot to ammunition slot; ranged strength increased from +28 to +102"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant platebody (h3) | OSRS Price Data
-description: "Adamant platebody (h3): Adamant platebody with a heraldic design.. High alch: 9,984 GP, GE limit: 8."
+description: "Adamant platebody (h3) is a heraldic-trim free-to-play body slot item requiring 30 Defence. High alch: 9,984 GP, GE limit: 8."
 osrs:
   id: 23398
   name: Adamant platebody (h3)
@@ -12,9 +12,99 @@ osrs:
   lowalch: 6656
   highalch: 9984
   limit: 8
-  about: "Adamant platebody (h3) is a free-to-play item in Old School RuneScape. High alchemy value: 9,984 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 11.339
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 11.339
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -15
+    defence_bonus:
+      stab: 65
+      slash: 63
+      crush: 55
+      magic: -6
+      ranged: 63
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Medium Treasure Trails reward casket
+        quantity: "1"
+        rarity: "1/1,133"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Adamant platebody
+      slug: adamant-platebody
+      relationship: variant
+      description: "Standard untrimmed adamant platebody"
+    - item_name: Adamant platebody (h1)
+      slug: adamant-platebody-h1
+      relationship: variant
+      description: "Heraldic adamant platebody with the Saradomin design"
+    - item_name: Adamant platebody (h2)
+      slug: adamant-platebody-h2
+      relationship: variant
+      description: "Heraldic adamant platebody with the Guthix design"
+    - item_name: Adamant platebody (h4)
+      slug: adamant-platebody-h4
+      relationship: variant
+      description: "Heraldic adamant platebody with the Zamorak design"
+    - item_name: Adamant platebody (h5)
+      slug: adamant-platebody-h5
+      relationship: variant
+      description: "Heraldic adamant platebody with the Bandos design"
+  about: |-
+    Adamant platebody (h3) is the heraldic Cooking Guild / Asgarnia variant of the standard adamant platebody, sharing the same stats but stamped with a tinted heraldic crest. It requires 30 Defence to wear and is a free-to-play item.
+
+    Heraldic platebodies enter the economy only as rare drops from medium Treasure Trails reward caskets at roughly 1/1,133 per casket, so trade volume is thin and the GE price often drifts far above standard adamant platebody.
+  market_strategy:
+    notes:
+      - "Heraldic variant — collector demand drives most of the premium"
+      - "Buy limit of 8 keeps daily flips small"
+      - "Identical stats to standard adamant platebody — pricing pure cosmetic"
+  trading_tips:
+    - "Watch medium clue drop rate tweaks — they reshape the floor price"
+    - "Compare against h1/h2/h4/h5 variants before deciding which heraldic to flip"
+  history:
+    - date: "2019-04-11"
+      description: "Released as part of the Treasure Trails Expansion."
+    - date: "2021-04-21"
+      description: "Ranged attack penalty adjusted in an equipment rebalance."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamantite-nails.mdx
@@ -12,73 +12,68 @@ osrs:
   lowalch: 18
   highalch: 27
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   material:
     type: nails
-    tier: adamantite
-  smithing:
-    level: 74
-    xp: 62.5
-    bars: 1
-    nails_per_bar: 15
-  construction:
-    bend_rate: Very Low
-    min_level: 1
+    tier: mid-high
+  properties:
+    release_date: "2005-05-17"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: smithing
       level: 74
       xp: 62.5
       materials:
         - item_name: Adamantite bar
-          item_id: 2361
           quantity: 1
-      product: Adamantite nails
-      product_id: 4823
-      product_quantity: 15
+      tools:
+        - Hammer
+      output_quantity: 15
   related_items:
-    - item_id: 2361
-      item_name: Adamantite bar
+    - item_name: Adamantite bar
       slug: adamantite-bar
       relationship: component
-      description: Smelting material
-    - item_id: 4822
-      item_name: Mithril nails
+      description: "Smithed on an anvil at level 74 Smithing to produce 15 nails per bar"
+    - item_name: Mithril nails
       slug: mithril-nails
       relationship: downgrade
-      description: Higher bend rate
-    - item_id: 4824
-      item_name: Rune nails
+      description: "Lower-tier nail with higher bend rate during Construction"
+    - item_name: Rune nails
       slug: rune-nails
       relationship: upgrade
-      description: Never bends
-    - item_id: 960
-      item_name: Plank
+      description: "Top-tier nail that never bends during Construction"
+    - item_name: Plank
       slug: plank
       relationship: component
-      description: Used with planks
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Bend rate | Very Low |
-    | Construction level | 1+ |
-    | Used with | Planks |
-
-    Excellent choice for Construction with very low bend rate.
-
-    | Nails | Bend Rate | Shop Price |
-    |-------|-----------|------------|
-    | Bronze | Highest | 1 GP |
-    | Iron | High | 2 GP |
-    | Steel | Medium | 5 GP |
-    | Mithril | Low | 10 GP |
-    | Adamantite | Very Low | 25 GP |
-    | Rune | Never bends | 100 GP |
+      description: "Used together with nails in Construction projects (e.g. crude wooden chair)"
+  about: "Adamantite nails are a Construction supply with a very low bend rate, smithed from one adamantite bar into 15 nails at 74 Smithing for 62.5 xp. They are the second-best nail tier behind rune nails, balancing reliability against cost when training Construction with planks."
   market_strategy:
     notes:
-      - Almost never bends
-      - Good for efficient Construction training
-      - Worth the extra cost for reliability
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand is driven by Construction trainers using nails-and-planks methods (e.g. crude wooden chair) instead of butler-served planks"
+      - "Supply comes from Smithing trainers turning adamantite bars into nails for xp, plus occasional shop restocks"
+      - "Large GE limit of 13,000 per 4 hours supports bulk Construction sessions"
+  trading_tips:
+    - "Compare GE price vs (Adamantite bar price / 15): if nails trade above 1/15th of a bar plus tax, smithing nails is profitable"
+    - "Watch Construction XP boost weekends or DXP — demand spikes for low-bend nails like adamant and rune"
+    - "Members-required tag is effectively soft (nails are usable on F2P Construction, but the item is tagged members on the wiki)"
+  history:
+    - date: "2005-05-17"
+      description: "Released with the Zogre Flesh Eaters quest update, alongside the broader nail tier line"
+    - date: "2005-07-05"
+      description: "Base value increased from 0 to 45 coins"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robeskirt-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robeskirt-0.mdx
@@ -12,9 +12,104 @@ osrs:
   lowalch: 18800
   highalch: 28200
   limit: 15
-  about: "Ahrim's robeskirt 0 is a members-only item in Old School RuneScape. High alchemy value: 28,200 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: magic-armour
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 11.339
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 11.339
+    requirements:
+      magic: 70
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 22
+      ranged: 0
+    defence_bonus:
+      stab: 33
+      slash: 30
+      crush: 36
+      magic: 22
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 1
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Barrows chest (Ahrim the Blighted)
+        quantity: "1"
+        rarity: "1/2530"
+  passive_effects:
+    - name: Ahrim's set effect
+      description: "Successful magic hits with the full set equipped have a chance to lower the target's Strength."
+    - name: Amulet of the Damned synergy
+      description: "Paired with Amulet of the Damned, autocast Ancient Magicks gains a 25% chance of dealing 30% extra damage."
+    - name: Degradation timer
+      description: "Fully charged on chest withdrawal: 15 hours of combat before fully degraded; repairs at Bob the Axe Dealer or a player-owned house armour stand."
+  related_items:
+    - item_name: Ahrim's robeskirt 25
+      slug: ahrim-s-robeskirt-25
+      relationship: variant
+      description: "Same skirt at 25% charge: degrades from the 0 state during combat"
+    - item_name: Ahrim's robeskirt 50
+      slug: ahrim-s-robeskirt-50
+      relationship: variant
+      description: 50% charge condition stage
+    - item_name: Ahrim's robeskirt 75
+      slug: ahrim-s-robeskirt-75
+      relationship: variant
+      description: 75% charge condition stage
+    - item_name: Ahrim's robeskirt 100
+      slug: ahrim-s-robeskirt-100
+      relationship: variant
+      description: Fully charged stage straight from the Barrows chest
+    - item_name: Ahrim's robetop 0
+      slug: ahrim-s-robetop-0
+      relationship: set-piece
+      description: Matching top from the Barrows set
+    - item_name: Ahrim's hood 0
+      slug: ahrim-s-hood-0
+      relationship: set-piece
+      description: Matching hood from the Barrows set
+    - item_name: Ahrim's staff 0
+      slug: ahrim-s-staff-0
+      relationship: set-piece
+      description: Matching staff from the Barrows set
+  about: "Ahrim's robeskirt 0 is the empty-charge state of the Barrows magic armour leg slot; even fully drained it keeps the Magic attack and Magic damage bonuses, but the full-set Strength-drain proc and degradation tick require recharging via the standard repair routes."
+  market_strategy:
+    notes:
+      - "Price tracks Barrows demand cycles and BiS magic-leg substitutes (e.g. virtus)."
+      - "Repairs are flat cost; the 0-charge variant trades at a fixed discount under repair price."
+  trading_tips:
+    - "Buy 0-charge stock when repair cost + GE 0-price beats fresh chest pulls."
+    - "Watch league launches: magic-leg demand spikes from low-defence pures."
+  history:
+    - date: "2005-05-09"
+      description: Released with the Barrows minigame launch.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-brew-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-brew-4.mdx
@@ -12,94 +12,90 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2022-01-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - "Drink"
+      - "Empty"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   potion:
-    doses: 4
-    herblore_level: 85
-    herblore_xp: 190
-    effect: Boosts Magic by 2, restores Prayer, drains Attack/Strength/Defence
     effects:
-      - stat: Magic
-        boost_type: boost
-        boost_value: 2
-      - stat: Prayer
-        boost_formula: 2 + floor(level / 4)
-      - stat: Attack
-        boost_type: drain
-        drain_value: 10% + 2
-      - stat: Strength
-        boost_type: drain
-        drain_value: 10% + 2
-      - stat: Defence
-        boost_type: drain
-        drain_value: 10% + 2
+      - description: "Boosts Magic by 2 to 6 levels depending on base level, decaying 1 level per minute"
+        duration: 60
+      - description: "Restores Prayer points (2 + 11 at higher levels), similar to super restore"
+        duration: 0
+      - description: "Drains Attack, Strength, and Defence by 10% + 2 levels"
+        duration: 60
   recipes:
     - skill: herblore
       level: 85
       xp: 190
       materials:
-        - item_name: Dwarf weed
-          item_id: 267
+        - item_name: Dwarf weed potion (unf)
           quantity: 1
         - item_name: Nihil dust
-          item_id: 26370
           quantity: 1
-        - item_name: Vial of water
-          item_id: 227
-          quantity: 1
-          consumed: true
-      ticks: 2
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 267
-      item_name: Dwarf weed
+    - item_name: Dwarf weed
       slug: dwarf-weed
       relationship: component
-      description: Primary herb
-    - item_id: 26370
-      item_name: Nihil dust
+      description: "Primary herb used in the unfinished potion"
+    - item_name: Nihil dust
       slug: nihil-dust
       relationship: component
-      description: Secondary ingredient
-    - item_id: 2434
-      item_name: Prayer potion(4)
+      description: "Secondary ingredient obtained from grinding nihil shards"
+    - item_name: Prayer potion(4)
       slug: prayer-potion-4
       relationship: alternative
-      description: Pure prayer restore
-    - item_id: 3024
-      item_name: Super restore(4)
+      description: "Pure prayer restore without magic boost"
+    - item_name: Super restore(4)
       slug: super-restore-4
       relationship: alternative
-      description: Restores all stats
-    - item_id: 26342
-      item_name: Ancient brew(3)
+      description: "Restores all stats including prayer"
+    - item_name: Ancient brew(3)
       slug: ancient-brew-3
       relationship: variant
-      description: 3-dose version
+      description: "3-dose version of the same potion"
   about: |-
-    Ancient brew provides unique effects:
-    - Boost: +2 Magic level
-    - Restore: Prayer points (like super restore)
-    - Drain: Attack, Strength, Defence by 10%+2
+    Ancient brew is a unique potion that combines magic boosting with prayer restoration, at the cost of melee stats. The +2 Magic boost is useful for activities like Tombs of Amascut where magic attacks dominate, and the prayer restore lets one flask act as both a boost and a restore.
 
-    Best for:
-    - Magic-focused PvM
-    - Situations where melee stats don't matter
-    - Raids (ToA especially)
+    Common use cases:
+    - Magic-focused PvM (ToA, Zulrah)
+    - Boosting for quest requirements
+    - Situations where melee stats are not used
   market_strategy:
-    profit_formulas:
-      - Ancient brew - Dwarf weed - Nihil dust
     notes:
-      - Unique Magic boost + Prayer restore
-      - ToA increased demand significantly
-      - Compare to super restore prices
-      - "Calculate:"
-      - High Herblore requirement (85)
-      - Nihil dust from Nex
-      - ToA drives demand
-      - Nex farming provides nihil dust
-      - Magic boost useful for boosting
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Profit equation: Ancient brew - Dwarf weed potion (unf) - Nihil dust"
+      - "ToA released raised baseline demand for magic-focused supplies"
+      - "Compare price against super restore for value-per-dose"
+      - "85 Herblore requirement gates supply"
+      - "Nihil dust supply tied to Nex farming pace"
+  trading_tips:
+    - "Watch Nex drop rate updates: nihil dust availability drives ingredient cost"
+    - "Buy unfinished potions in bulk during quiet hours and craft on weekends"
+    - "Stockpile ahead of ToA league or event resets"
+  history:
+    - date: "2021-12-16"
+      description: "Item added to game files but unobtainable"
+    - date: "2022-01-05"
+      description: "Released obtainable with Nex: The Fifth General update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-medallion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-medallion.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ancient medallion | OSRS Price Data
-description: "Ancient medallion: A mysterious artifact of ancient times, precious to emblem traders.. High alch: 2,400,000 GP, GE limit: 250."
+description: "Ancient medallion: A mysterious artifact of ancient times, precious to emblem traders. High alch: 2,400,000 GP, GE limit: 250."
 osrs:
   id: 22299
   name: Ancient medallion
@@ -12,9 +12,81 @@ osrs:
   lowalch: 1600000
   highalch: 2400000
   limit: 250
-  about: "Ancient medallion is a members-only item in Old School RuneScape. High alchemy value: 2,400,000 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: artifact
+    tier: high
+  properties:
+    release_date: "2018-02-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Revenant imp
+        quantity: "1"
+        rarity: "1/44000"
+      - source: Revenant goblin
+        quantity: "1"
+        rarity: "1/40000"
+      - source: Revenant dragon
+        quantity: "1"
+        rarity: "1/8000"
+      - source: Bounty crate (tier 1-9)
+        quantity: "1"
+        rarity: "9/1000"
+  related_items:
+    - item_name: Ancient emblem
+      slug: ancient-emblem
+      relationship: alternative
+      description: "Lower tier Revenant Caves artifact"
+    - item_name: Ancient totem
+      slug: ancient-totem
+      relationship: alternative
+      description: "Mid tier Revenant Caves artifact"
+    - item_name: Ancient statuette
+      slug: ancient-statuette
+      relationship: alternative
+      description: "Higher tier Revenant Caves artifact"
+    - item_name: Ancient effigy
+      slug: ancient-effigy
+      relationship: alternative
+      description: "Top tier Revenant Caves artifact"
+    - item_name: Ancient relic
+      slug: ancient-relic
+      relationship: alternative
+      description: "Rarest Revenant Caves artifact"
+    - item_name: Revenant ether
+      slug: revenant-ether
+      relationship: product
+      description: "Chisel the medallion to break it into 8,000 ether"
+  about: |-
+    > _"A mysterious artifact of ancient times, precious to emblem traders."_
+
+    The ancient medallion is a Revenant Caves artifact dropped by all revenants and from bounty crates. Since the 9 July 2025 update, using a chisel on the medallion breaks it down into 8,000 revenant ether, giving high-volume PKers a non-GE liquidity path. Buy limit 250 per 4 hours.
+  market_strategy:
+    notes:
+      - "Chisel-to-ether floor sets a hard arbitrage line vs ether price"
+      - "Supply tracks Revenant Caves PvP activity"
+      - "Bounty crate drop rate (9/1000) supplements organic supply"
+  trading_tips:
+    - "Compare GE price against 8,000 ether market value"
+    - "Watch Wilderness updates for revenant supply shocks"
+  history:
+    - date: "2018-02-08"
+      description: "Released alongside the Revenant Caves Wilderness update"
+    - date: "2025-07-09"
+      description: "Added chisel interaction breaking the medallion into 8,000 revenant ether"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ancient mix(1) | OSRS Price Data
-description: "Ancient mix(1): One dose of fishy ancient brew.. High alch: 75 GP."
+description: "Ancient mix(1): One dose of fishy ancient brew. High alch: 75 GP."
 osrs:
   id: 26353
   name: Ancient mix(1)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: null
-  about: "Ancient mix(1) is a members-only item in Old School RuneScape. High alchemy value: 75 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2022-10-26"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - "Drink"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Magic by 2-5 levels (2 + 10% of base)"
+        duration: 0
+      - description: "Drains Attack, Strength, Defence and Ranged by 10% of base level"
+        duration: 0
+      - description: "Restores Prayer points equal to 10 plus 1/10th of Prayer level"
+        duration: 0
+      - description: "Heals Hitpoints equal to fish bait used in creation"
+        duration: 0
+  related_items:
+    - item_name: Ancient mix(2)
+      slug: ancient-mix-2
+      relationship: variant
+      description: "Two-dose Ancient mix"
+    - item_name: Ancient brew(1)
+      slug: ancient-brew-1
+      relationship: alternative
+      description: "Non-fishy single-dose Ancient brew"
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: "Used to convert Ancient brew into Ancient mix"
+  about: |-
+    > _"One dose of fishy ancient brew."_
+
+    Ancient mix(1) is the fishy variant of Ancient brew, made by using caviar on an Ancient brew at the Myths' Guild fish tank. The mix boosts Magic and restores Prayer while draining melee and Ranged stats; it also heals Hitpoints equal to the fish bait added. Untradeable.
+  market_strategy:
+    notes:
+      - "Untradeable — value tied to production cost"
+      - "Demand limited to PvM/raids buffs"
+      - "Caviar supply is the main bottleneck"
+  trading_tips:
+    - "Skip GE — produce from Ancient brew + caviar"
+    - "Stockpile during raid pushes"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-3-5954.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-3-5954.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 115
   highalch: 172
   limit: 4000
-  about: "Antidote++(3) is a members-only item in Old School RuneScape. High alchemy value: 172 coins. Grand Exchange buy limit: 4,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "11 July 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - "Drink"
+      - "Empty"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and grants immunity to poison for 12 minutes."
+        duration: 720
+      - description: "Reduces venom to poison; second dose cures venom entirely with short venom immunity."
+        duration: 27
+  recipes:
+    - skill: herblore
+      level: 79
+      xp: 177.5
+      materials:
+        - item_name: Coconut milk
+          quantity: 1
+        - item_name: Irit leaf
+          quantity: 1
+        - item_name: Magic root
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Zulrah
+        quantity: "10 (noted)"
+        rarity: "2 x 9/249"
+      - source: Corporeal Beast
+        quantity: "40 (noted)"
+        rarity: "10/512"
+      - source: Venenatis
+        quantity: "20 (noted)"
+        rarity: "3/126"
+  related_items:
+    - item_name: Antidote++(1)
+      slug: antidote-1-5958
+      relationship: variant
+      description: "1-dose variant"
+    - item_name: Antidote++(2)
+      slug: antidote-2-5956
+      relationship: variant
+      description: "2-dose variant"
+    - item_name: Antidote++(4)
+      slug: antidote-4-5952
+      relationship: variant
+      description: "4-dose variant"
+    - item_name: Anti-venom(3)
+      slug: anti-venom-3
+      relationship: upgrade
+      description: "Upgraded venom-curing potion (87 Herblore + Zulrah scales)"
+  about: "Antidote++(3) is a members-only Herblore potion offering the longest poison immunity duration of any standard antipoison potion, making it the go-to choice for venomous boss fights and PvM trips."
+  market_strategy:
+    notes:
+      - "Volume is modest vs (4) dose; spread is wider but flips clear fast."
+      - "Demand surges around Zulrah, Venenatis, and Vorkath rushes."
+      - "Decant arbitrage between (3) and (4) is the most reliable angle."
+  trading_tips:
+    - "Track magic root supply: it dominates antidote++ cost basis."
+    - "Buy ahead of league or DMM venom-heavy meta announcements."
+    - "Watch Anti-venom margins, sometimes cheaper to drink antidote++ instead."
+  history:
+    - date: "11 July 2005"
+      description: "Released with the Farming skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-2.mdx
@@ -12,23 +12,62 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "27 February 2002"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.04
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and grants 90 seconds of poison immunity per dose"
+        duration: 90
   related_items:
-    - item_id: 175
-      item_name: Antipoison(3)
+    - item_name: Antipoison(3)
       slug: antipoison-3
       relationship: variant
-      description: 3-dose version
-    - item_id: 179
-      item_name: Antipoison(1)
+      description: "3-dose version"
+    - item_name: Antipoison(1)
       slug: antipoison-1
       relationship: variant
-      description: 1-dose version
+      description: "1-dose version"
+    - item_name: Antipoison(4)
+      slug: antipoison-4
+      relationship: variant
+      description: "4-dose version"
   about: |-
     > _"2 doses of antipoison potion."_
 
-    A 2-dose antipoison. Cures poison and grants 90 seconds immunity per dose.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    A 2-dose antipoison. Each dose cures poison and grants 90 seconds of poison immunity. Two doses can also clear venom by stepping it down to standard poison and then removing it.
+  market_strategy:
+    notes:
+      - "F2P-tradeable and routinely produced by Herblorists"
+      - "Demand floor comes from low-level questers and slayer staples"
+  trading_tips:
+    - "Decant flips between (1), (2), (3) and (4) can lock in per-dose spreads"
+    - "Watch unicorn horn / marrentill potion prices: feedstock drives margin"
+  history:
+    - date: "27 February 2002"
+      description: "Released with the Herblore skill"
+    - date: "7 April 2016"
+      description: "Drinking antipoison no longer reduces existing poison immunity"
+    - date: "3 May 2018"
+      description: "Made available to free-to-play players"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-3.mdx
@@ -12,23 +12,76 @@ osrs:
   lowalch: 115
   highalch: 172
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "27 February 2002"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and grants immunity to poison"
+        duration: 90
+      - description: "Two doses cure venom by stepping it down to poison and removing it"
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 5
+      xp: 37.5
+      materials:
+        - item_name: Marrentill potion (unf)
+          quantity: 1
+        - item_name: Unicorn horn dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 177
-      item_name: Antipoison(2)
+    - item_name: Antipoison(2)
       slug: antipoison-2
       relationship: variant
-      description: 2-dose version
-    - item_id: 179
-      item_name: Antipoison(1)
+      description: "2-dose version"
+    - item_name: Antipoison(1)
       slug: antipoison-1
       relationship: variant
-      description: 1-dose version
+      description: "1-dose version"
+    - item_name: Antipoison(4)
+      slug: antipoison-4
+      relationship: variant
+      description: "4-dose version"
+    - item_name: Superantipoison(4)
+      slug: superantipoison-4
+      relationship: upgrade
+      description: "Stronger antipoison with longer immunity"
   about: |-
-    > _"3 doses of antipoison potion."_
+    > *"3 doses of antipoison potion."*
 
-    The antipoison cures poison and grants 90 seconds of poison immunity per dose. Two doses cure venom. One of the earliest potions brewable with Herblore.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Antipoison cures poison and grants 90 seconds of poison immunity per dose. Two doses cure venom by stepping it down to poison and removing it. One of the earliest potions brewable with Herblore at level 5.
+  market_strategy:
+    notes:
+      - "Brewed at Herblore 5 — entry-level potion"
+      - "Demand from low-level PvM and Slayer training"
+      - "Low margin per unit; high turnover"
+  trading_tips:
+    - "Watch Marrentill and Unicorn horn dust prices for craft margin"
+    - "Volume spikes during poison-heavy slayer tasks"
+  history:
+    - date: "27 February 2002"
+      description: "Released with the launch of the Herblore skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/aquanite-hopper.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/aquanite-hopper.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: null
-  about: "Aquanite hopper is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Autoloader
+      description: "Grants crossbows an 11% chance to fire a second shot; the bonus shot has reduced accuracy and damage"
+  recipes:
+    - skill: smithing
+      level: 60
+      xp: 0
+      materials:
+        - item_name: Aquanite tendon
+          quantity: 1
+        - item_name: Mithril bar
+          quantity: 1
+      tools: ["Hammer", "Anvil"]
+      output_quantity: 1
+  related_items:
+    - item_name: Aquanite tendon
+      slug: aquanite-tendon
+      relationship: component
+      description: "Crafting input pulled from aquanite Slayer kills"
+    - item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: "Bar consumed when smithing the hopper"
+  about: |-
+    > *"An autoloading contraption made of aquanite bits. Slimy."*
+
+    Sailing-era shield-slot crossbow accessory smithed at 60 Smithing from an aquanite tendon and a mithril bar. Wielded as an off-hand it gives crossbows an 11% chance to autoload a second shot at reduced accuracy and damage, making it a niche DPS option for ranged setups that can absorb the accuracy hit.
+  market_strategy:
+    notes:
+      - "Tendon supply is gated by aquanite Slayer task availability"
+      - "Newer release — price discovery still settling around mid-tier ranged demand"
+      - "Compare DPS uplift versus competing off-hand defenders before bulk buying"
+  trading_tips:
+    - "Watch aquanite Slayer rotation for tendon supply spikes"
+    - "Track ranged DPS calculators — passive value scales with crossbow tier"
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the Sailing skill update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-chainskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-chainskirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Armadyl chainskirt | OSRS Price Data
-description: "Armadyl chainskirt is a members legs slot item requiring 70 Defence. High alch: 173,940 GP, GE limit: 8."
+description: "Armadyl chainskirt is a members legs slot item requiring 70 Defence and 70 Ranged. High alch: 173,940 GP, GE limit: 8."
 osrs:
   id: 11830
   name: Armadyl chainskirt
@@ -12,76 +12,98 @@ osrs:
   lowalch: 115960
   highalch: 173940
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: armadylean
+    tier: high
+  properties:
+    release_date: "2013-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.0
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 1.0
     requirements:
       ranged: 70
       defence: 70
-    stats:
-      defence_stab: 32
-      defence_slash: 26
-      defence_crush: 34
-      defence_magic: 40
-      defence_ranged: 33
-      attack_stab: -6
-      attack_slash: -6
-      attack_crush: -6
-      attack_ranged: 20
+    attack_bonus:
+      stab: -6
+      slash: -6
+      crush: -6
+      magic: 0
+      ranged: 20
+    defence_bonus:
+      stab: 32
+      slash: 26
+      crush: 34
+      magic: 40
+      ranged: 33
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 1
-  drop_sources:
-    - name: Kree'arra
-      combat_level: 580
-      drop_rate: 1/384
-      members_only: true
-    - name: Flight Kilisa
-      combat_level: 159
-      drop_rate: 1/16,000
-      members_only: true
+  drop_table:
+    sources:
+      - source: "Kree'arra"
+        quantity: "1"
+        rarity: "1/381"
+      - source: Flight Kilisa
+        quantity: "1"
+        rarity: "1/16129"
+      - source: Wingman Skree
+        quantity: "1"
+        rarity: "1/16129"
+      - source: Flockleader Geerin
+        quantity: "1"
+        rarity: "1/16129"
   related_items:
-    - item_id: 11826
-      item_name: Armadyl helmet
+    - item_name: Armadyl helmet
       slug: armadyl-helmet
       relationship: set-piece
-      description: Head slot
-    - item_id: 11828
-      item_name: Armadyl chestplate
+      description: "Head slot of the Armadyl armour set"
+    - item_name: Armadyl chestplate
       slug: armadyl-chestplate
       relationship: set-piece
-      description: Body slot
-    - item_id: 27241
-      item_name: Masori chaps (f)
+      description: "Body slot of the Armadyl armour set"
+    - item_name: Masori chaps (f)
       slug: masori-chaps-f
       relationship: upgrade
-      description: BiS upgrade
+      description: "BiS ranged legs upgrade"
+    - item_name: Karil's leathertop
+      slug: karils-leathertop
+      relationship: alternative
+      description: "Budget alternative ranged legs slot"
   about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +20 |
-    | Stab defence | +32 |
-    | Slash defence | +26 |
-    | Crush defence | +34 |
-    | Magic defence | +40 |
-    | Ranged defence | +33 |
-    | Prayer bonus | +1 |
-    | Requirements | 70 Ranged, 70 Defence |
+    > _"A chainskirt of great craftsmanship."_
 
-    Part of the Armadyl armour set:
-    - Armadyl helmet (head)
-    - Armadyl chestplate (body)
-    - Armadyl chainskirt (legs)
-
-    PvM:
-    - Mid-tier ranged legs
-    - Budget option before Masori
-    - God Wars Dungeon protection
+    Armadyl chainskirt is the legs slot piece of the Armadyl armour set, the standard mid-to-high tier ranged armour dropped by Kree'arra in the God Wars Dungeon. Provides +20 ranged attack, strong magic and ranged defences, and +1 prayer bonus. Requires 70 Ranged and 70 Defence to wear.
   market_strategy:
     notes:
-      - Kree'arra kills affect supply
-      - Budget BiS before Masori
-      - Armadylean plate source
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply driven by Kree'arra kill efficiency"
+      - "Price tracks Armadyl set demand"
+      - "Budget BiS legs before Masori"
+  trading_tips:
+    - "Buy on dips when supply spikes from boss-rate weeks"
+    - "Pair flips with helmet/chest for set markup"
+  history:
+    - date: "2013-10-17"
+      description: "Released with the God Wars Dungeon"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-crossbow.mdx
@@ -12,74 +12,85 @@ osrs:
   lowalch: 396000
   highalch: 594000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2013-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: 2h
-    type: crossbow
-    attack_style: ranged
+    weapon_type: crossbow
     attack_speed: 6
-    attack_range: 8
+    weight: 6
     requirements:
       ranged: 70
-    stats:
-      attack_ranged: 100
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 100
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 1
-  special_attack:
-    name: Armadyl Eye
-    energy: 50
-    effect: Doubles accuracy, doubles enchanted bolt proc chance
   drop_table:
     sources:
       - source: Commander Zilyana
-        source_id: 2205
-        combat_level: 596
         quantity: "1"
         rarity: 1/508
-        members_only: true
+  passive_effects:
+    - name: Armadyl Eye
+      description: "Special attack costing 50% energy: doubles overall accuracy and doubles the base chance of enchanted bolt special effects to proc"
   related_items:
-    - item_id: 26374
-      item_name: Zaryte crossbow
+    - item_name: Zaryte crossbow
       slug: zaryte-crossbow
       relationship: upgrade
-      description: Upgraded version
-    - item_id: 21012
-      item_name: Dragon hunter crossbow
+      description: "Upgrade combining the Armadyl crossbow with a nihil horn and 250 nihil shards"
+    - item_name: Dragon hunter crossbow
       slug: dragon-hunter-crossbow
       relationship: alternative
-      description: Dragon specialist
-    - item_id: 21944
-      item_name: Ruby dragon bolts (e)
+      description: "Dragon-specialist crossbow alternative for draconic targets"
+    - item_name: Ruby dragon bolts (e)
       slug: ruby-dragon-bolts-e
       relationship: component
-      description: Best bolt pairing
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +100 |
-    | Prayer | +1 |
-    | Attack speed | 6 tick (3.6s) |
-    | Range | 8 tiles (10 with Longrange) |
-    | Requirements | 70 Ranged |
-
-    Armadyl Eye (50% energy):
-    - Doubles accuracy
-    - Doubles enchanted bolt proc chance
-    - Great with ruby/diamond bolts
-
-    | Upgrade | Requirements |
-    |---------|--------------|
-    | Zaryte crossbow | + Nihil horn + 250 nihil shards |
-
-    Best For:
-    - Bossing with enchanted bolts
-    - Spec weapon for bolt procs
-    - Pre-Zaryte ranged option
+      description: "Best-in-slot bolt pairing for the Armadyl Eye special"
+  about: Armadyl crossbow is the strongest pre-Zaryte crossbow, dropped by Commander Zilyana at 1/508. Its Armadyl Eye special attack doubles accuracy and enchanted-bolt proc chance, making it elite for ruby and diamond bolt bossing.
   market_strategy:
     notes:
-      - Only crossbow with prayer bonus
-      - Great spec for ruby bolt procs
-      - Upgrade path to Zaryte
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Only crossbow that grants a prayer bonus"
+      - "Premier special-attack weapon for enchanted bolt procs"
+      - "Upgrade path consumes the crossbow into a Zaryte crossbow"
+  trading_tips:
+    - "Watch Commander Zilyana team-mass events for sudden supply bumps"
+    - "Pair flips with Ruby dragon bolts (e) demand: spec-weapon cycles correlate"
+    - "Pre-Zaryte upgrade events historically spike ACB demand"
+  history:
+    - date: "2013-10-17"
+      description: "Released as part of the God Wars Dungeon's Armadyl section drops"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-helmet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-helmet.mdx
@@ -12,76 +12,90 @@ osrs:
   lowalch: 115600
   highalch: 173400
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ranged-armour
+    tier: high
+  properties:
+    release_date: "2013-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 0.5
     requirements:
       ranged: 70
       defence: 70
-    stats:
-      defence_stab: 6
-      defence_slash: 8
-      defence_crush: 10
-      defence_magic: 10
-      defence_ranged: 8
-      attack_stab: -5
-      attack_slash: -5
-      attack_crush: -5
-      attack_ranged: 10
+    attack_bonus:
+      stab: -5
+      slash: -5
+      crush: -5
+      ranged: 10
+    defence_bonus:
+      stab: 6
+      slash: 8
+      crush: 10
+      magic: 10
+      ranged: 8
+    other_bonus:
       prayer: 1
-  drop_sources:
-    - name: Kree'arra
-      combat_level: 580
-      drop_rate: 1/384
-      members_only: true
-    - name: Flight Kilisa
-      combat_level: 159
-      drop_rate: 1/16,000
-      members_only: true
+  drop_table:
+    sources:
+      - source: Kree'arra
+        quantity: "1"
+        rarity: 1/381
+      - source: Flight Kilisa
+        quantity: "1"
+        rarity: 1/16000
+      - source: Armadylean guard
+        quantity: "1"
+        rarity: 1/2000000
+      - source: Bandosian guard
+        quantity: "1"
+        rarity: 1/2000000
   related_items:
-    - item_id: 11828
-      item_name: Armadyl chestplate
+    - item_name: Armadyl chestplate
       slug: armadyl-chestplate
       relationship: set-piece
-      description: Body slot
-    - item_id: 11830
-      item_name: Armadyl chainskirt
+      description: "Body slot of the Armadyl ranged set"
+    - item_name: Armadyl chainskirt
       slug: armadyl-chainskirt
       relationship: set-piece
-      description: Legs slot
-    - item_id: 27235
-      item_name: Masori mask (f)
+      description: "Legs slot of the Armadyl ranged set"
+    - item_name: Masori mask (f)
       slug: masori-mask-f
       relationship: upgrade
-      description: BiS upgrade
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +10 |
-    | Stab defence | +6 |
-    | Slash defence | +8 |
-    | Crush defence | +10 |
-    | Magic defence | +10 |
-    | Ranged defence | +8 |
-    | Prayer bonus | +1 |
-    | Requirements | 70 Ranged, 70 Defence |
-
-    Part of the Armadyl armour set:
-    - Armadyl helmet (head)
-    - Armadyl chestplate (body)
-    - Armadyl chainskirt (legs)
-
-    PvM:
-    - Mid-tier ranged helm
-    - Budget option before Masori
-    - God Wars Dungeon protection
+      description: "Best-in-slot ranged helmet upgrade"
+  about: "Armadyl helmet is a mid-to-high tier ranged helmet dropped primarily by Kree'arra in the God Wars Dungeon at 1/381. Requires 70 Ranged and 70 Defence; pairs with the Armadyl chestplate and chainskirt for the full set."
   market_strategy:
     notes:
-      - Kree'arra kills affect supply
-      - Second-best ranged attack helm
-      - Cheaper than Masori mask
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Kree'arra kills drive most supply"
+      - "Often a stepping stone before Masori"
+      - "Required for GWD aggression protection"
+  trading_tips:
+    - "Track Kree'arra kill volume during boss spotlights"
+    - "Watch Masori discounts that depress Armadyl demand"
+    - "Buy limit 8 supports steady flips"
+  history:
+    - date: "2013-10-17"
+      description: "Released with the God Wars Dungeon update."
+    - date: "2014-01-09"
+      description: "Base value raised from 20,000 to 289,000 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-page-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-page-3.mdx
@@ -12,43 +12,89 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Armadyl
-    page_number: 3
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: god-page
+    tier: mid
+  properties:
+    release_date: "2014-07-03"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
+  drop_table:
+    sources:
+      - source: Easy clue scroll (standard)
+        quantity: "1"
+        rarity: 11/9,504
+      - source: Easy clue scroll (Entrana)
+        quantity: "1"
+        rarity: 1/408
+      - source: Medium clue scroll (standard)
+        quantity: "1"
+        rarity: 10/8,184
+      - source: Medium clue scroll (Entrana)
+        quantity: "1"
+        rarity: 1/408
+      - source: Hard clue scroll
+        quantity: "1"
+        rarity: 1/650
+      - source: Elite clue scroll
+        quantity: "1"
+        rarity: 1/775
+      - source: Master clue scroll
+        quantity: "1"
+        rarity: 1/702.6
   related_items:
-    - item_id: 12617
-      item_name: Armadyl page 1
+    - item_name: Armadyl page 1
       slug: armadyl-page-1
       relationship: set-piece
-      description: Page 1 of 4
-    - item_id: 12618
-      item_name: Armadyl page 2
+      description: "Page 1 of 4"
+    - item_name: Armadyl page 2
       slug: armadyl-page-2
       relationship: set-piece
-      description: Page 2 of 4
-    - item_id: 12620
-      item_name: Armadyl page 4
+      description: "Page 2 of 4"
+    - item_name: Armadyl page 4
       slug: armadyl-page-4
       relationship: set-piece
-      description: Page 4 of 4
+      description: "Page 4 of 4"
+    - item_name: Book of law
+      slug: book-of-law
+      relationship: product
+      description: "Completed god book once all four pages are added"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Armadyl |
-    | Page | 3 of 4 |
-    | Tradeable | Yes |
+    Armadyl page 3 is one of four pages used to complete the Book of law (Armadyl god book). All four pages plus the unblessed book combine into the completed god book, which can then be wielded.
 
-    Add to incomplete Book of law (Armadyl god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Pages drop across all clue scroll difficulties from easy through master, with hard and elite tiers offering the best rates per scroll.
+  market_strategy:
+    notes:
+      - "Demand from players assembling Book of law"
+      - "Drop rates cap supply: clue scrolls only"
+      - "GE limit of 5 keeps spreads volatile"
+  trading_tips:
+    - "Watch all four page prices: hoarding one page only helps if it lags behind the others"
+    - "Best margins land right after clue-scroll demand spikes from streamer attention"
+  history:
+    - date: "2014-07-03"
+      description: "Released alongside the introduction of god books to Old School"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-hops.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-hops.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 11000
-  about: "Asgarnian hops is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: hops
+    tier: low
+  properties:
+    release_date: "11 July 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options: []
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Vanessa's Farming Shop
+      location: Catherby
+      price: 5
+      currency: coins
+      stock: 0
+    - shop_name: Richard's Farming Shop
+      location: East Ardougne
+      price: 5
+      currency: coins
+      stock: 0
+    - shop_name: Sarah's Farming Shop
+      location: South Falador Farm
+      price: 5
+      currency: coins
+      stock: 0
+    - shop_name: Alice's Farming Shop
+      location: Alice's Farm
+      price: 5
+      currency: coins
+      stock: 0
+  related_items:
+    - item_name: Asgarnian seed
+      slug: asgarnian-seed
+      relationship: component
+      description: "Seed planted to grow Asgarnian hops"
+    - item_name: Hammerstone hops
+      slug: hammerstone-hops
+      relationship: alternative
+      description: "Lower-tier hops variant"
+    - item_name: Yanillian hops
+      slug: yanillian-hops
+      relationship: alternative
+      description: "Higher-tier hops variant"
+    - item_name: Asgarnian ale
+      slug: asgarnian-ale
+      relationship: product
+      description: "Brewed from Asgarnian hops"
+  about: "Asgarnian hops are a Farming and Cooking ingredient harvested from a hops patch at Farming level 8, primarily used by brewers crafting Asgarnian ale and by farmers building Asgarnian seed yields for profit."
+  market_strategy:
+    notes:
+      - "Low margins; profit is in bulk volume for ale-brewing flips."
+      - "Supply tracks farming-bot rotation and seasonal events."
+      - "Used in Brewing minigame so demand floor is steady but unspectacular."
+  trading_tips:
+    - "Watch the asgarnian seed price: cheap seeds = cheap hops."
+    - "Stack orders across multiple worlds, hops fills slowly."
+    - "Sell into ale-brewing news bumps when hops are featured."
+  history:
+    - date: "11 July 2005"
+      description: "Added to the game with the Farming skill release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-magic-tree.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-magic-tree.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 10000
-  about: "Bagged magic tree is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: construction_decor
+    tier: mid
+  properties:
+    release_date: "31 May 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Garden Centre"
+      location: "Falador Park"
+      price: 50000
+      currency: coins
+      stock: 20
+    - shop_name: "Garden Centre"
+      location: "Farming Guild"
+      price: 50000
+      currency: coins
+      stock: 20
+  related_items:
+    - item_name: Magic tree
+      slug: magic-tree
+      relationship: product
+      description: "Decorative construction tree planted from the bag"
+    - item_name: Bagged yew
+      slug: bagged-yew
+      relationship: variant
+      description: "Lower-tier bagged tree variant"
+  about: |-
+    > *"You can plant this in your garden."*
+
+    The bagged magic tree is sold by Garden Centre vendors in Falador Park and the Farming Guild for 50,000 coins. Planting it as a decorative Magic tree in a Construction garden grants 223 XP in both Construction and Farming.
+  market_strategy:
+    notes:
+      - "Stocked by Garden Centre in Falador and Farming Guild"
+      - "Demand from Construction training and POH gardens"
+      - "Buy from shop at 50k for resale margin to GE"
+  trading_tips:
+    - "Bulk-buy at the Garden Centre during Construction events"
+    - "Margins narrow when shop restocks are popular"
+  history:
+    - date: "31 May 2006"
+      description: "Released with Construction skill expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-marigolds.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-marigolds.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10000
-  about: "Bagged marigolds is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: plant
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Garden Centre"
+      location: Falador Park
+      price: 10000
+      currency: coins
+      stock: 20
+    - shop_name: "Garden Centre"
+      location: Farming Guild
+      price: 10000
+      currency: coins
+      stock: 20
+  related_items:
+    - item_name: Marigold seed
+      slug: marigold-seed
+      relationship: alternative
+      description: "Farming seed grown into marigolds in a flower patch"
+    - item_name: Marigolds
+      slug: marigolds
+      relationship: product
+      description: "Result of planting bagged marigolds in a formal garden"
+  about: "Bagged marigolds are a members-only Construction item planted in formal gardens of player-owned houses. Planting requires 71 Construction and grants 100 XP each to Construction and Farming."
+  market_strategy:
+    notes:
+      - "Construction-only demand keeps trading volume thin"
+      - "Shop price of 10,000 gp creates a ceiling for GE pricing"
+      - "Spikes around POH formal-garden hype or training methods"
+  trading_tips:
+    - "Buy directly from Falador Park or Farming Guild Garden Centres to undercut GE prices"
+    - "High alch of 6,000 gp is below the shop price, so do not alch"
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Construction skill update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/banana-stew.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/banana-stew.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 6000
-  about: "Banana stew is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2004-12-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - "Eat"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Solihib's Food Stall"
+      location: Ape Atoll
+      price: 300
+      currency: coins
+      stock: 10
+  related_items:
+    - item_name: Banana
+      slug: banana
+      relationship: component
+      description: "Mashed into the stew"
+    - item_name: Stew
+      slug: stew
+      relationship: alternative
+      description: "Standard cooked stew variant"
+    - item_name: M'speak amulet
+      slug: mspeak-amulet
+      relationship: component
+      description: "Required to talk to monkeys and access Solihib's stall"
+  about: |-
+    Banana stew is a members-only food that heals 11 hitpoints per dose. Unlike most stews, it cannot be cooked, only purchased from Solihib's Food Stall on Ape Atoll once Monkey Madness is started.
+
+    Mostly used as a novelty or thematic food item rather than serious PvM healing.
+  market_strategy:
+    notes:
+      - "Limited to one shop, supply tied to player buyout pace"
+      - "11 HP heal is weak compared to swordfish/sharks at similar price points"
+      - "Niche cosmetic/RP food demand"
+  trading_tips:
+    - "Buy out the stall during quiet hours then flip on GE for margin"
+    - "Demand spikes during Ape Atoll-themed events"
+  history:
+    - date: "2004-12-06"
+      description: "Released with the Monkey Madness quest update"
+    - date: "2006-01-30"
+      description: "Inventory sprite graphically updated"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bananas-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bananas-5.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  about: "Bananas(5) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: fruit-basket
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.17
+    options:
+      - Fill
+      - Remove-one
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Fruit basket
+      slug: fruit-basket
+      relationship: component
+      description: "Empty basket filled with bananas"
+    - item_name: Banana
+      slug: banana
+      relationship: component
+      description: "Individual fruit used to fill the basket"
+  about: "Bananas(5) is a fruit basket fully stocked with five bananas. Baskets are filled by using individual bananas on an empty fruit basket and are most commonly used to supply farmers during Farming runs (notably for monkeys requiring banana payment)."
+  market_strategy:
+    notes:
+      - "Demand spikes for Farming run protection payments to monkeys at fruit tree patches."
+      - "Supply scales with banana farming and Karamja banana plantation activity."
+  trading_tips:
+    - "Stock up around large Farming league updates or league-style game modes."
+    - "GE volume is thin; expect to sit on bids for several hours."
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming skill update."
+    - date: "2018-03-22"
+      description: "Empty option added and shift-click behaviour updated for single-banana baskets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-coif.mdx
@@ -12,8 +12,32 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: blessed_dragonhide
+    tier: mid
+  properties:
+    release_date: "12 June 2014"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weight: 0.9
+    requirements:
+      ranged: 70
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,41 +55,48 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
-      defence: 40
+  drop_table:
+    sources:
+      - source: "Reward casket (hard)"
+        quantity: "1"
+        rarity: "1/1,625"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 10382
-      item_name: Guthix coif
+    - item_name: Guthix coif
       slug: guthix-coif
       relationship: variant
-      description: God blessed coif variant
-    - item_id: 10374
-      item_name: Zamorak coif
+      description: "God blessed coif variant"
+    - item_name: Zamorak coif
       slug: zamorak-coif
       relationship: variant
-      description: God blessed coif variant
-    - item_id: 12512
-      item_name: Armadyl coif
+      description: "God blessed coif variant"
+    - item_name: Armadyl coif
       slug: armadyl-coif
       relationship: variant
-      description: God blessed coif variant
-    - item_id: 12496
-      item_name: Ancient coif
+      description: "God blessed coif variant"
+    - item_name: Ancient coif
       slug: ancient-coif
       relationship: variant
-      description: God blessed coif variant
+      description: "God blessed coif variant"
   about: |-
     > *"A Bandos blessed dragonhide coif."*
 
-    All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
+    All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The Bandos coif also provides Bandosian protection within the God Wars Dungeon. The choice between god variants is purely cosmetic.
   market_strategy:
     notes:
-      - Hard clue exclusive — supply tied to clue completion rates
-      - Price differences between gods are cosmetic preference only
-      - Armadyl and Ancient tend to command slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Hard clue exclusive — supply tied to clue completion rates"
+      - "Price differences between gods are cosmetic preference only"
+      - "Armadyl and Ancient tend to command slight premiums"
+  trading_tips:
+    - "Hold during clue-scroll content events for resale spikes"
+    - "Bandosian protection adds niche GWD utility demand"
+  history:
+    - date: "12 June 2014"
+      description: "Released as part of the Treasure Trail Expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-d-hide-body.mdx
@@ -12,61 +12,83 @@ osrs:
   lowalch: 5200
   highalch: 7800
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 6
     requirements:
       ranged: 70
       defence: 40
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 30
-      defence_stab: 55
-      defence_slash: 47
-      defence_crush: 60
-      defence_magic: 50
-      defence_ranged: 55
-      melee_strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 55
+      slash: 47
+      crush: 60
+      magic: 50
+      ranged: 55
+    other_bonus:
+      strength: 0
       ranged_strength: 0
       magic_damage: 0
-      prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: 1/1,625
-        description: Reward from hard clue scroll caskets
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
   related_items:
-    - item_id: 10378
-      item_name: Guthix d'hide body
+    - item_name: Guthix d'hide body
       slug: guthix-d-hide-body
       relationship: variant
-      description: Guthix blessed dragonhide body
-    - item_id: 10370
-      item_name: Zamorak d'hide body
+      description: "Guthix blessed dragonhide body"
+    - item_name: Zamorak d'hide body
       slug: zamorak-d-hide-body
       relationship: variant
-      description: Zamorak blessed dragonhide body
-    - item_id: 12508
-      item_name: Armadyl d'hide body
+      description: "Zamorak blessed dragonhide body"
+    - item_name: Armadyl d'hide body
       slug: armadyl-d-hide-body
       relationship: variant
-      description: Armadyl blessed dragonhide body
-    - item_id: 12492
-      item_name: Ancient d'hide body
+      description: "Armadyl blessed dragonhide body"
+    - item_name: Ancient d'hide body
       slug: ancient-d-hide-body
       relationship: variant
-      description: Ancient blessed dragonhide body
-    - item_id: 2503
-      item_name: Black d'hide body
+      description: "Ancient blessed dragonhide body"
+    - item_name: Black d'hide body
       slug: black-d-hide-body
       relationship: downgrade
-      description: Standard black dragonhide body with lower defensive stats and no prayer bonus
+      description: "Standard black dragonhide body with lower defensive stats and no prayer bonus"
   about: |-
     The Bandos d'hide body is a blessed dragonhide body armour aligned with Bandos, the god of war. It is one of six blessed d'hide body variants obtainable from hard clue scrolls, each representing a different god in the RuneScape pantheon. Bandos and the other three newer god variants (Armadyl, Ancient, and Saradomin) were added later than the original Guthix and Zamorak blessed sets.
 
@@ -87,16 +109,16 @@ osrs:
 
     The blessed variants provide substantially better defensive bonuses across the board, with the largest improvements in stab defence (+25), crush defence (+15), and ranged defence (+5). The +1 prayer bonus is a further advantage that no standard dragonhide body offers. Since the requirements are identical, blessed d'hide bodies are a strict upgrade over the black d'hide body.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Bandos d'hide is often one of the cheaper blessed variants, making it a good budget option
-      - All six blessed d'hide bodies are functionally identical, so price differences are driven purely by cosmetic preference
-      - Prices are closely tied to the volume of hard clue scrolls being completed by the player base
-      - Compare prices across all six blessed variants before buying, as the cheapest one offers the same stats
-      - Bandos gear is popular in PvM communities, so the Bandos d'hide may hold a slight cosmetic premium for matching outfits
-      - Hard clue scroll farming events or updates can temporarily increase supply and lower prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Bandos d'hide is often one of the cheaper blessed variants, making it a good budget option"
+      - "All six blessed d'hide bodies are functionally identical, so price differences are driven purely by cosmetic preference"
+      - "Prices are closely tied to the volume of hard clue scrolls being completed by the player base"
+      - "Compare prices across all six blessed variants before buying, as the cheapest one offers the same stats"
+      - "Bandos gear is popular in PvM communities, so the Bandos d'hide may hold a slight cosmetic premium for matching outfits"
+      - "Hard clue scroll farming events or updates can temporarily increase supply and lower prices"
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-page-4.mdx
@@ -12,43 +12,78 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
-    god: Bandos
-    page_number: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: god-book-page
+    tier: mid
+  properties:
+    release_date: "2014-07-03"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: "Hard Treasure Trail casket"
+        quantity: "1"
+        rarity: "1/650"
+      - source: "Medium Treasure Trail casket (Standard)"
+        quantity: "1"
+        rarity: "10/8184"
+      - source: "Elite Treasure Trail casket"
+        quantity: "1"
+        rarity: "1/775"
+      - source: "Master Treasure Trail casket"
+        quantity: "1"
+        rarity: "1/702"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 12613
-      item_name: Bandos page 1
+    - item_name: Bandos page 1
       slug: bandos-page-1
       relationship: set-piece
-      description: Page 1 of 4
-    - item_id: 12614
-      item_name: Bandos page 2
+      description: "Page 1 of 4 required to complete a Damaged book (Bandos)"
+    - item_name: Bandos page 2
       slug: bandos-page-2
       relationship: set-piece
-      description: Page 2 of 4
-    - item_id: 12615
-      item_name: Bandos page 3
+      description: "Page 2 of 4 required to complete a Damaged book (Bandos)"
+    - item_name: Bandos page 3
       slug: bandos-page-3
       relationship: set-piece
-      description: Page 3 of 4
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Bandos |
-    | Page | 4 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of war (Bandos god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Page 3 of 4 required to complete a Damaged book (Bandos)"
+    - item_name: Book of war
+      slug: book-of-war
+      relationship: product
+      description: "Completed Bandos god book — equipable shield slot once all four pages are added to a Damaged book"
+  about: "Bandos page 4 is one of four pages required to complete the Book of war (the Bandos god book). The Damaged book (Bandos) is purchased from Jossik for 5,000 coins after Horror from the Deep, and all four pages are added to assemble the completed book. Pages drop from medium, hard, elite, and master Treasure Trail caskets."
+  market_strategy:
+    notes:
+      - "Demand is bounded by the number of players assembling Bandos god books — niche compared to Saradomin/Zamorak books"
+      - "Supply comes from medium/hard/elite/master clue completions; clue activity drives short-term volatility"
+      - "Buy limit of 5 per 4 hours makes large positions impractical; this is a slow flip item"
+  trading_tips:
+    - "Bandos god book is mainly used for preaching emotes; demand spikes during clue scroll updates or god alignment changes for GWD setups"
+    - "Compare price of four pages individually vs a completed Book of war to spot crafting arbitrage"
+    - "Master clue rates are unfavourable; most page supply comes from elite clues"
+  history:
+    - date: "2014-07-03"
+      description: "Added with the original god books update to Old School RuneScape, obtainable from Treasure Trails as reward pages"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-battleaxe.mdx
@@ -12,41 +12,85 @@ osrs:
   lowalch: 499
   highalch: 748
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2001-12-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - "Wield"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: battleaxe
-    tradeable: true
+    weapon_type: battleaxe
+    attack_speed: 6
     weight: 2.721
     requirements:
       attack: 10
-    stats:
-      attack_stab: -2
-      attack_slash: 20
-      attack_crush: 15
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: -2
+      slash: 20
+      crush: 15
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -1
+    other_bonus:
       strength: 24
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  shops:
+    - shop_name: "Brian's Battleaxe Bazaar"
+      location: Port Sarim
+      price: 1248
+      currency: coins
+      stock: 2
   related_items:
-    - item_id: 1369
-      item_name: Mithril battleaxe
+    - item_name: Mithril battleaxe
       slug: mithril-battleaxe
       relationship: upgrade
-      description: Higher tier battleaxe
-    - item_id: 1283
-      item_name: Black sword
+      description: "Next tier battleaxe at 20 Attack"
+    - item_name: Steel battleaxe
+      slug: steel-battleaxe
+      relationship: downgrade
+      description: "Lower tier two-handed slash weapon"
+    - item_name: Black sword
       slug: black-sword
       relationship: alternative
-      description: Better accuracy alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Faster attack alternative at the same metal tier"
+  about: |-
+    The black battleaxe is a F2P slash weapon at the black metal tier, requiring 10 Attack to wield. With a +20 slash bonus and +24 strength, it edges out the steel battleaxe while staying inside F2P-legal gear.
+
+    Useful for low-level training before scimitars take over the slash slot, and as a stepping stone toward mithril/adamant battleaxes.
+  market_strategy:
+    notes:
+      - "Stable F2P demand from low-level training accounts"
+      - "Direct shop competition from Brian's Battleaxe Bazaar"
+      - "GE limit of 125 favors small flips over bulk"
+  trading_tips:
+    - "Compare shop price vs GE: shop sells at value, GE often trades below"
+    - "High alch margin is thin: 748 - cost-of-nature-rune > shop price scenarios are rare"
+  history:
+    - date: "2001-12-08"
+      description: "Released as part of the original black equipment tier"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragonhide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-dragonhide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black dragonhide | OSRS Price Data
-description: "Black dragonhide: The scaly rough hide from a Black Dragon.. High alch: 90 GP, GE limit: 11,000."
+description: "Black dragonhide: The scaly rough hide from a Black Dragon. High alch: 90 GP, GE limit: 11,000."
 osrs:
   id: 1747
   name: Black dragonhide
@@ -12,78 +12,88 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   material:
     type: hide
     tier: high
-  tanning:
-    cost: 20
-    product_id: 2509
-    product_name: Black dragon leather
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Black dragon
-        source_id: 252
-        combat_level: 227
         quantity: "1"
-        rarity: always
-        members_only: true
+        rarity: Always
       - source: King Black Dragon
-        source_id: 239
-        combat_level: 276
         quantity: "2"
-        rarity: always
-        members_only: true
+        rarity: Always
       - source: Brutal black dragon
-        source_id: 7273
-        combat_level: 318
         quantity: "2"
-        rarity: always
-        members_only: true
+        rarity: Always
+      - source: Lava dragon
+        quantity: "1"
+        rarity: Always
+      - source: Vorkath
+        quantity: "1"
+        rarity: Common
+  recipes:
+    - skill: crafting
+      level: 84
+      xp: 0
+      materials:
+        - item_name: Black dragonhide
+          quantity: 1
+        - item_name: Coins
+          quantity: 20
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 2509
-      item_name: Black dragon leather
+    - item_name: Black dragon leather
       slug: black-dragon-leather
       relationship: product
-      description: Tanned version
-    - item_id: 2503
-      item_name: Black d'hide body
+      description: "Tanned version (20 GP per hide)"
+    - item_name: "Black d'hide body"
       slug: black-dhide-body
       relationship: product
-      description: Best ranged body (non-degradable)
-    - item_id: 1749
-      item_name: Red dragonhide
+      description: "Best non-degradable ranged body crafted from leather"
+    - item_name: Red dragonhide
       slug: red-dragonhide
-      relationship: alternative
-      description: Lower tier
-    - item_id: 1753
-      item_name: Green dragonhide
+      relationship: downgrade
+      description: "Lower tier hide"
+    - item_name: Green dragonhide
       slug: green-dragonhide
-      relationship: alternative
-      description: Entry level
+      relationship: downgrade
+      description: "Entry-level dragonhide"
   about: |-
-    Take to a tanner to convert into Black dragon leather.
-
-    | Cost | Location |
-    |------|----------|
-    | 20 GP | Most tanners |
-    | 45 GP | Canifis tanner |
-
-    Buy Limit: 11,000 per 4 hours
+    Black dragonhide is the highest tier non-special dragonhide, harvested from black, brutal black, and lava dragons as well as the King Black Dragon. Take to a tanner for 20 GP per hide (45 GP in Canifis) or use the Tan Leather lunar spell to convert five hides at once into Black dragon leather.
   market_strategy:
-    profit_formulas:
-      - Black dragon leather - Black dragonhide - 20 GP = Profit
     notes:
-      - Buy hide → Tan (20 GP) → Sell leather
-      - "Calculate:"
-      - Highest tier dragonhide = best margins
-      - Tans 5 hides per cast
-      - Faster than running to tanner
-      - Factor in rune costs
-      - Black dragons (Taverley Dungeon, Catacombs)
-      - King Black Dragon
-      - Brutal black dragons
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy hide, tan to leather, craft armour, sell"
+      - "Tan Leather lunar spell processes 5 hides per cast"
+      - "Highest tier dragonhide carries the best margins"
+      - "Buy limit 11,000 per 4 hours"
+  trading_tips:
+    - "Watch black dhide armour demand for crafting flips"
+    - "King Black Dragon trips average 2 hides per kill"
+  history:
+    - date: "2004-03-29"
+      description: "Released alongside black dragons"
+    - date: "2005-11-22"
+      description: "Renamed from Dragonhide to Black dragonhide to disambiguate colour variants"
+    - date: "2018-01-04"
+      description: "Grand Exchange shop value bumped from 80 to 150 GP"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-felling-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-felling-axe.mdx
@@ -12,9 +12,101 @@ osrs:
   lowalch: 153
   highalch: 230
   limit: null
-  about: "Black felling axe is a members-only item in Old School RuneScape. High alchemy value: 230 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2023-10-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: 2h_axe
+    attack_speed: 7
+    weight: 1.814
+    requirements:
+      attack: 10
+      woodcutting: 11
+    attack_bonus:
+      stab: 0
+      slash: 10
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 11
+      xp: 0
+      materials:
+        - item_name: Black axe
+          quantity: 1
+        - item_name: Felling axe handle
+          quantity: 1
+      tools:
+        - Anvil
+        - Hammer
+      output_quantity: 1
+  passive_effects:
+    - name: "Forester's ration synergy"
+      description: "While carrying forester's rations, grants 10% bonus Woodcutting XP and 20% chance to skip log collection per swing"
+  related_items:
+    - item_name: Black axe
+      slug: black-axe
+      relationship: component
+      description: "Combined with a felling axe handle at an anvil"
+    - item_name: Felling axe handle
+      slug: felling-axe-handle
+      relationship: component
+      description: "Forestry handle required for every felling axe upgrade"
+    - item_name: Steel felling axe
+      slug: steel-felling-axe
+      relationship: upgrade
+      description: "Next tier in the felling axe ladder"
+    - item_name: Iron felling axe
+      slug: iron-felling-axe
+      relationship: downgrade
+      description: "Lower tier in the felling axe ladder"
+  about: |-
+    > *"A woodcutter's axe."*
+
+    The black felling axe sits in the entry-mid bracket of the Forestry: Part Two woodcutting weapons, combining a black axe and a felling axe handle at an anvil with a hammer. The forge step is irreversible, but the finished axe remains tradeable.
+
+    It chops at the same speed as a standard black axe and unlocks Forestry passives: while carrying forester's rations, players gain 10% more Woodcutting XP and a 20% chance to skip log collection per swing — useful when training for XP rather than logs.
+  market_strategy:
+    notes:
+      - "Demand follows Forestry XP meta and event spawn rates"
+      - "Steel/mithril felling axes overshadow it once 30 Attack is hit"
+  trading_tips:
+    - "Buy black axes during Smithing training dips, fuse for resale"
+    - "Felling axe handle is the bottleneck — track it alongside the axe"
+  history:
+    - date: "2023-10-25"
+      description: "Released with Forestry: Part Two"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-knife-p-5665.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-knife-p-5665.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black knife(p++) | OSRS Price Data
-description: "Black knife(p++): A finely balanced throwing knife.. High alch: 10 GP, GE limit: 7,000."
+description: "Black knife(p++): A finely balanced throwing knife. High alch: 10 GP, GE limit: 7,000."
 osrs:
   id: 5665
   name: Black knife(p++)
@@ -12,9 +12,83 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 7000
-  about: "Black knife(p++) is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: black_metal
+    tier: low
+  properties:
+    release_date: "2003-03-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - "Wield"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0.4
+    requirements:
+      ranged: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 6
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Black knife
+      slug: black-knife
+      relationship: variant
+      description: "Unpoisoned base version"
+    - item_name: Black knife(p)
+      slug: black-knife-p
+      relationship: variant
+      description: "Standard poison variant"
+    - item_name: Black knife(p+)
+      slug: black-knife-p-plus
+      relationship: variant
+      description: "Stronger poison variant"
+    - item_name: Mithril knife(p++)
+      slug: mithril-knife-p-plus-plus
+      relationship: upgrade
+      description: "Higher-tier extra-strength poison throwing knife"
+  about: |-
+    > _"A finely balanced throwing knife."_
+
+    The Black knife(p++) is a thrown weapon coated with extra-strength weapon poison. It deals slightly more damage than the base black knife when poison procs, and is used by mid-level rangers who prefer thrown weapons.
+  market_strategy:
+    notes:
+      - "Niche thrown weapon — thin supply"
+      - "Mostly purchased by ironmen for poison procs"
+      - "Demand spikes during DMM/PvP events"
+  trading_tips:
+    - "Watch stack listings — sellers often dump in bulk"
+    - "GE price hugs high-alch floor"
+  history:
+    - date: "2003-03-31"
+      description: "Added with extra-strength weapon poison expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-med-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-med-helm.mdx
@@ -12,25 +12,85 @@ osrs:
   lowalch: 230
   highalch: 345
   limit: 125
-  item_id: 1151
-  item_type: armor
-  slot: head
-  type: med_helm
-  tradeable: true
-  weight: 1.814
-  requirements:
-    defence: 10
-  stats:
-    stab_defence: 9
-    slash_defence: 10
-    crush_defence: 8
-    magic_defence: -1
-    ranged_defence: 9
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 9
+      slash: 10
+      crush: 8
+      magic: -1
+      ranged: 9
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Dark warrior
+        quantity: "1"
+        rarity: 1/128
+      - source: Mutated bloodveld
+        quantity: "1"
+        rarity: 5/128
+  shops:
+    - shop_name: Seddu's Adventurers' Store
+      location: Nardah
+      price: 576
+      currency: coins
+      stock: 1
   related_items:
-    - slug: mithril-med-helm
-    - slug: black-full-helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Mithril med helm
+      slug: mithril-med-helm
+      relationship: upgrade
+      description: "Mithril tier medium helmet"
+    - item_name: Black full helm
+      slug: black-full-helm
+      relationship: upgrade
+      description: "Full helm version of the black helmet"
+  about: |-
+    The Black med helm is a free-to-play medium helmet made from black metal. It requires 10 Defence to wear and offers a slight upgrade over the Steel med helm with similar weight characteristics.
+
+    It can be purchased from Seddu's Adventurers' Store in Nardah, dropped by dark warriors and mutated bloodvelds, or obtained from various reward caskets and shade burning.
+  market_strategy:
+    notes:
+      - "Cheap free-to-play item with stable demand from low-level Defence pures"
+      - "Often farmed in bulk from shop runs to Seddu's Adventurers' Store"
+  history:
+    - date: "2002-02-27"
+      description: "Released with the original game"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-ochre-shell-round.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blamish-ochre-shell-round.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 13000
-  about: "Blamish ochre shell (round) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: shell
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: "Ochre Blamish Snail (Round)"
+        quantity: "1"
+        rarity: Always
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish ochre shell (round)
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_name: Ochre snelm (round)
+      slug: ochre-snelm-round
+      relationship: product
+      description: "Helmet crafted from this shell at 15 Crafting"
+    - item_name: Blamish myre shell (round)
+      slug: blamish-myre-shell-round
+      relationship: variant
+      description: "Myre coloured round shell variant"
+    - item_name: Blamish ochre shell (pointed)
+      slug: blamish-ochre-shell-pointed
+      relationship: variant
+      description: "Pointed ochre shell variant"
+  about: "Blamish ochre shell (round) is a members-only Crafting material dropped 100% by Ochre Blamish Snails in Mort Myre Swamp. With 15 Crafting it can be chiselled into an ochre snelm (round) for 32.5 Crafting XP."
+  market_strategy:
+    notes:
+      - "Low-volume niche Crafting material with thin daily trade"
+      - "Drop rate of 100% keeps supply elastic if demand spikes"
+      - "Best used by mid-level crafters, not flippers"
+  trading_tips:
+    - "Farm directly from Mort Myre Snails for guaranteed supply"
+    - "Convert to ochre snelm (round) only if Crafting XP justifies the GE delta"
+  history:
+    - date: "2004-10-14"
+      description: "Released with the Morytania expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blessed-spirit-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blessed-spirit-shield.mdx
@@ -12,80 +12,100 @@ osrs:
   lowalch: 480000
   highalch: 720000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: spirit_shield
+    tier: high
+  properties:
+    release_date: "16 October 2014"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: spirit_shield
+    weight: 2
     requirements:
       defence: 70
       prayer: 60
-    stats:
-      defence_stab: 53
-      defence_slash: 55
-      defence_crush: 73
-      defence_magic: 2
-      defence_ranged: 52
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 53
+      slash: 55
+      crush: 73
+      magic: 2
+      ranged: 52
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
-  creation:
-    materials:
-      - item_id: 12829
-        item_name: Spirit shield
-        slug: spirit-shield
-      - item_id: 12833
-        item_name: Holy elixir
-        slug: holy-elixir
-    requirements:
-      prayer: 85
-      boostable: false
+  recipes:
+    - skill: prayer
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Spirit shield
+          quantity: 1
+        - item_name: Holy elixir
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 12817
-      item_name: Elysian spirit shield
+    - item_name: Spirit shield
+      slug: spirit-shield
+      relationship: component
+      description: "Base shield required for blessing"
+    - item_name: Holy elixir
+      slug: holy-elixir
+      relationship: component
+      description: "Blessing reagent from Corporeal Beast"
+    - item_name: Elysian spirit shield
       slug: elysian-spirit-shield
       relationship: upgrade
-      description: Elysian sigil upgrade
-    - item_id: 12825
-      item_name: Arcane spirit shield
+      description: "Elysian sigil upgrade"
+    - item_name: Arcane spirit shield
       slug: arcane-spirit-shield
       relationship: upgrade
-      description: Arcane sigil upgrade
-    - item_id: 0
-      item_name: Corporeal Beast
-      slug: corporeal-beast
-      relationship: component
-      description: Material source
+      description: "Arcane sigil upgrade"
+    - item_name: Spectral spirit shield
+      slug: spectral-spirit-shield
+      relationship: upgrade
+      description: "Spectral sigil upgrade"
   about: |-
-    Combine Spirit shield + Holy elixir.
+    > *"An ethereal shield that has been blessed with holy powers."*
 
-    | Requirement | Value |
-    |-------------|-------|
-    | Prayer | 85 (non-boostable) |
+    The blessed spirit shield is created by combining a Spirit shield with a Holy elixir at 85 Prayer (non-boostable). It provides a +3 prayer bonus alongside strong melee defensive stats, making it a budget prayer shield and tank option.
 
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +53 |
-    | Slash | +55 |
-    | Crush | +73 |
-    | Magic | +2 |
-    | Ranged | +52 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +3 |
-
-    Requirements: 70 Defence, 60 Prayer
-
-    Essential for:
-    - Creating sigil spirit shields
-    - Budget prayer shield
-    - Tank shield
-
-    Base for all sigil shields.
+    The blessed shield is the base for all sigil spirit shields — Arcane, Spectral, and Elysian — created by attaching the corresponding sigil at 90 Prayer and 85 Smithing.
   market_strategy:
     notes:
-      - Holy elixir from Corp
-      - Spirit shield from Corp
-      - Attach sigils for upgrades
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Holy elixir sourced from Corporeal Beast"
+      - "Spirit shield also dropped by Corporeal Beast"
+      - "Used as base for all sigil shield upgrades"
+      - "Demand tracks sigil shield economy"
+  trading_tips:
+    - "Margins follow Holy elixir and Spirit shield supply"
+    - "Spikes during Corp mass events flood the market"
+    - "Hold inventory for sigil-shield crafters during dry spells"
+  history:
+    - date: "16 October 2014"
+      description: "Released as a base for sigil spirit shields."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-overload-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-overload-3.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 50
-  about: "Blighted overload (3) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "17 July 2024"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Attack, Strength, Ranged, Magic and Defence in dangerous areas; reapplies every 15 seconds for 5 minutes"
+        duration: 300
+      - description: "Inflicts 10 damage over 6 seconds on consumption"
+        duration: 6
+  related_items:
+    - item_name: Blighted overload (4)
+      slug: blighted-overload-4
+      relationship: variant
+      description: "4-dose version"
+    - item_name: Blighted overload (2)
+      slug: blighted-overload-2
+      relationship: variant
+      description: "2-dose version"
+    - item_name: Blighted overload (1)
+      slug: blighted-overload-1
+      relationship: variant
+      description: "1-dose version"
+  about: |-
+    > *"3 doses of blighted overload potion."*
+
+    Blighted overload is a Deadman Mode exclusive that only activates inside dangerous areas. While active it grants large boosts to Attack, Strength, Ranged, Magic and Defence and reapplies every 15 seconds for 5 minutes. It also drains 10 hitpoints over 6 seconds on consumption and reduces Defence over time. Stepping into a safe zone deactivates the potion after roughly 11 ticks.
+
+    Brewing requires Herblore 83 and combines super combat, ranging and magic potions with chitin.
+  market_strategy:
+    notes:
+      - "Only usable on Deadman Mode worlds (permanent world 345 or seasonal events)"
+      - "Highly cyclical: most demand concentrates around DMM tournaments"
+  trading_tips:
+    - "Stockpile chitin and base potions before DMM event announcements"
+    - "Buy limit is 50: bulk flipping requires multiple accounts or patience"
+  history:
+    - date: "17 July 2024"
+      description: "Released for Deadman Mode"
+    - date: "21 January 2026"
+      description: "Self-damage reduced from 25 to 10; Defence decay threshold raised to 90%"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-teleport-spell-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-teleport-spell-sack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blighted teleport spell sack | OSRS Price Data
-description: "Blighted teleport spell sack is a members-only OSRS item. High alch: 19 GP, GE limit: 10,000."
+description: "Blighted teleport spell sack lets 85 Magic players cast Tele Block or Teleport to Target in the Wilderness without runes. High alch: 19 GP, GE limit: 10,000."
 osrs:
   id: 24615
   name: Blighted teleport spell sack
@@ -12,9 +12,84 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 10000
-  about: "Blighted teleport spell sack is a members-only item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: consumable
+    tier: low
+  properties:
+    release_date: "2020-04-23"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: Wilderness-only Tele Block / Teleport to Target
+      description: "Consumed on cast to substitute for the runes of Tele Block or Teleport to Target; only usable in the Wilderness and requires 85 Magic"
+  shops:
+    - shop_name: "Justine's stuff for the Last Shopper Standing"
+      location: "Ferox Enclave"
+      price: 1
+      currency: "Last Man Standing point"
+      stock: 50
+    - shop_name: "Soul Wars Reward Shop"
+      location: "Ferox Enclave"
+      price: 10
+      currency: "Zeal Token"
+      stock: 50
+  drop_table:
+    sources:
+      - source: Revenants
+        quantity: "1-10"
+        rarity: "1/24"
+      - source: Wilderness dragons
+        quantity: "1-10"
+        rarity: "1/12"
+      - source: Wilderness demons
+        quantity: "1-10"
+        rarity: "1/12"
+  related_items:
+    - item_name: Blighted manta ray
+      slug: blighted-manta-ray
+      relationship: alternative
+      description: "Other Wilderness-only blighted consumable"
+    - item_name: Blighted super restore(4)
+      slug: blighted-super-restore-4
+      relationship: alternative
+      description: "Wilderness-only blighted super restore"
+    - item_name: Blighted anglerfish
+      slug: blighted-anglerfish
+      relationship: alternative
+      description: "Wilderness-only blighted food"
+    - item_name: Blighted vengeance sack
+      slug: blighted-vengeance-sack
+      relationship: alternative
+      description: "Wilderness-only Vengeance spell sack"
+  about: |-
+    The blighted teleport spell sack is a Wilderness-only consumable that lets players with 85 Magic cast Tele Block or Teleport to Target without supplying the corresponding runes. The sack is consumed on cast and stacks in the inventory, which trims rune slots when packing for PKing.
+
+    It originally only substituted for Tele Block on release and was renamed from "Blighted teleblock sack" when the 14 May 2020 update extended its function to also cover Teleport to Target.
+  market_strategy:
+    notes:
+      - "PvP-driven demand — spikes during Wilderness updates and bounty hunter resets"
+      - "Stackable — bulk flips are easy to hold"
+      - "Justine's shop and Soul Wars reward shop set a soft floor for big stocks"
+  trading_tips:
+    - "Compare GE price to the cost of casting with raw runes — players will swap whichever is cheaper"
+    - "Watch Wilderness boss drop table tweaks for supply shocks"
+  history:
+    - date: "2020-04-23"
+      description: "Released as the Blighted teleblock sack alongside other Wilderness blighted consumables."
+    - date: "2020-05-14"
+      description: "Renamed to Blighted teleport spell sack and expanded to also substitute for Teleport to Target."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-body.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 70
-  about: "Bloodbark body is a members-only item in Old School RuneScape. High alchemy value: 72,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: magic-armour
+    tier: mid-high
+  properties:
+    release_date: "2021-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 4.535
+    requirements:
+      magic: 60
+      defence: 60
+    attack_bonus:
+      magic: 21
+    defence_bonus:
+      stab: 53
+      slash: 39
+      crush: 64
+      magic: 24
+    other_bonus:
+      magic_damage: 1
+  recipes:
+    - skill: runecraft
+      level: 81
+      xp: 0
+      materials:
+        - item_name: Splitbark body
+          quantity: 1
+        - item_name: Blood rune
+          quantity: 500
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Bloodbark helm
+      slug: bloodbark-helm
+      relationship: set-piece
+      description: "Head slot of Bloodbark set"
+    - item_name: Bloodbark legs
+      slug: bloodbark-legs
+      relationship: set-piece
+      description: "Legs slot of Bloodbark set"
+    - item_name: Bloodbark boots
+      slug: bloodbark-boots
+      relationship: set-piece
+      description: "Feet slot of Bloodbark set"
+    - item_name: Bloodbark gauntlets
+      slug: bloodbark-gauntlets
+      relationship: set-piece
+      description: "Hands slot of Bloodbark set"
+    - item_name: Splitbark body
+      slug: splitbark-body
+      relationship: component
+      description: "Base item required for the recipe"
+  passive_effects:
+    - name: Blood spell healing
+      description: "Each Bloodbark piece increases blood spell self-healing by 2%, totalling 10% across the full set"
+  about: "Bloodbark body is a magic armour torso created at the Blood Altar by combining a splitbark body with 500 blood runes. Requires 60 Magic and 60 Defence to wear, and the runecrafting recipe needs 81 Runecraft after reading the runescroll of bloodbark."
+  market_strategy:
+    notes:
+      - "Crafted from splitbark body plus 500 blood runes"
+      - "Demand follows blood spell PvM setups"
+      - "Magic damage bonus keeps mid-game pricing steady"
+  trading_tips:
+    - "Cost basis tracks splitbark body and blood rune supply"
+    - "Set buyers may pay over single-piece sum"
+    - "Check Blood Altar throughput when runes spike"
+  history:
+    - date: "2021-01-27"
+      description: "Released alongside the Bloodbark armour set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-chaps-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-chaps-t.mdx
@@ -12,57 +12,89 @@ osrs:
   lowalch: 1728
   highalch: 2592
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragonhide
+    tier: mid
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: ranged armour
-    attack_style: ranged
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
     requirements:
       ranged: 50
-    stats:
-      attack_ranged: 11
-      attack_magic: -10
-      defence_stab: 13
-      defence_slash: 16
-      defence_crush: 20
-      defence_magic: 14
-      defence_ranged: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 11
+    defence_bonus:
+      stab: 13
+      slash: 16
+      crush: 20
+      magic: 14
+      ranged: 20
+    other_bonus:
+      strength: 0
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Medium
-        rarity: Rare
-        description: Rare reward from medium clue scrolls
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Reward casket (hard)"
+        quantity: "1"
+        rarity: "1/1,625"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 2493
-      item_name: Blue d'hide chaps
+    - item_name: Blue d'hide chaps
       slug: blue-dhide-chaps
       relationship: variant
-      description: Standard version with identical stats
-    - item_id: 7382
-      item_name: Blue d'hide chaps (g)
+      description: "Standard untrimmed version with identical combat stats"
+    - item_name: Blue d'hide chaps (g)
       slug: blue-dhide-chaps-g
       relationship: variant
-      description: Gold-trimmed variant with identical stats
-  about: |-
-    Made from 100% real dragonhide. With colourful trim!
-
-    Blue d'hide chaps (t) are a cosmetic variant of blue d'hide chaps featuring team-coloured trim. They are obtained exclusively from medium Treasure Trail reward caskets and cannot be created through the Crafting skill. Their stats are identical to standard blue d'hide chaps, making this item purely aesthetic.
-
-    These chaps require 50 Ranged to equip and provide solid ranged defence bonuses for mid-level rangers. The coloured trimming is the only visual difference from the base version.
+      description: "Gold-trimmed variant with identical combat stats"
+    - item_name: Blue dragonhide body (t)
+      slug: blue-dragonhide-body-t
+      relationship: set-piece
+      description: "Trimmed body piece that pairs with these chaps"
+  about: "Blue d'hide chaps (t) are a cosmetic trim variant rewarded from hard Treasure Trail caskets. Stats are identical to standard blue d'hide chaps, so the trim is purely aesthetic and used for fashionscape outfits."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Purely cosmetic upgrade over standard blue d'hide chaps
-      - Price is driven by fashion demand rather than combat utility
-      - Medium clue scroll rewards tend to have moderate supply
-      - Compare price to standard blue d'hide chaps to gauge the cosmetic premium
-      - Consider demand cycles around Treasure Trail update announcements
-      - Team-trimmed variants may have different demand patterns than gold-trimmed
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Pure cosmetic premium over standard blue d'hide chaps"
+      - "Hard clue drop rate of 1/1,625 caps supply, keeping prices firm"
+      - "Demand cycles around Treasure Trail update announcements"
+      - "Compare against gold-trimmed variant to gauge community trim preference"
+  trading_tips:
+    - "Track the price gap versus untrimmed blue d'hide chaps to spot fashion-driven spikes"
+    - "Buy limit of 8 per 4 hours means scaling positions takes patience"
+  history:
+    - date: "2006-02-20"
+      description: "Released as a hard Treasure Trail reward"
+    - date: "2021-09"
+      description: "Defence bonuses were rebalanced downward (stab from +25 to +13)"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blurberry-special.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blurberry-special.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Blurberry special is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cocktail
+    tier: mid
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 37
+      xp: 150
+      materials:
+        - item_name: Vodka
+          quantity: 1
+        - item_name: Brandy
+          quantity: 1
+        - item_name: Gin
+          quantity: 1
+        - item_name: Orange chunks
+          quantity: 1
+        - item_name: Lemon chunks
+          quantity: 1
+        - item_name: Lemon slices
+          quantity: 1
+        - item_name: Lime slices
+          quantity: 1
+        - item_name: Equa leaves
+          quantity: 1
+      tools:
+        - Cocktail shaker
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Restores 7 hitpoints when consumed."
+        duration: 0
+      - description: "Raises Strength by 5 percent plus 2 levels."
+        duration: 0
+      - description: "Lowers Attack by 2 percent minus 3 levels."
+        duration: 0
+  related_items:
+    - item_name: Blurberry cocktail
+      slug: blurberry-cocktail
+      relationship: alternative
+      description: "Lower-tier cocktail from the same bar"
+    - item_name: Drunk dragon
+      slug: drunk-dragon
+      relationship: alternative
+      description: "Other Gnome Stronghold cocktail recipe"
+  about: "Blurberry special is a Gnome Stronghold cocktail mixed at Blurberry Bar with 37 Cooking for 150 experience. It restores 7 hitpoints and provides a temporary Strength boost paired with an Attack reduction. It is also given to Harold during the Death Plateau quest to win the dice game."
+  market_strategy:
+    notes:
+      - "Demand is primarily Cooking trainers chasing XP and Death Plateau questers."
+      - "Margins are slim - cocktail ingredient costs dominate the price."
+  trading_tips:
+    - "Buy a small stock for Death Plateau and Tourist Trap-era questing accounts."
+    - "Daily volume is low; place limit orders rather than market-buying."
+  history:
+    - date: "2002-12-12"
+      description: "Released with the Gnome Cooking update at Blurberry Bar."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/boots-of-brimstone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/boots-of-brimstone.mdx
@@ -12,8 +12,34 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: hybrid_boots
+    tier: mid-high
+  properties:
+    release_date: "10 January 2019"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
+    weight: 3.175
+    requirements:
+      slayer: 44
+      magic: 70
+      ranged: 70
+      defence: 70
     attack_bonus:
       stab: 3
       slash: 0
@@ -31,106 +57,62 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      slayer: 44
-      magic: 70
-      ranged: 70
-      defence: 70
   recipes:
-    - name: Boots of brimstone
+    - skill: smithing
+      level: 1
+      xp: 0
       materials:
-        - item_id: 23037
-          item_name: Drake's claw
+        - item_name: Drake's claw
           quantity: 1
-        - item_id: 23049
-          item_name: Boots of stone
+        - item_name: Boots of stone
           quantity: 1
-      skill: none
-      description: Use Drake's claw on Boots of stone
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 23037
-      item_name: Drake's claw
+    - item_name: Drake's claw
       slug: drakes-claw
       relationship: component
-      description: Upgrade material from Drakes
-    - item_id: 23049
-      item_name: Boots of stone
+      description: "Upgrade material from Drakes"
+    - item_name: Boots of stone
       slug: boots-of-stone
       relationship: component
-      description: Base boots for creation
-    - item_id: 22443
-      item_name: Dragon boots
+      description: "Base boots for creation"
+    - item_name: Dragon boots
       slug: dragon-boots
       relationship: alternative
-      description: Melee-focused boots
-    - item_id: 2577
-      item_name: Ranger boots
+      description: "Melee-focused alternative boots"
+    - item_name: Ranger boots
       slug: ranger-boots
       relationship: alternative
-      description: Ranged-focused boots
-    - item_id: 6920
-      item_name: Infinity boots
+      description: "Ranged-focused alternative boots"
+    - item_name: Infinity boots
       slug: infinity-boots
       relationship: alternative
-      description: Magic-focused boots
+      description: "Magic-focused alternative boots"
   about: |-
     > *"A pair of heat resistant boots charged with the claw of the ferocious Drake."*
 
-    The boots of brimstone are created by using a Drake's claw on a pair of Boots of stone. This requires no skill levels to combine.
+    The boots of brimstone are created by using a Drake's claw on a pair of Boots of stone. They are a hybrid boot offering bonuses across all three combat styles, ideal for content requiring multiple combat styles without switching.
 
-    | Material | Source | Approx. Cost |
-    |----------|--------|-------------|
-    | Drake's claw | Drake (Slayer monster, 84 Slayer) | ~339,000 GP |
-    | Boots of stone | Volcanic Mine shop / GE | ~490 GP |
-    | Total | | ~339,500 GP |
+    Requirements: 44 Slayer, 70 Magic, 70 Ranged, 70 Defence.
 
-    | Attack | Value |
-    |--------|-------|
-    | Stab | +3 |
-    | Magic | +3 |
-    | Ranged | +5 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +5 |
-    | Ranged | +5 |
-
-    Requirements: 44 Slayer, 70 Magic, 70 Ranged, 70 Defence
-
-    Weight: 3.175 kg
-
-    | Stat | Brimstone | Dragon Boots | Ranger Boots | Infinity Boots | Devout Boots |
-    |------|-----------|-------------|--------------|----------------|-------------|
-    | Stab Atk | +3 | +0 | +0 | +0 | +0 |
-    | Magic Atk | +3 | -3 | -1 | +5 | +0 |
-    | Ranged Atk | +5 | -1 | +8 | +0 | +0 |
-    | Melee Def | +10/+10/+10 | +16/+16/+16 | +0/+0/+0 | +5/+5/+5 | +3/+3/+3 |
-    | Magic Def | +5 | -3 | +0 | +5 | +3 |
-    | Ranged Def | +5 | -1 | +0 | +0 | +3 |
-    | Str Bonus | +0 | +4 | +0 | +0 | +0 |
-    | Prayer | +0 | +0 | +0 | +0 | +5 |
-
-    The boots of brimstone are a hybrid boot offering bonuses across all three combat styles. They do not excel in any single style but provide solid all-around stats, making them ideal for content requiring multiple combat styles.
-
-    - Chambers of Xeric — popular hybrid boot choice
-    - Dagannoth Kings — switching between combat styles
-    - Gauntlet / Corrupted Gauntlet — hybrid combat
-    - Any content requiring multiple combat styles without switching boots
-    - Budget alternative to specialized boots when tribridding
-
-    Like their base (Boots of stone), boots of brimstone protect the wearer from the heat of the Karuulm Slayer Dungeon floor. This allows the player to walk on the heated floor without taking damage.
+    Like their base (Boots of stone), boots of brimstone protect the wearer from the heat of the Karuulm Slayer Dungeon floor.
   market_strategy:
     notes:
-      - Created from Drake's claw + Boots of stone
-      - Profit margin exists when claw price is low relative to finished boot price
-      - Popular with mid-game accounts doing hybrid PvM
-      - Drake's claw is the primary value driver (~99% of cost)
-      - Demand is steady from Chambers of Xeric and hybrid PvM players
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Created from Drake's claw + Boots of stone"
+      - "Profit margin exists when claw price is low relative to finished boot price"
+      - "Popular with mid-game accounts doing hybrid PvM"
+      - "Drake's claw is the primary value driver (~99% of cost)"
+      - "Demand is steady from Chambers of Xeric and hybrid PvM players"
+  trading_tips:
+    - "Watch Drake's claw GE price as the dominant cost driver"
+    - "Hybrid PvM demand keeps prices steady around CoX rotations"
+    - "Margins widen when claws dip post-Slayer task spikes"
+  history:
+    - date: "10 January 2019"
+      description: "Released as part of The Kebos Lowlands update."
+    - date: "17 January 2019"
+      description: "Received a graphical update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow.mdx
@@ -12,46 +12,107 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: arrow
+    tier: low
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    type: arrow
-    attack_style: ranged
-  requirements:
-    ranged: 1
-  stats:
-    other:
+    weapon_type: null
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 7
-  fletching:
-    level: 1
-    xp: 1.3
-    method: Bronze arrowtips + headless arrows
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 1
+      xp: 19.5
+      materials:
+        - item_name: Headless arrow
+          quantity: 15
+        - item_name: Bronze arrowtips
+          quantity: 15
+      tools: []
+      output_quantity: 15
   shops:
     - shop_name: Lowe's Archery Emporium
       location: Varrock
-      price: 7
+      price: 1
+      currency: coins
+      stock: 2000
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      price: 1
+      currency: coins
+      stock: 1000
+    - shop_name: Dargaud's Bow and Arrows
+      location: Ranging Guild
+      price: 1
+      currency: coins
+      stock: 1000
   related_items:
-    - item_id: 884
-      item_name: Iron arrow
+    - item_name: Iron arrow
       slug: iron-arrow
       relationship: upgrade
-      description: Higher tier arrow
-    - item_id: 39
-      item_name: Bronze arrowtips
+      description: "Higher tier arrow"
+    - item_name: Bronze arrowtips
       slug: bronze-arrowtips
       relationship: component
-      description: Fletching material
-    - item_id: 53
-      item_name: Headless arrow
+      description: "Fletching material"
+    - item_name: Headless arrow
       slug: headless-arrow
       relationship: component
-      description: Fletching material
-    - item_id: 841
-      item_name: Shortbow
+      description: "Fletching material"
+    - item_name: Shortbow
       slug: shortbow
       relationship: alternative
-      description: Compatible bow
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Compatible bow"
+  about: "Bronze arrow is the F2P entry-level arrow at +7 ranged strength, fletched from level 1 and stocked cheaply at every archery emporium."
+  market_strategy:
+    notes:
+      - "Multiple shops restock every 6 seconds keeping floor near 1 coin"
+      - "Daily volume in the millions supports tight spreads"
+      - "Used as the cheapest training arrow for low Ranged levels"
+  trading_tips:
+    - "Stock from Lowe's, Hickton's, or Dargaud's to dodge GE premiums"
+    - "Fletch at level 1 with arrowtips + headless arrows for cheap XP"
+  history:
+    - date: "4 January 2001"
+      description: "Released as a starting Ranged ammunition type."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-tip.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dart-tip.mdx
@@ -12,18 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options: ["Drop"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 4
+      xp: 12.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+      tools: ["Hammer", "Anvil"]
+      output_quantity: 10
   related_items:
-    - item_id: 820
-      item_name: Iron dart tip
+    - item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: "Smithed input — one bar yields 10 dart tips"
+    - item_name: Bronze dart
+      slug: bronze-dart
+      relationship: product
+      description: "Fletched at 10 Fletching using feathers"
+    - item_name: Iron dart tip
       slug: iron-dart-tip
       relationship: variant
-      description: Higher tier dart tip
+      description: "Higher tier dart tip"
   about: |-
-    > _"Can be used to make bronze darts."_
+    > *"A deadly looking dart tip made of bronze - needs feathers for flight."*
 
-    Bronze dart tips are used with feathers at 1 Fletching to create bronze darts (1.8 XP each). One bar makes 10 tips.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Entry-tier dart tip smithed at 4 Smithing after completing The Tourist Trap; one bronze bar produces 10 tips for 12.5 Smithing XP. Combined with feathers at 10 Fletching, the tips become bronze darts at 1.8 Fletching XP each — staple early-game throwing weapon for low-level Slayer and Fletching training.
+  market_strategy:
+    notes:
+      - "Non-alchable — pure crafting throughput item"
+      - "Buy limit 13,000 supports bulk Fletching XP flips"
+      - "Margin tracks bronze bar and feather spread closely"
+  trading_tips:
+    - "Compare bar cost × 10 versus tip GE price for smith-flip viability"
+    - "Stack with feathers to convert into bronze darts for Fletching XP gains"
+  history:
+    - date: "2003-04-14"
+      description: "Introduced during the New Throwing Weapons update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-full-helm.mdx
@@ -12,24 +12,98 @@ osrs:
   lowalch: 17
   highalch: 26
   limit: 125
-  item_id: 1155
-  item_type: armor
-  slot: head
-  type: full_helm
-  tradeable: true
-  weight: 2.721
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 4
-    slash_defence: 5
-    crush_defence: 3
-    ranged_defence: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.721
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 4
+      slash: 5
+      crush: 3
+      magic: -1
+      ranged: 4
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 7
+      xp: 25
+      materials:
+        - item_name: Bronze bar
+          quantity: 2
+      tools:
+        - Hammer
+      output_quantity: 1
+  shops:
+    - shop_name: Peksa's Helmet Shop
+      location: Barbarian Village
+      price: 44
+      currency: Coins
+      stock: 10
+    - shop_name: Thurid's Brain Buckets
+      location: Sunset Coast
+      price: 57
+      currency: Coins
+      stock: 5
   related_items:
-    - slug: iron-full-helm
-    - slug: bronze-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: upgrade
+      description: "Next metal tier in the full helm chain"
+    - item_name: Bronze platebody
+      slug: bronze-platebody
+      relationship: set-piece
+      description: "Matches the bronze armour set"
+    - item_name: Bronze med helm
+      slug: bronze-med-helm
+      relationship: downgrade
+      description: "Lighter helm at the same metal tier"
+  about: "Bronze full helm is the entry-level full helm, requiring just 1 Defence to wear and 7 Smithing to forge from 2 bronze bars. It is the cheapest full face helm in the game and the starting point of the metal armour progression."
+  market_strategy:
+    notes:
+      - "Smithers undercut Peksa's shop, keeping the GE price near alch value."
+      - "Demand is mostly low-level training accounts and ironmen sourcing armour pieces."
+  trading_tips:
+    - "Buy from Peksa's shop for resale on the GE if bar prices spike."
+    - "High alch margins are razor thin; treat as flip stock, not alch stock."
+  history:
+    - date: "2001-01-04"
+      description: "Released with the original Smithing skill at RuneScape Classic launch."
+    - date: "2021-04-21"
+      description: "Ranged attack penalty adjusted from -2 to -3."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-keel-parts.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 100
-  about: "Bronze keel parts is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "19 November 2025"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 10
+      xp: 62.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 5
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  related_items:
+    - item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: "Smelted feedstock used to forge keel parts"
+    - item_name: Large bronze keel parts
+      slug: large-bronze-keel-parts
+      relationship: product
+      description: "Higher tier sailing component made from 5 bronze keel parts"
+  about: |-
+    > *"Parts for creating a bronze keel for a boat."*
+
+    Bronze keel parts are the entry-level shipbuilding component introduced with the Sailing skill release. Each part is smithed from 5 bronze bars at an anvil, requiring Smithing 10 and granting 62.5 XP. They feed directly into bronze keels for skiffs and stack 5-per-large-part when forging large bronze keels.
+  market_strategy:
+    notes:
+      - "Supply is gated by bronze bar feedstock and the 100/day buy limit"
+      - "Demand follows new Sailing release content and shipbuilding tasks"
+  trading_tips:
+    - "Track bronze bar prices: keel parts are a thin wrapper on bar cost"
+    - "Spread buy orders over multiple accounts to bypass the 100 limit when stockpiling"
+  history:
+    - date: "19 November 2025"
+      description: "Released alongside the Sailing skill"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-med-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-med-helm.mdx
@@ -12,25 +12,111 @@ osrs:
   lowalch: 9
   highalch: 14
   limit: 125
-  item_id: 1139
-  item_type: armor
-  slot: head
-  type: med_helm
-  tradeable: true
-  weight: 1.814
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 3
-    slash_defence: 4
-    crush_defence: 2
-    magic_defence: -1
-    ranged_defence: 3
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: 0
+    defence_bonus:
+      stab: 3
+      slash: 4
+      crush: 2
+      magic: -1
+      ranged: 3
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 3
+      xp: 12.5
+      materials:
+        - item_name: Bronze bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: Peksa's Helmet Shop
+      location: Barbarian Village
+      price: 24
+      currency: coins
+      stock: 3
+    - shop_name: Warriors' Guild Armoury
+      location: Burthorpe
+      price: 24
+      currency: coins
+      stock: 5
+    - shop_name: Blair's Armour
+      location: Shayzien
+      price: 24
+      currency: coins
+      stock: 5
+    - shop_name: Thurid's Brain Buckets
+      location: Sunset Coast
+      price: 24
+      currency: coins
+      stock: 5
   related_items:
-    - slug: iron-med-helm
-    - slug: bronze-full-helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Iron med helm
+      slug: iron-med-helm
+      relationship: upgrade
+      description: "Next tier in the med helm progression"
+    - item_name: Steel med helm
+      slug: steel-med-helm
+      relationship: upgrade
+      description: "Higher-tier med helm"
+    - item_name: Bronze full helm
+      slug: bronze-full-helm
+      relationship: alternative
+      description: "Full helm variant with better coverage"
+  about: "The Bronze med helm is the entry-level head slot armour in OSRS, smithable at Smithing 3 from one bronze bar and worn by F2P starters working toward iron and steel gear."
+  market_strategy:
+    notes:
+      - "Tiny daily volume; trade on shop arbitrage rather than GE flips."
+      - "Smithing alch is unprofitable; value lives in skill XP."
+      - "Bronze bar parity sets the floor; rarely diverges."
+  trading_tips:
+    - "Bulk-buy from Peksa for 24 gp and high-alch only if nature runes are cheap."
+    - "Useful as a low-cost ironman head slot before steel/black."
+  history:
+    - date: "4 January 2001"
+      description: "Added to RuneScape Classic alongside the rest of the bronze armour set."
+    - date: "17 July 2007"
+      description: "Graphically updated to its modern appearance."
+    - date: "21 April 2021"
+      description: "Ranged attack bonus changed from -1 to 0 across the med helm line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cake-tin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cake-tin.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 40
-  about: "Cake tin is a free-to-play item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cookware
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Cooks' Guild Store
+      location: Cooks' Guild
+      price: 10
+      currency: Coins
+      stock: 5
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge
+      price: 13
+      currency: Coins
+      stock: 10
+  recipes:
+    - skill: cooking
+      level: 40
+      xp: 180
+      materials:
+        - item_name: Cake tin
+          quantity: 1
+        - item_name: Egg
+          quantity: 1
+        - item_name: Pot of flour
+          quantity: 1
+        - item_name: Bucket of milk
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Cake
+      slug: cake
+      relationship: product
+      description: "Baked using the cake tin with egg, flour, and milk"
+    - item_name: Uncooked cake
+      slug: uncooked-cake
+      relationship: product
+      description: "Intermediate produced before baking"
+    - item_name: Pot
+      slug: pot
+      relationship: alternative
+      description: "Other basic cooking vessel"
+  about: "Cake tin is a free-to-play baking vessel sold by the Cooks' Guild Store and the Culinaromancer's Chest. Required to make uncooked cakes from egg, pot of flour, and bucket of milk, and to 'make wax' during the Troll Romance quest."
+  market_strategy:
+    notes:
+      - "Tiny GE buy limit (40) keeps flow small"
+      - "Shop respawn caps margin on bulk flips"
+      - "Quest demand from Troll Romance and Recipe for Disaster runs"
+  trading_tips:
+    - "Buy from Cooks' Guild and resell on GE for a small consistent flip"
+    - "Spike around questing weekends when new players grind Troll Romance"
+  history:
+    - date: "2001-06-11"
+      description: "Released with the Cooking skill content"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-pyre-logs.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 176
   highalch: 264
   limit: null
-  about: "Camphor pyre logs is a members-only item in Old School RuneScape. High alchemy value: 264 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: wood
+    tier: mid-high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Light
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 1
+      xp: 20
+      materials:
+        - item_name: Camphor logs
+          quantity: 1
+        - item_name: Sacred oil(4)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Camphor logs
+      slug: camphor-logs
+      relationship: component
+      description: "Base log soaked in sacred oil to produce pyre logs"
+    - item_name: Sacred oil(4)
+      slug: sacred-oil-4
+      relationship: component
+      description: "Four doses of sacred oil saturate one set of camphor logs"
+    - item_name: Magic pyre logs
+      slug: magic-pyre-logs
+      relationship: alternative
+      description: "Higher tier pyre logs from magic logs"
+    - item_name: Redwood pyre logs
+      slug: redwood-pyre-logs
+      relationship: alternative
+      description: "Top tier pyre log for Shades of Mort'ton"
+  about: |-
+    > *"Camphor logs prepared with sacred oil for a funeral pyre."*
+
+    Camphor pyre logs slot between magic and redwood tiers in the Shades of Mort'ton cremation flow. Light them with a tinderbox alongside shade remains for a flat 320 Firemaking XP per cremation (480 with the Morytania Elite Diary), and Prayer XP scales with the remains burned: Loar 34.5, Phrin 47.5, Riyl 62, Asyn 79.5.
+
+    Net cost per log is currently around 1.6k, so they only make sense when chasing fast Prayer XP rather than profit.
+  market_strategy:
+    notes:
+      - "Sacred oil supply caps daily craft volume"
+      - "Prayer XP/hour drives most demand, not Firemaking XP"
+  trading_tips:
+    - "Sacred oil(4) is the bottleneck — buy in bulk before runs"
+    - "Stock during shade events; demand spikes for Prayer training"
+  history:
+    - date: "2025-11-19"
+      description: "Released with the camphor logs Firemaking expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-tuna.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chopped-tuna.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 41
   highalch: 62
   limit: 13000
-  about: "Chopped tuna is a members-only item in Old School RuneScape. High alchemy value: 62 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2006-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Tuna
+          quantity: 1
+        - item_name: Bowl
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Tuna
+      slug: tuna
+      relationship: component
+      description: "Cooked tuna chopped with a knife while holding a bowl"
+    - item_name: Bowl
+      slug: bowl
+      relationship: component
+      description: "Required container for the chopped tuna"
+    - item_name: Tuna potato
+      slug: tuna-potato
+      relationship: product
+      description: "Combined with a baked potato with butter for 68 Cooking food"
+    - item_name: Knife
+      slug: knife
+      relationship: component
+      description: "Tool used to chop the tuna"
+  about: |-
+    > *"A bowl of finely chopped tuna."*
+
+    Chopped tuna is the prepared filling for tuna potatoes — use a knife on a cooked tuna while holding a bowl to produce one in two ticks (no Cooking XP). Eats for 10 hitpoints on its own, but value is in feeding the tuna potato recipe at 68 Cooking.
+
+    Demand is driven by Cooking trainers and food prep for bossing; supply lags behind because tuna and bowls must be sourced separately.
+  market_strategy:
+    notes:
+      - "Tuna potato recipe drives almost all volume"
+      - "Spread is positive when tuna prices crash"
+  trading_tips:
+    - "Buy tuna + bowls in bulk during fishing XP dips"
+    - "Sell during Cooking-skill weekend events for top margin"
+  history:
+    - date: "2006-01-30"
+      description: "Released as a tuna potato ingredient"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/christmas-cracker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/christmas-cracker.mdx
@@ -1,6 +1,6 @@
 ---
 title: Christmas cracker | OSRS Price Data
-description: "Christmas cracker: I need to pull this.. High alch: 1 GP, GE limit: 4."
+description: "Christmas cracker: I need to pull this. High alch: 1 GP, GE limit: 4."
 osrs:
   id: 962
   name: Christmas cracker
@@ -12,13 +12,64 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  related_items: []
-  about: |-
-    > _"I need to pull this."_
-
-    The Christmas cracker is a holiday item. When used on another player, both receive rewards — a partyhat (in various colours) and a secondary item. Players can choose which specific partyhat they receive. One of the original holiday-themed items.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: holiday item
+    tier: high
+  properties:
+    release_date: "2001-12-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.2
+    options: ["Pull", "Drop"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Red partyhat
+      slug: red-partyhat
+      relationship: product
+      description: "One of six partyhat colours obtainable from pulling a cracker"
+    - item_name: Yellow partyhat
+      slug: yellow-partyhat
+      relationship: product
+      description: "One of six partyhat colours obtainable from pulling a cracker"
+    - item_name: White partyhat
+      slug: white-partyhat
+      relationship: product
+      description: "One of six partyhat colours obtainable from pulling a cracker"
+    - item_name: Green partyhat
+      slug: green-partyhat
+      relationship: product
+      description: "One of six partyhat colours obtainable from pulling a cracker"
+    - item_name: Blue partyhat
+      slug: blue-partyhat
+      relationship: product
+      description: "One of six partyhat colours obtainable from pulling a cracker"
+    - item_name: Purple partyhat
+      slug: purple-partyhat
+      relationship: product
+      description: "One of six partyhat colours obtainable from pulling a cracker"
+  about: "The Christmas cracker is a rare holiday item introduced in December 2001 during the Christmas event. When pulled between two players, both players now receive rewards, choosing a partyhat (red, yellow, white, green, blue, or purple) plus a secondary item such as chocolate, runes, ore, or daggers. Its single-event distribution makes it one of the most valuable tradeable items in the game."
+  market_strategy:
+    notes:
+      - "One-time 2001 holiday distribution makes supply fixed"
+      - "Pulled crackers are consumed and removed from circulation permanently"
+      - "Considered a status symbol comparable to the rarest discontinued items"
+  trading_tips:
+    - "Trade carefully via trusted middlemen due to scam risk on high-value rares"
+    - "Track partyhat price trends since cracker value tracks the underlying hat market"
+    - "Long-term holders typically use crackers as an inflation hedge against partyhat decay"
+  history:
+    - date: "2001-12-24"
+      description: "Christmas cracker released as the original 2001 Christmas event reward."
+    - date: "2024-05-01"
+      description: "Both players now receive rewards when a cracker is pulled."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/climbing-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/climbing-boots.mdx
@@ -12,8 +12,34 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 200
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: leather
+    tier: low
+  properties:
+    release_date: "9 August 2004"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.34
+    requirements:
+      quest: "Death Plateau"
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,58 +57,33 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements: {}
-    weight: 0.34
+  shops:
+    - shop_name: Tenzing's House
+      location: Death Plateau
+      price: 12
+      currency: coins
+      stock: 5
   related_items:
-    - item_id: 4131
-      item_name: Rune boots
+    - item_name: Rune boots
       slug: rune-boots
       relationship: alternative
-      description: Same strength bonus, higher defence
-    - item_id: 11840
-      item_name: Dragon boots
+      description: "Same strength bonus, higher defence with 40 Defence requirement"
+    - item_name: Dragon boots
       slug: dragon-boots
       relationship: upgrade
-      description: +4 Strength boots
-  about: |-
-    | Defence | Value |
-    |---------|-------|
-    | Slash | +2 |
-    | Crush | +2 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +2 |
-
-    Requirements: Death Plateau quest | Weight: 0.34 kg
-
-    The +2 Strength bonus with zero combat requirements makes climbing boots one of the most efficient items in the game:
-    - Available immediately after Death Plateau (no combat stats needed)
-    - Same Strength bonus as rune boots (which require 40 Defence)
-    - Only 12 coins from the shop
-    - No negative bonuses of any kind
-
-    | Boots | Str Bonus | Def Req | Approx Cost |
-    |-------|-----------|---------|-------------|
-    | Climbing boots | +2 | None | 12 GP |
-    | Rune boots | +2 | 40 Def | ~7K GP |
-    | Dragon boots | +4 | 60 Def | ~200K GP |
-    | Primordial boots | +5 | 75 Def | ~25M GP |
-
-    Climbing boots match rune boots for Strength — making them best-in-slot for any account without 60 Defence.
-
-    Essential for 1 Defence pures and low-Defence builds:
-    - +2 Strength with no Defence requirement
-    - Negligible cost (12 coins)
-    - Lightweight (0.34 kg)
-    - No quest combat requirements to complete Death Plateau
+      description: "+4 strength boots requiring 60 Defence"
+  about: "Climbing boots provide +2 strength with no combat requirement, making them best-in-slot for pures and a near-free upgrade from Tenzing after Death Plateau."
   market_strategy:
     notes:
-      - Buy from Tenzing for 12 coins (functionally free)
-      - GE price inflated above shop price
-      - Essential pure/zerker item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy from Tenzing at 12 coins for effectively free supply"
+      - "Grand Exchange price inflated above shop price by quest barrier"
+      - "Essential pure/zerker staple keeps demand steady"
+  trading_tips:
+    - "Stock from Tenzing during Death Plateau completion for instant resale"
+    - "Match rune boots for strength without a 40 Defence requirement"
+  history:
+    - date: "9 August 2004"
+      description: "Released with the Death Plateau quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/clothes-pouch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/clothes-pouch.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Clothes pouch is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: leather
+    tier: mid
+  properties:
+    release_date: "2023-06-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options: ["Open", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 50
+      xp: 0
+      materials:
+        - item_name: Clothes pouch blueprint
+          quantity: 1
+        - item_name: Leather
+          quantity: 1
+        - item_name: Thread
+          quantity: 1
+      tools: ["Needle"]
+      output_quantity: 1
+  related_items:
+    - item_name: Clothes pouch blueprint
+      slug: clothes-pouch-blueprint
+      relationship: component
+      description: "Blueprint required to craft the pouch"
+    - item_name: Lumberjack outfit
+      slug: lumberjack-outfit
+      relationship: alternative
+      description: "Outfit pieces the pouch can store for woodcutting XP bonus"
+    - item_name: Forestry kit
+      slug: forestry-kit
+      relationship: upgrade
+      description: "Pouch attaches to the kit for unified storage"
+  about: |-
+    > *"A pouch for your dirty work clothes!"*
+
+    Forestry storage pouch unlocked during the Forestry update. Crafted with a clothes pouch blueprint, leather, thread and a needle at 50 Crafting. Attaches to a Forestry kit or basket, storing Lumberjack or Forestry outfit pieces so the wearer still receives the woodcutting XP bonus without occupying gear slots. Players with 99 Woodcutting can additionally store cape pouches.
+  market_strategy:
+    notes:
+      - "No GE buy limit — pouch is craft-on-demand"
+      - "Demand spikes alongside Forestry events and Woodcutting training pushes"
+      - "Blueprint and leather costs determine the price floor"
+  trading_tips:
+    - "Cross-check blueprint price before flipping — blueprint is the bottleneck input"
+    - "Watch Wintertodt and Forestry event cycles for demand spikes"
+  history:
+    - date: "2023-06-28"
+      description: "Released with Forestry: The Way of the Forester - Part One"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-bracelet-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-bracelet-4.mdx
@@ -12,9 +12,35 @@ osrs:
   lowalch: 8416
   highalch: 12624
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: jewellery
+    tier: mid
+  properties:
+    release_date: "30 April 2007"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Rub
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
+    weapon_type: null
+    attack_speed: null
     weight: 0.007
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,72 +58,51 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  charges:
-    current: 4
-    max: 6
-    recharge: Legends' Guild or Fountain of Rune
-  special_effect:
-    name: Combat Bracelet Teleport
-    description: Teleports to Warriors' Guild, Champions' Guild, Monastery, Ranging Guild
-    triggers: on_use
+  passive_effects:
+    - name: Combat Bracelet Teleport
+      description: "Teleports the wearer to Warriors' Guild, Champions' Guild, Edgeville Monastery, or Ranging Guild; consumes one of 4 charges per use, recharge to 4 at Legends'/Myths' Guild or to 6 at the Fountain of Rune."
   recipes:
     - skill: magic
-      level: 63
-      xp: 67
-      spell: Lvl-4 Enchant
+      level: 68
+      xp: 78
       materials:
         - item_name: Dragonstone bracelet
-          item_id: 11126
           quantity: 1
         - item_name: Cosmic rune
-          item_id: 564
           quantity: 1
+        - item_name: Water rune
+          quantity: 15
         - item_name: Earth rune
-          item_id: 557
-          quantity: 10
-      members_only: true
+          quantity: 15
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 11126
-      item_name: Combat bracelet (uncharged)
+    - item_name: Combat bracelet (uncharged)
       slug: combat-bracelet
       relationship: variant
-      description: Uncharged version
-    - item_id: 11972
-      item_name: Combat bracelet(6)
+      description: "Uncharged version with no teleport charges"
+    - item_name: Combat bracelet(6)
       slug: combat-bracelet-6
       relationship: variant
-      description: Fully charged version
-    - item_id: 7462
-      item_name: Barrows gloves
+      description: "Fountain of Rune fully charged version"
+    - item_name: Barrows gloves
       slug: barrows-gloves
       relationship: upgrade
-      description: Best-in-slot gloves
-  about: |-
-    No combat bonuses - utility item for teleportation.
-
-    - Warriors' Guild
-    - Champions' Guild
-    - Monastery (Edgeville)
-    - Ranging Guild
-
-    | State | Charges |
-    |-------|---------|
-    | Current | 4 |
-    | Maximum | 6 (Fountain of Rune) |
+      description: "Best-in-slot melee gloves"
+  about: "Combat bracelet(4) is a teleport utility bracelet with 4 charges to four combat training guilds, made by enchanting a dragonstone bracelet."
   market_strategy:
     notes:
-      - Useful teleport locations
-      - Warriors' Guild access popular
-      - Combat training teleports
-      - Warriors' Guild access
-      - Combat training
-      - Ranging Guild teleport
-      - Quest requirements
-      - Recharge at Legends' Guild or Fountain of Rune
-      - Useful for defenders farming
-      - Ranging Guild teleport saves time
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Useful teleport coverage for Warriors' Guild defender farming and Ranging Guild"
+      - "Recharge path determines price spread between (4) and (6) variants"
+      - "Demand stable across mid-game combat training"
+  trading_tips:
+    - "Recharge at Fountain of Rune to flip into the (6) variant"
+    - "Track dragonstone bracelet + Lvl-5 Enchant cost as the production floor"
+  history:
+    - date: "30 April 2007"
+      description: "Released alongside the Fremennik Isles update."
+    - date: "2015"
+      description: "Partially charged bracelets became untradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-4.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 2000
-  about: "Combat potion(4) is a members-only item in Old School RuneScape. High alchemy value: 129 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - "Drink"
+      - "Empty"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Attack by 10% of current level plus 3."
+        duration: 60
+      - description: "Boosts Strength by 10% of current level plus 3."
+        duration: 60
+  recipes:
+    - skill: herblore
+      level: 36
+      xp: 84
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Goat horn dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Combat potion(3)
+      slug: combat-potion-3
+      relationship: downgrade
+      description: Three-dose form, drops one charge after a sip
+    - item_name: Combat potion(2)
+      slug: combat-potion-2
+      relationship: downgrade
+      description: Two-dose form
+    - item_name: Combat potion(1)
+      slug: combat-potion-1
+      relationship: downgrade
+      description: Single dose, decants from any higher-dose vial
+    - item_name: Super combat potion(4)
+      slug: super-combat-potion-4
+      relationship: upgrade
+      description: Stronger PvM successor adding Defence and using torstol
+  about: "Combat potion(4) hands out four sips that each grant +3 plus 10 percent to Attack and Strength, decaying by one point per minute (or every 90 seconds under the Preserve prayer)."
+  market_strategy:
+    notes:
+      - "Herblore-loss item: ingredient cost typically exceeds the GE price."
+      - "Most demand comes from low-level slayer accounts skipping super combats."
+  trading_tips:
+    - "Decant calculators: check whether (4) vs (3) is the cheaper per-dose buy."
+    - "Quest-grinding accounts move these in bulk near Waterfall and Vampyre Slayer runs."
+  history:
+    - date: "2006-10-18"
+      description: Added with the original Harralander potion lineup.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/confliction-gauntlets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/confliction-gauntlets.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 160000
   highalch: 240000
   limit: null
-  about: "Confliction gauntlets is a members-only item in Old School RuneScape. High alchemy value: 240,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: magic-armour
+    tier: high
+  properties:
+    release_date: "2025-07-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Inspect
+      - Drop
+    worn_options:
+      - Remove
+      - Inspect
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.226
+    requirements:
+      hitpoints: 90
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 20
+      ranged: -4
+    defence_bonus:
+      stab: 15
+      slash: 18
+      crush: 7
+      magic: 5
+      ranged: 5
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 7
+      prayer: 2
+  recipes:
+    - skill: crafting
+      level: 83
+      xp: 0
+      materials:
+        - item_name: Tormented bracelet
+          quantity: 1
+        - item_name: Mokhaiotl cloth
+          quantity: 1
+        - item_name: Demon tear
+          quantity: 10000
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Conflicted Strike
+      description: "On a missed magic attack with a one-handed weapon, the next attack against the same target rolls accuracy twice, dramatically improving hit chance at low accuracy"
+  related_items:
+    - item_name: Tormented bracelet
+      slug: tormented-bracelet
+      relationship: component
+      description: "Base item upgraded with mokhaiotl cloth and demon tears to create Confliction gauntlets"
+    - item_name: Mokhaiotl cloth
+      slug: mokhaiotl-cloth
+      relationship: component
+      description: "Untradeable boss drop required to craft Confliction gauntlets"
+  about: "Confliction gauntlets are a high-tier magic hand slot upgrade released in July 2025, requiring 90 Hitpoints to wear and 83 Crafting + 70 Smithing to create. They preserve the Tormented bracelet's +20 magic attack and +7% magic damage while adding meaningful melee, magic, and ranged defence and a +2 prayer bonus. The passive effect re-rolls accuracy on the attack following a missed magic hit, smoothing damage output at lower accuracy levels."
+  market_strategy:
+    notes:
+      - "Demand is concentrated in late-game magic content where the passive re-roll is most impactful"
+      - "Supply is gated by Mokhaiotl cloth (untradeable boss drop) — limited Ironmen cannot create extras for the GE"
+      - "Irreversible creation removes Tormented bracelet supply from circulation when these are made"
+  trading_tips:
+    - "Track Tormented bracelet price as a floor input; the gauntlet price should hold above bracelet + cloth value"
+    - "Watch boss attendance for Mokhaiotl: high clears = more cloth = more gauntlet supply"
+    - "Late-game magic meta changes (Tumeken's shadow, Sang staff balance) move this item more than typical updates"
+  history:
+    - date: "2025-07-23"
+      description: "Released as part of the Mokhaiotl boss content, providing the first true upgrade over the Tormented bracelet in the magic hand slot"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-hot-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-hot-water.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 13000
-  about: "Cup of hot water is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: consumable_intermediate
+    tier: low
+  properties:
+    release_date: "28 February 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Cup of water
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  related_items:
+    - item_name: Cup of water
+      slug: cup-of-water
+      relationship: component
+      description: "Base item heated to make hot water"
+    - item_name: Bowl of hot water
+      slug: bowl-of-hot-water
+      relationship: alternative
+      description: "Bowl-based alternative ingredient"
+    - item_name: Guthix rest (4)
+      slug: guthix-rest-4
+      relationship: product
+      description: "Tea brewed using cup of hot water"
+  about: |-
+    > *"It's hot!"*
+
+    The cup of hot water is an intermediary item used to brew Guthix rest potions and various herb teas (Herblore 14-59). Created by heating a cup of water on a fire or range, or combining a bowl of hot water with an empty cup.
+  market_strategy:
+    notes:
+      - "Pure utility item for Herblore tea recipes"
+      - "High GE limit (13,000) suits bulk traders"
+      - "Low margin per unit; profit is volume-driven"
+  trading_tips:
+    - "Profitable to make at scale by heating cups of water"
+    - "Watch herb tea / Guthix rest demand for spikes"
+  history:
+    - date: "28 February 2005"
+      description: "Released as part of the One Small Favour update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/defence-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/defence-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Defence mix(1) | OSRS Price Data
-description: "Defence mix(1): One dose of fishy Defence potion.. High alch: 36 GP, GE limit: 2,000."
+description: "Defence mix(1) is a 1-dose barbarian defence potion that also restores hitpoints. High alch: 36 GP, GE limit: 2,000."
 osrs:
   id: 11459
   name: Defence mix(1)
@@ -12,9 +12,78 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 2000
-  about: "Defence mix(1) is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Defence by floor(level / 10) + 3"
+        duration: 0
+      - description: "Restores 6 Hitpoints per dose"
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 33
+      xp: 25
+      materials:
+        - item_name: Defence potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Defence mix(2)
+      slug: defence-mix-2
+      relationship: variant
+      description: "Two-dose version of the mix"
+    - item_name: Defence potion(2)
+      slug: defence-potion-2
+      relationship: component
+      description: "Base potion mixed with caviar to create defence mix"
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: "Barbarian herblore mixing ingredient"
+    - item_name: Defence potion(1)
+      slug: defence-potion-1
+      relationship: alternative
+      description: "Standard 1-dose defence potion without HP restore"
+  about: |-
+    Defence mix(1) is the single-dose form of the barbarian herblore Defence mix, a hybrid potion that pairs a defence boost of floor(level / 10) + 3 with 6 Hitpoints restored per dose. It is made by combining a Defence potion(2) with caviar at level 33 Herblore for 25 XP.
+
+    Like all barbarian mixes, the potion requires the Barbarian Training subquest sections to be available, and the dual-effect makes it convenient for low-tier slayer or combat tasks where free healing is welcome.
+  market_strategy:
+    notes:
+      - "Low-volume barbarian mix — small flips only"
+      - "Per-dose value usually trails the (2) form's per-dose cost"
+      - "Caviar supply spikes can compress margins"
+  trading_tips:
+    - "Compare defence mix(1) and (2) prices per dose before listing"
+    - "Stockpile caviar during Barbarian Fishing surges to lock in cheaper potions"
+  history:
+    - date: "2007-07-03"
+      description: "Released as part of the Barbarian Training herblore mixes."
+    - date: "2016-04-15"
+      description: "Half-full potions made convertible to bank placeholders."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/devout-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/devout-boots.mdx
@@ -12,79 +12,96 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: prayer-armour
+    tier: high
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Dismantle
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
-    type: prayer
+    weapon_type: null
+    attack_speed: null
+    weight: 0.5
     requirements:
       prayer: 60
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
-  creation:
-    base_item_id: 12598
-    base_item_name: Holy sandals
-    component_id: 22941
-    component_name: Drake's tooth
   drop_table:
     sources:
-      - source: Drakes
-        source_id: 8612
-        combat_level: 192
-        quantity: 1 (Drake's tooth)
-        rarity: Rare
-        drop_rate: 1/512
-        members_only: true
+      - source: "Drake (84 Slayer) — drops Drake's tooth (component)"
+        quantity: "1"
+        rarity: "1/512"
+  recipes:
+    - skill: crafting
+      level: 60
+      xp: 0
+      materials:
+        - item_name: Holy sandals
+          quantity: 1
+        - item_name: Drake's tooth
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 12598
-      item_name: Holy sandals
+    - item_name: Holy sandals
       slug: holy-sandals
       relationship: component
-      description: Base item
-    - item_id: 22941
-      item_name: Drake's tooth
+      description: "Base item combined with Drake's tooth to create Devout boots"
+    - item_name: Drake's tooth
       slug: drakes-tooth
       relationship: component
-      description: Upgrade component
-    - item_id: 9672
-      item_name: Proselyte cuisse
+      description: "Upgrade component dropped by Drakes (84 Slayer requirement)"
+    - item_name: Proselyte cuisse
       slug: proselyte-cuisse
       relationship: alternative
-      description: Prayer gear
-  about: |-
-    Combine Holy sandals + Drake's tooth.
-
-    | Component | Source |
-    |-----------|--------|
-    | Holy sandals | Treasure Trails (medium) |
-    | Drake's tooth | Drakes (84 Slayer) |
-
-    | Offense | Value |
-    |---------|-------|
-    | All | +0 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +5 |
-
-    Requirements: 60 Prayer
-
-    BiS prayer bonus boots for:
-    - Prayer training
-    - Proselyte setups
-    - Protection prayer content
-    - GWD (counts as Saradomin)
-
-    Best prayer bonus in the feet slot.
+      description: "Alternative prayer-bonus leg gear used in the same Saradomin-aligned setups"
+  about: "Devout boots are the best-in-slot prayer bonus boots in the feet slot at +5 prayer. They are made by combining Holy sandals (a medium clue scroll reward) with a Drake's tooth from Drakes in the Karuulm Slayer Dungeon. They count as a Saradomin item for God Wars Dungeon entry and Bandit Camp aggression, and since the dismantle update they can be reverted into the component parts."
   market_strategy:
     notes:
-      - Drake's tooth from Drakes
-      - Best prayer boots
-      - Saradomin item for GWD
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand is driven by Prayer flicking content (CoX, ToB, GWD, slayer bosses) where the +5 prayer bonus enables longer trips"
+      - "Supply is gated by the Drake's tooth drop rate (1/512) and by Holy sandals supply from medium clues — both inputs are slow"
+      - "Dismantle option (Jan 2026) added a price floor close to the sum of components, reducing downside risk"
+  trading_tips:
+    - "Compare GE price vs cost of Holy sandals + Drake's tooth: if the sandals + tooth combined cost is lower than the boots, flip by crafting"
+    - "Watch prayer-content updates (CoX, ToB rebalances): rising attendance lifts demand for Devout boots"
+    - "Buy limit is 70 per 4 hours; large flips need multiple cycles"
+  history:
+    - date: "2019-01-10"
+      description: "Released alongside the Karuulm Slayer Dungeon and Drakes, providing the first feet slot with +5 prayer bonus"
+    - date: "2026-01-28"
+      description: "Added a Dismantle option to convert Devout boots back into Holy sandals and a Drake's tooth"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-bastion-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-bastion-potion-1.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 2000
-  about: "Divine bastion potion(1) is a members-only item in Old School RuneScape. High alchemy value: 108 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2020-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Ranged by 4 plus 10% of player Ranged level and Defence by 5 plus 15% of player Defence level for the full duration"
+        duration: 300
+      - description: "Prevents the boosted Ranged and Defence stats from draining below the boost amount during the duration"
+        duration: 300
+      - description: "Costs 10 Hitpoints on drink and requires at least 11 Hitpoints to consume"
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 86
+      xp: 0.5
+      materials:
+        - item_name: Bastion potion(1)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Bastion potion(1)
+      slug: bastion-potion-1
+      relationship: component
+      description: "Base potion combined with crystal dust to produce the divine variant"
+    - item_name: Divine bastion potion(2)
+      slug: divine-bastion-potion-2
+      relationship: variant
+      description: "Two dose variant of the same potion"
+    - item_name: Divine bastion potion(3)
+      slug: divine-bastion-potion-3
+      relationship: variant
+      description: "Three dose variant of the same potion"
+    - item_name: Divine bastion potion(4)
+      slug: divine-bastion-potion-4
+      relationship: variant
+      description: "Four dose variant of the same potion"
+    - item_name: Divine ranging potion(1)
+      slug: divine-ranging-potion-1
+      relationship: alternative
+      description: "Ranged-only divine boost without the defence component"
+  about: "Divine bastion potion(1) is a members-only single-dose herblore potion that combines a ranged and defence boost while preventing the stats from draining for five minutes. The potion share spell cannot distribute its effect."
+  market_strategy:
+    notes:
+      - "Made by combining bastion potion(1) with crystal dust at 86 Herblore."
+      - "Demand is driven by Bandos, Corp, and Inferno setups where divine drain prevention is critical."
+      - "Crystal dust supply from Prifddinas crystal shard conversions sets the input cost."
+  trading_tips:
+    - "Stockpile crystal shards during Zalcano dry spells for cheaper inputs"
+    - "Sell to ranged PvM accounts before weekend boss raids"
+  history:
+    - date: "2020-07-02"
+      description: "Icon graphically updated"
+    - date: "2020-04-30"
+      description: "Released with the Divine Potions update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/double-eye-patch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/double-eye-patch.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Double eye patch is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.006
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Eye patch
+      slug: eye-patch
+      relationship: variant
+      description: "Single-eye version sewn together to form this item"
+    - item_name: Book o' piracy
+      slug: book-o-piracy
+      relationship: component
+      description: "Required in inventory when paying Patchy to combine eye patches"
+  about: |-
+    The double eye patch is a cosmetic head slot item created by paying Patchy 500 coins to stitch a left eye patch with a right eye patch. Requires Cabin Fever quest completion and a book o' piracy in inventory.
+
+    Purely cosmetic with no combat bonuses, but can be stored in the costume room mahogany treasure chest at master tier.
+  market_strategy:
+    notes:
+      - "Pure cosmetic, no PvM demand"
+      - "Costume room storage drives modest collector demand"
+      - "Cabin Fever quest gate limits supply"
+  trading_tips:
+    - "Best to flip during Halloween/pirate-themed events"
+    - "Low GE limit (4): bulk reselling not viable"
+  history:
+    - date: "2016-07-06"
+      description: "Released with the Cabin Fever quest expansion patch update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bolts-p-21928.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bolts-p-21928.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 176
   highalch: 264
   limit: 11000
-  about: "Dragon bolts (p++) is a members-only item in Old School RuneScape. High alchemy value: 264 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: null
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 64
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 122
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Dragon bolts
+          quantity: 5
+        - item_name: Weapon poison(++)
+          quantity: 1
+      tools: []
+      output_quantity: 5
+  related_items:
+    - item_name: Dragon bolts
+      slug: dragon-bolts
+      relationship: component
+      description: "Unpoisoned base bolt used to craft this variant"
+    - item_name: Dragon bolts (p)
+      slug: dragon-bolts-p
+      relationship: variant
+      description: "Standard weapon poison variant"
+    - item_name: Dragon bolts (p+)
+      slug: dragon-bolts-p-plus
+      relationship: variant
+      description: "Weapon poison(+) variant with stronger poison damage"
+    - item_name: Weapon poison(++)
+      slug: weapon-poison-plus-plus
+      relationship: component
+      description: "Poison applied to dragon bolts to create the (p++) variant"
+  about: |-
+    Dragon bolts (p++) are the strongest poisoned variant of dragon bolts in OSRS, produced by applying Weapon poison(++) to five regular dragon bolts. They require 64 Ranged to fire and provide a +122 ranged strength bonus, identical to unpoisoned dragon bolts.
+
+    The poison effect can deal up to 6 damage per tick on a successful poison roll, making (p++) bolts attractive for sustained ranged combat where the extra damage matters. They cannot be enchanted with the Magic spellbook tipping spells.
+  market_strategy:
+    notes:
+      - "Per-bolt cost is mostly driven by Weapon poison(++) supply"
+      - "Demand is steady from players running ranged content where poison ticks add up"
+      - "Stack size of 11,000 makes them well suited for bulk flips"
+  history:
+    - date: "2018-01-04"
+      description: "Released as part of the Dragon Slayer II update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bolts.mdx
@@ -12,76 +12,86 @@ osrs:
   lowalch: 170
   highalch: 255
   limit: 11000
-  ammunition:
-    type: bolt
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammunition
+    weapon_type: bolt
+    attack_speed: null
     weight: 0
     requirements:
       ranged: 64
-    stats:
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 122
-  creation:
-    method: Fletching
-    requirements:
-      fletching: 84
-    materials:
-      - item_name: Dragon bolts (unfinished)
-        quantity: "10"
-      - item_name: Feathers
-        quantity: "10"
-    xp: 12
-    notes: Per bolt
-  variants:
-    - name: Dragon bolts (p)
-      effect: Basic poison
-    - name: Dragon bolts (p+)
-      effect: Extra poison
-    - name: Dragon bolts (p++)
-      effect: Super poison
-  notes:
-    - Can be tipped with gem bolt tips and enchanted
-  market:
-    buy_limit: 11000
-    price_estimate: 3500
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 84
+      xp: 12
+      materials:
+        - item_name: Dragon bolts (unf)
+          quantity: 10
+        - item_name: Feather
+          quantity: 10
+      tools: []
+      output_quantity: 10
   related_items:
-    - item_id: 21918
-      item_name: Dragon bolts (unf)
+    - item_name: Dragon bolts (unf)
       slug: dragon-bolts-unf
       relationship: component
-      description: Base item
-    - item_id: 21944
-      item_name: Ruby dragon bolts (e)
+      description: "Unfletched base requiring feathers to finish"
+    - item_name: Ruby dragon bolts (e)
       slug: ruby-dragon-bolts-e
       relationship: variant
-      description: Popular variant
-    - item_id: 21946
-      item_name: Diamond dragon bolts (e)
+      description: "Enchanted tip with the Blood Forfeit effect"
+    - item_name: Diamond dragon bolts (e)
       slug: diamond-dragon-bolts-e
       relationship: variant
-      description: Popular variant
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-    | Requirements | 64 Ranged |
-
-    | Stat | Bonus |
-    |------|-------|
-    | Ranged strength | +122 |
-
-    | Type | Effect |
-    |------|--------|
-    | Dragon bolts (p) | Basic poison |
-    | Dragon bolts (p+) | Extra poison |
-    | Dragon bolts (p++) | Super poison |
-
-    Can be tipped with gem bolt tips and enchanted.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Enchanted tip with the Armour Piercing effect"
+  about: "Dragon bolts are the second-strongest non-enchanted bolts in OSRS, sitting just below dragonstone dragon bolts (e). They require 64 Ranged and only fire from the dragon, Armadyl, dragon hunter and Zaryte crossbows. Players almost always tip and enchant them rather than firing the plain version."
+  market_strategy:
+    notes:
+      - "Plain dragon bolts are a fletching ingredient market - prices track tipped bolt demand."
+      - "Enchanted variants (ruby (e), diamond (e)) absorb most end-game PvM consumption."
+  trading_tips:
+    - "Buy unf + feathers when the gap to assembled bolts opens up."
+    - "Watch raids and PvP meta updates: ruby bolt (e) rallies pull this up."
+  history:
+    - date: "2018-01-04"
+      description: "Released as part of the Dragon Slayer II update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-platebody-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-platebody-ornament-kit.mdx
@@ -12,60 +12,61 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
     type: ornament_kit
+    tier: high
+  properties:
+    release_date: "25 January 2018"
     tradeable: true
-    target_item: Dragon platebody
-    target_id: 21892
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Master
-        drop_rate: Rare from reward casket
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: "Reward casket (master)"
+        quantity: "1"
+        rarity: "1/12,765"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
   related_items:
-    - item_id: 21892
-      item_name: Dragon platebody
+    - item_name: Dragon platebody
       slug: dragon-platebody
-      relationship: product
-      description: Base item to upgrade
-    - item_id: 22242
-      item_name: Dragon platebody (or)
+      relationship: component
+      description: "Base item the kit attaches to"
+    - item_name: Dragon platebody (or)
       slug: dragon-platebody-or
       relationship: product
-      description: Ornamented version
+      description: "Ornamented cosmetic variant"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ornament Kit |
-    | Target | Dragon platebody |
-    | Tradeable | Yes |
+    > *"Use on a dragon platebody to make it look fancier!"*
 
-    Use on a Dragon platebody to create a Dragon platebody (or).
-
-    The ornament kit:
-    - Adds gold trim to the platebody
-    - Purely cosmetic change
-    - Does not affect stats
-    - Can be reverted
-
-    Materials:
-    - Dragon platebody
-    - Dragon platebody ornament kit
-
-    Result:
-    - Dragon platebody (or) - gold trimmed version
-
-    The ornamented platebody can be reverted to return:
-    - Dragon platebody
-    - Dragon platebody ornament kit
+    The Dragon platebody ornament kit is a Master clue reward used on a Dragon platebody to create the cosmetic Dragon platebody (or). The ornamented platebody becomes untradeable but can be dismantled to recover both the platebody and the kit.
   market_strategy:
     notes:
-      - Master clue exclusive
-      - Cosmetic upgrade only
-      - Prestigious fashionscape item
-      - Collection log item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Master clue exclusive"
+      - "Cosmetic upgrade only"
+      - "Prestigious fashionscape item"
+      - "Collection log item"
+  trading_tips:
+    - "Supply tied to Master clue completion rates"
+    - "Low GE limit (4) means thin daily liquidity"
+    - "Hold during fashionscape hype windows for premium"
+  history:
+    - date: "25 January 2018"
+      description: "Released as part of the Master Clue Scrolls update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonbone-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonbone-necklace.mdx
@@ -12,83 +12,80 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bone
+    tier: high
+  properties:
+    release_date: "4 January 2018"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: necklace
-    tradeable: true
+    weapon_type: null
+    attack_speed: null
     weight: 0.005
     requirements:
       prayer: 70
-    stats:
-      attack_stab: 10
-      attack_slash: 10
-      attack_crush: 10
-      attack_magic: 10
-      attack_ranged: 10
-      strength: 2
-      defence_all: 2
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 2
+      slash: 2
+      crush: 2
+      magic: 2
+      ranged: 2
+    other_bonus:
+      melee_strength: 2
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 12
-  special_effect:
-    name: Prayer Restoration
-    trigger: Burying bones
-    works_with_bonecrusher: true
-    points_per_bone: 1-5 based on type
+  passive_effects:
+    - name: Prayer Restoration on Bury
+      description: "Restores 1-5 Prayer points when bones are buried; stacks with bonecrusher but not with Catacombs of Kourend or demonic ash scattering."
   drop_table:
     sources:
       - source: Vorkath
-        rate: 1/1,000
-  market:
-    buy_limit: 8
-    price_estimate: 101000
+        quantity: "1"
+        rarity: "1/1,000"
   related_items:
-    - item_id: 22115
-      item_name: Bonecrusher necklace
+    - item_name: Bonecrusher necklace
       slug: bonecrusher-necklace
       relationship: upgrade
-      description: Upgrade
-    - item_id: 13116
-      item_name: Bonecrusher
+      description: "Combined with bonecrusher and hydra tail"
+    - item_name: Bonecrusher
       slug: bonecrusher
       relationship: alternative
-      description: Auto-crush bones
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +10 |
-    | Ranged | +10 |
-    | Strength | +2 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +2 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +12 |
-
-    Requirements: 70 Prayer
-
-    Prayer Restoration:
-    - Restores prayer when burying bones
-    - Works with bonecrusher
-    - 1-5 points per bone based on type
-
-    Great for:
-    - Slayer with bonecrusher
-    - Catacombs of Kourend
-    - Any bone-drop content
-
-    Best prayer necklace for slayer.
+      description: "Auto-crush bones component"
+  about: "Dragonbone necklace is a 70 Prayer neck slot drop from Vorkath that restores prayer on bone bury and offers the highest prayer bonus available."
   market_strategy:
     notes:
-      - From Vorkath
-      - Combine into bonecrusher necklace
-      - DS2 required for Vorkath
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply gated by Vorkath kill rate at 1/1,000"
+      - "Combine path into bonecrusher necklace drains GE float quickly"
+      - "Dragon Slayer II is a hard requirement for the only source"
+  trading_tips:
+    - "Use with bonecrusher on bone-heavy Slayer tasks for full prayer recovery"
+    - "Buy limit of 8 makes stocking for combining a multi-cycle play"
+  history:
+    - date: "4 January 2018"
+      description: "Released with the Dragon Slayer II quest update as a Vorkath drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone.mdx
@@ -12,128 +12,129 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   material:
     type: gem
     tier: high
-  crafting:
-    cutting_level: 55
-    cutting_xp: 137.5
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: crafting
       level: 55
       xp: 100
       materials:
         - item_name: Dragonstone
-          item_id: 1615
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Dragonstone ring
-      product_id: 1645
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
+      tools: ["Furnace", "Ring mould"]
+      output_quantity: 1
     - skill: crafting
       level: 72
       xp: 105
       materials:
         - item_name: Dragonstone
-          item_id: 1615
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Dragon necklace
-      product_id: 1664
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
-    - skill: crafting
-      level: 80
-      xp: 150
-      materials:
-        - item_name: Dragonstone
-          item_id: 1615
-          quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Dragonstone amulet (u)
-      product_id: 1673
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
+      tools: ["Furnace", "Necklace mould"]
+      output_quantity: 1
     - skill: crafting
       level: 74
       xp: 110
       materials:
         - item_name: Dragonstone
-          item_id: 1615
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Dragonstone bracelet
-      product_id: 11115
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
+      tools: ["Furnace", "Bracelet mould"]
+      output_quantity: 1
     - skill: crafting
+      level: 80
+      xp: 150
+      materials:
+        - item_name: Dragonstone
+          quantity: 1
+        - item_name: Gold bar
+          quantity: 1
+      tools: ["Furnace", "Amulet mould"]
+      output_quantity: 1
+    - skill: fletching
       level: 71
       xp: 8.2
       materials:
         - item_name: Dragonstone
-          item_id: 1615
           quantity: 1
-      product: Dragonstone bolt tips
-      product_id: 9193
-      product_quantity: 12
-      facility: Chisel
-      members_only: true
+      tools: ["Chisel"]
+      output_quantity: 12
+  drop_table:
+    sources:
+      - source: Dragon impling jar
+        quantity: "1"
+        rarity: 1/19
+      - source: Crystal impling jar
+        quantity: "1"
+        rarity: 1/18
+      - source: Rune dragon
+        quantity: "1"
+        rarity: 7/127
+      - source: Vorkath (post-quest)
+        quantity: "1"
+        rarity: 3/150
   related_items:
-    - item_id: 1631
-      item_name: Uncut dragonstone
+    - item_name: Uncut dragonstone
       slug: uncut-dragonstone
       relationship: component
-      description: Raw gem
-    - item_id: 1712
-      item_name: Amulet of glory
+      description: "Raw gem cut at 55 Crafting"
+    - item_name: Amulet of glory
       slug: amulet-of-glory
       relationship: product
-      description: Main product
-    - item_id: 2572
-      item_name: Ring of wealth
+      description: "Best-in-slot hybrid amulet crafted from this gem"
+    - item_name: Ring of wealth
       slug: ring-of-wealth
       relationship: product
-      description: Ring product
-    - item_id: 11118
-      item_name: Combat bracelet
+      description: "Drop-rate ring enchanted from a dragonstone ring"
+    - item_name: Combat bracelet
       slug: combat-bracelet
       relationship: product
-      description: Bracelet product
+      description: "Combat skill teleport bracelet enchanted from a dragonstone bracelet"
+    - item_name: Dragonstone bolt tips
+      slug: dragonstone-bolt-tips
+      relationship: product
+      description: "Fletched 12 at a time from a single dragonstone"
   about: |-
-    | Item | Effect |
-    |------|--------|
-    | Ring of wealth | Improved rare drops |
-    | Skills necklace | Skill teleports |
-    | Amulet of glory | Best-in-slot hybrid |
-    | Combat bracelet | Combat teleports |
+    > *"This looks valuable."*
+
+    High-tier cut gem and the workhorse input for dragonstone jewellery. Cut from uncut dragonstone at 55 Crafting (137.5 XP). Used to make: dragonstone ring (55, 100 XP), dragon necklace (72, 105 XP), dragonstone bracelet (74, 110 XP), and dragonstone amulet (u) (80, 150 XP) at a furnace with the matching mould; 12 dragonstone bolt tips can be chiselled at 71 Fletching for 8.2 XP. Downstream enchants produce ring of wealth, combat bracelet, skills necklace, and amulet of glory.
   market_strategy:
     notes:
-      - Glory amulet production
-      - Ring of wealth crafting
-      - Combat bracelet crafting
-      - Amulet of glory
-      - Ring of wealth
-      - Combat bracelet
-      - Dragon bolts (e)
-      - Crystal chest supplies market
-      - Cut from uncut version
-      - High volume enchanting
-      - Good Crafting XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand driven by amulet of glory and ring of wealth crafting"
+      - "Combat bracelet and dragon bolts (e) absorb steady volume"
+      - "Crystal chest and impling supplies are the main supply taps"
+      - "Cut-from-uncut margin tracks the gold bar + gem spread"
+      - "High volume enchanting keeps GE turnover healthy"
+      - "Strong Crafting XP per gem at the higher jewellery tiers"
+  trading_tips:
+    - "Watch the uncut-to-cut spread for risk-free Crafting flips"
+    - "Pair purchases with gold bars to skip a step on jewellery batches"
+    - "Bolt-tip fletching scales with dragon bolts (e) demand during PvM patches"
+  history:
+    - date: "2002-02-27"
+      description: "Added to the game as the highest-tier standard gem"
+    - date: "2014-03-27"
+      description: "Dragonstone jewellery became rechargeable at the Fountain of Rune"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/earth-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/earth-orb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Earth orb | OSRS Price Data
-description: "Earth orb: A magic glowing orb.. High alch: 180 GP, GE limit: 11,000."
+description: "Earth orb: A magic glowing orb. High alch: 180 GP, GE limit: 11,000."
 osrs:
   id: 575
   name: Earth orb
@@ -12,64 +12,90 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 11000
-  item:
-    type: material
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: elemental orb
+    tier: mid
+  properties:
+    release_date: "2002-03-18"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: magic
       level: 60
       xp: 70
       materials:
-        - item_id: 567
-          item_name: Unpowered orb
+        - item_name: Unpowered orb
           quantity: 1
-        - item_id: 557
-          item_name: Earth rune
+        - item_name: Earth rune
           quantity: 30
-        - item_id: 564
-          item_name: Cosmic rune
+        - item_name: Cosmic rune
           quantity: 3
-      product: Earth orb
-      product_id: 575
+      tools: []
+      output_quantity: 1
     - skill: crafting
-      level: 63
-      xp: 100
+      level: 58
+      xp: 112.5
       materials:
-        - item_id: 575
-          item_name: Earth orb
+        - item_name: Earth orb
           quantity: 1
-        - item_id: 1391
-          item_name: Battlestaff
+        - item_name: Battlestaff
           quantity: 1
-      product: Earth battlestaff
-      product_id: 1399
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Abyssal Sire
+        quantity: "1"
+        rarity: Common
+      - source: Araxxor
+        quantity: "1"
+        rarity: Uncommon
+      - source: Earthen Nagua
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - item_id: 567
-      item_name: Unpowered orb
+    - item_name: Unpowered orb
       slug: unpowered-orb
       relationship: component
-      description: Base material for charging
-    - item_id: 1399
-      item_name: Earth battlestaff
+      description: "Base material charged at the Obelisk of Earth"
+    - item_name: Earth battlestaff
       slug: earth-battlestaff
       relationship: product
-      description: Crafted product
-    - item_id: 564
-      item_name: Cosmic rune
+      description: "Crafted by attaching an earth orb to a battlestaff at level 58 Crafting"
+    - item_name: Cosmic rune
       slug: cosmic-rune
       relationship: component
-      description: Required rune for charging
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.453 kg |
-
-    Combine with battlestaff (63 Crafting) to create earth battlestaff.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Required rune for charging unpowered orbs at the Obelisk of Earth"
+    - item_name: Earth rune
+      slug: earth-rune
+      relationship: component
+      description: "30 required to charge each unpowered orb at the Obelisk of Earth"
+  about: "Earth orbs are created by casting Charge Earth Orb at the Obelisk of Earth in the Edgeville Dungeon, requiring 60 Magic. They are most commonly used to craft earth battlestaves with a battlestaff at 58 Crafting, granting 112.5 XP per staff."
+  market_strategy:
+    notes:
+      - "Crafted from unpowered orbs at the Obelisk of Earth (60 Magic)"
+      - "Primary demand comes from earth battlestaff crafting at 58 Crafting"
+      - "Mid-tier elemental orb with steady demand from battlestaff crafters"
+  trading_tips:
+    - "Buy in bulk when prices dip and craft into earth battlestaves for Crafting XP plus profit"
+    - "Watch unpowered orb prices to gauge production cost"
+    - "Battlestaff and cosmic rune prices set the crafting margin"
+  history:
+    - date: "2002-03-18"
+      description: "Earth orb added to the game alongside other elemental orbs."
+    - date: "2020-09-10"
+      description: "Grand Exchange buy limit increased from 10,000 to 11,000."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/earth-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/earth-talisman.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Earth talisman is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: talisman
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.015
+    options:
+      - Locate
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: runecraft
+      level: 1
+      xp: 32.5
+      materials:
+        - item_name: Earth talisman
+          quantity: 1
+        - item_name: Tiara
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Man
+        quantity: "1"
+        rarity: 1/128
+      - source: Farmer
+        quantity: "1"
+        rarity: 1/64
+      - source: Feral Vampyre
+        quantity: "1"
+        rarity: 1/64
+      - source: Earth impling jar
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Earth tiara
+      slug: earth-tiara
+      relationship: product
+      description: "Created by combining the talisman with a tiara on the Earth altar"
+    - item_name: Earth rune
+      slug: earth-rune
+      relationship: product
+      description: "Crafted at the Earth altar using this talisman"
+    - item_name: Mud rune
+      slug: mud-rune
+      relationship: product
+      description: "Members combination rune crafted at the Water altar with this talisman"
+  about: "Earth talisman is a free-to-play talisman that grants access to the Earth Altar for crafting earth runes. It can be combined with a tiara at the altar to produce an earth tiara, freeing an inventory slot during runecrafting runs."
+  market_strategy:
+    notes:
+      - "Bulk supply comes from low-level monster drops and impling hunters."
+      - "Demand is driven by Runecraft training and tiara conversions for ironmen."
+  trading_tips:
+    - "Buy during peak NPC-killing hours when supply spikes."
+    - "Earth talismans see steady but unspectacular demand - small flips compound well."
+  history:
+    - date: "2004-03-29"
+      description: "Released with the Runecraft skill at the RuneScape 2 launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/echo-home-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/echo-home-teleport-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Echo home teleport scroll | OSRS Price Data
-description: "Echo home teleport scroll: A scroll which unlocks the Raging Echoes Home Teleport animation.. High alch: 15,000 GP."
+description: "Echo home teleport scroll: A scroll which unlocks the Raging Echoes Home Teleport animation. High alch: 15,000 GP."
 osrs:
   id: 30453
   name: Echo home teleport scroll
@@ -12,9 +12,55 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Echo home teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: scroll
+    tier: high
+  properties:
+    release_date: "2025-01-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  passive_effects:
+    - name: Cosmetic unlock
+      description: "Permanently unlocks the Raging Echoes Home Teleport animation override on read"
+  related_items:
+    - item_name: Echo death scroll
+      slug: echo-death-scroll
+      relationship: alternative
+      description: "Sibling Raging Echoes Leagues cosmetic scroll"
+    - item_name: Echo NPC contact scroll
+      slug: echo-npc-contact-scroll
+      relationship: alternative
+      description: "Another Leagues animation unlock from the same shop"
+  about: |-
+    > _"A scroll which unlocks the Raging Echoes Home Teleport animation."_
+
+    The echo home teleport scroll permanently unlocks an animation override for the Home Teleport spell. Purchasable from the Leagues Reward Shop at Lumbridge Castle for 1,000 League Points after participating in the Raging Echoes League. Tradeable on the GE until consumed, after which the unlock is bound to the account.
+  market_strategy:
+    notes:
+      - "Cosmetic demand from Leagues completionists drives most volume"
+      - "No GE buy limit on this item"
+      - "Not alchable, so price floor is purely cosmetic demand"
+  trading_tips:
+    - "Stock tends to spike post-Leagues then taper"
+    - "Compare against sibling Echo scroll prices for relative value"
+  history:
+    - date: "2024-11-27"
+      description: "Added to the game alongside the Raging Echoes League announcement"
+    - date: "2025-01-15"
+      description: "Became obtainable when Raging Echoes rewards went live"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elder-maul.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elder-maul.mdx
@@ -12,33 +12,70 @@ osrs:
   lowalch: 200004
   highalch: 300006
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: elder
+    tier: high
+  properties:
+    release_date: "2017-01-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: 2h
-    type: maul
-    attack_style: crush
+    weapon_type: bludgeon
     attack_speed: 6
+    weight: 5.443
     requirements:
       attack: 75
       strength: 75
-    stats:
-      attack_crush: 135
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 135
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 147
-  drop_sources:
-    - name: Chambers of Xeric
-      combat_level: 0
-      drop_rate: rare
-      members_only: true
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: Pulverise
+    description: "Increases accuracy by 25% and reduces the target's current Defence level by 35% on a successful hit"
+    energy: 50
+  drop_table:
+    sources:
+      - source: Chambers of Xeric
+        quantity: "1"
+        rarity: 2/69 of unique
   related_items:
-    - item_id: 13576
-      item_name: Dragon warhammer
+    - item_name: Dragon warhammer
       slug: dragon-warhammer
       relationship: alternative
-      description: Spec weapon alternative
-    - item_id: 11804
-      item_name: Bandos godsword
+      description: "Defence-draining spec weapon alternative"
+    - item_name: Bandos godsword
       slug: bandos-godsword
       relationship: alternative
-      description: Defence drain spec
+      description: "Higher-damage Defence drain spec alternative"
   about: |-
     | Stat | Value |
     |------|-------|
@@ -57,13 +94,16 @@ osrs:
     - Devastating KO potential
     - Slow attack speed is predictable
     - Often used for combos
+
+    The Elder maul's Pulverise special attack costs 50% energy and is regarded as a superior version of the Dragon warhammer's spec, applying both a 25% accuracy boost and a 35% current Defence reduction on a successful hit.
   market_strategy:
     notes:
-      - Raid reward drives supply
-      - Crush meta affects demand
-      - Popular for PKing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Raid reward drives supply"
+      - "Crush meta affects demand"
+      - "Popular for PKing"
+  history:
+    - date: "2017-01-05"
+      description: "Released as a unique drop from Chambers of Xeric"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elidinis-ward.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elidinis-ward.mdx
@@ -12,94 +12,96 @@ osrs:
   lowalch: 2000000
   highalch: 3000000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: magic-armour
+    tier: high
+  properties:
+    release_date: "2022-08-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.708
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: magic
+    weapon_type: null
+    attack_speed: null
+    weight: 0.708
     requirements:
       magic: 80
       defence: 80
       prayer: 80
-    stats:
-      attack_magic: 5
+    attack_bonus:
+      magic: 5
+    defence_bonus:
+      stab: 5
+      slash: 3
+      crush: 9
+      ranged: 6
+    other_bonus:
       magic_damage: 3
-      defence_stab: 5
-      defence_slash: 3
-      defence_crush: 9
-      defence_ranged: 6
       prayer: 1
-  upgrade:
-    result_name: Elidinis' ward (f)
-    component_id: 12825
-    component_name: Arcane sigil
-    material_id: 566
-    material_name: Soul rune
-    material_quantity: 10000
-    requirements:
-      prayer: 90
-      smithing: 90
   drop_table:
     sources:
       - source: Tombs of Amascut
-        source_id: 11751
-        combat_level: 0
         quantity: "1"
-        rarity: Rare
-        drop_rate: 3/24 of unique
-        members_only: true
+        rarity: 1/24 unique
+  recipes:
+    - skill: prayer
+      level: 90
+      xp: 260
+      materials:
+        - item_name: Elidinis' ward
+          quantity: 1
+        - item_name: Arcane sigil
+          quantity: 1
+        - item_name: Soul rune
+          quantity: 10000
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 12825
-      item_name: Arcane spirit shield
-      slug: arcane-spirit-shield
-      relationship: alternative
-      description: Alternative
-    - item_id: 12827
-      item_name: Arcane sigil
+    - item_name: Elidinis' ward (f)
+      slug: elidinis-ward-f
+      relationship: upgrade
+      description: "Fortified, untradeable version after combining with Arcane sigil"
+    - item_name: Arcane sigil
       slug: arcane-sigil
       relationship: component
-      description: For fortifying
-    - item_id: 25818
-      item_name: Book of the dead
+      description: "Required component for the fortified ward"
+    - item_name: Arcane spirit shield
+      slug: arcane-spirit-shield
+      relationship: alternative
+      description: "Alternative magic shield using the Arcane sigil"
+    - item_name: Book of the dead
       slug: book-of-the-dead
       relationship: alternative
-      description: Budget option
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Magic | +5 |
-    | Magic Damage | +3% |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +5 |
-    | Slash | +3 |
-    | Crush | +9 |
-    | Ranged | +6 |
-
-    | Other | Value |
-    |-------|-------|
-    | Prayer | +1 |
-
-    Requirements: 80 Magic, 80 Defence, 80 Prayer
-
-    Combine with:
-    - Arcane sigil
-    - 10,000 soul runes
-
-    Requires: 90 Prayer, 90 Smithing
-
-    BiS for:
-    - All mage combat (fortified)
-    - ToA
-    - General magic
-
-    Best magic shield in the game (fortified).
+      description: "Budget magic offhand option"
+  about: "Elidinis' ward is a tier-90 magic shield dropped from Tombs of Amascut at a 1/24 unique rate. Combine it with an Arcane sigil and 10,000 soul runes at 90 Prayer and 90 Smithing to produce the fortified version with stronger bonuses."
   market_strategy:
     notes:
-      - From Tombs of Amascut
-      - Fortify with arcane sigil
-      - High requirements
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply tied to Tombs of Amascut uniques"
+      - "Demand high for fortified upgrade path"
+      - "Added to GE item sink January 2023"
+  trading_tips:
+    - "Sink and ToA drop rate keep floor pricing firm"
+    - "Fortifying makes the shield untradeable, watch unfortified premium"
+    - "Compare against Book of the dead for budget Magic loadouts"
+  history:
+    - date: "2022-08-24"
+      description: "Released with the Tombs of Amascut update."
+    - date: "2023-01-11"
+      description: "Added to the Grand Exchange item sink list."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-bolts.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 21
   highalch: 31
   limit: 11000
-  about: "Emerald bolts is a members-only item in Old School RuneScape. High alchemy value: 31 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - "Wield"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammunition
+    weapon_type: bolts
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 36
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 85
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 58
+      xp: 55
+      materials:
+        - item_name: Mithril bolts
+          quantity: 10
+        - item_name: Emerald bolt tips
+          quantity: 10
+      tools: []
+      output_quantity: 10
+  related_items:
+    - item_name: Emerald bolts (e)
+      slug: emerald-bolts-e
+      relationship: upgrade
+      description: "Enchanted version with the Magical Poison special"
+    - item_name: Mithril bolts
+      slug: mithril-bolts
+      relationship: component
+      description: "Bolt shaft used as base"
+    - item_name: Emerald bolt tips
+      slug: emerald-bolt-tips
+      relationship: component
+      description: "Gem tips attached via Fletching"
+    - item_name: Ruby bolts
+      slug: ruby-bolts
+      relationship: upgrade
+      description: "Next gem-tip tier with stronger enchant"
+  about: |-
+    Emerald bolts are mithril crossbow bolts with emerald tips, fletched at 58 Fletching for 5.5 XP each. They require 36 Ranged to wield and provide +85 Ranged strength.
+
+    Their main use is the enchanted form: Magic level 27 with the Enchant Crossbow Bolt (Emerald) spell turns them into emerald bolts (e), which proc Magical Poison (a damage-over-time effect ignoring poison immunity).
+  market_strategy:
+    notes:
+      - "Profit equation: 10 mithril bolts + 10 emerald bolt tips vs 10 emerald bolts"
+      - "Enchant margin is the big value driver, not the raw bolt"
+      - "Steady supply from fletching trainers"
+      - "Demand tracks Slayer / niche PvM use of the (e) version"
+  trading_tips:
+    - "Watch nature rune cost: it sets the alch margin floor"
+    - "Buy raw bolts when enchanted form drops below break-even"
+    - "Bulk flips work given 11,000 buy limit"
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside the Enchant Crossbow Bolt spells"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-chaos-druid-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-chaos-druid-head.mdx
@@ -1,20 +1,77 @@
 ---
 title: Ensouled chaos druid head | OSRS Price Data
-description: "Ensouled chaos druid head: The creature's soul is still in here.. High alch: 179 GP, GE limit: 3,000."
+description: "Ensouled chaos druid head: The creature's soul is still in here. High alch: 179 GP, GE limit: 3,000."
 osrs:
   id: 13472
   name: Ensouled chaos druid head
   slug: ensouled-chaos-druid-head
-  examine: The creature's soul is still in here.
+  examine: "The creature's soul is still in here."
   members: true
   icon: Ensouled chaos druid head.png
   value: 299
   lowalch: 119
   highalch: 179
   limit: 3000
-  about: "Ensouled chaos druid head is a members-only item in Old School RuneScape. High alchemy value: 179 coins. Grand Exchange buy limit: 3,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ensouled_head
+    tier: mid
+  properties:
+    release_date: "2016-01-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Chaos druid
+        quantity: "1"
+        rarity: "1/35"
+      - source: Chaos druid warrior
+        quantity: "1"
+        rarity: "1/25"
+      - source: Elder Chaos druid
+        quantity: "1"
+        rarity: "1/20"
+  related_items:
+    - item_name: Ensouled goblin head
+      slug: ensouled-goblin-head
+      relationship: variant
+      description: "Lower-tier ensouled head"
+    - item_name: Ensouled bear head
+      slug: ensouled-bear-head
+      relationship: variant
+      description: "Adjacent tier reanimation head"
+    - item_name: Dark essence block
+      slug: dark-essence-block
+      relationship: alternative
+      description: "Alternative Arceuus prayer XP method"
+  about: |-
+    > _"The creature's soul is still in here."_
+
+    Ensouled chaos druid head is used with the Adept Reanimation spell (41 Magic) from the Arceuus spellbook to spawn a reanimated chaos druid. Defeating the reanimation awards 584 Prayer experience, making this a popular non-bone Prayer training method.
+  market_strategy:
+    notes:
+      - "Demand follows Arceuus prayer training"
+      - "Supply tied to chaos druid herblore botters"
+      - "Bulk noted stacks trade near alch floor"
+  trading_tips:
+    - "Buy when herblore supplies dump"
+    - "Reanimate near Dark Altar for efficiency"
+  history:
+    - date: "2016-01-07"
+      description: "Released with Zeah and the Arceuus reanimation spells"
+    - date: "2021-04-01"
+      description: "Examine text refresh across ensouled heads"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-1.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Extended antifire(1) is a members-only item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "27 March 2014"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 84
+      xp: 27.5
+      materials:
+        - item_name: Antifire potion (1)
+          quantity: 1
+        - item_name: Lava scale shard
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Extended antifire(4)
+      slug: extended-antifire-4
+      relationship: variant
+      description: "4-dose version"
+    - item_name: Extended antifire(3)
+      slug: extended-antifire-3
+      relationship: variant
+      description: "3-dose version"
+    - item_name: Extended antifire(2)
+      slug: extended-antifire-2
+      relationship: variant
+      description: "2-dose version"
+    - item_name: Extended super antifire(1)
+      slug: extended-super-antifire-1
+      relationship: upgrade
+      description: "Stronger antifire that fully blocks dragonfire without a shield"
+  about: |-
+    > *"1 dose of extended anti-firebreath potion."*
+
+    Extended antifire(1) is a single-dose variant of the extended antifire potion. Each dose grants 12 minutes (1,200 game ticks) of dragonfire protection when paired with an anti-dragon or dragonfire shield. The single-dose flask is the smallest portion and is mainly produced as a stepping-stone when decanting or sipping the last dose of a larger flask.
+
+    Brewing requires Herblore 84: combine an antifire potion with one lava scale shard at 27.5 XP per shard.
+  market_strategy:
+    notes:
+      - "Demand follows dragon-PvM and Vorkath rotations"
+      - "Single doses often arbitrage against higher doses via decanting NPCs"
+  trading_tips:
+    - "Watch lava scale shard price: feedstock cost dominates margin"
+    - "Decanting flips between (1) and (4) can lock in small per-dose spreads"
+  history:
+    - date: "27 March 2014"
+      description: "Released alongside extended antifire mechanic"
+    - date: "25 February 2016"
+      description: "Bank placeholder support added"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/feldip-hills-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/feldip-hills-teleport.mdx
@@ -1,6 +1,6 @@
 ---
 title: Feldip hills teleport | OSRS Price Data
-description: "Feldip hills teleport: Teleports you to Feldip hills.. High alch: 6 GP, GE limit: 10,000."
+description: "Feldip hills teleport: Teleports you to Feldip hills. High alch: 6 GP, GE limit: 10,000."
 osrs:
   id: 12404
   name: Feldip hills teleport
@@ -12,9 +12,67 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Feldip hills teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: teleport scroll
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.0
+    options: ["Teleport", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers: ["easy", "medium", "hard", "elite", "master"]
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: "1/340"
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - item_name: Mounted xerician
+      slug: mounted-xerician
+      relationship: alternative
+      description: "Permanent house teleport alternative for similar regions"
+    - item_name: Feldip hills tablet
+      slug: feldip-hills-tablet
+      relationship: alternative
+      description: "Construction-made tablet teleporting to the same destination"
+  about: "The Feldip hills teleport is a one-use scroll obtained from Treasure Trail reward caskets across multiple difficulty tiers. Reading it instantly teleports the player to Feldip Hills near the Hunting Expert with no skill requirements."
+  market_strategy:
+    notes:
+      - "Stackable consumable rewarded from Treasure Trail caskets"
+      - "Convenient teleport for Hunter trips and southern Kandarin travel"
+      - "High GE buy limit makes bulk supply easy for daily users"
+  trading_tips:
+    - "Stack in bulk when prices drop after clue-flood patches"
+    - "Cheap alternative to Construction tablets for occasional Hunter trips"
+    - "Volume is high so spreads are tight, ideal for steady flipping"
+  history:
+    - date: "2014-06-12"
+      description: "Feldip hills teleport added with the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fibula-piece.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fibula-piece.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Fibula piece is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bone
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Wallasalki
+        quantity: "1"
+        rarity: "2/128"
+  related_items:
+    - item_name: Dagannoth hide
+      slug: dagannoth-hide
+      relationship: component
+      description: "Combined with fibula piece to craft skeletal armour"
+    - item_name: Skeletal bottoms
+      slug: skeletal-bottoms
+      relationship: product
+      description: "Crafted from fibula piece via Peer the Seer"
+  about: "Fibula piece is a members-only bone shard dropped by Wallasalki on Waterbirth Island. It is one of three skeletal pieces used by Peer the Seer to craft skeletal armour for combat against the Dagannoth Kings."
+  market_strategy:
+    notes:
+      - "Wallasalki drop rate is 2/128 so supply is supply-constrained at low daily volume."
+      - "Demand spikes when groups gear for Dagannoth Kings runs."
+      - "Buy limit of 11,000 is generous so accumulation is easy when sellers post stock."
+  trading_tips:
+    - "Watch for ironman PK clearances which often dump skeletal pieces"
+    - "Pair fibula piece flips with circumferential pieces for skeletal set arbitrage"
+  history:
+    - date: "2005-08-01"
+      description: "Released with the Waterbirth Island update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-potion-1.mdx
@@ -12,23 +12,56 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily boosts Fishing by +3 levels"
+        duration: 360
   related_items:
-    - item_id: 151
-      item_name: Fishing potion(3)
+    - item_name: Fishing potion(3)
       slug: fishing-potion-3
       relationship: variant
-      description: 3-dose version
-    - item_id: 153
-      item_name: Fishing potion(2)
+      description: "3-dose version of the same potion"
+    - item_name: Fishing potion(2)
       slug: fishing-potion-2
       relationship: variant
-      description: 2-dose version
+      description: "2-dose version of the same potion"
+    - item_name: Fishing potion(4)
+      slug: fishing-potion-4
+      relationship: variant
+      description: "4-dose version of the same potion"
   about: |-
-    > _"1 dose of Fishing potion."_
+    A 1-dose Fishing potion that provides a temporary +3 boost to the Fishing skill. The boost is useful for catching fish slightly above your current level, such as reaching threshold tiers for monkfish, sharks, or anglerfish.
 
-    A 1-dose fishing potion. Provides a temporary +3 Fishing boost.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Single-dose potions are typically the cheapest per-dose option on the Grand Exchange, but they take up more inventory slots than higher-dose variants.
+  market_strategy:
+    notes:
+      - "Single-dose potions are usually the cheapest per dose on the Grand Exchange"
+      - "Higher dose variants are more inventory-efficient"
+      - "Demand is steady from skillers chasing milestone Fishing levels"
+  history:
+    - date: "2002-02-27"
+      description: "Released with the original potion system"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-blue-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-blue-shirt.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik blue shirt is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      price: 325
+      currency: Coins
+      stock: 5
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania
+      price: 250
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Fremennik red shirt
+      slug: fremennik-red-shirt
+      relationship: variant
+      description: "Red colour variant of the Fremennik shirt"
+    - item_name: Fremennik brown shirt
+      slug: fremennik-brown-shirt
+      relationship: variant
+      description: "Brown colour variant of the Fremennik shirt"
+    - item_name: Fremennik grey shirt
+      slug: fremennik-grey-shirt
+      relationship: variant
+      description: "Grey colour variant of the Fremennik shirt"
+  about: "Fremennik blue shirt is a body slot item sold by Yrsa's Accoutrements in Rellekka and the Miscellanian Clothes Shop. Provides minor +2 slash and +2 crush defence and serves mostly as a Fremennik fashion piece."
+  market_strategy:
+    notes:
+      - "Tight GE buy limit (150) keeps daily flow small"
+      - "Shop respawn supply caps upside on flips"
+      - "Steady cosmetic and Fremennik roleplay demand"
+  trading_tips:
+    - "Stock Yrsa's then resell on GE for a clean low-risk margin"
+    - "Track diary completion players who fashionscape Fremennik attire"
+  history:
+    - date: "2004-11-02"
+      description: "Released with The Fremennik Trials quest update"
+    - date: "2005-01-17"
+      description: "Graphics updated"
+    - date: "2014-12-10"
+      description: "Renamed from 'Fremennik shirt' to 'Fremennik blue shirt'"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-purple-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-purple-cloak.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik purple cloak is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      price: 325
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Fremennik blue cloak
+      slug: fremennik-blue-cloak
+      relationship: variant
+      description: "Alternative cloak colour with identical bonuses"
+    - item_name: Fremennik red cloak
+      slug: fremennik-red-cloak
+      relationship: variant
+      description: "Alternative cloak colour with identical bonuses"
+    - item_name: Fremennik green cloak
+      slug: fremennik-green-cloak
+      relationship: variant
+      description: "Alternative cloak colour with identical bonuses"
+  about: "Fremennik purple cloak is a members-only cape obtained from Yrsa's Accoutrements in Rellekka after completing The Fremennik Trials. It is primarily a cosmetic cape and is also used during the Wanted! quest to pursue Solus."
+  market_strategy:
+    notes:
+      - "Stock cap at Yrsa is small so resellers can flip the spread between shop and Grand Exchange."
+      - "Limit of 150 per 4 hours suits short-term flipping."
+      - "Demand is largely driven by Wanted! quest disguise checks."
+  trading_tips:
+    - "Visit Yrsa across multiple worlds for stock arbitrage"
+    - "List during Wanted! double XP events when quest completions spike"
+  history:
+    - date: "2004-11-02"
+      description: "Released with The Fremennik Trials quest"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gold-seal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gold-seal.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 13000
-  about: "Gold seal is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: artefact
+    tier: low
+  properties:
+    release_date: "2006-07-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Pyramid Plunder (Grand Gold Chest)
+        quantity: "1"
+        rarity: Common
+      - source: Pyramid Plunder (Sarcophagus)
+        quantity: "1"
+        rarity: Common
+      - source: Pyramid Plunder (Urn)
+        quantity: "1"
+        rarity: Common
+  shops:
+    - shop_name: Simon Templeton's exchange
+      location: Agility Pyramid
+      price: 750
+      currency: coins
+      stock: 100
+  related_items:
+    - item_name: Pharaoh's sceptre
+      slug: pharaohs-sceptre
+      relationship: product
+      description: "Six gold seals can be used to recharge the Pharaoh's sceptre"
+    - item_name: Ivory comb
+      slug: ivory-comb
+      relationship: alternative
+      description: "Lower-tier Pyramid Plunder artefact"
+    - item_name: Pottery scarab
+      slug: pottery-scarab
+      relationship: alternative
+      description: "Pyramid Plunder artefact"
+    - item_name: Golden statuette
+      slug: golden-statuette
+      relationship: alternative
+      description: "High-tier Pyramid Plunder artefact"
+  about: |-
+    The Gold seal is one of the artefacts looted from urns, chests, and sarcophagi inside the Pyramid Plunder minigame in Sophanem. Players need at least 41 Thieving to reach the rooms where it spawns.
+
+    Six gold seals can be combined to recharge the Pharaoh's sceptre, or each seal can be sold to Simon Templeton at the Agility Pyramid for 750 coins.
+  market_strategy:
+    notes:
+      - "Floor price is set by Simon Templeton's 750 coin buyback rate"
+      - "Demand spikes from teleport gathering ironmen recharging Pharaoh's sceptre"
+      - "Bulk supply is tied to Pyramid Plunder Thieving training popularity"
+  history:
+    - date: "2006-07-17"
+      description: "Released with the Pyramid Plunder minigame"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gourmet-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gourmet-impling-jar.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  about: "Gourmet impling jar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 18,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: container
+    tier: low
+  properties:
+    release_date: "2007-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "If you drop this it will disappear. Are you sure you want to do this?"
+  related_items:
+    - item_name: Empty impling jar
+      slug: empty-impling-jar
+      relationship: component
+      description: "Empty jar returned after looting (90% success rate)"
+    - item_name: Young impling jar
+      slug: young-impling-jar
+      relationship: downgrade
+      description: "Lower-tier impling caught at Hunter 22"
+    - item_name: Earth impling jar
+      slug: earth-impling-jar
+      relationship: upgrade
+      description: "Next-tier impling caught at Hunter 36"
+  about: "Gourmet impling jar contains a Gourmet impling caught at level 28 Hunter. Loot it for food rewards such as tuna, bass, lobster, shark, easy clue scrolls (1/25), and grubby keys (1/500). Three jars can be traded to Elnock Inquisitor for empty impling jars."
+  market_strategy:
+    notes:
+      - "Loot is dominated by easy clue scrolls and food, driving most demand"
+      - "Buy limit of 18,000 supports bulk flips and clue stockpiles"
+      - "Demand spikes during Treasure Trails or impling hype events"
+  trading_tips:
+    - "Compare GE price to expected loot value to decide between looting and reselling"
+    - "Track easy clue scroll prices to anticipate gourmet jar demand"
+  history:
+    - date: "2007-06-11"
+      description: "Released with the Impetuous Impulses minigame"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-blouse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-elegant-blouse.mdx
@@ -12,21 +12,78 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/2808
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers: ["easy"]
   related_items:
-    - item_id: 10434
-      item_name: Green elegant skirt
+    - item_name: Green elegant skirt
       slug: green-elegant-skirt
       relationship: set-piece
-      description: Matching elegant skirt
+      description: "Matching elegant skirt for the women's green elegant set"
   about: |-
     > *"A well made elegant ladies' green blouse."*
 
-    Purely cosmetic treasure trail reward with no combat stats. Part of the green elegant clothing set (women's variant). Pairs with the green elegant skirt.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Purely cosmetic easy clue reward with no combat stats. Part of the green elegant clothing set (women's variant). Pairs with the green elegant skirt and stores in the costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Buy limit 4 caps flipping volume sharply"
+      - "Supply gated by easy clue completion rates"
+      - "Premium often persists for collection log hunters"
+  trading_tips:
+    - "Track easy clue popularity — drops with seasonal events affect supply"
+    - "Cosmetic-only — price driven entirely by collection log demand"
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the elegant clothing easy clue reward pool"
+    - date: "2014-12"
+      description: "Renamed from Green ele' blouse to Green elegant blouse"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grey-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grey-robe-top.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Grey robe top is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Barkers' Haberdashery"
+      location: Canifis
+      price: 650
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Red robe top
+      slug: red-robe-top
+      relationship: variant
+      description: "Red Canifis robe variant with identical stats"
+    - item_name: Yellow robe top
+      slug: yellow-robe-top
+      relationship: variant
+      description: "Yellow Canifis robe variant with identical stats"
+  about: "Grey robe top is a members-only body slot item sold by Barkers' Haberdashery in Canifis. Part of the Canifis robes set, it offers minor defensive bonuses and is popular for fashionscape and werewolf-themed outfits."
+  market_strategy:
+    notes:
+      - "Shop-bought at 650 gp creates a price ceiling; flips margins are thin"
+      - "Demand spikes around Halloween-themed fashion events"
+      - "Buy limit of 150 per 4 hours rewards patient accumulation"
+  trading_tips:
+    - "Stock up cheaply from the Canifis shop and resell on the GE during fashion events"
+    - "High alch value of 300 gp is below market price, so avoid alching"
+  history:
+    - date: "2004-06-29"
+      description: "Released with the Priest in Peril quest update"
+    - date: "2014-12-10"
+      description: "Renamed from Robe top to Grey robe top"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-4.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Guthix balance(4) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "22 March 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - "Empty"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Used on frozen vampyre juveniles and juvinates: 16% destroy, 68% revert to human, 16% transform into a feral vampyre."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 22
+      xp: 100
+      materials:
+        - item_name: Guthix balance (unf)
+          quantity: 1
+        - item_name: Silver dust
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Guthix balance(1)
+      slug: guthix-balance-1
+      relationship: variant
+      description: "1-dose variant"
+    - item_name: Guthix balance(2)
+      slug: guthix-balance-2
+      relationship: variant
+      description: "2-dose variant"
+    - item_name: Guthix balance(3)
+      slug: guthix-balance-3
+      relationship: variant
+      description: "3-dose variant"
+    - item_name: Guthix balance (unf)
+      slug: guthix-balance-unf
+      relationship: component
+      description: "Unfinished potion used to craft Guthix balance"
+  about: "Guthix balance(4) is a members-only Herblore potion thrown at frozen vampyre juveniles and juvinates during the Myreque quest line, with a chance to destroy them outright, restore them to human form, or transform them into feral vampyres."
+  market_strategy:
+    notes:
+      - "Niche demand, mostly for In Aid of the Myreque and follow-up quests."
+      - "Volume spikes briefly when new Myreque content drops."
+      - "Spread per dose is wide; bulk flips clear slowly."
+  trading_tips:
+    - "Crafted en-masse for Sins of the Father/Myreque progression weeks."
+    - "Decant between doses when the per-dose price gap opens."
+    - "Silver dust supply gates production cost."
+  history:
+    - date: "22 March 2006"
+      description: "Introduced alongside the In Aid of the Myreque quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/half-full-wine-jug.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/half-full-wine-jug.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 50
-  about: "Half full wine jug is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "17 March 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 7 Hitpoints when drunk."
+        duration: 0
+      - description: "Temporarily lowers Attack by 2 levels."
+        duration: 0
+  related_items:
+    - item_name: Jug of wine
+      slug: jug-of-wine
+      relationship: variant
+      description: "Full wine jug variant"
+    - item_name: Jug
+      slug: jug
+      relationship: component
+      description: "Empty container after drinking"
+  about: "Half full wine jug is a F2P discontinued drink restoring 7 Hitpoints with an attack debuff, traditionally handed out at anniversary and rare drop events."
+  market_strategy:
+    notes:
+      - "Discontinued holiday distribution drives long-term scarcity"
+      - "Annual birthday event releases 2 noted copies, slowing scarcity gains"
+      - "Collector demand dominates over the trivial heal utility"
+  trading_tips:
+    - "Treat as a discontinued collectible rather than a consumable"
+    - "Buy limit of 50 keeps individual flips low volume"
+  history:
+    - date: "17 March 2001"
+      description: "Originally appeared in early RuneScape."
+    - date: "26 August 2013"
+      description: "Distributed during the 2013 Rare Drops event."
+    - date: "2020"
+      description: "Began annual birthday event distribution of 2 noted copies."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-body.mdx
@@ -12,94 +12,96 @@ osrs:
   lowalch: 5392
   highalch: 8088
   limit: null
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: hide
+    tier: high
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: ranged
-    tradeable: true
-    weight: 5
+    weapon_type: null
+    attack_speed: null
+    weight: 6.803
     requirements:
       defence: 40
       ranged: 70
-    stats:
-      attack_ranged: 30
-      attack_magic: -15
-      defence_stab: 55
-      defence_slash: 47
-      defence_crush: 60
-      defence_ranged: 55
-      defence_magic: 56
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 55
+      slash: 47
+      crush: 60
+      magic: 56
+      ranged: 55
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
   recipes:
     - skill: crafting
       level: 78
       xp: 285
       materials:
-        - item_id: 30085
-          item_name: Hueycoatl hide
+        - item_name: Hueycoatl hide
           quantity: 3
-        - item_id: 1734
-          item_name: Thread
+        - item_name: Thread
           quantity: 1
-  market:
-    buy_limit: 70
-    price_estimate: 1450000
+      tools: ["Needle"]
+      output_quantity: 1
   related_items:
-    - item_id: 30085
-      item_name: Hueycoatl hide
+    - item_name: Hueycoatl hide
       slug: hueycoatl-hide
       relationship: component
-      description: Crafting material
-    - item_id: 30073
-      item_name: Hueycoatl hide coif
+      description: "Crafting material harvested from the Hueycoatl boss"
+    - item_name: Hueycoatl hide coif
       slug: hueycoatl-hide-coif
       relationship: set-piece
-      description: Head armor
-    - item_id: 30079
-      item_name: Hueycoatl hide chaps
+      description: "Head armor in the Hueycoatl hide set"
+    - item_name: Hueycoatl hide chaps
       slug: hueycoatl-hide-chaps
       relationship: set-piece
-      description: Leg armor
-    - item_id: 30082
-      item_name: Hueycoatl hide vambraces
+      description: "Leg armor in the Hueycoatl hide set"
+    - item_name: Hueycoatl hide vambraces
       slug: hueycoatl-hide-vambraces
       relationship: set-piece
-      description: Gloves
+      description: "Glove slot piece in the Hueycoatl hide set"
   about: |-
-    - 40 Defence
-    - 70 Ranged
+    > *"Made from real Huey hide!"*
 
-    | Stat | Bonus |
-    |------|-------|
-    | Ranged Attack | +30 |
-    | Magic Attack | -15 |
-    | Stab Defence | +55 |
-    | Slash Defence | +47 |
-    | Crush Defence | +60 |
-    | Ranged Defence | +55 |
-    | Magic Defence | +56 |
-    | Prayer | +3 |
-
-    The Hueycoatl hide body is the most valuable piece of the set, offering:
-
-    - High ranged attack: +30 ranged attack bonus
-    - Strong defences: Excellent protection across all styles
-    - Prayer bonus: +3 prayer for extended trips
-
-    Best used with:
-    - Hueycoatl hide coif
-    - Hueycoatl hide chaps
-    - Hueycoatl hide vambraces
-
-    Comparison: Provides competitive stats with other high-tier ranged bodies while offering unique prayer bonuses.
+    Premier body piece of the Hueycoatl hide set. Requires 40 Defence and 70 Ranged, offering +30 Ranged attack, +3 Prayer, and balanced 47–60 defensive bonuses across stab/slash/crush/magic/ranged with only a -15 magic attack tradeoff. Crafted at 78 Crafting from 3 Hueycoatl hide, 1 thread and a needle for 285 Crafting XP. Sits as a defensive-leaning alternative to blessed dragonhide bodies thanks to its prayer and magic defence bumps.
   market_strategy:
     notes:
-      - Most expensive piece of the set
-      - Highest crafting requirement in the set
-      - Compare 3-hide crafting cost vs market price
-      - Prayer bonus makes it desirable for bossing
-      - Core piece - often purchased first when building the set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Most expensive piece of the set"
+      - "Highest Crafting requirement among the set pieces"
+      - "Compare 3-hide crafting cost versus GE price for flip viability"
+      - "Prayer bonus drives bossing demand"
+      - "Often the first piece bought when assembling the set"
+  trading_tips:
+    - "Watch Hueycoatl boss popularity for hide supply swings"
+    - "Stack against blessed d'hide pricing — prayer bonus justifies premium"
+  history:
+    - date: "2024-09-25"
+      description: "Released with Varlamore: The Rising Darkness"
+    - date: "2025-06"
+      description: "Crafting requirement reduced from 88 to 78"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hunting-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hunting-mix-1.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 2000
-  about: "Hunting mix(1) is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 58
+      xp: 40
+      materials:
+        - item_name: Hunter potion(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Boosts Hunter level by 3"
+        duration: 0
+      - description: "Heals 6 Hitpoints when consumed"
+        duration: 0
+  related_items:
+    - item_name: Hunter potion(2)
+      slug: hunter-potion-2
+      relationship: component
+      description: "Base potion used to mix the hunting mix"
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: "Secondary ingredient for the barbarian mix"
+    - item_name: Hunter potion(1)
+      slug: hunter-potion-1
+      relationship: alternative
+      description: "Single-dose Hunter potion without the heal"
+  about: "Hunting mix(1) is the single-dose barbarian variant of the Hunter potion, providing a +3 Hunter boost and a 6 HP heal. It is mixed at 58 Herblore from a Hunter potion(2) and caviar, after unlocking Barbarian Herblore training with Otto Godblessed."
+  market_strategy:
+    notes:
+      - "Demand follows Hunter training combined with HP top-ups"
+      - "Caviar supply caps production volume"
+      - "Buy limit of 2,000 supports steady churn"
+  trading_tips:
+    - "Caviar cost dominates the mix margin"
+    - "Watch ironman Hunter activity for spikes"
+    - "Half-dose placeholders are bankable since 2016 update"
+  history:
+    - date: "2007-07-03"
+      description: "Released with Barbarian Herblore training."
+    - date: "2016-04-15"
+      description: "Half-full potions added to bank placeholder system."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/imp-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/imp-mask.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
-  about: "Imp mask is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.002
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Goblin mask
+      slug: goblin-mask
+      relationship: alternative
+      description: "Another easy clue monster mask in the same cosmetic collection"
+    - item_name: Ankou mask
+      slug: ankou-mask
+      relationship: alternative
+      description: "Easy clue monster mask alternative from the same drop pool"
+  about: Imp mask is a rare cosmetic head reward from easy Treasure Trails, dropping at 1/1,404 from a Reward casket (easy). It can be stored in the costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Cosmetic head item with no combat bonuses"
+      - "Supply ties to easy clue completion volume"
+      - "Buy limit of 4 keeps daily flips modest"
+  trading_tips:
+    - "Watch for dips around easy-clue release events when supply spikes"
+    - "Cross-check pricing against other monster masks (Ankou, Goblin) for fair value"
+  history:
+    - date: "2014-06-12"
+      description: "Added to Old School RuneScape as an easy Treasure Trail reward"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/incomplete-light-ballista.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/incomplete-light-ballista.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Incomplete light ballista is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ballista-part
+    tier: high
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.5
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 47
+      xp: 15
+      materials:
+        - item_name: Light frame
+          quantity: 1
+        - item_name: Ballista limbs
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Light frame
+      slug: light-frame
+      relationship: component
+      description: "Wooden frame component"
+    - item_name: Ballista limbs
+      slug: ballista-limbs
+      relationship: component
+      description: "Limb component fletched onto the frame"
+    - item_name: Ballista spring
+      slug: ballista-spring
+      relationship: component
+      description: "Added next to produce the unstrung light ballista"
+    - item_name: Unstrung light ballista
+      slug: unstrung-light-ballista
+      relationship: product
+      description: "Next assembly step toward the finished ballista"
+    - item_name: Light ballista
+      slug: light-ballista
+      relationship: product
+      description: "Final two-handed ranged weapon"
+  about: |-
+    Incomplete light ballista is the first assembly stage of the light ballista, made at 47 Fletching by attaching ballista limbs to a light frame for 15 XP.
+
+    Next step: add a ballista spring (also 47 Fletching, 15 XP) to produce the unstrung light ballista, then string it to finish the weapon. Monkey Madness II is required to use the recipe chain.
+  market_strategy:
+    notes:
+      - "Intermediate craft, mostly Fletching ironman territory"
+      - "Profit equation: component cost vs unstrung light ballista price"
+      - "Supply tracks active ballista crafters"
+      - "GE limit of 8 keeps spreads wide"
+  trading_tips:
+    - "Buy when limb / frame prices drop, hold for ballista assembly cycles"
+    - "Margins improve when finished light ballista demand spikes from PvP events"
+  history:
+    - date: "2016-05-06"
+      description: "Released with the Monkey Madness II update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/infinity-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/infinity-gloves.mdx
@@ -12,56 +12,86 @@ osrs:
   lowalch: 4800
   highalch: 7200
   limit: 125
-  item_id: 6922
-  type: equipment
-  tradeable: true
-  weight: 0.226
-  buy_limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: magic-armour
+    tier: mid-high
+  properties:
+    release_date: "2006-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
-    type: magic_gloves
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
     requirements:
-      skills:
-        - skill: magic
-          level: 50
-        - skill: defence
-          level: 25
-    stats:
-      attack_magic: 5
-      defence_magic: 5
-  obtaining:
-    minigame:
-      name: Mage Training Arena
-      points_required:
-        telekinetic: 175
-        alchemist: 225
-        enchantment: 2250
-        graveyard: 175
+      magic: 50
+      defence: 25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 5
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 5
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   related_items:
-    - slug: infinity-hat
-      name: Infinity hat
-      relation: set_piece
-    - slug: infinity-top
-      name: Infinity top
-      relation: set_piece
-    - slug: infinity-bottoms
-      name: Infinity bottoms
-      relation: set_piece
-    - slug: infinity-boots
-      name: Infinity boots
-      relation: set_piece
-    - slug: tormented-bracelet
-      name: Tormented bracelet
-      relation: best_upgrade
-  about: |-
-    The full Infinity set includes:
-    - Infinity hat
-    - Infinity top
-    - Infinity bottoms
-    - Infinity boots
-    - Infinity gloves
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Infinity hat
+      slug: infinity-hat
+      relationship: set-piece
+      description: "Head slot piece of the Infinity set, also from Mage Training Arena"
+    - item_name: Infinity top
+      slug: infinity-top
+      relationship: set-piece
+      description: "Body slot piece of the Infinity set, also from Mage Training Arena"
+    - item_name: Infinity bottoms
+      slug: infinity-bottoms
+      relationship: set-piece
+      description: "Legs slot piece of the Infinity set, also from Mage Training Arena"
+    - item_name: Infinity boots
+      slug: infinity-boots
+      relationship: set-piece
+      description: "Feet slot piece of the Infinity set, also from Mage Training Arena"
+    - item_name: Tormented bracelet
+      slug: tormented-bracelet
+      relationship: upgrade
+      description: "Best-in-slot magic glove upgrade with +10 magic attack and +5% magic damage"
+  about: "Infinity gloves are the hands piece of the Infinity set, purchased from the Mage Training Arena's reward shop with pizazz points. They give +5 magic attack and +5 magic defence at a 50 Magic, 25 Defence requirement. They are typically only worn when a player lacks better hand options like a tormented bracelet or barrows gloves."
+  market_strategy:
+    notes:
+      - "Demand is shallow — most mid- to late-game mains move to Barrows gloves or Tormented bracelet"
+      - "Supply comes from Mage Training Arena reward shop (no GE arbitrage path), so prices stay close to alch with light volatility"
+      - "Buy limit of 125 every 4 hours is generous relative to volume, so MTA buyers can reliably offload"
+  trading_tips:
+    - "Track high alch (7,200): if GE price dips below alch + nature rune cost, alchers absorb supply"
+    - "Watch for MTA QoL or rework news; any change to pizazz rates affects the supply side of Infinity pieces"
+    - "Tradeable but ironmen cannot use GE — they must grind MTA themselves, isolating the buyer pool to main accounts"
+  history:
+    - date: "2006-01-04"
+      description: "Released as part of the Mage Training Arena minigame reward set, alongside the rest of the Infinity outfit"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/irit-tar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/irit-tar.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Irit tar is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ammunition
+    tier: mid
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: salamander_ammo
+    attack_speed: null
+    weight: 0
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 60
+  recipes:
+    - skill: herblore
+      level: 55
+      xp: 85
+      materials:
+        - item_name: Swamp tar
+          quantity: 15
+        - item_name: Irit leaf
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 15
+  related_items:
+    - item_name: Guam tar
+      slug: guam-tar
+      relationship: alternative
+      description: "Lower-tier salamander ammo"
+    - item_name: Marrentill tar
+      slug: marrentill-tar
+      relationship: alternative
+      description: "Mid-tier salamander ammo"
+    - item_name: Tarromin tar
+      slug: tarromin-tar
+      relationship: alternative
+      description: "Mid-tier salamander ammo"
+    - item_name: Harralander tar
+      slug: harralander-tar
+      relationship: alternative
+      description: "Higher-tier salamander ammo"
+    - item_name: Tecu salamander
+      slug: tecu-salamander
+      relationship: component
+      description: "Weapon that consumes Irit tar as ammo"
+  about: "Irit tar is the ammunition used by the tecu salamander, made at 55 Herblore from 15 swamp tar and one irit leaf with a pestle and mortar for 85 xp. Each batch yields 15 tars. The April 3 2024 buff increased its ranged strength bonus to +60."
+  market_strategy:
+    notes:
+      - "Direct demand from tecu salamander training"
+      - "Swamp tar and irit leaf supply drive cost"
+      - "High buy limit allows large rolling orders"
+  trading_tips:
+    - "Track swamp tar and irit leaf prices for margin"
+    - "Recipe yields 15 per batch, scale orders accordingly"
+    - "GE limit of 11,000 supports bulk flipping"
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore: Part One update."
+    - date: "2024-04-03"
+      description: "Ranged Strength bonus increased from +49 to +60."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow.mdx
@@ -12,41 +12,118 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    type: arrow
-    tradeable: true
+    weapon_type: arrow
+    attack_speed: null
     weight: 0
     requirements:
       ranged: 1
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 0
       ranged_strength: 10
       magic_damage: 0
       prayer: 0
+  drop_table:
+    sources:
+      - source: King Black Dragon
+        quantity: "690"
+        rarity: Common
+      - source: Moss giant
+        quantity: "15"
+        rarity: Common
+      - source: Minotaur
+        quantity: "5-14"
+        rarity: Common
+  shops:
+    - shop_name: Lowe's Archery Emporium
+      location: Varrock
+      price: 3
+      currency: Coins
+      stock: 100
+    - shop_name: Hickton's Archery Emporium
+      location: Catherby
+      price: 3
+      currency: Coins
+      stock: 100
+    - shop_name: Ava's Odds and Ends
+      location: Draynor Manor
+      price: 3
+      currency: Coins
+      stock: 100
+  recipes:
+    - skill: fletching
+      level: 15
+      xp: 37.5
+      materials:
+        - item_name: Iron arrowtips
+          quantity: 15
+        - item_name: Headless arrow
+          quantity: 15
+      tools: []
+      output_quantity: 15
   related_items:
-    - item_id: 886
-      item_name: Steel arrow
+    - item_name: Steel arrow
       slug: steel-arrow
       relationship: upgrade
-      description: Higher tier arrow
-    - item_id: 841
-      item_name: Shortbow
+      description: "Higher tier arrow"
+    - item_name: Bronze arrow
+      slug: bronze-arrow
+      relationship: downgrade
+      description: "Lower tier arrow"
+    - item_name: Iron arrow(p)
+      slug: iron-arrow-p
+      relationship: variant
+      description: "Poisoned variant"
+    - item_name: Shortbow
       slug: shortbow
       relationship: alternative
-      description: Compatible bow
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Compatible bow"
+  about: "Iron arrow is a free-to-play ranged ammunition projectile that requires only 1 Ranged to wield. It is a staple training arrow for low and mid level rangers and serves as a cheap option for monsters with low defence."
+  market_strategy:
+    notes:
+      - "Wide shop availability anchors the floor near 3 coins regardless of GE swings."
+      - "Volume is steady from new accounts training ranged in F2P."
+      - "Iron arrowtip and headless arrow flips often outperform finished arrow flips."
+  trading_tips:
+    - "Bulk buy near alch value during off-peak weekday hours"
+    - "Watch for slayer task bulk purchases that drive short-term spikes"
+  history:
+    - date: "2002-03-25"
+      description: "Added to the game at launch"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-plateskirt-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-plateskirt-g.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 4
-  about: "Iron plateskirt (g) is a free-to-play item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 8.164
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: -4
+      ranged: 10
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: "1/1,404"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Iron platelegs
+      slug: iron-platelegs
+      relationship: alternative
+      description: "Untrimmed male legs variant"
+    - item_name: Iron plateskirt
+      slug: iron-plateskirt
+      relationship: alternative
+      description: "Untrimmed female skirt variant"
+    - item_name: Iron platebody (g)
+      slug: iron-platebody-g
+      relationship: set-piece
+      description: "Matching chest from the gold-trimmed iron set"
+    - item_name: Iron full helm (g)
+      slug: iron-full-helm-g
+      relationship: set-piece
+      description: "Matching helm from the gold-trimmed iron set"
+  about: "Iron plateskirt (g) is a free-to-play gold-trimmed skirt obtained as a rare reward from easy Treasure Trails. It shares stats with the untrimmed iron plateskirt and is valued mostly for cosmetic appeal."
+  market_strategy:
+    notes:
+      - "Drop rate of 1/1,404 from easy clue caskets keeps supply scarce."
+      - "Buy limit of 4 per 4 hours makes bulk flipping impractical."
+      - "Cosmetic demand from fashionscape players drives most volume."
+  trading_tips:
+    - "List as a full gold-trimmed set for higher per-piece markup"
+    - "Easy clue events often flood supply so wait for normalization before bulk listing"
+  history:
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -7 to -11"
+    - date: "2014-06-12"
+      description: "Released as part of the gold-trimmed armour clue rewards"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-stone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-stone.mdx
@@ -9,61 +9,64 @@ osrs:
   members: true
   icon: Jar of stone.png
   value: 1
-  lowalch: 1
-  highalch: 1
+  lowalch: null
+  highalch: null
   limit: 4
-  equipment:
-    slot: none
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: collector
+    tier: high
+  properties:
+    release_date: "2017-10-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
   drop_table:
-    primary_source: Grotesque Guardians
-    best_drop_rate: 1/5000
     sources:
       - source: Grotesque Guardians
-        source_id: 7851
-        combat_level: 228
         quantity: "1"
-        rarity: very rare
-        drop_rate: 1/5000
-        members_only: true
+        rarity: 1/5000
   related_items:
-    - item_id: 21748
-      item_name: Noon
+    - item_name: Noon
       slug: noon
       relationship: alternative
-      description: Grotesque Guardian pet
-    - item_id: 21730
-      item_name: Black tourmaline core
+      description: "Pet drop from the same Grotesque Guardians boss"
+    - item_name: Black tourmaline core
       slug: black-tourmaline-core
       relationship: alternative
-      description: Boot upgrade material
-    - item_id: 21742
-      item_name: Granite hammer
+      description: "Granite boot upgrade material from Grotesque Guardians"
+    - item_name: Granite hammer
       slug: granite-hammer
       relationship: alternative
-      description: Grotesque Guardian weapon
-    - item_id: 13245
-      item_name: Jar of souls
+      description: "Weapon drop shared with the Grotesque Guardians drop table"
+    - item_name: Jar of souls
       slug: jar-of-souls
       relationship: alternative
-      description: Cerberus jar drop
-  about: |-
-    POH display:
-    - Place in Boss Lair Display
-    - Shows Grotesque Guardians model
-    - Requires Achievement Gallery
-
-    Collection item:
-    - Part of boss jar collection
-    - Rare trophy from Slayer boss
+      description: "Equivalent boss jar from Cerberus for the boss jar collection"
+  about: Jar of stone is a very rare (1/5,000) drop from the Grotesque Guardians on the Slayer Tower rooftop. Place it in the Boss Lair Display in the Achievement Gallery to showcase the Grotesque Guardians model.
   market_strategy:
     notes:
-      - Very rare drop (1/5,000)
-      - Primarily a collection item
-      - No practical combat use
-      - Shows dedication to boss
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Very rare 1/5,000 drop tied to a single boss"
+      - "Demand is collector-driven (Boss Lair Display)"
+      - "No combat utility or alch return"
+  trading_tips:
+    - "Price spikes follow Slayer Tower drop announcements and boss collection log resets"
+    - "Compare against other jars (Souls, Smoke) to gauge whether the boss-jar meta is rising"
+  history:
+    - date: "2017-10-26"
+      description: "Added with the Grotesque Guardians Slayer boss update"
+    - date: "2024-09-04"
+      description: "Inventory icon adjusted during the Varlamore expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-camo-top-equipped.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-camo-top-equipped.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: null
-  about: "Jungle camo top (equipped) is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.226
+    requirements:
+      hunter: 4
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 15
+      crush: 19
+      magic: 0
+      ranged: 12
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Feldip weasel fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 20
+      tools:
+        - Fancy Clothes Store tailor
+      output_quantity: 1
+  related_items:
+    - item_name: Jungle camo legs
+      slug: jungle-camo-legs
+      relationship: set-piece
+      description: "Matching legs from the jungle camouflage Hunter outfit"
+    - item_name: Larupia hat
+      slug: larupia-hat
+      relationship: alternative
+      description: "Higher-tier camouflage Hunter top alternative"
+  about: Jungle camo top (equipped) is a Hunter camouflage body requiring level 4 Hunter. Tailor it at the Fancy Clothes Store, Hunter Guild, or Prifddinas using 2 Feldip weasel furs and 20 coins. Provides -3 kg weight reduction post-Varlamore.
+  market_strategy:
+    notes:
+      - "Hunter camouflage body for jungle creatures"
+      - "Cheap to craft, abundant supply"
+      - "Weight reduction adds modest utility post-Varlamore"
+  trading_tips:
+    - "Stack with the matching jungle camo legs for full camouflage bonus"
+    - "Watch the Feldip weasel fur market: input costs anchor floor price"
+  history:
+    - date: "2006-11-21"
+      description: "Released alongside the Hunter skill update"
+    - date: "2024-03-20"
+      description: "Gained -3 kg weight reduction in the Varlamore: Part One update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kebab-mix.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kebab-mix.mdx
@@ -1,20 +1,92 @@
 ---
 title: Kebab mix | OSRS Price Data
-description: "Kebab mix: A mixture of chopped tomatoes, onions and ugthanki meat in a bowl.. High alch: 5 GP, GE limit: 11,000."
+description: "Kebab mix: A mixture of chopped tomatoes, onions and ugthanki meat in a bowl. High alch: 5 GP, GE limit: 11,000."
 osrs:
   id: 1881
   name: Kebab mix
   slug: kebab-mix
-  examine: A mixture of chopped tomatoes, onions and ugthanki meat in a bowl.
+  examine: "A mixture of chopped tomatoes, onions and ugthanki meat in a bowl."
   members: true
   icon: Kebab mix.png
   value: 9
   lowalch: 3
   highalch: 5
   limit: 11000
-  about: "Kebab mix is a members-only item in Old School RuneScape. High alchemy value: 5 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food_component
+    tier: low
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Ugthanki meat
+          quantity: 1
+        - item_name: Onion
+          quantity: 1
+        - item_name: Tomato
+          quantity: 1
+        - item_name: Bowl
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+    - skill: cooking
+      level: 1
+      xp: 40
+      materials:
+        - item_name: Kebab mix
+          quantity: 1
+        - item_name: Pitta bread
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Ugthanki kebab
+      slug: ugthanki-kebab
+      relationship: product
+      description: "Final kebab made by combining mix with pitta bread"
+    - item_name: Ugthanki meat
+      slug: ugthanki-meat
+      relationship: component
+      description: "Camel meat ingredient"
+    - item_name: Pitta bread
+      slug: pitta-bread
+      relationship: component
+      description: "Finishing ingredient"
+  about: |-
+    > _"A mixture of chopped tomatoes, onions and ugthanki meat in a bowl."_
+
+    Kebab mix is an intermediate ingredient used to craft ugthanki kebabs. Combine chopped ugthanki meat, onion and tomato in a bowl, then add pitta bread to finish (40 Cooking XP).
+  market_strategy:
+    notes:
+      - "Niche ingredient — thin volume"
+      - "Mostly used by ironmen and Gnome cooking trainers"
+      - "Ugthanki meat supply drives price"
+  trading_tips:
+    - "Resell only in small batches"
+    - "Better to flip the final ugthanki kebab"
+  history:
+    - date: "2003-04-14"
+      description: "Released with the Shilo Village update"
+    - date: "2006-01-30"
+      description: "Graphical update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kebbit-bolts.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 7
   highalch: 10
   limit: 11000
-  about: "Kebbit bolts is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bolt
+    tier: low
+  properties:
+    release_date: "21 November 2006"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: null
+    attack_speed: null
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 28
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 32
+      xp: 5.8
+      materials:
+        - item_name: Kebbit spike
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 12
+  related_items:
+    - item_name: Kebbit spike
+      slug: kebbit-spike
+      relationship: component
+      description: "Fletched into 12 bolts per spike"
+    - item_name: Hunters' crossbow
+      slug: hunters-crossbow
+      relationship: alternative
+      description: "Primary crossbow firing these bolts"
+    - item_name: Long kebbit bolts
+      slug: long-kebbit-bolts
+      relationship: variant
+      description: "Long spike variant"
+  about: "Kebbit bolts are members-only crossbow ammunition fletched from prickly kebbit spikes; primarily paired with the hunters' crossbow."
+  market_strategy:
+    notes:
+      - "Production doubled to 12 per spike after the 20 March 2024 update"
+      - "Supply chained to kebbit hunter activity in the Piscatoris Hunter area"
+      - "Alternative purchase from Leon at Aleck's Hunter Emporium at 1 spike + 20 coins"
+  trading_tips:
+    - "Fletch at 32 Fletching for cheap bolt stockpiles"
+    - "Buy raw spikes if hunter prices outpace bolt margins"
+  history:
+    - date: "21 November 2006"
+      description: "Released with the Hunter skill."
+    - date: "20 March 2024"
+      description: "Bolts produced per spike increased from 6 to 12."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kharidian-headpiece.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kharidian-headpiece.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Kharidian headpiece is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-04-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.07
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Ali Morrisane
+      location: Al Kharid
+      price: 1
+      currency: Coins
+      stock: 12
+    - shop_name: Pollnivneach general store
+      location: Pollnivneach
+      price: 1
+      currency: Coins
+      stock: 12
+  related_items:
+    - item_name: Karidian disguise
+      slug: karidian-disguise
+      relationship: alternative
+      description: "Costume used during The Feud quest sequence"
+  about: |-
+    > *"Wear it on your head."*
+
+    Cheap shop-sold desert headpiece tied to The Feud quest props. Despite the examine, it has no wear option; the item provides 12 seconds of desert heat protection when held. Shops in Al Kharid and Pollnivneach stock 12 at 1 coin each with a 6-second restock, so the GE price largely reflects collector convenience rather than supply scarcity.
+  market_strategy:
+    notes:
+      - "Buy limit 15 sharply caps flips"
+      - "Restock-from-shop floor keeps the GE price ceiling thin"
+      - "Demand driven by quest helpers and collection log filling"
+  trading_tips:
+    - "Restock from Ali Morrisane or Pollnivneach when GE outpaces shop price"
+    - "Niche item — list low quantities to clear faster"
+  history:
+    - date: "2005-04-04"
+      description: "Released alongside The Feud quest"
+    - date: "2015-02"
+      description: "Renamed from Karidian headpiece to Kharidian headpiece"
+    - date: "2023-03"
+      description: "Desert heat protection added (12 seconds)"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kovac-s-grog.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kovac-s-grog.mdx
@@ -1,66 +1,83 @@
 ---
 title: Kovac's grog | OSRS Price Data
-description: "Kovac's grog: Only Kovac knows what's gone into this.. High alch: 3 GP."
+description: "Kovac's grog: Only Kovac knows what's gone into this. High alch: 3 GP."
 osrs:
   id: 27014
   name: Kovac's grog
   slug: kovac-s-grog
-  examine: Only Kovac knows what's gone into this.
+  examine: "Only Kovac knows what's gone into this."
   members: true
   icon: Kovac's grog.png
   value: 5
   lowalch: 2
   highalch: 3
   limit: null
-  item:
-    type: potion
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ale
+    tier: mid
+  properties:
+    release_date: "2022-06-08"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.55
-  effect:
-    boost:
-      - skill: hitpoints
-        amount: 1
-      - skill: smithing
-        amount: 4
-    debuff:
-      - skill: attack
-        amount: -2
-      - skill: ranged
-        amount: -2
-      - skill: magic
-        amount: -2
-  obtaining:
-    source: Giants' Foundry
-    cost: 300 Foundry Reputation
+    options:
+      - "Drink"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Smithing by 4 levels"
+        duration: 0
+      - description: "Restores 1 Hitpoint"
+        duration: 0
+      - description: "Drains Attack by 2 levels"
+        duration: 0
+      - description: "Drains Ranged by 2 levels"
+        duration: 0
+      - description: "Drains Magic by 2 levels"
+        duration: 0
+  shops:
+    - shop_name: Giants' Foundry Reward Shop
+      location: Giants' Foundry, Varrock
+      price: 300
+      currency: Foundry reputation
+      stock: 1
   related_items:
-    - item_id: 2323
-      item_name: Dwarven stout
+    - item_name: Dwarven stout
       slug: dwarven-stout
       relationship: alternative
-      description: Alternative Smithing boost (+1)
-    - item_id: 1377
-      item_name: Dragon battleaxe
+      description: "Alternative Smithing boost (+1)"
+    - item_name: Mature dwarven stout
+      slug: mature-dwarven-stout
+      relationship: alternative
+      description: "+2 Smithing boost"
+    - item_name: Dragon battleaxe
       slug: dragon-battleaxe
       relationship: alternative
-      description: Alternative boost method
+      description: "Special attack boosts Smithing among other stats"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Potion |
-    | Tradeable | Yes |
-    | Weight | 0.55 kg |
+    > _"Only Kovac knows what's gone into this."_
 
-    | Stat | Change |
-    |------|--------|
-    | Hitpoints | +1 |
-    | Smithing | +4 |
-    | Attack | -2 |
-    | Ranged | -2 |
-    | Magic | -2 |
-
-    Second-highest Smithing boost in-game.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Kovac's grog is purchased from the Giants' Foundry Reward Shop for 300 Foundry reputation. Drinking it boosts Smithing by +4 (second-highest Smithing boost in-game) while draining Attack, Ranged, and Magic by 2 each and restoring 1 Hitpoint.
+  market_strategy:
+    notes:
+      - "Supply gated by Giants' Foundry reputation"
+      - "Demand from smithers chasing Smithing milestones"
+      - "Tradeable but margin thin vs reputation grind"
+  trading_tips:
+    - "Buy from GE when below reputation-conversion break-even"
+    - "Stockpile before Smithing rework events"
+  history:
+    - date: "2022-06-08"
+      description: "Released with the Giants' Foundry minigame"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-fur.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 10000
-  about: "Kyatt fur is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: fur
+    tier: mid
+  properties:
+    release_date: "21 November 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Sabre-toothed kyatt (pitfall trap)
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - item_name: Tatty kyatt fur
+      slug: tatty-kyatt-fur
+      relationship: downgrade
+      description: "Lower-quality drop from the same hunter creature"
+    - item_name: Kyatt hat
+      slug: kyatt-hat
+      relationship: product
+      description: "Cosmetic piece crafted from kyatt fur at the Fancy Clothes Store"
+    - item_name: Kyatt top
+      slug: kyatt-top
+      relationship: product
+      description: "Cosmetic top crafted from kyatt fur"
+    - item_name: Kyatt legs
+      slug: kyatt-legs
+      relationship: product
+      description: "Cosmetic legs crafted from kyatt fur"
+  about: |-
+    > *"It's a perfect-looking kyatt fur."*
+
+    Kyatt fur is obtained by pit-trapping Sabre-toothed kyatts in the polar hunting region; the tatty variant drops far more often, so a perfect fur signals a clean catch. Pit trapping the kyatt requires 55 Hunter.
+
+    The fur is the input for the Kyatt outfit at the Fancy Clothes Store in Varrock: hat (1,000 coins), top (200 coins) and legs (200 coins). Wearing the full set requires 52 Hunter and cuts damage taken from hunter creatures by 60%, but it does not boost hunter success rate.
+  market_strategy:
+    notes:
+      - "Supply is gated by polar hunter activity"
+      - "Demand spikes whenever new hunter content references the kyatt outfit"
+  trading_tips:
+    - "Watch tatty-vs-perfect fur ratios: a glut of tatty pulls perfect prices down"
+    - "Hunter-cape questers buy in bulk: a steady drip outperforms big dumps"
+  history:
+    - date: "21 November 2006"
+      description: "Released with the Hunter skill"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/larupia-legs.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
-  about: "Larupia legs is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: hunter_gear
+    tier: low
+  properties:
+    release_date: "21 November 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weight: 0.226
+    requirements:
+      hunter: 28
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: -7
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: 0
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Larupia hat
+      slug: larupia-hat
+      relationship: set-piece
+      description: "Head piece of the Larupia hunter set"
+    - item_name: Larupia top
+      slug: larupia-top
+      relationship: set-piece
+      description: "Body piece of the Larupia hunter set"
+  about: |-
+    > *"These should make me harder to spot in woodland and jungle areas."*
+
+    Larupia legs are part of the Larupia hunter gear set, providing a camouflage bonus when hunting in woodland and jungle environments. Requires 28 Hunter to equip and can be stored in a costume room's armour case.
+  market_strategy:
+    notes:
+      - "Demand tied to Hunter training and clothing-set collectors"
+      - "Low buy limit (150) keeps individual flips small"
+      - "Often noted in bulk by Hunter trainers"
+  trading_tips:
+    - "Stock up around Hunter XP weekends and tasks"
+    - "Larupia set demand persists for camouflage Hunter spots"
+  history:
+    - date: "21 November 2006"
+      description: "Released as part of the Hunter skill launch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lava-dragon-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lava-dragon-bones.mdx
@@ -12,57 +12,65 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 7500
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   material:
     type: bone
     tier: high
-  prayer:
-    xp_bury: 85
-    xp_gilded_altar: 297.5
-    xp_chaos_altar: 297.5
-    xp_ectofuntus: 340
-    xp_sinister_offering: 255
+  properties:
+    release_date: "13 March 2014"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.6
+    options:
+      - Bury
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: Prayer XP on Bury
+      description: "Bury 85 XP; Gilded altar (2 burners) 297.5 XP; Chaos altar averages 595 XP with 50% no-consume; Ectofuntus 340 XP; Sinister Offering 255 XP."
   drop_table:
     sources:
       - source: Lava dragon
-        source_id: 6593
-        combat_level: 252
         quantity: "1"
-        rarity: always
-        members_only: true
+        rarity: "Always"
   related_items:
-    - item_id: 536
-      item_name: Dragon bones
+    - item_name: Dragon bones
       slug: dragon-bones
       relationship: downgrade
-      description: Lower XP (72 base)
-    - item_id: 6729
-      item_name: Dagannoth bones
+      description: "Lower base 72 Prayer XP"
+    - item_name: Dagannoth bones
       slug: dagannoth-bones
       relationship: upgrade
-      description: Higher XP (125 base)
-    - item_id: 22786
-      item_name: Hydra bones
+      description: "Higher base 125 Prayer XP"
+    - item_name: Hydra bones
       slug: hydra-bones
       relationship: alternative
-      description: Higher XP (110 base)
-    - item_id: 11992
-      item_name: Lava scale
+      description: "Slayer-locked 110 base Prayer XP"
+    - item_name: Lava scale
       slug: lava-scale
       relationship: alternative
-      description: Used for extended antifires
+      description: "Used for extended antifires"
+  about: "Lava dragon bones are a Wilderness-only prayer training option dropped exclusively by lava dragons on Lava Dragon Isle, often cheapest per XP at the Chaos altar."
   market_strategy:
     notes:
-      - Supply limited by PKer risk
-      - Slightly better than dragon bones
-      - Price includes risk premium
-      - Wilderness activity
-      - PKer presence
-      - Anti-PK meta changes
-      - Often cheaper per XP than dragon bones
-      - Risk factor limits supply
-      - Good for Ironmen near Chaos altar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply throttled by PKer risk in Wilderness"
+      - "Often cheaper per XP than dragon bones at the Chaos altar"
+      - "Elite Wilderness Diary unlocks noted bone drops, easing supply"
+  trading_tips:
+    - "Stockpile during PK meta lulls for cheaper buys"
+    - "Pair with Chaos altar 50% no-consume mechanic for best XP-per-coin"
+  history:
+    - date: "13 March 2014"
+      description: "Released with the lava dragon NPC."
+    - date: "5 March 2015"
+      description: "Elite Wilderness Diary allows lava dragons to drop noted bones."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lava-staff-upgrade-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lava-staff-upgrade-kit.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: 50
-  about: "Lava staff upgrade kit is a members-only item in Old School RuneScape. High alchemy value: 900 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ornament-kit
+    tier: mid
+  properties:
+    release_date: "2017-02-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Last Man Standing lobby
+      price: 13
+      currency: Last Man Standing points
+      stock: 100
+  related_items:
+    - item_name: Lava battlestaff
+      slug: lava-battlestaff
+      relationship: component
+      description: "Base staff that the kit upgrades"
+    - item_name: Mystic lava staff
+      slug: mystic-lava-staff
+      relationship: component
+      description: "Alternative base staff for the upgrade"
+    - item_name: Lava battlestaff (or)
+      slug: lava-battlestaff-or
+      relationship: upgrade
+      description: "Cosmetic result when applied to a lava battlestaff"
+    - item_name: Mystic lava staff (or)
+      slug: mystic-lava-staff-or
+      relationship: upgrade
+      description: "Cosmetic result when applied to a mystic lava staff"
+  about: "The Lava staff upgrade kit is a cosmetic ornament kit purchased from Justine's Last Man Standing shop for 13 LMS points. Applying the kit consumes it and makes the resulting staff untradeable, though reverting is possible at the cost of the kit."
+  market_strategy:
+    notes:
+      - "Supply tied to Last Man Standing point spend"
+      - "Cosmetic-only, demand from collectors and mains"
+      - "Once applied the staff becomes untradeable"
+  trading_tips:
+    - "Compare GE price to opportunity cost of 13 LMS points"
+    - "Reverting the staff does not refund the kit"
+    - "Low buy limit constrains flips"
+  history:
+    - date: "2017-02-09"
+      description: "Added to Justine's Last Man Standing reward shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lemon-chunks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lemon-chunks.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Lemon chunks is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food-ingredient
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.08
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Lemon
+          quantity: 1
+        - item_name: Knife
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Lemon
+      slug: lemon
+      relationship: component
+      description: "Source fruit: diced with a knife to produce chunks"
+    - item_name: Orange chunks
+      slug: orange-chunks
+      relationship: alternative
+      description: "Alternative citrus chunks used in gnome cocktails"
+    - item_name: Sliced lime
+      slug: sliced-lime
+      relationship: component
+      description: "Co-ingredient in Blurberry special cocktail"
+  about: "Lemon chunks are a members-only gnome cooking ingredient produced by using a knife on a lemon. Primarily used in the Blurberry special cocktail (Cooking 37) alongside orange chunks, equa leaves, sliced lime, and mixed special base."
+  market_strategy:
+    notes:
+      - "Small margin from dicing lemons into chunks"
+      - "Demand tied to gnome cocktail training"
+      - "Stable low-volume ingredient market"
+  trading_tips:
+    - "Buy lemons and dice them: the chunks resell higher than the raw fruit"
+    - "Stock for Gnome Restaurant minigame and Blurberry special demand"
+  history:
+    - date: "2002-12-12"
+      description: "Released with the Gnome Stronghold cooking content"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/leprechaun-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/leprechaun-hat.mdx
@@ -5,16 +5,70 @@ osrs:
   id: 12359
   name: Leprechaun hat
   slug: leprechaun-hat
-  examine: Top o' the morning!
+  examine: "Top o' the morning!"
   members: true
   icon: Leprechaun hat.png
   value: 1000
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "Leprechaun hat is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Leprechaun top
+      slug: leprechaun-top
+      relationship: set-piece
+      description: "Body slot of the leprechaun outfit"
+    - item_name: Reward casket (medium)
+      slug: reward-casket-medium
+      relationship: component
+      description: "Source casket for the hat"
+  about: "The Leprechaun hat is a purely cosmetic head-slot reward from medium clue scrolls at roughly 1/1,133 from the reward casket. It can be stored in the costume room's treasure chest for collectors."
+  market_strategy:
+    notes:
+      - "Supply tied to medium clue completions"
+      - "Cosmetic-only, demand from collectors"
+      - "Tight buy limit caps flips"
+  trading_tips:
+    - "Compare against St. Patrick paraphernalia cycles"
+    - "Buy limit 4 keeps flipping volume small"
+    - "Costume chest storage preserves long-term demand"
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/light-trousers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/light-trousers.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 2400
   highalch: 3600
   limit: 4
-  about: "Light trousers is a members-only item in Old School RuneScape. High alchemy value: 3,600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 1
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_name: Light tuxedo jacket
+      slug: light-tuxedo-jacket
+      relationship: set-piece
+      description: "Body slot of Light tuxedo outfit"
+    - item_name: Light bow tie
+      slug: light-bow-tie
+      relationship: set-piece
+      description: "Neck slot accessory"
+    - item_name: Light tuxedo cuffs
+      slug: light-tuxedo-cuffs
+      relationship: set-piece
+      description: "Hands slot accessory"
+    - item_name: Light tuxedo shoes
+      slug: light-tuxedo-shoes
+      relationship: set-piece
+      description: "Feet slot accessory"
+  about: "Light trousers are a cosmetic legs slot reward from elite Treasure Trails at roughly 1/12,750 rarity. They form part of the Light tuxedo outfit and can be stored in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Elite clue cosmetic, supply tied to clue completions"
+      - "Low buy limit caps flipping volume"
+      - "Set demand spikes when collectors complete outfits"
+  trading_tips:
+    - "Watch elite clue completion trends before flipping"
+    - "Price reacts to full Light tuxedo set demand"
+    - "Buy limit of 4 keeps margins per cycle small"
+  history:
+    - date: "2016-07-06"
+      description: "Released as part of the Treasure Trails Expansion update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mackerel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mackerel.mdx
@@ -12,18 +12,60 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 6000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 10
+      xp: 60
+      materials:
+        - item_name: Raw mackerel
+          quantity: 1
+      tools:
+        - Fire
+        - Cooking range
+      output_quantity: 1
   related_items:
-    - item_id: 353
-      item_name: Raw mackerel
+    - item_name: Raw mackerel
       slug: raw-mackerel
       relationship: component
-      description: Uncooked version
-  about: |-
-    > _"Some nicely cooked mackerel."_
-
-    Mackerel heals 6 Hitpoints. A low-tier members fish caught with a big fishing net.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Uncooked version used as the cooking material"
+    - item_name: Burnt fish
+      slug: burnt-fish
+      relationship: alternative
+      description: "Failed cook result below the no-burn level"
+  about: "Mackerel is a members-only cooked fish that heals 6 Hitpoints when eaten. Cook raw mackerel at level 10 Cooking for 60 XP; burning stops entirely at level 45 (level 41 at the Lumbridge Castle range)."
+  market_strategy:
+    notes:
+      - "Low-tier healing food with thin margins"
+      - "Bulk demand from low-level cookers and skillers"
+      - "Buy limit of 6,000 supports volume flips"
+  trading_tips:
+    - "Stack cheap raw mackerel and cook to a no-burn level to convert XP into a small margin"
+    - "GE convenience fee was removed in May 2025, slightly improving flip economics"
+  history:
+    - date: "2002-02-27"
+      description: "Released as part of the original Cooking content"
+    - date: "2025-05-29"
+      description: "Exempted from the Grand Exchange convenience fee"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-comp-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-comp-bow.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 1000
   highalch: 1500
   limit: 8
-  about: "Magic comp bow is a members-only item in Old School RuneScape. High alchemy value: 1,500 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: wood
+    tier: mid-high
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.8
+    options:
+      - "Wield"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: "2h"
+    weapon_type: bow
+    attack_speed: 4
+    weight: 1.8
+    requirements:
+      ranged: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 71
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Treasure Trail (reward casket)
+        quantity: "1"
+        rarity: "1/270.8"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  passive_effects:
+    - name: Powershot
+      description: "Special attack: guaranteed hit on the target for 35% spec energy, but damage-boosting prayers are excluded from the damage roll."
+  related_items:
+    - item_name: Magic shortbow
+      slug: magic-shortbow
+      relationship: alternative
+      description: Faster magic-tier bow without the Powershot spec
+    - item_name: Magic longbow
+      slug: magic-longbow
+      relationship: alternative
+      description: Slower magic-tier bow with extended range
+    - item_name: Yew comp bow
+      slug: yew-comp-bow
+      relationship: downgrade
+      description: Lower-tier composite bow at 40 Ranged
+    - item_name: Crystal bow
+      slug: crystal-bow
+      relationship: upgrade
+      description: High-tier elven bow used at 70+ Ranged
+  about: "Magic comp bow is a Hard clue reward bow that fires one tick faster than a magic longbow while keeping the same 10-tile range; its Powershot special is a Halloween-throwback guarantee-hit hidden in plain sight."
+  market_strategy:
+    notes:
+      - "Tight 8-per-4hr buy limit makes meaningful stockpiling slow."
+      - "Demand mostly cosmetic / collector — combat slots are owned by msb(i)."
+  trading_tips:
+    - "Cross-reference Hard clue completion stats around DMM and league launches."
+    - "Margin scales with clue droughts: monitor casket loot logs for supply dips."
+  history:
+    - date: "2006-12-05"
+      description: Added to the Hard Treasure Trail reward table at launch.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-mask-f.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-mask-f.mdx
@@ -12,20 +12,51 @@ osrs:
   lowalch: 360000
   highalch: 540000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: masori
+    tier: high
+  properties:
+    release_date: "2022-08-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 1.5
     requirements:
       ranged: 80
       defence: 80
-    stats:
-      defence_stab: 8
-      defence_slash: 10
-      defence_crush: 12
-      defence_magic: 12
-      defence_ranged: 9
-      attack_ranged: 12
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 12
+    defence_bonus:
+      stab: 8
+      slash: 10
+      crush: 12
+      magic: 12
+      ranged: 9
+    other_bonus:
+      strength: 0
       ranged_strength: 2
+      magic_damage: 0
       prayer: 1
   recipes:
     - skill: crafting
@@ -33,65 +64,40 @@ osrs:
       xp: 830
       materials:
         - item_name: Masori mask
-          item_id: 27226
           quantity: 1
         - item_name: Armadylean plate
-          item_id: 27232
           quantity: 1
-      product: Masori mask (f)
-      product_id: 27235
-      product_quantity: 1
-      facility: Hammer
-      members_only: true
+      tools:
+        - Hammer
+      output_quantity: 1
   related_items:
-    - item_id: 27238
-      item_name: Masori body (f)
+    - item_name: Masori mask
+      slug: masori-mask
+      relationship: component
+      description: "Standard Masori mask consumed in the fortification recipe"
+    - item_name: Masori body (f)
       slug: masori-body-f
       relationship: set-piece
-      description: Body slot
-    - item_id: 27241
-      item_name: Masori chaps (f)
+      description: "Body slot of the fortified Masori set"
+    - item_name: Masori chaps (f)
       slug: masori-chaps-f
       relationship: set-piece
-      description: Legs slot
-    - item_id: 11826
-      item_name: Armadyl helmet
+      description: "Legs slot of the fortified Masori set"
+    - item_name: Armadyl helmet
       slug: armadyl-helmet
       relationship: alternative
-      description: Budget option
-  about: |-
-    Combine Masori mask with Armadylean plate using a hammer (90 Crafting).
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Masori mask | Tombs of Amascut | ~50M gp |
-    | Armadylean plate | Armadyl armour | ~1M gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged attack | +12 |
-    | Ranged strength | +2 |
-    | Defence bonuses | +8 to +12 |
-    | Prayer bonus | +1 |
-    | Requirements | 80 Ranged, 80 Defence |
-
-    Part of the Masori armour (fortified) set:
-    - Masori mask (f) (head)
-    - Masori body (f) (body)
-    - Masori chaps (f) (legs)
-
-    PvM:
-    - Best-in-slot ranged helm
-    - Tombs of Amascut
-    - Theatre of Blood
-    - General ranged content
+      description: "Budget BiS replacement for ranged head slot"
+  about: "Masori mask (f) is the best-in-slot ranged helmet for Tombs of Amascut and most ranged PvM, narrowly edging out the Armadyl helmet thanks to its set bonus when worn with the fortified body and chaps. Fortification is irreversible and consumes an Armadylean plate from Armadyl armour."
   market_strategy:
     notes:
-      - ToA completions affect supply
-      - BiS ranged helm
-      - Fortified has better defence
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply is gated by ToA Expert raid completions plus Armadylean plate availability."
+      - "Demand spikes alongside any ranged buff or ToA reward shop reshuffle."
+  trading_tips:
+    - "Watch the spread between Masori mask + Armadylean plate vs the fortified piece - arbitrage when it widens."
+    - "Buy limit of 8 per 4 hours makes flips capital-intensive; long-term holds work better."
+  history:
+    - date: "2022-08-24"
+      description: "Released with the Tombs of Amascut raid as part of the fortified Masori upgrade path."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-crossbow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-crossbow.mdx
@@ -12,50 +12,95 @@ osrs:
   lowalch: 313
   highalch: 469
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: crossbow
-    tradeable: true
+    weapon_type: crossbow
+    attack_speed: 6
     weight: 5
     requirements:
       ranged: 36
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      attack_ranged: 66
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 66
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    attack_range: 7
   recipes:
     - skill: fletching
       level: 54
+      xp: 32
       materials:
         - item_name: Mithril crossbow (u)
           quantity: 1
         - item_name: Crossbow string
           quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 9183
-      item_name: Adamant crossbow
+    - item_name: Adamant crossbow
       slug: adamant-crossbow
       relationship: upgrade
-      description: Next tier crossbow
-    - item_id: 9142
-      item_name: Mithril bolts
+      description: "Next tier crossbow with higher ranged attack bonus"
+    - item_name: Steel crossbow
+      slug: steel-crossbow
+      relationship: downgrade
+      description: "Previous tier crossbow with lower ranged attack bonus"
+    - item_name: Mithril bolts
       slug: mithril-bolts
       relationship: alternative
-      description: Compatible ammo
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Highest tier bolts this crossbow can fire"
+    - item_name: Mithril crossbow (u)
+      slug: mithril-crossbow-u
+      relationship: component
+      description: "Unstrung version used to fletch this crossbow"
+  about: "Mithril crossbow is a members-only crossbow requiring 36 Ranged to wield. It can fire bolts up to and including mithril bolts and is fletched at level 54 Fletching."
+  market_strategy:
+    notes:
+      - "Mid-tier ranged weapon mostly used as a stepping stone to Adamant or Rune crossbow"
+      - "Self-fletching costs more than the GE price, so flipping the unstrung version is the profitable angle"
+      - "Demand stays steady from low-mid Ranged trainers"
+  trading_tips:
+    - "Compare Mithril crossbow (u) plus crossbow string costs versus the strung GE price to spot fletching arbitrage"
+    - "Buy limit of 125 supports modest flipping volume"
+  history:
+    - date: "2006-07-31"
+      description: "Released as part of the crossbow rework expansion"
+    - date: "2014"
+      description: "Renamed from Mith c'bow"
+    - date: "2020"
+      description: "Renamed to the current Mithril crossbow"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-javelin-tips.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 66
   highalch: 99
   limit: 10000
-  about: "Mithril javelin tips is a members-only item in Old School RuneScape. High alchemy value: 99 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: smithing-product
+    tier: mid
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 56
+      xp: 50
+      materials:
+        - item_name: Mithril bar
+          quantity: 1
+        - item_name: Hammer
+          quantity: 1
+      tools: []
+      output_quantity: 5
+    - skill: fletching
+      level: 47
+      xp: 8
+      materials:
+        - item_name: Mithril javelin tips
+          quantity: 15
+        - item_name: Javelin shaft
+          quantity: 15
+      tools: []
+      output_quantity: 15
+  related_items:
+    - item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: "Smithed at an anvil into five javelin tips"
+    - item_name: Javelin shaft
+      slug: javelin-shaft
+      relationship: component
+      description: "Fletched onto the tips to make mithril javelins"
+    - item_name: Mithril javelin
+      slug: mithril-javelin
+      relationship: product
+      description: "Final javelin produced by combining tips with shafts"
+    - item_name: Adamant javelin tips
+      slug: adamant-javelin-tips
+      relationship: alternative
+      description: "Next-tier javelin tip"
+  about: "Mithril javelin tips are smithed five at a time from a mithril bar at 56 Smithing and combined with javelin shafts at 47 Fletching to produce mithril javelins. Stackable in the inventory; weightless."
+  market_strategy:
+    notes:
+      - "Stack-stable supply from Monkey Madness II content path"
+      - "Demand tied to ranged training with javelins"
+      - "Margin chained between bars, tips, and finished javelins"
+  trading_tips:
+    - "Track the bar to tip to javelin chain for the best leg in the spread"
+    - "Bulk fletch with shafts when tips dip below javelin sale price"
+  history:
+    - date: "2016-05-06"
+      description: "Released as part of the Monkey Madness II expansion"
+    - date: "2025-11-05"
+      description: "Renamed from 'Mithril javelin heads' to 'Mithril javelin tips'"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-kiteshield.mdx
@@ -12,24 +12,98 @@ osrs:
   lowalch: 884
   highalch: 1326
   limit: 125
-  item_id: 1197
-  item_type: armor
-  slot: shield
-  type: kiteshield
-  tradeable: true
-  weight: 4.535
-  requirements:
-    defence: 20
-  stats:
-    stab_defence: 18
-    slash_defence: 22
-    crush_defence: 20
-    ranged_defence: 20
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 4.535
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 4.535
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 18
+      slash: 22
+      crush: 20
+      magic: 0
+      ranged: 20
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 62
+      xp: 150
+      materials:
+        - item_name: Mithril bar
+          quantity: 3
+      tools: ["Hammer", "Anvil"]
+      output_quantity: 1
+  shops:
+    - shop_name: Cassie's shield shop
+      location: Falador
+      price: 2210
+      currency: Coins
+      stock: 5
+    - shop_name: Jatizso shield shop
+      location: Jatizso
+      price: 2210
+      currency: Coins
+      stock: 5
   related_items:
-    - slug: adamant-kiteshield
-    - slug: mithril-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: "Three bars smithed into the shield"
+    - item_name: Adamant kiteshield
+      slug: adamant-kiteshield
+      relationship: upgrade
+      description: "Next-tier kiteshield"
+    - item_name: Mithril platebody
+      slug: mithril-platebody
+      relationship: set-piece
+      description: "Matching mithril body armor"
+  about: |-
+    > *"A large metal shield."*
+
+    Free-to-play mid-tier kiteshield smithed at 62 Smithing from 3 mithril bars for 150 Smithing XP. Requires 20 Defence to wield. Defensive bonuses peak at +22 slash and +20 crush/ranged with a 0 magic defence and -8 magic attack penalty. Bar input cost typically exceeds the GE price, so smithing for profit is unviable; production exists primarily for Smithing XP runs.
+  market_strategy:
+    notes:
+      - "GE price routinely sits under 3-bar smithing cost — unprofitable to forge for sale"
+      - "F2P availability keeps supply steady"
+      - "Buy limit 125 caps flips"
+  trading_tips:
+    - "Treat as a Smithing XP sink, not a profit forge"
+    - "Bulk-buy under high alch ceiling for low-risk alchemy fodder"
+  history:
+    - date: "2001-01-04"
+      description: "Released during the RuneScape beta launch"
+    - date: "2021-04"
+      description: "Ranged attack bonus reduced from -2 to -3"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platelegs-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platelegs-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril platelegs (t) | OSRS Price Data
-description: "Mithril platelegs (t): Mithril platelegs with trim.. High alch: 1,560 GP, GE limit: 8."
+description: "Mithril platelegs (t) is a trimmed free-to-play legs slot item requiring 20 Defence. High alch: 1,560 GP, GE limit: 8."
 osrs:
   id: 12289
   name: Mithril platelegs (t)
@@ -12,9 +12,95 @@ osrs:
   lowalch: 1040
   highalch: 1560
   limit: 8
-  about: "Mithril platelegs (t) is a free-to-play item in Old School RuneScape. High alchemy value: 1,560 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: mithril
+    tier: low
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 7.711
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 7.711
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -4
+      ranged: -11
+    defence_bonus:
+      stab: 24
+      slash: 22
+      crush: 20
+      magic: -4
+      ranged: 22
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Medium Treasure Trails reward casket
+        quantity: "1"
+        rarity: "1/1,133"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Mithril platelegs
+      slug: mithril-platelegs
+      relationship: variant
+      description: "Untrimmed standard mithril platelegs"
+    - item_name: Mithril platelegs (g)
+      slug: mithril-platelegs-g
+      relationship: variant
+      description: "Gold-trim version of the platelegs"
+    - item_name: Mithril platebody (t)
+      slug: mithril-platebody-t
+      relationship: set-piece
+      description: "Matching trimmed body slot piece"
+    - item_name: Mithril full helm (t)
+      slug: mithril-full-helm-t
+      relationship: set-piece
+      description: "Matching trimmed full helm"
+  about: |-
+    Mithril platelegs (t) are the trimmed cosmetic variant of mithril platelegs, sharing identical stats with the standard pair but stamped with a silver-blue trim. They are free-to-play and require 20 Defence to wear.
+
+    Trimmed mithril enters the economy from medium Treasure Trails reward caskets at roughly 1/1,133, keeping supply thin enough for the variant to trade at a multiple of the regular legs.
+  market_strategy:
+    notes:
+      - "Cosmetic variant — trim premium drives the price"
+      - "Buy limit of 8 keeps daily flips small"
+      - "Set value can outpace individual piece value when collectors are accumulating"
+  trading_tips:
+    - "Track medium clue drop weighting updates — supply moves with it"
+    - "Compare against the (g) gold-trim variant before listing"
+  history:
+    - date: "2014-06-12"
+      description: "Released as part of the Treasure Trail Expansion."
+    - date: "2021-04-21"
+      description: "Ranged attack penalty adjusted in an equipment rebalance."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-sq-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-sq-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril sq shield | OSRS Price Data
-description: "Mithril sq shield: A medium square shield.. High alch: 936 GP, GE limit: 125."
+description: "Mithril sq shield: A medium square shield. High alch: 936 GP, GE limit: 125."
 osrs:
   id: 1181
   name: Mithril sq shield
@@ -12,25 +12,105 @@ osrs:
   lowalch: 624
   highalch: 936
   limit: 125
-  item_id: 1181
-  item_type: armor
-  slot: shield
-  type: square_shield
-  tradeable: true
-  weight: 3.175
-  requirements:
-    defence: 20
-  stats:
-    stab_defence: 17
-    slash_defence: 19
-    crush_defence: 15
-    magic_defence: 0
-    ranged_defence: 17
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 3.175
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: 0
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 15
+      magic: 0
+      ranged: 17
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 58
+      xp: 100
+      materials:
+        - item_name: Mithril bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  shops:
+    - shop_name: "Cassie's Shield Shop"
+      location: Falador
+      price: 1560
+      currency: coins
+      stock: 3
+    - shop_name: Jatizso Armour Shop
+      location: Jatizso
+      price: 1716
+      currency: coins
+      stock: 0
   related_items:
-    - slug: adamant-sq-shield
-    - slug: mithril-kiteshield
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Adamant sq shield
+      slug: adamant-sq-shield
+      relationship: upgrade
+      description: "Higher tier square shield"
+    - item_name: Steel sq shield
+      slug: steel-sq-shield
+      relationship: downgrade
+      description: "Lower tier square shield"
+    - item_name: Mithril kiteshield
+      slug: mithril-kiteshield
+      relationship: alternative
+      description: "Larger mithril shield with better defence bonuses"
+    - item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: "Two bars smith the shield at 58 Smithing"
+  about: |-
+    > _"A medium square shield."_
+
+    The mithril square shield is a free-to-play mid-tier shield requiring 20 Defence to equip. Smithed from two mithril bars at level 58 Smithing for 100 XP. Stat-wise it sits between the steel and adamant sq shields; most defence-focused players skip it for the mithril kiteshield instead.
+  market_strategy:
+    notes:
+      - "Net loss vs bar cost makes smithing for profit unviable"
+      - "Better suited for Smithing XP/hr training than flipping"
+      - "Low GE buy limit of 125 caps flip volume"
+  trading_tips:
+    - "Check Cassie's shop restocks during low-demand windows"
+    - "Bar cost vs finished shield governs Smithing margin"
+  history:
+    - date: "2001-01-04"
+      description: "Released with original RuneScape Classic shield set"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-top.mdx
@@ -12,9 +12,97 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 100
-  about: "Mixed hide top is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: hide
+    tier: mid-high
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 3
+    requirements:
+      ranged: 60
+      defence: 50
+    attack_bonus:
+      stab: 4
+      slash: -2
+      crush: -3
+      magic: -15
+      ranged: 27
+    defence_bonus:
+      stab: 33
+      slash: 39
+      crush: 43
+      magic: 30
+      ranged: 32
+    other_bonus:
+      strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 72
+      xp: 150
+      materials:
+        - item_name: Mixed hide base
+          quantity: 1
+        - item_name: Sunlight antelope fur
+          quantity: 2
+        - item_name: Thread
+          quantity: 1
+        - item_name: Needle
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Mixed hide base
+      slug: mixed-hide-base
+      relationship: component
+      description: "Required base for crafting the top"
+    - item_name: Mixed hide legs
+      slug: mixed-hide-legs
+      relationship: set-piece
+      description: "Matching leg armour from the mixed hide set"
+    - item_name: Mixed hide boots
+      slug: mixed-hide-boots
+      relationship: set-piece
+      description: "Matching boots from the mixed hide set"
+    - item_name: Fighter torso
+      slug: fighter-torso
+      relationship: alternative
+      description: "Comparable chest with similar strength bonus"
+  about: "Mixed hide top is a members-only ranged chest piece released with Varlamore Part One. It is the only chestpiece in the game with a stab attack bonus, making it useful against stab-weak enemies while providing strong all-around defensive stats."
+  market_strategy:
+    notes:
+      - "Crafting from base hide and sunlight antelope furs at 72 Crafting can yield a profit of around 985 coins per piece after GE tax."
+      - "Buying from Pellem at the Hunter Guild costs 20,000 coins plus furs and results in a net loss compared to GE pricing."
+      - "Daily volume is moderate so flipping in large quantity may require patience to fill orders."
+  trading_tips:
+    - "Compare crafting cost vs GE price before producing for profit"
+    - "Stock the mixed hide base and sunlight antelope fur when prices dip"
+    - "Limit is 100 per 4 hours so plan flipping windows carefully"
+  history:
+    - date: "2024-03-20"
+      description: "Released with the Varlamore: Part One update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-mead-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moonlight-mead-4.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Moonlight mead(4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: beverage
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Drinking a pint heals 1 hitpoint and acts as a brewed beverage with minor effects"
+        duration: 0
+  related_items:
+    - item_name: Moonlight mead(3)
+      slug: moonlight-mead-3
+      relationship: variant
+      description: "Three-pint keg variant"
+    - item_name: Moonlight mead(2)
+      slug: moonlight-mead-2
+      relationship: variant
+      description: "Two-pint keg variant"
+    - item_name: Moonlight mead(1)
+      slug: moonlight-mead-1
+      relationship: variant
+      description: "One-pint keg variant"
+    - item_name: Beer glass
+      slug: beer-glass
+      relationship: component
+      description: "Used on the keg to extract a single pint"
+  about: "Moonlight mead(4) is a full keg containing four pints of moonlight mead. Drink directly for the full effect or use a beer glass to draw individual pints; once poured, a pint cannot be returned to the keg."
+  market_strategy:
+    notes:
+      - "Low alch floor; price tracks demand from costume room collectors"
+      - "Partially drunk versions are untradeable post-2015"
+      - "Stable bulk supply from brewing"
+  trading_tips:
+    - "Hold full (4) kegs for the costume room ale rack and Brewing diaries"
+    - "Sell into spikes around new costume room or Karamja diary content"
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Brewing update introducing keg storage"
+    - date: "2015-02-26"
+      description: "Partially drunk kegs became untradeable on the Grand Exchange"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-feet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-feet.mdx
@@ -12,9 +12,89 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Mummy's feet is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: "1/12,765"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Mummy's head
+      slug: mummy-s-head
+      relationship: set-piece
+      description: "Matching head from the mummy outfit"
+    - item_name: Mummy's body
+      slug: mummy-s-body
+      relationship: set-piece
+      description: "Matching body from the mummy outfit"
+    - item_name: Mummy's legs
+      slug: mummy-s-legs
+      relationship: set-piece
+      description: "Matching legs from the mummy outfit"
+    - item_name: Mummy's hands
+      slug: mummy-s-hands
+      relationship: set-piece
+      description: "Matching hands from the mummy outfit"
+  about: "Mummy's feet is a members-only cosmetic boot piece obtained as a rare reward from master Treasure Trails. Provides no combat stats and is valued by fashionscape collectors completing the mummy outfit."
+  market_strategy:
+    notes:
+      - "Drop rate of 1/12,765 from master caskets makes supply extremely limited."
+      - "Buy limit of 4 caps reseller turnover."
+      - "Price tracks fashionscape demand and overall master clue completion volume."
+  trading_tips:
+    - "Acquire individual pieces during clue scroll competitions when supply briefly spikes"
+    - "Pair listings with other mummy outfit pieces to attract set buyers"
+  history:
+    - date: "2016-07-06"
+      description: "Released as a master clue scroll reward"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mummy-s-legs.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Mummy's legs is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/12765
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Mummy's head
+      slug: mummy-s-head
+      relationship: set-piece
+      description: "Head slot of the Mummy outfit"
+    - item_name: Mummy's body
+      slug: mummy-s-body
+      relationship: set-piece
+      description: "Body slot of the Mummy outfit"
+    - item_name: Mummy's hands
+      slug: mummy-s-hands
+      relationship: set-piece
+      description: "Glove slot of the Mummy outfit"
+    - item_name: Mummy's feet
+      slug: mummy-s-feet
+      relationship: set-piece
+      description: "Boot slot of the Mummy outfit"
+  about: "Mummy's legs is a cosmetic leg piece obtained from master clue reward caskets at a 1/12,765 rate. It has no combat stats and is part of the Mummy outfit, which can be stored in the costume room of a player-owned house."
+  market_strategy:
+    notes:
+      - "Buy limit of 4 per 4 hours keeps the GE thin and price-volatile."
+      - "Demand comes from collectors completing the Mummy outfit; supply is purely master clue dependent."
+  trading_tips:
+    - "Track when prominent streamers run master clues - large drops can dip the price briefly."
+    - "Patience pays: hold through cosmetic-set hype cycles for better exits."
+  history:
+    - date: "2016-07-06"
+      description: "Released with the Treasure Trail Expansion as a master clue reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom-potato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mushroom-potato.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mushroom potato | OSRS Price Data
-description: "Mushroom potato: A baked potato with mushroom and onions.. High alch: 27 GP, GE limit: 13,000."
+description: "Mushroom potato: A baked potato with mushroom and onions. High alch: 27 GP, GE limit: 13,000."
 osrs:
   id: 7058
   name: Mushroom potato
@@ -12,9 +12,68 @@ osrs:
   lowalch: 18
   highalch: 27
   limit: 13000
-  about: "Mushroom potato is a members-only item in Old School RuneScape. High alchemy value: 27 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2006-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 64
+      xp: 55
+      materials:
+        - item_name: Potato with butter
+          quantity: 1
+        - item_name: Mushroom & onion
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Healing
+      description: "Restores 20 Hitpoints when eaten"
+  related_items:
+    - item_name: Potato with butter
+      slug: potato-with-butter
+      relationship: component
+      description: "Base ingredient for the topped potato"
+    - item_name: "Mushroom & onion"
+      slug: mushroom-and-onion
+      relationship: component
+      description: "Topping mix combined with the buttered potato"
+    - item_name: Tuna potato
+      slug: tuna-potato
+      relationship: alternative
+      description: "Higher-tier topped potato that heals 22 HP"
+  about: |-
+    > _"A baked potato with mushroom and onions."_
+
+    The mushroom potato is a members cooked food that heals 20 Hitpoints. Made by combining a potato with butter and a mushroom & onion mix at 64 Cooking for 55 XP. Eating the ingredients separately actually heals more total HP, so the mushroom potato is mostly used as a compact mid-tier food for slayer trips.
+  market_strategy:
+    notes:
+      - "Profit comes from cooking topped potatoes for high cooking XP/hr"
+      - "Topping cost: mushroom & onion plus potato with butter"
+      - "Single-tick to cook on bonfire makes XP/hr competitive"
+  trading_tips:
+    - "Watch margin between ingredient totals and finished potato"
+    - "Buy limit 13,000 per 4 hours"
+  history:
+    - date: "2006-01-30"
+      description: "Released as part of the Gnome Cooking expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-water-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-water-staff.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic water staff | OSRS Price Data
-description: "Mystic water staff is a members weapon slot item with +50 melee strength requiring 40 Attack. High alch: 25,500 GP, GE limit: 18,000."
+description: "Mystic water staff is a members two-handed staff with +50 strength and +14 magic, requiring 40 Attack and 40 Magic. High alch: 25,500 GP, GE limit: 18,000."
 osrs:
   id: 1403
   name: Mystic water staff
@@ -12,9 +12,35 @@ osrs:
   lowalch: 17000
   highalch: 25500
   limit: 18000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: staff
+    tier: mid
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: staff
     attack_speed: 5
+    weight: 2.267
+    requirements:
+      attack: 40
+      magic: 40
     attack_bonus:
       stab: 10
       slash: -1
@@ -28,66 +54,53 @@ osrs:
       magic: 14
       ranged: 0
     other_bonus:
-      melee_strength: 50
+      strength: 50
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 40
-      magic: 40
-    weight: 2.267
+  passive_effects:
+    - name: Unlimited water runes
+      description: "Provides unlimited water runes while wielded, including for Lunar Humidify and Charge Water Orb"
   related_items:
-    - item_id: 1401
-      item_name: Mystic fire staff
+    - item_name: Water battlestaff
+      slug: water-battlestaff
+      relationship: downgrade
+      description: "Base battlestaff upgraded by Thormac into the mystic version"
+    - item_name: Mystic fire staff
       slug: mystic-fire-staff
-      relationship: set-piece
-      description: Fire elemental mystic staff
-    - item_id: 1407
-      item_name: Mystic earth staff
+      relationship: variant
+      description: "Fire elemental mystic staff"
+    - item_name: Mystic earth staff
       slug: mystic-earth-staff
-      relationship: set-piece
-      description: Earth elemental mystic staff
-    - item_id: 6563
-      item_name: Mystic mud staff
+      relationship: variant
+      description: "Earth elemental mystic staff"
+    - item_name: Mystic air staff
+      slug: mystic-air-staff
+      relationship: variant
+      description: "Air elemental mystic staff"
+    - item_name: Mystic mud staff
       slug: mystic-mud-staff
       relationship: upgrade
-      description: Water+Earth combination staff
+      description: "Water and Earth combination mystic staff"
+    - item_name: Mystic steam staff
+      slug: mystic-steam-staff
+      relationship: upgrade
+      description: "Water and Fire combination mystic staff"
   about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +14 |
-    | Crush | +40 |
+    The mystic water staff is the upgraded form of the water battlestaff, made by paying Thormac in the Sorcerers' Tower south of Seers' Village after completing Scorpion Catcher. The standard upgrade fee is 40,000 coins, reduced to 30,000 with the Hard Kandarin Diary and 20,000 with the Elite Kandarin Diary.
 
-    | Defence | Value |
-    |---------|-------|
-    | Magic | +14 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +50 |
-
-    Requirements: 40 Attack, 40 Magic
-
-    Provides unlimited water runes. Useful for:
-    - Water spells (Water Blast through Water Surge)
-    - Charge Water Orb — saves water runes for crafting
-    - Humidify (Lunar spellbook) — requires water runes
-    - Autocast with standard spellbook
-
-    | Diary Tier | Cost | Battlestaff GE | Profit |
-    |-----------|------|----------------|--------|
-    | None | 40,000 | ~8,500 | ~-6,000 |
-    | Hard Kandarin | 30,000 | ~8,500 | ~4,000 |
-    | Elite Kandarin | 20,000 | ~8,500 | ~14,000 |
-
-    The Kandarin diary discount makes mystic staff upgrades progressively more profitable.
+    It provides unlimited water runes for any water-based spell, autocast styles, Charge Water Orb crafting, and Lunar spellbook utility spells such as Humidify, on top of being a reasonable budget crush weapon thanks to +40 crush attack and +50 strength.
   market_strategy:
     notes:
-      - Thormac upgrade profitable with Hard+ diary
-      - High volume item
-      - GE price tracks near high alch value
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Thormac upgrade profitable with Hard or Elite Kandarin Diary"
+      - "High GE volume — slim margins, predictable fills"
+      - "GE price tracks close to high alch value most days"
+  trading_tips:
+    - "Use battlestaff buy / Thormac sell to GE as a steady money maker once Kandarin Hard is unlocked"
+    - "Compare against the air, earth, and fire mystic staves before alching — sometimes one outpaces high alch"
+  history:
+    - date: "2002-03-25"
+      description: "Released alongside the rest of the elemental mystic staves."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nihil-dust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nihil-dust.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
-  about: "Nihil dust is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: secondary
+    tier: high
+  properties:
+    release_date: "2022-01-05"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Nihil shard
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  related_items:
+    - item_name: Nihil shard
+      slug: nihil-shard
+      relationship: component
+      description: "Crushed in a pestle and mortar to produce nihil dust"
+    - item_name: Ancient brew(3)
+      slug: ancient-brew-3
+      relationship: product
+      description: "Made by adding nihil dust to a dwarf weed potion (unf)"
+    - item_name: Dwarf weed potion (unf)
+      slug: dwarf-weed-potion-unf
+      relationship: component
+      description: "Unfinished base for the ancient brew recipe"
+  about: |-
+    > *"Dust from a crushed magical shard."*
+
+    Nihil dust is the Herblore secondary unlocked from the Nex: The Fifth General update. Players crush a nihil shard with a pestle and mortar to produce one dust, then add it to a dwarf weed potion (unf) at Herblore 85 for 190 XP and an ancient brew(3).
+
+    The brew chain is one of the most efficient sources of secondary-gated Herblore XP for mid-to-late game accounts farming Nex.
+  market_strategy:
+    notes:
+      - "Tied directly to Nex loot pool and ancient brew demand"
+      - "Nihil shard supply spikes after Nex group nights drive dust prices down"
+  trading_tips:
+    - "Buy dust at peak Nex hours, flip after weekly maintenance"
+    - "Wesley in Nardah crushes herblore secondaries for 50 gp each"
+  history:
+    - date: "2022-01-05"
+      description: "Released with the Nex: The Fifth General update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nunchaku.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nunchaku.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 2400
   highalch: 3600
   limit: 8
-  about: "Nunchaku is a members-only item in Old School RuneScape. High alchemy value: 3,600 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: 2h
+    weapon_type: blunt
+    attack_speed: 5
+    weight: 1.36
+    requirements: {}
+    attack_bonus:
+      stab: -4
+      slash: -4
+      crush: 11
+      magic: -4
+      ranged: -4
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 14
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Granite hammer
+      slug: granite-hammer
+      relationship: alternative
+      description: "Comparable crush weapon at similar tier"
+    - item_name: Viggora's chainmace
+      slug: viggoras-chainmace
+      relationship: alternative
+      description: "Higher-tier crush option for Wilderness content"
+  about: Nunchaku is a two-handed crush weapon obtained as a 1/1,625 reward from hard Treasure Trails. Its examine text references Michelangelo of the Teenage Mutant Ninja Turtles, alluding to his love of pizza.
+  market_strategy:
+    notes:
+      - "Cosmetic-leaning crush weapon with niche bossing use"
+      - "Supply comes entirely from hard clue caskets"
+      - "GE limit of 8 caps daily flip volume"
+  trading_tips:
+    - "Track hard clue cycles for predictable supply pulses"
+    - "Cross-list with Granite hammer to spot relative mispricing in the crush tier"
+  history:
+    - date: "2016-07-06"
+      description: "Added as a rare hard Treasure Trail reward"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-armour-case-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-armour-case-flatpack.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak armour case (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "18 October 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 46
+      xp: 180
+      materials:
+        - item_name: Oak plank
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Oak armour case
+      slug: oak-armour-case
+      relationship: product
+      description: "Built furniture form placed in the costume room"
+    - item_name: Teak armour case (flatpack)
+      slug: teak-armour-case-flatpack
+      relationship: upgrade
+      description: "Higher-tier teak flatpack variant"
+    - item_name: Mahogany armour case (flatpack)
+      slug: mahogany-armour-case-flatpack
+      relationship: upgrade
+      description: "Top-tier mahogany flatpack variant"
+  about: "Oak armour case (flatpack) is a Construction-skilled flatpack built at the steel framed workbench from three oak planks; placed in a player-owned house Costume Room to store armour sets without the planks-in-house overhead."
+  market_strategy:
+    notes:
+      - "Trivial alch margin; almost all volume is direct buyers building POHs."
+      - "Demand bursts around Construction XP-waste alternatives or skill events."
+      - "Oak plank price floors the cost basis."
+  trading_tips:
+    - "Sell into the flatpack-bot lull between major skilling updates."
+    - "Track oak plank price; flatpack flips evaporate when planks spike."
+    - "Watch for Construction QoL news that nudges flatpack popularity."
+  history:
+    - date: "18 October 2006"
+      description: "Released with the Costume Room expansion of Construction."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-bench-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-bench-flatpack.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak bench (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 22
+      xp: 240
+      materials:
+        - item_name: Oak plank
+          quantity: 4
+      tools:
+        - Saw
+        - Hammer
+        - Oak workbench
+      output_quantity: 1
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: "Four oak planks are consumed per flatpack at the oak workbench"
+    - item_name: Oak bench
+      slug: oak-bench
+      relationship: variant
+      description: "Player-owned house dining hotspot built from this flatpack"
+  about: Oak bench (flatpack) is a Construction flatpack made at an oak workbench using 4 oak planks at level 22 Construction for 240 xp. Used in player-owned house dining rooms; flatpacks let players furnish a house without an in-room workbench.
+  market_strategy:
+    notes:
+      - "Negative crafting margin once GE tax applies"
+      - "Low daily volume, often unprofitable alone"
+      - "Convenience product for high-Construction houses"
+  trading_tips:
+    - "Profitability lives in oak plank cost; flip only when plank prices dip"
+    - "Useful XP-buy for Construction grinders; bulk demand is event-driven"
+  history:
+    - date: "2006-05-31"
+      description: "Added with the introduction of flatpack furniture"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-amulet.mdx
@@ -12,9 +12,106 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 10000
-  about: "Opal amulet is a members-only item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: opal
+    tier: low
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.007
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 4
+      materials:
+        - item_name: Unstrung opal amulet
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - skill: magic
+      level: 80
+      xp: 83
+      materials:
+        - item_name: Unstrung opal amulet
+          quantity: 1
+        - item_name: Water rune
+          quantity: 5
+        - item_name: Earth rune
+          quantity: 10
+        - item_name: Astral rune
+          quantity: 2
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Unstrung opal amulet
+      slug: unstrung-opal-amulet
+      relationship: component
+      description: "String with wool to make this amulet"
+    - item_name: Amulet of bounty
+      slug: amulet-of-bounty
+      relationship: upgrade
+      description: "Enchanted form via Lvl-1 Enchant"
+    - item_name: Opal
+      slug: opal
+      relationship: component
+      description: "Base gem cut from an uncut opal"
+  about: |-
+    > *"I wonder if I can get this enchanted."*
+
+    The opal amulet is the entry-tier semi-precious amulet, strung with wool from an unstrung opal amulet. It carries no combat stats on its own and exists primarily as the precursor to the Amulet of bounty, enchanted via Lvl-1 Enchant.
+
+    Most players skip this jewellery rung entirely once they have access to higher gems, but it remains a cheap Magic XP target for low-level Crafting/Magic training combos.
+  market_strategy:
+    notes:
+      - "Volume driven by Lvl-1 Enchant Magic training"
+      - "Slight net loss to craft and string at current GE prices"
+  trading_tips:
+    - "Watch unstrung opal amulet spread before crafting bulk"
+    - "Enchant to Amulet of bounty for better resale margin"
+  history:
+    - date: "2017-02-02"
+      description: "Released alongside the opal jewellery line"
+    - date: "2017-02-16"
+      description: "Inventory sprite rotated for consistency"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-dragon-bolts-e.mdx
@@ -12,32 +12,71 @@ osrs:
   lowalch: 232
   highalch: 348
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "4 January 2018"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
+    weapon_type: thrown
+    attack_speed: null
+    weight: 0
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
       ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      strength: 0
       ranged_strength: 122
+      magic_damage: 0
       prayer: 0
-    requirements: {}
   recipes:
     - skill: magic
       level: 4
       xp: 9
-      inputs:
+      materials:
         - item_name: Opal dragon bolts
           quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Air rune
+          quantity: 2
+      tools: []
       output_quantity: 10
   related_items:
-    - item_id: 9236
-      item_name: Opal bolts (e)
+    - item_name: Opal dragon bolts
+      slug: opal-dragon-bolts
+      relationship: component
+      description: "Unenchanted base used in Enchant Crossbow Bolt (Opal)"
+    - item_name: Opal bolts (e)
       slug: opal-bolts-e
       relationship: downgrade
-      description: Regular crossbow version
+      description: "Regular enchanted opal bolts with much lower ranged strength"
   about: |-
     > *"Enchanted Dragon crossbow bolts, tipped with opal."*
 
@@ -54,16 +93,23 @@ osrs:
     | Stat | Dragon (e) | Regular (e) |
     |------|-----------|-------------|
     | Ranged Str | +122 | +14 |
-    | Base bolt | Dragon crossbow bolt | Bronze–Runite bolt |
+    | Base bolt | Dragon crossbow bolt | Bronze-Runite bolt |
 
     The dragon bolt base provides significantly higher ranged strength, making enchanted dragon bolts the top-tier ammunition choice for crossbow users.
   market_strategy:
     notes:
-      - Lowest enchant level of any bolt enchantment (Magic 4)
-      - Cheapest dragon bolt (e) variant to produce
-      - Effect is minor compared to higher-tier enchantments
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Lowest enchant level of any bolt enchantment (Magic 4)"
+      - "Cheapest dragon bolt (e) variant to produce"
+      - "Effect is minor compared to higher-tier enchantments"
+  trading_tips:
+    - "Margin is the gap between unenchanted dragon bolts and enchanted: buy unenchanted in dips"
+    - "Bulk-enchant in stacks of 10 to maximize Magic XP per cast"
+  passive_effects:
+    - name: Lucky Lightning
+      description: "5% chance (5.5% with hard Kandarin Diary) to deal bonus damage equal to 10% of visible Ranged level"
+  history:
+    - date: "4 January 2018"
+      description: "Released with the Dragon Slayer II update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/opal-machete.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/opal-machete.mdx
@@ -12,9 +12,98 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 15
-  about: "Opal machete is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: machete
+    tier: mid
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: slash_sword
+    attack_speed: 4
+    weight: 1.36
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 8
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Trading sticks
+          quantity: 300
+        - item_name: Opal
+          quantity: 3
+        - item_name: Gout tuber
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      location: Tai Bwo Wannai
+      price: 600
+      currency: Trading sticks
+      stock: 2
+  drop_table:
+    sources:
+      - source: Ninja impling jar
+        quantity: "1"
+        rarity: 1/198
+  related_items:
+    - item_name: Machete
+      slug: machete
+      relationship: downgrade
+      description: "Baseline non-gem machete with weaker stats"
+    - item_name: Jade machete
+      slug: jade-machete
+      relationship: upgrade
+      description: "Next gem-machete tier above opal"
+    - item_name: Red topaz machete
+      slug: red-topaz-machete
+      relationship: upgrade
+      description: "Highest tier gem-tipped machete"
+  about: "Opal machete is the entry-level gem machete used in the Tai Bwo Wannai Cleanup minigame. It is bought from Gabooty for 600 trading sticks (500 with Karamja gloves), crafted by Safta Doc, or looted from ninja implings. It doubles as a low-level slash weapon with +8 slash attack and +4 strength."
+  market_strategy:
+    notes:
+      - "Demand is tied to Tai Bwo Wannai Cleanup activity and ninja impling hunters."
+      - "Buy limit of 15 per 4 hours keeps GE flips small."
+  trading_tips:
+    - "Stock up when Karamja Diary clue routes spike and machetes get consumed quickly."
+    - "Compare GE price to the 600-stick shop floor before flipping in bulk."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Cleanup minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/osmumten-s-fang.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/osmumten-s-fang.mdx
@@ -12,52 +12,78 @@ osrs:
   lowalch: 400000
   highalch: 600000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: unique
+    tier: high
+  properties:
+    release_date: "2022-08-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: stab-sword
-    attack_style: stab
-    attack_speed: 4
+    weapon_type: stab-sword
+    attack_speed: 5
+    weight: 1.814
     requirements:
       attack: 82
-    stats:
-      attack_stab: 105
-      attack_slash: 75
+    attack_bonus:
+      stab: 105
+      slash: 75
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 103
-  effect:
-    double_accuracy_roll: true
-    damage_normalization: true
-    damage_range: 15-85% of max hit
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Double accuracy roll
+      description: "When using a stab attack style, the weapon rerolls accuracy on an unsuccessful hit, effectively doubling the chance to land a hit"
+    - name: Damage normalisation
+      description: "Damage rolls are confined to between 15% and 85% of the maximum hit, lowering variance at the cost of capping max-rolls"
   special_attack:
     name: Eviscerate
+    description: "Consumes 25% special energy, granting a 50% accuracy bonus and allowing the hit to roll the true maximum damage instead of the usual 85% cap"
     energy: 25
-    accuracy_bonus: 50
-    uses_true_max: true
-    damage_increase: 17.65
   drop_table:
     sources:
       - source: Tombs of Amascut
-        source_id: 11751
-        combat_level: 0
         quantity: "1"
-        rarity: Rare
-        drop_rate: 7/24 of unique
-        members_only: true
+        rarity: 7/24 of unique
   related_items:
-    - item_id: 22324
-      item_name: Ghrazi rapier
+    - item_name: Ghrazi rapier
       slug: ghrazi-rapier
       relationship: alternative
-      description: Standard stab
-    - item_id: 23995
-      item_name: Blade of saeldor
+      description: "Standard stab weapon alternative from Theatre of Blood"
+    - item_name: Blade of saeldor
       slug: blade-of-saeldor
       relationship: alternative
-      description: Slash alternative
-    - item_id: 27241
-      item_name: Lightbearer
+      description: "Slash alternative with strong damage output"
+    - item_name: Lightbearer
       slug: lightbearer
       relationship: alternative
-      description: Spec synergy
+      description: "Ring that pairs with Osmumten's fang for special attack spam"
   about: |-
     | Offense | Value |
     |---------|-------|
@@ -88,11 +114,12 @@ osrs:
     Best weapon vs high defence.
   market_strategy:
     notes:
-      - From Tombs of Amascut
-      - Excels vs high-def
-      - Great accuracy mechanics
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "From Tombs of Amascut"
+      - "Excels vs high-def"
+      - "Great accuracy mechanics"
+  history:
+    - date: "2022-08-24"
+      description: "Released as a unique drop from Tombs of Amascut"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/penguin-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/penguin-mask.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 480
   highalch: 720
   limit: 4
-  about: "Penguin mask is a members-only item in Old School RuneScape. High alchemy value: 720 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_name: Casket (medium)
+      slug: casket-medium
+      relationship: component
+      description: "Reward casket that can drop the mask"
+    - item_name: Beret
+      slug: beret
+      relationship: alternative
+      description: "Other clue trail cosmetic head item"
+  about: "Penguin mask is a medium clue scroll reward referencing the Penguin Hide and Seek minigame. Cosmetic head slot item with no combat bonuses; storable in the costume room treasure chest."
+  market_strategy:
+    notes:
+      - "Tight GE buy limit (4) keeps supply thin"
+      - "Cosmetic clue reward sustains collector demand"
+      - "Costume room storage reduces circulating supply over time"
+  trading_tips:
+    - "Snipe undercuts during clue events when more masks enter the market"
+    - "Long hold: cosmetic clue rewards trend upward as the game ages"
+  history:
+    - date: "2014-06-12"
+      description: "Added as a reward from medium clue scrolls"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/phrin-remains.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/phrin-remains.mdx
@@ -1,6 +1,6 @@
 ---
 title: Phrin remains | OSRS Price Data
-description: "Phrin remains: The remains of a deadly shade.. High alch: 1 GP, GE limit: 7,500."
+description: "Phrin remains: The remains of a deadly shade. High alch: 1 GP, GE limit: 7,500."
 osrs:
   id: 3398
   name: Phrin remains
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Phrin remains is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: shade remains
+    tier: low
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options: ["Drop"]
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Phrin Shade
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Loar remains
+      slug: loar-remains
+      relationship: alternative
+      description: "Tier 1 shade remains used in Shades of Mort'ton pyres"
+    - item_name: Riyl remains
+      slug: riyl-remains
+      relationship: alternative
+      description: "Tier 3 shade remains used in Shades of Mort'ton pyres"
+    - item_name: Asyn remains
+      slug: asyn-remains
+      relationship: upgrade
+      description: "Higher tier shade remains for Mort'ton pyres"
+    - item_name: Fiyr remains
+      slug: fiyr-remains
+      relationship: upgrade
+      description: "Higher tier shade remains for Mort'ton pyres"
+  about: "Phrin remains are the dropped remains of Phrin Shades (combat level 60) found in the Shade Catacombs behind a solid bronze door. They are burned on funeral pyres with various pyre logs (requiring Firemaking 5+ and Prayer 1+) during the Shades of Mort'ton minigame, yielding Firemaking and Prayer experience plus shade keys or coins."
+  market_strategy:
+    notes:
+      - "Always dropped by Phrin Shades in the Shade Catacombs"
+      - "Burned on pyre logs for Firemaking and Prayer XP plus shade key rewards"
+      - "Tier 2 shade remains in the Mort'ton funeral pyre sequence"
+  trading_tips:
+    - "Stockpile by farming Phrin Shades behind the bronze door in the Shade Catacombs"
+    - "Pair with pyre logs (regular, oak, willow, etc.) for the best XP per remain"
+    - "Higher tier pyre logs grant more XP per Phrin remain burned"
+  history:
+    - date: "2004-10-18"
+      description: "Phrin remains added with the Shades of Mort'ton minigame expansion."
+    - date: "2024-05-15"
+      description: "Shade key and coin despawn time extended to 5 minutes with player-protection mechanics."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-leggings-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-leggings-blue.mdx
@@ -12,9 +12,81 @@ osrs:
   lowalch: 140
   highalch: 210
   limit: 150
-  about: "Pirate leggings (blue) is a members-only item in Old School RuneScape. High alchemy value: 210 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic_clothing
+    tier: low
+  properties:
+    release_date: "7 February 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weight: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Dodgy Mike's Second-hand Clothing"
+      location: "Mos Le'Harmless"
+      price: 350
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Pirate bandana (blue)
+      slug: pirate-bandana-blue
+      relationship: set-piece
+      description: "Headwear of the pirate outfit"
+    - item_name: Pirate shirt
+      slug: pirate-shirt
+      relationship: set-piece
+      description: "Top piece of the pirate outfit"
+    - item_name: Pirate boots
+      slug: pirate-boots
+      relationship: set-piece
+      description: "Footwear of the pirate outfit"
+  about: |-
+    > *"A sea worthy pair of trousers."*
+
+    Pirate leggings (blue) are part of the pirate outfit purchasable from Dodgy Mike's Second-hand Clothing on Mos Le'Harmless. They provide no combat bonuses — purely cosmetic fashionscape.
+  market_strategy:
+    notes:
+      - "Shop supply on Mos Le'Harmless drives price ceiling"
+      - "Cosmetic-only demand; no combat usage"
+      - "Pirate set collectors are the primary buyers"
+  trading_tips:
+    - "Buy from Dodgy Mike's for resale margin on the GE"
+    - "Demand rises around pirate-themed seasonal events"
+  history:
+    - date: "7 February 2006"
+      description: "Released as part of the Cabin Fever update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-s-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-s-hat.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 4
-  about: "Pirate's hat is a members-only item in Old School RuneScape. High alchemy value: 108 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.001
+    requirements: {}
+    attack_bonus: {}
+    defence_bonus: {}
+    other_bonus: {}
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Right eye patch
+      slug: right-eye-patch
+      relationship: component
+      description: "Combine with the hat via Patchy to make a hat eyepatch"
+    - item_name: Hat eyepatch
+      slug: hat-eyepatch
+      relationship: upgrade
+      description: "Cosmetic produced by combining the hat with a right eye patch"
+  about: "The Pirate's hat is a cosmetic head-slot reward from hard clue scrolls at 1/1,625 from the reward casket. After completing Cabin Fever it can be combined with a right eye patch and 500 coins via Patchy to make a hat eyepatch."
+  market_strategy:
+    notes:
+      - "Supply tied to hard clue completions"
+      - "Cosmetic, popular with pirate-themed builds"
+      - "Costume room storage limits drop-and-flip churn"
+  trading_tips:
+    - "Watch hard clue popularity events for supply"
+    - "Hat eyepatch crafting consumes the hat"
+    - "GE limit of 4 keeps cycles short"
+  history:
+    - date: "2004-05-05"
+      description: "Released with the Bigger Banks & Treasure Trails update."
+    - date: "2004-07-13"
+      description: "Recoloured in a graphical update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-s-y-crunch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-s-y-crunch.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 34
   highalch: 51
   limit: 6000
-  about: "Premade s'y crunch is a members-only item in Old School RuneScape. High alchemy value: 51 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "12 December 2002"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Gianne's Restaurant
+      location: Grand Tree, Tree Gnome Stronghold
+      price: 85
+      currency: Coins
+      stock: 3
+  related_items:
+    - item_name: Spicy crunchies
+      slug: spicy-crunchies
+      relationship: alternative
+      description: "Player-made gnome cooking version with identical effect"
+    - item_name: Premade ch'y crunch
+      slug: premade-chy-crunch
+      relationship: variant
+      description: "Chocolate chip crunchies variant"
+    - item_name: Premade w'm crunch
+      slug: premade-wm-crunch
+      relationship: variant
+      description: "Worm crunchies variant"
+    - item_name: Premade t'd crunch
+      slug: premade-td-crunch
+      relationship: variant
+      description: "Toad crunchies variant"
+  about: |-
+    > *"Some premade Spicy Crunchies."*
+
+    Premade s'y crunch is a pre-cooked spicy crunchies snack sold by the Gnome Waiter inside the Grand Tree and at Gianne's Restaurant. It heals 7 hitpoints, matching the player-made spicy crunchies. The shop restocks one every minute up to a base stock of 3.
+
+    The shorthand name is a relic of the early gnome cooking shop UI: the item was renamed from "Spicy crunchies" in 2006 to fit the inventory width.
+  market_strategy:
+    notes:
+      - "Cheap, low-volume staple for low-level food flips"
+      - "Restock cycle at Gianne's anchors the price floor"
+  trading_tips:
+    - "Bulk premade gnome food sells fast during low-level event bonuses"
+    - "Margin is thin: factor GE tax before committing to large flips"
+  history:
+    - date: "12 December 2002"
+      description: "Released with the Gnome Cooking update"
+    - date: "7 August 2006"
+      description: "Renamed from 'Spicy crunchies' to 'Premade s'y crunch'"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-worm-hole.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-worm-hole.mdx
@@ -12,9 +12,48 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 6000
-  about: "Premade worm hole is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Gianne's Restaurant
+      location: Grand Tree
+      price: 150
+      currency: coins
+      stock: 3
+  related_items:
+    - item_name: Worm hole
+      slug: worm-hole
+      relationship: variant
+      description: "Player-cooked version made via the Cooking skill"
+  about: |-
+    The Premade worm hole is a gnome food dish sold by the Gnome Waiter at Gianne's Restaurant in the Grand Tree. Eating it restores 12 Hitpoints.
+
+    Unlike the player-made Worm hole, the premade variant cannot be used in the Gnome Restaurant minigame to deliver to customers.
+  market_strategy:
+    notes:
+      - "Cheap healing food sold in bulk at gnome restaurants"
+      - "Shop-bought at 150 gp typically trades below shop value on the GE"
+  history:
+    - date: "2002-12-12"
+      description: "Released alongside the Gnome cooking system"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Purple cape | OSRS Price Data
-description: "Purple cape: A thick purple cape.. High alch: 19 GP, GE limit: 150."
+description: "Purple cape: A thick purple cape. High alch: 19 GP, GE limit: 150."
 osrs:
   id: 1029
   name: Purple cape
@@ -12,9 +12,89 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 150
-  about: "Purple cape is a free-to-play item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2001-12-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 2.5
+      materials:
+        - item_name: Red cape
+          quantity: 1
+        - item_name: Purple dye
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Red cape
+      slug: red-cape
+      relationship: alternative
+      description: "Base cape used for dyeing"
+    - item_name: Purple dye
+      slug: purple-dye
+      relationship: component
+      description: "Required to dye the cape"
+    - item_name: Blue cape
+      slug: blue-cape
+      relationship: variant
+      description: "Other coloured cape variant"
+  about: |-
+    > _"A thick purple cape."_
+
+    The purple cape is a free-to-play cape created by using purple dye on a coloured cape (most often red). It offers minor slash, crush, and ranged defence bonuses with no negative penalties.
+  market_strategy:
+    notes:
+      - "Crafted from cheap base cape + dye"
+      - "Low daily volume — listings often slow"
+      - "Fashion / completionist demand"
+  trading_tips:
+    - "Buy below crafting cost for arbitrage"
+    - "List during fashionscape events"
+  history:
+    - date: "2001-12-08"
+      description: "Released with the original capes update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-elegant-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-elegant-shirt.mdx
@@ -12,21 +12,89 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "5 December 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: "8/18,128"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 10418
-      item_name: Purple elegant legs
+    - item_name: Purple elegant legs
       slug: purple-elegant-legs
       relationship: set-piece
-      description: Matching elegant legs
-  about: |-
-    > *"A well made elegant men's purple shirt."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the purple elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching elegant legs"
+    - item_name: Black elegant shirt
+      slug: black-elegant-shirt
+      relationship: alternative
+      description: "Black colour variant"
+    - item_name: White elegant blouse
+      slug: white-elegant-blouse
+      relationship: alternative
+      description: "Female counterpart in white"
+    - item_name: Gold elegant shirt
+      slug: gold-elegant-shirt
+      relationship: alternative
+      description: "Gold colour variant"
+  about: "The purple elegant shirt is a cosmetic medium clue scroll reward; purely fashionscape with no combat stats, worn alongside purple elegant legs for the matching outfit."
+  market_strategy:
+    notes:
+      - "Buy limit of 4 makes restocking the GE the choke point."
+      - "Demand is fashionscape-driven; spikes on cosmetic content updates."
+      - "Cross-listed with purple elegant legs in matched-set bids."
+  trading_tips:
+    - "Watch medium clue droprates and Master clue news for movement."
+    - "Patient flips on small stacks beat trying to corner the supply."
+    - "Costume-room storage means long-term holders rarely sell back."
+  history:
+    - date: "5 December 2006"
+      description: "Added as part of the elegant clothing Treasure Trails reward set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-robe-top.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Purple robe top is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-06-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Barker's Haberdashery"
+      location: "Canifis"
+      price: 650
+      currency: "Coins"
+      stock: 5
+  related_items:
+    - item_name: Purple robe bottoms
+      slug: purple-robe-bottoms
+      relationship: set-piece
+      description: "Matching legs from Barker's Haberdashery"
+    - item_name: Red robe top
+      slug: red-robe-top
+      relationship: alternative
+      description: "Same shop, different colour"
+    - item_name: Yellow robe top
+      slug: yellow-robe-top
+      relationship: alternative
+      description: "Same shop, different colour"
+  about: |-
+    > *"Some fine werewolf clothing."*
+
+    The purple robe top is one of the colour variants sold by Barker at Barker's Haberdashery in Canifis, unlocked after starting Priest in Peril. It is purely cosmetic werewolf fashion with negligible defensive bonuses, mostly bought for fashionscape and clue scroll emote requirements.
+
+    Buy limit is 150 per 4 hours and shop stock restocks every minute.
+  market_strategy:
+    notes:
+      - "Low daily volume — moves on fashionscape demand"
+      - "Shop arbitrage from Canifis caps profitable margin"
+  trading_tips:
+    - "Restock farm from Barker for guaranteed flip margin"
+    - "Buy in bulk before fashionscape competition events"
+  history:
+    - date: "2004-06-29"
+      description: "Released with Priest in Peril and Morytania"
+    - date: "2014-12-10"
+      description: "Renamed from Robe top to Purple robe top during the Trading Post update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-cane.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-cane.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: null
-  about: "Raging echoes cane is a members-only item in Old School RuneScape. High alchemy value: 600 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2025-01-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: blunt
+    attack_speed: 5
+    weight: 1.814
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Raging echoes top (t3)
+      slug: raging-echoes-top-t3
+      relationship: set-piece
+      description: "Tier 3 Leagues outfit body bundled with the cane purchase"
+    - item_name: Trailblazer reloaded cane
+      slug: trailblazer-reloaded-cane
+      relationship: alternative
+      description: "Equivalent cosmetic cane from the prior Leagues reward shop"
+  about: Raging echoes cane is a cosmetic one-handed weapon bundled with the tier 3 Raging Echoes Relic Hunter outfit, purchased for 20,000 league points. All combat stats are zero; combat styles only adjust accuracy and strength stances.
+  market_strategy:
+    notes:
+      - "Cosmetic-only cane, no combat bonuses"
+      - "Supply gated by Leagues V (Raging Echoes) points"
+      - "Pairs with the tier 3 Raging Echoes outfit"
+  trading_tips:
+    - "Track Leagues V nostalgia cycles for predictable demand swings"
+    - "Compare against the Trailblazer reloaded cane for relative cosmetic pricing"
+  history:
+    - date: "2024-11-27"
+      description: "Added to the game ahead of Leagues V launch"
+    - date: "2025-01-15"
+      description: "Made obtainable via the Raging Echoes Leagues Reward Shop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-boar-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-boar-meat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw boar meat | OSRS Price Data
-description: "Raw boar meat: I need to cook this first.. High alch: 1 GP."
+description: "Raw boar meat: I need to cook this first. High alch: 1 GP."
 osrs:
   id: 25833
   name: Raw boar meat
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Raw boar meat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: raw_meat
+    tier: low
+  properties:
+    release_date: "2021-06-23"
+    tradeable: false
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.425
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw boar meat
+          quantity: 1
+      tools:
+        - Range
+      output_quantity: 1
+    - skill: cooking
+      level: 1
+      xp: 3
+      materials:
+        - item_name: Raw boar meat
+          quantity: 1
+      tools:
+        - Range
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Boar
+        quantity: "1"
+        rarity: Always
+      - source: Enraged boar
+        quantity: "1"
+        rarity: Always
+  related_items:
+    - item_name: Cooked meat
+      slug: cooked-meat
+      relationship: product
+      description: "Cooked output (30 XP)"
+    - item_name: Sinew
+      slug: sinew
+      relationship: product
+      description: "Crafting material via cooking raw meat"
+    - item_name: Raw beef
+      slug: raw-beef
+      relationship: alternative
+      description: "Other early-game raw meat"
+  about: |-
+    > _"I need to cook this first."_
+
+    Raw boar meat drops from boars and enraged boars in the woods west of Kourend Castle and near The Node. Cook on a range at level 1 Cooking for 30 XP to produce cooked meat, or use on a range to make sinew (3 XP).
+  market_strategy:
+    notes:
+      - "Untradeable — no GE flips"
+      - "Bulk farmed near Hosidius for sinew"
+      - "Minor F2P cooking starter resource"
+  trading_tips:
+    - "Self-source from boars; cannot be bought"
+    - "Pair with range trips for sinew"
+  history:
+    - date: "2021-06-23"
+      description: "Released with the Kebos Lowlands expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-mackerel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-mackerel.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw mackerel | OSRS Price Data
-description: "Raw mackerel: I should try cooking this.. High alch: 9 GP, GE limit: 15,000."
+description: "Raw mackerel: I should try cooking this. High alch: 9 GP, GE limit: 15,000."
 osrs:
   id: 353
   name: Raw mackerel
@@ -12,18 +12,80 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 15000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: raw_fish
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.35
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 10
+      xp: 60
+      materials:
+        - item_name: Raw mackerel
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Mountain troll
+        quantity: "1"
+        rarity: Common
+      - source: Ice troll
+        quantity: "1"
+        rarity: Common
+      - source: Wallasalki
+        quantity: "1"
+        rarity: Uncommon
+  shops:
+    - shop_name: Gerrant's Fishy Business
+      location: Port Sarim
+      price: 19
+      currency: Coins
+      stock: 5
+    - shop_name: Fishing Shop
+      location: Catherby
+      price: 19
+      currency: Coins
+      stock: 5
   related_items:
-    - item_id: 355
-      item_name: Mackerel
+    - item_name: Mackerel
       slug: mackerel
       relationship: product
-      description: Cooked version
+      description: "Cooked version at 10 Cooking"
+    - item_name: Raw cod
+      slug: raw-cod
+      relationship: alternative
+      description: "Similar big-net catch"
   about: |-
     > _"I should try cooking this."_
 
-    Raw mackerel can be cooked at 10 Cooking. One of the first fish caught with a big fishing net at sea fishing spots.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Raw mackerel is caught with a big fishing net at sea fishing spots such as Catherby and Rellekka. Cook at level 10 Cooking for 60 XP to produce mackerel.
+  market_strategy:
+    notes:
+      - "Steady supply from net fishers"
+      - "Mostly bought for cooking XP"
+      - "Drops by trolls add minor supply"
+  trading_tips:
+    - "Buy in bulk near GE mid-price"
+    - "Flip after cooking-XP demand spikes"
+  history:
+    - date: "2002-02-27"
+      description: "Released with Big Net fishing"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-sunlight-antelope.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-sunlight-antelope.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Raw sunlight antelope is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: meat
+    tier: mid
+  properties:
+    release_date: "2024-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 68
+      xp: 175
+      materials:
+        - item_name: Raw sunlight antelope
+          quantity: 1
+      tools:
+        - Range
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Sunlight antelope (Hunter 72)
+        quantity: "1"
+        rarity: always
+  related_items:
+    - item_name: Sunlight antelope
+      slug: sunlight-antelope
+      relationship: product
+      description: Cooked form healing more than the raw drop
+    - item_name: Raw moonlight antelope
+      slug: raw-moonlight-antelope
+      relationship: alternative
+      description: Higher-tier nightfall counterpart from Varlamore Hunter
+    - item_name: Burnt antelope
+      slug: burnt-antelope
+      relationship: alternative
+      description: Failure state when cooking below the burn threshold
+  about: "Raw sunlight antelope is the Varlamore Hunter drop turned into a cookable steak at 68 Cooking; alternatively, Soar Leader Pitri swaps each carcass for three quetzal whistle charges."
+  market_strategy:
+    notes:
+      - "Daily volume tracks Varlamore Hunter activity — relog spikes drag GE prices down."
+      - "Cooking flips depend on cooked-antelope GE delta minus burn risk."
+  trading_tips:
+    - "Stockpile around double Cooking weekends when chefs raid the GE."
+    - "Quetzal whistle owners burn through these even when GE price tanks."
+  history:
+    - date: "2024-03-20"
+      description: Added with the Varlamore expansion launch.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-bead.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-bead.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Red bead is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: gem
+    tier: low
+  properties:
+    release_date: "2001-02-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: true
+    weight: 0.003
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Imp
+        quantity: "1"
+        rarity: "5/128"
+  related_items:
+    - item_name: Black bead
+      slug: black-bead
+      relationship: variant
+      description: "Black coloured bead drop from imps"
+    - item_name: White bead
+      slug: white-bead
+      relationship: variant
+      description: "White coloured bead drop from imps"
+    - item_name: Yellow bead
+      slug: yellow-bead
+      relationship: variant
+      description: "Yellow coloured bead drop from imps"
+    - item_name: Amulet of accuracy
+      slug: amulet-of-accuracy
+      relationship: product
+      description: "Crafted using all four coloured beads during Imp Catcher"
+  about: "Red bead is a free-to-play quest item used in Imp Catcher to create the amulet of accuracy. It can also bait traps when hunting imps and is dropped commonly by imps across multiple regions."
+  market_strategy:
+    notes:
+      - "Imp Catcher quest demand keeps a steady floor of buyers."
+      - "Drop rate of 5/128 from imps ensures supply is plentiful."
+      - "Leagues hunter content periodically increases farm rates and supply."
+  trading_tips:
+    - "Bulk buy near alch value to satisfy Imp Catcher questers"
+    - "Pair listings with other coloured beads for set arbitrage"
+  history:
+    - date: "2001-02-16"
+      description: "Added to the game with Imp Catcher quest content"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red d'hide shield | OSRS Price Data
-description: "Red d'hide shield: A solid magic wood shield covered in red dragon leather.. High alch: 6,600 GP, GE limit: 125."
+description: "Red d'hide shield: A solid magic wood shield covered in red dragon leather. High alch: 6,600 GP, GE limit: 125."
 osrs:
   id: 22281
   name: Red d'hide shield
@@ -12,9 +12,92 @@ osrs:
   lowalch: 4400
   highalch: 6600
   limit: 125
-  about: "Red d'hide shield is a members-only item in Old School RuneScape. High alchemy value: 6,600 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ranged shield
+    tier: mid
+  properties:
+    release_date: "2018-02-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 8.0
+    options: ["Wield", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 8.0
+    requirements:
+      ranged: 60
+      defence: 40
+    attack_bonus:
+      stab: -15
+      slash: -15
+      crush: -11
+      magic: -10
+      ranged: 6
+    defence_bonus:
+      stab: 18
+      slash: 16
+      crush: 14
+      magic: 13
+      ranged: 13
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 76
+      xp: 156
+      materials:
+        - item_name: Red dragon leather
+          quantity: 2
+        - item_name: Magic shield
+          quantity: 1
+        - item_name: Adamantite nails
+          quantity: 15
+      tools: ["Hammer"]
+      output_quantity: 1
+  related_items:
+    - item_name: Magic shield
+      slug: magic-shield
+      relationship: component
+      description: "Base shield used in the Crafting recipe"
+    - item_name: Red dragon leather
+      slug: red-dragon-leather
+      relationship: component
+      description: "Two leathers required to stitch the shield covering"
+    - item_name: Black d'hide shield
+      slug: black-d-hide-shield
+      relationship: upgrade
+      description: "Higher tier dragonhide shield requiring 70 Ranged"
+    - item_name: Blue d'hide shield
+      slug: blue-d-hide-shield
+      relationship: downgrade
+      description: "Lower tier dragonhide shield requiring 50 Ranged"
+  about: "The Red d'hide shield is a mid-tier Ranged shield crafted at 76 Crafting using 2 red dragon leather, a magic shield, and 15 adamantite nails. It requires 60 Ranged and 40 Defence to wield, granting solid ranged defence bonuses while preserving a small ranged attack bonus."
+  market_strategy:
+    notes:
+      - "Crafted at 76 Crafting from magic shield, red dragonhide, and adamantite nails"
+      - "Niche demand from Rangers wanting a shield slot during PvM tasks"
+      - "GE price often sits below material cost, making it a Crafting XP loss"
+  trading_tips:
+    - "Check magic shield and red dragon leather prices before crafting for profit"
+    - "Useful for HCIM and Rangers who need a shield slot without dropping much Ranged accuracy"
+    - "Watch League and PvP cosmetic demand as it can spike Ranged shield interest"
+  history:
+    - date: "2018-02-01"
+      description: "Red d'hide shield added alongside the d'hide shield family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-elegant-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-elegant-shirt.mdx
@@ -12,21 +12,87 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 1
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: "Easy clue scroll reward casket"
+        quantity: "1"
+        rarity: "1/2808"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 10406
-      item_name: Red elegant legs
+    - item_name: Red elegant legs
       slug: red-elegant-legs
       relationship: set-piece
-      description: Matching elegant legs
+      description: "Matching elegant trousers from easy clues"
+    - item_name: Green elegant shirt
+      slug: green-elegant-shirt
+      relationship: alternative
+      description: "Green colour variant from easy clues"
+    - item_name: Blue elegant shirt
+      slug: blue-elegant-shirt
+      relationship: alternative
+      description: "Blue colour variant from easy clues"
   about: |-
     > *"A well made elegant men's red shirt."*
 
-    Purely cosmetic treasure trail reward with no combat stats. Part of the red elegant clothing set used for fashionscape and emote clue requirements.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Purely cosmetic easy clue scroll reward with no combat stats. Pairs with red elegant legs for the full men's red elegant set and is often used for fashionscape and emote clue requirements. Storable in the costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Tight buy limit of 4 caps short-term flip volume"
+      - "Long-term demand tied to easy clue grinders dumping caskets"
+  trading_tips:
+    - "Stack offers across multiple worlds for fashionscape rolls"
+    - "Watch for buy-limit-reset windows for bulk acquisition"
+  history:
+    - date: "2006-12-05"
+      description: "Released as part of the elegant clothing easy clue reward set"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/redwood-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/redwood-pyre-logs.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 358
   highalch: 537
   limit: 11000
-  about: "Redwood pyre logs is a members-only item in Old School RuneScape. High alchemy value: 537 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: pyre-logs
+    tier: high
+  properties:
+    release_date: "2016-06-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 90
+      xp: 20
+      materials:
+        - item_name: Redwood logs
+          quantity: 1
+        - item_name: Sacred oil(4)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Redwood logs
+      slug: redwood-logs
+      relationship: component
+      description: "Base log chopped from redwood trees in the Woodcutting Guild, soaked in sacred oil"
+    - item_name: Sacred oil(4)
+      slug: sacred-oil-4
+      relationship: component
+      description: "Sanctified oil applied to redwood logs to make redwood pyre logs"
+    - item_name: Magic pyre logs
+      slug: magic-pyre-logs
+      relationship: downgrade
+      description: "Lower-xp pyre log used before unlocking redwoods"
+  about: "Redwood pyre logs are the top-tier pyre logs used to cremate shade remains at Mort'ton, yielding 500 Firemaking xp per pyre and contributing to Shades of Mort'ton minigame progress. They are made by applying sacred oil(4) to redwood logs, which requires 90 Firemaking and yields 20 xp per soak."
+  market_strategy:
+    notes:
+      - "Demand spikes during Shades of Mort'ton minigame and on Firemaking xp weekends"
+      - "Supply is constrained by redwood log yield (Woodcutting Guild) and sacred oil(4) Crafting requirements"
+      - "Buy limit of 11,000 per 4 hours supports bulk shade-burning sessions"
+  trading_tips:
+    - "Compare GE price vs (redwood log + sacred oil(4) cost): the spread is the maker's profit"
+    - "Stock up before community-driven Shades of Mort'ton events; pyre log demand follows minigame activity"
+    - "Make-All addition in 2024 reduced friction for hand-creating pyre logs — keep an eye on supply when Firemaking events run"
+  history:
+    - date: "2016-06-02"
+      description: "Released alongside redwood trees and the Woodcutting Guild as the top-tier pyre log"
+    - date: "2024-07-31"
+      description: "Make-All added for pyre log creation; pyre log warning added when attempting to burn without remains; sacred oil application standardized to a flat 5 Firemaking xp per dose"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/roast-rabbit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/roast-rabbit.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 6000
-  about: "Roast rabbit is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "20 February 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 16
+      xp: 72.5
+      materials:
+        - item_name: Skewered rabbit
+          quantity: 1
+      tools:
+        - Iron spit
+      output_quantity: 1
+  related_items:
+    - item_name: Skewered rabbit
+      slug: skewered-rabbit
+      relationship: component
+      description: "Raw input cooked on a fire to produce roast rabbit"
+    - item_name: Raw rabbit
+      slug: raw-rabbit
+      relationship: component
+      description: "Uncooked rabbit meat used to skewer"
+    - item_name: Burnt rabbit
+      slug: burnt-rabbit
+      relationship: alternative
+      description: "Failure result when cooking under level"
+    - item_name: Cooked rabbit
+      slug: cooked-rabbit
+      relationship: alternative
+      description: "Alternative cooked rabbit prepared on a regular fire"
+  about: |-
+    > *"A delicious looking piece of roast rabbit."*
+
+    Roast rabbit is cooked from a skewered rabbit on a fire. The cook needs Cooking 16 and yields 72.5 XP per success. Eating heals 7 hitpoints. Burning can occur at lower levels and stops entirely at Cooking 99. The dish also appears as a Regicide quest item.
+  market_strategy:
+    notes:
+      - "Niche low-level food: profit is driven by skewered rabbit feedstock"
+      - "Cheap heal alternative for budget skillers"
+  trading_tips:
+    - "Watch skewered rabbit + iron spit costs: roast rabbit only flips when raw inputs are cheap"
+    - "Diary cook spots cut burn losses: scale supply on Catherby/Hosidius spawn windows"
+  history:
+    - date: "20 February 2006"
+      description: "Released as part of the Eagles' Peak / Hunter content era cooking lineup"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune dagger(p) | OSRS Price Data
-description: "Rune dagger(p): The blade is covered with a nasty poison.. High alch: 4,800 GP, GE limit: 70."
+description: "Rune dagger(p) is a poisoned rune dagger requiring 40 Attack. High alch: 4,800 GP, GE limit: 70."
 osrs:
   id: 1229
   name: Rune dagger(p)
@@ -12,9 +12,101 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 70
-  about: "Rune dagger(p) is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: rune
+    tier: mid
+  properties:
+    release_date: "2001-08-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 25
+      slash: 12
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 24
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Poison
+      description: "Has a chance to poison opponents on hit, applying gradual damage over time"
+  recipes:
+    - skill: herblore
+      level: 5
+      xp: 0
+      materials:
+        - item_name: Rune dagger
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Rune dagger
+      slug: rune-dagger
+      relationship: downgrade
+      description: "Unpoisoned base dagger"
+    - item_name: Rune dagger(p+)
+      slug: rune-dagger-p-plus
+      relationship: upgrade
+      description: "Upgraded with weapon poison+"
+    - item_name: Rune dagger(p++)
+      slug: rune-dagger-p-plus-plus
+      relationship: upgrade
+      description: "Upgraded with weapon poison++"
+    - item_name: Dragon dagger(p)
+      slug: dragon-dagger-p
+      relationship: upgrade
+      description: "Stronger poisoned stab special dagger"
+    - item_name: Weapon poison
+      slug: weapon-poison
+      relationship: component
+      description: "Used to poison the rune dagger"
+  about: |-
+    Rune dagger(p) is the poisoned form of the rune dagger, created by applying weapon poison to a regular rune dagger. It uses the stab combat style and has the fastest attack speed tier among one-handed melee weapons.
+
+    At 40 Attack required, it is a popular budget poisoned stab weapon for low-level PvP, Slayer trash, and pures who cannot equip a dragon dagger yet.
+  market_strategy:
+    notes:
+      - "Mid-tier poisoned stab weapon — low buy limit caps daily flips"
+      - "GE price tracks base rune dagger + weapon poison cost"
+      - "Higher poison tiers (p+, p++) command stronger premiums"
+  trading_tips:
+    - "Buy rune dagger + weapon poison separately when the poisoned variant is overpriced"
+    - "Watch poison ingredient updates — they ripple through this market"
+  history:
+    - date: "2001-08-13"
+      description: "Released alongside the rune dagger."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-plateskirt-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-plateskirt-g.mdx
@@ -12,22 +12,88 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: runite
+    tier: high
+  properties:
+    release_date: "2004-10-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 9.071
     requirements:
       defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 3477
-      item_name: Rune plateskirt (t)
+    - item_name: Rune plateskirt
+      slug: rune-plateskirt
+      relationship: variant
+      description: "Untrimmed base plateskirt with identical stats"
+    - item_name: Rune plateskirt (t)
       slug: rune-plateskirt-t
       relationship: variant
-      description: Trimmed variant
+      description: "Trimmed cosmetic variant"
+    - item_name: Rune platelegs (g)
+      slug: rune-platelegs-g
+      relationship: alternative
+      description: "Matching gold-trimmed legs slot variant"
+    - item_name: Rune platebody (g)
+      slug: rune-platebody-g
+      relationship: set-piece
+      description: "Matching gold-trimmed body piece"
   about: |-
-    > *"Rune plateskirt with gold trim."*
+    > _"Rune plateskirt with gold trim."_
 
-    The rune plateskirt (g) is a gold-trimmed cosmetic variant of the rune plateskirt. Same stats as rune platelegs with slightly less weight, requiring 40 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The rune plateskirt (g) is a gold-trimmed cosmetic variant of the rune plateskirt, dropped from hard Treasure Trails reward caskets at 1/1,625. Mechanically identical to the base rune plateskirt and rune platelegs in defence bonuses while sitting in the legs slot. Free-to-play and stores in a costume room treasure chest as part of the rune gold-trimmed armour set.
+  market_strategy:
+    notes:
+      - "Hard clue supply is the only major source — cannot be smithed"
+      - "GE buy limit of 8 caps flip volume hard"
+      - "Cosmetic demand drives most of the price premium over base plateskirt"
+  trading_tips:
+    - "Compare gold-trim vs base rune plateskirt for relative premium"
+    - "Hard clue update windows shift supply heavily"
+  history:
+    - date: "2004-10-26"
+      description: "Released with the trimmed and gold-trimmed Treasure Trails rewards expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-crossbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-crossbow-u.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 6466
   highalch: 9700
   limit: 10000
-  about: "Runite crossbow (u) is a members-only item in Old School RuneScape. High alchemy value: 9,700 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: unstrung-weapon
+    tier: high
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 8
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 69
+      xp: 100
+      materials:
+        - item_name: Yew stock
+          quantity: 1
+        - item_name: Runite limbs
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Yew stock
+      slug: yew-stock
+      relationship: component
+      description: "Wood stock combined with runite limbs to fletch the unstrung crossbow"
+    - item_name: Runite limbs
+      slug: runite-limbs
+      relationship: component
+      description: "Smithed limbs combined with a yew stock to fletch the unstrung crossbow"
+    - item_name: Rune crossbow
+      slug: rune-crossbow
+      relationship: product
+      description: "Strung result — attach a crossbow string for 50 Fletching xp at level 69"
+    - item_name: Adamant crossbow (u)
+      slug: adamant-crossbow-u
+      relationship: downgrade
+      description: "Lower-tier unstrung crossbow at 61 Fletching"
+  about: "Runite crossbow (u) is the unstrung form of the rune crossbow, fletched from one yew stock and one runite limbs at 69 Fletching for 100 xp. Adding a crossbow string completes it into a Rune crossbow (50 xp), the best mainstream pre-dragon-crossbow ranged weapon for ironmen and budget setups."
+  market_strategy:
+    notes:
+      - "Demand is driven by Fletching trainers passing through 69 to higher levels and by ironmen building rune crossbows"
+      - "Supply is gated by runite limbs (Smithing) and yew stocks (Fletching); both intermediates have steady availability"
+      - "Buy limit of 10,000 per 4 hours supports bulk Fletching grinds without GE friction"
+  trading_tips:
+    - "Compare GE price vs (yew stock + runite limbs): a positive spread means fletchers profit by selling unstrung"
+    - "Strung Rune crossbow demand is steady; the unstrung form generally trades close to material cost"
+    - "Watch DXP weekends — Fletching xp events lift unstrung crossbow supply as bulk grinders dump output"
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside crossbow content as part of the Fletching expansion to support metal crossbows"
+    - date: "2014-12-10"
+      description: "Renamed from 'Runite c'bow (u)' to 'Runite crossbow (u)' for consistency"
+    - date: "2015-09-24"
+      description: "Allowed creation while boosted into the Fletching level requirement"
+    - date: "2021-07-07"
+      description: "Adjusted female player animation so the crossbow is held correctly"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sacred-oil-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sacred-oil-1.mdx
@@ -12,9 +12,72 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 2000
-  about: "Sacred oil(1) is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Used to coat logs and create pyre logs that grant Firemaking experience when burned during Shades of Mort'ton funeral rites"
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Olive oil(1)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Olive oil(1)
+      slug: olive-oil-1
+      relationship: component
+      description: "Base oil consecrated at the Flamtaer altar"
+    - item_name: Sacred oil(2)
+      slug: sacred-oil-2
+      relationship: variant
+      description: "Two dose variant of the same potion"
+    - item_name: Sacred oil(3)
+      slug: sacred-oil-3
+      relationship: variant
+      description: "Three dose variant of the same potion"
+    - item_name: Sacred oil(4)
+      slug: sacred-oil-4
+      relationship: variant
+      description: "Four dose variant of the same potion"
+    - item_name: Pyre logs
+      slug: pyre-logs
+      relationship: product
+      description: "Created by applying sacred oil to standard logs"
+  about: "Sacred oil(1) is a members-only single-dose potion produced by consecrating olive oil at the Flamtaer fire altar after Shades of Mort'ton. It is used to coat various logs into pyre logs for funeral rites and Firemaking training."
+  market_strategy:
+    notes:
+      - "Olive oil to sacred oil conversion is highly profitable for ironman and main accounts alike."
+      - "Sanctity must be at 10% for the altar to accept conversions which gates supply."
+      - "Demand scales with Mort'ton funeral content and pyre log Firemaking strategies."
+  trading_tips:
+    - "Stockpile olive oil before sanctity events to maximize conversion uptime"
+    - "Sell during Firemaking double XP events when pyre logs spike"
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Shades of Mort'ton quest"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-bracelet.mdx
@@ -12,30 +12,85 @@ osrs:
   lowalch: 460
   highalch: 690
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: sapphire
+    tier: mid
+  properties:
+    release_date: "2007-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.25
     requirements:
       crafting: 23
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 23
       xp: 60
-      inputs:
+      materials:
         - item_name: Sapphire
           quantity: 1
         - item_name: Gold bar
           quantity: 1
+      tools:
+        - Furnace
+        - Bracelet mould
       output_quantity: 1
   related_items:
-    - item_id: 11076
-      item_name: Emerald bracelet
+    - item_name: Bracelet of clay
+      slug: bracelet-of-clay
+      relationship: upgrade
+      description: "Enchanted form via Lvl-1 Enchant for soft clay without water"
+    - item_name: Emerald bracelet
       slug: emerald-bracelet
       relationship: upgrade
-      description: Next tier bracelet
+      description: "Next tier bracelet enchanted into Castle wars bracelet"
+    - item_name: Sapphire
+      slug: sapphire
+      relationship: component
+      description: "Cut sapphire required for the bracelet recipe"
+    - item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: "Gold bar smelted into the bracelet base"
   about: |-
     Crafting (Level 23): Sapphire + Gold bar at a furnace with bracelet mould (60 XP)
 
-    > *"A sapphire bracelet."*
+    > *"I wonder if this is valuable."*
 
     Lvl-1 Enchant (7 Magic): 1 cosmic rune + 1 water rune (17.5 XP)
 
@@ -54,11 +109,15 @@ osrs:
     | Onyx | 84 | Lvl-6 (87) | Regen bracelet | 2x HP regen |
   market_strategy:
     notes:
-      - Bracelet of clay in high demand for Construction
-      - Consumed after 28 uses — recurring demand
-      - Cheap to enchant
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Bracelet of clay in high demand for Construction"
+      - "Consumed after 28 uses — recurring demand"
+      - "Cheap to enchant"
+  trading_tips:
+    - "Buy unenchanted, enchant, flip as Bracelet of clay for margin"
+    - "Track Sapphire and Gold bar spreads — craft is profit-positive"
+  history:
+    - date: "2007-04-30"
+      description: "Released with the OSRS jewellery rework"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire.mdx
@@ -12,119 +12,125 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   material:
     type: gem
     tier: low
-  crafting:
-    level: 20
-    xp: 50
+  properties:
+    release_date: "2001-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: crafting
       level: 20
       xp: 40
       materials:
         - item_name: Sapphire
-          item_id: 1607
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Sapphire ring
-      product_id: 1637
-      product_quantity: 1
-      facility: Furnace
+        - item_name: Ring mould
+          quantity: 1
+      tools: []
+      output_quantity: 1
     - skill: crafting
       level: 22
       xp: 55
       materials:
         - item_name: Sapphire
-          item_id: 1607
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Sapphire necklace
-      product_id: 1656
-      product_quantity: 1
-      facility: Furnace
-    - skill: crafting
-      level: 24
-      xp: 65
-      materials:
-        - item_name: Sapphire
-          item_id: 1607
+        - item_name: Necklace mould
           quantity: 1
-        - item_name: Gold bar
-          item_id: 2357
-          quantity: 1
-      product: Sapphire amulet (u)
-      product_id: 1675
-      product_quantity: 1
-      facility: Furnace
+      tools: []
+      output_quantity: 1
     - skill: crafting
       level: 23
       xp: 60
       materials:
         - item_name: Sapphire
-          item_id: 1607
           quantity: 1
         - item_name: Gold bar
-          item_id: 2357
           quantity: 1
-      product: Sapphire bracelet
-      product_id: 11072
-      product_quantity: 1
-      facility: Furnace
-      members_only: true
+        - item_name: Bracelet mould
+          quantity: 1
+      tools: []
+      output_quantity: 1
+    - skill: crafting
+      level: 24
+      xp: 65
+      materials:
+        - item_name: Sapphire
+          quantity: 1
+        - item_name: Gold bar
+          quantity: 1
+        - item_name: Amulet mould
+          quantity: 1
+      tools: []
+      output_quantity: 1
     - skill: fletching
       level: 56
       xp: 4
       materials:
         - item_name: Sapphire
-          item_id: 1607
           quantity: 1
-      product: Sapphire bolt tips
-      product_id: 9189
-      product_quantity: 12
-      members_only: true
+        - item_name: Chisel
+          quantity: 1
+      tools: []
+      output_quantity: 12
   related_items:
-    - item_id: 1623
-      item_name: Uncut sapphire
+    - item_name: Uncut sapphire
       slug: uncut-sapphire
       relationship: component
-      description: Raw gem
-    - item_id: 2550
-      item_name: Ring of recoil
-      slug: ring-of-recoil
+      description: "Raw gem cut with a chisel to produce the sapphire"
+    - item_name: Sapphire ring
+      slug: sapphire-ring
       relationship: product
-      description: Enchanted ring
-    - item_id: 3853
-      item_name: Games necklace
-      slug: games-necklace
+      description: "Crafted with a gold bar at 20 Crafting"
+    - item_name: Sapphire necklace
+      slug: sapphire-necklace
       relationship: product
-      description: Enchanted necklace
-    - item_id: 1605
-      item_name: Emerald
+      description: "Crafted with a gold bar at 22 Crafting"
+    - item_name: Sapphire bracelet
+      slug: sapphire-bracelet
+      relationship: product
+      description: "Members bracelet crafted at 23 Crafting"
+    - item_name: Sapphire amulet (u)
+      slug: sapphire-amulet-u
+      relationship: product
+      description: "Unstrung amulet crafted at 24 Crafting"
+    - item_name: Sapphire bolt tips
+      slug: sapphire-bolt-tips
+      relationship: product
+      description: "Twelve bolt tips fletched per gem at 56 Fletching"
+    - item_name: Emerald
       slug: emerald
       relationship: alternative
-      description: Higher tier gem
-  about: |-
-    | Item | Effect |
-    |------|--------|
-    | Ring of recoil | Reflects 10% damage |
-    | Games necklace | Minigame teleports |
-    | Bracelet of clay | Soft clay mining |
-    | Amulet of magic | +10 Magic attack |
+      description: "Next-tier cut gem above sapphire"
+  about: "Sapphire is the lowest tier cut gem, used to craft sapphire jewellery (ring, necklace, bracelet, amulet) and to fletch sapphire bolt tips. Foundational gem for early Crafting training and ring of recoil production."
   market_strategy:
     notes:
-      - Ring of recoil production
-      - Games necklace production
-      - Crafting training
-      - Lowest tier cut gem
-      - High volume trading
-      - Ring of recoil always needed
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "High-volume free-to-play gem market"
+      - "Ring of recoil demand provides stable floor"
+      - "Tight margin vs uncut sapphire; cut for XP, not flips"
+  trading_tips:
+    - "Watch the cut vs uncut spread to time your processing"
+    - "Bulk craft sapphire rings for ring of recoil enchanting flips"
+  history:
+    - date: "2001-05-08"
+      description: "Released as part of the original Crafting skill content"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-kiteshield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Saradomin kiteshield | OSRS Price Data
-description: "Saradomin kiteshield: Rune kiteshield in the colours of Saradomin.. High alch: 32,640 GP, GE limit: 8."
+description: "Saradomin kiteshield: Rune kiteshield in the colours of Saradomin. High alch: 32,640 GP, GE limit: 8."
 osrs:
   id: 2667
   name: Saradomin kiteshield
@@ -12,9 +12,88 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 8
-  about: "Saradomin kiteshield is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: runite
+    tier: high
+  properties:
+    release_date: "2004-05-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: variant
+      description: "Untrimmed base shield with identical defensive stats"
+    - item_name: Guthix kiteshield
+      slug: guthix-kiteshield
+      relationship: alternative
+      description: "God-aligned counterpart with identical bonuses"
+    - item_name: Zamorak kiteshield
+      slug: zamorak-kiteshield
+      relationship: alternative
+      description: "God-aligned counterpart with identical bonuses"
+    - item_name: Saradomin platebody
+      slug: saradomin-platebody
+      relationship: set-piece
+      description: "Matching Saradomin armour piece"
+  about: |-
+    > _"Rune kiteshield in the colours of Saradomin."_
+
+    The Saradomin kiteshield is a rune kiteshield reskinned with Saradomin iconography. Stats are identical to the standard rune kiteshield but it gains +1 Prayer bonus, making it a budget Prayer option. Obtained as a reward from hard Treasure Trails clue scrolls at a 1/1,625 drop rate. Stores in a costume room treasure chest as part of the Saradomin armour set.
+  market_strategy:
+    notes:
+      - "Hard clue completion supply is the only major source"
+      - "GE buy limit of 8 caps flip volume hard"
+      - "+1 Prayer bonus drives demand among god-aligned cosmetic loadouts"
+  trading_tips:
+    - "Compare against Guthix and Zamorak kiteshields for relative pricing"
+    - "Hard clue update events shift supply heavily"
+  history:
+    - date: "2004-05-05"
+      description: "Released with the original Treasure Trails minigame"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-platebody.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
-  about: "Saradomin platebody is a free-to-play item in Old School RuneScape. High alchemy value: 39,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "5 May 2004"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 9.979
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -15
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: "1/1,625"
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Rune platebody
+      slug: rune-platebody
+      relationship: alternative
+      description: "Base rune platebody with identical stats"
+    - item_name: Zamorak platebody
+      slug: zamorak-platebody
+      relationship: alternative
+      description: "Zamorak-aligned god platebody"
+    - item_name: Guthix platebody
+      slug: guthix-platebody
+      relationship: alternative
+      description: "Guthix-aligned god platebody"
+    - item_name: Saradomin plateskirt
+      slug: saradomin-plateskirt
+      relationship: set-piece
+      description: "Matching Saradomin leg armour"
+    - item_name: Saradomin full helm
+      slug: saradomin-full-helm
+      relationship: set-piece
+      description: "Matching Saradomin head armour"
+  about: "Saradomin platebody is a hard clue scroll reward that re-skins the rune platebody in Saradomin colours, adding a small Prayer bonus that makes it a budget choice for low-level prayer-flicked combat."
+  market_strategy:
+    notes:
+      - "Buy limit of 8 keeps spreads wide; flip in small repeated batches."
+      - "Demand is split between cosmetic collectors and casket gamblers."
+      - "Hard clue volume drives price; falls during seasonal events."
+  trading_tips:
+    - "Track other god platebodies, they trade as a basket."
+    - "Buy after hard-clue burnout weekends, sell at content launches."
+    - "High alch is rarely profitable; price stays above 39k."
+  history:
+    - date: "5 May 2004"
+      description: "Released as part of the original Treasure Trails update."
+    - date: "21 April 2021"
+      description: "Magic and ranged attack bonuses standardised with rune platebody."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/seaweed-spore.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/seaweed-spore.mdx
@@ -12,75 +12,91 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 600
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   material:
     type: seed
     tier: mid
+  properties:
+    release_date: "2017-09-07"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
-      - source: Fossil Island underwater
-      - source: Seaweed patch harvesting
-      - source: Drift net fishing
-  farming:
-    level: 23
-    location: Underwater seaweed patch
-    growth_time_minutes: 40
-    patches: 2
-    product_id: 21504
-    product_name: Giant seaweed
-  market:
-    buy_limit: 600
-    price_estimate: 50
+      - source: Fossil Island underwater spawn
+        quantity: "1"
+        rarity: Common
+      - source: Ammonite Crab
+        quantity: "1"
+        rarity: Uncommon
+      - source: Lobstrosity
+        quantity: "1"
+        rarity: Uncommon
+      - source: Fossil Island Wyvern
+        quantity: "1"
+        rarity: Uncommon
+      - source: Master Farmer
+        quantity: "1"
+        rarity: Rare
+  shops:
+    - shop_name: Mairin's Market
+      location: Fossil Island underwater area
+      price: 20
+      currency: Mermaid's tears
+      stock: 100
+  recipes:
+    - skill: farming
+      level: 23
+      xp: 19
+      materials:
+        - item_name: Seaweed spore
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 21504
-      item_name: Giant seaweed
+    - item_name: Giant seaweed
       slug: giant-seaweed
       relationship: product
-      description: Harvest product
-    - item_id: 1775
-      item_name: Molten glass
+      description: "Harvest product of the seaweed patch"
+    - item_name: Molten glass
       slug: molten-glass
       relationship: product
-      description: End product
-    - item_id: 1783
-      item_name: Bucket of sand
+      description: "End product when used with Superglass Make"
+    - item_name: Bucket of sand
       slug: bucket-of-sand
       relationship: alternative
-      description: Partner for glass
-    - item_id: 22016
-      item_name: Drift net
+      description: "Companion ingredient for molten glass"
+    - item_name: Drift net
       slug: drift-net
       relationship: component
-      description: Alternative source
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 23 |
-    | Location | Underwater seaweed patch |
-    | Growth time | 40 minutes |
-    | Yield | Giant seaweed |
+      description: "Alternative source via underwater fishing"
+  about: "Seaweed spore is the only farmable input for giant seaweed and a backbone of the Superglass Make / molten glass crafting chain. It grows at 23 Farming in the underwater Fossil Island patches in 40 minutes, yielding three or more per patch with high-tier compost."
   market_strategy:
-    title: |-
-      - Giant seaweed farming
-      - Superglass Make chain
-      - Ironman accounts
-      - Crafting training
     notes:
-      - Only way to farm giant seaweed
-      - Low buy limit
-      - Essential for Crafting
-      - Giant seaweed farming
-      - Superglass Make chain
-      - Ironman accounts
-      - Crafting training
-      - Very low buy limit (600)
-      - Spawn underwater on Fossil Island
-      - Harvest gives more spores
-      - 2 patches available
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand driven by molten glass and Superglass Make"
+      - "Buy limit 600 keeps flips small per cycle"
+      - "Underwater patches favored by ironmen"
+  trading_tips:
+    - "Track Crafting training trends for demand spikes"
+    - "Mermaid's tears alternative caps GE upside"
+    - "Master Farmer pickpocketing adds passive supply"
+  history:
+    - date: "2017-09-07"
+      description: "Released with the Fossil Island update."
+    - date: "2018-05-31"
+      description: "Mairin's Market price dropped from 50 to 20 mermaid's tears."
+    - date: "2020-09-16"
+      description: "Added to the Master Farmer loot table."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-teleport-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shattered teleport scroll | OSRS Price Data
-description: "Shattered teleport scroll: A scroll which unlocks the Shattered Relics home teleport animation.. High alch: 15,000 GP."
+description: "Shattered teleport scroll: A scroll which unlocks the Shattered Relics home teleport animation. High alch: 15,000 GP."
 osrs:
   id: 26500
   name: Shattered teleport scroll
@@ -12,9 +12,50 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: null
-  about: "Shattered teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic unlock
+    tier: high
+  properties:
+    release_date: "2022-01-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options: ["Read", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Trailblazer teleport scroll
+      slug: trailblazer-teleport-scroll
+      relationship: alternative
+      description: "Equivalent home teleport scroll from the Trailblazer League"
+    - item_name: Twisted teleport scroll
+      slug: twisted-teleport-scroll
+      relationship: alternative
+      description: "Equivalent home teleport scroll from the Twisted League"
+  about: "The Shattered teleport scroll is a cosmetic reward purchased from the Leagues Reward Shop for 1,000 League Points during the Shattered Relics League. Reading the scroll unlocks the Shattered Relics-themed home teleport animation, consuming the item in the process."
+  market_strategy:
+    notes:
+      - "One-time cosmetic unlock for the Shattered Relics home teleport animation"
+      - "Limited supply from a closed League event drives high market value"
+      - "Once read, the scroll is consumed and the unlock is account-bound"
+  trading_tips:
+    - "Confirm the buyer wants the unlock before selling, it cannot be reversed once read"
+    - "Pricing follows other League cosmetic unlocks like Trailblazer and Twisted scrolls"
+    - "Volume is thin, expect wider buy/sell spreads on the Grand Exchange"
+  history:
+    - date: "2022-01-19"
+      description: "Shattered teleport scroll added to the game."
+    - date: "2022-03-16"
+      description: "Made obtainable through the Leagues Reward Shop for 1,000 League Points."
+    - date: "2023-11-15"
+      description: "Item's visual orientation adjusted."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-trousers-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-trousers-t3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Shattered trousers (t3) | OSRS Price Data
-description: "Shattered trousers (t3): The trousers of a Shattered Relic Hunter.. High alch: 9,000 GP."
+description: "Shattered trousers (t3): The trousers of a Shattered Relic Hunter. High alch: 9,000 GP."
 osrs:
   id: 26457
   name: Shattered trousers (t3)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered trousers (t3) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2022-03-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Shattered hood (t3)
+      slug: shattered-hood-t3
+      relationship: set-piece
+      description: "Matching tier 3 Shattered Relic Hunter headwear"
+    - item_name: Shattered top (t3)
+      slug: shattered-top-t3
+      relationship: set-piece
+      description: "Matching tier 3 Shattered Relic Hunter torso"
+    - item_name: Shattered gloves (t3)
+      slug: shattered-gloves-t3
+      relationship: set-piece
+      description: "Matching tier 3 Shattered Relic Hunter gloves"
+    - item_name: Shattered boots (t3)
+      slug: shattered-boots-t3
+      relationship: set-piece
+      description: "Matching tier 3 Shattered Relic Hunter boots"
+  about: |-
+    > _"The trousers of a Shattered Relic Hunter."_
+
+    Shattered trousers (t3) are a cosmetic legs slot item from the Shattered Relic League rewards. Purchasable for 15,000 League Points from the Leagues Reward Shop as the highest-tier Shattered Relic Hunter outfit. Provides zero combat bonuses but can be stored in a costume room armour case or displayed on a League hall outfit stand.
+  market_strategy:
+    notes:
+      - "Pure cosmetic demand; price tracks league nostalgia cycles"
+      - "No GE buy limit"
+      - "Higher tier outfits historically trade above lower tiers"
+  trading_tips:
+    - "Demand spikes during Leagues anniversaries"
+    - "Full t3 set often clears faster than individual pieces"
+  history:
+    - date: "2022-03-16"
+      description: "Released with PvP Arena rewards beta update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-chef.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-chef.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of the chef is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: sigil
+    tier: mid-high
+  properties:
+    release_date: "2021-08-25"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - "Attune"
+      - "Inspect"
+      - "Destroy"
+    worn_options: []
+    alchable: true
+    destroy: "You must unattune the Sigil before you can destroy it."
+  passive_effects:
+    - name: "Mass Cook"
+      description: "When Cooking food or making Jugs of Wine, all items in inventory are processed in a single action"
+  drop_table:
+    sources:
+      - source: Deadman Mode general drop table
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - item_name: Sigil of the smith
+      slug: sigil-of-the-smith
+      relationship: alternative
+      description: "Smithing-focused sigil from the same Deadman pool"
+    - item_name: Sigil of the fletcher
+      slug: sigil-of-the-fletcher
+      relationship: alternative
+      description: "Fletching-focused sigil from the same Deadman pool"
+  about: |-
+    The Sigil of the chef is a Deadman-mode sigil that, once attuned to a player, lets all inventory items be cooked or all wines be made in a single action. Used during Deadman: Reborn temporary events.
+
+    Untuned sigils are tradeable; attuned ones bind to the account and must be unattuned before being dropped or destroyed.
+  market_strategy:
+    notes:
+      - "Only meaningful during active Deadman seasons"
+      - "Supply tied to seasonal drop rates from regular monsters"
+      - "GE limit of 10 caps flipping volume"
+  trading_tips:
+    - "Buy ahead of Deadman season announcements, sell into hype window"
+    - "Outside seasonal events, demand drops to near zero"
+  history:
+    - date: "2021-08-25"
+      description: "Released as a Deadman Mode reward sigil"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skills-necklace-6.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skills-necklace-6.mdx
@@ -12,9 +12,35 @@ osrs:
   lowalch: 8080
   highalch: 12120
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: jewellery
+    tier: mid-high
+  properties:
+    release_date: "2007-04-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Rub
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
+    weapon_type: null
+    attack_speed: null
     weight: 0.01
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,53 +58,36 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  charges:
-    current: 6
-    max: 6
-    recharge: Fountain of Rune
-  special_effect:
-    name: Skills Necklace Teleport
-    description: Teleports to Fishing Guild, Mining Guild, Crafting Guild, Cooking Guild, Woodcutting Guild, Farming Guild
-    triggers: on_use
+  passive_effects:
+    - name: Skills Necklace Teleport
+      description: "Rub or wear-rub to teleport to the Fishing Guild, Mining Guild, Crafting Guild, Cooks' Guild, Woodcutting Guild, or Farming Guild"
   related_items:
-    - item_id: 11113
-      item_name: Skills necklace (uncharged)
+    - item_name: Skills necklace
       slug: skills-necklace
       relationship: variant
-      description: Uncharged version
-    - item_id: 11105
-      item_name: Skills necklace(4)
+      description: "Uncharged base necklace"
+    - item_name: Skills necklace(4)
       slug: skills-necklace-4
       relationship: variant
-      description: 4 charge version
-  about: |-
-    No combat bonuses - utility item for teleportation to skilling locations.
-
-    - Fishing Guild
-    - Mining Guild
-    - Crafting Guild
-    - Cooking Guild
-    - Woodcutting Guild
-    - Farming Guild
-
-    | State | Charges |
-    |-------|---------|
-    | Current | 6 |
-    | Maximum | 6 |
+      description: "Four-charge version recharged at the Legends Guild"
+    - item_name: Skills necklace(5)
+      slug: skills-necklace-5
+      relationship: variant
+      description: "Five-charge intermediate variant"
+  about: "Skills necklace(6) is the maximum-charge variant of the skills necklace, obtained by recharging at the Fountain of Rune after Legends' Quest. Teleports to six skilling guilds with no combat bonuses."
   market_strategy:
     notes:
-      - Maximum charges from Fountain of Rune
-      - More efficient than 4-charge version
-      - Popular for efficient skillers
-      - Skilling efficiency
-      - Mining Guild access
-      - Farming Guild access
-      - Maximum charge seekers
-      - Recharged at Fountain of Rune only for 6 charges
-      - More value per teleport than skills necklace(4)
-      - Essential for efficient skilling methods
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Fountain of Rune access gates supply behind Legends Quest"
+      - "Premium over (4) variant for the extra two charges"
+      - "Strong skiller and ironman alt demand"
+  trading_tips:
+    - "Bulk recharge at the Fountain of Rune to flip (4) into (6)"
+    - "Demand spikes during community Skill of the Week and Farming Guild events"
+  history:
+    - date: "2007-04-30"
+      description: "Released with the 24 Carat Update adding the skills necklace"
+    - date: "2018-09-20"
+      description: "Farming Guild added as a teleport destination"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-bell.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-bell.mdx
@@ -1,6 +1,6 @@
 ---
 title: Slayer bell | OSRS Price Data
-description: "Slayer bell: Don't make anyone jump when you ring this!. High alch: 90 GP, GE limit: 40."
+description: "Slayer bell: Don't make anyone jump when you ring this! High alch: 90 GP, GE limit: 40."
 osrs:
   id: 10952
   name: Slayer bell
@@ -12,9 +12,76 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 40
-  about: "Slayer bell is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: slayer equipment
+    tier: low
+  properties:
+    release_date: "2007-03-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options: ["Ring", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Slayer Equipment
+      location: Burthorpe
+      price: 150
+      currency: coins
+      stock: 50
+    - shop_name: Slayer Equipment
+      location: Draynor Village
+      price: 150
+      currency: coins
+      stock: 50
+    - shop_name: Slayer Equipment
+      location: Edgeville
+      price: 150
+      currency: coins
+      stock: 50
+    - shop_name: Slayer Equipment
+      location: Canifis
+      price: 150
+      currency: coins
+      stock: 50
+    - shop_name: Slayer Equipment
+      location: Mount Karuulm
+      price: 150
+      currency: coins
+      stock: 50
+  related_items:
+    - item_name: Slayer staff
+      slug: slayer-staff
+      relationship: alternative
+      description: "Another piece of slayer equipment sold at the same shops"
+    - item_name: Spiny helmet
+      slug: spiny-helmet
+      relationship: alternative
+      description: "Slayer-shop accessory used against certain task targets"
+  about: "The Slayer bell is a piece of Slayer equipment used to lure molanisks off walls during Slayer tasks at level 39+ Slayer. It is sold at 150 coins by every Slayer Master's equipment shop across Gielinor."
+  market_strategy:
+    notes:
+      - "Sold in unlimited supply by every Slayer equipment shop at 150 coins"
+      - "Buy limit of 40 per 4 hours keeps Grand Exchange supply tight"
+      - "Niche demand from Molanisk Slayer task hunters"
+  trading_tips:
+    - "Cheapest source is buying directly from any Slayer Master shop"
+    - "Grand Exchange resellers typically markup against the shop price"
+    - "Stack with other Slayer equipment purchases to save trips"
+  history:
+    - date: "2007-03-20"
+      description: "Slayer bell added with the Slayer equipment expansion."
+    - date: "2013-04-25"
+      description: "Animation conflicts in the Duel Arena resolved."
+    - date: "2019-04-25"
+      description: "Chat filtering added for the bell's sound effect message."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-respite-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-respite-m4.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Slayer's respite(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: beverage
+    tier: mid
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 59
+      xp: 215
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Wildblood hops
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Calquat keg
+          quantity: 2
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Slayer's respite(m3)
+      slug: slayer-s-respite-m3
+      relationship: variant
+      description: "Same keg with one pint already drunk"
+    - item_name: Slayer's respite(m2)
+      slug: slayer-s-respite-m2
+      relationship: variant
+      description: "Same keg with two pints already drunk"
+    - item_name: Slayer's respite(m1)
+      slug: slayer-s-respite-m1
+      relationship: variant
+      description: "Same keg with three pints already drunk"
+    - item_name: Slayer's respite (keg)
+      slug: slayer-s-respite-keg
+      relationship: alternative
+      description: "Non-matured 4-pint keg variant"
+    - item_name: Slayer's respite
+      slug: slayer-s-respite
+      relationship: variant
+      description: "Single pint of the standard ale"
+  about: |-
+    > *"This keg contains 4 pints of mature Slayer's Respite."*
+
+    Slayer's respite(m4) is the freshly brewed mature variant of the Slayer's respite keg, brewed in a brewery at 59 Cooking using two buckets of water, two barley malt, four wildblood hops, one ale yeast, and two calquat kegs for 215 Cooking XP per batch. Maturation occurs over time at the brewery.
+
+    Each pint mirrors the mature single Slayer's respite, granting temporary Slayer XP boosts. Once partially drunk the keg becomes untradeable — only the sealed (m4) variant moves through the Grand Exchange.
+  market_strategy:
+    notes:
+      - "Daily volume tied to slayer training streamers and ironmen brewing parties"
+      - "Mature variants command a premium over fresh kegs"
+  trading_tips:
+    - "Stock during brewery downtime — supply lags after maintenance"
+    - "Listing as (m4) only; lower pint counts are not tradeable"
+  history:
+    - date: "2005-07-11"
+      description: "Released alongside the Brewery and Farming update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/small-box-hedge-bagged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/small-box-hedge-bagged.mdx
@@ -12,9 +12,63 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 10000
-  about: "Small box hedge (bagged) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: plant
+    tier: mid
+  properties:
+    release_date: "31 May 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 64
+      xp: 122
+      materials:
+        - item_name: Small box hedge (bagged)
+          quantity: 1
+      tools:
+        - Watering can (full)
+      output_quantity: 1
+  shops:
+    - shop_name: Garden Supplier
+      location: Falador Park
+      price: 15000
+      currency: coins
+      stock: 5
+    - shop_name: Farming Guild Garden Supplier
+      location: Farming Guild
+      price: 15000
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Watering can
+      slug: watering-can
+      relationship: component
+      description: "Required (filled) to plant"
+  about: "Small box hedge (bagged) is a 64 Construction decorative hedge for player-owned house formal gardens, granting 122 Construction and Farming XP per plant."
+  market_strategy:
+    notes:
+      - "Pure cosmetic with no functional benefit"
+      - "Construction XP route competes with cheaper alternatives"
+      - "Steady but low volume because hedge upgrades come from shop stock"
+  trading_tips:
+    - "Stock directly from Falador Park or Farming Guild gardeners for fixed supply"
+    - "Watch GE premium over the 15,000 coin shop price as a flip signal"
+  history:
+    - date: "31 May 2006"
+      description: "Released as a Construction garden decoration."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spider-on-shaft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spider-on-shaft.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 6000
-  about: "Spider on shaft is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 16
+      xp: 80
+      materials:
+        - item_name: Spider carcass
+          quantity: 1
+        - item_name: Arrow shaft
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Spider on stick
+      slug: spider-on-stick
+      relationship: alternative
+      description: "Stick variant cooked on a skewer"
+    - item_name: Arrow shaft
+      slug: arrow-shaft
+      relationship: component
+      description: "Base shaft used to skewer the spider"
+  about: "Spider on shaft is a members-only cooked food made by using an arrow shaft on a spider carcass at 16 Cooking. It heals 7-10 hitpoints and stops burning at 48 Cooking. Cooking one counts toward the Karamja Diary (medium)."
+  market_strategy:
+    notes:
+      - "Demand is driven by Karamja Diary completionists and budget food seekers."
+      - "Volume is low; price tends to track the cost of arrow shafts plus spider carcass scarcity."
+  trading_tips:
+    - "Buy in bulk when arrow shaft prices dip to flip into cooked stock."
+    - "Limit of 6,000 per 4 hours leaves room for sizeable runs."
+  history:
+    - date: "2005-08-09"
+      description: "Released alongside the Tai Bwo Wannai Cleanup minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spiky-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spiky-vambraces.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 125
-  about: "Spiky vambraces is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: leather
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weapon_type: null
+    attack_speed: null
+    weight: 0.226
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 4
+    defence_bonus:
+      stab: 2
+      slash: 2
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 2
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 32
+      xp: 6
+      materials:
+        - item_name: Leather vambraces
+          quantity: 1
+        - item_name: Kebbit claws
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Leather vambraces
+      slug: leather-vambraces
+      relationship: component
+      description: Base vambraces used in the crafting recipe
+    - item_name: Kebbit claws
+      slug: kebbit-claws
+      relationship: component
+      description: Hunter drop used to spike the vambraces
+    - item_name: Hard leather vambraces
+      slug: hard-leather-vambraces
+      relationship: upgrade
+      description: Higher-defence vambraces from hard leather
+    - item_name: Green spiky vambraces
+      slug: green-spiky-vambraces
+      relationship: variant
+      description: Dragonhide-tier spiked variant in green
+  about: "Spiky vambraces are leather vambraces fitted with kebbit claws; they keep the base leather defences but tack on +2 Strength and +4 Ranged attack, and they remain Entrana-legal despite the offensive bonuses."
+  market_strategy:
+    notes:
+      - "Crafting recipe ties price to kebbit-claw supply — low-level hunters set the floor."
+      - "Niche niche niche: barely used outside ironman early-game and fashionscape."
+  trading_tips:
+    - "Buy kebbit claws + leather vambraces separately when craft margin > GE price."
+    - "Volume is thin — list at margin and wait, do not chase the buy line."
+  history:
+    - date: "2006-11-21"
+      description: Added with the original Hunter skill release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/squid-beak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/squid-beak.mdx
@@ -1,6 +1,6 @@
 ---
 title: Squid beak | OSRS Price Data
-description: "Squid beak: The beak of a squid.. High alch: 3,000 GP."
+description: "Squid beak: The beak of a squid. High alch: 3,000 GP."
 osrs:
   id: 31572
   name: Squid beak
@@ -12,9 +12,63 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Squid beak is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: fletching
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Raw swordtip squid
+        quantity: "1"
+        rarity: "1/1024"
+      - source: Raw jumbo squid
+        quantity: "1"
+        rarity: "1/512"
+  related_items:
+    - item_name: Camphor blowpipe (empty)
+      slug: camphor-blowpipe-empty
+      relationship: product
+      description: "Fletched with the beak at 58 Fletching"
+    - item_name: Ironwood blowpipe (empty)
+      slug: ironwood-blowpipe-empty
+      relationship: product
+      description: "Fletched with the beak at 72 Fletching"
+    - item_name: Rosewood blowpipe (empty)
+      slug: rosewood-blowpipe-empty
+      relationship: product
+      description: "Fletched with the beak at 84 Fletching"
+  about: |-
+    > _"The beak of a squid."_
+
+    Squid beak is a Fletching ingredient introduced with the wooden blowpipe rework. Rolls off raw swordtip squid (1/1,024) and raw jumbo squid (1/512) while fishing or cooking. Used to fletch camphor, ironwood, and rosewood blowpipes. No GE buy limit and not currently tradeable through restricted accounts.
+  market_strategy:
+    notes:
+      - "Demand floor set by blowpipe fletching profit"
+      - "Drop rates were corrected on 2025-11-20 right after release"
+      - "Watch raw squid catch rates for supply spikes"
+  trading_tips:
+    - "Compare empty blowpipe GE prices against beak cost"
+    - "Jumbo squid yields beaks at double the swordtip rate"
+  history:
+    - date: "2025-11-19"
+      description: "Released as part of the wooden blowpipe Fletching update"
+    - date: "2025-11-20"
+      description: "Drop rates from raw squid corrected after launch"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stamina-potion-3.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 2000
-  about: "Stamina potion(3) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "3 July 2014"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - "Drink"
+      - "Empty"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 20% of run energy per dose and reduces run energy depletion by 70% for 2 minutes."
+        duration: 120
+  recipes:
+    - skill: herblore
+      level: 77
+      xp: 25.5
+      materials:
+        - item_name: Super energy potion
+          quantity: 1
+        - item_name: Amylase crystal
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  shops:
+    - shop_name: Theatre of Blood Chest
+      location: Ver Sinhaza
+      price: 0
+      currency: coins
+      stock: 1
+  related_items:
+    - item_name: Stamina potion(1)
+      slug: stamina-potion-1
+      relationship: variant
+      description: "1-dose variant"
+    - item_name: Stamina potion(2)
+      slug: stamina-potion-2
+      relationship: variant
+      description: "2-dose variant"
+    - item_name: Stamina potion(4)
+      slug: stamina-potion-4
+      relationship: variant
+      description: "4-dose variant"
+    - item_name: Stamina mix(2)
+      slug: stamina-mix-2
+      relationship: upgrade
+      description: "Barbarian-mixed variant with healing"
+  about: "Stamina potion(3) is a members-only Herblore potion that restores run energy and dramatically slows energy depletion, making it essential for long-distance running tasks, slayer trips, and PvM activities like Theatre of Blood."
+  market_strategy:
+    notes:
+      - "High daily volume keeps spreads tight; flips work best on bulk orders."
+      - "Demand spikes during DMM, leagues, and ToB hard-mode windows."
+      - "Decant between (3) and (4) doses when per-dose price diverges."
+  trading_tips:
+    - "Track Amylase crystal cost: stamina prices follow crystal supply."
+    - "Buy during quiet evenings, sell during weekend PvM peaks."
+    - "Convert (3) doses to (4) doses via decanting NPCs when arbitrage opens."
+  history:
+    - date: "3 July 2014"
+      description: "Stamina potions added to the game alongside Amylase crystals from Barbarian Assault."
+    - date: "8 January 2025"
+      description: "Make-X process updated so that drinking no longer cancels movement."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strawberry.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strawberry.mdx
@@ -12,59 +12,66 @@ osrs:
   lowalch: 6
   highalch: 10
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
   properties:
+    release_date: "2005-07-11"
     tradeable: true
-    tradeable_ge: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.028
-  food:
-    heals: 1
-    heals_max: 6
-    heals_formula: based on Hitpoints level
-  skilling_sources:
+    options:
+      - "Eat"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
     - skill: farming
       level: 31
       xp: 26
+      materials:
+        - item_name: Strawberry seed
+          quantity: 1
+      tools: []
+      output_quantity: 1
   drop_table:
     sources:
-      - source: Fruit stall
-        source_id: 0
-        combat_level: 0
+      - source: Fruit stall (Thieving 25)
         quantity: "1"
-        rarity: common
-        drop_rate: 7/100
-        members_only: true
-      - source: Gourmet impling
-        source_id: 1643
-        combat_level: 0
+        rarity: "7/100"
+      - source: Gourmet impling jar
         quantity: "1"
-        rarity: rare
-        drop_rate: 1/100
-        members_only: true
+        rarity: "1/100"
+      - source: Strawberry spawn near Shayziens' Wall
+        quantity: "1"
+        rarity: respawn
   related_items:
-    - item_id: 5323
-      item_name: Strawberry seed
+    - item_name: Strawberry seed
       slug: strawberry-seed
       relationship: component
-      description: Farming source
-    - item_id: 5405
-      item_name: Strawberry basket
+      description: Farming seed grown in an allotment patch
+    - item_name: Strawberry basket
       slug: strawberry-basket
       relationship: product
-      description: Processed form
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Farming Product / Food |
-    | Tradeable | Yes |
-    | Weight | 0.028 kg |
-    | Requirements | 31 Farming |
-
-    Food: Heals 1-6 HP based on hitpoints level
-
-    Cooking: Strawberry basket ingredient
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Basket holding five strawberries: 30 HP of food per slot"
+  about: "Strawberry is a Farming-grown food healing 1 plus 6 percent of maximum Hitpoints per bite; five fit into a strawberry basket to compress the heal into one inventory slot."
+  market_strategy:
+    notes:
+      - "Volume is dominated by Tithe-Farm / allotment skillers dumping harvests."
+      - "Demand rises when herblore brews need them as a backup heal."
+  trading_tips:
+    - "Bulk-buy on weekends when farmers flood the GE."
+    - "Convert into baskets when basket prices outpace raw fruit five-fold."
+  history:
+    - date: "2005-07-11"
+      description: Released with the original Farming skill launch.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-2.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 288
   highalch: 432
   limit: 2000
-  about: "Super antifire potion(2) is a members-only item in Old School RuneScape. High alchemy value: 432 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - "Drink"
+      - "Empty"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Grants complete immunity to regular dragonfire"
+        duration: 180
+      - description: "Partially blocks stronger dragonfire from King Black Dragon, Galvek, and Vorkath"
+        duration: 180
+  recipes:
+    - skill: herblore
+      level: 92
+      xp: 130
+      materials:
+        - item_name: Antifire potion(4)
+          quantity: 1
+        - item_name: Crushed superior dragon bones
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Super antifire potion(4)
+      slug: super-antifire-potion-4
+      relationship: variant
+      description: "Full 4-dose version"
+    - item_name: Antifire potion(4)
+      slug: antifire-potion-4
+      relationship: component
+      description: "Base potion used in the recipe"
+    - item_name: Crushed superior dragon bones
+      slug: crushed-superior-dragon-bones
+      relationship: component
+      description: "Secondary ingredient from superior dragons"
+    - item_name: Extended super antifire(4)
+      slug: extended-super-antifire-4
+      relationship: upgrade
+      description: "Longer-duration variant requiring 98 Herblore and lava scale shards"
+  about: |-
+    Super antifire is the strongest dragonfire defense available, granting total immunity to regular dragonfire and partial protection against the boosted dragonfire of KBD, Galvek, and Vorkath.
+
+    Two doses last three minutes total: one minute per dose. Pair with an antifire shield or dragonfire ward for full protection at endgame dragon bosses.
+  market_strategy:
+    notes:
+      - "Required staple at Vorkath, supply is steady"
+      - "Crushed superior dragon bones cost dominates the recipe"
+      - "Profit margins thinnest right after Vorkath nerfs or buffs"
+      - "92 Herblore gates supply"
+  trading_tips:
+    - "Decant 4-dose potions to 2-dose when 4s trade above 2x the 2-dose price"
+    - "Watch crushed superior dragon bones GE swings: ingredient cost drives potion cost"
+  history:
+    - date: "2018-01-04"
+      description: "Released with the Dragon Slayer II update"
+    - date: "2018-01-25"
+      description: "Effect duration extended from two to three minutes"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-3.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 304
   highalch: 456
   limit: 2000
-  about: "Super antifire potion(3) is a members-only item in Old School RuneScape. High alchemy value: 456 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.06
+    options:
+      - "Drink"
+      - "Empty"
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Grants complete immunity to standard dragonfire, partial protection against stronger dragonfire variants."
+        duration: 180
+  recipes:
+    - skill: herblore
+      level: 92
+      xp: 130
+      materials:
+        - item_name: Antifire potion(3)
+          quantity: 1
+        - item_name: Crushed superior dragon bones
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Super antifire potion(4)
+      slug: super-antifire-potion-4
+      relationship: upgrade
+      description: Four-dose form, one extra sip per inventory slot
+    - item_name: Super antifire potion(2)
+      slug: super-antifire-potion-2
+      relationship: downgrade
+      description: Two-dose form
+    - item_name: Super antifire potion(1)
+      slug: super-antifire-potion-1
+      relationship: downgrade
+      description: Single-dose form
+    - item_name: Extended super antifire(4)
+      slug: extended-super-antifire-4
+      relationship: upgrade
+      description: "Extended variant doubling duration: requires 98 Herblore"
+    - item_name: Antifire potion(3)
+      slug: antifire-potion-3
+      relationship: component
+      description: Base potion combined with crushed superior dragon bones
+  about: "Super antifire potion(3) is the post-Dragon-Slayer-II dragon protection sip used at Vorkath, Galvek and dragon-heavy slayer tasks, fully neutralising standard fire and softening enhanced breath."
+  market_strategy:
+    notes:
+      - "Demand spikes during double Slayer XP weekends and Vorkath grinding sessions."
+      - "Crushed superior dragon bones supply (Adamant/Rune dragons) is the real price driver."
+  trading_tips:
+    - "Watch 4-dose vs 3-dose decant gap before flipping in either direction."
+    - "Stock up before league launches: PvM accounts panic-buy stacks of 2,000."
+  history:
+    - date: "2018-01-04"
+      description: Added alongside the Dragon Slayer II reward suite.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-restore-1.mdx
@@ -12,84 +12,91 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 2000
-  potion:
-    doses: 1
-    type: restore
-    effect: Restores all stats (except Hitpoints) and Prayer
-    effects:
-      - stat: All stats
-        boost_formula: 8 + floor(level / 4)
-      - stat: Prayer
-        boost_formula: 8 + floor(level / 4)
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid-high
   properties:
+    release_date: "2004-07-27"
     tradeable: true
-    tradeable_ge: true
-    weight: 0.035
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores all stats except Hitpoints by floor(level / 4) + 8 points"
+        duration: 0
+      - description: "Restores Prayer by floor(level / 4) + 8 points (floor(level * 0.27) + 8 with holy wrench)"
+        duration: 0
   recipes:
     - skill: herblore
       level: 63
       xp: 142.5
       materials:
         - item_name: Snapdragon potion (unf)
-          item_id: 3004
           quantity: 1
         - item_name: Red spiders' eggs
-          item_id: 223
           quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 3024
-      item_name: Super restore(4)
+    - item_name: Super restore(4)
       slug: super-restore-4
       relationship: variant
-      description: Full dose variant
-    - item_id: 3000
-      item_name: Snapdragon
-      slug: snapdragon
+      description: "Full 4-dose variant"
+    - item_name: Super restore(2)
+      slug: super-restore-2
+      relationship: variant
+      description: "2-dose variant"
+    - item_name: Super restore(3)
+      slug: super-restore-3
+      relationship: variant
+      description: "3-dose variant"
+    - item_name: Snapdragon potion (unf)
+      slug: snapdragon-potion-unf
       relationship: component
-      description: Primary herb
-    - item_id: 223
-      item_name: Red spiders' eggs
+      description: "Unfinished potion base"
+    - item_name: Red spiders' eggs
       slug: red-spiders-eggs
       relationship: component
-      description: Secondary ingredient
-    - item_id: 6685
-      item_name: Saradomin brew(4)
-      slug: saradomin-brew-4
+      description: "Secondary herblore ingredient"
+    - item_name: Prayer potion(1)
+      slug: prayer-potion-1
       relationship: alternative
-      description: Paired consumable
+      description: "Cheaper prayer-only restore"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Potion |
-    | Tradeable | Yes |
-    | Weight | 0.035 kg |
+    Super restore(1) is a single dose of the super restore potion. It restores all drained stats (except Hitpoints) and Prayer points using the formula floor(level / 4) + 8. With a holy wrench, ring of the gods (i), or Prayer cape equipped, Prayer restoration uses floor(level * 0.27) + 8 instead.
 
-    Combine Snapdragon potion (unf) + Red spiders' eggs.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore | 63 |
-    | XP | 142.5 |
-
-    Stat + Prayer Restoration:
-    - All stats: floor(Level x 0.25) + 8
-    - Prayer with Holy wrench: floor(Level x 0.27) + 8
-    - Does NOT restore Hitpoints
-
-    Essential for:
-    - Raids
-    - Bossing
-    - Any stat-draining content
-
-    Better than prayer potion for most content.
+    The potion is a staple for raids, bossing, and any stat-draining content, and is the primary partner to Saradomin brews since brews lower combat stats that super restore promptly tops back up.
   market_strategy:
     notes:
-      - Restores all drained stats
-      - Essential for Sara brews
-      - Core raid consumable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Restores all drained combat and non-combat stats"
+      - "Essential pair for Saradomin brews in PvM"
+      - "Core consumable across Chambers of Xeric, Theatre of Blood, and Tombs of Amascut"
+      - "Decanting from larger doses can be cheaper per dose"
+  trading_tips:
+    - "Compare per-dose pricing across the (1)(2)(3)(4) variants before buying"
+    - "Bulk decanting can flip larger doses into single doses for profit"
+  history:
+    - date: "2004-07-27"
+      description: "Super restore potions released."
+    - date: "2004-09-01"
+      description: "Now restores non-combat skills in addition to combat stats."
+    - date: "2004-10-26"
+      description: "Added an Empty option to the potion."
+    - date: "2016-04-15"
+      description: "Half-full potions made convertible to bank placeholders."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-lizard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swamp-lizard.mdx
@@ -12,9 +12,88 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 125
-  about: "Swamp lizard is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: creature
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Wield
+      - Release
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: salamander
+    attack_speed: 5
+    weight: 4
+    requirements:
+      attack: 30
+      ranged: 30
+      magic: 30
+      hunter: 29
+    attack_bonus:
+      stab: 0
+      slash: 10
+      crush: 0
+      magic: 0
+      ranged: 20
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 22
+      ranged_strength: 16
+      magic_damage: 56
+      prayer: 0
+  related_items:
+    - item_name: Orange salamander
+      slug: orange-salamander
+      relationship: upgrade
+      description: "Higher tier salamander hunted at Kharidian Desert"
+    - item_name: Red salamander
+      slug: red-salamander
+      relationship: upgrade
+      description: "Hunted near Karamja volcano"
+    - item_name: Black salamander
+      slug: black-salamander
+      relationship: upgrade
+      description: "Top tier salamander hunted at Wilderness"
+    - item_name: Guam tar
+      slug: guam-tar
+      relationship: component
+      description: "Ammunition used by the swamp lizard"
+  about: |-
+    > *"A very slimy and generally disgusting green lizard."*
+
+    Swamp lizard is the entry-tier salamander, caught east of Canifis with net traps at 29 Hunter for 152 Hunter XP per catch. Once wielded it acts as a three-style hybrid weapon: Scorch (Slash, 5-tick, +22 Strength), Flare (Ranged, 4-tick), and Blaze (Magic, 5-tick, +56 magic damage). Uses guam tar as ammunition.
+
+    Requires 30 in Attack, Ranged, and Magic to wield. If unprotected on death it runs away rather than dropping as an item.
+  market_strategy:
+    notes:
+      - "Hunter shortage keeps prices low — high supply from leveling"
+      - "Demand bumps from low-level slayer task hybrid setups"
+  trading_tips:
+    - "Bulk buy at low Hunter XP windows after major updates"
+    - "Pair with guam tar listings for slayer beginners"
+  history:
+    - date: "2006-11-21"
+      description: "Released with the original Hunter skill"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swampbark-body.mdx
@@ -1,6 +1,6 @@
 ---
 title: Swampbark body | OSRS Price Data
-description: "Swampbark body: Keeps my chest protected.. High alch: 72,000 GP."
+description: "Swampbark body: Keeps my chest protected. High alch: 72,000 GP."
 osrs:
   id: 25389
   name: Swampbark body
@@ -12,9 +12,95 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: null
-  about: "Swampbark body is a members-only item in Old School RuneScape. High alchemy value: 72,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: magic armour
+    tier: mid-high
+  properties:
+    release_date: "2021-01-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options: ["Wear", "Drop"]
+    worn_options: ["Remove"]
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 4.535
+    requirements:
+      magic: 50
+      defence: 50
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 15
+      ranged: 0
+    defence_bonus:
+      stab: 38
+      slash: 44
+      crush: 48
+      magic: 21
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: runecraft
+      level: 48
+      xp: 0
+      materials:
+        - item_name: Splitbark body
+          quantity: 1
+        - item_name: Nature rune
+          quantity: 500
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Swampbark set bind bonus
+      description: "Adds 2 ticks (1.2 seconds) to bind spell duration; stacks with swampbark helm and legs for a 6-tick (3.6 second) total bonus."
+  related_items:
+    - item_name: Splitbark body
+      slug: splitbark-body
+      relationship: component
+      description: "Base body item infused at the Nature Altar to create the swampbark body"
+    - item_name: Swampbark helm
+      slug: swampbark-helm
+      relationship: set-piece
+      description: "Set piece that contributes 2 ticks to the bind duration bonus"
+    - item_name: Swampbark legs
+      slug: swampbark-legs
+      relationship: set-piece
+      description: "Set piece that contributes 2 ticks to the bind duration bonus"
+    - item_name: Runescroll of swampbark
+      slug: runescroll-of-swampbark
+      relationship: component
+      description: "Must be read before infusing splitbark armour into swampbark"
+  about: "The Swampbark body is a mid-tier Magic body armour crafted by infusing a splitbark body with 500 nature runes at the Nature Altar (48 Runecraft). It requires 50 Magic and 50 Defence to wear and is part of the swampbark set that increases bind spell duration."
+  market_strategy:
+    notes:
+      - "Crafted at the Nature Altar after reading the runescroll of swampbark"
+      - "Demand driven by PvM Mages who use Ice Barrage or Bind for crowd control"
+      - "Helm, body, and legs together grant the full 6-tick bind extension"
+  trading_tips:
+    - "Track nature rune and splitbark body prices to estimate crafting margin"
+    - "Set pieces are typically cheapest mid-week, watch for restock cycles"
+    - "Best used with other bind-extending gear for PvM specialist setups"
+  history:
+    - date: "2021-01-27"
+      description: "Swampbark body released alongside the swampbark armour set."
+    - date: "2023-06-21"
+      description: "Set bonus adjusted so maximum benefit is reached with helm, body, and legs alone."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem-g.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Swords and emblem (g) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2025-10-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Events Reward Shop
+      location: Varrock Square
+      price: 1100
+      currency: Event points
+      stock: 1
+  related_items:
+    - item_name: Grid master tabard (g)
+      slug: grid-master-tabard-g
+      relationship: set-piece
+      description: "Matching tabard cosmetic from the Grid Master event reward shop"
+  about: "Swords and emblem (g) is a cosmetic cape released alongside the Grid Master community event in October 2025. It is purchased from the Events Reward Shop in Varrock Square for 1,100 event points and provides no combat bonuses. It can be stored in a costume room armour case."
+  market_strategy:
+    notes:
+      - "Demand is purely cosmetic — drives mainly by collectors and outfit completionists"
+      - "Supply was tied to the Grid Master event window; post-event scarcity supports the price floor"
+      - "No alchemy value (lowalch/highalch null) means no alch backstop on price drops"
+  trading_tips:
+    - "Pair-trade with grid master tabard (g) — completers want the matching set"
+    - "Event-window collectibles tend to rise after the event ends as supply dries up"
+    - "Untradeable to anyone who missed the event — the buyer pool is essentially fixed"
+  history:
+    - date: "2025-10-15"
+      description: "Released as a reward in the Grid Master community event, sold from the Events Reward Shop in Varrock Square"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem-p.mdx
@@ -9,12 +9,74 @@ osrs:
   members: true
   icon: Swords and emblem (p).png
   value: 100000
-  lowalch: null
-  highalch: null
+  lowalch: 40000
+  highalch: 60000
   limit: null
-  about: Swords and emblem (p) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2025-10-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Grid master tabard (p)
+      slug: grid-master-tabard-p
+      relationship: set-piece
+      description: "Pairs with the swords and emblem (p) as part of the Grid Master cosmetic outfit"
+    - item_name: Swords and emblem
+      slug: swords-and-emblem
+      relationship: variant
+      description: "Standard recolour variant of the same Grid Master cape"
+  about: Swords and emblem (p) is a cosmetic cape obtained from the Events Reward Shop for 1,100 event points during the Grid Master community event. The blades are decorative only and the cape provides no combat bonuses.
+  market_strategy:
+    notes:
+      - "Cosmetic-only cape with zero combat stats"
+      - "Supply is gated by Grid Master event participation"
+      - "Pairs with the Grid master tabard (p) for the matching set"
+  trading_tips:
+    - "Treat as a collector cosmetic: value tracks event nostalgia, not gameplay"
+    - "Cross-shop with the standard Swords and emblem to spot mispriced variants"
+  history:
+    - date: "2025-10-15"
+      description: "Released alongside the Grid Master community event reward shop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-clock-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-clock-flatpack.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak clock (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: construction-supply
+    tier: mid
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 55
+      xp: 202
+      materials:
+        - item_name: Teak plank
+          quantity: 2
+        - item_name: Clockwork
+          quantity: 1
+      tools: ["Hammer", "Saw", "Steel-framed bench"]
+      output_quantity: 1
+  related_items:
+    - item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: "Plank input for the flatpack"
+    - item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: "Crafted mechanism required to assemble the clock"
+  about: |-
+    > *"How does it all fit in there?"*
+
+    Construction flatpack assembled at a steel-framed workbench from 2 teak planks plus 1 clockwork at 55 Construction, yielding 202 XP per build. Once built, the flatpack can be placed in a player-owned house bedroom corner space as a decorative clock. Production typically operates at a small loss after GE tax, so the item is primarily a Construction XP vehicle.
+  market_strategy:
+    notes:
+      - "Buy limit 500 caps daily flip volume"
+      - "Clockwork cost is the primary margin lever"
+      - "Demand driven by Construction trainers and POH decorators"
+  trading_tips:
+    - "Cross-check clockwork + 2 teak plank cost against flatpack price before bulk smithing"
+    - "Volume picks up during double XP events as XP-per-tick options get scouted"
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Player-owned houses update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-pyre-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-pyre-logs.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 11000
-  about: "Teak pyre logs is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 1
+      xp: 15
+      materials:
+        - item_name: Teak logs
+          quantity: 1
+        - item_name: Sacred oil(4)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Teak logs
+      slug: teak-logs
+      relationship: component
+      description: "Base log soaked in sacred oil to create pyre logs"
+    - item_name: Sacred oil(4)
+      slug: sacred-oil-4
+      relationship: component
+      description: "Blessed olive oil used to prepare the logs"
+    - item_name: Oak pyre logs
+      slug: oak-pyre-logs
+      relationship: downgrade
+      description: "Lower tier pyre log used at lower Firemaking requirements"
+    - item_name: Mahogany pyre logs
+      slug: mahogany-pyre-logs
+      relationship: upgrade
+      description: "Higher tier pyre log used at higher Firemaking requirements"
+  about: "Teak pyre logs are members-only logs used in the Shades of Mort'ton minigame to cremate shade remains. Building a pyre requires 40 Firemaking and a tinderbox, awarding 120 Firemaking XP and 33.7-61.2 Prayer XP based on the shade tier."
+  market_strategy:
+    notes:
+      - "Demand driven by Shades of Mort'ton runners chasing fang or amulet rewards"
+      - "Self-prep economics depend on teak logs and sacred oil spot prices"
+      - "Buy limit of 11,000 supports bulk supply for Shades grinders"
+  trading_tips:
+    - "Compare GE price versus teak logs plus sacred oil(4) to choose buying or making"
+    - "Track Shades of Mort'ton hype cycles for short-term demand spikes"
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Shades of Mort'ton minigame"
+    - date: "2024-07"
+      description: "Pyre log creation changed to a flat 5 XP per oil dose consumed"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-33-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-33-cape.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-33 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: team-cape
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Larry's Wilderness Cape Shop
+      location: Bone Yard, Wilderness
+      price: 50
+      currency: Coins
+      stock: 100
+  related_items:
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: "Different team-numbered colour variant"
+    - item_name: Team-32 cape
+      slug: team-32-cape
+      relationship: variant
+      description: "Adjacent team-numbered colour variant"
+    - item_name: Team-34 cape
+      slug: team-34-cape
+      relationship: variant
+      description: "Adjacent team-numbered colour variant"
+  about: "Team-33 cape is one of the original 50 team capes used to coordinate friendly fire in clan wars and Wilderness PvP. It provides minor defensive bonuses and is purchased from Larry's Wilderness Cape Shop in the Bone Yard."
+  market_strategy:
+    notes:
+      - "Shop floor at 50 coins caps upside; flips rely on the GE-shop spread."
+      - "Volume is steady but small; treat as a side flip rather than primary stock."
+  trading_tips:
+    - "Buy directly from Larry's shop and resell on the GE when stock is depleted."
+    - "Watch for clan-event spikes that briefly push demand higher."
+  history:
+    - date: "2005-02-22"
+      description: "Released alongside team capes 1 through 50 for clan combat."
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-37-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-37-cape.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-37 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "22 February 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Neil's Wilderness Cape Shop
+      location: Bandit Camp
+      price: 50
+      currency: coins
+      stock: 100
+  related_items:
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: alternative
+      description: "First-numbered team cape variant"
+    - item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: alternative
+      description: "Highest-numbered team cape variant"
+    - item_name: Team cape zero
+      slug: team-cape-zero
+      relationship: alternative
+      description: "Unnumbered team cape design"
+  about: "The Team-37 cape is one of fifty numbered team capes sold by Neil at the Bandit Camp in the Wilderness for 50 coins, used in PvP and clan settings so allied players display as blue minimap dots instead of white."
+  market_strategy:
+    notes:
+      - "Shop floor of 50 gp caps upside; GE price rarely strays far."
+      - "Demand comes from clan colour-coordination and PK teams."
+      - "Limit of 150 makes bulk supply easy; spreads are pennies."
+  trading_tips:
+    - "Buy direct from Neil instead of GE when restocking for clan."
+    - "Stockpile ahead of clan-cup or PvP tournament weekends."
+    - "Cross-list with adjacent team numbers for full clan setups."
+  history:
+    - date: "22 February 2005"
+      description: "Released as part of the original numbered team cape line-up."
+    - date: "23 May 2013"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topiary-hedge-bagged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topiary-hedge-bagged.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 10000
-  about: "Topiary hedge (bagged) is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: construction-supply
+    tier: mid-high
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 10
+    options: ["Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Garden supplier
+      location: Falador
+      price: 20000
+      currency: Coins
+      stock: 5
+    - shop_name: Farming Guild garden supplier
+      location: Farming Guild
+      price: 20000
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Watering can
+      slug: watering-can
+      relationship: component
+      description: "Required tool: filled watering can to plant the hedge"
+  about: |-
+    > *"You can plant this in your garden."*
+
+    Decorative Construction item purchased bagged from Garden suppliers in Falador or the Farming Guild for 20,000 coins. Plant it in a formal garden as a topiary hedge (Construction 68) or in a superior garden as a topiary bush (Construction 65); each placement grants 141 Construction and Farming experience.
+  market_strategy:
+    notes:
+      - "Fixed shop price 20,000 — flip ceiling capped by buy limit"
+      - "Demand driven by POH builders training Construction at higher tiers"
+      - "Bagged plants typically trade near or slightly above shop price on GE"
+  trading_tips:
+    - "Stock check Falador and Farming Guild garden suppliers before buying GE"
+    - "Bulk buy under high alch ceiling for steady POH demand"
+  history:
+    - date: "2006-05-31"
+      description: "Released alongside the Player-owned houses update as a Garden supplier stock item"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torstol-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torstol-potion-unf.mdx
@@ -12,70 +12,70 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 10000
-  potion:
-    type: unfinished
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: unfinished-potion
     tier: high
-  herblore:
-    level: 78
-    xp: 0
-    method: Add torstol to vial of water
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.056
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: herblore
       level: 78
       xp: 0
       materials:
         - item_name: Vial of water
-          item_id: 227
           quantity: 1
         - item_name: Torstol
-          item_id: 269
           quantity: 1
-      product: Torstol potion (unf)
-      product_id: 111
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 269
-      item_name: Torstol
+    - item_name: Torstol
       slug: torstol
       relationship: component
-      description: Herb ingredient
-    - item_id: 227
-      item_name: Vial of water
+      description: "Clean herb added to the vial"
+    - item_name: Vial of water
       slug: vial-of-water
       relationship: component
-      description: Base liquid
-    - item_id: 247
-      item_name: Jangerberries
-      slug: jangerberries
-      relationship: component
-      description: Secondary for zamorak brew
-    - item_id: 189
-      item_name: Zamorak brew(3)
+      description: "Base liquid for the unfinished potion"
+    - item_name: Zamorak brew(3)
       slug: zamorak-brew-3
       relationship: product
-      description: Attack boost potion
-    - item_id: 3042
-      item_name: Super combat potion(4)
+      description: "Finished with jangerberries at 78 Herblore"
+    - item_name: Super combat potion(4)
       slug: super-combat-potion-4
       relationship: product
-      description: Ultimate combat potion
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 78 Herblore |
-
-    Add secondary ingredient to create:
-    - Zamorak brew (+ jangerberries)
-    - Super combat potion (combined with other potions)
-
-    High-level herblore content.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Combined with super attack/strength/defence at 90 Herblore"
+    - item_name: Anti-venom+(4)
+      slug: anti-venom-plus-4
+      relationship: product
+      description: "Finished at 94 Herblore for venom immunity"
+  about: "Torstol potion (unf) is the unfinished base for several high-level herblore products including zamorak brew, super combat potion, surge potion, and anti-venom+. Made by combining torstol with a vial of water at 78 Herblore."
+  market_strategy:
+    notes:
+      - "Tracks torstol and vial supply tightly"
+      - "Bulk-made for super combat shop runs"
+      - "Used by Herblore alts to bank XP/hr"
+  trading_tips:
+    - "Buy unfinished and finish into super combat(4) for predictable margin"
+    - "Watch torstol farming patch cycles for supply swings"
+  history:
+    - date: "2002-12-12"
+      description: "Released alongside the Herblore skill rework introducing torstol-based potions"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-relic-hunter-t1-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-relic-hunter-t1-armour-set.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Trailblazer relic hunter (t1) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic set
+    tier: high
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: ["Exchange", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Trailblazer hood (t1)
+      slug: trailblazer-hood-t1
+      relationship: set-piece
+      description: "Headpiece component of the Trailblazer relic hunter (t1) set"
+    - item_name: Trailblazer top (t1)
+      slug: trailblazer-top-t1
+      relationship: set-piece
+      description: "Body component of the Trailblazer relic hunter (t1) set"
+    - item_name: Trailblazer trousers (t1)
+      slug: trailblazer-trousers-t1
+      relationship: set-piece
+      description: "Legs component of the Trailblazer relic hunter (t1) set"
+    - item_name: Trailblazer boots (t1)
+      slug: trailblazer-boots-t1
+      relationship: set-piece
+      description: "Boots component of the Trailblazer relic hunter (t1) set"
+    - item_name: Trailblazer relic hunter (t2) armour set
+      slug: trailblazer-relic-hunter-t2-armour-set
+      relationship: upgrade
+      description: "Tier 2 Trailblazer League cosmetic armour set"
+    - item_name: Trailblazer relic hunter (t3) armour set
+      slug: trailblazer-relic-hunter-t3-armour-set
+      relationship: upgrade
+      description: "Tier 3 Trailblazer League cosmetic armour set"
+  about: "The Trailblazer relic hunter (t1) armour set is a cosmetic bundle containing the Trailblazer hood (t1), Trailblazer top (t1), Trailblazer trousers (t1), and Trailblazer boots (t1). It was earned by participants of the Trailblazer League and can be exchanged at the Grand Exchange to retrieve the individual pieces."
+  market_strategy:
+    notes:
+      - "Closed-supply cosmetic from the Trailblazer League"
+      - "Set price reflects bundling premium over the four individual pieces"
+      - "Tier 1 is the most affordable Trailblazer League cosmetic set"
+  trading_tips:
+    - "Compare set price against the four component pieces before exchanging"
+    - "Watch demand around League nostalgia events"
+    - "Exchange via the Grand Exchange to split into individual pieces for resale"
+  history:
+    - date: "2021-01-06"
+      description: "Trailblazer relic hunter (t1) armour set released as Trailblazer League rewards."
+    - date: "2022-01-19"
+      description: "Display image corrected to show the Trailblazer top."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-relic-hunter-t3-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-relic-hunter-t3-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer relic hunter (t3) armour set | OSRS Price Data
-description: "Trailblazer relic hunter (t3) armour set is a members-only OSRS item. High alch: 30,000 GP."
+description: "Trailblazer relic hunter (t3) armour set bundles the four Tier 3 Trailblazer cosmetic pieces. High alch: 30,000 GP."
 osrs:
   id: 25386
   name: Trailblazer relic hunter (t3) armour set
@@ -12,9 +12,61 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Trailblazer relic hunter (t3) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Trailblazer hood (t3)
+      slug: trailblazer-hood-t3
+      relationship: set-piece
+      description: "Head slot piece included in the set"
+    - item_name: Trailblazer top (t3)
+      slug: trailblazer-top-t3
+      relationship: set-piece
+      description: "Body slot piece included in the set"
+    - item_name: Trailblazer trousers (t3)
+      slug: trailblazer-trousers-t3
+      relationship: set-piece
+      description: "Legs slot piece included in the set"
+    - item_name: Trailblazer boots (t3)
+      slug: trailblazer-boots-t3
+      relationship: set-piece
+      description: "Feet slot piece included in the set"
+    - item_name: Trailblazer relic hunter (t2) armour set
+      slug: trailblazer-relic-hunter-t2-armour-set
+      relationship: downgrade
+      description: "Tier 2 trailblazer relic hunter set"
+  about: |-
+    The Trailblazer relic hunter (t3) armour set bundles the four Tier 3 Trailblazer cosmetic pieces (hood, top, trousers, and boots) into a single tradeable wrapper. It is purely cosmetic, untradeable on the GE as individual pieces in some cases, but the set wrapper itself trades.
+
+    The bundle is assembled (or unpacked) through any Grand Exchange clerk's "Sets" interface, allowing collectors to flip the wrapper instead of moving four individual line items. Set premium versus the sum of the components is the primary price signal.
+  market_strategy:
+    notes:
+      - "Pure cosmetic — collector demand drives the premium"
+      - "Set wrapper trades at a markup over the four individual pieces"
+      - "Soul Wars anniversary and league re-runs reshape supply"
+  trading_tips:
+    - "Compare set price vs sum of components — flip in whichever direction is cheaper"
+    - "Use the GE clerk Sets interface to convert between bundle and pieces"
+  history:
+    - date: "2021-01-06"
+      description: "Released via the Soul Wars and 20th Anniversary Event update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-boots-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-boots-t1.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded boots (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "29 November 2023"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.34
+    options:
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weapon_type: null
+    attack_speed: null
+    weight: 0.34
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer reloaded boots (t2)
+      slug: trailblazer-reloaded-boots-t2
+      relationship: upgrade
+      description: "Tier 2 boots in the Trailblazer Reloaded outfit"
+    - item_name: Trailblazer reloaded boots (t3)
+      slug: trailblazer-reloaded-boots-t3
+      relationship: upgrade
+      description: "Tier 3 boots in the Trailblazer Reloaded outfit"
+    - item_name: Trailblazer reloaded headband (t1)
+      slug: trailblazer-reloaded-headband-t1
+      relationship: set-piece
+      description: "Matching t1 headband"
+    - item_name: Trailblazer reloaded top (t1)
+      slug: trailblazer-reloaded-top-t1
+      relationship: set-piece
+      description: "Matching t1 top"
+    - item_name: Trailblazer reloaded trousers (t1)
+      slug: trailblazer-reloaded-trousers-t1
+      relationship: set-piece
+      description: "Matching t1 trousers"
+  about: "Trailblazer reloaded boots (t1) are a cosmetic feet-slot cape unlock from the Trailblazer Reloaded League, purchased for 1,000 League points and worn alongside the rest of the tier 1 Relic Hunter outfit."
+  market_strategy:
+    notes:
+      - "No buy limit but daily volume is near zero, plan exits before entries."
+      - "Cosmetic-only, price tied entirely to league nostalgia and set collectors."
+      - "Tier 3 commands the premium; t1 floors fastest during dry spells."
+  trading_tips:
+    - "Stock up while leagues content is dormant, sell on hype announcements."
+    - "Cross-list against headband and top to gauge full-set demand."
+    - "Storable in the costume room armour case; long-term holders are common."
+  history:
+    - date: "15 November 2023"
+      description: "Added to the game ahead of Trailblazer Reloaded League launch."
+    - date: "29 November 2023"
+      description: "Became obtainable from the Leagues Reward Shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-relic-hunter-t1-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-relic-hunter-t1-armour-set.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: null
-  about: "Trailblazer reloaded relic hunter (t1) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Trailblazer reloaded headband (t1)
+      slug: trailblazer-reloaded-headband-t1
+      relationship: set-piece
+      description: "Hood component of the tier 1 armour set"
+    - item_name: Trailblazer reloaded top (t1)
+      slug: trailblazer-reloaded-top-t1
+      relationship: set-piece
+      description: "Top component of the tier 1 armour set"
+    - item_name: Trailblazer reloaded trousers (t1)
+      slug: trailblazer-reloaded-trousers-t1
+      relationship: set-piece
+      description: "Trousers component of the tier 1 armour set"
+    - item_name: Trailblazer reloaded boots (t1)
+      slug: trailblazer-reloaded-boots-t1
+      relationship: set-piece
+      description: "Boots component of the tier 1 armour set"
+  about: |-
+    The Trailblazer reloaded relic hunter (t1) armour set bundles all four cosmetic tier 1 Trailblazer Reloaded pieces into a single bank-friendly placeholder. Players exchange the individual components with the Grand Exchange clerk via the Sets option to receive the set, or break the set back into its parts.
+
+    The set is purely a storage convenience for Grand Exchange trading; equipping the cosmetic requires breaking the set back into individual pieces.
+  market_strategy:
+    notes:
+      - "Set price typically trades at a discount versus the sum of its components"
+      - "Use the GE clerk's Sets interface to merge or break the set"
+      - "Trailblazer Reloaded cosmetics are tied to the 2023 Leagues iteration and rarely re-release"
+  history:
+    - date: "2023-11-29"
+      description: "Released alongside Leagues IV: Trailblazer Reloaded"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-top-t1.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Trailblazer reloaded top (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2023-11-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer reloaded headband (t1)
+      slug: trailblazer-reloaded-headband-t1
+      relationship: set-piece
+      description: "Matching tier 1 headband for the Trailblazer Reloaded outfit"
+    - item_name: Trailblazer reloaded trousers (t1)
+      slug: trailblazer-reloaded-trousers-t1
+      relationship: set-piece
+      description: "Matching tier 1 trousers for the Trailblazer Reloaded outfit"
+    - item_name: Trailblazer reloaded boots (t1)
+      slug: trailblazer-reloaded-boots-t1
+      relationship: set-piece
+      description: "Matching tier 1 boots for the Trailblazer Reloaded outfit"
+  about: Trailblazer reloaded top (t1) is the tier 1 cosmetic body from the Trailblazer Reloaded Relic Hunter outfit, purchased from the Leagues Reward Shop for 1,000 league points. It can be stored in costume room armour cases or displayed on outfit stands in the League hall.
+  market_strategy:
+    notes:
+      - "Cosmetic body with no combat stats"
+      - "Supply gated by Leagues reward points"
+      - "Demand peaks during nostalgia cycles for past Leagues"
+  trading_tips:
+    - "Cross-shop tier 1 pieces against tier 2/3 to gauge the full-set premium"
+    - "Track Leagues anniversary content windows for predictable demand bumps"
+  history:
+    - date: "2023-11-15"
+      description: "Added to the game ahead of Trailblazer Reloaded launch"
+    - date: "2023-11-29"
+      description: "Made obtainable from the Leagues Reward Shop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-top-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-top-t3.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 5
-  about: "Trailblazer top (t3) is a members-only item in Old School RuneScape. High alchemy value: 90,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer hood (t3)
+      slug: trailblazer-hood-t3
+      relationship: set-piece
+      description: "Matching head slot piece of the Trailblazer Relic Hunter (t3) outfit"
+    - item_name: Trailblazer trousers (t3)
+      slug: trailblazer-trousers-t3
+      relationship: set-piece
+      description: "Matching legs slot piece of the Trailblazer Relic Hunter (t3) outfit"
+    - item_name: Trailblazer boots (t3)
+      slug: trailblazer-boots-t3
+      relationship: set-piece
+      description: "Matching feet slot piece of the Trailblazer Relic Hunter (t3) outfit"
+  about: "Trailblazer top (t3) is the body piece of the tier 3 Trailblazer Relic Hunter cosmetic outfit, awarded from the Trailblazer Reloaded League. It carries no combat bonuses and is purely cosmetic, but the full t3 set is a long-term trophy for League veterans."
+  market_strategy:
+    notes:
+      - "Originates from Leagues Reward Shop (15,000 League points); supply is fixed by past League participation"
+      - "Value: 150,000 base gives 90,000 high alch but the GE price reflects collectible demand far above alch"
+      - "GE limit of 5 per 4 hours makes large flips slow; thin liquidity means wide bid/ask spreads"
+  trading_tips:
+    - "Track the full t3 set price (hood + top + trousers + boots) — pieces tend to move together when a Leagues season is announced"
+    - "Avoid buying during Leagues hype peaks; cosmetic Leagues rewards typically retrace once new cosmetics are announced"
+    - "Members-only and tradeable: ironmen cannot use the GE for these, so demand comes from main accounts only"
+  history:
+    - date: "2020-10-28"
+      description: "Added to the game as 'Trailblazer coat (t3)' during the Trailblazer League preparation update"
+    - date: "2021-01-06"
+      description: "Renamed to 'Trailblazer top (t3)' and made obtainable from the Leagues Reward Shop; base value increased from 100,000 to 150,000 coins"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/triangle-sandwich.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/triangle-sandwich.mdx
@@ -12,9 +12,58 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 6000
-  about: "Triangle sandwich is a free-to-play item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2006-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.02
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Sandwich lady (random event)
+        quantity: "1"
+        rarity: Common
+      - source: Tower of Life construction workers (pickpocket)
+        quantity: "1"
+        rarity: Uncommon
+      - source: Tower of Life crates
+        quantity: "1"
+        rarity: Uncommon
+  related_items:
+    - item_name: Baguette
+      slug: baguette
+      relationship: alternative
+      description: "Alternative Sandwich lady drop"
+    - item_name: Roll
+      slug: roll
+      relationship: alternative
+      description: "Alternative Sandwich lady drop"
+  about: "Triangle sandwich is a free-to-play food obtained from the Sandwich lady random event, pickpocketing Tower of Life construction workers, or telekinetic-grabbing the spawn in the Woodcutting Guild. Heals 6 hitpoints per bite."
+  market_strategy:
+    notes:
+      - "Low alch value caps downside risk"
+      - "Steady supply from random events and pickpocket loot"
+      - "Niche food for low-level training and ironmen"
+  trading_tips:
+    - "Bulk pickup target: stack Tower of Life thieving runs and note the loot"
+    - "Watch for Sandwich lady event spikes during double XP weekends"
+  history:
+    - date: "2006-01-10"
+      description: "Released with The Hand in the Sand update alongside the Sandwich lady random event"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/turquoise-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/turquoise-robe-top.mdx
@@ -12,25 +12,80 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 150
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fine Fashions
+      location: Tree Gnome Stronghold (Grand Tree upper floor)
+      price: 180
+      currency: coins
+      stock: 5
   related_items:
-    - item_id: 634
-      item_name: Turquoise boots
+    - item_name: Turquoise boots
       slug: turquoise-boots
       relationship: set-piece
-      description: Matching boots
-    - item_id: 654
-      item_name: Turquoise robe bottoms
+      description: "Matching feet slot piece of the turquoise gnome outfit"
+    - item_name: Turquoise robe bottoms
       slug: turquoise-robe-bottoms
       relationship: set-piece
-      description: Matching bottoms
-  about: |-
-    > _"A turquoise robe top."_
-
-    The turquoise robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching legs slot piece of the turquoise gnome outfit"
+  about: "Turquoise robe top is a member-only cosmetic body piece from Rometti's Fine Fashions shop in the Grand Tree. Required for an easy-tier Treasure Trails Yawn emote step at Civitas illa Fortis Grand Museum. Stats are minimal (+2 slash and +2 crush defence)."
+  market_strategy:
+    notes:
+      - "Demand peaks when easy emote clues circulate the gnome shop wardrobe requirements"
+      - "Supply comes from Fine Fashions (5 stock, 2-minute restock); supply is effectively unlimited at the shop price"
+      - "GE price often exceeds shop price (180) due to convenience for clue completers"
+  trading_tips:
+    - "Buy from Rometti at 180 coins and flip on the GE when easy-clue demand surges"
+    - "Track the wider gnome wardrobe set (boots + bottoms + top) — clue scroll players often buy all three at once"
+    - "Buy limit of 150 per 4 hours gives room for steady scaling"
+  history:
+    - date: "2002-12-12"
+      description: "Released alongside the Agility skill update, originally as part of the Tree Gnome Stronghold tailor's wardrobe"
+    - date: "2014-12-10"
+      description: "Renamed from 'Robe top' to 'Turquoise robe top' to disambiguate the gnome cosmetic robe colours"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-coat-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-coat-t2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Twisted coat (t2) | OSRS Price Data
-description: "Twisted coat (t2): The coat of a twisted relic hunter.. High alch: 6,000 GP, GE limit: 5."
+description: "Twisted coat (t2): The coat of a twisted relic hunter. High alch: 6,000 GP, GE limit: 5."
 osrs:
   id: 24399
   name: Twisted coat (t2)
@@ -12,9 +12,94 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 5
-  about: "Twisted coat (t2) is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2019-11-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Trailblazer League
+      price: 2500
+      currency: League Points
+      stock: 1
+  related_items:
+    - item_name: Twisted hood (t2)
+      slug: twisted-hood-t2
+      relationship: set-piece
+      description: "Head slot of the Tier 2 twisted relic hunter outfit"
+    - item_name: Twisted trousers (t2)
+      slug: twisted-trousers-t2
+      relationship: set-piece
+      description: "Legs slot of the Tier 2 twisted relic hunter outfit"
+    - item_name: Twisted boots (t2)
+      slug: twisted-boots-t2
+      relationship: set-piece
+      description: "Feet slot of the Tier 2 twisted relic hunter outfit"
+    - item_name: Twisted coat (t1)
+      slug: twisted-coat-t1
+      relationship: downgrade
+      description: "Tier 1 version of the coat"
+    - item_name: Twisted coat (t3)
+      slug: twisted-coat-t3
+      relationship: upgrade
+      description: "Tier 3 version of the coat"
+  about: |-
+    Twisted coat (t2) is the body slot piece of the Tier 2 twisted relic hunter outfit, originally distributed through the Trailblazer League reward shop. It is purely cosmetic and grants no combat bonuses.
+
+    The coat was untradeable when first added with the Twisted League event, but the 16 January 2020 update made the surplus Trailblazer rewards tradeable and noteable, opening the GE market for collectors.
+  market_strategy:
+    notes:
+      - "Pure cosmetic — value driven by collector demand"
+      - "Buy limit of 5 keeps daily flips small"
+      - "Set value tends to track the four matching pieces together"
+  trading_tips:
+    - "Watch event re-runs and leagues anniversaries — fresh supply tanks price"
+    - "Compare to t1 and t3 coats before listing"
+  history:
+    - date: "2019-11-14"
+      description: "Added to the game alongside the Twisted League rewards."
+    - date: "2020-01-16"
+      description: "Made obtainable from the Leagues Reward Shop, tradeable, and noteable; value increased from 500 to 10,000 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-coat-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-coat-t3.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 5
-  about: "Twisted coat (t3) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2020-01-16"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Twisted hood (t3)
+      slug: twisted-hood-t3
+      relationship: set-piece
+      description: "Matching tier 3 hood from the Twisted Relic Hunter outfit"
+    - item_name: Twisted trousers (t3)
+      slug: twisted-trousers-t3
+      relationship: set-piece
+      description: "Matching tier 3 trousers from the Twisted Relic Hunter outfit"
+    - item_name: Twisted boots (t3)
+      slug: twisted-boots-t3
+      relationship: set-piece
+      description: "Matching tier 3 boots from the Twisted Relic Hunter outfit"
+  about: |-
+    The Twisted coat (t3) is the body piece of the tier 3 Twisted Relic Hunter outfit, awarded for participation in the Twisted League. It is purely cosmetic and provides no combat bonuses.
+
+    The coat can be purchased for 10,000 League points from the Leagues Reward Shop and stored in the costume room or displayed on a League hall outfit stand with matching pieces.
+  market_strategy:
+    notes:
+      - "Cosmetic item with collector demand driven by Leagues nostalgia"
+      - "Low buy limit (5) amplifies price swings around Leagues anniversaries"
+      - "Set pieces often trade in lockstep with the matching hood, trousers, and boots"
+  history:
+    - date: "2020-01-16"
+      description: "Released as a Twisted League reward shop cosmetic"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-horns.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-horns.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 5
-  about: "Twisted horns is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bone
+    tier: high
+  properties:
+    release_date: "2020-01-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Inspect
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Twisted slayer helmet
+      slug: twisted-slayer-helmet
+      relationship: product
+      description: "Cosmetic helmet created by combining these horns with a slayer helmet"
+    - item_name: "Twisted slayer helmet (i)"
+      slug: twisted-slayer-helmet-i
+      relationship: product
+      description: "Imbued cosmetic variant for combining with an imbued slayer helmet"
+    - item_name: Slayer helmet
+      slug: slayer-helmet
+      relationship: component
+      description: "Base helmet attached to the horns"
+  about: "Twisted horns are a members-only cosmetic Slayer reward originally sold in the Trailblazer Leagues Reward Shop for 6,000 league points. They unlock the Twisted slayer helmet cosmetic after purchasing the Twisted Vision unlock for 1,000 slayer reward points."
+  market_strategy:
+    notes:
+      - "Cosmetic-only demand from Slayer fashionscape enthusiasts"
+      - "Hard supply cap from Leagues makes this a premium collectible"
+      - "Buy limit of 5 per 4 hours keeps positions small"
+  trading_tips:
+    - "Track Slayer/Leagues update news for demand catalysts"
+    - "Do not alch — 60,000 gp high alch value is far below market price"
+  history:
+    - date: "2020-01-16"
+      description: "Released via the Trailblazer League Reward Shop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-relic-hunter-t2-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-relic-hunter-t2-armour-set.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 5
-  about: "Twisted relic hunter (t2) armour set is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic set
+    tier: high
+  properties:
+    release_date: "2020-01-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options: ["Exchange", "Drop"]
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Twisted hat (t2)
+      slug: twisted-hat-t2
+      relationship: set-piece
+      description: "Headpiece component of the Twisted relic hunter (t2) set"
+    - item_name: Twisted coat (t2)
+      slug: twisted-coat-t2
+      relationship: set-piece
+      description: "Body component of the Twisted relic hunter (t2) set"
+    - item_name: Twisted trousers (t2)
+      slug: twisted-trousers-t2
+      relationship: set-piece
+      description: "Legs component of the Twisted relic hunter (t2) set"
+    - item_name: Twisted boots (t2)
+      slug: twisted-boots-t2
+      relationship: set-piece
+      description: "Boots component of the Twisted relic hunter (t2) set"
+    - item_name: Twisted relic hunter (t1) armour set
+      slug: twisted-relic-hunter-t1-armour-set
+      relationship: downgrade
+      description: "Tier 1 Twisted League cosmetic armour set"
+    - item_name: Twisted relic hunter (t3) armour set
+      slug: twisted-relic-hunter-t3-armour-set
+      relationship: upgrade
+      description: "Tier 3 Twisted League cosmetic armour set"
+  about: "The Twisted relic hunter (t2) armour set is a cosmetic bundle containing the Twisted hat (t2), Twisted coat (t2), Twisted trousers (t2), and Twisted boots (t2). It was earned by participants of the Twisted League and can be exchanged at the Grand Exchange to retrieve the individual pieces."
+  market_strategy:
+    notes:
+      - "Closed-supply cosmetic from the Twisted League event"
+      - "Set typically trades at a premium over the four individual pieces combined"
+      - "Buy limit of 5 per 4 hours keeps trading thin"
+  trading_tips:
+    - "Compare set price against the four component pieces before exchanging"
+    - "Hold during League promotion periods when demand spikes"
+    - "Exchange via the Grand Exchange to split into individual pieces for resale"
+  history:
+    - date: "2020-01-23"
+      description: "Twisted relic hunter (t2) armour set released with the Twisted League rewards."
+    - date: "2020-10-28"
+      description: "Item renamed from 'Twisted relichunter' to 'Twisted relic hunter'."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-onion.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ugthanki-onion.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 2
   highalch: 4
   limit: 11000
-  about: "Ugthanki & onion is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Chopped onion
+          quantity: 1
+        - item_name: Ugthanki meat
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Onion
+          quantity: 1
+        - item_name: Chopped ugthanki
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Kebab mix
+      slug: kebab-mix
+      relationship: product
+      description: "Combine with a tomato to make the kebab mix used for ugthanki kebabs"
+    - item_name: Ugthanki meat
+      slug: ugthanki-meat
+      relationship: component
+      description: "Camel meat needed alongside chopped onion to make this mixture"
+  about: Ugthanki & onion is an intermediate cooking ingredient for ugthanki kebabs. It is combined with a tomato to produce kebab mix, the base for the Gnome Restaurant minigame favourite.
+  market_strategy:
+    notes:
+      - "Niche cooking intermediate, low daily volume"
+      - "Used in the ugthanki kebab supply chain"
+      - "High GE limit but minimal price ceiling"
+  trading_tips:
+    - "Pair sourcing with chopped onion and ugthanki meat trades to maximize margins"
+    - "Watch for chef-quest spikes (e.g. Gertrude content events) that drive demand"
+  history:
+    - date: "2003-12-01"
+      description: "Added to the RS2 Beta cache"
+    - date: "2004-02-02"
+      description: "Became obtainable in the RS2 Beta"
+    - date: "2004-03-29"
+      description: "Made permanently available with the RS2 launch"
+    - date: "2006-01-30"
+      description: "Graphically updated"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-light-ballista.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unstrung-light-ballista.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  about: "Unstrung light ballista is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: wood
+    tier: mid-high
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.75
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 47
+      xp: 15
+      materials:
+        - item_name: Incomplete light ballista
+          quantity: 1
+        - item_name: Ballista spring
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Light ballista
+      slug: light-ballista
+      relationship: product
+      description: "Final two-handed ballista produced after attaching a monkey tail"
+    - item_name: Ballista spring
+      slug: ballista-spring
+      relationship: component
+      description: "Spring required to assemble this intermediate part"
+    - item_name: Incomplete light ballista
+      slug: incomplete-light-ballista
+      relationship: component
+      description: "Wooden frame combined with the spring to make this item"
+    - item_name: Monkey tail
+      slug: monkey-tail
+      relationship: component
+      description: "Attached to this item to finish the Light ballista"
+  about: "Unstrung light ballista is a Monkey Madness II Fletching intermediate. Combine an incomplete light ballista with a ballista spring at 47 Fletching for 15 XP, then attach a monkey tail to finish the Light ballista (300 XP)."
+  market_strategy:
+    notes:
+      - "Niche Monkey Madness II Fletching intermediate with thin daily volume"
+      - "Crafting from parts often costs more than the strung GE price"
+      - "Spikes around Fletching XP method discussions"
+  trading_tips:
+    - "Compare the parts cost versus the finished Light ballista to avoid net losses"
+    - "Buy limit of 8 keeps positions small"
+  history:
+    - date: "2016-05-06"
+      description: "Released with the Monkey Madness II quest"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/weeds.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/weeds.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  about: "Weeds is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: organic
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Farming patch (rake)
+        quantity: "1"
+        rarity: always
+  related_items:
+    - item_name: Compost
+      slug: compost
+      relationship: product
+      description: "Compost bin output: 15 weeds rot into one compost bucket"
+    - item_name: Supercompost
+      slug: supercompost
+      relationship: product
+      description: Tier-up compost made by adding higher-grade botanicals
+    - item_name: Pot of weeds
+      slug: pot-of-weeds
+      relationship: alternative
+      description: Pot-contained variant used in quests
+  about: "Weeds are scraped from farming patches with a rake; bulk-rotting fifteen of them in a compost bin yields a regular compost bucket after roughly an hour."
+  market_strategy:
+    notes:
+      - "Demand tracks Farming activity — bulk compost makers buy in stacks of hundreds."
+      - "High-volume / low-margin: flips are 1-2 gp per unit, scale only with size."
+  trading_tips:
+    - "Sell during Farming bonus events when compost demand spikes."
+    - "Stock up cheaply from skillers cleaning patches near tier 1 herb runs."
+  history:
+    - date: "2007-08-06"
+      description: Inventory sprite updated alongside the wider graphical refresh.
+    - date: "2005-07-11"
+      description: Released with the original Farming skill launch.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-apron.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-apron.mdx
@@ -12,9 +12,77 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 150
-  about: "White apron is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "4 January 2001"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Thessalia's Fine Clothes
+      location: Varrock
+      price: 2
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Pirate's Treasure
+      slug: pirates-treasure
+      relationship: alternative
+      description: "Quest requiring this item"
+    - item_name: Mourning's End Part II
+      slug: mournings-end-part-ii
+      relationship: alternative
+      description: "Quest requiring this item"
+  about: "White apron is a F2P body slot cosmetic with zero combat stats, spawning around Port Sarim and sold at Thessalia's, used in several quests."
+  market_strategy:
+    notes:
+      - "Free spawns at Gerrant's and Wydin's stores in Port Sarim"
+      - "Thessalia's Fine Clothes sells at 2 coins"
+      - "Demand driven by quest requirements rather than combat"
+  trading_tips:
+    - "Grab spawns in Port Sarim before paying GE price"
+    - "Cannot telegrab the Gerrant's shop apron: it stays on the hook"
+  history:
+    - date: "4 January 2001"
+      description: "Released with the early F2P inventory."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-bead.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-bead.mdx
@@ -1,6 +1,6 @@
 ---
 title: White bead | OSRS Price Data
-description: "White bead: A small round white bead.. High alch: 2 GP, GE limit: 11,000."
+description: "White bead: A small round white bead. High alch: 2 GP, GE limit: 11,000."
 osrs:
   id: 1476
   name: White bead
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "White bead is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: bead
+    tier: low
+  properties:
+    release_date: "2001-02-16"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: true
+    weight: 0.003
+    options:
+      - "Drop"
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Imp
+        quantity: "1"
+        rarity: "5/128"
+  related_items:
+    - item_name: Black bead
+      slug: black-bead
+      relationship: set-piece
+      description: "Imp Catcher bead set"
+    - item_name: Red bead
+      slug: red-bead
+      relationship: set-piece
+      description: "Imp Catcher bead set"
+    - item_name: Yellow bead
+      slug: yellow-bead
+      relationship: set-piece
+      description: "Imp Catcher bead set"
+    - item_name: Amulet of accuracy
+      slug: amulet-of-accuracy
+      relationship: product
+      description: "Reward from Imp Catcher quest"
+  about: |-
+    > _"A small round white bead."_
+
+    The white bead is required for the Imp Catcher quest — collect black, red, white and yellow beads and return them to Wizard Mizgog for an Amulet of accuracy. Imps drop the bead at roughly 5/128 rarity. The beads are also used as optional bait when box-trapping imps in Hunter.
+  market_strategy:
+    notes:
+      - "Sticky F2P quest item — buffered demand"
+      - "Imp drop supply consistent"
+      - "Volume low; price hugs GE midline"
+  trading_tips:
+    - "Buy for Imp Catcher questers"
+    - "Bead sets often listed together"
+  history:
+    - date: "2001-02-16"
+      description: "Released with Imp Catcher quest"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-dagger-p-6595.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-dagger-p-6595.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 125
-  about: "White dagger(p+) is a members-only item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: white
+    tier: mid
+  properties:
+    release_date: "17 October 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: stab_sword
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 10
+      slash: 5
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  related_items:
+    - item_name: White dagger
+      slug: white-dagger
+      relationship: variant
+      description: "Unpoisoned base dagger"
+    - item_name: White dagger(p)
+      slug: white-dagger-p-2986
+      relationship: downgrade
+      description: "Standard poison variant with shorter poison duration"
+    - item_name: White dagger(p++)
+      slug: white-dagger-p-6597
+      relationship: upgrade
+      description: "Highest poison tier of the white dagger"
+  about: |-
+    > *"This dagger is poisoned."*
+
+    The White dagger(p+) is the mid-poison variant of the White dagger. Wielding requires Attack 10 and completion of Wanted! to access Sir Vyvin's stock; the dagger itself is also tradeable on the Grand Exchange. Stats match the regular white dagger (+10 stab, +5 slash, +7 strength) with the added poison effect on hit.
+
+    The (p+) tier sits between (p) and (p++) in poison duration and damage tier, and is mostly chosen by Peon-rank Black Knight pures and casual stabbers.
+  market_strategy:
+    notes:
+      - "Buy limit of 125 caps daily flip volume"
+      - "Demand tracks Wanted! and pure-build cycles"
+  trading_tips:
+    - "Check the unpoisoned + weapon poison(+) price: cheaper combos undercut the (p+) dagger"
+    - "Sir Vyvin's restocks set a soft ceiling on (p) variants; arbitrage opportunistically"
+  passive_effects:
+    - name: Weapon poison (+)
+      description: "Chance to apply poison on hit, dealing recurring damage to the target"
+  history:
+    - date: "17 October 2005"
+      description: "Released as part of the White equipment line tied to Wanted!"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-med-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-med-helm.mdx
@@ -12,9 +12,82 @@ osrs:
   lowalch: 230
   highalch: 345
   limit: 125
-  about: "White med helm is a members-only item in Old School RuneScape. High alchemy value: 345 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: white_armour
+    tier: low
+  properties:
+    release_date: "17 October 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Drop
+    worn_options:
+      - Wear
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weight: 1.814
+    requirements:
+      defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: 0
+    defence_bonus:
+      stab: 9
+      slash: 10
+      crush: 8
+      magic: -1
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: "White Knight Armoury"
+      location: "Falador"
+      price: 576
+      currency: coins
+      stock: 5
+  related_items:
+    - item_name: Black med helm
+      slug: black-med-helm
+      relationship: alternative
+      description: "Black variant with same stats minus prayer bonus"
+    - item_name: White full helm
+      slug: white-full-helm
+      relationship: upgrade
+      description: "Full helm variant with greater coverage"
+  about: |-
+    > *"A medium sized helmet."*
+
+    The white med helm is sold by Sir Vyvin at the White Knight Armoury in Falador to players who have reached Page rank within the White Knights. It offers identical stats to a black med helm with an added +1 prayer bonus.
+  market_strategy:
+    notes:
+      - "Available from Sir Vyvin after reaching Page rank"
+      - "Shop supply limits liquidity outside the GE"
+      - "Niche demand from prayer-focused budget setups"
+  trading_tips:
+    - "Buy from Sir Vyvin and resell on GE for margin"
+    - "Watch demand from low-level prayer training accounts"
+  history:
+    - date: "17 October 2005"
+      description: "Released as part of the Wanted! quest update."
+    - date: "17 July 2007"
+      description: "Received a graphical update."
+    - date: "21 April 2021"
+      description: "Ranged attack bonus adjusted from -1 to 0."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wizard-blizzard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wizard-blizzard.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Wizard blizzard is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cocktail
+    tier: low
+  properties:
+    release_date: "12 December 2002"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 18
+      xp: 110
+      materials:
+        - item_name: Mixed blizzard
+          quantity: 1
+        - item_name: Pineapple chunks
+          quantity: 1
+        - item_name: Lime slices
+          quantity: 1
+      tools:
+        - Cocktail glass
+      output_quantity: 1
+  shops:
+    - shop_name: Gabooty's Tai Bwo Wannai Drinky Store
+      location: Tai Bwo Wannai
+      price: 30
+      currency: Trading sticks
+      stock: 3
+  related_items:
+    - item_name: Mixed blizzard
+      slug: mixed-blizzard
+      relationship: component
+      description: "Base mix before garnishing"
+  about: |-
+    > *"This looks like a strange mix."*
+
+    The Wizard blizzard is a Gnome Cooking cocktail crafted at Cooking 18. Drinking it restores 5 Hitpoints, boosts Strength by floor(Strength x 6 / 100) + 1, and lowers Attack by floor(Attack x 2 / 100) + 3. The Strength boost is one of the cheapest available, which is what keeps the cocktail relevant.
+
+    The base Mixed blizzard requires two vodka, one gin, one orange, one lime, and one lemon. Garnishing it with pineapple chunks and lime slices finishes the cocktail.
+  market_strategy:
+    notes:
+      - "Niche demand: low-level Strength boost for budget pures"
+      - "Cocktail glass + Gnome Cooking ingredients drive feedstock price"
+  trading_tips:
+    - "Karamja Gabooty's stock at 30 trading sticks is the floor competitor"
+    - "Flips well in pure-account meta cycles; otherwise thin volume"
+  history:
+    - date: "12 December 2002"
+      description: "Released as part of Gnome Cooking"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/woven-top-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/woven-top-blue.mdx
@@ -12,9 +12,85 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 150
-  about: "Woven top (blue) is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.07
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.07
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 650
+      currency: Coins
+      stock: 5
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania
+      price: 650
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Woven top (brown)
+      slug: woven-top-brown
+      relationship: variant
+      description: Brown recolour from the same Keldagrim line
+    - item_name: Woven top (yellow)
+      slug: woven-top-yellow
+      relationship: variant
+      description: Yellow recolour from the same Keldagrim line
+    - item_name: Shirt (blue)
+      slug: shirt-blue
+      relationship: alternative
+      description: Matching blue dwarven shirt
+  about: "Woven top (blue) is a Keldagrim-tailored cosmetic body slot piece worn over diminutive frames; it carries zero combat bonuses and exists purely for dwarven dress-up."
+  market_strategy:
+    notes:
+      - "Cosmetic-only piece: speculation hinges on rare-set collectors."
+      - "Bulk supply via shops keeps the GE floor flat — flips are razor-thin."
+  trading_tips:
+    - "Restock direct from Keldagrim shops when GE price drifts above 700 gp."
+    - "Hold long-tail in stacks of 10-20 for fashion-piece spikes around updates."
+  history:
+    - date: "2005-05-31"
+      description: Added with the Giant Dwarf quest and the Keldagrim clothier expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-cape.mdx
@@ -12,9 +12,104 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 150
-  about: "Yellow cape is a free-to-play item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2001-12-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Fancy Clothes Store
+      location: Varrock
+      price: 32
+      currency: Coins
+      stock: 5
+    - shop_name: Ranael's Super Skirt Store
+      location: Al Kharid
+      price: 32
+      currency: Coins
+      stock: 5
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 2.5
+      materials:
+        - item_name: Red cape
+          quantity: 1
+        - item_name: Yellow dye
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Red cape
+      slug: red-cape
+      relationship: alternative
+      description: F2P cape variant in red
+    - item_name: Blue cape
+      slug: blue-cape
+      relationship: alternative
+      description: F2P cape variant in blue
+    - item_name: Green cape
+      slug: green-cape
+      relationship: alternative
+      description: F2P cape variant in green
+    - item_name: Black cape
+      slug: black-cape
+      relationship: alternative
+      description: F2P cape variant in black with higher defence
+    - item_name: Yellow dye
+      slug: yellow-dye
+      relationship: component
+      description: Crafting reagent used to recolour a base cape
+  about: "Yellow cape is a free-to-play cosmetic cape that pre-dates the Grand Exchange; light defences in slash, crush, and ranged make it a noticeable upgrade over no cape at all on a low-level pure."
+  market_strategy:
+    notes:
+      - "Margin lives entirely in fashionscape demand; volumes are tiny."
+      - "Crafting from red capes + yellow dye can profit a few gp per dye after GE tax."
+  trading_tips:
+    - "Reroll inventory from Al Kharid or Varrock when GE drifts above 50 gp."
+    - "Bulk crafting only worth it during double Crafting XP windows."
+  history:
+    - date: "2001-12-08"
+      description: Launched as one of the original cosmetic capes in early RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellowfin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellowfin.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: null
-  about: "Yellowfin is a members-only item in Old School RuneScape. High alchemy value: 102 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: fish
+    tier: mid-high
+  properties:
+    release_date: "19 November 2025"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.65
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 79
+      xp: 200
+      materials:
+        - item_name: Raw yellowfin
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Raw yellowfin
+      slug: raw-yellowfin
+      relationship: component
+      description: "Cooking ingredient"
+    - item_name: Burnt yellowfin
+      slug: burnt-yellowfin
+      relationship: alternative
+      description: "Failed cook result"
+  about: "Yellowfin is a high-tier cooked fish that restores 19 Hitpoints and 20% run energy when eaten, requiring 79 Cooking to prepare."
+  market_strategy:
+    notes:
+      - "Combined heal + run energy makes it competitive with sharks for bossing"
+      - "Supply tied to raw yellowfin availability"
+      - "Burn rate drops to zero at 98 Cooking in Hosidius Kitchen with elite Kourend & Kebos Diary"
+  trading_tips:
+    - "Cook in Hosidius Kitchen to minimize burn losses"
+    - "Stable price compared to sharks given identical heal tier"
+  history:
+    - date: "19 November 2025"
+      description: "Released alongside the raw yellowfin cooking content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-necklace.mdx
@@ -12,53 +12,105 @@ osrs:
   lowalch: 80800
   highalch: 121200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: zenyte
+    tier: high
+  properties:
+    release_date: "2016-05-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - "Wear"
+      - "Drop"
+    worn_options:
+      - "Remove"
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
     requirements:
       crafting: 92
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 92
       xp: 165
-      inputs:
+      materials:
         - item_name: Zenyte
           quantity: 1
         - item_name: Gold bar
           quantity: 1
+        - item_name: Necklace mould
+          quantity: 1
+      tools:
+        - Furnace
       output_quantity: 1
   related_items:
-    - item_id: 6577
-      item_name: Onyx necklace
+    - item_name: Necklace of anguish
+      slug: necklace-of-anguish
+      relationship: upgrade
+      description: "Enchanted form, BiS ranged neck slot"
+    - item_name: Zenyte
+      slug: zenyte
+      relationship: component
+      description: "Primary gem used in crafting"
+    - item_name: Onyx necklace
       slug: onyx-necklace
       relationship: downgrade
-      description: Previous tier necklace
+      description: "Previous tier necklace before zenyte"
+    - item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: "Metal base for the necklace mould"
   about: |-
-    Crafting (Level 92): Zenyte + Gold bar at a furnace with necklace mould (165 XP)
+    The zenyte necklace is the unenchanted base for the necklace of anguish, OSRS's best-in-slot ranged neck. Crafted at a furnace with 92 Crafting using a zenyte gem, gold bar, and necklace mould for 165 XP per cast.
 
-    > *"A zenyte necklace."*
+    Once enchanted via Lvl-7 Enchant (93 Magic, 1 cosmic + 20 blood + 20 soul runes for 110 XP) it becomes a permanent BiS item with +15 Ranged attack, +5 Ranged strength, and +2 Prayer.
 
-    Lvl-7 Enchant (93 Magic): 1 cosmic rune + 20 blood runes + 20 soul runes (110 XP)
-
-    The Necklace of anguish is the best-in-slot ranged necklace:
-    - +15 Ranged attack
-    - +5 Ranged Strength
-    - +2 Prayer
-    - Highest ranged accuracy and damage of any neck slot
-
-    | Amulet | Ranged Atk | Ranged Str | Prayer |
-    |--------|-----------|------------|--------|
-    | Necklace of anguish | +15 | +5 | +2 |
-    | Amulet of fury | +10 | +0 | +5 |
-    | Amulet of glory | +10 | +0 | +3 |
-
-    The +5 ranged strength is a significant DPS increase over fury/glory.
+    The +5 ranged strength delivers a major DPS jump over Amulet of fury (+10 atk, +5 prayer) and Amulet of glory (+10 atk, +3 prayer) at endgame ranged content.
   market_strategy:
     notes:
-      - Zenyte shard from Demonic gorillas (1/300) + onyx = zenyte
-      - BiS ranged neck — permanent demand
-      - High-value enchant
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Zenyte shard drops from Demonic gorillas at 1/300, gating supply"
+      - "BiS ranged neck = permanent demand"
+      - "Enchant margin: zenyte necklace cost vs anguish price"
+      - "Buy limit reduced from 70 to 8 in 2020, tightening flips"
+  trading_tips:
+    - "Watch demonic gorilla droprate updates and resource changes"
+    - "Best margins come from crafting your own gems then enchanting"
+    - "Stock up ahead of leagues / DMM resets where anguish demand spikes"
+  history:
+    - date: "2016-05-06"
+      description: "Released with the Monkey Madness II update"
+    - date: "2018-02-22"
+      description: "Inventory sprite rotated to distinguish from enchanted jewelry"
+    - date: "2020-09-10"
+      description: "Grand Exchange buy limit reduced from 70 to 8"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-robe-bottom.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zuriel-s-robe-bottom.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10
-  about: "Zuriel's robe bottom is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: high
+  properties:
+    release_date: "2023-05-24"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Uncharge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 5.443
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 46
+      ranged: -7
+    defence_bonus:
+      stab: 38
+      slash: 35
+      crush: 44
+      magic: 25
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 2
+      prayer: 0
+  shops:
+    - shop_name: Bounty Hunter Store
+      location: Daimon's Crater
+      price: 400
+      currency: Bounty Hunter points
+      stock: 1
+  passive_effects:
+    - name: Zuriel set bonus
+      description: "When worn with the matching hood and robe top, grants 25% accuracy bonus for magic spells and special attacks of magic weapons inside PvP combat zones"
+  related_items:
+    - item_name: Zuriel's hood
+      slug: zuriel-s-hood
+      relationship: set-piece
+      description: "Matching hood from the Zuriel set"
+    - item_name: Zuriel's robe top
+      slug: zuriel-s-robe-top
+      relationship: set-piece
+      description: "Matching chest from the Zuriel set"
+    - item_name: Zuriel's staff
+      slug: zuriel-s-staff
+      relationship: set-piece
+      description: "Matching staff from the Zuriel set"
+  about: "Zuriel's robe bottom is a members-only Bounty Hunter reward in the ancient warriors armour line. It is restricted to PvP zones such as Daimon's Crater, Castle Wars, Clan Wars, Soul Wars and TzHaar Fight Pit but offers some of the strongest magic legs available."
+  market_strategy:
+    notes:
+      - "Item is untradeable so flipping is not possible."
+      - "Acquisition is gated behind Bounty Hunter points so dedicated PvP grinders are the only suppliers."
+      - "Resource is highly dependent on the Bounty Hunter reroll meta."
+  trading_tips:
+    - "Stock Bounty Hunter points by completing tasks to unlock the robe bottom"
+    - "Set bonus only activates within PvP zones so plan loadouts accordingly"
+  history:
+    - date: "2025-01-15"
+      description: "Magic attack bonus increased from 25 to 46"
+    - date: "2023-06-07"
+      description: "Added 2% Magic Damage bonus"
+    - date: "2023-05-24"
+      description: "Released as part of the Bounty Hunter rework rewards"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
- Random sample of 200 OSRS item MDX files migrated from `mdx_version: 2` to `3`
- WebFetch-verified wiki stats, drops, recipes, history
- Schema normalization: market_strategy.notes array, materials[].item_name, passive_effects[].name

## Local CI mirror
- `npx astro sync` — clean
- `npx astro build` — 7689 pages in 293.34s, no errors

## Test plan
- [ ] CI manifest guard passes
- [ ] CI build passes
- [ ] Spot-check a couple of pages in preview