### PR TITLE
feat(kbve,mc-lot): dbmate test + Rust client scaffold for the lot system

### DIFF
--- a/packages/data/sql/dbmate/migration-tests/20260526223407_mc_lot_system.test.sql
+++ b/packages/data/sql/dbmate/migration-tests/20260526223407_mc_lot_system.test.sql
@@ -1,0 +1,276 @@
+-- Companion test fixtures for 20260526223407_mc_lot_system.
+-- Run via: ./test-migration.sh 20260526223407_mc_lot_system
+--
+-- Focus areas:
+--   * domain ranges (lot_state, build_action_kind, build_apply_state)
+--   * table-level invariants (flags mask, resource_path, GIST EXCLUDE)
+--   * partial index presence (transitional_repair, pending_claim,
+--     one_active_per_lot)
+--   * round-17 hardening: auth.role() guards, FOR NO KEY UPDATE
+--   * down: tables / domains / proxies removed
+--
+-- This test deliberately stops short of full purchase/build flow because
+-- wallet.service_debit requires a per-currency account + balance and the
+-- focus here is schema correctness. Functional flow is covered by the
+-- axum-kbve integration tests against a real Supabase instance.
+
+-- SEED
+WITH test_users (id) AS (
+    VALUES
+        ('11111111-1111-1111-1111-111111111111'::uuid),
+        ('22222222-2222-2222-2222-222222222222'::uuid)
+)
+DELETE FROM auth.users WHERE id IN (SELECT id FROM test_users);
+
+INSERT INTO auth.users (id)
+VALUES
+    ('11111111-1111-1111-1111-111111111111'),
+    ('22222222-2222-2222-2222-222222222222');
+
+-- ASSERT_AFTER_UP
+
+-- 1. Domains present with correct ranges.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+         WHERE n.nspname = 'mc' AND t.typname = 'lot_state'
+    ) THEN
+        RAISE EXCEPTION 'fail: mc.lot_state domain missing';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+         WHERE n.nspname = 'mc' AND t.typname = 'build_apply_state'
+    ) THEN
+        RAISE EXCEPTION 'fail: mc.build_apply_state domain missing';
+    END IF;
+END;
+$$;
+
+-- 2. mc.lot.flags mask CHECK rejects high bits.
+DO $$
+DECLARE
+    v_msg TEXT;
+BEGIN
+    BEGIN
+        INSERT INTO mc.lot (lot_id, chunk_x_range, chunk_z_range, anchor_y, flags)
+        VALUES ('lot:flags-mask-bad', int4range(0, 1), int4range(0, 1), 64, 65536);
+        RAISE EXCEPTION 'fail: flags=65536 should violate mc_lot_flags_mask_chk';
+    EXCEPTION WHEN check_violation THEN
+        GET STACKED DIAGNOSTICS v_msg = MESSAGE_TEXT;
+        IF v_msg NOT LIKE '%mc_lot_flags_mask_chk%' THEN
+            RAISE EXCEPTION 'fail: wrong constraint raised: %', v_msg;
+        END IF;
+    END;
+END;
+$$;
+
+-- 3. mc.schematic.resource_path CHECK rejects '//' and '\\'.
+DO $$
+BEGIN
+    BEGIN
+        INSERT INTO mc.schematic
+            (schematic_id, name, category, dims_x, dims_y, dims_z, resource_path)
+        VALUES ('bad:double-slash', 'x', 'house', 4, 4, 4, 'schematics//bad.nbt');
+        RAISE EXCEPTION 'fail: resource_path with // should be rejected';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+
+    BEGIN
+        INSERT INTO mc.schematic
+            (schematic_id, name, category, dims_x, dims_y, dims_z, resource_path)
+        VALUES ('bad:backslash', 'x', 'house', 4, 4, 4, 'schematics/bad\path.nbt');
+        RAISE EXCEPTION 'fail: resource_path with backslash should be rejected';
+    EXCEPTION WHEN check_violation THEN NULL;
+    END;
+
+    -- Good path still accepted.
+    INSERT INTO mc.schematic
+        (schematic_id, name, category, dims_x, dims_y, dims_z, resource_path)
+    VALUES ('ok:test-house', 'Test House', 'house', 8, 8, 8,
+            'schematics/test_house.nbt');
+END;
+$$;
+
+-- 4. GIST EXCLUDE forbids chunk overlap in the same world.
+DO $$
+BEGIN
+    INSERT INTO mc.lot (lot_id, chunk_x_range, chunk_z_range, anchor_y)
+    VALUES ('lot:overlap-a', int4range(10, 14), int4range(10, 14), 64);
+
+    BEGIN
+        INSERT INTO mc.lot (lot_id, chunk_x_range, chunk_z_range, anchor_y)
+        VALUES ('lot:overlap-b', int4range(12, 16), int4range(12, 16), 64);
+        RAISE EXCEPTION 'fail: overlapping chunk_x/z_range should be rejected';
+    EXCEPTION WHEN exclusion_violation THEN NULL;
+    END;
+
+    -- Non-overlapping in same world is fine.
+    INSERT INTO mc.lot (lot_id, chunk_x_range, chunk_z_range, anchor_y)
+    VALUES ('lot:overlap-c', int4range(20, 24), int4range(20, 24), 64);
+
+    -- Same range, different world is fine.
+    INSERT INTO mc.lot (lot_id, world, chunk_x_range, chunk_z_range, anchor_y)
+    VALUES ('lot:overlap-nether', 'minecraft:the_nether',
+            int4range(10, 14), int4range(10, 14), 64);
+END;
+$$;
+
+-- 5. Generated block_* columns track chunk_*_range * 16.
+DO $$
+DECLARE
+    v_row mc.lot%ROWTYPE;
+BEGIN
+    SELECT * INTO v_row FROM mc.lot WHERE lot_id = 'lot:overlap-a';
+    IF v_row.block_x_min <> 10 * 16 OR v_row.block_x_max <> 14 * 16 - 1
+       OR v_row.block_z_min <> 10 * 16 OR v_row.block_z_max <> 14 * 16 - 1 THEN
+        RAISE EXCEPTION 'fail: block_* generated columns do not match chunk * 16';
+    END IF;
+END;
+$$;
+
+-- 6. Round-17 partial / repair indexes exist.
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'mc'
+           AND indexname = 'idx_mc_lot_transitional_repair'
+    ) THEN
+        RAISE EXCEPTION 'fail: idx_mc_lot_transitional_repair missing';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'mc'
+           AND indexname = 'idx_mc_lot_vacant_world_chunk_cursor'
+    ) THEN
+        RAISE EXCEPTION 'fail: idx_mc_lot_vacant_world_chunk_cursor missing';
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'mc'
+           AND indexname = 'uq_mc_lot_build_log_one_active_per_lot'
+    ) THEN
+        RAISE EXCEPTION 'fail: uq_mc_lot_build_log_one_active_per_lot missing';
+    END IF;
+END;
+$$;
+
+-- 7. The round-17 duplicate explicit gist must NOT exist; viewport reads
+-- ride the EXCLUDE-backed gist instead.
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_indexes
+         WHERE schemaname = 'mc'
+           AND indexname = 'idx_mc_lot_world_chunk_ranges_gist'
+    ) THEN
+        RAISE EXCEPTION 'fail: idx_mc_lot_world_chunk_ranges_gist must be dropped; EXCLUDE constraint already provides it';
+    END IF;
+END;
+$$;
+
+-- 8. Internal helpers must NOT be callable by service_role
+-- (round-17 hardening; admin proxies reach them via SECURITY DEFINER).
+DO $$
+BEGIN
+    IF has_function_privilege('service_role',
+                              'mc._derive_idem_key(uuid, text)',
+                              'EXECUTE') THEN
+        RAISE EXCEPTION 'fail: service_role should NOT have EXECUTE on mc._derive_idem_key';
+    END IF;
+    IF has_function_privilege('service_role',
+                              'mc._user_account_id(uuid)',
+                              'EXECUTE') THEN
+        RAISE EXCEPTION 'fail: service_role should NOT have EXECUTE on mc._user_account_id';
+    END IF;
+END;
+$$;
+
+-- 9. mc.lot_build_log apply_state domain accepts 0..4 incl. cancelled.
+DO $$
+BEGIN
+    -- Set up a vacant + owned lot + schematic so the FK chain holds.
+    UPDATE mc.lot
+       SET owner_user_id = '11111111-1111-1111-1111-111111111111',
+           state = 1
+     WHERE lot_id = 'lot:overlap-a';
+
+    INSERT INTO mc.lot_build_log
+        (lot_id, actor_user_id, action_kind, schematic_id,
+         lot_state_before, idempotency_key, apply_state)
+    VALUES
+        ('lot:overlap-a',
+         '11111111-1111-1111-1111-111111111111',
+         0,
+         'ok:test-house',
+         1,
+         gen_random_uuid(),
+         4);  -- cancelled
+
+    -- Round-17 claimed_consistency_chk still allows apply_state=4 with NULL claim.
+    IF NOT EXISTS (
+        SELECT 1 FROM mc.lot_build_log
+         WHERE lot_id = 'lot:overlap-a' AND apply_state = 4
+    ) THEN
+        RAISE EXCEPTION 'fail: apply_state=4 (cancelled) insert did not land';
+    END IF;
+END;
+$$;
+
+-- 10. Reset test rows so re-runs and rollback paths stay clean.
+DELETE FROM mc.lot_build_log
+ WHERE actor_user_id IN (
+     '11111111-1111-1111-1111-111111111111',
+     '22222222-2222-2222-2222-222222222222');
+UPDATE mc.lot SET owner_user_id = NULL, state = 0
+ WHERE lot_id LIKE 'lot:overlap-%';
+DELETE FROM mc.lot WHERE lot_id LIKE 'lot:overlap-%';
+DELETE FROM mc.schematic WHERE schematic_id LIKE 'ok:%' OR schematic_id LIKE 'bad:%';
+
+-- ASSERT_AFTER_DOWN
+
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM pg_class c
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'mc'
+           AND c.relname IN ('lot', 'lot_purchase', 'lot_build_log', 'schematic')
+    ) THEN
+        RAISE EXCEPTION 'fail: mc tables still present after rollback';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+         WHERE n.nspname = 'mc'
+           AND t.typname IN ('lot_state', 'build_action_kind', 'build_apply_state')
+    ) THEN
+        RAISE EXCEPTION 'fail: mc domains still present after rollback';
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM pg_proc p
+          JOIN pg_namespace n ON n.oid = p.pronamespace
+         WHERE n.nspname = 'public'
+           AND p.proname IN (
+               'proxy_purchase_lot',
+               'proxy_queue_build_on_lot',
+               'proxy_queue_demolish_lot',
+               'proxy_list_vacant_lots',
+               'proxy_list_my_active_lots',
+               'proxy_list_my_transitional_lots',
+               'proxy_list_lots_in_viewport',
+               'proxy_service_claim_pending_builds',
+               'proxy_service_mark_build_applied',
+               'proxy_service_mark_build_failed',
+               'proxy_service_get_lot'
+           )
+    ) THEN
+        RAISE EXCEPTION 'fail: mc public proxies still present after rollback';
+    END IF;
+END;
+$$;

