### PR TITLE
perf(rareicon): jobify ProfessionOfferBuildSystem big scans + counting sort

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionOfferBuildSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionOfferBuildSystem.cs
@@ -1,11 +1,12 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Rebuilds the world-level TaskOffer pool + dispatch context on cadence (§0-C). Keeps offer enumeration out of ProfessionDispatchSystem so the per-unit scoring loop reads one flat list and the world-scan cost amortises. BuildVersion increments each rebuild so the dispatcher can gate "full dispatch" frames off the singleton instead of owning its own timer. ISystem + [BurstCompile] — managed bootstrap lives in OnCreate; the per-frame cadence check + Rebuild run on Burst.</summary>
+    /// <summary>Rebuilds the world-level TaskOffer pool + dispatch context on cadence (§0-C). Keeps offer enumeration out of ProfessionDispatchSystem so the per-unit scoring loop reads one flat list and the world-scan cost amortises. BuildVersion increments each rebuild so the dispatcher can gate "full dispatch" frames off the singleton instead of owning its own timer. The two big world scans (HexResources × HexCoord and HexCoord × ItemDrop) run as [BurstCompile] IJobEntity parallel jobs into NativeList<TaskOffer>.ParallelWriter; smaller foreach scans (FarmTag, GoblinCaveTag, ConstructionSite, damaged buildings, BarracksTag, FurnaceTag) stay main-thread since each iterates few entities. A trailing Burst IJob does counting + per-kind sort off the main thread.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateBefore(typeof(ProfessionDispatchSystem))]
@@ -15,6 +16,9 @@ namespace RareIcon
 
         Entity _singleton;
         float  _lastBuildTime;
+
+        EntityQuery _hexResourceQuery;
+        EntityQuery _itemDropQuery;
 
         public void OnCreate(ref SystemState state)
         {
@@ -35,11 +39,15 @@ namespace RareIcon
             state.EntityManager.SetComponentData(_singleton, db);
 
             _lastBuildTime = -BuildIntervalSeconds;
+
+            _hexResourceQuery = SystemAPI.QueryBuilder().WithAll<HexResources, HexCoord>().Build();
+            _itemDropQuery    = SystemAPI.QueryBuilder().WithAll<HexCoord, ItemDrop>().Build();
         }
 
         public void OnDestroy(ref SystemState state)
         {
             if (!state.EntityManager.Exists(_singleton)) return;
+            state.CompleteDependency();
             var db = state.EntityManager.GetComponentData<ProfessionOffersSingleton>(_singleton);
             if (db.Offers.IsCreated)             db.Offers.Dispose();
             if (db.OffersPerKind.IsCreated)      db.OffersPerKind.Dispose();
@@ -62,9 +70,13 @@ namespace RareIcon
         [BurstCompile]
         void Rebuild(ref SystemState state)
         {
-            ref var db   = ref SystemAPI.GetSingletonRW<ProfessionOffersSingleton>().ValueRW;
-            var itemDB   = SystemAPI.GetSingleton<ItemDBSingleton>();
-            var capLookup  = SystemAPI.GetBufferLookup<CapitalLedger>(true);
+            ref var db    = ref SystemAPI.GetSingletonRW<ProfessionOffersSingleton>().ValueRW;
+            var itemDB    = SystemAPI.GetSingleton<ItemDBSingleton>();
+            var capLookup = SystemAPI.GetBufferLookup<CapitalLedger>(true);
+
+            // Previous tick's dispatcher / consumers must finish before we
+            // mutate Offers / OffersSortedByKind / OfferKindStart/Count.
+            state.CompleteDependency();
 
             db.Offers.Clear();
             db.NeedyCaves.Clear();
@@ -107,31 +119,8 @@ namespace RareIcon
 
             var offers = db.Offers;
 
-            foreach (var (resRO, coordRO) in
-                     SystemAPI.Query<RefRO<HexResources>, RefRO<HexCoord>>())
-            {
-                var res = resRO.ValueRO;
-                var hex = new int2(coordRO.ValueRO.Q, coordRO.ValueRO.R);
-
-                if ((res.Wood | res.Leaves | res.Branches) != 0)
-                    offers.Add(new TaskOffer { Kind = ProfessionKind.Lumberjack, Variant = OfferVariant.Default, Hex = hex });
-                if (res.Stone != 0)
-                    offers.Add(new TaskOffer { Kind = ProfessionKind.Miner, Variant = OfferVariant.Default, Hex = hex });
-                if ((res.Berries | res.Mushrooms | res.Herbs | res.Cactus) != 0)
-                    offers.Add(new TaskOffer { Kind = ProfessionKind.Looter, Variant = OfferVariant.LooterForage, Hex = hex });
-            }
-
-            foreach (var (coordRO, dropsRO) in
-                     SystemAPI.Query<RefRO<HexCoord>, DynamicBuffer<ItemDrop>>())
-            {
-                if (dropsRO.Length == 0) continue;
-                var hex = new int2(coordRO.ValueRO.Q, coordRO.ValueRO.R);
-                offers.Add(new TaskOffer { Kind = ProfessionKind.Looter, Variant = OfferVariant.LooterDropPickup, Hex = hex });
-            }
-
-            if (db.HasFarm)
-                offers.Add(new TaskOffer { Kind = ProfessionKind.Farmer, Variant = OfferVariant.Default, Hex = db.FarmHex, Target = db.NearestFarm });
-
+            // Small scans iterate few entities each — staying main-thread
+            // is cheaper than the schedule overhead of additional jobs.
             foreach (var (siteRO, e) in SystemAPI.Query<RefRO<ConstructionSite>>().WithEntityAccess())
             {
                 offers.Add(new TaskOffer { Kind = ProfessionKind.Builder, Variant = OfferVariant.BuilderSite, Hex = siteRO.ValueRO.RootHex, Target = e });
@@ -174,46 +163,121 @@ namespace RareIcon
                 });
             }
 
+            if (db.HasFarm)
+                offers.Add(new TaskOffer { Kind = ProfessionKind.Farmer, Variant = OfferVariant.Default, Hex = db.FarmHex, Target = db.NearestFarm });
+
             for (int ci = 0; ci < db.NeedyCaves.Length; ci++)
                 offers.Add(new TaskOffer { Kind = ProfessionKind.Looter, Variant = OfferVariant.LooterDeliver, Hex = db.NeedyCaves[ci].Hex, Target = db.NeedyCaves[ci].Entity });
 
             if (db.HasCapital && db.CapitalHasFood && db.NeedyCaves.Length > 0)
                 offers.Add(new TaskOffer { Kind = ProfessionKind.Looter, Variant = OfferVariant.LooterFetch, Hex = db.CapitalHex, Target = db.Capital });
 
-            var opk = db.OffersPerKind;
-            for (int oi = 0; oi < offers.Length; oi++)
-            {
-                byte ok = offers[oi].Kind;
-                if (ok < opk.Length) opk[ok]++;
-            }
+            // Pre-grow offers capacity for the two big parallel scans so
+            // AddNoResize is safe. HexResources contributes up to 3 offers
+            // per hex (Lumberjack | Miner | Looter), ItemDrop up to 1.
+            int hexResourceCount = _hexResourceQuery.CalculateEntityCount();
+            int itemDropCount    = _itemDropQuery.CalculateEntityCount();
+            int extraNeeded      = hexResourceCount * 3 + itemDropCount;
+            int required         = offers.Length + extraNeeded;
+            if (offers.Capacity < required)
+                offers.SetCapacity(math.max(required, offers.Capacity * 2));
 
-            // Counting sort offers by Kind into OffersSortedByKind so
-            // ProfessionDispatchSystem can walk the slice for each kind
-            // the unit cares about instead of scanning the global pool.
-            var oks = db.OfferKindStart;
-            var okc = db.OfferKindCount;
-            int running = 0;
-            for (int k = 0; k < ProfessionKind.Count; k++)
-            {
-                oks[k] = running;
-                okc[k] = opk[k];
-                running += opk[k];
-            }
+            var hexHandle  = new BuildHexResourceOffersJob { Writer = offers.AsParallelWriter() }.ScheduleParallel(state.Dependency);
+            var dropHandle = new BuildItemDropOffersJob    { Writer = offers.AsParallelWriter() }.ScheduleParallel(state.Dependency);
 