--- a/packages/rust/kbve/src/lib.rs
+++ b/packages/rust/kbve/src/lib.rs
@@ -33,6 +33,11 @@ pub mod wallet;
 #[cfg(feature = "wallet")]
 pub mod referral;
 
+// MC lot/schematic system. Shares the wallet connection pool because lot
+// purchases settle through wallet.service_debit.
+#[cfg(feature = "wallet")]
+pub mod lot;
+
 pub use holy;
 
 #[cfg(feature = "legacy-sync-db")]

--- a/packages/rust/kbve/src/lot/error.rs
+++ b/packages/rust/kbve/src/lot/error.rs
@@ -1,0 +1,159 @@
+//! Typed errors emitted by the lot client.
+//!
+//! Maps Postgres SQLSTATEs raised by the `mc.service_*` /
+//! `public.proxy_*` functions to dedicated variants. The mapping is
+//! conservative: structural SQLSTATEs (CheckViolation, NotNullViolation,
+//! ExclusionViolation, UniqueViolation) get dedicated variants; raised
+//! exception messages get prefix-matched against a small known set.
+
+use diesel::result::{DatabaseErrorKind, Error as DieselError};
+use thiserror::Error;
+
+use crate::wallet::error::WalletError;
+
+#[derive(Debug, Error)]
+pub enum LotError {
+    #[error("not authenticated")]
+    NotAuthenticated,
+
+    #[error("not authorized")]
+    NotAuthorized,
+
+    #[error("lot not found")]
+    LotNotFound,
+
+    #[error("schematic not found")]
+    SchematicNotFound,
+
+    #[error("build job not found")]
+    BuildNotFound,
+
+    #[error("lot not vacant")]
+    LotNotVacant,
+
+    #[error("lot not owned by caller")]
+    LotNotOwned,
+
+    #[error("lot already has an active queued/claimed job")]
+    ActiveJobConflict,
+
+    #[error("chunk overlap with existing lot")]
+    ChunkOverlap,
+
+    #[error("idempotency_key reused with different payload")]
+    ReplayMismatch,
+
+    #[error("insufficient funds")]
+    InsufficientFunds,
+
+    #[error("invalid argument: {0}")]
+    InvalidArgument(String),
+
+    #[error("null argument: {0}")]
+    NullArgument(String),
+
+    #[error("wallet: {0}")]
+    Wallet(#[from] WalletError),
+
+    #[error("pool error: {0}")]
+    Pool(String),
+
+    #[error(transparent)]
+    Db(#[from] DieselError),
+}
+
+impl LotError {
+    pub fn from_diesel(e: DieselError) -> Self {
+        if let DieselError::DatabaseError(kind, ref info) = e {
+            match kind {
+                DatabaseErrorKind::UniqueViolation => {
+                    // uq_mc_lot_build_log_one_active_per_lot fires when
+                    // queue / retry races with an existing active job.
+                    if info.constraint_name() == Some("uq_mc_lot_build_log_one_active_per_lot") {
+                        return LotError::ActiveJobConflict;
+                    }
+                    return LotError::InvalidArgument(info.message().to_string());
+                }
+                DatabaseErrorKind::ExclusionViolation => {
+                    return LotError::ChunkOverlap;
+                }
+                DatabaseErrorKind::CheckViolation => {
+                    return LotError::InvalidArgument(info.message().to_string());
+                }
+                DatabaseErrorKind::NotNullViolation => {
+                    return LotError::NullArgument(info.message().to_string());
+                }
+                DatabaseErrorKind::SerializationFailure => {
+                    return LotError::ReplayMismatch;
+                }
+                DatabaseErrorKind::ForeignKeyViolation => {
+                    let m = info.message().to_lowercase();
+                    if m.contains("schematic") {
+                        return LotError::SchematicNotFound;
+                    }
+                    return LotError::LotNotFound;
+                }
+                _ => {}
+            }
+            if let Some(err) = classify_message(info.message()) {
+                return err;
+            }
+        }
+        LotError::Db(e)
+    }
+}
+
+fn classify_message(msg: &str) -> Option<LotError> {
+    let m = msg.to_lowercase();
+    if m.contains("not authenticated") {
+        return Some(LotError::NotAuthenticated);
+    }
+    if m.contains("service_role required") || m.contains("not owned by caller") {
+        return Some(LotError::NotAuthorized);
+    }
+    if m.contains("lot not found") {
+        return Some(LotError::LotNotFound);
+    }
+    if m.contains("schematic") && (m.contains("not found") || m.contains("disabled")) {
+        return Some(LotError::SchematicNotFound);
+    }
+    if m.contains("build") && m.contains("not found") {
+        return Some(LotError::BuildNotFound);
+    }
+    if m.contains("not vacant") {
+        return Some(LotError::LotNotVacant);
+    }
+    if m.contains("not owned") || m.contains("does not own") {
+        return Some(LotError::LotNotOwned);
+    }
+    if m.contains("active queued/claimed job") || m.contains("active build job") {
+        return Some(LotError::ActiveJobConflict);
+    }
+    if m.contains("idempotency_key reused") {
+        return Some(LotError::ReplayMismatch);
+    }
+    if m.contains("insufficient funds") {
+        return Some(LotError::InsufficientFunds);
+    }
+    if m.contains("cannot be null") || m.contains("is required") {
+        return Some(LotError::NullArgument(msg.to_string()));
+    }
+    if m.contains("invalid") || m.contains("must be") || m.contains("cannot retry") {
+        return Some(LotError::InvalidArgument(msg.to_string()));
+    }
+    None
+}
+
+impl From<bb8::RunError<diesel_async::pooled_connection::PoolError>> for LotError {
+    fn from(e: bb8::RunError<diesel_async::pooled_connection::PoolError>) -> Self {
+        LotError::Pool(e.to_string())
+    }
+}
+
+impl From<diesel_async::pooled_connection::PoolError> for LotError {
+    fn from(e: diesel_async::pooled_connection::PoolError) -> Self {
+        LotError::Pool(e.to_string())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, LotError>;

--- a/packages/rust/kbve/src/lot/mod.rs
+++ b/packages/rust/kbve/src/lot/mod.rs
@@ -1,0 +1,24 @@
+//! `kbve::lot` — MC lot/schematic system client.
+//!
+//! Mirrors the `mc` Postgres schema (packages/data/sql/schema/mc/mc_lot.sql).
+//! Calls SECURITY DEFINER `public.proxy_*` RPCs via diesel against the same
+//! Postgres pool used by [`crate::wallet::WalletClient`] — both schemas live
+//! in the supabase database and lot purchases settle through
+//! `wallet.service_debit` under the hood.
+//!
+//! Enable with the `wallet` Cargo feature (the lot client reuses
+//! [`crate::wallet::client`] for connection management).
+//!
+//! Two surfaces:
+//!   - User RPCs (proxy.rs): purchase, queue build/demolish, list vacant /
+//!     my-active / my-transitional / viewport, list schematics.
+//!   - Service RPCs (service.rs): worker claim batch, mark applied/failed,
+//!     admin retry/release/repair, raw get-lot.
+
+pub mod error;
+pub mod proxy;
+pub mod service;
+pub mod types;
+
+pub use error::LotError;
+pub use types::*;

--- a/packages/rust/kbve/src/lot/proxy.rs
+++ b/packages/rust/kbve/src/lot/proxy.rs
@@ -1,0 +1,543 @@
+//! User-facing lot/schematic RPCs.
+//!
+//! All call `public.proxy_*` SECURITY DEFINER wrappers that resolve the
+//! caller via `auth.uid()`. The connection enters a transaction with
+//! `request.jwt.claims` set so RLS / auth.uid()-based ownership checks
+//! succeed.
+
+use chrono::{DateTime, Utc};
+use diesel::QueryableByName;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Bool, Integer, Nullable, SmallInt, Text};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use uuid::Uuid;
+
+use crate::wallet::client::{WalletClient, set_user_claims};
+
+use super::error::{LotError, Result};
+use super::types::*;
+
+#[derive(QueryableByName)]
+struct SchematicRowDb {
+    #[diesel(sql_type = Text)]
+    schematic_id: String,
+    #[diesel(sql_type = Text)]
+    name: String,
+    #[diesel(sql_type = Text)]
+    category: String,
+    #[diesel(sql_type = SmallInt)]
+    tier: i16,
+    #[diesel(sql_type = SmallInt)]
+    dims_x: i16,
+    #[diesel(sql_type = SmallInt)]
+    dims_y: i16,
+    #[diesel(sql_type = SmallInt)]
+    dims_z: i16,
+    #[diesel(sql_type = BigInt)]
+    price_credits: i64,
+    #[diesel(sql_type = BigInt)]
+    price_khash: i64,
+}
+
+#[derive(QueryableByName)]
+struct VacantLotRowDb {
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = Integer)]
+    chunk_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_area: i32,
+    #[diesel(sql_type = SmallInt)]
+    anchor_y: i16,
+    #[diesel(sql_type = BigInt)]
+    price_credits: i64,
+    #[diesel(sql_type = BigInt)]
+    price_khash: i64,
+}
+
+#[derive(QueryableByName)]
+struct OwnedLotRowDb {
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = Integer)]
+    chunk_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_area: i32,
+    #[diesel(sql_type = SmallInt)]
+    anchor_y: i16,
+    #[diesel(sql_type = SmallInt)]
+    state: i16,
+    #[diesel(sql_type = Nullable<Text>)]
+    current_schematic_id: Option<String>,
+    #[diesel(sql_type = BigInt)]
+    price_credits: i64,
+    #[diesel(sql_type = BigInt)]
+    price_khash: i64,
+}
+
+#[derive(QueryableByName)]
+struct ViewportLotRowDb {
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = Integer)]
+    chunk_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_max: i32,
+    #[diesel(sql_type = SmallInt)]
+    anchor_y: i16,
+    #[diesel(sql_type = Bool)]
+    is_owned: bool,
+    #[diesel(sql_type = Bool)]
+    is_owned_by_me: bool,
+    #[diesel(sql_type = SmallInt)]
+    state: i16,
+    #[diesel(sql_type = Nullable<Text>)]
+    current_schematic_id: Option<String>,
+}
+
+#[derive(QueryableByName)]
+struct PurchaseLotRowDb {
+    #[diesel(sql_type = Text)]
+    purchase_id: String,
+}
+
+#[derive(QueryableByName)]
+struct BuildIdRowDb {
+    #[diesel(sql_type = Text)]
+    build_id: String,
+}
+
+// ===========================================================================
+// LotClient — thin facade over [`WalletClient`] that exposes the lot RPCs.
+// ===========================================================================
+
+/// Thin wrapper around a shared [`WalletClient`] pool. Held by the axum
+/// transport layer so handlers can call lot RPCs without dragging the
+/// wallet API into their signatures.
+#[derive(Clone)]
+pub struct LotClient {
+    inner: WalletClient,
+}
+
+impl LotClient {
+    pub fn new(inner: WalletClient) -> Self {
+        Self { inner }
+    }
+
+    pub fn wallet(&self) -> &WalletClient {
+        &self.inner
+    }
+
+    // ---------------- catalog ----------------
+
+    pub async fn list_schematics(&self, category: Option<String>) -> Result<Vec<SchematicRow>> {
+        let mut conn = self.inner.read().await.map_err(LotError::Wallet)?;
+        list_schematics_async(&mut conn, category).await
+    }
+
+    // ---------------- vacant / my / viewport ----------------
+
+    pub async fn list_vacant_lots(
+        &self,
+        user_id: Uuid,
+        world: String,
+        limit: i32,
+        cursor: LotChunkCursor,
+    ) -> Result<Vec<VacantLotRow>> {
+        let mut conn = self.inner.read().await.map_err(LotError::Wallet)?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<VacantLotRow>, LotError, _>(async |c| {
+                set_user_claims(c, user_id)
+                    .await
+                    .map_err(LotError::Wallet)?;
+                list_vacant_async(c, &world, limit, &cursor).await
+            })
+            .await
+    }
+
+    pub async fn list_my_active_lots(
+        &self,
+        user_id: Uuid,
+        world: String,
+        limit: i32,
+        cursor: LotChunkCursor,
+    ) -> Result<Vec<OwnedLotRow>> {
+        let mut conn = self.inner.read().await.map_err(LotError::Wallet)?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<OwnedLotRow>, LotError, _>(async |c| {
+                set_user_claims(c, user_id)
+                    .await
+                    .map_err(LotError::Wallet)?;
+                list_owned_async(
+                    c,
+                    "public.proxy_list_my_active_lots",
+                    &world,
+                    limit,
+                    &cursor,
+                )
+                .await
+            })
+            .await
+    }
+
+    pub async fn list_my_transitional_lots(
+        &self,
+        user_id: Uuid,
+        world: String,
+        limit: i32,
+        cursor: LotChunkCursor,
+    ) -> Result<Vec<OwnedLotRow>> {
+        let mut conn = self.inner.read().await.map_err(LotError::Wallet)?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<OwnedLotRow>, LotError, _>(async |c| {
+                set_user_claims(c, user_id)
+                    .await
+                    .map_err(LotError::Wallet)?;
+                list_owned_async(
+                    c,
+                    "public.proxy_list_my_transitional_lots",
+                    &world,
+                    limit,
+                    &cursor,
+                )
+                .await
+            })
+            .await
+    }
+
+    /// Viewport map RPC. `state_filter` optionally narrows to a single
+    /// `mc.lot_state` value; pass `None` for everything in the box.
+    pub async fn list_lots_in_viewport(
+        &self,
+        user_id: Uuid,
+        world: String,
+        min_chunk_x: i32,
+        max_chunk_x: i32,
+        min_chunk_z: i32,
+        max_chunk_z: i32,
+        state_filter: Option<LotState>,
+        limit: i32,
+    ) -> Result<Vec<ViewportLotRow>> {
+        let mut conn = self.inner.read().await.map_err(LotError::Wallet)?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<Vec<ViewportLotRow>, LotError, _>(async |c| {
+                set_user_claims(c, user_id)
+                    .await
+                    .map_err(LotError::Wallet)?;
+                list_viewport_async(
+                    c,
+                    &world,
+                    min_chunk_x,
+                    max_chunk_x,
+                    min_chunk_z,
+                    max_chunk_z,
+                    state_filter,
+                    limit,
+                )
+                .await
+            })
+            .await
+    }
+
+    // ---------------- mutate (purchase / queue) ----------------
+
+    pub async fn purchase_lot(
+        &self,
+        user_id: Uuid,
+        lot_id: String,
+        idempotency_key: Uuid,
+    ) -> Result<String> {
+        let mut conn = self.inner.write().await.map_err(LotError::Wallet)?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<String, LotError, _>(async |c| {
+                set_user_claims(c, user_id)
+                    .await
+                    .map_err(LotError::Wallet)?;
+                let r: PurchaseLotRowDb =
+                    sql_query("SELECT public.proxy_purchase_lot($1, $2) AS purchase_id")
+                        .bind::<Text, _>(lot_id)
+                        .bind::<diesel::sql_types::Uuid, _>(idempotency_key)
+                        .get_result(c)
+                        .await
+                        .map_err(LotError::from_diesel)?;
+                Ok(r.purchase_id)
+            })
+            .await
+    }
+
+    pub async fn queue_build_on_lot(
+        &self,
+        user_id: Uuid,
+        lot_id: String,
+        schematic_id: String,
+        idempotency_key: Uuid,
+    ) -> Result<String> {
+        let mut conn = self.inner.write().await.map_err(LotError::Wallet)?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<String, LotError, _>(async |c| {
+                set_user_claims(c, user_id)
+                    .await
+                    .map_err(LotError::Wallet)?;
+                let r: BuildIdRowDb =
+                    sql_query("SELECT public.proxy_queue_build_on_lot($1, $2, $3) AS build_id")
+                        .bind::<Text, _>(lot_id)
+                        .bind::<Text, _>(schematic_id)
+                        .bind::<diesel::sql_types::Uuid, _>(idempotency_key)
+                        .get_result(c)
+                        .await
+                        .map_err(LotError::from_diesel)?;
+                Ok(r.build_id)
+            })
+            .await
+    }
+
+    pub async fn queue_demolish_lot(
+        &self,
+        user_id: Uuid,
+        lot_id: String,
+        idempotency_key: Uuid,
+    ) -> Result<String> {
+        let mut conn = self.inner.write().await.map_err(LotError::Wallet)?;
+        let inner: &mut AsyncPgConnection = &mut *conn;
+        inner
+            .transaction::<String, LotError, _>(async |c| {
+                set_user_claims(c, user_id)
+                    .await
+                    .map_err(LotError::Wallet)?;
+                let r: BuildIdRowDb =
+                    sql_query("SELECT public.proxy_queue_demolish_lot($1, $2) AS build_id")
+                        .bind::<Text, _>(lot_id)
+                        .bind::<diesel::sql_types::Uuid, _>(idempotency_key)
+                        .get_result(c)
+                        .await
+                        .map_err(LotError::from_diesel)?;
+                Ok(r.build_id)
+            })
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Connection-level helpers (free functions so service.rs can reuse them).
+// ---------------------------------------------------------------------------
+
+async fn list_schematics_async(
+    conn: &mut AsyncPgConnection,
+    category: Option<String>,
+) -> Result<Vec<SchematicRow>> {
+    let rows: Vec<SchematicRowDb> = sql_query(
+        "SELECT schematic_id, name, category, tier::SMALLINT, dims_x, dims_y, dims_z, \
+                price_credits, price_khash \
+         FROM public.proxy_list_schematics($1)",
+    )
+    .bind::<Nullable<Text>, _>(category)
+    .get_results(conn)
+    .await
+    .map_err(LotError::from_diesel)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| SchematicRow {
+            schematic_id: r.schematic_id,
+            name: r.name,
+            category: r.category,
+            tier: r.tier,
+            dims_x: r.dims_x,
+            dims_y: r.dims_y,
+            dims_z: r.dims_z,
+            price_credits: r.price_credits,
+            price_khash: r.price_khash,
+        })
+        .collect())
+}
+
+async fn list_vacant_async(
+    conn: &mut AsyncPgConnection,
+    world: &str,
+    limit: i32,
+    cursor: &LotChunkCursor,
+) -> Result<Vec<VacantLotRow>> {
+    let rows: Vec<VacantLotRowDb> = sql_query(
+        "SELECT lot_id, chunk_x_min, chunk_x_max, chunk_z_min, chunk_z_max, \
+                block_x_min, block_x_max, block_z_min, block_z_max, \
+                chunk_area, anchor_y, price_credits, price_khash \
+         FROM public.proxy_list_vacant_lots($1, $2, $3, $4, $5)",
+    )
+    .bind::<Text, _>(world)
+    .bind::<Integer, _>(limit)
+    .bind::<Nullable<Integer>, _>(cursor.after_chunk_x)
+    .bind::<Nullable<Integer>, _>(cursor.after_chunk_z)
+    .bind::<Nullable<Text>, _>(cursor.after_lot_id.clone())
+    .get_results(conn)
+    .await
+    .map_err(LotError::from_diesel)?;
+    Ok(rows
+        .into_iter()
+        .map(|r| VacantLotRow {
+            lot_id: r.lot_id,
+            chunk_x_min: r.chunk_x_min,
+            chunk_x_max: r.chunk_x_max,
+            chunk_z_min: r.chunk_z_min,
+            chunk_z_max: r.chunk_z_max,
+            block_x_min: r.block_x_min,
+            block_x_max: r.block_x_max,
+            block_z_min: r.block_z_min,
+            block_z_max: r.block_z_max,
+            chunk_area: r.chunk_area,
+            anchor_y: r.anchor_y,
+            price_credits: r.price_credits,
+            price_khash: r.price_khash,
+        })
+        .collect())
+}
+
+async fn list_owned_async(
+    conn: &mut AsyncPgConnection,
+    fn_name: &str,
+    world: &str,
+    limit: i32,
+    cursor: &LotChunkCursor,
+) -> Result<Vec<OwnedLotRow>> {
+    let query = format!(
+        "SELECT lot_id, chunk_x_min, chunk_x_max, chunk_z_min, chunk_z_max, \
+                block_x_min, block_x_max, block_z_min, block_z_max, \
+                chunk_area, anchor_y, state, current_schematic_id, \
+                price_credits, price_khash \
+         FROM {fn_name}($1, $2, $3, $4, $5)"
+    );
+    let rows: Vec<OwnedLotRowDb> = sql_query(query)
+        .bind::<Text, _>(world)
+        .bind::<Integer, _>(limit)
+        .bind::<Nullable<Integer>, _>(cursor.after_chunk_x)
+        .bind::<Nullable<Integer>, _>(cursor.after_chunk_z)
+        .bind::<Nullable<Text>, _>(cursor.after_lot_id.clone())
+        .get_results(conn)
+        .await
+        .map_err(LotError::from_diesel)?;
+    rows.into_iter()
+        .map(|r| {
+            let state = LotState::from_pg(r.state).ok_or_else(|| {
+                LotError::InvalidArgument(format!("unknown lot_state: {}", r.state))
+            })?;
+            Ok(OwnedLotRow {
+                lot_id: r.lot_id,
+                chunk_x_min: r.chunk_x_min,
+                chunk_x_max: r.chunk_x_max,
+                chunk_z_min: r.chunk_z_min,
+                chunk_z_max: r.chunk_z_max,
+                block_x_min: r.block_x_min,
+                block_x_max: r.block_x_max,
+                block_z_min: r.block_z_min,
+                block_z_max: r.block_z_max,
+                chunk_area: r.chunk_area,
+                anchor_y: r.anchor_y,
+                state,
+                current_schematic_id: r.current_schematic_id,
+                price_credits: r.price_credits,
+                price_khash: r.price_khash,
+            })
+        })
+        .collect()
+}
+
+async fn list_viewport_async(
+    conn: &mut AsyncPgConnection,
+    world: &str,
+    min_chunk_x: i32,
+    max_chunk_x: i32,
+    min_chunk_z: i32,
+    max_chunk_z: i32,
+    state_filter: Option<LotState>,
+    limit: i32,
+) -> Result<Vec<ViewportLotRow>> {
+    let state_arg: Option<i16> = state_filter.map(|s| s as i16);
+    let rows: Vec<ViewportLotRowDb> = sql_query(
+        "SELECT lot_id, chunk_x_min, chunk_x_max, chunk_z_min, chunk_z_max, \
+                block_x_min, block_x_max, block_z_min, block_z_max, \
+                anchor_y, is_owned, is_owned_by_me, state, current_schematic_id \
+         FROM public.proxy_list_lots_in_viewport($1, $2, $3, $4, $5, $6, $7)",
+    )
+    .bind::<Text, _>(world)
+    .bind::<Integer, _>(min_chunk_x)
+    .bind::<Integer, _>(max_chunk_x)
+    .bind::<Integer, _>(min_chunk_z)
+    .bind::<Integer, _>(max_chunk_z)
+    .bind::<Nullable<SmallInt>, _>(state_arg)
+    .bind::<Integer, _>(limit)
+    .get_results(conn)
+    .await
+    .map_err(LotError::from_diesel)?;
+    rows.into_iter()
+        .map(|r| {
+            let state = LotState::from_pg(r.state).ok_or_else(|| {
+                LotError::InvalidArgument(format!("unknown lot_state: {}", r.state))
+            })?;
+            Ok(ViewportLotRow {
+                lot_id: r.lot_id,
+                chunk_x_min: r.chunk_x_min,
+                chunk_x_max: r.chunk_x_max,
+                chunk_z_min: r.chunk_z_min,
+                chunk_z_max: r.chunk_z_max,
+                block_x_min: r.block_x_min,
+                block_x_max: r.block_x_max,
+                block_z_min: r.block_z_min,
+                block_z_max: r.block_z_max,
+                anchor_y: r.anchor_y,
+                is_owned: r.is_owned,
+                is_owned_by_me: r.is_owned_by_me,
+                state,
+                current_schematic_id: r.current_schematic_id,
+            })
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
+fn ts_to_string(ts: DateTime<Utc>) -> String {
+    ts.to_rfc3339()
+}

--- a/packages/rust/kbve/src/lot/service.rs
+++ b/packages/rust/kbve/src/lot/service.rs
@@ -1,0 +1,442 @@
+//! Service-role lot RPCs.
+//!
+//! These call the `public.proxy_service_*` wrappers that gate on
+//! `auth.role() = 'service_role'`. The handler layer is responsible for
+//! ensuring the request reaches Postgres under a service-role JWT.
+
+use chrono::{DateTime, Utc};
+use diesel::QueryableByName;
+use diesel::sql_query;
+use diesel::sql_types::{BigInt, Bool, Integer, Nullable, SmallInt, Text, Timestamptz};
+use diesel_async::RunQueryDsl;
+use uuid::Uuid;
+
+use super::error::{LotError, Result};
+use super::proxy::LotClient;
+use super::types::*;
+
+#[derive(QueryableByName)]
+struct ServiceLotRowDb {
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = Text)]
+    world: String,
+    #[diesel(sql_type = Integer)]
+    chunk_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_area: i32,
+    #[diesel(sql_type = SmallInt)]
+    anchor_y: i16,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Uuid>)]
+    owner_user_id: Option<Uuid>,
+    #[diesel(sql_type = Nullable<Text>)]
+    current_schematic_id: Option<String>,
+    #[diesel(sql_type = SmallInt)]
+    state: i16,
+    #[diesel(sql_type = BigInt)]
+    price_credits: i64,
+    #[diesel(sql_type = BigInt)]
+    price_khash: i64,
+    #[diesel(sql_type = Timestamptz)]
+    created_at: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    updated_at: DateTime<Utc>,
+}
+
+#[derive(QueryableByName)]
+struct ClaimedBuildRowDb {
+    #[diesel(sql_type = Text)]
+    build_id: String,
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    actor_user_id: Uuid,
+    #[diesel(sql_type = SmallInt)]
+    action_kind: i16,
+    #[diesel(sql_type = Nullable<Text>)]
+    schematic_id: Option<String>,
+    #[diesel(sql_type = Timestamptz)]
+    queued_at: DateTime<Utc>,
+    #[diesel(sql_type = Text)]
+    world: String,
+    #[diesel(sql_type = Integer)]
+    chunk_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    chunk_z_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_x_max: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_min: i32,
+    #[diesel(sql_type = Integer)]
+    block_z_max: i32,
+    #[diesel(sql_type = SmallInt)]
+    anchor_y: i16,
+    #[diesel(sql_type = Nullable<Text>)]
+    resource_path: Option<String>,
+    #[diesel(sql_type = Nullable<SmallInt>)]
+    dims_x: Option<i16>,
+    #[diesel(sql_type = Nullable<SmallInt>)]
+    dims_y: Option<i16>,
+    #[diesel(sql_type = Nullable<SmallInt>)]
+    dims_z: Option<i16>,
+}
+
+#[derive(QueryableByName)]
+struct RequeueSummaryDb {
+    #[diesel(sql_type = Integer)]
+    requeued_count: i32,
+    #[diesel(sql_type = Integer)]
+    exhausted_count: i32,
+}
+
+#[derive(QueryableByName)]
+struct BoolRow {
+    #[diesel(sql_type = Bool)]
+    ok: bool,
+}
+
+#[derive(QueryableByName)]
+struct FailedBuildRowDb {
+    #[diesel(sql_type = Text)]
+    build_id: String,
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    actor_user_id: Uuid,
+    #[diesel(sql_type = SmallInt)]
+    action_kind: i16,
+    #[diesel(sql_type = Nullable<Text>)]
+    schematic_id: Option<String>,
+    #[diesel(sql_type = Nullable<Text>)]
+    apply_error: Option<String>,
+    #[diesel(sql_type = Timestamptz)]
+    failed_at: DateTime<Utc>,
+    #[diesel(sql_type = Integer)]
+    attempt_count: i32,
+}
+
+#[derive(QueryableByName)]
+struct ReleasedLotRowDb {
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = SmallInt)]
+    prior_state: i16,
+}
+
+#[derive(QueryableByName)]
+struct RepairedLotRowDb {
+    #[diesel(sql_type = Text)]
+    lot_id: String,
+    #[diesel(sql_type = SmallInt)]
+    prior_state: i16,
+    #[diesel(sql_type = SmallInt)]
+    new_state: i16,
+    #[diesel(sql_type = Nullable<Text>)]
+    latest_build_id: Option<String>,
+    #[diesel(sql_type = Nullable<SmallInt>)]
+    latest_apply_state: Option<i16>,
+    #[diesel(sql_type = Nullable<Timestamptz>)]
+    latest_failed_at: Option<DateTime<Utc>>,
+    #[diesel(sql_type = Nullable<Text>)]
+    latest_apply_error: Option<String>,
+}
+
+impl LotClient {
+    // -------- service: get one lot (raw shape) --------
+
+    pub async fn service_get_lot(&self, lot_id: String) -> Result<Option<ServiceLotRow>> {
+        let mut conn = self.wallet().read().await.map_err(LotError::Wallet)?;
+        let row_opt: Option<ServiceLotRowDb> = sql_query(
+            "SELECT lot_id, world, chunk_x_min, chunk_x_max, chunk_z_min, chunk_z_max, \
+                    block_x_min, block_x_max, block_z_min, block_z_max, \
+                    chunk_area, anchor_y, owner_user_id, current_schematic_id, \
+                    state, price_credits, price_khash, created_at, updated_at \
+             FROM public.proxy_service_get_lot($1)",
+        )
+        .bind::<Text, _>(lot_id)
+        .get_results::<ServiceLotRowDb>(&mut *conn)
+        .await
+        .map_err(LotError::from_diesel)?
+        .into_iter()
+        .next();
+        row_opt
+            .map(|r| {
+                let state = LotState::from_pg(r.state).ok_or_else(|| {
+                    LotError::InvalidArgument(format!("unknown lot_state: {}", r.state))
+                })?;
+                Ok(ServiceLotRow {
+                    lot_id: r.lot_id,
+                    world: r.world,
+                    chunk_x_min: r.chunk_x_min,
+                    chunk_x_max: r.chunk_x_max,
+                    chunk_z_min: r.chunk_z_min,
+                    chunk_z_max: r.chunk_z_max,
+                    block_x_min: r.block_x_min,
+                    block_x_max: r.block_x_max,
+                    block_z_min: r.block_z_min,
+                    block_z_max: r.block_z_max,
+                    chunk_area: r.chunk_area,
+                    anchor_y: r.anchor_y,
+                    owner_user_id: r.owner_user_id,
+                    current_schematic_id: r.current_schematic_id,
+                    state,
+                    price_credits: r.price_credits,
+                    price_khash: r.price_khash,
+                    created_at: r.created_at,
+                    updated_at: r.updated_at,
+                })
+            })
+            .transpose()
+    }
+
+    // -------- worker: claim, mark applied/failed --------
+
+    pub async fn service_claim_pending_builds(
+        &self,
+        worker_id: String,
+        limit: i32,
+    ) -> Result<Vec<ClaimedBuildRow>> {
+        let mut conn = self.wallet().write().await.map_err(LotError::Wallet)?;
+        let rows: Vec<ClaimedBuildRowDb> = sql_query(
+            "SELECT build_id, lot_id, actor_user_id, action_kind, schematic_id, queued_at, \
+                    world, chunk_x_min, chunk_x_max, chunk_z_min, chunk_z_max, \
+                    block_x_min, block_x_max, block_z_min, block_z_max, anchor_y, \
+                    resource_path, dims_x, dims_y, dims_z \
+             FROM public.proxy_service_claim_pending_builds($1, $2)",
+        )
+        .bind::<Text, _>(worker_id)
+        .bind::<Integer, _>(limit)
+        .get_results(&mut *conn)
+        .await
+        .map_err(LotError::from_diesel)?;
+        rows.into_iter()
+            .map(|r| {
+                let action_kind = BuildActionKind::from_pg(r.action_kind).ok_or_else(|| {
+                    LotError::InvalidArgument(format!("unknown action_kind: {}", r.action_kind))
+                })?;
+                Ok(ClaimedBuildRow {
+                    build_id: r.build_id,
+                    lot_id: r.lot_id,
+                    actor_user_id: r.actor_user_id,
+                    action_kind,
+                    schematic_id: r.schematic_id,
+                    queued_at: r.queued_at,
+                    world: r.world,
+                    chunk_x_min: r.chunk_x_min,
+                    chunk_x_max: r.chunk_x_max,
+                    chunk_z_min: r.chunk_z_min,
+                    chunk_z_max: r.chunk_z_max,
+                    block_x_min: r.block_x_min,
+                    block_x_max: r.block_x_max,
+                    block_z_min: r.block_z_min,
+                    block_z_max: r.block_z_max,
+                    anchor_y: r.anchor_y,
+                    resource_path: r.resource_path,
+                    dims_x: r.dims_x,
+                    dims_y: r.dims_y,
+                    dims_z: r.dims_z,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn service_mark_build_applied(
+        &self,
+        build_id: String,
+        worker_id: String,
+    ) -> Result<bool> {
+        let mut conn = self.wallet().write().await.map_err(LotError::Wallet)?;
+        let row: BoolRow =
+            sql_query("SELECT public.proxy_service_mark_build_applied($1, $2) AS ok")
+                .bind::<Text, _>(build_id)
+                .bind::<Text, _>(worker_id)
+                .get_result(&mut *conn)
+                .await
+                .map_err(LotError::from_diesel)?;
+        Ok(row.ok)
+    }
+
+    pub async fn service_mark_build_failed(
+        &self,
+        build_id: String,
+        worker_id: String,
+        error: String,
+    ) -> Result<bool> {
+        let mut conn = self.wallet().write().await.map_err(LotError::Wallet)?;
+        let row: BoolRow =
+            sql_query("SELECT public.proxy_service_mark_build_failed($1, $2, $3) AS ok")
+                .bind::<Text, _>(build_id)
+                .bind::<Text, _>(worker_id)
+                .bind::<Text, _>(error)
+                .get_result(&mut *conn)
+                .await
+                .map_err(LotError::from_diesel)?;
+        Ok(row.ok)
+    }
+
+    pub async fn service_requeue_stale_claims(
+        &self,
+        older_than_seconds: i32,
+        limit: i32,
+    ) -> Result<RequeueStaleSummary> {
+        let mut conn = self.wallet().write().await.map_err(LotError::Wallet)?;
+        let row: RequeueSummaryDb = sql_query(
+            "SELECT requeued_count, exhausted_count \
+             FROM public.proxy_service_requeue_stale_claims($1, $2)",
+        )
+        .bind::<Integer, _>(older_than_seconds)
+        .bind::<Integer, _>(limit)
+        .get_result(&mut *conn)
+        .await
+        .map_err(LotError::from_diesel)?;
+        Ok(RequeueStaleSummary {
+            requeued_count: row.requeued_count,
+            exhausted_count: row.exhausted_count,
+        })
+    }
+
+    // -------- admin: retry, list failed, release, repair --------
+
+    pub async fn service_retry_failed_build(
+        &self,
+        build_id: String,
+        reset_attempts: bool,
+    ) -> Result<bool> {
+        let mut conn = self.wallet().write().await.map_err(LotError::Wallet)?;
+        let row: BoolRow =
+            sql_query("SELECT public.proxy_service_retry_failed_build($1, $2) AS ok")
+                .bind::<Text, _>(build_id)
+                .bind::<Bool, _>(reset_attempts)
+                .get_result(&mut *conn)
+                .await
+                .map_err(LotError::from_diesel)?;
+        Ok(row.ok)
+    }
+
+    pub async fn service_list_failed_builds(
+        &self,
+        limit: i32,
+        cursor: FailedBuildCursor,
+    ) -> Result<Vec<FailedBuildRow>> {
+        let mut conn = self.wallet().read().await.map_err(LotError::Wallet)?;
+        let rows: Vec<FailedBuildRowDb> = sql_query(
+            "SELECT build_id, lot_id, actor_user_id, action_kind, schematic_id, \
+                    apply_error, failed_at, attempt_count \
+             FROM public.proxy_service_list_failed_builds($1, $2, $3)",
+        )
+        .bind::<Integer, _>(limit)
+        .bind::<Nullable<Timestamptz>, _>(cursor.after_failed_at)
+        .bind::<Nullable<Text>, _>(cursor.after_build_id)
+        .get_results(&mut *conn)
+        .await
+        .map_err(LotError::from_diesel)?;
+        rows.into_iter()
+            .map(|r| {
+                let action_kind = BuildActionKind::from_pg(r.action_kind).ok_or_else(|| {
+                    LotError::InvalidArgument(format!("unknown action_kind: {}", r.action_kind))
+                })?;
+                Ok(FailedBuildRow {
+                    build_id: r.build_id,
+                    lot_id: r.lot_id,
+                    actor_user_id: r.actor_user_id,
+                    action_kind,
+                    schematic_id: r.schematic_id,
+                    apply_error: r.apply_error,
+                    failed_at: r.failed_at,
+                    attempt_count: r.attempt_count,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn service_release_user_lots(
+        &self,
+        user_id: Uuid,
+        force: bool,
+    ) -> Result<Vec<ReleasedLotRow>> {
+        let mut conn = self.wallet().write().await.map_err(LotError::Wallet)?;
+        let rows: Vec<ReleasedLotRowDb> = sql_query(
+            "SELECT lot_id, prior_state \
+             FROM public.proxy_service_release_user_lots($1, $2)",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(user_id)
+        .bind::<Bool, _>(force)
+        .get_results(&mut *conn)
+        .await
+        .map_err(LotError::from_diesel)?;
+        rows.into_iter()
+            .map(|r| {
+                let prior_state = LotState::from_pg(r.prior_state).ok_or_else(|| {
+                    LotError::InvalidArgument(format!("unknown lot_state: {}", r.prior_state))
+                })?;
+                Ok(ReleasedLotRow {
+                    lot_id: r.lot_id,
+                    prior_state,
+                })
+            })
+            .collect()
+    }
+
+    pub async fn service_repair_orphan_transitional(
+        &self,
+        dry_run: bool,
+    ) -> Result<Vec<RepairedLotRow>> {
+        let mut conn = self.wallet().write().await.map_err(LotError::Wallet)?;
+        let rows: Vec<RepairedLotRowDb> = sql_query(
+            "SELECT lot_id, prior_state, new_state, latest_build_id, \
+                    latest_apply_state, latest_failed_at, latest_apply_error \
+             FROM public.proxy_service_repair_orphan_transitional($1)",
+        )
+        .bind::<Bool, _>(dry_run)
+        .get_results(&mut *conn)
+        .await
+        .map_err(LotError::from_diesel)?;
+        rows.into_iter()
+            .map(|r| {
+                let prior_state = LotState::from_pg(r.prior_state).ok_or_else(|| {
+                    LotError::InvalidArgument(format!("unknown lot_state: {}", r.prior_state))
+                })?;
+                let new_state = LotState::from_pg(r.new_state).ok_or_else(|| {
+                    LotError::InvalidArgument(format!("unknown lot_state: {}", r.new_state))
+                })?;
+                let latest_apply_state = r
+                    .latest_apply_state
+                    .map(|v| {
+                        BuildApplyState::from_pg(v).ok_or_else(|| {
+                            LotError::InvalidArgument(format!("unknown build_apply_state: {v}"))
+                        })
+                    })
+                    .transpose()?;
+                Ok(RepairedLotRow {
+                    lot_id: r.lot_id,
+                    prior_state,
+                    new_state,
+                    latest_build_id: r.latest_build_id,
+                    latest_apply_state,
+                    latest_failed_at: r.latest_failed_at,
+                    latest_apply_error: r.latest_apply_error,
+                })
+            })
+            .collect()
+    }
+}

--- a/packages/rust/kbve/src/lot/types.rs
+++ b/packages/rust/kbve/src/lot/types.rs
@@ -1,0 +1,290 @@
+//! Wire types for the MC lot/schematic surface.
+//!
+//! Mirrors the row shapes returned by the `public.proxy_*` RPCs in
+//! `20260526223407_mc_lot_system.sql`. Numeric state fields stay i16 to
+//! match the Postgres `SMALLINT` returns.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+/// Lifecycle state for a parcel. Matches the `mc.lot_state` SMALLINT
+/// domain (0..4).
+#[repr(i16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LotState {
+    Vacant = 0,
+    Owned = 1,
+    Built = 2,
+    UnderBuild = 3,
+    Demolishing = 4,
+}
+
+impl LotState {
+    pub fn from_pg(v: i16) -> Option<Self> {
+        match v {
+            0 => Some(LotState::Vacant),
+            1 => Some(LotState::Owned),
+            2 => Some(LotState::Built),
+            3 => Some(LotState::UnderBuild),
+            4 => Some(LotState::Demolishing),
+            _ => None,
+        }
+    }
+}
+
+/// Worker queue state for a `mc.lot_build_log` row. Matches the
+/// `mc.build_apply_state` SMALLINT domain (0..4).
+#[repr(i16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildApplyState {
+    Queued = 0,
+    Applied = 1,
+    Failed = 2,
+    Claimed = 3,
+    Cancelled = 4,
+}
+
+impl BuildApplyState {
+    pub fn from_pg(v: i16) -> Option<Self> {
+        match v {
+            0 => Some(BuildApplyState::Queued),
+            1 => Some(BuildApplyState::Applied),
+            2 => Some(BuildApplyState::Failed),
+            3 => Some(BuildApplyState::Claimed),
+            4 => Some(BuildApplyState::Cancelled),
+            _ => None,
+        }
+    }
+}
+
+#[repr(i16)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildActionKind {
+    Build = 0,
+    Demolish = 1,
+}
+
+impl BuildActionKind {
+    pub fn from_pg(v: i16) -> Option<Self> {
+        match v {
+            0 => Some(BuildActionKind::Build),
+            1 => Some(BuildActionKind::Demolish),
+            _ => None,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Catalog
+// ---------------------------------------------------------------------------
+
+/// Public schematic row from `public.proxy_list_schematics`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SchematicRow {
+    pub schematic_id: String,
+    pub name: String,
+    pub category: String,
+    pub tier: i16,
+    pub dims_x: i16,
+    pub dims_y: i16,
+    pub dims_z: i16,
+    pub price_credits: i64,
+    pub price_khash: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Lot rows
+// ---------------------------------------------------------------------------
+
+/// Row shape returned by `public.proxy_list_vacant_lots`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VacantLotRow {
+    pub lot_id: String,
+    pub chunk_x_min: i32,
+    pub chunk_x_max: i32,
+    pub chunk_z_min: i32,
+    pub chunk_z_max: i32,
+    pub block_x_min: i32,
+    pub block_x_max: i32,
+    pub block_z_min: i32,
+    pub block_z_max: i32,
+    pub chunk_area: i32,
+    pub anchor_y: i16,
+    pub price_credits: i64,
+    pub price_khash: i64,
+}
+
+/// Row shape returned by `public.proxy_list_my_active_lots` /
+/// `public.proxy_list_my_transitional_lots`. Adds state + current
+/// schematic on top of the vacant shape.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OwnedLotRow {
+    pub lot_id: String,
+    pub chunk_x_min: i32,
+    pub chunk_x_max: i32,
+    pub chunk_z_min: i32,
+    pub chunk_z_max: i32,
+    pub block_x_min: i32,
+    pub block_x_max: i32,
+    pub block_z_min: i32,
+    pub block_z_max: i32,
+    pub chunk_area: i32,
+    pub anchor_y: i16,
+    pub state: LotState,
+    pub current_schematic_id: Option<String>,
+    pub price_credits: i64,
+    pub price_khash: i64,
+}
+
+/// Row shape returned by `public.proxy_list_lots_in_viewport`. Owner-
+/// identity is reduced to a boolean to avoid leaking other users' UUIDs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ViewportLotRow {
+    pub lot_id: String,
+    pub chunk_x_min: i32,
+    pub chunk_x_max: i32,
+    pub chunk_z_min: i32,
+    pub chunk_z_max: i32,
+    pub block_x_min: i32,
+    pub block_x_max: i32,
+    pub block_z_min: i32,
+    pub block_z_max: i32,
+    pub anchor_y: i16,
+    pub is_owned: bool,
+    pub is_owned_by_me: bool,
+    pub state: LotState,
+    pub current_schematic_id: Option<String>,
+}
+
+/// Full row from `public.proxy_service_get_lot` (service-role only).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServiceLotRow {
+    pub lot_id: String,
+    pub world: String,
+    pub chunk_x_min: i32,
+    pub chunk_x_max: i32,
+    pub chunk_z_min: i32,
+    pub chunk_z_max: i32,
+    pub block_x_min: i32,
+    pub block_x_max: i32,
+    pub block_z_min: i32,
+    pub block_z_max: i32,
+    pub chunk_area: i32,
+    pub anchor_y: i16,
+    pub owner_user_id: Option<Uuid>,
+    pub current_schematic_id: Option<String>,
+    pub state: LotState,
+    pub price_credits: i64,
+    pub price_khash: i64,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+// ---------------------------------------------------------------------------
+// Worker claim payload
+// ---------------------------------------------------------------------------
+
+/// Single job row returned by `public.proxy_service_claim_pending_builds`.
+/// Denormalized so the worker can build without follow-up reads.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClaimedBuildRow {
+    pub build_id: String,
+    pub lot_id: String,
+    pub actor_user_id: Uuid,
+    pub action_kind: BuildActionKind,
+    pub schematic_id: Option<String>,
+    pub queued_at: DateTime<Utc>,
+    pub world: String,
+    pub chunk_x_min: i32,
+    pub chunk_x_max: i32,
+    pub chunk_z_min: i32,
+    pub chunk_z_max: i32,
+    pub block_x_min: i32,
+    pub block_x_max: i32,
+    pub block_z_min: i32,
+    pub block_z_max: i32,
+    pub anchor_y: i16,
+    /// Catalog `resource_path` for the schematic (nbt/schem file under
+    /// `schematics/`). `None` for demolish jobs.
+    pub resource_path: Option<String>,
+    pub dims_x: Option<i16>,
+    pub dims_y: Option<i16>,
+    pub dims_z: Option<i16>,
+}
+
+// ---------------------------------------------------------------------------
+// Failed build listing (admin)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailedBuildRow {
+    pub build_id: String,
+    pub lot_id: String,
+    pub actor_user_id: Uuid,
+    pub action_kind: BuildActionKind,
+    pub schematic_id: Option<String>,
+    pub apply_error: Option<String>,
+    pub failed_at: DateTime<Utc>,
+    pub attempt_count: i32,
+}
+
+// ---------------------------------------------------------------------------
+// Cursors
+// ---------------------------------------------------------------------------
+
+/// Keyset cursor for the public partial-index list RPCs. All four fields
+/// must be provided together (or none at all) — the SQL side raises
+/// 22023 on mixed-null cursors.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LotCursor {
+    pub after_world: Option<String>,
+    pub after_chunk_x: Option<i32>,
+    pub after_chunk_z: Option<i32>,
+    pub after_lot_id: Option<String>,
+}
+
+/// Two-field cursor for the partial-index "my lots" / "vacant" wrappers
+/// that hard-code the `world` argument.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LotChunkCursor {
+    pub after_chunk_x: Option<i32>,
+    pub after_chunk_z: Option<i32>,
+    pub after_lot_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FailedBuildCursor {
+    pub after_failed_at: Option<DateTime<Utc>>,
+    pub after_build_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Result of forced release
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReleasedLotRow {
+    pub lot_id: String,
+    pub prior_state: LotState,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RepairedLotRow {
+    pub lot_id: String,
+    pub prior_state: LotState,
+    pub new_state: LotState,
+    pub latest_build_id: Option<String>,
+    pub latest_apply_state: Option<BuildApplyState>,
+    pub latest_failed_at: Option<DateTime<Utc>>,
+    pub latest_apply_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct RequeueStaleSummary {
+    pub requeued_count: i32,
+    pub exhausted_count: i32,
+}


### PR DESCRIPTION
## Summary

Two deliverables for the MC lot/schematic system that landed in PR #11389:

1. **dbmate migration test** — companion `.test.sql` for `20260526223407_mc_lot_system` plus verified runs against both the local vanilla postgres (\`dev-docker-compose\`) and the production-replica kilobase image (\`kilobase-docker-compose\`).
2. **Rust client scaffold** — new \`kbve::lot\` module (under the existing \`wallet\` feature, since purchases settle through \`wallet.service_debit\`) with a \`LotClient\` facade, typed errors, and row mirrors for every public proxy in the migration.

## dbmate test coverage

- Domains present (\`mc.lot_state\`, \`mc.build_apply_state\`).
- \`mc_lot_flags_mask_chk\` rejects bits above the low 16.
- \`mc_schematic_resource_path_chk\` rejects \`//\` and \`\\\\\` (round-17 hardening).
- GIST EXCLUDE forbids in-world chunk overlap but allows cross-world.
- Generated \`block_*\` columns equal \`chunk_*_range * 16\`.
- Partial / repair indexes present: \`idx_mc_lot_transitional_repair\`, \`idx_mc_lot_vacant_world_chunk_cursor\`, \`uq_mc_lot_build_log_one_active_per_lot\`.
- Duplicate explicit gist (\`idx_mc_lot_world_chunk_ranges_gist\`) is intentionally absent; viewport reads ride the EXCLUDE-backed gist.
- Internal helpers \`mc._derive_idem_key\` and \`mc._user_account_id\` are revoked from \`service_role\`.
- \`apply_state = 4\` cancelled inserts pass \`claimed_consistency_chk\`.
- Down-side: tables, domains, proxies removed.

Verified locally:
- Vanilla: \`./test-migration.sh 20260526223407_mc_lot_system\` → green.
- Kilobase: \`docker compose -f kilobase-docker-compose.yml up -d\` → init scripts loaded → dbmate up → assert_after_up → green.

## Rust scaffold

\`kbve::lot\` reuses the wallet pool. \`LotClient\` exposes:

- **User**: \`list_schematics\`, \`list_vacant_lots\`, \`list_my_active_lots\`, \`list_my_transitional_lots\`, \`list_lots_in_viewport\`, \`purchase_lot\`, \`queue_build_on_lot\`, \`queue_demolish_lot\`.
- **Worker / admin**: \`service_get_lot\`, \`service_claim_pending_builds\`, \`service_mark_build_applied\`, \`service_mark_build_failed\`, \`service_requeue_stale_claims\`, \`service_retry_failed_build\`, \`service_list_failed_builds\`, \`service_release_user_lots\`, \`service_repair_orphan_transitional\`.

\`LotError\` maps:
- \`ExclusionViolation\` → \`ChunkOverlap\`.
- \`UniqueViolation\` on \`uq_mc_lot_build_log_one_active_per_lot\` → \`ActiveJobConflict\`.
- FK violation mentioning \"schematic\" → \`SchematicNotFound\`; else \`LotNotFound\`.
- Raised messages: \"not authenticated\", \"service_role required\", \"not vacant\", \"active queued/claimed job\", \"idempotency_key reused\", \"insufficient funds\".

\`cargo check --features wallet\` on the \`kbve\` crate is clean. \`cargo check\` on \`axum-kbve\` (and its full transitive bevy/lightyear graph) is clean.

axum transport handlers + route registration intentionally follow in a separate commit/PR once the public HTTP shape is agreed.

## Test plan

- [ ] \`./packages/data/sql/dbmate/test-migration.sh 20260526223407_mc_lot_system\` passes against \`dev-docker-compose\`.
- [ ] Same migration applies + rolls back + re-applies cleanly against the kilobase image (\`kilobase-docker-compose.yml\`, after \`./init/*.sql\` are loaded into the \`supabase\` db).
- [ ] \`cargo check --manifest-path packages/rust/kbve/Cargo.toml --features wallet\` is clean.
- [ ] \`cargo check --manifest-path apps/kbve/axum-kbve/Cargo.toml\` is clean.