-            var sorted = db.OffersSortedByKind;
-            sorted.Clear();
-            sorted.Length = offers.Length;
-            var cursor = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
-            for (int oi = 0; oi < offers.Length; oi++)
+            var finalizeJob = new FinalizeOffersJob
             {
-                var o = offers[oi];
-                if (o.Kind >= ProfessionKind.Count) continue;
-                int idx = oks[o.Kind] + cursor[o.Kind]++;
-                sorted[idx] = o;
-            }
-            cursor.Dispose();
+                Offers             = db.Offers,
+                OffersPerKind      = db.OffersPerKind,
+                OffersSortedByKind = db.OffersSortedByKind,
+                OfferKindStart     = db.OfferKindStart,
+                OfferKindCount     = db.OfferKindCount,
+            };
+            state.Dependency = finalizeJob.Schedule(
+                JobHandle.CombineDependencies(hexHandle, dropHandle));
 
             db.BuildVersion++;
+        }
+
+        [BurstCompile]
+        partial struct BuildHexResourceOffersJob : IJobEntity
+        {
+            public NativeList<TaskOffer>.ParallelWriter Writer;
+
+            void Execute(in HexResources r, in HexCoord c)
+            {
+                var hex = new int2(c.Q, c.R);
+                if ((r.Wood | r.Leaves | r.Branches) != 0)
+                    Writer.AddNoResize(new TaskOffer { Kind = ProfessionKind.Lumberjack, Variant = OfferVariant.Default, Hex = hex });
+                if (r.Stone != 0)
+                    Writer.AddNoResize(new TaskOffer { Kind = ProfessionKind.Miner, Variant = OfferVariant.Default, Hex = hex });
+                if ((r.Berries | r.Mushrooms | r.Herbs | r.Cactus) != 0)
+                    Writer.AddNoResize(new TaskOffer { Kind = ProfessionKind.Looter, Variant = OfferVariant.LooterForage, Hex = hex });
+            }
+        }
+
+        [BurstCompile]
+        partial struct BuildItemDropOffersJob : IJobEntity
+        {
+            public NativeList<TaskOffer>.ParallelWriter Writer;
+
+            void Execute(in HexCoord c, in DynamicBuffer<ItemDrop> drops)
+            {
+                if (drops.Length == 0) return;
+                Writer.AddNoResize(new TaskOffer
+                {
+                    Kind    = ProfessionKind.Looter,
+                    Variant = OfferVariant.LooterDropPickup,
+                    Hex     = new int2(c.Q, c.R),
+                });
+            }
+        }
+
+        [BurstCompile]
+        struct FinalizeOffersJob : IJob
+        {
+            [ReadOnly] public NativeList<TaskOffer> Offers;
+            public NativeArray<int>      OffersPerKind;
+            public NativeList<TaskOffer> OffersSortedByKind;
+            public NativeArray<int>      OfferKindStart;
+            public NativeArray<int>      OfferKindCount;
+
+            public void Execute()
+            {
+                var opk = OffersPerKind;
+                for (int i = 0; i < opk.Length; i++) opk[i] = 0;
+
+                for (int oi = 0; oi < Offers.Length; oi++)
+                {
+                    byte ok = Offers[oi].Kind;
+                    if (ok < opk.Length) opk[ok]++;
+                }
+
+                // Counting sort offers by Kind into OffersSortedByKind so
+                // ProfessionDispatchSystem can walk the slice for each kind
+                // the unit cares about instead of scanning the global pool.
+                var oks = OfferKindStart;
+                var okc = OfferKindCount;
+                int running = 0;
+                for (int k = 0; k < ProfessionKind.Count; k++)
+                {
+                    oks[k] = running;
+                    okc[k] = opk[k];
+                    running += opk[k];
+                }
+
+                OffersSortedByKind.Clear();
+                OffersSortedByKind.Length = Offers.Length;
+                var cursor = new NativeArray<int>(ProfessionKind.Count, Allocator.Temp);
+                for (int oi = 0; oi < Offers.Length; oi++)
+                {
+                    var o = Offers[oi];
+                    if (o.Kind >= ProfessionKind.Count) continue;
+                    int idx = oks[o.Kind] + cursor[o.Kind]++;
+                    OffersSortedByKind[idx] = o;
+                }
+                cursor.Dispose();
+            }
         }
 
         static int CountFood(in ItemDBSingleton itemDB, DynamicBuffer<BankLedgerBase> buf)


### PR DESCRIPTION
Continues the perf arc — same pattern as #11719 / #11723 / #11728 / #11733 / #11741 / #11743, applied to the dispatcher's upstream feeder.

## Was

`ProfessionOfferBuildSystem.Rebuild` was eight main-thread `foreach` scans + a sequential counting sort + the offer-list build, all on the main thread, fired every `BuildIntervalSeconds = 5s`. Visible stutter when the cadence tripped.

The two big scans were:

| Scan | Entity shape | Notes |
|---|---|---|
| `HexResources × HexCoord` | Every terrain hex | Adds up to 3 offers per hex (Lumberjack \| Miner \| Looter forage) |
| `HexCoord × ItemDrop` | Every hex with a drops buffer | Adds 1 offer (Looter DropPickup) |

The post-build counting sort was also main-thread O(N) on the assembled offers.

## Now

```
Main thread:
  - Singleton lookups (Capital, Farm, ItemDB, CapitalLedger)
  - Small foreach scans (caves, sites, damaged buildings, barracks,
    furnaces) — few entities each, schedule overhead would beat the work
  - Singleton inline adds (Farm, Chef, LooterDeliver per cave, LooterFetch)
  - Pre-grow Offers.Capacity for the parallel adds
      ↓
  ( BuildHexResourceOffersJob ‖ BuildItemDropOffersJob )
      ↓ IJobEntity parallel + Burst, AddNoResize on shared ParallelWriter
  FinalizeOffersJob (IJob, Burst, single-threaded on worker)
      ↓ counting sort by Kind → OffersSortedByKind + OfferKindStart/Count
```

`state.CompleteDependency()` at the top of Rebuild syncs the previous tick's dispatcher / consumers before the `Offers.Clear` so the mutation is race-free. Trailing `state.Dependency = finalizeJob` handle chains downstream consumers onto the finalize, so the dispatcher's next read picks up the rebuilt singleton without an extra sync.

## Capacity

`Offers.SetCapacity` pre-grown to the worst case before the parallel jobs schedule:

```csharp
int extraNeeded = hexResourceCount * 3 + itemDropCount;
int required    = offers.Length + extraNeeded;
```

Sized via two cached `EntityQuery.CalculateEntityCount()` calls. HexResources \* 3 covers the worst case where every hex has all three resource families set; over-allocation is bounded by world size.

## Behaviour preserved

- Identical offer set produced (Lumberjack + Miner + Looter forage from HexResources, Looter DropPickup from ItemDrop, Builder Site + BuilderDamaged, Chef at Capital, Craftsman at Barracks, Blacksmith at Furnace, Farmer at Farm, Looter Deliver/Fetch from cave needs).
- Same `CapitalHasFood` gate on LooterFetch.
- Same `OffersPerKind` / `OfferKindStart` / `OfferKindCount` / `OffersSortedByKind` shapes consumed by ProfessionDispatchSystem (#11719 per-kind slicing stays untouched).
- BuildVersion increments same as before; cadence trigger unchanged.

## Test plan

- [ ] Burst compiles `BuildHexResourceOffersJob` + `BuildItemDropOffersJob` + `FinalizeOffersJob` clean.
- [ ] No safety errors with `ENABLE_UNITY_COLLECTIONS_CHECKS` on the shared `AsParallelWriter()` flow.
- [ ] Offer set per kind matches pre-PR (smoke test each kind: spawn forest hex → Lumberjack offer, drop hex → Looter DropPickup, etc.).
- [ ] Frame-time delta at the 5s cadence trigger: main-thread `ProfessionOfferBuildSystem` time should drop noticeably; total worker time roughly equal (work moved, not eliminated).
- [ ] BuildVersion still increments once per Rebuild; ProfessionDispatchSystem's "full dispatch" gating still fires on the right ticks.
- [ ] No `NativeList capacity` errors under a sudden world expansion (e.g. 10k+ hex resources added between two cadences).

## Roadmap

Original dispatch optimization roadmap (#11716) is closed. This PR is part of the broader cadence — same pattern, extended to the dispatcher's upstream and the BehaviorSystemGroup at large. Next candidates if continuing: `TaskInvalidationSystem`, building-tier systems, movement systems.