### PR TITLE
content(osrs): migrate batch 22 (200 items) v2 → v3

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-bow.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: 3rd age
+    tier: master
   equipment:
     slot: weapon
     type: shortbow
@@ -19,26 +24,27 @@ osrs:
     attack_speed: 4
     requirements:
       ranged: 65
-    stats:
-      attack_ranged: 65
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 65
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       ranged_strength: 0
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Master clue scroll casket
+        quantity: "1"
         rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+        notes: Extremely rare reward from master clue scrolls
   related_items:
     - item_id: 12426
       item_name: 3rd age longsword
@@ -65,16 +71,14 @@ osrs:
 
     3rd age weapons are highly sought after due to their extreme rarity and status symbol value. The bow can use any type of arrow.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Extremely valuable due to rarity
-      - Price fluctuates based on collector demand
-      - More common than druidic but still very rare
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Investment Notes"
+      - "Extremely valuable due to rarity"
+      - "Price fluctuates based on collector demand"
+      - "More common than druidic but still very rare"
+      - "Verify authenticity when trading high-value items"
+      - "Use Grand Exchange for secure trades"
+      - "Monitor price trends before purchasing"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-druidic-staff.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: 3rd age
+    tier: master
   equipment:
     slot: weapon
     type: staff
@@ -20,27 +25,28 @@ osrs:
     requirements:
       attack: 65
       magic: 65
-    stats:
-      attack_stab: 25
-      attack_slash: 45
-      attack_crush: 55
-      attack_magic: 25
-      attack_ranged: 0
-      defence_stab: 2
-      defence_slash: 3
-      defence_crush: 1
-      defence_magic: 25
-      defence_ranged: 0
+    attack_bonus:
+      stab: 25
+      slash: 45
+      crush: 55
+      magic: 25
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 25
+      ranged: 0
+    other_bonus:
       melee_strength: 60
       magic_damage: 0
-      prayer_bonus: 5
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
+      prayer: 5
+  drop_table:
+    sources:
+      - source: Master clue scroll casket
+        quantity: "1"
         rarity: Extremely Rare
-        description: Rarest reward from master clue scrolls
+        notes: Rarest reward from master clue scrolls
   related_items:
     - item_id: 23336
       item_name: 3rd age druidic robe top
@@ -62,16 +68,14 @@ osrs:
 
     The druidic set is considered one of the most valuable item sets in the game due to its extreme rarity. It can only be obtained from Treasure Trails, specifically from master clue scroll caskets at an exceptionally low drop rate.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Among the most valuable items in OSRS
-      - Extremely rare collector's item
-      - Price driven by wealthy collectors
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Consider using trusted middlemen for trades exceeding max cash
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Investment Notes"
+      - "Among the most valuable items in OSRS"
+      - "Extremely rare collector's item"
+      - "Price driven by wealthy collectors"
+      - "Verify authenticity when trading high-value items"
+      - "Use Grand Exchange for secure trades"
+      - "Consider using trusted middlemen for trades exceeding max cash"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-p.mdx
@@ -12,6 +12,22 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: adamant
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    options:
+      - wield
+      - drop
+    worn_options:
+      - remove
   equipment:
     slot: weapon
     attack_speed: 6
@@ -30,8 +46,6 @@ osrs:
     > _"An adamant tipped javelin with a poisoned tip."_
 
     An adamant javelin tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-mace.mdx
@@ -12,11 +12,22 @@ osrs:
   lowalch: 576
   highalch: 864
   limit: 125
+  material:
+    type: adamant
+    tier: mid-high
+  properties:
+    release_date: "2001-04-11"
+    options:
+      - Wield
+      - Examine
+    worn_options:
+      - Remove
   equipment:
     slot: weapon
     type: mace
     tradeable: true
     weight: 2.041
+    attack_speed: 5
     requirements:
       attack: 30
     stats:
@@ -45,8 +56,8 @@ osrs:
       slug: adamant-warhammer
       relationship: alternative
       description: Higher strength alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platebody-h4.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 6656
   highalch: 9984
   limit: 8
+  material:
+    type: metal
+    tier: adamant
   about: "Adamant platebody (h4) is a free-to-play item in Old School RuneScape. High alchemy value: 9,984 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/aether-catalyst.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/aether-catalyst.mdx
@@ -13,8 +13,55 @@ osrs:
   highalch: 120
   limit: 25000
   about: "Aether catalyst is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 25,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: catalyst
+    tier: high
+  properties:
+    release_date: "2024-10-23"
+    quest_item: false
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    destroy_action: drop
+    options:
+      - drop
+  drop_table:
+    sources:
+      - source: Amoxliatl
+        source_id: 13837
+        combat_level: 115
+        quantity: "1"
+        rarity: common
+        members_only: true
+      - source: Hueycoatl
+        source_id: 14013
+        combat_level: 723
+        quantity: "1"
+        rarity: common
+        members_only: true
+  related_items:
+    - item_id: 565
+      item_name: Blood rune
+      slug: blood-rune
+      relationship: component
+      description: Pairs with catalyst in spellbook augments
+    - item_id: 30772
+      item_name: Sun-kissed bones
+      slug: sun-kissed-bones
+      relationship: alternative
+      description: Alternate Varlamore reward drop
+  market_strategy:
+    notes:
+      - "Newer Varlamore drop"
+      - "Used in Aether spell augments"
+      - "High volume from Hueycoatl farming"
+      - "Price tracks PvM popularity"
+  trading_tips:
+    - "Buying tip: dip-buy after Hueycoatl mass-farm streams"
+    - "Selling tip: list during high-end magic content updates"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/agility-potion-1.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 2000
-  about: "Agility potion(1) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2005-09-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Boosts Agility level by 3."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 34
+      xp: 80
+      materials:
+        - item_name: Agility potion(2)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Agility potion(2)
+      slug: agility-potion-2
+      relationship: variant
+      description: Two-dose version split into single doses.
+    - item_name: Agility potion(3)
+      slug: agility-potion-3
+      relationship: variant
+      description: Standard three-dose brew base.
+    - item_name: Agility potion(4)
+      slug: agility-potion-4
+      relationship: variant
+      description: Decanted four-dose version for full-inventory use.
+    - item_name: Toadflax potion (unf)
+      slug: toadflax-potion-unf
+      relationship: component
+      description: Unfinished potion used to brew agility potions with toad's legs.
+  about: "Agility potion(1) is a one-dose Agility boost potion that raises the Agility level by 3 for a single use. Created by decanting larger doses or brewed at 34 Herblore from a toadflax potion (unf) and toad's legs, it is most commonly used at Wilderness Agility shortcuts and during Brimhaven Agility Arena ticket runs where the +3 boost unlocks otherwise out-of-reach obstacles."
+  market_strategy:
+    notes:
+      - "Decant-arbitrage candidate against agility potion(2/3/4) at the GE"
+      - "Niche demand from Wilderness shortcuts and Brimhaven Arena"
+      - "Low buy limit (2,000) caps flip volume"
+  trading_tips:
+    - "Decant lower-doses up when single-dose price overshoots"
+    - "Watch Brimhaven ticket meta swings for short-term demand"
+  history:
+    - date: "2005-09-26"
+      description: "Released with the Agility potion brew chain."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-arrow-p.mdx
@@ -12,9 +12,94 @@ osrs:
   lowalch: 196
   highalch: 294
   limit: 11000
-  about: "Amethyst arrow(p) is a members-only item in Old School RuneScape. High alchemy value: 294 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: amethyst
+    tier: mid-high
+  properties:
+    release_date: "2017-06-22"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: arrows
+    attack_speed: null
+    weight: 0
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 55
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 82
+      xp: 202.5
+      materials:
+        - item_name: Headless arrow
+          quantity: 15
+        - item_name: Amethyst arrowtips
+          quantity: 15
+      tools:
+        - Feather
+      output_quantity: 15
+  related_items:
+    - item_name: Amethyst arrow
+      slug: amethyst-arrow
+      relationship: variant
+      description: "Unpoisoned variant of the arrow"
+    - item_name: Amethyst arrowtips
+      slug: amethyst-arrowtips
+      relationship: component
+      description: "Crafted onto headless arrows to make amethyst arrows"
+    - item_name: Rune arrow
+      slug: rune-arrow
+      relationship: downgrade
+      description: "Lower tier ranged ammunition"
+    - item_name: Dragon arrow
+      slug: dragon-arrow
+      relationship: upgrade
+      description: "Higher tier ranged ammunition"
+  about: |-
+    Amethyst arrows are mid-high tier ammunition that fall between rune and dragon arrows in ranged strength. The poisoned (p) version applies a starting poison damage of 4 to opponents on hit, useful for prolonged fights and PvP encounters. Amethyst arrows function with Ava's devices despite not being metallic.
+  market_strategy:
+    notes:
+      - "Mid-high tier ranged ammunition, +6 ranged strength over rune arrows"
+      - "Poisoned (p) version best for slayer or PvP setups"
+      - "Crafted at 82 Fletching, but typically unprofitable to make"
+      - "Works with Ava's devices, recovers most shots automatically"
+  trading_tips:
+    - "Check break-even versus dragon arrows for high-end content"
+    - "Buy bulk for slayer tasks needing poison procs"
+    - "Watch arrowtip prices, fletching profit margin is volatile"
+  history:
+    - date: "2017-06-22"
+      description: "Item added to the game with the amethyst content update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-dart-tip.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-dart-tip.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 11000
-  about: "Amethyst dart tip is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: amethyst
+    tier: high
+  recipes:
+    - skill: crafting
+      level: 89
+      xp: 14
+      materials:
+        - item_name: Amethyst
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+      output_quantity: 15
+    - skill: fletching
+      level: 90
+      xp: 10
+      materials:
+        - item_name: Amethyst dart tip
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Amethyst
+      slug: amethyst
+      relationship: component
+    - item_name: Amethyst dart
+      relationship: product
+    - item_name: Dragon dart tip
+      relationship: alternative
+    - item_name: Feather
+      relationship: component
+  market_strategy:
+    notes:
+      - "Chiselled from amethyst at 89 Crafting; supply is gated on Mining/Crafting throughput."
+      - "Demand from fletchers producing amethyst darts for ranged training."
+  trading_tips:
+    - "Track amethyst raw price to spot arbitrage windows."
+    - "Bulk margins are thin; volume matters more than spread."
+  history:
+    - date: "2020-08-26"
+      description: "Amethyst dart tip released alongside the rest of the amethyst ammunition line."
+  properties:
+    release_date: "2020-08-26"
+    update: Amethyst Ammunition
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Amethyst dart tip is a members-only Crafting product used to fletch amethyst darts. High alchemy value: 120 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-p-21322.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-p-21322.mdx
@@ -1,6 +1,6 @@
 ---
 title: Amethyst javelin(p+) | OSRS Price Data
-description: "Amethyst javelin(p+): An amethyst tipped javelin.. High alch: 252 GP, GE limit: 7,000."
+description: "Amethyst javelin(p+) is a poison-plus tipped ballista ammunition giving +135 ranged strength and an enhanced poison proc. High alch: 252 GP, GE limit: 7,000."
 osrs:
   id: 21322
   name: Amethyst javelin(p+)
@@ -12,9 +12,104 @@ osrs:
   lowalch: 168
   highalch: 252
   limit: 7000
-  about: "Amethyst javelin(p+) is a members-only item in Old School RuneScape. High alchemy value: 252 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: javelin
+    tier: high
+  equipment:
+    slot: ammo
+    weapon_type: javelin
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 135
+      magic_damage: 0
+      prayer: 0
+  ammunition:
+    type: javelin
+    tier: amethyst
+    ranged_strength: 135
+    enchanted: false
+    compatible_weapons:
+      - Light ballista
+      - Heavy ballista
+  passive_effects:
+    - name: Enhanced poison
+      description: Has a chance to inflict the enhanced poison plus damage-over-time effect on hit.
+      trigger: on_hit
+  recipes:
+    - skill: herblore
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Amethyst javelin
+          quantity: 5
+        - item_name: Weapon poison(+)
+          quantity: 1
+      tools: []
+      output_quantity: 5
+  related_items:
+    - item_name: Amethyst javelin
+      slug: amethyst-javelin
+      relationship: variant
+      description: Unpoisoned amethyst javelin
+    - item_name: Amethyst javelin(p)
+      slug: amethyst-javelin-p
+      relationship: variant
+      description: Standard poisoned amethyst javelin
+    - item_name: Amethyst javelin(p++)
+      slug: amethyst-javelin-pp
+      relationship: variant
+      description: Top-tier poison++ amethyst javelin
+    - item_name: Heavy ballista
+      slug: heavy-ballista
+      relationship: component
+      description: Primary launcher used with amethyst javelins
+    - item_name: Weapon poison(+)
+      slug: weapon-poison-plus
+      relationship: component
+      description: Herblore poison applied to amethyst javelins
+  about: Amethyst javelin(p+) is the poison-plus version of the amethyst javelin made by applying weapon poison(+) to five amethyst javelins. It keeps the +135 ranged strength of the base ammo and adds an enhanced poison proc on hit when fired from a light or heavy ballista.
+  market_strategy:
+    notes:
+      - "Demand spikes during PvP scenes and ballista-heavy slayer rotations"
+      - "Poison tier choice is a margin lever — compare (p) vs (p+) vs (p++) cost per javelin"
+      - "Supply is gated by amethyst javelin supply and weapon poison(+) herblore throughput"
+  trading_tips:
+    - Track amethyst javelin and weapon poison(+) prices — combined cost sets the floor
+    - GE buy limit of 7,000 leaves room for ballista-stack flipping
+  history:
+    - date: "2017-06-22"
+      description: Released as part of the amethyst ranged ammunition family.
+  properties:
+    release_date: "2017-06-22"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amethyst-javelin-tips.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 608
   highalch: 912
   limit: 10000
+  material:
+    type: gem
+    tier: amethyst
   about: "Amethyst javelin tips is a members-only item in Old School RuneScape. High alchemy value: 912 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-6.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-glory-6.mdx
@@ -12,94 +12,111 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 10000
-  equipment:
-    slot: neck
-    type: teleport amulet
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragonstone
+    tier: high
+  properties:
+    release_date: "2002-02-27"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
     weight: 0.01
-    requirements:
-      magic: 68
-    stats:
-      attack_stab: 10
-      attack_slash: 10
-      attack_crush: 10
-      attack_magic: 10
-      attack_ranged: 10
-      defence_stab: 3
-      defence_slash: 3
-      defence_crush: 3
-      defence_magic: 3
-      defence_ranged: 3
-      strength: 6
-      prayer: 3
-  teleport:
-    charges: 4
-    recharge_locations:
-      - name: Heroes' Guild
-        charges: 4
-      - name: Fountain of Rune
-        charges: 6
-    destinations:
+    options:
+      - Rub
+      - Wear
+      - Drop
+    worn_options:
+      - Rub
       - Edgeville
       - Karamja
       - Draynor Village
       - Al Kharid
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.01
+    requirements:
+      magic: 68
+    attack_bonus:
+      stab: 10
+      slash: 10
+      crush: 10
+      magic: 10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 3
+      crush: 3
+      magic: 3
+      ranged: 3
+    other_bonus:
+      strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+  recipes:
+    - skill: magic
+      level: 68
+      xp: 78
+      materials:
+        - item_name: Dragonstone amulet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 15
+        - item_name: Earth rune
+          quantity: 15
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Gem drop boost
+      description: "While charged, increases gem table odds from 1/256 to 1/86 when mining"
+    - name: Teleport charges
+      description: "Holds 4 charges (6 from Fountain of Rune) to Edgeville, Karamja, Draynor Village, or Al Kharid"
   related_items:
-    - item_id: 19707
-      item_name: Amulet of eternal glory
+    - item_name: Amulet of eternal glory
       slug: amulet-of-eternal-glory
       relationship: upgrade
-      description: Unlimited charges version
-    - item_id: 6585
-      item_name: Amulet of fury
+      description: "Unlimited charges version of the glory"
+    - item_name: Amulet of fury
       slug: amulet-of-fury
       relationship: upgrade
-      description: Higher stats upgrade
-    - item_id: 10362
-      item_name: Glory (t)
-      slug: glory-t
-      relationship: alternative
-      description: Trimmed cosmetic variant
+      description: "Higher combat stat amulet upgrade"
+    - item_name: Amulet of glory (t)
+      slug: amulet-of-glory-t
+      relationship: variant
+      description: "Trimmed cosmetic clue reward variant"
+    - item_name: Dragonstone amulet
+      slug: dragonstone-amulet
+      relationship: component
+      description: "Base amulet enchanted to create the glory"
   about: |-
-    Lvl-5 Enchant on Dragonstone amulet.
-
-    | Runes Required |
-    |----------------|
-    | 1 Cosmic |
-    | 15 Water |
-    | 15 Earth |
-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +10 |
-    | Slash | +10 |
-    | Crush | +10 |
-    | Magic | +10 |
-    | Ranged | +10 |
-    | Strength | +6 |
-    | Prayer | +3 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | +3 |
-    | Slash | +3 |
-    | Crush | +3 |
-    | Magic | +3 |
-    | Ranged | +3 |
-
-    | Destination |
-    |-------------|
-    | Edgeville |
-    | Karamja |
-    | Draynor Village |
-    | Al Kharid |
-
-    | Method | Charges |
-    |--------|---------|
-    | Heroes' Guild | 4 |
-    | Fountain of Rune | 6 |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Amulet of glory(6) is a fully charged dragonstone amulet enchanted via Level-5 Enchant at 68 Magic. It offers strong all-round combat bonuses, four daily teleport destinations, and a passive gem drop rate boost while mining. Tradeable only at 0, 4, or 6 charges.
+  market_strategy:
+    notes:
+      - "Top-tier all-round neck amulet for mid-level PvM"
+      - "Six charges from Fountain of Rune in Wilderness for extra value"
+      - "Gem drop boost while charged is huge for slayer"
+      - "Tradeable at 0, 4, or 6 charges only"
+  trading_tips:
+    - "Arbitrage between (0), (4), and (6) charge versions"
+    - "Recharge at Fountain of Rune for free 2 extra charges"
+    - "Buy uncharged dragonstone amulets, enchant, and resell"
+  history:
+    - date: "2002-02-27"
+      description: "Amulet of glory added with the dragonstone update"
+    - date: "2007-12-04"
+      description: "Fountain of Rune added providing 6-charge recharges"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-magic.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-magic.mdx
@@ -12,26 +12,63 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: amulet
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
   equipment:
     slot: neck
-    type: amulet
-    tradeable: true
     weight: 0.01
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 10
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 10
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  recipes:
+    - skill: magic
+      level: 7
+      xp: 17.5
+      materials:
+        - item_name: Sapphire amulet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 1
+        - item_name: Mind rune
+          quantity: 1
+      tools: []
+      output_quantity: 1
   related_items:
     - item_id: 1694
       item_name: Sapphire amulet
@@ -43,8 +80,19 @@ osrs:
       slug: amulet-of-power
       relationship: alternative
       description: Balanced alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Amulet of magic is a sapphire amulet enchanted with Lvl-1 Enchant, granting +10 magic attack and defence. Common training amulet for low-level mages and F2P PKers."
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Enchanting sapphire amulets yields Magic XP — supply driven by mid-Magic training."
+      - "High alch 540 gp limits profit margins on flips."
+      - "Steady demand from F2P magic accounts."
+  trading_tips:
+    - "Watch sapphire amulet spreads when enchanting for profit."
+    - "GE limit 125 per 4 hours keeps flips small."
+  history:
+    - date: "2001-01-04"
+      description: "Released into the game alongside enchanted gem amulets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancestral-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancestral-hat.mdx
@@ -12,40 +12,84 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 8
+  material:
+    type: mage_armour
+    tier: bis
+  properties:
+    release_date: "2017-01-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    weight: 0.453
+    quest_item: false
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
   equipment:
     slot: head
-    type: mage_armour
+    attack_speed: null
     requirements:
       magic: 75
       defence: 65
-    stats:
-      defence_stab: 12
-      defence_slash: 11
-      defence_crush: 13
-      defence_magic: 5
-      attack_magic: 8
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 8
+      ranged: 0
+    defence_bonus:
+      stab: 12
+      slash: 11
+      crush: 13
+      magic: 5
+      ranged: 0
+    other_bonus:
+      strength: 0
+      prayer: 0
       magic_damage_percent: 3
-  drop_sources:
-    - name: Chambers of Xeric
-      combat_level: 0
-      drop_rate: rare
-      members_only: true
+  drop_table:
+    sources:
+      - source: Chambers of Xeric
+        combat_level: 0
+        quantity: "1"
+        rarity: rare
+        members: true
   related_items:
     - item_id: 21021
       item_name: Ancestral robe top
       slug: ancestral-robe-top
       relationship: set-piece
-      description: Body slot
+      description: Body slot ancestral piece
     - item_id: 21024
       item_name: Ancestral robe bottom
       slug: ancestral-robe-bottom
       relationship: set-piece
-      description: Legs slot
+      description: Legs slot ancestral piece
     - item_id: 12931
       item_name: Serpentine helm
       slug: serpentine-helm
       relationship: alternative
-      description: Venom utility
+      description: Defensive alternative with venom utility
+  market_strategy:
+    notes:
+      - "CoX completions drive supply"
+      - "Best-in-slot mage helm sustains demand floor"
+      - "Buff to +3% magic damage in May 2024 lifted the price ceiling"
+      - "GE limit of 8 makes accumulation slow"
+  trading_tips:
+    - "Buy strategy: scale into the piece during raid content droughts"
+    - "Demand: BiS mage setup keeps a long-term price floor"
+    - "Risk: future ancestral or mage-helm releases can compress price"
+  history:
+    - date: "2017-01-05"
+      description: "Release: added as a rare reward from the Chambers of Xeric"
+    - date: "2024-05-22"
+      description: "Update: magic damage bonus increased from +2% to +3% in the mage rebalance"
   about: |-
     | Stat | Value |
     |------|-------|
@@ -69,13 +113,8 @@ osrs:
     - Essential for max magic DPS
     - Chambers of Xeric
     - Theatre of Blood
-  market_strategy:
-    notes:
-      - CoX completions affect supply
-      - Part of BiS mage setup
-      - Always in high demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-mace.mdx
@@ -13,8 +13,27 @@ osrs:
   highalch: 600
   limit: 8
   about: "Ancient mace is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ancient
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    options:
+      - Wield
+      - Examine
+    worn_options:
+      - Remove
+  equipment:
+    slot: weapon
+    type: mace
+    tradeable: true
+    weight: 1.36
+    attack_speed: 5
+    requirements:
+      attack: 40
+      prayer: 30
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-totem.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-totem.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 400000
   highalch: 600000
   limit: 250
-  about: "Ancient totem is a members-only item in Old School RuneScape. High alchemy value: 600,000 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: artifact
+    tier: high
+  properties:
+    release_date: "2017-08-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Trade
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Revenant imp
+        quantity: "1"
+        rarity: "1/1,664"
+      - source: Revenant goblin
+        quantity: "1"
+        rarity: "1/1,508"
+      - source: Revenant pyrefiend
+        quantity: "1"
+        rarity: "1/1,118"
+      - source: Revenant hobgoblin
+        quantity: "1"
+        rarity: "1/1,014"
+      - source: Revenant cyclops
+        quantity: "1"
+        rarity: "1/870"
+      - source: Revenant hellhound
+        quantity: "1"
+        rarity: "1/736"
+      - source: Revenant demon
+        quantity: "1"
+        rarity: "1/645"
+      - source: Revenant ork
+        quantity: "1"
+        rarity: "1/586"
+      - source: Revenant dark beast
+        quantity: "1"
+        rarity: "1/512"
+      - source: Revenant knight
+        quantity: "1"
+        rarity: "1/472"
+      - source: Revenant dragon
+        quantity: "1"
+        rarity: "1/438"
+  related_items:
+    - item_name: Ancient emblem
+      slug: ancient-emblem
+      relationship: variant
+      description: Lower-tier revenant artefact traded with the Emblem Trader.
+    - item_name: Ancient medallion
+      slug: ancient-medallion
+      relationship: variant
+      description: Mid-tier revenant artefact in the same drop pool.
+    - item_name: Ancient statuette
+      slug: ancient-statuette
+      relationship: variant
+      description: Top-tier revenant artefact rewarded by the Emblem Trader.
+    - item_name: Bracelet of ethereum
+      slug: bracelet-of-ethereum
+      relationship: alternative
+      description: Wilderness utility item from Revenant Caves runs.
+  about: "The ancient totem is a high-tier artefact dropped by all revenants in the Wilderness Revenant Caves. Players sell it to the Emblem Trader at Edgeville for a fixed coin payout (around 350k after the 2019 rebalance) and bonus Slayer XP if killed on task, keeping it a steady revenant-loot pillar alongside emblems, medallions, and statuettes."
+  market_strategy:
+    notes:
+      - "Steady supply from revenant farming; price floored by Emblem Trader payout"
+      - "Acts as one of the headline revenant loot drops alongside emblems"
+      - "Demand stays high from PKers and PvMers selling on the GE for convenience"
+  trading_tips:
+    - "Compare GE offers against the Emblem Trader payout to choose the better exit"
+    - "Stockpile during Wilderness rework discussions; payouts can shift with updates"
+  history:
+    - date: "2017-08-10"
+      description: "Released with the Revenant Caves update inside the Wilderness."
+    - date: "2019-04-25"
+      description: "Emblem Trader payout adjusted as part of the revenant loot rebalance."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/annihilation-blueprints.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/annihilation-blueprints.mdx
@@ -12,9 +12,40 @@ osrs:
   lowalch: null
   highalch: null
   limit: 5
-  about: "Annihilation blueprints is a members-only item in Old School RuneScape. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: misc
+    tier: high
+  properties:
+    release_date: "2024-12-04"
+    update: "Wilderness Boss Rework"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Read
+      - Use
+      - Drop
+    alchable: false
+    destroy: Drop
+  about: "Annihilation blueprints unlock the Wilderness-themed Player-Owned House decoration when redeemed at an estate agent. Obtained as a rare reward from Wilderness bosses."
+  market_strategy:
+    notes:
+      - "Investment Notes"
+      - "Low GE limit of 5 per 4 hours restricts flipping volume."
+      - "Demand driven by POH cosmetic collectors."
+      - "Supply tied to Wilderness boss kill counts."
+  trading_tips:
+    - "Niche cosmetic item — price volatility on low volume."
+    - "Use Grand Exchange for secure trades."
+  history:
+    - date: "2024-12-04"
+      update: "Wilderness Boss Rework"
+      description: "Annihilation blueprints released as a Wilderness boss drop for POH theming."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-1-12919.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-venom-1-12919.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 44
   highalch: 66
   limit: 2000
-  about: "Anti-venom+(1) is a members-only item in Old School RuneScape. High alchemy value: 66 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2015-07-09"
+    update: "Hunter and Other Improvements"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  potion:
+    effects:
+      - description: "Cures venom and grants venom immunity for 3 minutes."
+        duration: 180
+  recipes:
+    - skill: herblore
+      level: 94
+      xp: 30
+      materials:
+        - item_name: Anti-venom+ (4)
+          quantity: 1
+      tools:
+        - Vial
+      output_quantity: 1
+  about: "Anti-venom+(1) is a 1-dose super antivenom potion that cures venom and grants 3 minutes of venom immunity. Used widely at venomous bosses like Zulrah and Vorkath."
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "High alch 66 gp vs typical GE price — alching is unprofitable."
+      - "Decant 4-dose into smaller doses for tighter spreads."
+      - "Demand spikes with Zulrah and Vorkath kill counts."
+  trading_tips:
+    - "Bulk consumed by venom-immune PvM grinds."
+    - "GE buy limit 2,000 per 4 hours."
+  history:
+    - date: "2015-07-09"
+      update: "Hunter and Other Improvements"
+      description: "Anti-venom+ released alongside the Anti-venom potion rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antipoison-mix-2.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 2000
-  about: "Antipoison mix(2) is a members-only item in Old School RuneScape. High alchemy value: 129 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2004-08-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Cures poison and grants poison immunity."
+        duration: 90
+      - description: "Heals 3 Hitpoints on consumption."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 50
+      xp: 30
+      materials:
+        - item_name: Antipoison(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Antipoison(2)
+      slug: antipoison-2
+      relationship: component
+      description: Base two-dose antipoison mixed with caviar to produce the fishy variant.
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore secondary used to brew the mix.
+    - item_name: Antipoison mix(1)
+      slug: antipoison-mix-1
+      relationship: variant
+      description: One-dose version of the same Barbarian potion.
+  about: "Antipoison mix(2) is the two-dose Barbarian Herblore variant of the antipoison potion, adding a 3 HP heal on each drink while preserving 90 seconds of poison immunity. Brewed at 50 Herblore with an antipoison(2) and caviar after completing the Fishing chapter of Barbarian Training."
+  market_strategy:
+    notes:
+      - "Profit follows caviar price; tracks Barbarian secondary inversely"
+      - "Niche demand from PvM/slayer accounts wanting extra HP per inventory slot"
+      - "Buy limit of 2,000 supports steady Herblore-XP flips"
+  trading_tips:
+    - "Buy caviar during weekday lulls and mix when GE volume thins"
+    - "Sell ahead of poison-heavy slayer task spikes"
+  history:
+    - date: "2004-08-31"
+      description: "Released with Barbarian Training Herblore mixes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arceuus-library-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arceuus-library-teleport-tablet.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Arceuus library teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: tablet
+    tier: low
+  properties:
+    release_date: "28 April 2021"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 6
+      xp: 10
+      action: Cast at an Arceuus lectern
+      materials:
+        - item_name: Dark essence block
+          quantity: 1
+        - item_name: Law rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 2
+      tools:
+        - Lectern (Arceuus)
+      output_quantity: 1
+  related_items:
+    - item_name: Dark essence block
+      slug: dark-essence-block
+      relationship: component
+      description: "Arceuus substrate replacing soft clay for tablet creation"
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: "Teleport rune required for the tablet"
+    - item_name: Earth rune
+      slug: earth-rune
+      relationship: component
+      description: "Catalyst rune for the Arceuus library teleport spell"
+    - item_name: Battlefront teleport (tablet)
+      slug: battlefront-teleport-tablet
+      relationship: alternative
+      description: "Another Arceuus lectern teleport tablet"
+  about: "Arceuus library teleport (tablet) is an Arceuus spellbook tablet that teleports the user to the Arceuus Library. Made at an Arceuus lectern with one dark essence block, one law rune, and two earth runes at Magic 6 for 10 XP, it provides a quick stackable shortcut for Master librarian book deliveries and library Hunter contracts."
+  market_strategy:
+    notes:
+      - "High volume daily turnover driven by Arceuus library book runs"
+      - "Tied to dark essence block farming; supply shocks ripple through tablet price"
+      - "Buy limit 10,000 per 4 hours supports bulk consumption"
+  trading_tips:
+    - "Compare against dark essence + law + earth rune cost to gauge production margin"
+    - "Stockpile during Arceuus content updates that drive library traffic"
+  history:
+    - date: "28 April 2021"
+      description: "Released as part of the Arceuus library and lectern teleport rework"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-brew-3.mdx
@@ -12,9 +12,59 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 2000
-  about: "Armadyl brew(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2024-08-21"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: Drop
+  potion:
+    effects:
+      - description: "Restores Prayer points equal to 10 + 25% of current Prayer level."
+        duration: 0
+      - description: "Boosts Magic level by 4 and Defence by 2."
+        duration: 60
+      - description: "Drains Attack, Strength, and Ranged by 2."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 88
+      xp: 180
+      materials:
+        - item_name: Armadyl brew (4)
+          quantity: 1
+      tools:
+        - Vial
+      output_quantity: 1
+  about: "Armadyl brew(3) is a 3-dose Armadyl brew, a high-level Herblore potion that restores Prayer and boosts Magic and Defence at the cost of Attack, Strength, and Ranged."
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "High alch 102 gp vs typical 3-dose GE price — alching is usually unprofitable."
+      - "Decant 4-dose into 3/2/1 doses for finer market arbitrage."
+      - "Heavily consumed at Vorkath, Tombs of Amascut, and inferno prep."
+  trading_tips:
+    - "Demand spikes around new Magic-heavy PvM content."
+    - "GE buy limit 2,000 per 4 hours."
+  history:
+    - date: "2024-08-21"
+      update: "Varlamore: The Final Dawn"
+      description: "Armadyl brew released with the final Varlamore update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-page-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-page-4.mdx
@@ -12,31 +12,33 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 5
-  item:
-    type: god_page
+  material:
+    type: paper
+    tier: god_page
+  properties:
     god: Armadyl
     page_number: 4
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite
-        drop_rate: Varies by tier
+  drop_table:
+    sources:
+      - source: Treasure Trails (Hard/Elite)
+        quantity: "1"
+        rarity: Varies by tier
   related_items:
     - item_id: 12617
       item_name: Armadyl page 1
       slug: armadyl-page-1
-      relationship: set-piece
+      relationship: variant
       description: Page 1 of 4
     - item_id: 12618
       item_name: Armadyl page 2
       slug: armadyl-page-2
-      relationship: set-piece
+      relationship: variant
       description: Page 2 of 4
     - item_id: 12619
       item_name: Armadyl page 3
       slug: armadyl-page-3
-      relationship: set-piece
+      relationship: variant
       description: Page 3 of 4
   about: |-
     | Property | Value |
@@ -47,8 +49,8 @@ osrs:
     | Tradeable | Yes |
 
     Add to incomplete Book of law (Armadyl god book) to complete it.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-platelegs.mdx
@@ -12,9 +12,18 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: rune
+    tier: mid
+  properties:
+    release_date: "2007-12-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: false
   about: "Armadyl platelegs is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-set-sk.mdx
@@ -13,8 +13,16 @@ osrs:
   highalch: 2700
   limit: 8
   about: "Black set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 2,700 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: mid
+  properties:
+    release_date: "2007-12-04"
+    options:
+      - Examine
+    worn_options: []
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-anglerfish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blighted-anglerfish.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 10000
-  about: "Blighted anglerfish is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: blighted-food
+    tier: high
+  properties:
+    release_date: "2019-08-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Justine's Stuff for the Last Shopper Standing
+      location: Ferox Enclave
+      price: 1300
+      stock: 0
+  related_items:
+    - item_name: Anglerfish
+      slug: anglerfish
+      relationship: variant
+      description: Non-blighted version eaten anywhere in Gielinor.
+    - item_name: Blighted manta ray
+      slug: blighted-manta-ray
+      relationship: alternative
+      description: Lower-tier blighted food for Wilderness consumption.
+    - item_name: Blighted karambwan
+      slug: blighted-karambwan
+      relationship: alternative
+      description: Blighted combo food for tick-eating in the Wilderness.
+    - item_name: Raw anglerfish
+      slug: raw-anglerfish
+      relationship: component
+      description: Cooked into anglerfish before being blighted.
+  about: "Blighted anglerfish is a Wilderness-only food obtained from the Last Man Standing Bounty Hunter shop in Ferox Enclave, healing up to 22 HP based on the eater's level. Purchasable for 1,300 coins via Bounty Hunter points or 240 Last Man Standing points, it gives PKers and Wilderness slayers anglerfish-tier healing without flooding the regular GE supply since it cannot be eaten outside the Wilderness."
+  market_strategy:
+    notes:
+      - "Demand follows PKing meta and Wilderness PvM popularity"
+      - "Supply is point-shop gated; bulk buys move price more than typical foods"
+      - "Buy limit of 10,000 supports large PK restock orders"
+  trading_tips:
+    - "Stockpile during Bounty Hunter or LMS update windows"
+    - "Watch Wilderness boss release cadence for spike windows"
+  history:
+    - date: "2019-08-08"
+      description: "Released with the blighted supplies update for Wilderness PvP and PvM."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-chestplate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-chestplate.mdx
@@ -12,9 +12,13 @@ osrs:
   lowalch: 116004
   highalch: 174006
   limit: 15
+  material:
+    type: blood-moon
+    tier: high
   equipment:
     slot: body
     weight: 5.443
+    attack_speed: 4
     attack_bonus:
       stab: 0
       slash: 0
@@ -62,6 +66,9 @@ osrs:
       slug: blood-moon-tassets
       relationship: set-piece
       description: Leg armour in set
+  passive_effects:
+    - name: Bloodrager
+      description: "When wearing the full Blood moon set with the Dual macuahuitl: 33% chance on a successful hit to attack one tick earlier."
   about: |-
     When wearing the full Blood moon armour set with the Dual macuahuitl:
     - Bloodrager: 33% chance upon successful hit to attack one tick earlier
@@ -80,11 +87,35 @@ osrs:
     - High ranged defence (+79)
   market_strategy:
     notes:
-      - Core piece for Blood moon builds
-      - Good standalone defensive option
-      - Factor in repair costs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Investment Notes"
+      - "Core piece for Blood moon builds."
+      - "Good standalone defensive body slot option."
+      - "Factor in 1.5M NPC repair cost when costing per-trip."
+  trading_tips:
+    - "Lunar Chest supply: drop rate 1/224 from Neypotzli."
+    - "Hold across content droughts; demand spikes on new melee boss releases."
+  history:
+    - date: "2024-07-24"
+      description: "Blood moon chestplate added with Varlamore: The Final Dawn (Neypotzli)."
+  properties:
+    release_date: "2024-07-24"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blood-moon-helm.mdx
@@ -12,9 +12,24 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: blood-moon
+    tier: high
+  properties:
+    release_date: "2024-05-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: false
   equipment:
     slot: head
+    attack_speed: 4
     weight: 1
+    requirements:
+      strength: 75
+      defence: 50
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,9 +47,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      strength: 75
-      defence: 50
     degradable: true
     charges: 3000
   drop_table:
@@ -80,11 +92,9 @@ osrs:
     - Melee DPS optimization
   market_strategy:
     notes:
-      - Value tied to full set synergy
-      - Factor in repair costs
-      - Part of Varlamore content
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Value tied to full set synergy"
+      - "Factor in repair costs"
+      - "Part of Varlamore content"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-d-hide-vambraces.mdx
@@ -12,19 +12,21 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
+  material:
+    type: hide
+    tier: blue_dragonhide
   equipment:
     slot: hands
     type: ranged_armour
-    ranged_requirement: 50
-    defence_requirement: 40
-  attack_bonuses:
-    ranged: 9
-  defence_bonuses:
-    ranged: 8
-    magic: 5
-  crafting:
-    level: 66
-    xp: 70
+    attack_speed: 4
+    requirements:
+      ranged: 50
+      defence: 40
+    attack_bonus:
+      ranged: 9
+    defence_bonus:
+      ranged: 8
+      magic: 5
   recipes:
     - skill: crafting
       level: 66
@@ -38,7 +40,7 @@ osrs:
           quantity: 1
       product: Blue d'hide vambraces
       product_id: 2487
-      product_quantity: 1
+      output_quantity: 1
       facility: Needle and thread
       members_only: true
   related_items:
@@ -55,22 +57,22 @@ osrs:
     - item_id: 2499
       item_name: Blue d'hide body
       slug: blue-dhide-body
-      relationship: alternative
+      relationship: variant
       description: Matching body
     - item_id: 2493
       item_name: Blue d'hide chaps
       slug: blue-dhide-chaps
-      relationship: alternative
+      relationship: variant
       description: Matching legs
     - item_id: 1065
       item_name: Green d'hide vambraces
       slug: green-dhide-vambraces
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier vambraces
     - item_id: 2489
       item_name: Red d'hide vambraces
       slug: red-dhide-vambraces
-      relationship: alternative
+      relationship: upgrade
       description: Higher tier vambraces
   about: |-
     | Method | Level | Materials |
@@ -87,17 +89,17 @@ osrs:
     | Magic defence | +5 |
   market_strategy:
     notes:
-      - Second dragonhide glove tier
-      - Members only
-      - Popular crafting item
-      - Crafting training (70 XP)
-      - Mid-level ranged armor
-      - Budget gear
-      - 1 leather per vambraces
-      - Fast crafting method
-      - Lowest level in blue set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Second dragonhide glove tier"
+      - "Members only"
+      - "Popular crafting item"
+      - "Crafting training: 70 XP"
+      - "Mid-level ranged armor"
+      - "Budget gear"
+      - "1 leather per vambraces"
+      - "Fast crafting method"
+      - "Lowest level in blue set"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/body-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/body-talisman.mdx
@@ -12,9 +12,40 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Body talisman is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: talisman
+    tier: low
+  properties:
+    release_date: "2001-03-27"
+    update: "Runecrafting"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    options:
+      - Locate
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  about: "Body talisman allows access to the Body altar for crafting Body runes. Common F2P Runecrafting talisman with low GE value."
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "High alch 2 gp — alching is unprofitable."
+      - "High GE limit of 11,000 supports bulk flipping."
+      - "Supply driven by monster drops and Runecrafting demand."
+  trading_tips:
+    - "Cheap Runecrafting unlock for early Body rune crafting."
+    - "Margins are slim — focus on volume."
+  history:
+    - date: "2001-03-27"
+      update: "Runecrafting"
+      description: "Body talisman released with the Runecrafting skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-canvas.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-canvas.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 13000
-  about: "Bolt of canvas is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: crafting_material
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    weight: 1
+    quest_item: false
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: crafting
+      level: 39
+      xp: 75
+      materials:
+        - item_name: Hemp yarn
+          item_id: 31470
+          quantity: 2
+      product: Bolt of canvas
+      product_id: 31475
+      output_quantity: 1
+      facility: Loom
+      members_only: true
+  related_items:
+    - item_id: 31470
+      item_name: Hemp yarn
+      slug: hemp-yarn
+      relationship: component
+      description: Loom input for the canvas bolt
+    - item_id: 31480
+      item_name: Sails
+      slug: sails
+      relationship: product
+      description: Used to construct boat sails (Raft, Skiff, Sloop)
+    - item_id: 31490
+      item_name: Gem satchel
+      slug: gem-satchel
+      relationship: product
+      description: Crafted from canvas for gem storage
+  market_strategy:
+    notes:
+      - "Sailing skill input drives core demand"
+      - "Supply hinges on hemp yarn farming"
+      - "Boat-sail crafting consumes large bulk volume"
+      - "New skill content creates fluctuating early-cycle prices"
+  trading_tips:
+    - "Buy strategy: scale into bolts during hemp yarn price dips"
+    - "Demand: sails for Raft/Skiff/Sloop set a recurring floor"
+    - "Risk: Sailing update tuning can shift recipe requirements mid-cycle"
+  history:
+    - date: "2025-11-19"
+      description: "Release: added with the Sailing skill launch as a crafted loom product"
+  about: "Bolt of canvas is a Sailing-era Crafting product woven on a loom from 2 hemp yarn at 39 Crafting for 75 XP. Used to construct boat sails for Rafts, Skiffs, and Sloops, plus the gem satchel. High alchemy value: 60 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bottle-of-wine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bottle-of-wine.mdx
@@ -12,9 +12,51 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 10000
-  about: "Bottle of wine is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "2006-04-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: Wine Shop
+      location: Draynor Village
+      price: 500
+      currency: Coins
+      stock: 2
+  drop_table:
+    sources:
+      - source: Wine stall (Thieving level 22)
+        quantity: "1"
+        rarity: 11/100
+  passive_effects:
+    - name: Drink
+      description: "Restores 14 Hitpoints but temporarily lowers Attack by 3; produces an empty wine bottle when drunk."
+  about: "Bottle of wine is a members drink sold at Fortunato's Wine Shop in Draynor Village. Used for thieving training and minor self-healing."
+  market_strategy:
+    notes:
+      - "Restocks every 15 minutes at the Draynor wine shop"
+      - "Useful for Thieving training via the wine stall"
+  trading_tips:
+    - "Buy limit: 10,000 per 4 hours"
+    - Shop price often undercuts the Grand Exchange when stock is available
+  history:
+    - date: "2006-04-10"
+      description: Item released
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-slaughter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bracelet-of-slaughter.mdx
@@ -12,76 +12,99 @@ osrs:
   lowalch: 1000
   highalch: 1500
   limit: 15000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: enchanted_jewellery
+    tier: mid
+  properties:
+    release_date: "2017-02-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Wear
+      - Check
+      - Break
+      - Drop
+    worn_options:
+      - Check
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
-    type: slayer_bracelet
-    tradeable: true
-    weight: 0.007
-    charges: 30
-  creation:
-    method: Enchant Topaz bracelet with Lvl-3 Enchant
-    requirements:
-      magic: 49
-    runes:
-      - rune: Cosmic
-        quantity: "1"
-      - rune: Fire
-        quantity: "5"
-  special_effect:
-    name: Slayer Extension
-    description: 25% chance to not count kill toward task
-    charges: 30
-    notes:
-      - Still grants XP
-      - "Elite CA: 10% recharge chance"
-  market:
-    buy_limit: 15000
-    price_estimate: 6400
+    weapon_type: null
+    attack_speed: null
+    weight: 0.25
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: magic
+      level: 49
+      xp: 59
+      materials:
+        - item_name: Topaz bracelet
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Fire rune
+          quantity: 5
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Slayer Extension
+      description: "25% chance per kill to prevent the slayer task count from being decremented; still grants Slayer XP. 30 charges before depletion."
   related_items:
-    - item_id: 21177
-      item_name: Expeditious bracelet
+    - item_name: Expeditious bracelet
       slug: expeditious-bracelet
       relationship: alternative
-      description: Task shortening
-    - item_id: 11864
-      item_name: Slayer helmet
+      description: "Alternative slayer bracelet: shortens tasks rather than extending them"
+    - item_name: Slayer helmet
       slug: slayer-helmet
       relationship: alternative
-      description: Slayer gear
-    - item_id: 11085
-      item_name: Topaz bracelet
+      description: Core slayer gear worn in the head slot
+    - item_name: Topaz bracelet
       slug: topaz-bracelet
       relationship: component
-      description: Base item
-  about: |-
-    Enchant Topaz bracelet with Lvl-3 Enchant.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Magic | 49 |
-    | Cosmic rune | 1 |
-    | Fire rune | 5 |
-
-    All bonuses +0
-
-    Slayer Extension:
-    - 25% chance to not count kill
-    - Still grants XP
-    - 30 charges
-
-    Essential for:
-    - Extending good tasks
-    - Superior spawn chances
-    - Slayer point efficiency
-
-    Extends profitable slayer tasks.
+      description: Base bracelet enchanted with Lvl-3 Enchant to create this item
+  about: "Bracelet of slaughter is an enchanted Topaz bracelet that occasionally prevents Slayer task kills from counting, extending profitable tasks. Created with 49 Magic via Lvl-3 Enchant."
   market_strategy:
     notes:
-      - "Elite CA: 10% recharge chance"
-      - Only for tasks you like
-      - Cheap and effective
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Elite Combat Achievements grant a 10% recharge chance on activation"
+      - "Reserve for high-value slayer tasks worth extending"
+      - "Cheap to produce relative to slayer profit gains"
+  trading_tips:
+    - "Buy limit: 15,000 per 4 hours"
+    - Stack multiple bracelets for long slayer trips
+  history:
+    - date: "2017-02-02"
+      description: "Item released"
+    - date: "2017-02-09"
+      description: '"Break" option added to the inventory menu'
+    - date: "2017-02-16"
+      description: Inventory sprite rotated for visual consistency
+    - date: "2020-08-06"
+      description: Grammar tweaks applied to examine text
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-halberd.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 125
-  about: "Bronze halberd is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: 2h
+    weapon_type: polearm
+    attack_speed: 7
+    weight: 3.175
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 4
+      slash: 7
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 2
+      crush: 3
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Quartermaster's Stores
+      location: Tyras Camp
+      price: 104
+      currency: coins
+      members_only: true
+  related_items:
+    - item_id: 3192
+      item_name: Iron halberd
+      slug: iron-halberd
+      relationship: upgrade
+      description: Stronger iron-tier halberd
+  about: "Bronze halberd is a members two-handed polearm with a 2 tile reach and 7-tick attack speed, sold by the Quartermaster's Stores in Tyras Camp. The lowest tier of the halberd family, it requires no levels to wield."
+  market_strategy:
+    notes:
+      - "Shop price tracks the Grand Exchange listing closely"
+      - "Niche demand from collectors and very-low-level pures"
+      - "Limited daily volume due to low buy limit"
+  history:
+    - date: "2004-09-20"
+      update: Halberd Update
+      description: "Bronze halberd released alongside other tier halberds."
+  properties:
+    release_date: "2004-09-20"
+    update: Halberd Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 3.175
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-sap.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-sap.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 15
-  about: "Bucket of sap is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ingredient
+    tier: low
+  recipes:
+    - skill: woodcutting
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Bucket
+          quantity: 1
+        - item_name: Knife
+          quantity: 1
+      tools:
+        - Evergreen tree
+      output_quantity: 1
+  related_items:
+    - item_name: Bucket
+      slug: bucket
+      relationship: component
+      description: Empty bucket used with a knife on an evergreen
+    - item_name: Snake hide
+      slug: snake-hide
+      relationship: alternative
+      description: Companion ingredient in Nature Spirit quest steps
+  about: "Bucket of sap is obtained by using a knife on an evergreen tree while holding a bucket. It is primarily required for the Nature Spirit quest and as a Slayer component for blessing silver sickles."
+  market_strategy:
+    notes:
+      - "Niche demand driven by quest and Slayer prep"
+      - "Very low buy limit at 15 per 4 hours"
+      - "Players can self-gather quickly, capping resale interest"
+  trading_tips:
+    - "Stock during Nature Spirit guide surges"
+    - "Compare GE price against the self-gather opportunity cost"
+  history:
+    - date: "2003-12-15"
+      description: "Released alongside the Nature Spirit quest."
+  properties:
+    release_date: "2003-12-15"
+    update: Nature Spirit
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    quest: Nature Spirit
+    weight: 1.36
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-wax.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bucket-of-wax.mdx
@@ -12,6 +12,19 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: organic
+    tier: basic
+  properties:
+    release_date: "2002-08-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    options:
+      - drop
   related_items:
     - item_id: 28
       item_name: Insect repellent
@@ -22,8 +35,6 @@ osrs:
     > _"It's a bucket of wax."_
 
     A bucket of wax is a members-only quest item. Used in Merlin's Crystal (given to the candle maker in Catherby to create a black candle) and Troll Romance (combined with swamp tar and cake tin to wax a sled).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cake.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cake.mdx
@@ -12,9 +12,90 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 6000
-  about: "Cake is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.3
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 40
+      xp: 180
+      materials:
+        - item_name: Uncooked cake
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  shops:
+    - shop_name: Ardougne Baker's Stall
+      location: East Ardougne
+      price: 50
+      currency: Coins
+      stock: 3
+    - shop_name: Keldagrim's Best Bread
+      location: Keldagrim
+      price: 75
+      currency: Coins
+      stock: 3
+    - shop_name: Prifddinas Foodstuffs
+      location: Prifddinas
+      price: 50
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Uncooked cake
+      slug: uncooked-cake
+      relationship: component
+      description: "Raw input cooked at level 40 Cooking"
+    - item_name: 2/3 cake
+      slug: 2-3-cake
+      relationship: downgrade
+      description: "Result of taking one bite of a full cake"
+    - item_name: Slice of cake
+      slug: slice-of-cake
+      relationship: downgrade
+      description: "Final bite stage of the cake"
+    - item_name: Chocolate cake
+      slug: chocolate-cake
+      relationship: variant
+      description: "Chocolate-coated variant with higher heal value"
+    - item_name: Burnt cake
+      slug: burnt-cake
+      relationship: alternative
+      description: "Result of a failed cake cook"
+  about: |-
+    Plain sponge cake restoring 12 Hitpoints across three bites of 4 HP each. Cooked from an uncooked cake at level 40 Cooking on a range for 180 xp; success rate climbs with Cooking level and is guaranteed at level 74+. Stealing one from the Ardougne Baker's Stall counts toward the Ardougne easy diary.
+  market_strategy:
+    notes:
+      - "Free-to-play food with steady low-tier demand"
+      - "GE prices often undercut by shop runs in Ardougne and Prifddinas"
+      - "Bulk buyers favour uncooked cake for Cooking xp instead"
+      - "Diary-locked thieving keeps F2P supply modest"
+  trading_tips:
+    - "Compare GE price against shop stock to find arbitrage windows"
+    - "Cake heals 12 HP total but only across 3 bites - inferior to single-bite alternatives"
+    - "GE limit of 6,000 leaves room for bulk flips"
+  history:
+    - date: "2001-06-11"
+      description: "Released as part of early Cooking content"
+    - date: "2009-12-01"
+      description: "Inventory icon updated alongside many Cooking items"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cannon-base.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cannon-base.mdx
@@ -12,6 +12,17 @@ osrs:
   lowalch: 75000
   highalch: 112500
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: quest-item
+    tier: mid
+  properties:
+    release_date: "2002-03-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: true
   related_items:
     - item_id: 8
       item_name: Cannon stand
@@ -32,8 +43,6 @@ osrs:
     > _"The cannon is built on this."_
 
     The cannon base is the first component placed when setting up a dwarf multicannon. Requires completion of the Dwarf Cannon quest to use. All four cannon parts must be placed in order: base, stand, barrels, furnace. Tradeable on the Grand Exchange.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/carved-oak-bench-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/carved-oak-bench-flatpack.mdx
@@ -12,9 +12,36 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Carved oak bench (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: flatpack
+    tier: oak
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    options:
+      - drop
+  recipes:
+    - skill: construction
+      level: 38
+      xp: 240
+      materials:
+        - item_name: Oak plank
+          quantity: 4
+      output_quantity: 1
+      notes: "Built on a Workbench 2 or higher in the Workshop"
+  related_items:
+    - item_id: 8537
+      item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Required material to flatpack
+  about: |-
+    A flatpacked version of the carved oak bench. Used by players to build furniture in another player's house, or sold to the Grand Exchange for profit when training Construction.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/carved-teak-table-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/carved-teak-table-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Carved teak table (flatpack) | OSRS Price Data
-description: "Carved teak table (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Carved teak table (flatpack) is a members construction flatpack requiring 45 Construction to make. High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8556
   name: Carved teak table (flatpack)
@@ -12,9 +12,87 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Carved teak table (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: teak
+  equipment:
+    slot: null
+    weight: null
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: construction
+      level: 45
+      xp: 600
+      materials:
+        - item_name: Teak plank
+          quantity: 6
+        - item_name: Bolt of cloth
+          quantity: 4
+      output_quantity: 1
+      notes: "Flatpacked at a steel framed workbench using a hammer and saw."
+  related_items:
+    - item_name: Teak table (flatpack)
+      slug: teak-table-flatpack
+      relationship: alternative
+      description: Lower-tier teak dining table flatpack.
+    - item_name: Mahogany table (flatpack)
+      slug: mahogany-table-flatpack
+      relationship: upgrade
+      description: Higher-tier mahogany dining table flatpack.
+    - item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Primary construction material used to flatpack this table.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Sold by construction trainers using steel framed workbench unlock."
+      - "Demand driven by cheap construction XP for low-level players."
+      - "Buy limit of 500 per 4 hours allows moderate flips."
+  trading_tips:
+    - "Compare plank cost vs flatpack price: profit hinges on teak plank supply."
+    - Buy in bulk for resale during construction skill events.
+    - "Watch GE tax: small margin items get eroded quickly."
+  about: Carved teak table (flatpack) is a members-only construction flatpack used to instantly build a Carved teak table in a player-owned house dining room, popular with Construction trainers.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2006-05-31"
+    update: "PLAYER-OWNED HOUSES!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2006-05-31"
+      update: "PLAYER-OWNED HOUSES!"
+      description: Carved teak table flatpack released with the Construction skill update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/celastrus-bark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/celastrus-bark.mdx
@@ -15,21 +15,29 @@ osrs:
   material:
     type: farming_product
     tier: high
-  farming:
-    level: 85
-    xp: 0
-    source: Celastrus tree
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    weight: 1
+    quest_item: false
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
   recipes:
     - skill: fletching
       level: 40
-      xp: 6
+      xp: 80
       materials:
         - item_name: Celastrus bark
           item_id: 22935
           quantity: 1
       product: Battlestaff
       product_id: 1391
-      product_quantity: 1
+      output_quantity: 1
       members_only: true
   related_items:
     - item_id: 22869
@@ -53,26 +61,22 @@ osrs:
       relationship: component
       description: For air battlestaff
   market_strategy:
-    title: Battlestaff Chain
-    steps:
-      - order: 1
-        action: Grow celastrus tree (85 Farming)
-      - order: 2
-        action: Harvest bark
-      - order: 3
-        action: Fletch into battlestaff
-      - order: 4
-        action: Attach orb for elemental staff
-      - order: 5
-        action: Alch or sell
     notes:
-      - Celastrus trees are profitable to grow
-      - Multiple bark per harvest
-      - Consistent supply from farming runs
-      - Compare bark + fletching vs buying battlestaves from Zaff
-      - Zaff's stock is limited daily
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Celastrus trees are profitable to grow"
+      - "Minimum 3 bark per harvest"
+      - "Consistent supply from farming runs"
+      - "Compare bark + fletching vs buying battlestaves from Zaff"
+      - "Zaff's stock is limited daily"
+  trading_tips:
+    - "Buy strategy: stock during farming-run waves when supply spikes"
+    - "Margin: bark to battlestaff fletch margin tends to beat raw bark flips"
+    - "Risk: Zaff's daily 64 battlestaves cap the upside on battlestaff prices"
+  history:
+    - date: "2019-01-10"
+      description: "Release: added with the Farming Guild expansion alongside celastrus trees"
+  about: "Celastrus bark is a Farming product harvested from celastrus trees at 85 Farming. Fletched into battlestaves at 40 Fletching for 80 XP each. High alchemy value: 270 coins. Grand Exchange buy limit: 12,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chaos-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chaos-rune.mdx
@@ -12,105 +12,95 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 18000
-  rune:
-    type: combat
-  runecraft:
-    level: 35
-    xp: 8.5
-    multiple_at: 74
-    altar: Chaos Altar
-    altar_location: Wilderness (level 9)
-    essence_type: pure
-  shops:
-    - shop_name: Rune shops
-      stock: Limited
-      price: 140
-  drop_table:
-    sources:
-      - source: Chaos druids
-        combat_level: 13
-        quantity: "3"
-        rarity: common
-        members_only: true
-      - source: Barrows
-        combat_level: 0
-        quantity: Variable
-        rarity: uncommon
-        members_only: true
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: rune
+    tier: mid
+  properties:
+    release_date: "2001-05-24"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: runecraft
       level: 35
       xp: 8.5
       materials:
         - item_name: Pure essence
-          item_id: 7936
           quantity: 1
-      product: Chaos rune
-      product_id: 562
-      product_quantity: 1
-      facility: Chaos altar
-      members_only: true
+      tools:
+        - Chaos talisman
+      output_quantity: 1
+  shops:
+    - shop_name: Aubury's Rune Shop
+      location: Varrock
+      price: 140
+      currency: coins
+      stock: 1000
+    - shop_name: Betty's Magic Emporium
+      location: Port Sarim
+      price: 140
+      currency: coins
+      stock: 1000
+  drop_table:
+    sources:
+      - source: Chaos druid
+        quantity: "1"
+        rarity: 1/3
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: uncommon
+      - source: Barrows chest
+        quantity: "1"
+        rarity: 1/14
   related_items:
-    - item_id: 560
-      item_name: Death rune
+    - item_name: Death rune
       slug: death-rune
       relationship: upgrade
-      description: Upgrade from chaos
-    - item_id: 565
-      item_name: Blood rune
+      description: "Higher tier combat rune for blast spells"
+    - item_name: Blood rune
       slug: blood-rune
       relationship: upgrade
-      description: High-tier combat
-    - item_id: 558
-      item_name: Mind rune
+      description: "High-tier combat rune for ancient spells"
+    - item_name: Mind rune
       slug: mind-rune
       relationship: downgrade
-      description: Budget option
-    - item_id: 554
-      item_name: Fire rune
+      description: "Lower tier combat rune for strike spells"
+    - item_name: Fire rune
       slug: fire-rune
       relationship: component
-      description: Fire Bolt combo
-    - item_id: 1409
-      item_name: Iban's staff
-      slug: ibans-staff
-      relationship: alternative
-      description: Uses chaos runes
+      description: "Paired with chaos runes in fire bolt and god spells"
+    - item_name: Pure essence
+      slug: pure-essence
+      relationship: component
+      description: "Crafted into chaos runes at the Chaos Altar"
   about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Runecraft Level | 35 |
-    | XP per rune | 8.5 |
-    | Runes per essence | 1 (2 at 74) |
-    | Abyss recommended | Yes |
-
-    Multipliers:
-    - Level 74: 2x runes
-
-    | Spell | Chaos Runes | Other Runes |
-    |-------|-------------|-------------|
-    | Wind Bolt | 1 | 2 Air |
-    | Water Bolt | 1 | 2 Air, 2 Water |
-    | Earth Bolt | 1 | 2 Air, 3 Earth |
-    | Fire Bolt | 1 | 3 Air, 4 Fire |
-    | Crumble Undead | 2 | 2 Air, 2 Earth |
-    | Iban Blast | 1 | 5 Fire (Iban staff) |
-    | Saradomin Strike | 2 | 4 Fire, 2 Blood |
+    Chaos rune powers low-level missile spells including the four elemental bolts. Members craft them at 35 Runecraft via the Wilderness Chaos Altar from pure essence for 8.5 XP each, doubling output at 74 Runecraft. Free players can buy from magic shops and pick up Wilderness spawns.
   market_strategy:
     notes:
-      - Bolt spells primary use
-      - Ironman training popular
-      - Wilderness chaos altar
-      - Fire Bolt training
-      - God spells (Mage Arena)
-      - Early-game Magic
-      - Ironman accounts
-      - Chaos druids drop frequently
-      - Wilderness altar doubles
-      - Bolt spells for Slayer
-      - Lower demand at high levels
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Core ammunition rune for bolt spells and god spells"
+      - "Chaos druids in Edgeville Dungeon drop at common rarity"
+      - "Wilderness Chaos Altar doubles output at 74 Runecraft"
+      - "Steady demand for early-mid Magic training and Slayer"
+  trading_tips:
+    - "Crash dips after bot wave bans, rebound is consistent"
+    - "Watch Mage Arena and Slayer task spikes for short flips"
+    - "Combo with fire rune for Fire Bolt training stockpiles"
+  history:
+    - date: "2001-05-24"
+      description: "Chaos rune released with the original Runecraft skill"
+    - date: "2004-03-29"
+      description: "Chaos altar accessibility expanded with Abyss update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chaos-tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chaos-tiara.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 40
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   about: "Chaos tiara is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chocolate-dust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chocolate-dust.mdx
@@ -12,34 +12,83 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  item:
-    type: material
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: secondary
+    tier: low
+  properties:
+    release_date: "2002-08-27"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.15
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Chocolate bar
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Chocolate bar
+          quantity: 1
+      tools:
+        - Pestle and mortar
+      output_quantity: 1
+  shops:
+    - shop_name: Funch's Fine Groceries
+      location: Grand Tree
+      price: 2
+      currency: coins
+      stock: 10
+    - shop_name: Grand Tree Groceries
+      location: Grand Tree
+      price: 2
+      currency: coins
+      stock: 10
   related_items:
-    - item_id: 1973
-      item_name: Chocolate bar
+    - item_name: Chocolate bar
       slug: chocolate-bar
       relationship: component
-      description: Source material
-    - item_id: 3010
-      item_name: Energy potion
+      description: "Source bar crushed into dust"
+    - item_name: Energy potion
       slug: energy-potion
-      relationship: alternative
-      description: Primary use
+      relationship: product
+      description: "Primary Herblore use as a secondary"
+    - item_name: Chocolate cake
+      slug: chocolate-cake
+      relationship: product
+      description: "Used as Cooking ingredient"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.15 kg |
-    | Requirements | None |
-
-    Secondary ingredient for energy potions.
-
-    Also used in various food recipes.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Chocolate dust is a Herblore secondary ingredient made by using a knife or pestle and mortar on a chocolate bar. It is the main secondary for energy potions and is also used in chocolate cake and chef's delight Cooking recipes.
+  market_strategy:
+    notes:
+      - "Herblore secondary for energy potions at 26 Herblore"
+      - "Profitable to buy bars at GE and crush for resale"
+      - "Wesley in Nardah crushes noted bars for 50 gp each"
+      - "Free-to-play accessible, stable demand"
+  trading_tips:
+    - "Track chocolate bar vs dust margin daily"
+    - "Use Wesley for bulk noted bar processing"
+    - "Sell during energy potion price spikes"
+  history:
+    - date: "2002-08-27"
+      description: "Chocolate dust added with the Herblore expansion"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/coconut-milk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/coconut-milk.mdx
@@ -15,6 +15,14 @@ osrs:
   material:
     type: herblore_base
     tier: mid
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Drink
+      - Drop
+    worn_options: []
   recipes:
     - skill: crafting
       level: 0
@@ -28,7 +36,7 @@ osrs:
           quantity: 1
       product: Coconut milk
       product_id: 5935
-      product_quantity: 1
+      output_quantity: 1
       byproduct: Coconut shell
       byproduct_id: 5978
       members_only: true
@@ -47,6 +55,7 @@ osrs:
           quantity: 1
       product: Antidote++(3)
       product_id: 5954
+      output_quantity: 1
       members_only: true
   related_items:
     - item_id: 5976
@@ -79,25 +88,22 @@ osrs:
     - 1 Coconut milk (vial)
     - 1 Coconut shell (supercompost material)
   market_strategy:
-    title: Profit Chain
-    steps:
-      - order: 1
-        action: Coconut (crack) -> Half coconut
-      - order: 2
-        action: Half coconut + Vial -> Coconut milk + Shell
-      - order: 3
-        action: Coconut milk -> Antidote++
     notes:
-      - Coconuts from palm tree farming
-      - Also from Tai Bwo Wannai cleanup
-      - Kingdom of Miscellania (hardwood workers)
-      - Coconut shell makes supercompost
-      - Added value from byproduct
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Coconuts from palm tree farming"
+      - "Also from Tai Bwo Wannai cleanup"
+      - "Kingdom of Miscellania (hardwood workers)"
+      - "Coconut shell makes supercompost"
+      - "Added value from byproduct"
+  trading_tips:
+    - "Step 1: Coconut crack into Half coconut"
+    - "Step 2: Half coconut plus Vial into Coconut milk plus Shell"
+    - "Step 3: Coconut milk into Antidote plus plus"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-bracelet-6.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-bracelet-6.mdx
@@ -12,9 +12,35 @@ osrs:
   lowalch: 8416
   highalch: 12624
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: jewellery
+    tier: mid
+  properties:
+    release_date: "30 April 2007"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Rub
+      - Drop
+    worn_options:
+      - Rub
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
+    weapon_type: null
+    attack_speed: null
     weight: 0.007
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,56 +58,38 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  charges:
-    current: 6
-    max: 6
-    recharge: Fountain of Rune
-  special_effect:
-    name: Combat Bracelet Teleport
-    description: Teleports to Warriors' Guild, Champions' Guild, Monastery, Ranging Guild
-    triggers: on_use
+  passive_effects:
+    - name: Combat Bracelet Teleport
+      description: "Teleports the wearer to Warriors' Guild, Champions' Guild, Edgeville Monastery, or Ranging Guild; this variant carries six charges obtained exclusively from the Fountain of Rune after Legends' Quest."
   related_items:
-    - item_id: 11126
-      item_name: Combat bracelet (uncharged)
+    - item_name: Combat bracelet (uncharged)
       slug: combat-bracelet
       relationship: variant
-      description: Uncharged version
-    - item_id: 11118
-      item_name: Combat bracelet(4)
+      description: "Uncharged version with no teleport charges"
+    - item_name: Combat bracelet(4)
       slug: combat-bracelet-4
       relationship: variant
-      description: 4 charge version
-    - item_id: 7462
-      item_name: Barrows gloves
+      description: "Four-charge version recharged at Legends'/Myths' Guild"
+    - item_name: Barrows gloves
       slug: barrows-gloves
       relationship: upgrade
-      description: Best-in-slot gloves
-  about: |-
-    No combat bonuses - utility item for teleportation.
-
-    - Warriors' Guild
-    - Champions' Guild
-    - Monastery (Edgeville)
-    - Ranging Guild
-
-    | State | Charges |
-    |-------|---------|
-    | Current | 6 |
-    | Maximum | 6 |
+      description: "Best-in-slot melee gloves"
+  about: "Combat bracelet(6) is the maximum-charge variant of the combat bracelet, granting six teleports to Warriors' Guild, Champions' Guild, Edgeville Monastery, or Ranging Guild. Charges are restored to six only at the Fountain of Rune (requires Legends' Quest); the standard Legends'/Myths' Guild recharge tops out at four. Slayer task progress is displayed when charged."
   market_strategy:
     notes:
-      - Maximum charges from Fountain of Rune
-      - More efficient than 4-charge version
-      - Popular for efficiency
-      - Warriors' Guild farming
-      - Combat training efficiency
-      - Ranging Guild access
-      - Maximum charge seekers
-      - Recharged at Fountain of Rune only for 6 charges
-      - More value per teleport than combat bracelet(4)
-      - Useful for defender farming runs
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Premium over the (4) variant tracks Fountain of Rune accessibility for endgame players"
+      - "Defender farmers prefer (6) for fewer recharge trips"
+      - "Partial charges are GE-locked since 2015, capping supply"
+  trading_tips:
+    - "Compare the (6) vs (4) spread against the Fountain of Rune trip time"
+    - "Watch dragonstone bracelet plus Lvl-5 Enchant cost as the long-term floor"
+  history:
+    - date: "30 April 2007"
+      description: "Released with the Fremennik Isles update"
+    - date: "11 March 2014"
+      description: "Fountain of Rune began recharging dragonstone jewellery to maximum charges"
+    - date: "2015"
+      description: "Partially charged dragonstone bracelets became untradeable on the Grand Exchange"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-mystery-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-mystery-meat.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: null
-  about: "Cooked mystery meat is a members-only item in Old School RuneScape. High alchemy value: 2 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  food:
+    heals: 4
+    type: meat
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 30
+      materials:
+        - item_name: Raw mystery meat
+          quantity: 1
+      tools:
+        - Cooking range or fire
+      output_quantity: 1
+  related_items:
+    - item_name: Raw mystery meat
+      slug: raw-mystery-meat
+      relationship: component
+      description: Uncooked version cooked into this item
+    - item_name: Cooked meat
+      slug: cooked-meat
+      relationship: alternative
+      description: Standard cooked meat with similar healing
+  about: "Cooked mystery meat is a members-only food obtained by cooking raw mystery meat. It heals a small amount of Hitpoints and primarily serves as a low-tier emergency food or Cooking training output during certain events."
+  market_strategy:
+    notes:
+      - "Healing too low for serious combat use"
+      - "Mainly a Cooking training output"
+      - "Untradeable in some forms — verify GE listing before flipping"
+  trading_tips:
+    - "Volume is thin; treat as a curiosity rather than a flip"
+    - "Demand spikes during themed events that distribute the raw variant"
+  history:
+    - date: "2021-04-14"
+      description: "Released as part of an event-tied food drop."
+  properties:
+    release_date: "2021-04-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-infinity-colour-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-infinity-colour-kit.mdx
@@ -12,9 +12,54 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Dark infinity colour kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  related_items:
+    - item_name: Light infinity colour kit
+      slug: light-infinity-colour-kit
+      relationship: variant
+    - item_name: Infinity top
+      slug: infinity-top
+      relationship: component
+    - item_name: Infinity hat
+      relationship: component
+    - item_name: Infinity bottoms
+      relationship: component
+    - item_name: Infinity boots
+      relationship: component
+    - item_name: Infinity gloves
+      relationship: component
+  market_strategy:
+    notes:
+      - "Cosmetic-only kit recolouring infinity pieces dark; supply from Last Man Standing rewards."
+      - "Buy limit of 4 per 4 hours throttles bulk flipping."
+      - "Investment Notes"
+  trading_tips:
+    - "Track LMS reward shop pricing as the supply floor."
+    - "Hold across content droughts when prestige cosmetics rise."
+  history:
+    - date: "2016-09-15"
+      description: "Dark infinity colour kit added to the Last Man Standing reward shop."
+  properties:
+    release_date: "2016-09-15"
+    update: Last Man Standing
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Dark infinity colour kit is a members-only cosmetic kit that recolours infinity robes. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/defence-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Defence potion(1) | OSRS Price Data
-description: "Defence potion(1): 1 dose of Defence potion.. High alch: 36 GP, GE limit: 2,000."
+description: "Defence potion(1): 1 dose of Defence potion. High alch: 36 GP, GE limit: 2,000."
 osrs:
   id: 137
   name: Defence potion(1)
@@ -12,6 +12,45 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 2000
+  about: "Defence potion(1) is a single-dose potion that temporarily boosts Defence by 3 + 10% of the player's current level. Crafted at 30 Herblore from ranarr and white berries."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2002-02-27"
+    weight: 0.02
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    options:
+      - Drink
+      - Empty
+      - Drop
+      - Examine
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  potion:
+    doses: 1
+    effects:
+      - skill: defence
+        boost: "3 + 10% of current level"
+        duration: 300
+        description: "Defence boost decays at 1 level per minute"
+  recipes:
+    - skill: herblore
+      level: 30
+      xp: 75
+      materials:
+        - item_name: Ranarr potion (unf)
+          quantity: 1
+        - item_name: White berries
+          quantity: 1
+      output_quantity: 1
+      notes: "Yields a 3-dose Defence potion which can be split into singles"
   related_items:
     - item_id: 133
       item_name: Defence potion(3)
@@ -23,12 +62,30 @@ osrs:
       slug: defence-potion-2
       relationship: variant
       description: 2-dose version
-  about: |-
-    > _"1 dose of Defence potion."_
-
-    A 1-dose defence potion. Boosts Defence by 3 + 10% of current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 139
+      item_name: Defence potion(4)
+      slug: defence-potion-4
+      relationship: variant
+      description: 4-dose version
+    - item_id: 163
+      item_name: Super defence(4)
+      slug: super-defence-4
+      relationship: upgrade
+      description: Stronger 5 + 15% defence boost
+  market_strategy:
+    notes:
+      - "Single dose — niche pre-trip topup"
+      - "Boost weaker than Super defence; cheaper alternative"
+      - "Stackable as drops; tradeable on GE"
+  trading_tips:
+    - "Boost formula: 3 + 10% of current Defence level"
+    - "Decay rate: 1 level per minute (90s with Preserve prayer)"
+    - "Combine with caviar for Defence mix via Barbarian Herblore"
+  history:
+    - date: "2002-02-27"
+      description: "Released with the original Herblore skill"
+    - date: "2004-10-01"
+      description: "Empty option added to potions"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dexterous-prayer-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dexterous-prayer-scroll.mdx
@@ -12,87 +12,61 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 5
-  item:
-    type: prayer_scroll
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: prayer-scroll
+    tier: high
+  properties:
+    release_date: "2017-01-05"
     tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0.015
-  unlocks:
-    prayer_name: Rigour
-    prayer_level: 74
-    requirements:
-      prayer: 74
-      defence: 70
-    effect:
-      ranged_attack: +20%
-      ranged_strength: +23%
-      defence: +25%
-    drain_rate: 40 points per minute
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
-      - source: Chambers of Xeric
-        source_id: 7554
-        combat_level: 0
+      - source: Chambers of Xeric (Ancient chest)
         quantity: "1"
-        rarity: ~29%
-        drop_rate: 29/100 from Ancient chest
-        members_only: true
-  market:
-    buy_limit: 5
-    price_estimate: 153000000
+        rarity: "1/100"
+  passive_effects:
+    - name: Unlocks Rigour
+      description: "Reading the scroll permanently unlocks the Rigour prayer at 74 Prayer and 70 Defence, granting +20% Ranged attack, +23% Ranged strength, and +25% Defence while active."
   related_items:
-    - item_id: 21079
-      item_name: Arcane prayer scroll
+    - item_name: Arcane prayer scroll
       slug: arcane-prayer-scroll
       relationship: alternative
-      description: Augury unlock
-    - item_id: 21047
-      item_name: Torn prayer scroll
+      description: Unlocks the Augury prayer for magic users.
+    - item_name: Torn prayer scroll
       slug: torn-prayer-scroll
       relationship: alternative
-      description: Preserve unlock
-    - item_id: 20997
-      item_name: Twisted bow
+      description: Unlocks the Preserve prayer.
+    - item_name: Twisted bow
       slug: twisted-bow
       relationship: alternative
-      description: Benefits from Rigour
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Prayer Scroll |
-    | Tradeable | Yes |
-    | Weight | 0.015 kg |
-
-    Rigour Prayer:
-    - +20% Ranged Attack
-    - +23% Ranged Strength
-    - +25% Defence
-
-    Requirements: 74 Prayer, 70 Defence
-
-    Drain Rate: 40 prayer points per minute
-
-    Essential for all ranged combat:
-    - Raids (CoX, ToB, ToA)
-    - Inferno
-    - Slayer
-    - All ranged bossing
-
-    Most important ranged upgrade in the game.
-
-    Rigour provides the largest DPS increase for ranged combat available from any single unlock, making it a priority purchase for any player focusing on ranged content.
-
-    | Prayer | Attack Boost | Damage Boost |
-    |--------|--------------|--------------|
-    | Eagle Eye | +15% | +15% |
-    | Rigour | +20% | +23% |
+      description: Premier ranged weapon that benefits heavily from Rigour.
+  about: "The dexterous prayer scroll is a one-time-use unlock dropped from the Chambers of Xeric Ancient chest at roughly 1/100. Reading it permanently unlocks Rigour, a 74 Prayer / 70 Defence prayer giving +20% Ranged attack, +23% Ranged strength, and +25% Defence, drains at 40 points per minute, and is the strongest single ranged upgrade in the game for raids, Inferno, slayer, and general ranged bossing."
   market_strategy:
     notes:
-      - One-time unlock (consumed on use)
-      - Priority upgrade for ranged users
-      - More expensive than Augury
-      - Best obtained through CoX grinding
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Single-use unlock consumed on read, generating constant supply sink"
+      - "Permanent BiS ranged prayer unlock; demand floors the price"
+      - "Best obtained directly from Chambers of Xeric grinding"
+  trading_tips:
+    - "Buy from active CoX teams selling drops to skip the 5-item limit cooldowns"
+    - "Watch ranged meta updates - rigour demand spikes around new raid releases"
+  history:
+    - date: "2017-01-05"
+      description: "Released with the Chambers of Xeric raid."
+    - date: "2017-01-19"
+      description: "Drop rate adjusted following raid loot balance pass."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-helm.mdx
@@ -12,35 +12,42 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: barrows
+    tier: mid
+  properties:
+    weight: 2.7
+    tradeable: true
+    degradeable: true
   equipment:
     slot: head
     type: barrows
+    attack_speed: null
     set: Dharok
-    tradeable: true
-    degradeable: true
-    weight: 2.7
     requirements:
       defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -3
-      attack_ranged: 0
-      defence_stab: 45
-      defence_slash: 48
-      defence_crush: 44
-      defence_magic: -1
-      defence_ranged: 51
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: 0
+    defence_bonus:
+      stab: 45
+      slash: 48
+      crush: 44
+      magic: -1
+      ranged: 51
+    other_bonus:
       strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  set_effect:
-    name: Wretched Strength
-    pieces_required: 4
-    description: Damage increases as HP decreases. Up to +98.9% damage at 1 HP with 99 max HP
-    formula: Extra damage = (Max HP - Current HP) * Max HP / 100
+  passive_effects:
+    - name: Wretched Strength
+      description: "Set effect (4 pieces): Damage increases as HP decreases. Up to +98.9% damage at 1 HP with 99 max HP. Formula: Extra damage = (Max HP - Current HP) * Max HP / 100"
   related_items:
     - item_id: 4720
       item_name: Dharok's platebody
@@ -86,11 +93,9 @@ osrs:
     - Repair cost: ~100k for full set at Bob
   market_strategy:
     notes:
-      - Popular for NMZ training
-      - Full set required for effect
-      - Often used with Absorption potions
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Popular for NMZ training"
+      - "Full set required for effect"
+      - "Often used with Absorption potions"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platelegs-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platelegs-0.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 110000
   highalch: 165000
   limit: 15
-  about: "Dharok's platelegs 0 is a members-only item in Old School RuneScape. High alchemy value: 165,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: barrows
+    tier: dharok
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - wear
+      - drop
+    worn_options:
+      - remove
+  equipment:
+    slot: legs
+    attack_speed: 4
+    requirements:
+      defence: 70
+    defence_bonus:
+      stab: 110
+      slash: 105
+      crush: 117
+      magic: -7
+      ranged: 124
+      melee_strength: 4
+  drop_table:
+    sources:
+      - source: Barrows chest (Dharok the Wretched)
+        quantity: "1"
+        rarity: "1/2500"
+        notes: "Degraded variant with 0 charges remaining"
+  passive_effects:
+    - name: Dharok's set effect
+      description: "When wearing the full Dharok's set, damage scales upward as Hitpoints drop, peaking at 1 HP for massive max hits."
+  related_items:
+    - item_id: 4722
+      item_name: Dharok's platelegs
+      slug: dharok-s-platelegs
+      relationship: variant
+      description: Fully charged version
+    - item_id: 4900
+      item_name: Dharok's platelegs 25
+      slug: dharok-s-platelegs-25
+      relationship: variant
+      description: 25-charge degraded version
+  about: |-
+    Dharok's platelegs 0 is the fully degraded variant of Dharok's platelegs with no charges remaining. Must be repaired at an armour stand or by Bob in Lumbridge before it can be used in combat.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/digsite-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/digsite-teleport.mdx
@@ -12,48 +12,46 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  item:
-    type: teleport_scroll
-    destination: Digsite
+  about: "Digsite teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  material:
+    type: scroll
+    tier: utility
+  properties:
+    release_date: "2007-07-31"
+    quest_item: false
     tradeable: true
     stackable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite/Master
-        drop_rate: Varies by tier
+    noteable: false
+    equipable: false
+    destroy_action: drop
+    options:
+      - teleport
+      - drop
+  treasure_trail:
+    tier: hard
+    reward_type: teleport_scroll
   related_items:
     - item_id: 12402
       item_name: Nardah teleport
       slug: nardah-teleport
       relationship: alternative
       description: Another clue teleport scroll
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Teleport Scroll |
-    | Destination | Digsite |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-
-    Right-click and select "Teleport" to travel to the Digsite.
-
-    Teleport Location:
-    - Digsite east of Varrock
-    - Near the Digsite exam centre
-    - Close to Fossil Island barge
-
-    - Fossil Island access
-    - Digsite activities
-    - Clue scroll steps
-    - Varrock Diary
+    - item_id: 12404
+      item_name: Feldip Hills teleport
+      slug: feldip-hills-teleport
+      relationship: alternative
+      description: Adjacent clue teleport scroll
   market_strategy:
     notes:
-      - Useful for Fossil Island
-      - Stock up for clue hunting
-      - Popular utility teleport
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Useful for Fossil Island access"
+      - "Stock up for clue hunting"
+      - "Popular utility teleport"
+      - "Steady consistent demand"
+  trading_tips:
+    - "Buying tip: bulk for Fossil Island and clue runs"
+    - "Selling tip: list when clue content trends"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-tip.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-dart-tip.mdx
@@ -12,33 +12,38 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 11000
-  ammunition:
-    type: dart tip
-    ranged_strength: 0
-  fletching:
-    level: 95
-    xp: 25
-    product: Dragon dart
-    product_id: 11230
-    quantity_per_action: 10
+  about: "Dragon dart tip is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  material:
+    type: dragon_metal
+    tier: dragon
+  properties:
+    release_date: "2010-07-06"
+    quest_item: false
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    destroy_action: drop
+    options:
+      - drop
   drop_table:
     sources:
       - source: Vorkath
         source_id: 8061
         combat_level: 732
-        quantity: 25-50
+        quantity: "1"
         rarity: common
         members_only: true
       - source: Zalcano
         source_id: 9049
         combat_level: 654
-        quantity: 15-35
+        quantity: "1"
         rarity: common
         members_only: true
       - source: Dragon impling
         source_id: 1653
         combat_level: 0
-        quantity: 100-350
+        quantity: "1"
         rarity: uncommon
         members_only: true
   recipes:
@@ -52,9 +57,7 @@ osrs:
         - item_name: Feather
           item_id: 314
           quantity: 10
-      product: Dragon dart
-      product_id: 11230
-      product_quantity: 10
+      output_quantity: 10
       members_only: true
   related_items:
     - item_id: 11230
@@ -79,19 +82,22 @@ osrs:
       description: Alternative dart tip
   market_strategy:
     notes:
-      - Up to 2.25M XP/hour
-      - Requires feathers
-      - High demand tips
-      - Fletching training (99 grind)
-      - Dragon dart production
-      - Toxic blowpipe ammo
-      - High-level PvM
-      - Best Fletching XP method
-      - Vorkath primary source
-      - Expensive but fast
-      - 10 darts per action
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Up to 2.25M XP/hour"
+      - "Requires feathers"
+      - "High demand tips"
+      - "Fletching training (99 grind)"
+      - "Dragon dart production"
+      - "Toxic blowpipe ammo"
+      - "High-level PvM"
+      - "Best Fletching XP method"
+      - "Vorkath primary source"
+      - "Expensive but fast"
+      - "10 darts per action"
+  trading_tips:
+    - "Buying tip: stock up before Fletching DXP weekends"
+    - "Selling tip: list when Vorkath drop supply dips"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-harpoon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-harpoon.mdx
@@ -12,36 +12,43 @@ osrs:
   lowalch: 22000
   highalch: 33000
   limit: 5
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: dragon
+  properties:
+    weight: 2.267
+    tradeable: true
   equipment:
     slot: weapon
     type: harpoon
+    attack_speed: 4
     attack_style: stab
-    tradeable: true
-    weight: 2.267
     requirements:
       attack: 60
       fishing: 61
-    stats:
-      attack_stab: 38
-      attack_slash: 32
+    attack_bonus:
+      stab: 38
+      slash: 32
+    other_bonus:
       strength: 42
+  passive_effects:
+    - name: Fishing Bonus
+      description: +20% catch rate vs regular harpoon, +5% at Tempoross
   special_attack:
     name: Fishstabber
     energy: 100
     effect: +3 visible Fishing levels
-  special_effect:
-    name: Fishing Bonus
-    description: +20% catch rate vs regular harpoon, +5% at Tempoross
   drop_table:
     sources:
       - source: Wyrm
         rate: 1/2,000
+        quantity: "1"
         notes: On task
       - source: Shadow Wyrm
         rate: 1/2,000
-  market:
-    buy_limit: 8
-    price_estimate: 2400000
+        quantity: "1"
   related_items:
     - item_id: 23762
       item_name: Crystal harpoon
@@ -83,11 +90,9 @@ osrs:
     Best harpoon (base) in the game.
   market_strategy:
     notes:
-      - Wyrms on task best source
-      - 62 Slayer required
-      - Upgrade options available
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Wyrms on task best source"
+      - "62 Slayer required"
+      - "Upgrade options available"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta-p-22737.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-hasta-p-22737.mdx
@@ -5,16 +5,98 @@ osrs:
   id: 22737
   name: Dragon hasta(p+)
   slug: dragon-hasta-p
-  examine: A poison-tipped, one-handed dragon hasta
+  examine: A poison-tipped, one-handed dragon hasta.
   members: true
   icon: Dragon hasta(p+).png
   value: 62400
   lowalch: 24960
   highalch: 37440
   limit: 70
-  about: "Dragon hasta(p+) is a members-only item in Old School RuneScape. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: weapon
+    tier: high
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    weight: 2.267
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: weapon
+    attack_speed: 4
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 55
+      slash: 55
+      crush: 55
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -15
+      slash: -15
+      crush: -12
+      magic: 0
+      ranged: -15
+    other_bonus:
+      strength: 60
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Dragon hasta
+          item_id: 11407
+          quantity: 1
+        - item_name: Weapon poison(+)
+          item_id: 5937
+          quantity: 1
+      product: Dragon hasta(p+)
+      product_id: 22737
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 11407
+      item_name: Dragon hasta
+      slug: dragon-hasta
+      relationship: component
+      description: Base unpoisoned dragon hasta
+    - item_id: 5937
+      item_name: Weapon poison(+)
+      slug: weapon-poison-plus
+      relationship: component
+      description: Applied to base hasta to make the (p+) variant
+    - item_id: 22738
+      item_name: Dragon hasta(p++)
+      slug: dragon-hasta-pp
+      relationship: upgrade
+      description: Higher-grade poisoned variant using Weapon poison(++)
+  market_strategy:
+    notes:
+      - "Niche poisoned variant of the dragon hasta"
+      - "Requires Barbarian Training Smithing for the base hasta"
+      - "Limited demand from PvP and Slayer setups"
+      - "Supply hinges on Weapon poison(+) availability"
+  trading_tips:
+    - "Buy strategy: watch base dragon hasta + Weapon poison(+) prices for arbitrage"
+    - "Demand: PvM use is light; price tracks the unpoisoned hasta closely"
+    - "Risk: poison utility is low against most current PvM targets"
+  history:
+    - date: "2019-01-10"
+      description: "Release: added as a poison variant alongside the dragon hasta system rework"
+  about: "Dragon hasta(p+) is a poison-tipped one-handed dragon hasta requiring 60 Attack to wield. Created by applying Weapon poison(+) to a dragon hasta. High alchemy value: 37,440 coins. Grand Exchange buy limit: 70 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-tips.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 780
   highalch: 1170
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragon
+    tier: high
   about: "Dragon javelin tips is a members-only item in Old School RuneScape. High alchemy value: 1,170 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-platelegs.mdx
@@ -12,8 +12,32 @@ osrs:
   lowalch: 108000
   highalch: 162000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: dragon
+  properties:
+    release_date: "2005-01-25"
+    update: "Dragon Equipment"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
   equipment:
     slot: legs
+    requirements:
+      defence: 60
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,8 +55,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 60
   drop_table:
     primary_source: Bronze dragon
     best_drop_rate: 1/256
@@ -78,11 +100,18 @@ osrs:
     - Budget option before Bandos tassets
   market_strategy:
     notes:
-      - High supply from Slayer tasks
-      - Dragon plateskirt has identical stats
-      - Budget melee legs before tassets
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Trading Notes"
+      - "High supply from Slayer tasks"
+      - "Dragon plateskirt has identical stats"
+      - "Budget melee legs before tassets"
+  trading_tips:
+    - "Watch metal dragon Slayer task popularity for supply spikes."
+    - "GE limit 70 per 4 hours keeps flips moderate."
+    - "Demand stable from mid-game accounts gearing melee."
+  history:
+    - date: "2005-01-25"
+      update: "Dragon Equipment"
+      description: "Dragon platelegs added as a rare drop from metal dragons."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-thrownaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-thrownaxe.mdx
@@ -12,9 +12,23 @@ osrs:
   lowalch: 300
   highalch: 450
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-07-26"
+    tradeable: true
+    stackable: true
+    noteable: false
+    quest_item: false
   equipment:
     slot: weapon
     attack_speed: 3
+    weight: 0.3
+    requirements:
+      ranged: 61
     attack_bonus:
       stab: 0
       slash: 0
@@ -32,17 +46,14 @@ osrs:
       ranged_strength: 47
       magic_damage: 0
       prayer: 0
-    requirements:
-      ranged: 61
-    weight: 0.3
   special_attack:
     name: Draconic Puncture
     energy: 25
-    description: Attack speed changed to 2 tick (1.2s) for 6 seconds.
+    description: "Attack speed changed to 2 tick (1.2s) for 6 seconds."
   drop_table:
     sources:
       - source: Chambers of Xeric
-        quantity: 50-100
+        quantity: "1"
         rarity: uncommon
         members_only: true
   related_items:
@@ -72,11 +83,9 @@ osrs:
     - 25% cost allows 4 specs per bar
   market_strategy:
     notes:
-      - CoX-only drop — supply tied to raid activity
-      - Consumed as ammo (stackable thrown weapon)
-      - PvP niche demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "CoX-only drop — supply tied to raid activity"
+      - "Consumed as ammo (stackable thrown weapon)"
+      - "PvP niche demand"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bracelet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bracelet.mdx
@@ -12,15 +12,19 @@ osrs:
   lowalch: 7650
   highalch: 11475
   limit: 10000
+  material:
+    type: gem
+    tier: dragonstone
   equipment:
     slot: hands
+    attack_speed: 4
     requirements:
       crafting: 74
   recipes:
     - skill: crafting
       level: 74
       xp: 110
-      inputs:
+      materials:
         - item_name: Dragonstone
           quantity: 1
         - item_name: Gold bar
@@ -58,11 +62,11 @@ osrs:
     Rechargeable at the Legends' Guild fountain.
   market_strategy:
     notes:
-      - Combat bracelet widely used for Warriors' Guild teleport
-      - Dragonstone cost drives price
-      - Enchanting often profitable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Combat bracelet widely used for Warriors' Guild teleport"
+      - "Dragonstone cost drives price"
+      - "Enchanting often profitable"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-full-helm.mdx
@@ -1,20 +1,96 @@
 ---
 title: Dragonstone full helm | OSRS Price Data
-description: "Dragonstone full helm: A stylish rune full helm inlaid with dragonstones.. High alch: 21,120 GP."
+description: "Dragonstone full helm: A stylish rune full helm inlaid with dragonstones. High alch: 21,120 GP."
 osrs:
   id: 24034
   name: Dragonstone full helm
   slug: dragonstone-full-helm
   examine: A stylish rune full helm inlaid with dragonstones.
-  members: false
+  members: true
   icon: Dragonstone full helm.png
   value: 35200
   lowalch: 14080
   highalch: 21120
   limit: null
-  about: "Dragonstone full helm is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Dragonstone full helm is a cosmetic rune full helm inlaid with dragonstones, obtained as a rare reward from the Elven Crystal Chest in Prifddinas after Song of the Elves."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: rune
+  properties:
+    release_date: "2019-07-25"
+    weight: 2.721
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: head
+    attack_speed: null
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Elven Crystal Chest
+        rarity: 1/2500
+        quantity: "1"
+        notes: "Requires completion of Song of the Elves"
+  related_items:
+    - item_id: 1163
+      item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: variant
+      description: Plain rune full helm with identical stats
+    - item_id: 24030
+      item_name: Dragonstone platebody
+      slug: dragonstone-platebody
+      relationship: set-piece
+      description: Matching dragonstone armour set
+    - item_id: 24032
+      item_name: Dragonstone platelegs
+      slug: dragonstone-platelegs
+      relationship: set-piece
+      description: Matching dragonstone armour set
+  market_strategy:
+    notes:
+      - "Rare Elven Crystal Chest cosmetic — supply tied to Prifddinas chest farmers"
+      - "Stats identical to rune full helm; value is purely visual"
+      - "Storable in costume room treasure chest"
+  trading_tips:
+    - "Drop rate: 1/2500 from the Elven Crystal Chest"
+    - "Requires Song of the Elves completion to access the chest"
+    - "Pair with platebody/platelegs for the full dragonstone look"
+  history:
+    - date: "2019-07-25"
+      description: "Released with Song of the Elves and the Prifddinas Elven Crystal Chest"
+    - date: "2021-04-21"
+      description: "Ranged attack bonus decreased from -2 to -3 in equipment rebalancing"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dust-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dust-battlestaff.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dust battlestaff | OSRS Price Data
-description: "Dust battlestaff is a members weapon slot item requiring 30 Attack. High alch: 9,300 GP, GE limit: 8."
+description: "Dust battlestaff is a members two-handed staff that provides unlimited air and earth runes when wielded. High alch: 9,300 GP, GE limit: 8."
 osrs:
   id: 20736
   name: Dust battlestaff
@@ -12,70 +12,89 @@ osrs:
   lowalch: 6200
   highalch: 9300
   limit: 8
+  material:
+    type: battlestaff
+    tier: mid
   equipment:
     slot: weapon
-    type: staff
-    attack_style: magic
-    tradeable: true
+    weapon_type: bladed_staff
+    attack_speed: 5
     weight: 2.267
     requirements:
       attack: 30
       magic: 30
-    stats:
-      magic_attack: 12
-      attack_crush: 28
-      strength: 35
-      magic_def: 12
-  special_effect:
-    name: Unlimited Runes
-    description: Provides infinite air and earth runes
-    autocast: true
-  upgrade:
-    npc: Thormac
-    cost: 20K-40K gp
-    result_id: 20739
-    result_name: Mystic dust staff
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 28
+      magic: 12
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 12
+      ranged: 0
+    other_bonus:
+      melee_strength: 35
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Unlimited air and earth runes
+      description: Provides unlimited air and earth runes when wielded, enabling combo spells from the Standard spellbook without consuming either rune.
+      trigger: while_worn
   drop_table:
     sources:
       - source: Dust devil
-        rate: 1/4,000
+        rate: Varies
       - source: Superior slayer monsters
         rate: Varies
-  market:
-    buy_limit: 8
-    price_estimate: 10400
   related_items:
     - item_id: 20739
       item_name: Mystic dust staff
       slug: mystic-dust-staff
       relationship: upgrade
-      description: Upgraded version
+      description: Thormac upgrade of the dust battlestaff
     - item_id: 20730
       item_name: Mist battlestaff
       slug: mist-battlestaff
       relationship: variant
-      description: Water variant
-    - item_id: 2404
-      item_name: Dust devil
-      slug: dust-devil
+      description: Air + water combo battlestaff variant
+    - item_name: Battlestaff
+      slug: battlestaff
       relationship: component
-      description: Drop source
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Magic | +12 |
-    | Crush | +28 |
-    | Strength | +35 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Magic | +12 |
-
-    Unlimited Runes: Provides infinite air and earth runes.
-
-    Can upgrade to Mystic dust staff at Thormac (20K-40K gp).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Base staff used across all elemental battlestaves
+  about: Dust battlestaff is a two-handed combination battlestaff dropped by dust devils and superior slayer monsters. It supplies unlimited air and earth runes while wielded, supports Standard spellbook autocast, and upgrades into the Mystic dust staff via Thormac for 20,000-40,000 coins.
+  market_strategy:
+    notes:
+      - "Supply is gated by dust devil slayer assignments, so price tracks slayer popularity"
+      - "Provides ongoing rune savings for mid-level mages running Earth/Air combo spells"
+      - "Upgrade path through Thormac keeps high-end demand sticky"
+  trading_tips:
+    - Compare to mist and smoke battlestaves before committing — task pressure drives all three
+    - Factor Thormac upgrade cost when valuing against Mystic dust staff
+  history:
+    - date: "2016-09-15"
+      description: Released alongside the other combination battlestaves as a dust devil drop.
+  properties:
+    release_date: "2016-09-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/earmuffs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/earmuffs.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   about: "Earmuffs is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclectic-impling-jar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclectic-impling-jar.mdx
@@ -12,58 +12,58 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 18000
-  item:
-    type: impling jar
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: hunter-loot
+    tier: mid
+  properties:
+    release_date: "2007-06-11"
     tradeable: true
-    hunter_level: 50
-    barehand_level: 70
-  loot:
-    average_value: 1291
-    notable_drops:
-      - item_name: Clue scroll (medium)
-        rarity: 1/25
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Loot
+      - Destroy
+    worn_options: []
+    alchable: true
+    destroy: "If you drop this it will disappear. Are you sure you want to do this?"
+  drop_table:
+    sources:
+      - source: Eclectic impling (Puro-Puro / overworld)
+        quantity: "1"
+        rarity: Always
   related_items:
-    - item_id: 11260
-      item_name: Impling jar
+    - item_name: Impling jar
       slug: impling-jar
       relationship: component
-      description: Required to catch implings
-    - item_id: 2801
-      item_name: Clue scroll (medium)
+      description: Empty jar returned after looting an impling capture.
+    - item_name: Clue scroll (medium)
       slug: clue-scroll-medium
       relationship: alternative
-      description: Main target drop from eclectic implings
-    - item_id: 2577
-      item_name: Ranger boots
+      description: Headline drop the eclectic jar is farmed for.
+    - item_name: Ranger boots
       slug: ranger-boots
       relationship: alternative
-      description: Valuable reward from medium clue scrolls
-  about: |-
-    Notable Drops:
-
-    | Item | Rarity | Quantity |
-    |------|--------|----------|
-    | Medium clue scroll | 1/25 | 1 |
-    | Snape grass | 1/10 | 3 |
-    | Oak plank | 1/10 | 4 |
-    | Watermelon seed | 1/10 | 3 |
-    | Gold ore | 1/10 | 5 |
-    | Battlestaff | 1/100 | 1 |
-    | Rune dagger | 1/100 | 1 |
-
-    Average Loot Value: ~1,291 gp
-
-    Medium Clue Farming:
-    - Best method for obtaining medium clue scrolls
-    - 1/25 drop rate makes it efficient
-    - Used for ranger boots hunting
+      description: High-value reward chased through medium clue scrolls.
+  about: "The eclectic impling jar is the mid-tier impling capture loot rolled for medium clue scrolls (1/25) plus a small pool of utility drops including snape grass, oak planks, watermelon seeds, gold ore, battlestaff, and rune dagger. Average loot value sits near 1,291 gp, and the jar is a staple supply of medium clues for ironmen and the Grand Exchange alike."
   market_strategy:
     notes:
-      - Popular for clue scroll farming
-      - Often profitable to open in bulk
-      - Price fluctuates with ranger boots demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Popular for clue scroll farming and bulk opening"
+      - "Often profitable to open in bulk when medium clue rewards spike"
+      - "Price tracks ranger boots demand closely"
+  trading_tips:
+    - "Open in bulk during ranger boot price spikes to chase clue value"
+    - "Sell empty jars back to the market to recover supply cost"
+  history:
+    - date: "2007-06-11"
+      description: "Released with Impetuous Impulses and the introduction of Puro-Puro."
+    - date: "2015-02-26"
+      description: "Made tradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/edible-seaweed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/edible-seaweed.mdx
@@ -12,13 +12,89 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  related_items: []
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2003-07-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Rock crab
+        quantity: "1"
+        rarity: Common
+      - source: Sand crab
+        quantity: "1"
+        rarity: Common
+      - source: Ammonite crab
+        quantity: "1"
+        rarity: Common
+      - source: Swamp crab
+        quantity: "1"
+        rarity: Common
+      - source: Giant sea snake
+        quantity: "1"
+        rarity: Common
+      - source: Dagannoth
+        quantity: "1"
+        rarity: Uncommon
+      - source: Kraken
+        quantity: "1"
+        rarity: Uncommon
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Edible seaweed
+          quantity: 1
+      tools:
+        - Fire or Range
+      output_quantity: 1
+  related_items:
+    - item_name: Soda ash
+      slug: soda-ash
+      relationship: product
+      description: "Created by cooking edible seaweed on a fire or range"
+    - item_name: Seaweed
+      slug: seaweed
+      relationship: alternative
+      description: "Standard seaweed variant used in glass-making"
+    - item_name: Molten glass
+      slug: molten-glass
+      relationship: product
+      description: "Crafting product downstream from soda ash"
   about: |-
-    > _"Slightly damp seaweed."_
-
-    Edible seaweed heals 4 Hitpoints when eaten. Can also be cooked on a fire or range to produce soda ash, used in making molten glass for Crafting.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Slightly damp seaweed that heals 4 Hitpoints when eaten. Cooks into soda ash on a fire or range (no Cooking xp), feeding the molten glass pipeline. Drops from many sea-themed monsters and spawns on Fossil Island and Mos Le'Harmless beaches.
+  market_strategy:
+    notes:
+      - "Soda ash demand from Crafting (molten glass) underpins long-term value"
+      - "Multiple drop sources keep supply elastic"
+      - "Cheap stack-up food for low-tier ironman content"
+      - "Fossil Island spawns make ironman gathering trivial"
+  trading_tips:
+    - "Compare against regular seaweed - edible variant has the cooking quirk"
+    - "Watch Crafting xp meta updates that spike glass demand"
+    - "Random event Fairytale I - Growing Pains can demand one as a quest item"
+  history:
+    - date: "2003-07-28"
+      description: "Released alongside expanded Cooking and Crafting content"
+    - date: "2017-09-07"
+      description: "Added to Fossil Island ground spawn pools"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/egg-potato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/egg-potato.mdx
@@ -1,6 +1,6 @@
 ---
 title: Egg potato | OSRS Price Data
-description: "Egg potato: A baked potato with egg and tomato.. High alch: 7 GP, GE limit: 13,000."
+description: "Egg potato is a 51 Cooking baked-potato dish that heals 16 Hitpoints in one tick. High alch: 7 GP, GE limit: 13,000."
 osrs:
   id: 7056
   name: Egg potato
@@ -12,9 +12,68 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 13000
-  about: "Egg potato is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2006-01-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  food:
+    heal_amount: 16
+    is_combo: false
+  recipes:
+    - skill: cooking
+      level: 51
+      xp: 45
+      materials:
+        - item_name: Potato with butter
+          quantity: 1
+        - item_name: Egg and tomato
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Potato with butter
+      slug: potato-with-butter
+      relationship: component
+      description: Buttered potato base for the egg potato
+    - item_name: Egg and tomato
+      slug: egg-and-tomato
+      relationship: component
+      description: Topping mixed with the buttered potato
+    - item_name: Potato with cheese
+      slug: potato-with-cheese
+      relationship: alternative
+      description: Same 16 HP heal with a simpler recipe
+    - item_name: Chilli potato
+      slug: chilli-potato
+      relationship: variant
+      description: Other baked-potato variant in the dish family
+  about: Egg potato is a baked-potato dish made at 51 Cooking by combining a potato with butter and an egg and tomato topping for 45 Cooking XP. It heals 16 Hitpoints in a single tick, the same as the simpler potato with cheese.
+  market_strategy:
+    notes:
+      - "Demand follows mid-level Cooking training and casual PvM food usage"
+      - "Eating the components separately heals more, so most demand is from Cooking XP rather than PvM"
+  trading_tips:
+    - Check potato with butter and egg and tomato prices together — combined cost vs. GE price drives margins
+    - Watch potato with cheese listings as a substitute that heals the same amount
+  history:
+    - date: "2006-01-30"
+      description: Added with the baked potato toppings expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-skirt-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-skirt-yellow.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: null
-  about: "Elven skirt (yellow) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Lliann's Wares
+      location: Prifddinas
+      price: 5000
+      currency: Coins
+      stock: 5
+  about: "Elven skirt (yellow) is a cosmetic legs slot item from the Song of the Elves update, sold by Lliann in Prifddinas as part of the elven clothing collection."
+  market_strategy:
+    notes:
+      - "Pure cosmetic with no combat bonuses"
+      - "Available directly from Lliann's Wares for 5,000 coins"
+  trading_tips:
+    - No Grand Exchange buy limit applies
+    - Compare shop price to live GE price before buying
+  history:
+    - date: "2019-07-25"
+      description: "Released with the Song of the Elves quest update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/empty-oil-lantern.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/empty-oil-lantern.mdx
@@ -12,9 +12,39 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 10000
-  about: "Empty oil lantern is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: tool
+    tier: basic
+  properties:
+    release_date: "2003-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    options:
+      - use
+      - drop
+  recipes:
+    - skill: crafting
+      level: 26
+      xp: 22
+      materials:
+        - item_name: Empty oil lantern frame
+          quantity: 1
+        - item_name: Molten glass
+          quantity: 1
+      output_quantity: 1
+      notes: "Use molten glass on the empty oil lantern frame"
+  related_items:
+    - item_id: 4537
+      item_name: Oil lantern
+      slug: oil-lantern
+      relationship: upgrade
+      description: Completed version after filling with oil
+  about: |-
+    An empty oil lantern crafted from a lantern frame and molten glass. Must be filled with lamp oil before it can be used as a light source.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-stamina-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-stamina-potion-4.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: null
-  about: "Extended stamina potion(4) is a members-only item in Old School RuneScape. High alchemy value: 150 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 40% run energy on consumption"
+        duration: 0
+      - description: "Reduces run energy depletion by 70% for the duration; effects do not stack — additional doses reset the timer"
+        duration: 240
+  recipes:
+    - skill: herblore
+      level: 85
+      xp: 110
+      materials:
+        - item_name: Stamina potion(4)
+          quantity: 1
+        - item_name: Marlin scales
+          quantity: 4
+      tools: []
+      output_quantity: 1
+  about: "Extended stamina potion(4) provides four doses of a stronger Stamina potion. Each dose grants 40% run energy and a 70% run-depletion reduction for four minutes; effects reset rather than stack."
+  market_strategy:
+    notes:
+      - "Doses brew from Stamina potion(1) + Marlin scales at 85 Herblore"
+      - "Recently released — expect price volatility while supply ramps"
+  trading_tips:
+    - No Grand Exchange buy limit listed yet
+    - Decant or split doses to match buyer preferences
+  history:
+    - date: "2025-11-19"
+      description: "Released with the late 2025 game update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/farseer-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/farseer-helm.mdx
@@ -12,8 +12,14 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 70
+  material:
+    type: fremennik
+    tier: mid
   equipment:
     slot: head
+    weight: 2.721
+    requirements:
+      defence: 45
     attack_bonus:
       stab: -5
       slash: -5
@@ -31,51 +37,59 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 45
-    weight: 2.721
+  shops:
+    - shop_name: Skulgrimen's Battle Gear
+      location: Rellekka
+      price: 78000
+      currency: Coins
+      members_only: true
   related_items:
     - item_id: 3751
       item_name: Berserker helm
       slug: berserker-helm
       relationship: alternative
-      description: Melee variant (+3 Str)
+      description: Melee strength Fremennik helm variant
     - item_id: 3749
       item_name: Archer helm
       slug: archer-helm
       relationship: alternative
-      description: Ranged variant
+      description: Ranged Fremennik helm variant
   about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Magic | +6 |
+    > _"This helmet is worn by farseers."_
 
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +8 |
-    | Slash | +10 |
-    | Crush | +12 |
-    | Magic | +6 |
-
-    Requirements: 45 Defence | Weight: 2.72 kg
-
-    At +6 magic attack, the farseer helm matches the Infinity hat and is only surpassed by Ancestral hat (+8) and Virtus mask (+8) among tradeable helms. It requires only 45 Defence versus Infinity's 50 Magic/25 Defence.
-
-    | Stat | Farseer | Mystic Hat | Infinity Hat | Ancestral Hat |
-    |------|---------|-----------|-------------|--------------|
-    | Magic Atk | +6 | +4 | +6 | +8 |
-    | Magic Def | +6 | +4 | +6 | +8 |
-    | Melee Def | +8/+10/+12 | 0/0/0 | 0/0/0 | 0/0/0 |
-    | Req | 45 Def | 40 Mag/20 Def | 50 Mag/25 Def | 75 Mag/65 Def |
-
-    The farseer's melee defence stats are a significant advantage — it's the only mid-tier magic helm with meaningful physical protection.
+    The farseer helm is the magic-oriented Fremennik helm awarded after completing The Fremennik Trials. At +6 magic attack it matches the Infinity hat and is only surpassed by Ancestral hat (+8) and Virtus mask (+8) among tradeable helms. It requires only 45 Defence versus Infinity's 50 Magic / 25 Defence, making it a popular mid-game magic helm with meaningful melee defence stats.
   market_strategy:
     notes:
-      - Best magic helm at 45 Defence
-      - Popular for Barrows and mid-game Slayer
-      - Affordable compared to Infinity/Ancestral
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Best magic helm available at 45 Defence"
+      - "Popular for Barrows and mid-game Slayer"
+      - "Affordable compared to Infinity and Ancestral"
+      - "Supply comes from Fremennik Trials completion and resales"
+  trading_tips:
+    - "Compare against the Mystic hat for pure magic builds without melee defence"
+    - "Demand spikes during Slayer task popularity for magic-weak monsters"
+  history:
+    - date: "2004-11-02"
+      description: "Released via The Fremennik Trials update."
+  properties:
+    release_date: "2004-11-02"
+    update: The Fremennik Trials
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    quest: The Fremennik Trials
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-pie.mdx
@@ -13,8 +13,72 @@ osrs:
   highalch: 60
   limit: 10000
   about: "Fish pie is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: consumable
+  properties:
+    release_date: "2006-11-21"
+    quest_item: false
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    destroy_action: drop
+    options:
+      - eat
+      - drop
+  consumable:
+    heals: 8
+    boosts:
+      - skill: fishing
+        amount: 3
+    bites: 2
+  recipes:
+    - skill: cooking
+      level: 47
+      xp: 164
+      materials:
+        - item_name: Pie shell
+          item_id: 2315
+          quantity: 1
+        - item_name: Raw trout
+          item_id: 343
+          quantity: 1
+        - item_name: Raw cod
+          item_id: 341
+          quantity: 1
+        - item_name: Potato
+          item_id: 1942
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 2315
+      item_name: Pie shell
+      slug: pie-shell
+      relationship: component
+      description: Base ingredient for any pie
+    - item_id: 7190
+      item_name: Half a fish pie
+      slug: half-a-fish-pie
+      relationship: variant
+      description: Leftover after one bite
+    - item_id: 7218
+      item_name: Admiral pie
+      slug: admiral-pie
+      relationship: alternative
+      description: Higher tier fish-based pie
+  market_strategy:
+    notes:
+      - "Provides a temporary +3 Fishing boost"
+      - "Useful for low-level Fishing milestones"
+      - "Steady demand from Cooking trainers"
+      - "Cheap raw ingredients keep margins thin"
+  trading_tips:
+    - "Buying tip: bulk for Fishing level-up boosts"
+    - "Selling tip: list during Cooking events for higher turnover"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/flared-trousers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/flared-trousers.mdx
@@ -12,9 +12,34 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
-  about: "Flared trousers is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-10-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - wear
+      - drop
+    worn_options:
+      - remove
+  equipment:
+    slot: legs
+    attack_speed: 4
+    requirements: {}
+  related_items:
+    - item_id: 10396
+      item_name: Pantaloons
+      slug: pantaloons
+      relationship: variant
+      description: Another rare cosmetic legs cosmetic
+  about: |-
+    Flared trousers is a cosmetic legs slot item dropped exclusively by Mysterious Old Man during Random Events. Provides no combat bonuses but is sought after for its rarity.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/flattened-hide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/flattened-hide.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Flattened hide is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: monster_drop
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Dagannoth (level 88, ranged, Waterbirth Island Dungeon)
+        quantity: "1"
+        rarity: 2/128
+  related_items:
+    - item_name: Dagannoth hide
+      slug: dagannoth-hide
+      relationship: component
+      description: "Standard dagannoth hide combined with flattened/stretched hides for spined body"
+    - item_name: Stretched hide
+      slug: stretched-hide
+      relationship: alternative
+      description: "Companion hide in the spined armour exchange"
+    - item_name: Circular hide
+      slug: circular-hide
+      relationship: alternative
+      description: "Companion hide in the spined armour exchange"
+    - item_name: Spined body
+      slug: spined-body
+      relationship: product
+      description: "Crafted via Sigli the Huntsman trade-in"
+  about: |-
+    Tattered chunk of dagannoth hide dropped by level 88 ranged Dagannoths in the Waterbirth Island Dungeon at 2/128. Exchanged with Sigli the Huntsman (post-Fremennik Trials) alongside three dagannoth hides and 10,000 coins for a spined body, or traded to Askeladden for cooked tuna (pre-quest) or cooked lobster (post-quest).
+  market_strategy:
+    notes:
+      - "Locked behind The Fremennik Trials for spined body crafting"
+      - "Drop rate 2/128 is modest - supply tied to AFK Dagannoth grind"
+      - "Spined armour demand drives floor price"
+      - "Askeladden lobster trade is a stable sink for unwanted hides"
+  trading_tips:
+    - "Compare flattened + stretched + circular hide prices together - they craft the full spined set"
+    - "Buy in bulk only if Fremennik diary requirement is met"
+    - "Limit of 11,000 gives plenty of room for flips"
+  history:
+    - date: "2005-08-01"
+      description: "Released with the Waterbirth Island update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/forgotten-brew-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/forgotten-brew-4.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Forgotten brew(4) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    effects:
+      - description: "Boosts Magic level by 3 + 8% of base Magic level."
+        duration: 60
+      - description: "Restores 10% of base Magic level prayer points on consumption."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 91
+      xp: 175
+      materials:
+        - item_name: Ancient essence
+          quantity: 25
+        - item_name: Magic potion(4)
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Forgotten brew(1)
+      relationship: variant
+    - item_name: Forgotten brew(2)
+      relationship: variant
+    - item_name: Forgotten brew(3)
+      relationship: variant
+    - item_name: Magic potion(4)
+      relationship: component
+    - item_name: Ancient essence
+      relationship: component
+  market_strategy:
+    notes:
+      - "High-tier magic boost used by PvMers; demand correlates with magic-heavy boss releases."
+      - "Made from Magic potion(4) + 25 ancient essence at 91 Herblore."
+  trading_tips:
+    - "Stock 4-dose for highest GE turnover."
+    - "Decant arbitrage with (3) and (2) doses when prices diverge."
+  history:
+    - date: "2022-10-12"
+      description: "Forgotten brew introduced with Tombs of Amascut Herblore content."
+  properties:
+    release_date: "2022-10-12"
+    update: Tombs of Amascut
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Forgotten brew(4) is a members-only Herblore potion boosting Magic and restoring prayer. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-grey-shirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-grey-shirt.mdx
@@ -12,9 +12,76 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik grey shirt is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: null
+    attack_speed: null
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Yrsa's Accoutrements
+      location: Rellekka
+      price: 325
+      currency: Coins
+      stock: 5
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania and Etceteria Dungeon
+      price: 250
+      currency: Coins
+      stock: 5
+  about: "Fremennik grey shirt is a cosmetic Fremennik-themed body item sold by Yrsa in Rellekka and the Miscellania clothes vendor."
+  market_strategy:
+    notes:
+      - "Cosmetic cloth body slot for Fremennik-themed outfits"
+      - "Cheaper to buy from Yrsa than from the Grand Exchange when stocked"
+  trading_tips:
+    - "Buy limit: 150 per 4 hours"
+    - Restock at Yrsa's Accoutrements if shop stock is empty
+  history:
+    - date: "2004-11-02"
+      description: Item released
+    - date: "2005-01-17"
+      description: Received a graphical update
+    - date: "2014-12-10"
+      description: 'Renamed from "Fremennik shirt" to "Fremennik grey shirt"'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ghrazi-rapier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ghrazi-rapier.mdx
@@ -12,6 +12,28 @@ osrs:
   lowalch: 2000000
   highalch: 3000000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: rapier
+    tier: master
+  properties:
+    release_date: "2018-01-04"
+    update: "Theatre of Blood"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
   equipment:
     slot: weapon
     type: rapier
@@ -19,15 +41,30 @@ osrs:
     attack_speed: 4
     requirements:
       attack: 80
-    stats:
-      attack_stab: 94
-      attack_slash: 55
-      strength: 89
-  drop_sources:
-    - name: Theatre of Blood
-      combat_level: 0
-      drop_rate: rare
-      members_only: true
+    attack_bonus:
+      stab: 94
+      slash: 55
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 89
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    primary_source: Theatre of Blood
+    sources:
+      - source: Theatre of Blood
+        quantity: "1"
+        rarity: rare
+        members_only: true
   related_items:
     - item_id: 12006
       item_name: Abyssal tentacle
@@ -71,11 +108,18 @@ osrs:
     - Pairs well with dragon defender
   market_strategy:
     notes:
-      - ToB completions affect supply
-      - Meta weapon for high-level PvM
-      - Always in demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Investment Notes"
+      - "ToB completions affect supply"
+      - "Meta weapon for high-level PvM"
+      - "Always in demand"
+  trading_tips:
+    - "Verify ToB drop rate trends before flipping"
+    - "Best-in-slot stab demand keeps price stable"
+    - "Use Grand Exchange for secure trades"
+  history:
+    - date: "2018-01-04"
+      update: "Theatre of Blood"
+      description: "Ghrazi rapier released as a rare drop from the Theatre of Blood raid."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/giant-egg-sac-full.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/giant-egg-sac-full.mdx
@@ -12,9 +12,39 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 100
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: misc
+    tier: low
+  properties:
+    release_date: "2018-09-26"
+    update: "Kebos Lowlands"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Open
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
   about: "Giant egg sac(full) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "High alch 6 gp — not profitable to alch."
+      - "Low GE limit of 100 per 4 hours restricts flipping volume."
+  trading_tips:
+    - "Used for Aerial Fishing prep at Lake Molch."
+    - "Demand tied to Aerial Fishing popularity."
+  history:
+    - date: "2018-09-26"
+      update: "Kebos Lowlands"
+      description: "Giant egg sac introduced with the Kebos Lowlands expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-d-hide-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-d-hide-chaps.mdx
@@ -12,93 +12,85 @@ osrs:
   lowalch: 16000
   highalch: 24000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ranged_armour
+    tier: mid
+  properties:
+    release_date: "11 April 2019"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: ranged_armour
+    weapon_type: null
+    attack_speed: null
+    weight: 5
     requirements:
       ranged: 40
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -10
-      attack_ranged: 8
-      defence_stab: 22
-      defence_slash: 16
-      defence_crush: 24
-      defence_magic: 8
-      defence_ranged: 22
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 8
+    defence_bonus:
+      stab: 22
+      slash: 16
+      crush: 24
+      magic: 8
+      ranged: 22
+    other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    weight: 5
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: Reward casket (elite)
-        drop_rate: 1/14,662.5
+        quantity: "1"
+        rarity: 1/14662.5
       - source: Reward casket (master)
-        drop_rate: 1/13,616
+        quantity: "1"
+        rarity: 1/13616
   related_items:
-    - item_id: 2497
-      item_name: Black d'hide chaps
+    - item_name: Black d'hide chaps
       slug: black-dhide-chaps
       relationship: alternative
-      description: Same stats, non-gilded
-    - item_id: 23264
-      item_name: Gilded d'hide body
+      description: "Same stats, non-cosmetic crafted version"
+    - item_name: Gilded d'hide body
       slug: gilded-dhide-body
-      relationship: alternative
-      description: Matching gilded body
-    - item_id: 23261
-      item_name: Gilded d'hide vambraces
+      relationship: set-piece
+      description: "Matching gilded chestplate"
+    - item_name: Gilded d'hide vambraces
       slug: gilded-dhide-vambraces
-      relationship: alternative
-      description: Matching gilded gloves
-    - item_id: 23258
-      item_name: Gilded coif
+      relationship: set-piece
+      description: "Matching gilded vambraces"
+    - item_name: Gilded coif
       slug: gilded-coif
-      relationship: alternative
-      description: Matching gilded helm
-  about: |-
-    "Made with 100% golden dragonhide."
-
-    | Stat | Value |
-    |------|-------|
-    | Stab Attack | +0 |
-    | Slash Attack | +0 |
-    | Crush Attack | +0 |
-    | Magic Attack | -10 |
-    | Ranged Attack | +8 |
-    | Stab Defence | +22 |
-    | Slash Defence | +16 |
-    | Crush Defence | +24 |
-    | Magic Defence | +8 |
-    | Ranged Defence | +22 |
-    | Melee Strength | +0 |
-    | Ranged Strength | +0 |
-    | Magic Damage | +0% |
-    | Prayer | +0 |
-
-    Requirements: 40 Ranged
-
-    | Item | Ranged Atk | Ranged Def | Magic Def | Source |
-    |------|-----------|-----------|----------|--------|
-    | Gilded d'hide chaps | +8 | +22 | +8 | Elite/Master clues |
-    | Black d'hide chaps | +8 | +22 | +8 | Crafting (82) |
-
-    Stats are identical to the black d'hide chaps. The gilded version is purely cosmetic and significantly more expensive due to its rarity from Treasure Trails.
+      relationship: set-piece
+      description: "Matching gilded helm"
+  about: "Gilded d'hide chaps are a cosmetic ranged legs slot reward from Elite and Master clue scroll caskets, requiring 40 Ranged to wear. Stats are identical to black d'hide chaps; the gilded version exists purely for fashionscape rarity and collection log completion."
   market_strategy:
     notes:
-      - Fashionscape / cosmetic flex
-      - Elite clue reward rarity
-      - Collection log completionists
-      - Identical stats to black d'hide chaps
-      - Value is purely cosmetic rarity
-      - Price fluctuates with clue scroll activity
-      - Low trade volume, watch for manipulation
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Identical stats to black d'hide chaps; price is pure cosmetic rarity"
+      - "Low trade volume from Elite and Master clue completion rates"
+      - "Watch for short-term manipulation given thin order book"
+  trading_tips:
+    - "Track clue scroll activity events; supply tightens after big PvM updates"
+    - "Compare against full gilded ranged set price for completion arbitrage"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-sq-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-sq-shield.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 15360
   highalch: 23040
   limit: 70
+  material:
+    type: metal
+    tier: mid
   about: "Gilded sq shield is a free-to-play item in Old School RuneScape. High alchemy value: 23,040 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goading-potion-4.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 2000
+  material:
+    type: consumable
+    tier: potion
+  potion:
+    doses: 4
   about: "Goading potion(4) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/golden-chef-s-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/golden-chef-s-hat.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
+  material:
+    type: cloth
+    tier: mid
   about: "Golden chef's hat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-dark-bow-paint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-dark-bow-paint.mdx
@@ -1,6 +1,6 @@
 ---
 title: Green dark bow paint | OSRS Price Data
-description: "Green dark bow paint: Paints things green!. High alch: 1 GP, GE limit: 4."
+description: "Green dark bow paint: Paints things green! High alch: 1 GP, GE limit: 4."
 osrs:
   id: 12759
   name: Green dark bow paint
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Green dark bow paint is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Green dark bow paint is a cosmetic item from the Last Man Standing reward shop that recolours a dark bow green. Purely visual with no stat effect."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2014-09-18"
+    weight: 0.001
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    options:
+      - Use
+      - Drop
+      - Examine
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  shops:
+    - shop_name: Justine's stuff for the Last Shopper Standing
+      location: Last Man Standing lobby
+      price: 25
+      currency: Last Man Standing points
+      stock: 100
+      notes: "Purchased with LMS points; resold on the Grand Exchange"
+  related_items:
+    - item_id: 11235
+      item_name: Dark bow
+      slug: dark-bow
+      relationship: component
+      description: Target weapon for recolour
+    - item_id: 12757
+      item_name: Blue dark bow paint
+      slug: blue-dark-bow-paint
+      relationship: alternative
+      description: Blue dark bow recolour variant
+    - item_id: 12761
+      item_name: Yellow dark bow paint
+      slug: yellow-dark-bow-paint
+      relationship: alternative
+      description: Yellow dark bow recolour variant
+    - item_id: 12763
+      item_name: White dark bow paint
+      slug: white-dark-bow-paint
+      relationship: alternative
+      description: White dark bow recolour variant
+  market_strategy:
+    notes:
+      - "Pure cosmetic — supply driven by LMS engagement"
+      - "Tiny 4-per-4h GE limit caps flips"
+      - "Applies a permanent green recolour to a dark bow"
+  trading_tips:
+    - "Cost: 25 LMS points per paint"
+    - "GE buy limit: 4 per 4 hours"
+    - "Recolour is permanent and untradeable once applied"
+  history:
+    - date: "2014-09-18"
+      description: "Released with the original Bounty Hunter / LMS-precursor cosmetic shop"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-dragon-mask.mdx
@@ -12,9 +12,71 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Green dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 2.267
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1625
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  about: "Green dragon mask is a cosmetic head slot reward from hard Treasure Trails. Storable in the costume room's treasure chest."
+  market_strategy:
+    notes:
+      - "Pure cosmetic with no combat bonuses"
+      - "Buy limit of 4 keeps Grand Exchange supply tight"
+  trading_tips:
+    - "Buy limit: 4 per 4 hours"
+    - Consider listing slightly above mid-price due to low limit
+  history:
+    - date: "2014-06-12"
+      description: Released as a hard clue scroll reward
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-altar-icon-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grid-master-altar-icon-scroll.mdx
@@ -12,9 +12,69 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
-  about: Grid master altar icon scroll is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2025-10-15"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  shops:
+    - shop_name: Events Reward Shop
+      location: Grid Master community event
+      price: 6000
+      currency: Event points
+      stock: 1
+  recipes:
+    - skill: construction
+      level: 45
+      xp: 180
+      materials:
+        - item_name: Grid master altar icon scroll
+          quantity: 1
+        - item_name: Oak plank
+          quantity: 3
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Grid master torch scroll
+      slug: grid-master-torch-scroll
+      relationship: alternative
+      description: "Sibling Grid Master event reward for POH torch decoration"
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: "Construction material combined with the scroll"
+  about: |-
+    Cosmetic POH construction scroll purchased from the Events Reward Shop for 6,000 event points during the Grid Master community event. Combine with 3 oak planks at level 45 Construction (180 xp) to build a Grid Master Icon in a chapel's icon hotspot. Not alchemisable.
+  market_strategy:
+    notes:
+      - "Event-limited supply - new stock only during Grid Master events"
+      - "Demand driven by POH chapel completionists"
+      - "Base value 2.5M reflects scarcity, GE trades well below until events end"
+      - "No buy limit reported - bulk buyers can accumulate"
+  trading_tips:
+    - "Stock up during event windows when participants flood the GE"
+    - "Sell post-event when supply tightens"
+    - "Compare against Grid master torch scroll - they often move together"
+  history:
+    - date: "2025-10-15"
+      description: "Released as a Grid Master community event reward"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-mjolnir.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-mjolnir.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix mjolnir | OSRS Price Data
-description: "Guthix mjolnir: A Guthix Mjolnir.. High alch: 375 GP, GE limit: 8."
+description: "Guthix mjolnir is a members two-handed crush weapon obtained from The Enchanted Key miniquest. High alch: 375 GP, GE limit: 8."
 osrs:
   id: 6760
   name: Guthix mjolnir
@@ -12,9 +12,73 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 8
-  about: "Guthix mjolnir is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mjolnir
+    tier: mid
+  equipment:
+    slot: weapon
+    weapon_type: two-handed
+    attack_speed: 6
+    weight: 2.267
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 11
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 14
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Saradomin mjolnir
+      slug: saradomin-mjolnir
+      relationship: variant
+      description: Saradomin-aligned mjolnir variant
+    - item_name: Zamorak mjolnir
+      slug: zamorak-mjolnir
+      relationship: variant
+      description: Zamorak-aligned mjolnir variant
+    - item_name: Enchanted key
+      slug: enchanted-key
+      relationship: component
+      description: Miniquest key that leads to the mjolnir reward
+  about: Guthix mjolnir is a two-handed crush weapon awarded during The Enchanted Key miniquest. It is tipped with the Tear of Guthix and shares stats with the Saradomin and Zamorak variants, but is limited to one per account.
+  market_strategy:
+    notes:
+      - "Only one is obtainable per account through the miniquest, so supply is tightly capped"
+      - "GE volume is low and prices are driven by collectors and cosmetic demand"
+  trading_tips:
+    - Watch the Saradomin and Zamorak mjolnir markets for spillover demand from set collectors
+    - Confirm uniqueness before paying premiums — only one can sit in your inventory at a time
+  history:
+    - date: "2005-11-22"
+      description: Added with The Enchanted Key miniquest as one of three god-themed mjolnirs.
+  properties:
+    release_date: "2005-11-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hueycoatl-hide-coif.mdx
@@ -12,93 +12,98 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: null
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: armor
+    tier: high
+  properties:
+    release_date: "2024-09-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: ranged
-    tradeable: true
-    weight: 0.4
+    weapon_type: null
+    attack_speed: null
+    weight: 0.9
     requirements:
       defence: 40
       ranged: 70
-    stats:
-      attack_ranged: 7
-      attack_magic: -1
-      defence_stab: 4
-      defence_slash: 7
-      defence_crush: 10
-      defence_ranged: 8
-      defence_magic: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: 7
+    defence_bonus:
+      stab: 4
+      slash: 7
+      crush: 10
+      magic: 5
+      ranged: 8
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 2
   recipes:
     - skill: crafting
       level: 76
       xp: 190
       materials:
-        - item_id: 30085
-          item_name: Hueycoatl hide
+        - item_name: Hueycoatl hide
           quantity: 2
-        - item_id: 1734
-          item_name: Thread
+        - item_name: Thread
           quantity: 1
-  market:
-    buy_limit: 70
-    price_estimate: 950000
+      tools:
+        - Needle
+      output_quantity: 1
   related_items:
-    - item_id: 30085
-      item_name: Hueycoatl hide
+    - item_name: Hueycoatl hide
       slug: hueycoatl-hide
       relationship: component
-      description: Crafting material
-    - item_id: 30076
-      item_name: Hueycoatl hide body
+      description: "Crafting material - two hides per coif"
+    - item_name: Hueycoatl hide body
       slug: hueycoatl-hide-body
       relationship: set-piece
-      description: Body armor
-    - item_id: 30079
-      item_name: Hueycoatl hide chaps
+      description: "Torso piece of the Hueycoatl hide set"
+    - item_name: Hueycoatl hide chaps
       slug: hueycoatl-hide-chaps
       relationship: set-piece
-      description: Leg armor
-    - item_id: 30082
-      item_name: Hueycoatl hide vambraces
+      description: "Leg piece of the Hueycoatl hide set"
+    - item_name: Hueycoatl hide vambraces
       slug: hueycoatl-hide-vambraces
       relationship: set-piece
-      description: Gloves
+      description: "Glove piece of the Hueycoatl hide set"
   about: |-
-    - 40 Defence
-    - 70 Ranged
-
-    | Stat | Bonus |
-    |------|-------|
-    | Ranged Attack | +7 |
-    | Magic Attack | -1 |
-    | Stab Defence | +4 |
-    | Slash Defence | +7 |
-    | Crush Defence | +10 |
-    | Ranged Defence | +8 |
-    | Magic Defence | +5 |
-    | Prayer | +2 |
-
-    The Hueycoatl hide coif is part of the Hueycoatl hide armor set. Key features:
-
-    - Prayer bonus: Provides +2 prayer, useful for extended trips
-    - Balanced defences: Good all-around defensive stats
-    - Ranged focus: Designed for ranged combat setups
-
-    Best used with:
-    - Hueycoatl hide body
-    - Hueycoatl hide chaps
-    - Hueycoatl hide vambraces
-
-    Full set prayer bonus: +8 total prayer from all pieces combined
+    Ranged head slot crafted from two Hueycoatl hides and a thread at 76 Crafting (190 xp). Provides +7 ranged attack, balanced defences, and a +2 prayer bonus. Part of the four-piece Hueycoatl hide set sourced from the Hueycoatl boss in the Varlamore expansion.
   market_strategy:
     notes:
-      - Compare crafting cost vs buying price
-      - Part of a set - demand correlates with other pieces
-      - Prayer bonus makes it attractive for specific content
-      - Check hide prices before deciding to craft or buy
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Crafting level reduced from 86 to 76 in the June 2025 update, expanding the crafter pool"
+      - "Set-wide prayer bonus (+8 total) drives demand for completionist setups"
+      - "Hueycoatl hide drop volume dictates floor price"
+      - "Compare craft profit vs GE before buying directly"
+  trading_tips:
+    - "Watch Hueycoatl boss meta - drop rate adjustments swing hide prices"
+    - "Pieces trade together - body and chaps are the price drivers"
+    - "No GE buy limit reported - bulk trades are viable"
+  history:
+    - date: "2024-09-25"
+      description: "Released with the Varlamore: The Hunter Called expansion and the Hueycoatl boss"
+    - date: "2025-06-18"
+      description: "Crafting requirement reduced from level 86 to level 76"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ice-plateau-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ice-plateau-teleport-tablet.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Ice plateau teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: teleport-tablet
+    tier: mid
+  properties:
+    release_date: "2020-09-30"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Configure
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: magic
+      level: 89
+      xp: 92
+      materials:
+        - item_name: Law rune
+          quantity: 3
+        - item_name: Water rune
+          quantity: 8
+        - item_name: Astral rune
+          quantity: 3
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Lunar lectern
+      output_quantity: 1
+  related_items:
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: "Required to enchant the tablet"
+    - item_name: Astral rune
+      slug: astral-rune
+      relationship: component
+      description: "Lunar spellbook reagent for the tablet"
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: "Base material the tablet is enchanted onto"
+    - item_name: Ape atoll teleport (tablet)
+      slug: ape-atoll-teleport-tablet
+      relationship: alternative
+      description: "Another lunar teleport tablet"
+  about: |-
+    The Ice plateau teleport tablet lets any player without Magic level 89 reach the Ice Plateau in level 53 Wilderness. Breaking it triggers a warning dialog before teleporting since the destination is deep Wilderness. The Configure option toggles that warning prompt.
+  market_strategy:
+    notes:
+      - "Bulk teleport for Wilderness content and DDS pkers"
+      - "Made on Lunar spellbook for ~396 gp profit per tablet"
+      - "No Magic requirement to break, useful for low-level mules"
+  trading_tips:
+    - "Stockpile when soft clay or astral runes are cheap"
+    - "Spike in demand during Wilderness events and DMM"
+    - "Sell during Wilderness PvP weekends for best margins"
+  history:
+    - date: "2020-09-30"
+      description: "Tablet variant added with the lunar lectern update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/infinity-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/infinity-boots.mdx
@@ -12,40 +12,52 @@ osrs:
   lowalch: 4800
   highalch: 7200
   limit: 125
-  item_id: 6920
-  type: equipment
-  tradeable: true
-  weight: 0.453
-  buy_limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: magic_boots
+    tier: infinity
+  properties:
+    release_date: "2004-12-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    weight: 0.453
+    options:
+      - wear
+      - drop
+    worn_options:
+      - remove
   equipment:
     slot: feet
-    type: magic_boots
+    attack_speed: 4
     requirements:
-      skills:
-        - skill: magic
-          level: 50
-        - skill: defence
-          level: 25
-    stats:
-      attack_magic: 5
-      defence_magic: 5
-  obtaining:
-    minigame:
-      name: Mage Training Arena
-      points_required:
-        telekinetic: 120
-        alchemist: 120
-        enchantment: 1200
-        graveyard: 120
+      magic: 50
+      defence: 25
+    attack_bonus:
+      magic: 5
+    defence_bonus:
+      magic: 5
+  drop_table:
+    sources:
+      - source: Mage Training Arena reward shop
+        quantity: "1"
+        rarity: "Purchase"
+        notes: "Requires 120 Telekinetic, 120 Alchemist, 1200 Enchantment, and 120 Graveyard points"
   related_items:
-    - slug: eternal-boots
-      name: Eternal boots
-      relation: best_upgrade
-    - slug: wizard-boots
-      name: Wizard boots
-      relation: budget_alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 24135
+      item_name: Eternal boots
+      slug: eternal-boots
+      relationship: upgrade
+      description: Upgraded version with higher magic attack bonus
+    - item_id: 2361
+      item_name: Wizard boots
+      slug: wizard-boots
+      relationship: alternative
+      description: Budget alternative for low-level mages
+  about: |-
+    Infinity boots are part of the Infinity robes set obtained from the Mage Training Arena minigame. Provides a +5 Magic attack and +5 Magic defence bonus, popular for mid-tier magic builds.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/irit-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/irit-potion-unf.mdx
@@ -12,13 +12,14 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid-high
   potion:
     type: unfinished
     tier: mid-high
-  herblore:
-    level: 45
-    xp: 0
-    method: Add irit leaf to vial of water
   recipes:
     - skill: herblore
       level: 45
@@ -30,9 +31,9 @@ osrs:
         - item_name: Irit leaf
           item_id: 259
           quantity: 1
-      product: Irit potion (unf)
-      product_id: 101
-      product_quantity: 1
+      output: Irit potion (unf)
+      output_id: 101
+      output_quantity: 1
       members_only: true
   related_items:
     - item_id: 259
@@ -67,8 +68,6 @@ osrs:
     Add secondary ingredient to create:
     - Super attack (+ eye of newt)
     - Antidote+ (+ yew roots)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow-p-5617.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-arrow-p-5617.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron arrow(p+) | OSRS Price Data
-description: "Iron arrow(p+): Venomous-looking arrows.. High alch: 1 GP, GE limit: 7,000."
+description: "Iron arrow(p+): Venomous-looking arrows. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 5617
   name: Iron arrow(p+)
@@ -12,9 +12,95 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Iron arrow(p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Iron arrow(p+) is an iron arrow coated in extra strong weapon poison. Used with shortbows and longbows for ranged combat with stronger poison damage than the standard (p) variant."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: iron
+  properties:
+    release_date: "2005-12-12"
+    weight: 0
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: ammo
+    attack_speed: null
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 10
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Iron arrow
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      output_quantity: 1
+      notes: "Apply weapon poison(+) to iron arrows for the p+ variant"
+  passive_effects:
+    - name: Extra Strong Poison
+      description: "Inflicts extra strong weapon poison damage on hit; stronger than standard (p)"
+  related_items:
+    - item_id: 884
+      item_name: Iron arrow
+      slug: iron-arrow
+      relationship: variant
+      description: Unpoisoned base arrow
+    - item_id: 885
+      item_name: Iron arrow(p)
+      slug: iron-arrow-p-885
+      relationship: downgrade
+      description: Standard poison variant
+    - item_id: 5618
+      item_name: Iron arrow(p++)
+      slug: iron-arrow-p-plus-plus
+      relationship: upgrade
+      description: Super strong poison variant
+  market_strategy:
+    notes:
+      - "Niche poison ammo for low-level training and PvP"
+      - "Cheap supply once iron arrows + weapon poison(+) are common"
+      - "GE limit 7,000 per 4 hours"
+  trading_tips:
+    - "Combine: iron arrows + weapon poison(+)"
+    - "Renamed from Iron arrow(+) to Iron arrow(p+) in 2006"
+    - "Iron arrows exempt from GE convenience fee since May 2025"
+  history:
+    - date: "2002-03-25"
+      description: "Base iron arrow released"
+    - date: "2005-12-12"
+      description: "Poison variants added to the game"
+    - date: "2006-01-09"
+      description: "Renamed from Iron arrow(+) to Iron arrow(p+)"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-gold-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-gold-trimmed-set-lg.mdx
@@ -12,12 +12,24 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 8
+  material:
+    type: armor_set
+    tier: low
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Open
+      - Drop
+    worn_options: []
   about: "Iron gold-trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-limbs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-limbs.mdx
@@ -12,9 +12,50 @@ osrs:
   lowalch: 28
   highalch: 42
   limit: 10000
-  about: "Iron limbs is a members-only item in Old School RuneScape. High alchemy value: 42 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: iron
+  properties:
+    release_date: "2007-08-28"
+    update: "Crossbows"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: smithing
+      level: 36
+      xp: 25
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  about: "Iron limbs are crossbow limbs smithed from iron bars at level 36 Smithing. Combined with a wooden stock to make an iron crossbow."
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "High GE limit of 10,000 supports bulk flipping."
+      - "Supply driven by Smithing training and crossbow demand."
+      - "High alch 42 gp — alching is unprofitable."
+  trading_tips:
+    - "Margins tied to iron bar spot price."
+    - "Cheap intermediate for early-tier crossbow crafters."
+  history:
+    - date: "2007-08-28"
+      update: "Crossbows"
+      description: "Iron limbs released as part of the metal crossbow expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-spear-p-5706.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-spear-p-5706.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 125
+  material:
+    type: metal
+    tier: iron
   about: "Iron spear(p+) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-sword.mdx
@@ -12,29 +12,47 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 125
-  item_id: 1279
-  item_type: equipment
-  slot: weapon
-  type: sword
-  attack_style: stab
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 1
-  stats:
-    stab_attack: 6
-    slash_attack: 4
-    crush_attack: -2
-    strength: 7
+  material:
+    type: weapon
+    tier: low
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+  equipment:
+    slot: weapon
+    type: sword
+    attack_style: stab
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 1
+    stats:
+      stab_attack: 6
+      slash_attack: 4
+      crush_attack: -2
+      strength: 7
   related_items:
-    - slug: steel-sword
-    - slug: iron-scimitar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Steel sword
+      slug: steel-sword
+      relationship: upgrade
+      description: Next tier sword
+    - item_name: Iron scimitar
+      slug: iron-scimitar
+      relationship: alternative
+      description: Same tier slash weapon
+  about: "Iron sword is a free-to-play item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 125 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-warhammer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-warhammer.mdx
@@ -12,11 +12,22 @@ osrs:
   lowalch: 69
   highalch: 103
   limit: 125
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2001-04-11"
+    options:
+      - Wield
+      - Examine
+    worn_options:
+      - Remove
   equipment:
     slot: weapon
     type: warhammer
     tradeable: true
     weight: 1.814
+    attack_speed: 6
     requirements:
       attack: 1
     stats:
@@ -45,8 +56,8 @@ osrs:
       slug: iron-mace
       relationship: alternative
       description: Alternative crush weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-necklace.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jade necklace | OSRS Price Data
-description: "Jade necklace: I wonder if this is valuable.. High alch: 765 GP, GE limit: 10,000."
+description: "Jade necklace: I wonder if this is valuable. High alch: 765 GP, GE limit: 10,000."
 osrs:
   id: 21093
   name: Jade necklace
@@ -12,9 +12,84 @@ osrs:
   lowalch: 510
   highalch: 765
   limit: 10000
-  about: "Jade necklace is a members-only item in Old School RuneScape. High alchemy value: 765 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Jade necklace is a members-only piece of silver jewellery crafted from a silver bar and a jade gem. It can be enchanted into a necklace of passage for utility teleports."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: gem
+    tier: jade
+  properties:
+    release_date: "2017-02-02"
+    weight: 0.01
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: neck
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 25
+      xp: 54
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+        - item_name: Jade
+          quantity: 1
+      output_quantity: 1
+      notes: "Use silver bar with furnace while carrying a necklace mould and a jade gem"
+  related_items:
+    - item_id: 1683
+      item_name: Necklace of passage(5)
+      slug: necklace-of-passage-5
+      relationship: product
+      description: Lvl-2 Enchant target — teleport necklace
+    - item_id: 21095
+      item_name: Topaz necklace
+      slug: topaz-necklace
+      relationship: alternative
+      description: Adjacent silver-tier necklace
+  market_strategy:
+    notes:
+      - "Crafting input for necklace of passage via Lvl-2 Enchant"
+      - "Profit margin depends on jade and silver bar spreads"
+      - "Low ROI per cast — bulk only"
+  trading_tips:
+    - "Jade + silver bar combine at any furnace with necklace mould"
+    - "Enchant cost: Lvl-2 Enchant (1 cosmic + 3 air rune)"
+    - "Sells at GE post-tax around break-even on jade dips"
+  history:
+    - date: "2017-02-02"
+      description: "Added to OSRS in the silver jewellery expansion"
+    - date: "2017-02-16"
+      description: "Inventory sprite rotated to a non-standard angle"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 13000
-  about: "Jade is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: gem
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 13
+      xp: 20
+      materials:
+        - item_name: Uncut jade
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+      output_quantity: 1
+    - skill: fletching
+      level: 26
+      xp: 2.4
+      materials:
+        - item_name: Jade
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+      output_quantity: 12
+  related_items:
+    - item_name: Uncut jade
+      relationship: component
+    - item_name: Jade bolt tips
+      relationship: product
+    - item_name: Jade amulet (u)
+      relationship: product
+    - item_name: Opal
+      relationship: downgrade
+    - item_name: Topaz
+      relationship: upgrade
+  market_strategy:
+    notes:
+      - "Cut from uncut jade at 13 Crafting; used in fletching jade bolt tips."
+      - "Demand from mid-level Crafting and ranged ammunition players."
+  trading_tips:
+    - "Track uncut jade pricing for craft margin."
+    - "Bolt tip demand spikes during ranged training pushes."
+  history:
+    - date: "2002-09-26"
+      description: "Jade introduced with the original Crafting skill release."
+  properties:
+    release_date: "2002-09-26"
+    update: Crafting
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Jade is a members-only semi precious gem used in Crafting and Fletching. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jug.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jug.mdx
@@ -12,9 +12,75 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Jug is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: pottery
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 1
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 7
+      xp: 25
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+      tools:
+        - Potter's wheel
+        - Pottery oven
+      output_quantity: 1
+  shops:
+    - shop_name: Ardougne general store
+      location: East Ardougne
+      price: 1
+      stock: 5
+    - shop_name: Lumbridge general store
+      location: Lumbridge
+      price: 1
+      stock: 2
+  related_items:
+    - item_name: Jug of water
+      slug: jug-of-water
+      relationship: product
+      description: Filled at a water source for cooking and Herblore.
+    - item_name: Jug of wine
+      slug: jug-of-wine
+      relationship: product
+      description: Made by adding grapes to a jug of water.
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Crafted on the potter's wheel into an unfired jug.
+    - item_name: Bowl
+      slug: bowl
+      relationship: alternative
+      description: Similar low-level pottery item used in Cooking.
+  about: "The jug is a free-to-play pottery container crafted at 7 Crafting from soft clay using a potter's wheel and pottery oven. It can be filled at any water source to create a jug of water, then combined with grapes for jug of wine, making it a staple supply item for Cooking, Herblore, and quest recipes."
+  market_strategy:
+    notes:
+      - "Sits at alch floor of 1 gp; profitability is marginal even in bulk"
+      - "Demand driven by Cooking and Herblore training restock cycles"
+      - "Crafting and shop runs flood supply at predictable cadence"
+  trading_tips:
+    - "Bulk buy from general stores beats GE flip for ironman supply runs"
+    - "Watch low-level Crafting events for short demand spikes"
+  history:
+    - date: "2001-01-04"
+      description: "Released with the initial RuneScape Cooking and Crafting systems."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/justiciar-faceguard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/justiciar-faceguard.mdx
@@ -12,9 +12,22 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 8
+  material:
+    type: armor
+    tier: high
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
   equipment:
     slot: head
     type: tank
+    attack_speed: 1
     requirements:
       defence: 75
     stats:
@@ -30,6 +43,9 @@ osrs:
     formula: Defence bonus / 3000
     minimum_reduction: 1
     stacks_with: Elysian spirit shield
+  passive_effects:
+    - name: Justiciar Damage Reduction
+      description: "Full set damage reduction: Defence bonus / 3000, minimum 1. Stacks with Elysian spirit shield."
   drop_table:
     sources:
       - source: Theatre of Blood
@@ -82,14 +98,19 @@ osrs:
     Best tank armour in the game.
   market_strategy:
     notes:
-      - Full set required for bonus
-      - From Theatre of Blood
-      - Massive defensive stats
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Full set required for bonus"
+      - "From Theatre of Blood"
+      - "Massive defensive stats"
+  trading_tips:
+    - "BiS tank head slot in OSRS"
+    - "Source: Theatre of Blood rare drop"
+    - "Full set required for damage reduction bonus"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-hat.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 150
-  about: "Kyatt hat is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: leather
+    tier: kyatt
+  properties:
+    release_date: "2006-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - wear
+      - drop
+    worn_options:
+      - remove
+  equipment:
+    slot: head
+    attack_speed: 4
+    requirements:
+      ranged: 40
+      hitpoints: 40
+    defence_bonus:
+      stab: 1
+      slash: 0
+      crush: 2
+      magic: -1
+      ranged: 2
+  recipes:
+    - skill: crafting
+      level: 67
+      xp: 168
+      materials:
+        - item_name: Kyatt fur
+          quantity: 2
+        - item_name: Thread
+          quantity: 1
+        - item_name: Needle
+          quantity: 1
+      output_quantity: 1
+      notes: "Crafted at a loom or by using needle on fur"
+  related_items:
+    - item_id: 10041
+      item_name: Kyatt top
+      slug: kyatt-top
+      relationship: set-piece
+      description: Body slot piece of the Kyatt set
+    - item_id: 10043
+      item_name: Kyatt legs
+      slug: kyatt-legs
+      relationship: set-piece
+      description: Legs slot piece of the Kyatt set
+  about: |-
+    Kyatt hat is part of the polar camouflage set used in Fremennik Hunter areas. Provides camouflage in polar regions and a small ranged defence bonus.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/large-rune-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/large-rune-keel-parts.mdx
@@ -12,9 +12,52 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 100
-  about: "Large rune keel parts is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: runite
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 86
+      xp: 5
+      materials:
+        - item_name: Rune keel parts
+          quantity: 5
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  related_items:
+    - item_name: Rune keel parts
+      slug: rune-keel-parts
+      relationship: component
+      description: "Combine 5 of these on an anvil to forge one Large rune keel parts"
+  about: "Large rune keel parts are smithed at level 86 Smithing from 5 Rune keel parts. Used in building runite keels for larger boats; the recipe and item gate behind the Pandemonium quest."
+  market_strategy:
+    notes:
+      - "Requires Pandemonium quest completion to smith"
+      - "A full rune keel needs 16 large parts (400 runite bars total)"
+  trading_tips:
+    - "Buy limit: 100 per 4 hours"
+    - Profit margin tracks closely with runite bar price — watch the spread
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Pandemonium quest content"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lean-snail-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lean-snail-meat.mdx
@@ -12,12 +12,23 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 6000
+  material:
+    type: food_raw
+    tier: low
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Drop
+    worn_options: []
   about: "Lean snail meat is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/light-tuxedo-cuffs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/light-tuxedo-cuffs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Light tuxedo cuffs | OSRS Price Data
-description: "Light tuxedo cuffs: Linked tuxedo cuffs with a gold trim.. High alch: 1,800 GP, GE limit: 4."
+description: "Light tuxedo cuffs: Linked tuxedo cuffs with a gold trim. High alch: 1,800 GP, GE limit: 4."
 osrs:
   id: 19976
   name: Light tuxedo cuffs
@@ -12,9 +12,89 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 4
-  about: "Light tuxedo cuffs is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Light tuxedo cuffs are a cosmetic hands-slot reward from elite Treasure Trails, part of the five-piece light tuxedo outfit."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    weight: 0.5
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: hands
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: elite
+    rarity: 1/12750
+  related_items:
+    - item_id: 19970
+      item_name: Light tuxedo jacket
+      slug: light-tuxedo-jacket
+      relationship: set-piece
+      description: Matching jacket
+    - item_id: 19973
+      item_name: Light tuxedo trousers
+      slug: light-tuxedo-trousers
+      relationship: set-piece
+      description: Matching trousers
+    - item_id: 19967
+      item_name: Light bowtie
+      slug: light-bowtie
+      relationship: set-piece
+      description: Matching bowtie
+    - item_id: 19979
+      item_name: Light tuxedo shoes
+      slug: light-tuxedo-shoes
+      relationship: set-piece
+      description: Matching shoes
+    - item_id: 19985
+      item_name: Dark tuxedo cuffs
+      slug: dark-tuxedo-cuffs
+      relationship: alternative
+      description: Dark-coloured cuffs variant
+  market_strategy:
+    notes:
+      - "Elite clue cosmetic — supply driven by elite clue completion rate"
+      - "Part of the five-piece light tuxedo outfit"
+      - "Storable in costume room treasure chest"
+  trading_tips:
+    - "Elite clue: 1/12,750 from elite reward caskets"
+    - "Buy all 5 pieces for the full tuxedo look"
+    - "GE limit: 4 per 4 hours"
+  history:
+    - date: "2016-07-06"
+      description: "Added as part of the elite Treasure Trail tuxedo cosmetic rewards"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/light-tuxedo-shoes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/light-tuxedo-shoes.mdx
@@ -12,9 +12,18 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2017-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: false
   about: "Light tuxedo shoes is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/long-kebbit-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/long-kebbit-bolts.mdx
@@ -13,8 +13,55 @@ osrs:
   highalch: 18
   limit: 11000
   about: "Long kebbit bolts is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bone
+    tier: low
+  properties:
+    release_date: "2005-09-26"
+    quest_item: false
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    destroy_action: drop
+    options:
+      - wield
+      - drop
+    worn_options:
+      - remove
+  equipment:
+    slot: ammo
+    attack_speed: 4
+    weapon_type: bolts
+    requirements:
+      ranged: 1
+  related_items:
+    - item_id: 10158
+      item_name: Kebbit bolts
+      slug: kebbit-bolts
+      relationship: alternative
+      description: Standard kebbit bolts
+    - item_id: 10156
+      item_name: Hunters' crossbow
+      slug: hunters-crossbow
+      relationship: alternative
+      description: Crossbow that fires kebbit bolts
+    - item_id: 10115
+      item_name: Long kebbit spike
+      slug: long-kebbit-spike
+      relationship: component
+      description: Raw spike used to fletch the bolt
+  market_strategy:
+    notes:
+      - "Niche Hunter crossbow ammo"
+      - "Tiny demand outside hunters"
+      - "Cheap to source via Hunter activity"
+      - "Thin steady turnover"
+  trading_tips:
+    - "Buying tip: bulk cheap from Hunter trainers"
+    - "Selling tip: list during Hunter content updates"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lunar-isle-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lunar-isle-teleport.mdx
@@ -12,9 +12,70 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Lunar isle teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: tablet
+    tier: low
+  teleport:
+    destination: Lunar Isle (outside the Astral Altar)
+    type: tablet
+    quest_requirement: Lunar Diplomacy (to use destination)
+  recipes:
+    - skill: magic
+      level: 69
+      xp: 70
+      facility: Lectern
+      spellbook: Lunar
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Astral rune
+          quantity: 2
+        - item_name: Earth rune
+          quantity: 2
+        - item_name: Law rune
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Astral rune
+      slug: astral-rune
+      relationship: component
+      description: Lunar spellbook rune used in tablet creation
+    - item_name: Moonclan teleport
+      slug: moonclan-teleport
+      relationship: alternative
+      description: Alternative Lunar tablet that lands inside the Moonclan settlement
+  about: "Lunar isle teleport is a Lunar spellbook tablet that teleports the user to Lunar Isle outside the Astral Altar. Creation requires 69 Magic on a House lectern and completion of the Lunar Diplomacy quest to use the destination."
+  market_strategy:
+    notes:
+      - "Steady demand from Astral runecrafters"
+      - "Soft clay supply caps daily tablet production"
+      - "Lower alch value means flipping margin is thin"
+  trading_tips:
+    - "Volume tracks the Lunar Diplomacy completion rate and Astral RC popularity"
+    - "Stock when soft clay prices dip to capture margin"
+  history:
+    - date: "2006-07-05"
+      description: "Lunar isle teleport tablet introduced alongside the Lunar spellbook expansion."
+  properties:
+    release_date: "2006-07-05"
+    update: Lunar Diplomacy
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    quest: Lunar Diplomacy
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-sapling.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Maple sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: farming
+    tier: mid
+  recipes:
+    - skill: farming
+      level: 45
+      xp: 22
+      materials:
+        - item_name: Maple seed
+          quantity: 1
+        - item_name: Plant pot (filled)
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Maple seed
+      relationship: component
+    - item_name: Maple logs
+      relationship: product
+    - item_name: Plant pot
+      relationship: component
+  market_strategy:
+    notes:
+      - "Made from maple seeds at 45 Farming; tracks the seed market closely."
+      - "Used by mid-level Farming players growing maple trees for Woodcutting."
+  trading_tips:
+    - "Buy seeds when cheap and stockpile saplings for the next bonus event."
+    - "Watch for arbitrage between seed cost and sapling GE price."
+  history:
+    - date: "2005-07-12"
+      description: "Maple sapling released with the original Farming launch."
+  properties:
+    release_date: "2005-07-12"
+    update: Farming
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Check-health
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Maple sapling is a members-only Farming sapling for tree patches. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marble-cape-rack-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marble-cape-rack-flatpack.mdx
@@ -13,8 +13,51 @@ osrs:
   highalch: 6
   limit: 500
   about: "Marble cape rack (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: marble
+  properties:
+    release_date: "2006-05-31"
+    quest_item: false
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    destroy_action: drop
+    options:
+      - drop
+  recipes:
+    - skill: construction
+      level: 84
+      xp: 500
+      materials:
+        - item_name: Marble block
+          item_id: 8788
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 8788
+      item_name: Marble block
+      slug: marble-block
+      relationship: component
+      description: Construction material
+    - item_id: 9846
+      item_name: Gilded cape rack (flatpack)
+      slug: gilded-cape-rack-flatpack
+      relationship: alternative
+      description: Higher tier cape rack flatpack
+  market_strategy:
+    notes:
+      - "Top tier cape rack for Costume Room"
+      - "Used by Construction trainers"
+      - "Bought by max-house decorators"
+      - "Demand spikes with Construction events"
+  trading_tips:
+    - "Buying tip: stock up before Construction DXP weekends"
+    - "Selling tip: list during Construction-focused leagues"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/marlin-scales.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/marlin-scales.mdx
@@ -1,6 +1,6 @@
 ---
 title: Marlin scales | OSRS Price Data
-description: "Marlin scales: Small shiny scales.. High alch: 30 GP, GE limit: 11,000."
+description: "Marlin scales is a members Herblore secondary obtained by cutting raw marlin. High alch: 30 GP, GE limit: 11,000."
 osrs:
   id: 32362
   name: Marlin scales
@@ -12,9 +12,97 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 11000
-  about: "Marlin scales is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: secondary
+    tier: mid
+  equipment:
+    slot: null
+    weight: null
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Raw marlin
+          quantity: 1
+        - item_name: Knife
+          quantity: 1
+      output_quantity: 3
+      notes: "Use knife on raw marlin; chum station multiplies yield."
+    - skill: herblore
+      level: 85
+      xp: 0
+      materials:
+        - item_name: Stamina potion
+          quantity: 1
+        - item_name: Marlin scales
+          quantity: 1
+      output_quantity: 1
+      notes: "Each dose of extended stamina requires one marlin scale."
+  related_items:
+    - item_name: Raw marlin
+      slug: raw-marlin
+      relationship: component
+      description: Source fish cut to produce marlin scales.
+    - item_name: Extended stamina potion
+      slug: extended-stamina-potion
+      relationship: alternative
+      description: Primary Herblore product requiring marlin scales.
+    - item_name: Fine fish offcuts
+      slug: fine-fish-offcuts
+      relationship: alternative
+      description: Byproduct produced alongside scales when cutting marlin.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Demand driven by extended stamina potion crafting at 85 Herblore."
+      - "Supply tied to deep sea trawling and Sailing skill output."
+      - "High GE limit of 11,000 enables bulk Herblore stocking."
+  trading_tips:
+    - "Compare scale price vs raw marlin: cut yourself for margin."
+    - Stockpile during Sailing skill spotlight events.
+    - Watch extended stamina demand around bossing meta shifts.
+  about: Marlin scales is a members-only Herblore secondary obtained by cutting raw marlin, primarily used to brew extended stamina potions at 85 Herblore.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2025-11-19"
+      update: "Sailing"
+      description: Marlin scales released alongside the Sailing skill and deep sea trawling.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/meat-tenderiser.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/meat-tenderiser.mdx
@@ -13,8 +13,17 @@ osrs:
   highalch: 24900
   limit: 50
   about: "Meat tenderiser is a members-only item in Old School RuneScape. High alchemy value: 24,900 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2004-11-23"
+    options:
+      - Use
+      - Examine
+    worn_options: []
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/merfolk-trident.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/merfolk-trident.mdx
@@ -12,69 +12,96 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: weapon
+    tier: mid
+  properties:
+    release_date: "2017-09-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Check
+      - Channel
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: 2h
-    type: spear
-    tradeable: true
+    weapon_type: spear
+    attack_speed: 5
     weight: 0.907
-    stats:
-      attack_stab: 8
-      attack_slash: 8
-      attack_crush: 8
+    requirements: {}
+    attack_bonus:
+      stab: 8
+      slash: 8
+      crush: 8
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
       strength: 4
-      stab_def: 1
-      slash_def: 1
-  special_effects:
-    - name: Drift Net Fishing
-      description: Increases chance to scare fish into nets
-    - name: Underwater Breathing
-      description: Charge with up to 10 pufferfish to regain breath
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Mairin's Market
+      location: Underwater Fossil Island
+      price: 400
+      currency: Mermaid's tears
+      stock: 10
+  passive_effects:
+    - name: Drift net fishing aid
+      description: "Increases chance to scare shoals into nets during drift net fishing"
+    - name: Underwater breathing
+      description: "Can be charged with up to 10 pufferfish to refill the player's air"
     - name: Swimming
-      description: One of few weapons allowing swimming while wielding
-  shop:
-    npc: Mairin's Market
-    location: Underwater Fossil Island
-    price: 400
-    currency: Mermaid tears
-  market:
-    buy_limit: 8
-    price_estimate: 2050000
+      description: "One of the few weapons that allows swimming while wielded"
   related_items:
-    - item_id: 21516
-      item_name: Fossil Island
-      slug: fossil-island
-      relationship: alternative
-      description: Location
-    - item_id: 21656
-      item_name: Mermaid tear
-      slug: mermaid-tear
+    - item_name: Mermaid's tear
+      slug: mermaids-tear
       relationship: component
-      description: Currency
-    - item_id: 22016
-      item_name: Drift net
+      description: "Currency used to purchase the trident at Mairin's Market"
+    - item_name: Drift net
       slug: drift-net
       relationship: alternative
-      description: Use with
+      description: "Net used together with the trident for shoal fishing"
+    - item_name: Pufferfish
+      slug: pufferfish
+      relationship: component
+      description: "Charge fuel for underwater breathing"
+    - item_name: Tackle box
+      slug: tackle-box
+      relationship: alternative
+      description: "Storage container for the trident"
   about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +8 |
-    | Slash | +8 |
-    | Crush | +8 |
-    | Strength | +4 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | +1 |
-    | Slash | +1 |
-
-    Drift Net Fishing: Increases chance to scare fish into nets.
-
-    Underwater Breathing: Charge with up to 10 pufferfish to regain breath.
-
-    Swimming: One of few weapons allowing swimming while wielding.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Two-handed underwater spear bought from Mairin's Market on Fossil Island for 400 mermaid's tears. Aids drift net fishing, can be charged with pufferfish for underwater breathing, and is one of the only weapons that allows swimming while wielded.
+  market_strategy:
+    notes:
+      - "Effective only underwater - niche but mandatory for drift net fishing"
+      - "GE limit 125 supports flips during Fossil Island content spikes"
+      - "Tied directly to mermaid's tear farming cycle"
+  trading_tips:
+    - "Buy direct from Mairin's Market if you have mermaid's tears to save GP"
+    - "Check pufferfish prices - charges drive ongoing cost"
+    - "Demand correlates with drift net fishing meta updates"
+  history:
+    - date: "2017-09-07"
+      description: "Released with the Fossil Island update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mith-grapple-tip.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mith-grapple-tip.mdx
@@ -12,9 +12,65 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 11000
-  about: "Mith grapple tip is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: smithing_component
+    tier: mid
+  properties:
+    release_date: "31 July 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 59
+      xp: 50
+      action: Smith on an anvil
+      materials:
+        - item_name: Mithril bar
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Mithril bar
+      slug: mithril-bar
+      relationship: component
+      description: "Smithed into a mith grapple tip at level 59 Smithing"
+    - item_name: Mithril bolts
+      slug: mithril-bolts
+      relationship: component
+      description: "Fletched onto the grapple tip to form an unfinished grapple"
+    - item_name: Mith grapple
+      slug: mith-grapple
+      relationship: product
+      description: "Final grapple used with a crossbow for agility-based climbs"
+    - item_name: Rope
+      slug: rope
+      relationship: component
+      description: "Tied to the grapple to finish the assembly"
+  about: "Mith grapple tip is the smithed mithril component used to make mithril grapples. Forged at 59 Smithing from one mithril bar on an anvil with a hammer for 50 XP, it then receives mithril bolts via Fletching (59, 11 XP) before being tied to a rope to produce the finished mith grapple used with crossbows for grappling shortcuts."
+  market_strategy:
+    notes:
+      - "Demand tied to Agility shortcut grappling and Western Provinces achievements"
+      - "Mithril bar floor sets the production cost; profit margin usually negative without bonus XP"
+      - "Buy limit 11,000 per 4 hours allows mass purchases for grapple crafting"
+  trading_tips:
+    - "Compare against mithril bar plus 50 Smithing XP value to decide buy vs smith"
+    - "Watch mith grapple resale price for bottle-neck flips"
+  history:
+    - date: "31 July 2006"
+      description: "Released with the Regicide quest and grappling mechanic"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-bolts-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril bolts (p) | OSRS Price Data
-description: "Mithril bolts (p): Some poisoned mithril bolts.. High alch: 12 GP, GE limit: 11,000."
+description: "Mithril bolts (p): Some poisoned mithril bolts. High alch: 12 GP, GE limit: 11,000."
 osrs:
   id: 9289
   name: Mithril bolts (p)
@@ -12,9 +12,91 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 11000
-  about: "Mithril bolts (p) is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mithril bolts (p) are poisoned mithril crossbow bolts requiring 25 Ranged to wield. Made by applying weapon poison to standard mithril bolts."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: mithril
+  properties:
+    release_date: "2006-07-31"
+    weight: 0
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: ammo
+    attack_speed: null
+    requirements:
+      ranged: 25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 46
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Mithril bolts
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      output_quantity: 1
+      notes: "Apply weapon poison to mithril bolts to create the (p) variant"
+  passive_effects:
+    - name: Poison
+      description: "Inflicts standard weapon poison on hit; cannot be combined with gem tips"
+  related_items:
+    - item_id: 9142
+      item_name: Mithril bolts
+      slug: mithril-bolts
+      relationship: variant
+      description: Unpoisoned base bolt
+    - item_id: 9290
+      item_name: Mithril bolts (p+)
+      slug: mithril-bolts-p-plus
+      relationship: upgrade
+      description: Extra strong poison variant
+    - item_id: 9291
+      item_name: Mithril bolts (p++)
+      slug: mithril-bolts-p-plus-plus
+      relationship: upgrade
+      description: Super strong poison variant
+  market_strategy:
+    notes:
+      - "Mid-tier ranged ammo with light poison utility"
+      - "Cannot be tipped with gems once poisoned"
+      - "Supply scales with weapon poison + bolt fletching"
+  trading_tips:
+    - "Created via: weapon poison + mithril bolts"
+    - "Useful for low-level PvP / poison-immune slayer skipping"
+    - "GE limit: 11,000 per 4 hours"
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside the crossbows skill update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-felling-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-felling-axe.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 208
   highalch: 312
   limit: null
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: mithril
   about: "Mithril felling axe is a members-only item in Old School RuneScape. High alchemy value: 312 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-kiteshield-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-kiteshield-t.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 884
   highalch: 1326
   limit: 8
-  about: "Mithril kiteshield (t) is a free-to-play item in Old School RuneScape. High alchemy value: 1,326 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: shield
+    weapon_type: null
+    attack_speed: null
+    weight: 4.535
+    requirements:
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 18
+      slash: 20
+      crush: 19
+      magic: -1
+      ranged: 19
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_name: Mithril kiteshield
+      slug: mithril-kiteshield
+      relationship: variant
+      description: Untrimmed base version with identical stats
+    - item_name: Mithril kiteshield (g)
+      slug: mithril-kiteshield-g
+      relationship: variant
+      description: Gold-trimmed cosmetic variant
+  about: "Mithril kiteshield (t) is a team-trimmed cosmetic variant of the standard mithril kiteshield. It has identical stats to the untrimmed version, requires 20 Defence, and is obtained exclusively from easy Treasure Trail reward caskets."
+  market_strategy:
+    notes:
+      - "Purely cosmetic over the untrimmed mithril kiteshield"
+      - "Demand driven by fashion and collectors, not combat utility"
+      - "Easy clue scroll supply directly impacts price floor"
+      - "Trimmed variants typically command a fashion premium"
+  trading_tips:
+    - "Compare price against the regular mithril kiteshield to gauge cosmetic premium"
+    - "Buy limit of 8 makes large flips slow even with healthy spread"
+  history:
+    - date: "2007-08-15"
+      description: "Mithril kiteshield (t) released alongside the trimmed armour set rewards refresh."
+  properties:
+    release_date: "2007-08-15"
+    update: Treasure Trails Trimmed Armour
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platelegs-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-platelegs-g.mdx
@@ -12,9 +12,18 @@ osrs:
   lowalch: 1040
   highalch: 1560
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2002-09-30"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: false
   about: "Mithril platelegs (g) is a free-to-play item in Old School RuneScape. High alchemy value: 1,560 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-spear-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-spear-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril spear(p) | OSRS Price Data
-description: "Mithril spear(p): A poisoned mithril tipped spear.. High alch: 507 GP, GE limit: 125."
+description: "Mithril spear(p) is a members poisoned two-handed melee spear requiring 20 Attack. High alch: 507 GP, GE limit: 125."
 osrs:
   id: 1257
   name: Mithril spear(p)
@@ -12,9 +12,94 @@ osrs:
   lowalch: 338
   highalch: 507
   limit: 125
-  about: "Mithril spear(p) is a members-only item in Old School RuneScape. High alchemy value: 507 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: spear
+    tier: mithril
+  equipment:
+    slot: two-handed
+    weight: 1.814
+    attack_speed: 4
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 17
+      slash: 17
+      crush: 17
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 18
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: herblore
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Mithril spear
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      output_quantity: 1
+      notes: "Apply weapon poison to a regular mithril spear."
+  related_items:
+    - item_id: 1243
+      item_name: Mithril spear
+      slug: mithril-spear
+      relationship: variant
+      description: Unpoisoned base version.
+    - item_name: Mithril spear(p+)
+      slug: mithril-spear-p-plus
+      relationship: variant
+      description: Poison+ upgrade variant.
+    - item_name: Mithril spear(p++)
+      slug: mithril-spear-p-plus-plus
+      relationship: variant
+      description: Poison++ upgrade variant.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Poisoned variant retains base alch value with weapon-poison cost added."
+      - "Demand tied to PvM and low-level PvP poison usage."
+      - "GE limit of 125 caps speculative purchases."
+  trading_tips:
+    - "Margin check vs alch: 507 GP high alch sets the floor."
+    - Cheaper to poison your own mithril spear than buy poisoned variant.
+    - Track weapon poison prices when arbitraging variants.
+  about: Mithril spear(p) is the standard poisoned variant of the mithril spear, dealing poison damage on hit while retaining the base weapon's stats.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2003-04-14"
+    update: "New Throwing Weapons!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2003-04-14"
+      update: "New Throwing Weapons!"
+      description: Mithril spear and poisoned variants released.
+    - date: "2021-03-25"
+      update: Game Update
+      description: "Attack speed improved from 5 ticks to 4 ticks."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-spear.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril spear | OSRS Price Data
-description: "Mithril spear: A mithril tipped spear.. High alch: 507 GP, GE limit: 125."
+description: "Mithril spear is a members two-handed melee spear requiring 20 Attack to wield. High alch: 507 GP, GE limit: 125."
 osrs:
   id: 1243
   name: Mithril spear
@@ -12,9 +12,101 @@ osrs:
   lowalch: 338
   highalch: 507
   limit: 125
-  about: "Mithril spear is a members-only item in Old School RuneScape. High alchemy value: 507 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: spear
+    tier: mithril
+  equipment:
+    slot: two-handed
+    weight: 1.814
+    attack_speed: 4
+    requirements:
+      attack: 20
+    attack_bonus:
+      stab: 17
+      slash: 17
+      crush: 17
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 18
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Mount Karuulm Weapon Shop
+      price: 845
+      stock: 5
+    - shop_name: Fortis Blacksmith
+      price: 845
+      stock: 3
+  recipes:
+    - skill: smithing
+      level: 55
+      xp: 50
+      materials:
+        - item_name: Mithril bar
+          quantity: 1
+        - item_name: Maple logs
+          quantity: 1
+      output_quantity: 1
+      notes: "Requires Barbarian Smithing training; crafted at a barbarian anvil."
+  related_items:
+    - item_id: 1257
+      item_name: Mithril spear(p)
+      slug: mithril-spear-p
+      relationship: variant
+      description: Poisoned version of the mithril spear.
+    - item_name: Adamant spear
+      slug: adamant-spear
+      relationship: upgrade
+      description: Higher-tier metal spear.
+    - item_name: Steel spear
+      slug: steel-spear
+      relationship: alternative
+      description: Lower-tier metal spear.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Cheap mid-tier melee spear with steady demand for alching."
+      - "Supply driven by smithing alts and monster drops."
+      - "Buy limit of 125 per 4 hours restricts large-scale flipping."
+  trading_tips:
+    - "Compare GE price vs high alch: 507 GP for break-even checks."
+    - Stock up from shops at base 845 GP for resell margins.
+    - Watch barbarian smithing patches that shift supply.
+  about: Mithril spear is a members-only two-handed melee weapon requiring 20 Attack to wield, valued for steady stab/slash/crush bonuses at a low tier.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2003-04-14"
+    update: "New Throwing Weapons!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2003-04-14"
+      update: "New Throwing Weapons!"
+      description: Mithril spear released alongside other thrown and spear weapons.
+    - date: "2021-03-25"
+      update: Game Update
+      description: "Attack speed improved from 5 ticks to 4 ticks."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nail-beast-nails.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nail-beast-nails.mdx
@@ -12,79 +12,85 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   material:
     type: monster_drop
-    tier: low
+    tier: mid
+  properties:
+    release_date: "2007-03-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   drop_table:
-    primary_source: Nail beast
     sources:
-      - source: Nail beast
-        source_id: 1552
-        quantity: 2-3
-        rarity: always
-        members_only: true
-        location: Temple Trekking
+      - source: Nail beast (level 69)
+        quantity: "1"
+        rarity: Always (2-3)
+      - source: Nail beast (level 98)
+        quantity: "1"
+        rarity: Always (2-3)
+      - source: Nail beast (level 141)
+        quantity: "1"
+        rarity: Always (2-3)
   recipes:
     - skill: herblore
       level: 65
       xp: 192
       materials:
         - item_name: Super restore(4)
-          item_id: 3024
           quantity: 1
         - item_name: Unicorn horn dust
-          item_id: 235
           quantity: 1
         - item_name: Snake weed
-          item_id: 1526
           quantity: 1
         - item_name: Nail beast nails
-          item_id: 10937
           quantity: 1
-      product: Sanfew serum(4)
-      product_id: 10925
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 10925
-      item_name: Sanfew serum(4)
+    - item_name: Sanfew serum(4)
       slug: sanfew-serum-4
       relationship: product
-      description: Used in creation
-    - item_id: 235
-      item_name: Unicorn horn dust
-      slug: unicorn-horn-dust
-      relationship: component
-      description: Also needed for Sanfew
-    - item_id: 1526
-      item_name: Snake weed
-      slug: snake-weed
-      relationship: component
-      description: Also needed for Sanfew
-    - item_id: 3024
-      item_name: Super restore(4)
+      description: "Crafted at 65 Herblore using nail beast nails"
+    - item_name: Super restore(4)
       slug: super-restore-4
       relationship: component
-      description: Base for Sanfew
+      description: "Base potion combined with nails for Sanfew serum"
+    - item_name: Unicorn horn dust
+      slug: unicorn-horn-dust
+      relationship: component
+      description: "Secondary ingredient in Sanfew serum"
+    - item_name: Snake weed
+      slug: snake-weed
+      relationship: component
+      description: "Secondary ingredient in Sanfew serum"
   about: |-
-    Sole purpose is creating Sanfew serum:
-
-    | Potion | Ingredients | Level |
-    |--------|-------------|-------|
-    | Sanfew serum(4) | Super restore + Unicorn horn dust + Snake weed + Nail beast nails | 65 |
+    The claws of a nail beast, dropped 2-3 at a time from every nail beast encountered during Temple Trekking. Sole purpose is the Sanfew serum recipe at 65 Herblore - combine with a super restore(4), unicorn horn dust, and snake weed for 192 xp.
   market_strategy:
     notes:
-      - Only source of nail beast nails
-      - Infrequent random event
-      - Plan trips when farming nails
-      - Often the bottleneck ingredient for Sanfew
-      - Price fluctuates based on supply
-      - Check relative prices of all 4 ingredients
-      - Must do Temple Trekking
-      - Stock up when encounters happen
-      - Sanfew serum essential for CoX
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Only obtainable through Temple Trekking - supply gated by activity engagement"
+      - "Demand tied to Sanfew serum, a core CoX supply"
+      - "Bottleneck ingredient since the other Sanfew secondaries are farmable"
+      - "Drop quantity increased to 2-3 in the 2024-08-07 update"
+  trading_tips:
+    - "Compare all four Sanfew ingredient prices before flipping any single one"
+    - "Buy when Temple Trekking is meta-quiet, sell into CoX patch spikes"
+    - "GE limit 11,000 supports decent flips for serious flippers"
+  history:
+    - date: "2007-03-13"
+      description: "Released with the Temple Trekking minigame"
+    - date: "2024-08-07"
+      description: "Drop quantity standardised to 2-3 per kill across all nail beast variants"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nasturtiums.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nasturtiums.mdx
@@ -12,9 +12,74 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 600
-  about: "Nasturtiums is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: flower
+    tier: low
+  properties:
+    release_date: "11 July 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  farming:
+    level: 24
+    plant_xp: 19.5
+    harvest_xp: 19.5
+    patch_type: flower
+    growth_time: 20
+    seed_id: 5098
+    seed_name: Nasturtium seed
+  recipes:
+    - skill: herblore
+      level: 3
+      xp: 1
+      action: Make Imp repellent
+      materials:
+        - item_name: Nasturtiums
+          quantity: 1
+        - item_name: Anchovy oil
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Nasturtium seed
+      slug: nasturtium-seed
+      relationship: component
+      description: "Farming seed planted at 24 Farming in a flower patch"
+    - item_name: Anchovy oil
+      slug: anchovy-oil
+      relationship: component
+      description: "Combined with nasturtiums to brew imp repellent"
+    - item_name: Watermelon seed
+      slug: watermelon-seed
+      relationship: alternative
+      description: "Allotment crop protected by adjacent nasturtium patches"
+    - item_name: Marigolds
+      slug: marigolds
+      relationship: alternative
+      description: "Another flower used as crop protection payment"
+  about: "Nasturtiums are a flower harvested from a flower patch at level 24 Farming after planting nasturtium seeds. They protect adjacent watermelon allotments from disease when fully grown, serve as protection payment for wildblood hops, and brew imp repellent at low Herblore. Excess can be composted in compost bins."
+  market_strategy:
+    notes:
+      - "Demand floor set by watermelon farmers planting protection flowers"
+      - "Imp repellent recipe consumes one per craft, adding minor steady draw"
+      - "Buy limit 600 per 4 hours; thin volume keeps margins narrow"
+  trading_tips:
+    - "Track nasturtium seed price; produce-to-sell only profitable when seeds are cheap"
+    - "Watch watermelon farming run profitability for short-term price ticks"
+  history:
+    - date: "11 July 2005"
+      description: "Released with the Farming skill"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-dining-table-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-dining-table-flatpack.mdx
@@ -12,9 +12,18 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: wood
+    tier: mid
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: false
   about: "Oak dining table (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-hull-parts.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 250
   highalch: 375
   limit: 100
-  about: "Oak hull parts is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: construction
+    tier: mid
+  properties:
+    release_date: "19 November 2025"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 8
+      xp: 150
+      materials:
+        - item_name: Oak plank
+          quantity: 5
+      tools:
+        - Saw
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: "Five oak planks consumed per oak hull parts craft at the Shipwrights' Workbench"
+    - item_name: Large oak hull parts
+      slug: large-oak-hull-parts
+      relationship: upgrade
+      description: "Five oak hull parts combine into a larger hull assembly"
+    - item_name: Oak hull
+      slug: oak-hull
+      relationship: product
+      description: "Skiff-tier oak hull assembled from ten parts plus iron nails and swamp tar"
+  about: "Oak hull parts are an intermediate Construction component for the Sailing skill, crafted at the Shipwrights' Workbench from five oak planks at level 8 Construction for 150 XP. Players combine them into larger hull sections or full oak hulls used to build skiffs and other early-tier boats."
+  market_strategy:
+    notes:
+      - "Material cost driven by oak plank pricing; profit margin is typically negative without Construction contract bonuses"
+      - "Demand tracks Sailing skill activity and new boat builds"
+      - "Buy limit of 100 per 4 hours throttles bulk supply"
+  trading_tips:
+    - "Watch oak plank floor; tip is profitable only when planks dip below the parts' GE price"
+    - "Stockpile during Sailing rework patches for short-term spikes"
+  history:
+    - date: "19 November 2025"
+      description: "Released alongside the Sailing skill and Shipwrights' Workbench"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/obsidian-armour-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Obsidian armour set | OSRS Price Data
-description: "Obsidian armour set: A set containing an Obsidian helmet, platebody and platelegs.. High alch: 75,600 GP, GE limit: 5."
+description: "Obsidian armour set is a members Grand Exchange bundle of obsidian helmet, platebody, and platelegs. High alch: 75,600 GP, GE limit: 5."
 osrs:
   id: 21279
   name: Obsidian armour set
@@ -12,9 +12,81 @@ osrs:
   lowalch: 50400
   highalch: 75600
   limit: 5
-  about: "Obsidian armour set is a members-only item in Old School RuneScape. High alchemy value: 75,600 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour-set
+    tier: obsidian
+  equipment:
+    slot: null
+    weight: null
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Obsidian helmet
+      slug: obsidian-helmet
+      relationship: set-piece
+      description: Head slot piece of the obsidian set.
+    - item_name: Obsidian platebody
+      slug: obsidian-platebody
+      relationship: set-piece
+      description: Body slot piece of the obsidian set.
+    - item_name: Obsidian platelegs
+      slug: obsidian-platelegs
+      relationship: set-piece
+      description: Leg slot piece of the obsidian set.
+    - item_name: Berserker necklace
+      slug: berserker-necklace
+      relationship: alternative
+      description: Activates the obsidian armour damage bonus with obsidian melee weapons.
+  market_strategy:
+    notes:
+      - "Investment Notes"
+      - "Use Grand Exchange Sets interface to bundle three pieces for resale."
+      - "Daily volume around 188 trades supports moderate liquidity."
+      - "Buy limit of 5 sets per 4 hours restricts bulk flipping."
+      - "Margin tracks the underlying obsidian piece prices."
+  trading_tips:
+    - "Track individual piece prices: arbitrage set vs unbundled inventory."
+    - Useful for selling full sets after TzHaar grinds with one transaction.
+    - Always exchange via GE clerk Sets interface for free bundling.
+  about: Obsidian armour set is a Grand Exchange convenience bundle that packages an obsidian helmet, platebody, and platelegs for single-transaction trading.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2017-06-01"
+    update: "The Inferno"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2017-06-01"
+      update: "The Inferno"
+      description: Obsidian armour set released as a Grand Exchange bundle alongside The Inferno launch.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oil-lantern-frame.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oil-lantern-frame.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oil lantern frame | OSRS Price Data
-description: "Oil lantern frame: Add the glass to complete.. High alch: 54 GP, GE limit: 10,000."
+description: "Oil lantern frame is a Smithing intermediate forged from an iron bar that becomes an oil lantern once glass is fitted. High alch: 54 GP, GE limit: 10,000."
 osrs:
   id: 4540
   name: Oil lantern frame
@@ -12,9 +12,59 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 10000
-  about: "Oil lantern frame is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: smithed-component
+    tier: low
+  properties:
+    release_date: "2005-03-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: smithing
+      level: 26
+      xp: 25
+      materials:
+        - item_name: Iron bar
+          quantity: 1
+      tools:
+        - Hammer
+      output_quantity: 1
+  related_items:
+    - item_name: Iron bar
+      slug: iron-bar
+      relationship: component
+      description: Smelted bar smithed into the frame at an anvil
+    - item_name: Lantern lens
+      slug: lantern-lens
+      relationship: component
+      description: Glass component fitted to complete the oil lantern
+    - item_name: Oil lantern
+      slug: oil-lantern
+      relationship: product
+      description: Finished lantern once the frame and lens are combined
+  about: Oil lantern frame is the Smithing intermediate for the oil lantern, forged from one iron bar on an anvil with a hammer at 26 Smithing for 25 XP. Players then attach a lantern lens at 26 Crafting to produce an empty oil lantern.
+  market_strategy:
+    notes:
+      - "Demand is driven by low-level Crafting and Firemaking training, so volume is steady but thin"
+      - "Iron bar price floor sets the input cost — undercut at GE rarely pays off"
+  trading_tips:
+    - Compare GE price vs. smelting and smithing an iron bar yourself before buying in bulk
+    - Pair purchases with lantern lens so you can finish lanterns in one bank trip
+  history:
+    - date: "2005-03-14"
+      description: Added to Smithing tables for the empty oil lantern recipe chain.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Olive oil(2) | OSRS Price Data
-description: "Olive oil(2): 2 doses of olive oil.. High alch: 10 GP, GE limit: 10,000."
+description: "Olive oil(2) is a 2-dose Shades of Mort'ton consumable used to make sacred oil. High alch: 10 GP, GE limit: 10,000."
 osrs:
   id: 3426
   name: Olive oil(2)
@@ -12,9 +12,92 @@ osrs:
   lowalch: 6
   highalch: 10
   limit: 10000
-  about: "Olive oil(2) is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: consumable
+    tier: mid
+  equipment:
+    slot: null
+    weight: null
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Razmire General Store
+      price: 28
+      stock: 5
+    - shop_name: Rasolo the Wandering Merchant
+      price: 40
+      stock: 1
+  related_items:
+    - item_name: Olive oil(1)
+      slug: olive-oil-1
+      relationship: variant
+      description: Single-dose variant.
+    - item_name: Olive oil(3)
+      slug: olive-oil-3
+      relationship: variant
+      description: Three-dose variant.
+    - item_name: Olive oil(4)
+      slug: olive-oil-4
+      relationship: variant
+      description: Four-dose variant.
+    - item_name: Sacred oil(2)
+      slug: sacred-oil-2
+      relationship: upgrade
+      description: Result of using olive oil on the Temple of Mort'ton altar.
+    - item_name: Pyre logs
+      slug: pyre-logs
+      relationship: alternative
+      description: Created from sacred oil and logs for the Shades minigame.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Mid-dose variant used in Shades of Mort'ton supply chains."
+      - "Demand correlates with shade burning events."
+      - "Buy limit of 10,000 per 4 hours supports steady flipping."
+  trading_tips:
+    - "Compare per-dose price: 2-dose vs 4-dose for inventory efficiency."
+    - Stockpile when Shades of Mort'ton is in spotlight bonus.
+    - Cheap Razmire shop alts can sustainably resupply.
+  about: Olive oil(2) is a members-only 2-dose container of olive oil used in the Shades of Mort'ton minigame to create sacred oil at the temple altar.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2004-10-18"
+    update: "Mortton Shades and Mage Armour"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2004-10-18"
+      update: "Mortton Shades and Mage Armour"
+      description: Olive oil and the Shades of Mort'ton minigame introduced.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onions-10.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onions-10.mdx
@@ -12,12 +12,23 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
+  material:
+    type: food
+    tier: low
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Drop
+    worn_options: []
   about: "Onions(10) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-amulet.mdx
@@ -12,15 +12,22 @@ osrs:
   lowalch: 80400
   highalch: 120600
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: gem
+    tier: onyx
   equipment:
     slot: neck
+    type: jewellery
+    attack_speed: null
     requirements:
       crafting: 90
   recipes:
     - skill: crafting
       level: 90
       xp: 165
-      inputs:
+      materials:
         - item_name: Onyx
           quantity: 1
         - item_name: Gold bar
@@ -56,11 +63,9 @@ osrs:
     - Used in virtually every combat style
   market_strategy:
     notes:
-      - Onyx cost (from TzHaar shops or Zulrah) drives the price
-      - Fury has massive demand — BiS hybrid neck
-      - High-value enchant — check margins
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Onyx cost (from TzHaar shops or Zulrah) drives the price"
+      - "Fury has massive demand: BiS hybrid neck"
+      - "High-value enchant: check margins"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pineapple-sapling.mdx
@@ -12,9 +12,55 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Pineapple sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: farming
+    tier: mid
+  recipes:
+    - skill: farming
+      level: 51
+      xp: 81.5
+      materials:
+        - item_name: Pineapple seed
+          quantity: 1
+        - item_name: Plant pot (filled)
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Pineapple seed
+      relationship: component
+    - item_name: Pineapple
+      relationship: product
+    - item_name: Plant pot
+      relationship: component
+  market_strategy:
+    notes:
+      - "Crafted from pineapple seeds with 51 Farming; demand tracks fruit tree training."
+      - "Used in the Bone Voyage and Tai Bwo Wannai Trio quest interactions for some players."
+  trading_tips:
+    - "Buy seeds in bulk and craft saplings when seed supply is cheap."
+    - "Watch for spikes during Farming bonus weekends."
+  history:
+    - date: "2005-07-12"
+      description: "Pineapple sapling added with the fruit tree expansion of Farming."
+  properties:
+    release_date: "2005-07-12"
+    update: Farming Update
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Check-health
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Pineapple sapling is a members-only Farming sapling for fruit tree patches. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-leggings-red.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-leggings-red.mdx
@@ -13,8 +13,54 @@ osrs:
   highalch: 210
   limit: 150
   about: "Pirate leggings (red) is a members-only item in Old School RuneScape. High alchemy value: 210 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2006-06-26"
+    quest_item: false
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    destroy_action: drop
+    options:
+      - wear
+      - drop
+    worn_options:
+      - remove
+  equipment:
+    slot: legs
+    attack_speed: 4
+    requirements:
+      defence: 1
+  related_items:
+    - item_id: 7124
+      item_name: Pirate bandana (red)
+      slug: pirate-bandana-red
+      relationship: set-piece
+      description: Matching red pirate bandana
+    - item_id: 7122
+      item_name: Pirate shirt (red)
+      slug: pirate-shirt-red
+      relationship: set-piece
+      description: Matching red pirate shirt
+    - item_id: 7128
+      item_name: Pirate boots
+      slug: pirate-boots
+      relationship: set-piece
+      description: Matching pirate boots
+  market_strategy:
+    notes:
+      - "Cosmetic pirate-themed legwear"
+      - "Part of the red pirate outfit set"
+      - "Limited demand outside fashionscape"
+      - "Steady low-volume turnover"
+  trading_tips:
+    - "Buying tip: pair with shirt and bandana for full set value"
+    - "Selling tip: target fashionscape collectors"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/piscarilius-hood.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/piscarilius-hood.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Piscarilius hood is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/851
+  related_items:
+    - item_name: Reward casket (master)
+      slug: reward-casket-master
+      relationship: component
+      description: "Source casket from master Treasure Trails"
+    - item_name: Hosidius hood
+      slug: hosidius-hood
+      relationship: alternative
+      description: "Other Great Kourend house hood from master clues"
+    - item_name: Lovakengj hood
+      slug: lovakengj-hood
+      relationship: alternative
+      description: "Lovakengj cosmetic counterpart"
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  about: |-
+    The Piscarilius hood is a master Treasure Trail cosmetic head slot reward themed around the Great Kourend house. It offers no combat bonuses and is collected for fashionscape, storable in a mahogany costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Cosmetic master clue reward, niche demand"
+      - "Buy limit of 4 caps quick flips"
+      - "Long-term value tied to master clue supply"
+  trading_tips:
+    - "Stock during master clue droughts for resale spikes"
+    - "Watch casket master volume for incoming supply"
+    - "Patient buy orders, daily volume is low"
+  history:
+    - date: "2016-07-06"
+      description: "Added with the Treasure Trail Expansion update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pizza-base.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pizza-base.mdx
@@ -12,9 +12,73 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Pizza base is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cooking_ingredient
+    tier: low
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    weight: 0.1
+    quest_item: false
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: cooking
+      level: 35
+      xp: 0
+      materials:
+        - item_name: Pot of flour
+          item_id: 1933
+          quantity: 1
+        - item_name: Bowl of water
+          item_id: 1921
+          quantity: 1
+      product: Pizza base
+      product_id: 2283
+      output_quantity: 1
+      members_only: false
+  related_items:
+    - item_id: 1933
+      item_name: Pot of flour
+      slug: pot-of-flour
+      relationship: component
+      description: Flour ingredient
+    - item_id: 1921
+      item_name: Bowl of water
+      slug: bowl-of-water
+      relationship: component
+      description: Water ingredient
+    - item_id: 2285
+      item_name: Incomplete pizza
+      slug: incomplete-pizza
+      relationship: product
+      description: Add tomato to pizza base
+    - item_id: 2289
+      item_name: Plain pizza
+      slug: plain-pizza
+      relationship: product
+      description: Finished cooked pizza
+  market_strategy:
+    notes:
+      - "Cooking training intermediate"
+      - "Bulk demand from pizza chains for healing food"
+      - "Cheap, high-volume turnover"
+      - "Available from Culinaromancer's Chest at fixed price"
+  trading_tips:
+    - "Buy strategy: stack large quantities when GE supply spikes"
+    - "Demand: tied to pizza/anchovy pizza training and combat consumables"
+    - "Alternative: Tony's Pizza Bases shop in the Wilderness Bandit Camp"
+  history:
+    - date: "2001-06-11"
+      description: "Release: introduced with the original Cooking content"
+  about: "Pizza base is a free-to-play cooking intermediate made by combining a pot of flour with a bowl of water at 35 Cooking. Adding tomato produces an incomplete pizza, which becomes plain pizza after cheese and cooking. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pointed-ochre-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pointed-ochre-snelm.mdx
@@ -13,8 +13,64 @@ osrs:
   highalch: 180
   limit: 150
   about: "Pointed ochre snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: shell
+    tier: low
+  properties:
+    release_date: "2003-09-15"
+    quest_item: false
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    destroy_action: drop
+    options:
+      - wear
+      - drop
+    worn_options:
+      - remove
+  equipment:
+    slot: head
+    attack_speed: 4
+    requirements:
+      defence: 1
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32
+      materials:
+        - item_name: Ochre shell
+          item_id: 3325
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 3325
+      item_name: Ochre shell
+      slug: ochre-shell
+      relationship: component
+      description: Required raw shell
+    - item_id: 3337
+      item_name: Pointed red snelm
+      slug: pointed-red-snelm
+      relationship: alternative
+      description: Red coloured variant
+    - item_id: 3339
+      item_name: Pointed blue snelm
+      slug: pointed-blue-snelm
+      relationship: alternative
+      description: Blue coloured variant
+  market_strategy:
+    notes:
+      - "Niche helmet from snail shells"
+      - "Used by low-level Crafting trainers"
+      - "Cosmetic appeal for nostalgia outfits"
+      - "Thin steady volume"
+  trading_tips:
+    - "Buying tip: cheap to source from low-level players"
+    - "Selling tip: pair with full snelm sets for collectors"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-sgg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-sgg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Premade sgg | OSRS Price Data
-description: "Premade sgg: A premade Short Green Guy.. High alch: 18 GP, GE limit: 2,000."
+description: "Premade sgg is a members pre-made Short Green Guy cocktail with a temporary strength boost. High alch: 18 GP, GE limit: 2,000."
 osrs:
   id: 2038
   name: Premade sgg
@@ -12,9 +12,93 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Premade sgg is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: drink
+    tier: mid
+  equipment:
+    slot: null
+    weight: null
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Blurberry Bar
+      price: 30
+      stock: 2
+  potion:
+    doses: 1
+    effects:
+      - stat: hitpoints
+        boost: 5
+        duration: 0
+      - stat: strength
+        boost: 1
+        duration: 0
+      - stat: attack
+        boost: -2
+        duration: 0
+  related_items:
+    - item_name: Short green guy
+      slug: short-green-guy
+      relationship: variant
+      description: Player-made version usable in Gnome Restaurant.
+    - item_name: Premade choc saturday
+      slug: premade-choc-saturday
+      relationship: alternative
+      description: Another premade Blurberry Bar cocktail.
+    - item_name: Premade fr&apos;n&apos;h
+      slug: premade-frn-h
+      relationship: alternative
+      description: Premade Fruit Blast variant.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Sold by Blurberry Bar at 30 GP for shop runs."
+      - "Cocktail buff has niche PvM and stat-juggling use."
+      - "Buy limit of 2,000 per 4 hours supports moderate flipping."
+  trading_tips:
+    - "Margin opportunity: 30 GP shop price vs Grand Exchange spread."
+    - Cannot be used in Gnome Restaurant minigame so demand is limited.
+    - Watch boost demand for niche strength micro-buffs.
+  about: Premade sgg is a members-only pre-made Short Green Guy cocktail sold at the Blurberry Bar, restoring hitpoints and boosting strength while reducing attack.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2002-12-12"
+    update: "Agility skill"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2002-12-12"
+      update: "Agility skill"
+      description: Premade Blurberry Bar cocktails introduced with the Agility skill update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-rug.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-rug.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raging echoes rug | OSRS Price Data
-description: "Raging echoes rug: An opulent rug dyed with the colours of the Raging Echoes league.. High alch: 300 GP."
+description: "Raging echoes rug is a members construction material from Leagues V. High alch: 300 GP."
 osrs:
   id: 30554
   name: Raging echoes rug
@@ -12,9 +12,90 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: null
-  about: "Raging echoes rug is a members-only item in Old School RuneScape. High alchemy value: 300 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: construction
+    tier: mid
+  equipment:
+    slot: null
+    weight: null
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: construction
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Raging echoes rug
+          quantity: 1
+        - item_name: Bolt of cloth
+          quantity: 4
+      output_quantity: 1
+      notes: "Build a Raging echoes rug furniture in the player-owned house dining room."
+  related_items:
+    - item_name: Raging echoes curtains
+      slug: raging-echoes-curtains
+      relationship: set-piece
+      description: Matching Leagues V house decoration.
+    - item_name: Raging echoes portal frame
+      slug: raging-echoes-portal-frame
+      relationship: set-piece
+      description: Matching Leagues V portal decoration.
+    - item_name: Trailblazer reloaded rug
+      slug: trailblazer-reloaded-rug
+      relationship: alternative
+      description: Equivalent rug from a prior League.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Supply tied to one-off Leagues V reward shop cashouts."
+      - "Prestige construction cosmetic with niche collector demand."
+      - "Price floor near base value of 500 GP after rename."
+  trading_tips:
+    - Watch league anniversary spikes when collectors restock houses.
+    - "Cosmetic-only item: factor zero gameplay utility into resale."
+    - Keep one for personal POH before flipping the rest.
+  about: Raging echoes rug is a members-only cosmetic construction material from Leagues V, used to decorate a player-owned house with the Raging Echoes league colours.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2024-11-27"
+    update: "Leagues V: Raging Echoes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: Drop
+  history:
+    - date: "2024-11-27"
+      update: "Leagues V: Raging Echoes"
+      description: Raging echoes rug released with the Leagues V update.
+    - date: "2025-01-15"
+      update: Game Update
+      description: "Item became obtainable, renamed from nexus rug, and value decreased from 25,000 to 500 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-top-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-top-t2.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: null
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   about: "Raging echoes top (t2) is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ranarr-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ranarr-potion-unf.mdx
@@ -12,13 +12,20 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2002-12-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: false
   potion:
     type: unfinished
     tier: mid
-  herblore:
-    level: 30
-    xp: 0
-    method: Add ranarr weed to vial of water
   recipes:
     - skill: herblore
       level: 30
@@ -32,7 +39,7 @@ osrs:
           quantity: 1
       product: Ranarr potion (unf)
       product_id: 99
-      product_quantity: 1
+      output_quantity: 1
       members_only: true
   related_items:
     - item_id: 257
@@ -66,8 +73,6 @@ osrs:
 
     Add secondary ingredient to create:
     - Prayer potion (+ snape grass)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-marlin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-marlin.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 15000
-  about: "Raw marlin is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 15,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: raw_fish
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.7
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Marlin shoal (deep sea trawling)
+        quantity: "1"
+        rarity: Common
+      - source: Glistening shoal
+        quantity: "1"
+        rarity: 5/100
+      - source: Vibrant shoal
+        quantity: "1"
+        rarity: 50/100
+  recipes:
+    - skill: cooking
+      level: 91
+      xp: 225
+      materials:
+        - item_name: Raw marlin
+          quantity: 1
+      tools:
+        - Cooking range
+      output_quantity: 1
+  related_items:
+    - item_name: Marlin
+      slug: marlin
+      relationship: product
+      description: "Cooked output at 91 Cooking"
+    - item_name: Burnt marlin
+      slug: burnt-marlin
+      relationship: alternative
+      description: "Failed cooking result"
+    - item_name: Fine fish offcuts
+      slug: fine-fish-offcuts
+      relationship: product
+      description: "Obtained by cutting raw marlin with a knife"
+    - item_name: Marlin scales
+      slug: marlin-scales
+      relationship: product
+      description: "Herblore secondary, up to 3 from cutting"
+  about: |-
+    Raw marlin is caught at 91 Fishing from marlin shoals via deep sea trawling (265.5 xp) or a fishing rod (53.1 xp). Cooks into marlin at 91 Cooking for 225 xp on a range. Knife-cut into fine fish offcuts and marlin scales for Herblore.
+  market_strategy:
+    notes:
+      - "High-level food gated behind 91 Fishing + 91 Cooking"
+      - "Marlin scale demand from Herblore underpins raw price"
+      - "Shoal RNG keeps supply tight versus other 90+ fish"
+      - "Deep sea trawling alts dominate consistent supply"
+  trading_tips:
+    - "Buy raw to flip into cooked marlin when scale demand spikes"
+    - "Check fish crate (marlin) prices - bulk buyers move them"
+    - "GE limit 15,000 supports decent volume flips"
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the marlin shoal Fishing content"
+    - date: "2026-05-13"
+      description: "Inventory icon graphically updated for vibrancy"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-oomlie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-oomlie.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw oomlie | OSRS Price Data
-description: "Raw oomlie: Raw meat from the oomlie bird.. High alch: 6 GP, GE limit: 15."
+description: "Raw oomlie is delicate meat dropped by oomlie birds in the Kharazi Jungle that must be wrapped before cooking. High alch: 6 GP, GE limit: 15."
 osrs:
   id: 2337
   name: Raw oomlie
@@ -12,9 +12,66 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15
-  about: "Raw oomlie is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: raw-food
+    tier: mid
+  properties:
+    release_date: "2003-08-20"
+    update: Legends' Quest
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.225
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: cooking
+      level: 50
+      xp: 0
+      materials:
+        - item_name: Raw oomlie
+          quantity: 1
+        - item_name: Palm leaf
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  related_items:
+    - item_name: Wrapped oomlie
+      slug: wrapped-oomlie
+      relationship: product
+      description: Raw oomlie wrapped in a palm leaf, ready to cook
+    - item_name: Cooked oomlie wrap
+      slug: cooked-oomlie-wrap
+      relationship: product
+      description: Finished food once the wrapped oomlie is cooked at 50 Cooking
+    - item_name: Burnt oomlie
+      slug: burnt-oomlie
+      relationship: variant
+      description: Result of trying to cook raw oomlie unwrapped
+    - item_name: Palm leaf
+      slug: palm-leaf
+      relationship: component
+      description: Required wrapper before cooking the oomlie
+  about: Raw oomlie is the carcass dropped by oomlie birds (combat 46) in the Kharazi Jungle south of Shilo Village. Attempting to cook it directly always burns; players must first wrap it with a palm leaf at 50 Cooking and then cook the wrap.
+  market_strategy:
+    notes:
+      - "GE buy limit is tiny (15) so supply is bottlenecked"
+      - "Most players hunt their own oomlie birds, keeping listed volume low"
+  trading_tips:
+    - Stock palm leaves in the same trip — they spoil the recipe if not paired
+    - Check wrapped/cooked oomlie price vs. raw + palm leaf cost before buying
+  history:
+    - date: "2003-08-20"
+      update: Legends' Quest
+      description: Added with Legends' Quest as a Kharazi Jungle hunting drop.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/restore-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/restore-mix-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Restore mix(2) | OSRS Price Data
-description: "Restore mix(2): Two doses of fishy restore potion.. High alch: 39 GP, GE limit: 2,000."
+description: "Restore mix(2) is a 2-dose Barbarian Herblore upgrade of restore potion(2) that also heals 6 Hitpoints. High alch: 39 GP, GE limit: 2,000."
 osrs:
   id: 11449
   name: Restore mix(2)
@@ -12,9 +12,75 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 2000
-  about: "Restore mix(2) is a members-only item in Old School RuneScape. High alchemy value: 39 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: herblore
+      level: 24
+      xp: 21
+      materials:
+        - item_name: Restore potion(2)
+          quantity: 1
+        - item_name: Roe
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Restores Attack, Strength, Defence, Ranged and Magic by 10 + 30% of base level"
+        duration: 0
+      - description: "Heals 3 Hitpoints per dose"
+        duration: 0
+  related_items:
+    - item_name: Restore mix(1)
+      slug: restore-mix-1
+      relationship: variant
+      description: One-dose variant of the restore mix
+    - item_name: Restore potion(2)
+      slug: restore-potion-2
+      relationship: component
+      description: Base potion mixed with roe to make the Barbarian variant
+    - item_name: Roe
+      slug: roe
+      relationship: component
+      description: Barbarian Herblore ingredient added to the potion
+    - item_name: Super restore mix(2)
+      slug: super-restore-mix-2
+      relationship: upgrade
+      description: Higher-tier mix that also restores Prayer
+  about: |-
+    > *"Two doses of fishy restore potion."*
+
+    Restore mix(2) is the Barbarian Herblore upgrade of restore potion(2), keeping the stat-restore effect while also healing 3 Hitpoints per dose. It is useful for hybrid PvM and clue-step kits where small Hitpoints top-ups matter alongside skill restoration.
+  market_strategy:
+    notes:
+      - "Margins are tight once GE tax and roe cost are accounted for"
+      - "Demand follows mid-level slayer and clue-step popularity"
+  trading_tips:
+    - Watch roe supply from Barbarian Fishing trips for upstream price shifts
+    - Compare cost vs. restore potion(2) before buying in bulk
+  history:
+    - date: "2007-07-03"
+      description: Released with the Barbarian Training Herblore expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/roast-bird-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/roast-bird-meat.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 6
   highalch: 10
   limit: 6000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   about: "Roast bird meat is a members-only item in Old School RuneScape. High alchemy value: 10 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-blowpipe-empty.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rosewood-blowpipe-empty.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 1920
   highalch: 2880
   limit: 8
-  about: "Rosewood blowpipe (empty) is a members-only item in Old School RuneScape. High alchemy value: 2,880 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: ranged_weapon
+    tier: mid
+  properties:
+    release_date: "19 November 2025"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Fill
+      - Drop
+    worn_options:
+      - Wield
+      - Check
+      - Unload
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0.3
+    requirements:
+      ranged: 65
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 22
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 6
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 84
+      xp: 200
+      action: Fletch with a knife
+      materials:
+        - item_name: Rosewood logs
+          quantity: 2
+        - item_name: Squid beak
+          quantity: 1
+      tools:
+        - Knife
+      output_quantity: 1
+  related_items:
+    - item_name: Rosewood logs
+      slug: rosewood-logs
+      relationship: component
+      description: "Two rosewood logs consumed per blowpipe craft"
+    - item_name: Squid beak
+      slug: squid-beak
+      relationship: component
+      description: "Sailing-sourced component required to finish the blowpipe"
+    - item_name: Toxic blowpipe
+      slug: toxic-blowpipe
+      relationship: upgrade
+      description: "Higher-tier blowpipe with poison stack and overhead spec"
+  about: "Rosewood blowpipe (empty) is a two-handed Ranged weapon introduced with the Sailing skill update, requiring 65 Ranged to wield. Fletched at 84 Fletching from two rosewood logs and a squid beak, it attacks every 3 ticks in PvM and 4 ticks in PvP, fires darts loaded from the inventory, and unloads via the Unload right-click option. It sits as a mid-tier non-poisoned alternative to the toxic blowpipe."
+  market_strategy:
+    notes:
+      - "Limited GE buy limit of 8 keeps liquidity thin and price spreads wide"
+      - "Demand swings with PvM bossing meta and dart consumption rates"
+      - "Sailing rework patches can shift squid beak supply and pinch margins"
+  trading_tips:
+    - "Compare empty blowpipe price to fletching inputs (2 rosewood logs + squid beak) for craft margin"
+    - "Watch toxic blowpipe price as the upgrade ceiling caps adoption"
+  history:
+    - date: "19 November 2025"
+      description: "Released with the Sailing skill rollout"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-claws.mdx
@@ -12,9 +12,34 @@ osrs:
   lowalch: 4800
   highalch: 7200
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: weapon
+    type: claws
+    attack_style: melee
+    attack_speed: 4
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 14
+      slash: 14
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 14
+      slash: 14
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 14
+      prayer: 0
   about: "Rune claws is a members-only item in Old School RuneScape. High alchemy value: 7,200 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dart-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dart-p.mdx
@@ -12,26 +12,89 @@ osrs:
   lowalch: 140
   highalch: 210
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: runite
+    tier: high
+  properties:
+    release_date: "2003-04-14"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: thrown
     attack_speed: 3
+    weight: 0
     requirements:
       ranged: 40
     attack_bonus:
-      ranged: 13
-    ranged_strength: 19
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 26
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: fletching
+      level: 81
+      xp: 18.8
+      materials:
+        - item_name: Rune dart tip
+          quantity: 1
+        - item_name: Feather
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Weapon poison
+      description: "Has a chance to apply standard weapon poison on hit, dealing extra damage over time"
   related_items:
-    - item_id: 816
-      item_name: Adamant dart (p)
+    - item_name: Adamant dart (p)
       slug: adamant-dart-p
+      relationship: downgrade
+      description: Lower-tier poisoned thrown dart
+    - item_name: Rune dart
+      slug: rune-dart
       relationship: variant
-      description: Lower tier poisoned dart
-  about: |-
-    > _"A rune tipped dart with a poisoned tip."_
-
-    A rune dart tipped with basic weapon poison. Requires 40 Ranged. The highest standard tier of poisoned dart.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Unpoisoned variant of the same dart
+  about: "Rune dart(p) is the highest standard-tier poisoned thrown dart, requiring 40 Ranged. Created by fletching rune dart tips with feathers and applying weapon poison."
+  market_strategy:
+    notes:
+      - "Crafting tips needs 89 Smithing and Tourist Trap completion"
+      - "Fletching 10 in Varrock counts toward the Elite Varrock Diary"
+  trading_tips:
+    - "Buy limit: 11,000 per 4 hours"
+    - Stack with cheaper darts to reduce average per-throw cost
+  history:
+    - date: "2003-04-14"
+      description: Item released
+    - date: "2021-06-30"
+      description: "Ranged attack bonus reduced to 0 (from +15); ranged strength bumped to +26 (from +14)"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-felling-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-felling-axe.mdx
@@ -12,9 +12,80 @@ osrs:
   lowalch: 5120
   highalch: 7680
   limit: null
-  about: "Rune felling axe is a members-only item in Old School RuneScape. High alchemy value: 7,680 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: rune
+  properties:
+    release_date: "2023-02-15"
+    update: "Forestry"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: weapon
+    type: felling-axe
+    attack_style: slash
+    attack_speed: 5
+    requirements:
+      attack: 40
+      woodcutting: 41
+    attack_bonus:
+      stab: 0
+      slash: 30
+      crush: 22
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 33
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 86
+      xp: 75
+      materials:
+        - item_name: Rune axe
+          quantity: 1
+        - item_name: Rune axe head
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  about: "Rune felling axe is an untradeable Forestry woodcutting axe that supports the felling group event mechanics. Wieldable as a slash weapon at 40 Attack."
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Untradeable on the Grand Exchange — value derived from alch and Forestry utility."
+      - "High alch 7,680 gp if alching unwanted copies."
+      - "Crafted via Smithing from a regular rune axe."
+  trading_tips:
+    - "Not flippable — produced for personal Woodcutting use."
+    - "Demand tied to Forestry group event participation."
+  history:
+    - date: "2023-02-15"
+      update: "Forestry"
+      description: "Rune felling axe released with the Forestry skill expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h1.mdx
@@ -12,8 +12,12 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
+  material:
+    type: metal
+    tier: rune
   equipment:
     slot: body
+    attack_speed: 4
     requirements:
       defence: 40
   related_items:
@@ -26,8 +30,8 @@ osrs:
     > *"Provides excellent protection with a heraldic design."*
 
     The rune platebody (h1) is a heraldic cosmetic variant of the rune platebody. Identical stats, requiring 40 Defence and Dragon Slayer I quest. One of five heraldic designs available from hard clue scrolls.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-h2.mdx
@@ -12,10 +12,31 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: rune
+    tier: high
   equipment:
     slot: body
+    type: platebody
     requirements:
       defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -10
+    defence_bonus:
+      stab: 82
+      slash: 80
+      crush: 72
+      magic: -6
+      ranged: 80
+    other_bonus:
+      melee_strength: 0
+      prayer: 0
   related_items:
     - item_id: 23209
       item_name: Rune platebody (h1)
@@ -26,8 +47,6 @@ osrs:
     > *"Provides excellent protection with a heraldic design."*
 
     The rune platebody (h2) is a heraldic cosmetic variant of the rune platebody. Identical stats, requiring 40 Defence and Dragon Slayer I quest.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sacred-oil-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sacred-oil-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sacred oil(4) | OSRS Price Data
-description: "Sacred oil(4): 4 doses of sacred Oil.. High alch: 60 GP, GE limit: 2,000."
+description: "Sacred oil(4): 4 doses of sacred Oil. High alch: 60 GP, GE limit: 2,000."
 osrs:
   id: 3430
   name: Sacred oil(4)
@@ -12,9 +12,75 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 2000
-  about: "Sacred oil(4) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sacred oil(4) is a four-dose oil made by blessing olive oil at the Flamtaer altar in Mort'ton. Used to create pyre logs for Firemaking and Prayer training via the Shades of Mort'ton minigame."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2004-10-18"
+    weight: 0.035
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    options:
+      - Empty
+      - Drop
+      - Examine
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: prayer
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Olive oil(4)
+          quantity: 1
+      output_quantity: 1
+      notes: "Use 4-dose olive oil on the Flamtaer altar in Mort'ton with at least 10% sanctity; requires Shades of Mort'ton completion"
+  related_items:
+    - item_id: 3424
+      item_name: Sacred oil(1)
+      slug: sacred-oil-1
+      relationship: variant
+      description: 1-dose version
+    - item_id: 3426
+      item_name: Sacred oil(2)
+      slug: sacred-oil-2
+      relationship: variant
+      description: 2-dose version
+    - item_id: 3428
+      item_name: Sacred oil(3)
+      slug: sacred-oil-3
+      relationship: variant
+      description: 3-dose version
+    - item_id: 3438
+      item_name: Pyre logs
+      slug: pyre-logs
+      relationship: product
+      description: Created with regular logs and sacred oil
+    - item_id: 3434
+      item_name: Olive oil(4)
+      slug: olive-oil-4
+      relationship: component
+      description: Pre-blessing input olive oil
+  market_strategy:
+    notes:
+      - "Used to make pyre logs for Shades of Mort'ton Prayer XP"
+      - "Doses align with tiered logs (regular 2, oak 3, willow/teak 4, etc.)"
+      - "Supply driven by olive oil collection + altar trips"
+  trading_tips:
+    - "Firemaking XP: 5 XP per dose used on a log (post-July 2024 standardisation)"
+    - "Requires Shades of Mort'ton completion to use for pyre logs"
+    - "Bless olive oil at the Flamtaer altar with at least 10% sanctity"
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Shades of Mort'ton members minigame"
+    - date: "2024-07-17"
+      description: "Pyre log Firemaking XP standardised to 5 XP per dose of oil"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-greaves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-greaves.mdx
@@ -1,6 +1,6 @@
 ---
 title: Samurai greaves | OSRS Price Data
-description: "Samurai greaves: Armoured greaves of the Samurai.. High alch: 1,920 GP, GE limit: 70."
+description: "Samurai greaves are a master-tier Treasure Trail leg slot drop requiring 35 Defence with strong all-round defensive stats. High alch: 1,920 GP, GE limit: 70."
 osrs:
   id: 20044
   name: Samurai greaves
@@ -12,9 +12,86 @@ osrs:
   lowalch: 1280
   highalch: 1920
   limit: 70
-  about: "Samurai greaves is a members-only item in Old School RuneScape. High alchemy value: 1,920 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic-armour
+    tier: high
+  equipment:
+    slot: legs
+    weight: 1.5
+    requirements:
+      defence: 35
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 42
+      slash: 40
+      crush: 38
+      magic: 3
+      ranged: 40
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Samurai kasa
+      slug: samurai-kasa
+      relationship: set-piece
+      description: Helmet from the samurai set
+    - item_name: Samurai shirt
+      slug: samurai-shirt
+      relationship: set-piece
+      description: Body slot from the samurai set
+    - item_name: Samurai gloves
+      slug: samurai-gloves
+      relationship: set-piece
+      description: Hands slot from the samurai set
+    - item_name: Samurai boots
+      slug: samurai-boots
+      relationship: set-piece
+      description: Feet slot from the samurai set
+  about: Samurai greaves are the leg slot of the samurai cosmetic outfit, dropped from master Treasure Trail reward caskets at roughly 1/851. They require 35 Defence to wear and provide solid melee and ranged defence at the cost of any offensive bonus.
+  market_strategy:
+    notes:
+      - "Investment Notes"
+      - "Supply is gated by master clue completions, so price tracks clue popularity"
+      - "Set buyers drive premiums over per-piece value when other samurai pieces are scarce"
+      - "Watch master clue droprates for the full samurai set before committing capital"
+  trading_tips:
+    - Track the rest of the samurai set — bundled flips often beat piece-by-piece sales
+    - GE buy limit of 70 leaves room for moderate inventory swings
+  history:
+    - date: "2016-07-06"
+      update: Treasure Trails Expansion
+      description: Added as a master Treasure Trails reward in the samurai outfit set.
+  properties:
+    release_date: "2016-07-06"
+    update: Treasure Trails Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-bolts-e.mdx
@@ -12,13 +12,30 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 11000
+  material:
+    type: ammo
+    tier: mid
+  properties:
+    tradeable: true
+    stackable: true
+    noteable: false
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
   equipment:
     slot: ammo
+    attack_speed: 1
     other_bonus:
       ranged_strength: 83
     requirements:
       ranged: 1
     weight: 0
+  passive_effects:
+    - name: Clear Mind
+      description: "On activation: drains the opponent's Prayer points by 1/20th of the attacker's Ranged level. The attacker recovers half the drained amount as Prayer points."
+      proc_chance: "5% (5.5% with Kandarin hard diary)"
   related_items:
     - item_id: 9239
       item_name: Topaz bolts (e)
@@ -44,14 +61,19 @@ osrs:
     Sapphire bolts are used in PvP smiting strategies — gradually draining Prayer to remove Protect Item. Most effective in prolonged fights where the cumulative drain adds up.
   market_strategy:
     notes:
-      - PvP niche for Prayer draining
-      - Useful in multi-combat team fights
-      - Cheap to enchant at only 7 Magic
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "PvP niche for Prayer draining"
+      - "Useful in multi-combat team fights"
+      - "Cheap to enchant at only 7 Magic"
+  trading_tips:
+    - "Proc chance: 5% base, 5.5% with Kandarin hard diary"
+    - "Enchant cost: only 7 Magic required"
+    - "Best use: prolonged PvP fights for cumulative Prayer drain"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-brew-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-brew-3.mdx
@@ -12,10 +12,17 @@ osrs:
   lowalch: 70
   highalch: 105
   limit: 2000
-  item_id: 6687
-  type: potion
-  tradeable: true
-  buy_limit: 2000
+  material:
+    type: potion
+    tier: high
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Drink
+      - Drop
+    worn_options: []
   potion:
     doses: 3
     base_item: Saradomin brew(4)
@@ -26,31 +33,40 @@ osrs:
       - stat: Hitpoints
         boost_formula: floor(level * 0.15) + 2
         description: Heals 15% + 2 of max HP
+        duration: 0
       - stat: Defence
         boost_formula: floor(level * 0.20) + 2
         description: Boosts Defence by 20% + 2
+        duration: 0
       - stat: Attack
         boost_formula: -(floor(level * 0.10) + 2)
         description: Lowers Attack by 10% + 2
+        duration: 0
       - stat: Strength
         boost_formula: -(floor(level * 0.10) + 2)
         description: Lowers Strength by 10% + 2
+        duration: 0
       - stat: Magic
         boost_formula: -(floor(level * 0.10) + 2)
         description: Lowers Magic by 10% + 2
+        duration: 0
       - stat: Ranged
         boost_formula: -(floor(level * 0.10) + 2)
         description: Lowers Ranged by 10% + 2
+        duration: 0
   related_items:
-    - slug: saradomin-brew-4
-      name: Saradomin brew(4)
-      relation: full_dose_variant
-    - slug: super-restore-4
-      name: Super restore(4)
-      relation: counters_stat_drain
-    - slug: crushed-nest
-      name: Crushed nest
-      relation: creation_material
+    - item_name: Saradomin brew(4)
+      slug: saradomin-brew-4
+      relationship: variant
+      description: Full 4-dose variant
+    - item_name: Super restore(4)
+      slug: super-restore-4
+      relationship: alternative
+      description: Counters stat drain from brew
+    - item_name: Crushed nest
+      slug: crushed-nest
+      relationship: component
+      description: Required creation material
   about: |-
     3-dose variant of Saradomin brew(4).
 
@@ -73,14 +89,19 @@ osrs:
     Brew to Restore Ratio: Use 3 doses of brew per 1 dose of super restore to maintain combat stats.
   market_strategy:
     notes:
-      - Decants to/from 4-dose version
-      - High demand from raiders
-      - Often more expensive per dose than 4-dose
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Decants to/from 4-dose version"
+      - "High demand from raiders"
+      - "Often more expensive per dose than 4-dose"
+  trading_tips:
+    - "Herblore level: 81 required to brew"
+    - "Decants: between 1/2/3/4 dose versions"
+    - "Ratio: 3 brew doses per 1 super restore dose"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-coif.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
-  about: "Saradomin coif is a members-only item in Old School RuneScape. High alchemy value: 1,200 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: blessed-dragonhide
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.453
+    requirements:
+      ranged: 40
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 2
+    defence_bonus:
+      stab: 2
+      slash: 4
+      crush: 6
+      magic: 4
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/1133
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_name: Coif
+      slug: coif
+      relationship: variant
+      description: Untrimmed base dragonhide coif
+    - item_name: Guthix coif
+      slug: guthix-coif
+      relationship: variant
+      description: Guthix-blessed dragonhide coif variant
+    - item_name: Zamorak coif
+      slug: zamorak-coif
+      relationship: variant
+      description: Zamorak-blessed dragonhide coif variant
+  about: "Saradomin coif is a Saradomin-blessed cosmetic variant of the standard coif, dropped from hard Treasure Trail reward caskets. It carries the same stats as a regular coif plus a +1 Prayer bonus, making it a niche Ranger-prayer hybrid head slot piece."
+  market_strategy:
+    notes:
+      - "Cosmetic ranger head slot with +1 Prayer bonus"
+      - "Hard clue scroll supply directly impacts price floor"
+      - "Demand spikes during god-themed cosmetic flips"
+      - "Low buy limit at 8 per 4 hours throttles large flips"
+  trading_tips:
+    - "Compare against Guthix and Zamorak coifs to gauge faction premium"
+    - "Pair with the matching blessed d'hide set for set-completion sales"
+  history:
+    - date: "2007-08-15"
+      description: "Released as part of the god-blessed dragonhide Treasure Trail rewards refresh."
+  properties:
+    release_date: "2007-08-15"
+    update: God Blessed Dragonhide
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-crozier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-crozier.mdx
@@ -12,29 +12,94 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
+  material:
+    type: prayer_equipment
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    weight: 2
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
   equipment:
     slot: weapon
+    attack_speed: 5
     requirements:
       prayer: 60
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 25
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
     other_bonus:
+      strength: 32
       prayer: 6
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard
-        description: Reward from hard clue scrolls
+  treasure_trail:
+    tier: hard
+    obtained_from:
+      - Reward casket (hard)
+    notes: Rolled in the easy rewards section of hard clue caskets at 1/1,625
   related_items:
+    - item_id: 10458
+      item_name: Saradomin mitre
+      slug: saradomin-mitre
+      relationship: set-piece
+      description: Head slot vestment piece
+    - item_id: 10446
+      item_name: Saradomin cloak
+      slug: saradomin-cloak
+      relationship: set-piece
+      description: Cape slot vestment piece
     - item_id: 10470
       item_name: Saradomin stole
       slug: saradomin-stole
       relationship: set-piece
-      description: Saradomin vestment neck piece
+      description: Neck slot vestment piece
+    - item_id: 10464
+      item_name: Saradomin robe top
+      slug: saradomin-robe-top
+      relationship: set-piece
+      description: Body slot vestment piece
+    - item_id: 10466
+      item_name: Saradomin robe legs
+      slug: saradomin-robe-legs
+      relationship: set-piece
+      description: Legs slot vestment piece
+  market_strategy:
+    notes:
+      - "Supply driven by hard clue completions"
+      - "Fashionscape demand from Saradomin themes"
+      - "God Wars Dungeon utility (counts as Saradominist item)"
+      - "Niche prayer bonus weapon"
+  trading_tips:
+    - "Buy strategy: stock during clue update windows when supply spikes"
+    - "Demand: vestment set collectors keep a floor on price"
+    - "Use case: God Wars Dungeon Saradomin protection without a holy symbol slot"
+  history:
+    - date: "2006-12-05"
+      description: "Release: added with the God Wars Dungeon and Treasure Trails vestment expansion"
   about: |-
     > *"A Saradomin crozier."*
 
     The Saradomin crozier is a weapon slot staff from the Saradomin vestment set. It provides a +6 Prayer bonus and requires 60 Prayer to wield. As a Saradominist item, it counts for God Wars Dungeon protection. Primarily used for its prayer bonus and fashionscape rather than combat.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-full-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Saradomin full helm | OSRS Price Data
-description: "Saradomin full helm: Rune full helmet in the colours of Saradomin.. High alch: 21,120 GP, GE limit: 8."
+description: "Saradomin full helm: Rune full helmet in the colours of Saradomin. High alch: 21,120 GP, GE limit: 8."
 osrs:
   id: 2665
   name: Saradomin full helm
@@ -12,9 +12,87 @@ osrs:
   lowalch: 14080
   highalch: 21120
   limit: 8
-  about: "Saradomin full helm is a free-to-play item in Old School RuneScape. High alchemy value: 21,120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Saradomin full helm is a free-to-play rune full helm decorated with the colours of Saradomin. Obtained from hard Treasure Trails and part of the Saradomin armour set."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: rune
+  properties:
+    release_date: "2004-05-05"
+    weight: 2.721
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: head
+    attack_speed: null
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -3
+    defence_bonus:
+      stab: 30
+      slash: 32
+      crush: 27
+      magic: -1
+      ranged: 30
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    rarity: 1/1625
+  related_items:
+    - item_id: 1163
+      item_name: Rune full helm
+      slug: rune-full-helm
+      relationship: variant
+      description: Plain undyed rune full helm
+    - item_id: 2657
+      item_name: Zamorak full helm
+      slug: zamorak-full-helm
+      relationship: alternative
+      description: Zamorak-colored counterpart
+    - item_id: 2673
+      item_name: Guthix full helm
+      slug: guthix-full-helm
+      relationship: alternative
+      description: Guthix-colored counterpart
+    - item_id: 2661
+      item_name: Saradomin platebody
+      slug: saradomin-platebody
+      relationship: set-piece
+      description: Matching Saradomin platebody
+  market_strategy:
+    notes:
+      - "Clue scroll cosmetic; supply driven by hard clue completion rate"
+      - "Pairs with other Saradomin armour for the costume room set"
+      - "Provides Saradomin god alignment in God Wars Dungeon"
+  trading_tips:
+    - "Hard clue reward: 1/1625 from hard reward caskets"
+    - "Wear any Saradomin armour piece for Saradomin GWD non-aggression"
+    - "Store the set in the costume room treasure chest to save bank space"
+  history:
+    - date: "2004-05-05"
+      description: "Released alongside other Saradomin equipment items"
+    - date: "2021-04-21"
+      description: "Ranged attack bonus rebalanced as part of equipment tuning"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-page-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-page-1.mdx
@@ -12,64 +12,89 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
     type: god_page
-    god: Saradomin
-    page_number: 1
+    tier: mid
+  properties:
+    release_date: "2004-11-17"
     tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Reward casket (easy) — Standard
+        quantity: "1"
+        rarity: 11/9504
+      - source: Reward casket (easy) — Entrana
+        quantity: "1"
+        rarity: 1/408
+      - source: Reward casket (medium) — Standard
+        quantity: "1"
+        rarity: 10/8184
+      - source: Reward casket (medium) — Entrana
+        quantity: "1"
+        rarity: 1/408
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: 1/650
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: 1/775
+      - source: Reward casket (master)
+        quantity: "1"
+        rarity: 1/702
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - easy
+      - medium
+      - hard
+      - elite
+      - master
   related_items:
-    - item_id: 3828
-      item_name: Saradomin page 2
+    - item_name: Saradomin page 2
       slug: saradomin-page-2
       relationship: set-piece
-      description: Page 2 of 4
-    - item_id: 3829
-      item_name: Saradomin page 3
+      description: Page 2 of 4 needed to complete the Book of wisdom
+    - item_name: Saradomin page 3
       slug: saradomin-page-3
       relationship: set-piece
-      description: Page 3 of 4
-    - item_id: 3830
-      item_name: Saradomin page 4
+      description: Page 3 of 4 needed to complete the Book of wisdom
+    - item_name: Saradomin page 4
       slug: saradomin-page-4
       relationship: set-piece
-      description: Page 4 of 4
-    - item_id: 3840
-      item_name: Illuminated book of wisdom
-      slug: illuminated-book-of-wisdom
+      description: Page 4 of 4 needed to complete the Book of wisdom
+    - item_name: Book of wisdom
+      slug: book-of-wisdom
       relationship: product
-      description: Completed god book
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | God Page |
-    | God | Saradomin |
-    | Page | 1 of 4 |
-    | Tradeable | Yes |
-
-    Add to incomplete Book of wisdom (Saradomin god book) to complete it.
-
-    Requires all 4 pages:
-    - Saradomin page 1
-    - Saradomin page 2
-    - Saradomin page 3
-    - Saradomin page 4
-
-    When complete, the Book of wisdom provides:
-    - +5 prayer bonus
-    - Counts as Saradomin item in GWD
-    - Can be illuminated after Horror from the Deep
+      description: "Saradomin god book completed by combining all 4 pages"
+  about: "Saradomin page 1 is one of four torn pages used to complete the Book of wisdom. Pages drop from all standard clue caskets except Beginner."
   market_strategy:
     notes:
-      - Collect all 4 pages
-      - Complete god book for prayer bonus
-      - Useful for GWD protection
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Combine all 4 pages with the damaged book of wisdom to complete it"
+      - "Completed book grants +5 prayer bonus and counts as a Saradomin item in GWD"
+  trading_tips:
+    - "Buy limit: 5 per 4 hours"
+    - Page sets often trade as a 4-piece bundle — compare bundle vs individual prices
+  history:
+    - date: "2004-11-17"
+      description: "Released with the Horror from the Deep quest"
+    - date: "2006-07-11"
+      description: 'Renamed from "Torn page 1(s)"'
+    - date: "2019-01-24"
+      description: "Inventory model updated to match the holy book's colours"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/scaly-blue-dragonhide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/scaly-blue-dragonhide.mdx
@@ -12,12 +12,23 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: null
+  material:
+    type: crafting_material
+    tier: mid
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    options:
+      - Drop
+    worn_options: []
   about: "Scaly blue dragonhide is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/searing-page.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/searing-page.mdx
@@ -12,12 +12,24 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: null
+  material:
+    type: quest_item
+    tier: mid
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: false
+    options:
+      - Read
+      - Drop
+    worn_options: []
   about: "Searing page is a members-only item in Old School RuneScape. High alchemy value: 120 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-2.mdx
@@ -12,9 +12,28 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 2000
-  about: "Serum 207 (2) is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: basic
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    options:
+      - drink
+      - drop
+  potion:
+    doses: 2
+    effects:
+      - item_name: Cure Mort'ton plague
+        duration: 0
+        description: "Used to cure plagued villagers in Mort'ton during the Shades of Mort'ton minigame."
+  about: |-
+    Serum 207 (2) is a 2-dose potion used in the Shades of Mort'ton minigame to cure plagued villagers. Created from tarromin and ashes of the dead.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/serum-207-3.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 2000
-  about: "Serum 207 (3) is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    effects:
+      - description: "Used on shades during the Shades of Mort'ton minigame to weaken them."
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 15
+      xp: 50
+      materials:
+        - item_name: Tarromin potion (unf)
+          quantity: 1
+        - item_name: Ashes
+          quantity: 1
+      output_quantity: 1
+  related_items:
+    - item_name: Serum 207 (1)
+      relationship: variant
+    - item_name: Serum 207 (2)
+      relationship: variant
+    - item_name: Serum 207 (4)
+      relationship: variant
+    - item_name: Tarromin potion (unf)
+      relationship: component
+    - item_name: Ashes
+      relationship: component
+    - item_name: Olive oil
+      relationship: alternative
+  market_strategy:
+    notes:
+      - "Niche use in Shades of Mort'ton; demand is event-driven."
+      - "Cheap to craft from tarromin unf + ashes."
+  trading_tips:
+    - "Volume only matters during Shades XP events."
+    - "Decant 4-dose stock when prices on (3) move above (4) cost."
+  history:
+    - date: "2003-05-27"
+      description: "Serum 207 introduced with Shades of Mort'ton."
+  properties:
+    release_date: "2003-05-27"
+    update: "Shades of Mort'ton"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Serum 207 (3) is a members-only Herblore potion used in Shades of Mort'ton. High alchemy value: 7 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-trousers-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shattered-trousers-t1.mdx
@@ -12,9 +12,92 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: null
-  about: "Shattered trousers (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: legs
+    weapon_type: none
+    weight: 0.45
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Leagues Reward Shop
+      location: Leagues lobby
+      stock: 0
+      price: 1000
+      currency: League points
+      members_only: true
+  related_items:
+    - item_name: Shattered hood (t1)
+      slug: shattered-hood-t1
+      relationship: set-piece
+      description: Head slot of the Shattered Relic Hunter t1 outfit
+    - item_name: Shattered top (t1)
+      slug: shattered-top-t1
+      relationship: set-piece
+      description: Body slot of the Shattered Relic Hunter t1 outfit
+    - item_name: Shattered boots (t1)
+      slug: shattered-boots-t1
+      relationship: set-piece
+      description: Feet slot of the Shattered Relic Hunter t1 outfit
+    - item_name: Shattered cape (t1)
+      slug: shattered-cape-t1
+      relationship: set-piece
+      description: Cape slot of the Shattered Relic Hunter t1 outfit
+    - item_name: Shattered trousers (t2)
+      slug: shattered-trousers-t2
+      relationship: upgrade
+      description: Tier 2 upgraded variant of the trousers
+  about: "Shattered trousers (t1) are a cosmetic legs slot reward from the Leagues IV: Shattered Relics outfit, purchasable for 1,000 League points. They contribute no combat stats and act as a set-piece for the Shattered Relic Hunter outfit. High alchemy value: 9,000 coins."
+  market_strategy:
+    notes:
+      - "Demand is collector-driven; supply was capped at the Leagues IV event window."
+      - "Price tends to drift with rare-cosmetic flips and outfit-completion demand."
+  trading_tips:
+    - "Pair flips with other Shattered set pieces for completion premiums."
+    - "Costume room storage means listings come and go in waves."
+  history:
+    - date: "2022-01-19"
+      description: "Shattered trousers (t1) added to the game as part of Leagues IV preparations."
+    - date: "2022-03-16"
+      description: "Made obtainable through the PvP Arena: Rewards Beta and Leagues reward shop."
+  properties:
+    release_date: "2022-01-19"
+    update: "Leagues IV: Shattered Relics"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.45
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/short-green-guy.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/short-green-guy.mdx
@@ -13,8 +13,69 @@ osrs:
   highalch: 18
   limit: 2000
   about: "Short green guy is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cocktail
+    tier: consumable
+  properties:
+    release_date: "2004-08-23"
+    quest_item: false
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    destroy_action: drop
+    options:
+      - drink
+      - empty
+      - drop
+  consumable:
+    heals: 3
+  recipes:
+    - skill: cooking
+      level: 19
+      xp: 30
+      materials:
+        - item_name: Cocktail glass
+          item_id: 2026
+          quantity: 1
+        - item_name: Vodka
+          item_id: 2015
+          quantity: 1
+        - item_name: Lime chunks
+          item_id: 2122
+          quantity: 1
+        - item_name: Lemon chunks
+          item_id: 2104
+          quantity: 1
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 2026
+      item_name: Cocktail glass
+      slug: cocktail-glass
+      relationship: component
+      description: Vessel for mixing
+    - item_id: 2025
+      item_name: Cocktail shaker
+      slug: cocktail-shaker
+      relationship: component
+      description: Required for mixing
+    - item_id: 2074
+      item_name: Pineapple punch
+      slug: pineapple-punch
+      relationship: alternative
+      description: Another Gnome cocktail
+  market_strategy:
+    notes:
+      - "Gnome cocktail recipe item"
+      - "Tiny heal makes it niche"
+      - "Used by Cooking trainers"
+      - "Steady but small volume"
+  trading_tips:
+    - "Buying tip: source cheap from Gnome chefs"
+    - "Selling tip: bundle with other gnome dishes for diary completion"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shorts-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shorts-brown.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 150
-  about: "Shorts (brown) is a members-only item in Old School RuneScape. High alchemy value: 168 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: legs
+    weight: 0.1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Agmundi Quality Clothes
+      location: Keldagrim
+      price: 364
+      currency: Coins
+      members_only: true
+    - shop_name: Miscellanian Clothes Shop
+      location: Miscellania and Etceteria Dungeon
+      price: 280
+      currency: Coins
+      members_only: true
+  related_items:
+    - item_name: Shorts (blue)
+      slug: shorts-blue
+      relationship: variant
+      description: Blue-coloured cosmetic shorts variant
+    - item_name: Shorts (yellow)
+      slug: shorts-yellow
+      relationship: variant
+      description: Yellow-coloured cosmetic shorts variant
+  about: "Shorts (brown) is a cosmetic legs slot item sold by clothing shops in Keldagrim and Miscellania. Purely fashionscape with no combat stats."
+  market_strategy:
+    notes:
+      - "Cosmetic legs slot item with no combat bonuses"
+      - "Sold by Keldagrim and Miscellania clothing shops"
+      - "Low buy limit at 150 per 4 hours"
+  history:
+    - date: "2005-05-31"
+      update: Keldagrim - The Dwarven City
+      description: "Released as a cosmetic clothing option from Keldagrim shops."
+  properties:
+    release_date: "2005-05-31"
+    update: Keldagrim - The Dwarven City
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-hunter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-hunter.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: null
   highalch: null
   limit: null
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: sigil
+    tier: high
   about: Sigil of the hunter is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/smoke-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/smoke-battlestaff.mdx
@@ -12,69 +12,94 @@ osrs:
   lowalch: 6200
   highalch: 9300
   limit: 8
-  equipment:
-    slot: weapon
-    type: staff
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: weapon
+    tier: high
+  properties:
+    release_date: "2014-04-10"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: 2h
+    weapon_type: staff
+    attack_speed: 5
     weight: 2.267
     requirements:
       attack: 30
       magic: 30
-    stats:
-      attack_magic: 12
-      attack_crush: 28
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 28
+      magic: 12
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 12
+      ranged: 0
+    other_bonus:
       strength: 35
-      defence_magic: 12
-  passive_effects:
-    - name: Unlimited Runes
-      description: Provides infinite air and fire runes
-    - name: Damage Boost
-      description: +10% Magic accuracy and damage for standard spellbook (includes curses)
-  obtaining:
-    methods:
+      ranged_strength: 0
+      magic_damage: 10
+      prayer: 0
+  drop_table:
+    sources:
       - source: Thermonuclear smoke devil
-        drop_rate: 1/512
-        requirements:
-          slayer: 93
-  upgrade:
-    to_item_id: 12000
-    to_item_name: Mystic smoke staff
-    vendor: Thormac
-    cost: 20K-40K gp
+        quantity: "1"
+        rarity: 1/512
+  passive_effects:
+    - name: Unlimited runes
+      description: "Provides unlimited air and fire runes when wielded"
+    - name: Standard spellbook bonus
+      description: "+10% magic accuracy and damage when casting spells from the standard spellbook (curses included)"
   related_items:
-    - item_id: 0
-      item_name: Thermonuclear smoke devil
-      slug: thermonuclear-smoke-devil
-      relationship: component
-      description: Only source
-    - item_id: 12000
-      item_name: Mystic smoke staff
+    - item_name: Mystic smoke staff
       slug: mystic-smoke-staff
       relationship: upgrade
-      description: Upgrade
-    - item_id: 11787
-      item_name: Steam battlestaff
+      description: "Upgraded variant crafted by Thormac for 20,000-40,000 coins"
+    - item_name: Steam battlestaff
       slug: steam-battlestaff
       relationship: alternative
-      description: Water+fire variant
+      description: "Water and fire elemental sibling battlestaff"
+    - item_name: Thermonuclear smoke devil
+      slug: thermonuclear-smoke-devil
+      relationship: component
+      description: "Sole drop source at 1/512"
+    - item_name: Lava battlestaff
+      slug: lava-battlestaff
+      relationship: alternative
+      description: "Earth and fire elemental sibling battlestaff"
   about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Magic | +12 |
-    | Crush | +28 |
-    | Strength | +35 |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Magic | +12 |
-
-    Unlimited Runes: Provides infinite air and fire runes.
-
-    Damage Boost: +10% Magic accuracy and damage for standard spellbook (includes curses).
-
-    Can upgrade to Mystic smoke staff at Thormac (20K-40K gp).
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Magic-focused battlestaff providing unlimited air and fire runes plus a +10% accuracy and damage bonus when casting standard spellbook spells (curses included). Dropped 1/512 by Thermonuclear smoke devil at 93 Slayer. Upgradable to the Mystic smoke staff via Thormac for 20,000-40,000 coins depending on diary completion.
+  market_strategy:
+    notes:
+      - "Drop-only sourcing keeps supply tight - Thermo devils are 93 Slayer-locked"
+      - "Upgrade path to Mystic smoke staff lifts long-term demand"
+      - "GE limit 8 throttles flipping - retail flippers struggle here"
+      - "Standard spellbook DPS staple, especially for Pyromancer setups"
+  trading_tips:
+    - "Compare against Mystic smoke staff price minus Thormac fee to identify upgrade arbitrage"
+    - "Smoke devil boss spikes often deflate price short-term"
+    - "Watch for spellbook meta changes - DPS calcs move price quickly"
+  history:
+    - date: "2014-04-10"
+      description: "Released as part of the Smoke Devil Slayer monster update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/snake-hide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/snake-hide.mdx
@@ -12,9 +12,68 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 13000
-  about: "Snake hide is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: hide
+    tier: low
+  properties:
+    release_date: "9 August 2005"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Bush snake
+        quantity: "1"
+        rarity: Always
+      - source: Hoop snake
+        quantity: "1"
+        rarity: Always
+      - source: Snake (Mos Le'Harmless)
+        quantity: "1"
+        rarity: Always
+      - source: Temple Trekking event
+        quantity: "1"
+        rarity: Common
+  related_items:
+    - item_name: Snakeskin
+      slug: snakeskin
+      relationship: product
+      description: "Tanned form used in 45 Crafting snakeskin armour"
+    - item_name: Snakeskin body
+      slug: snakeskin-body
+      relationship: product
+      description: "Crafted from tanned snakeskin at 53 Crafting"
+    - item_name: Snakeskin boots
+      slug: snakeskin-boots
+      relationship: product
+      description: "Crafted from tanned snakeskin at 45 Crafting"
+    - item_name: Green dragonhide
+      slug: green-dragonhide
+      relationship: alternative
+      description: "Higher-tier hide for ranged armour crafting"
+  about: "Snake hide is a members crafting material dropped by bush snakes, hoop snakes, and Mos Le'Harmless snakes, as well as obtained from Temple Trekking. Tanned for 15 coins (25 in Canifis) into snakeskin, the resulting material crafts snakeskin armour at 45+ Crafting. A 78 Magic spell can mass-tan up to five hides per cast."
+  market_strategy:
+    notes:
+      - "Steady supply from Temple Trekking and slayer side drops keeps prices low"
+      - "Demand driven by Crafting trainers seeking cheap leather-tier XP"
+      - "Buy limit 13,000 per 4 hours allows bulk Crafting buyouts"
+  trading_tips:
+    - "Tan-to-armour profit live when snakeskin armour outpaces hide+tan cost"
+    - "Mass-tan via spell scales the margin when raw hides dip below the tanned floor"
+  history:
+    - date: "9 August 2005"
+      description: "Released with the Cabin Fever quest and Mos Le'Harmless content"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrow-p-5624.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-arrow-p-5624.mdx
@@ -12,9 +12,18 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: steel
+    tier: mid
+  properties:
+    release_date: "2005-09-26"
+    tradeable: true
+    stackable: true
+    noteable: false
+    quest_item: false
   about: "Steel arrow(p++) is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dagger-p-5690.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dagger-p-5690.mdx
@@ -13,8 +13,26 @@ osrs:
   highalch: 75
   limit: 125
   about: "Steel dagger(p++) is a members-only item in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: steel
+    tier: mid
+  properties:
+    release_date: "2004-07-13"
+    options:
+      - Wield
+      - Examine
+    worn_options:
+      - Remove
+  equipment:
+    slot: weapon
+    type: dagger
+    tradeable: true
+    weight: 1.0
+    attack_speed: 4
+    requirements:
+      attack: 5
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-scimitar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-scimitar.mdx
@@ -12,24 +12,100 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 125
-  item_id: 1325
-  item_type: equipment
-  slot: weapon
-  type: scimitar
-  attack_style: slash
-  attack_speed: 4
-  tradeable: true
-  weight: 1.814
-  requirements:
-    attack: 5
-  stats:
-    slash_attack: 15
-    strength: 14
+  material:
+    type: weapon
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    weight: 1.814
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: weapon
+    attack_speed: 4
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 4
+      slash: 15
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 14
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 35
+      xp: 75
+      materials:
+        - item_name: Steel bar
+          item_id: 2353
+          quantity: 2
+      product: Steel scimitar
+      product_id: 1325
+      output_quantity: 1
+      facility: Anvil
+      members_only: false
+  shops:
+    - shop_name: Daga's Scimitar Smithy
+      location: Ape Atoll
+      price: 400
+      stock: 5
+      members: true
+    - shop_name: Zeke's Superior Scimitars
+      location: Al Kharid
+      price: 400
+      stock: 3
+      members: false
   related_items:
-    - slug: black-scimitar
-    - slug: steel-bar
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1323
+      item_name: Iron scimitar
+      slug: iron-scimitar
+      relationship: alternative
+      description: Lower tier scimitar
+    - item_id: 1327
+      item_name: Black scimitar
+      slug: black-scimitar
+      relationship: upgrade
+      description: Higher tier scimitar
+    - item_id: 2353
+      item_name: Steel bar
+      slug: steel-bar
+      relationship: component
+      description: Smithing material
+  market_strategy:
+    notes:
+      - "Common low-tier smithing product"
+      - "Cheap to flip but low margins"
+      - "Supply driven by smithing trainers and bot output"
+      - "Mid-tier F2P combat option for level 5+ Attack"
+  trading_tips:
+    - "Buy strategy: stack during smithing training windows"
+    - "Risk: net smithing loss limits supply from human crafters"
+    - "Use case: F2P stepping stone before mithril scimitar"
+  history:
+    - date: "2001-01-04"
+      description: "Release: launched with the original RuneScape Classic scimitar lineup"
+  about: "Steel scimitar is a free-to-play slash weapon in Old School RuneScape requiring 5 Attack to wield. Smithed from 2 steel bars at 35 Smithing for 75 XP. High alchemy value: 240 coins. Grand Exchange buy limit: 125 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-studs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-studs.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 13000
-  about: "Steel studs is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2002-09-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 36
+      xp: 37.5
+      materials:
+        - item_name: Steel bar
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
+  related_items:
+    - item_name: Studded body
+      slug: studded-body
+      relationship: product
+      description: Created by adding steel studs to a leather body.
+    - item_name: Studded chaps
+      slug: studded-chaps
+      relationship: product
+      description: Created by adding steel studs to leather chaps.
+    - item_name: Steel bar
+      slug: steel-bar
+      relationship: component
+      description: Smithed at level 36 Smithing to produce steel studs.
+    - item_name: Leather body
+      slug: leather-body
+      relationship: alternative
+      description: Base leather body upgraded with steel studs.
+  about: "Steel studs are a Crafting material smithed from a steel bar at 36 Smithing, used at 41 Crafting to upgrade leather body and leather chaps into studded variants. The combine grants 40 Crafting XP and is a common low-level Crafting training method for members."
+  market_strategy:
+    notes:
+      - "Demand driven by low-level Crafting trainers and ironmen alt restocking"
+      - "Steel bar price floor sets the effective cost of studs"
+      - "Buy limit of 13,000 supports large smith-and-flip runs"
+  trading_tips:
+    - "Margin tracks steel bar price; flip when bars dip"
+    - "Stockpile when Crafting events boost low-level training demand"
+  history:
+    - date: "2002-09-04"
+      description: "Released alongside studded leather equipment."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strange-fruit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strange-fruit.mdx
@@ -12,13 +12,26 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  related_items: []
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: food
+    tier: utility
+  potion:
+    type: food
+    tier: utility
+    effects:
+      - item_name: Cure poison
+        description: Cures poison and venom instantly
+      - item_name: Poison immunity
+        duration: 18
+        description: Grants short poison immunity
+      - item_name: Run energy
+        description: Restores 30% run energy
   about: |-
     > _"I wonder what this tastes like?"_
 
     Strange fruit cures poison and venom instantly, grants ~18 seconds poison immunity, and restores 30% run energy. Does not heal Hitpoints. Useful as a lightweight anti-poison alternative.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strange-old-lockpick-full.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strange-old-lockpick-full.mdx
@@ -12,32 +12,43 @@ osrs:
   lowalch: 12800
   highalch: 19200
   limit: 50
-  item:
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
     type: tool
+    tier: unique
+  properties:
+    release_date: "2020-09-30"
     tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
     weight: 0.002
-  obtaining:
-    - source: Hallowed Sepulchre coffins
-      rates:
-        - floor: 1
-          drop_rate: 1/200
-        - floor: 2
-          drop_rate: 1/120
-        - floor: 3
-          drop_rate: 1/90
-        - floor: 4
-          drop_rate: 1/60
-        - floor: 5
-          drop_rate: 1/40
-  effect:
-    barrows: Opens any door set (consumes charges)
-    sepulchre:
-      - Improves coffin success rate
-      - Speeds up coffin looting
-      - No charges consumed
-  charging:
-    starting_charges: 50
-    notes: Disappears when depleted
+    options:
+      - use
+      - drop
+  drop_table:
+    sources:
+      - source: Hallowed Sepulchre Floor 1 coffin
+        quantity: "1"
+        rarity: "1/200"
+      - source: Hallowed Sepulchre Floor 2 coffin
+        quantity: "1"
+        rarity: "1/120"
+      - source: Hallowed Sepulchre Floor 3 coffin
+        quantity: "1"
+        rarity: "1/90"
+      - source: Hallowed Sepulchre Floor 4 coffin
+        quantity: "1"
+        rarity: "1/60"
+      - source: Hallowed Sepulchre Floor 5 coffin
+        quantity: "1"
+        rarity: "1/40"
+  passive_effects:
+    - name: Barrows door unlock
+      description: "Opens any door set inside Barrows, consuming a charge per use."
+    - name: Sepulchre coffin assist
+      description: "Improves coffin success rate and looting speed inside Hallowed Sepulchre with no charge consumption."
   related_items:
     - item_id: 1523
       item_name: Lockpick
@@ -45,22 +56,7 @@ osrs:
       relationship: alternative
       description: Standard version
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Tool |
-    | Tradeable | Yes (full only) |
-    | Weight | 0.002 kg |
-
-    Barrows: Opens any door set (consumes charges).
-
-    Hallowed Sepulchre:
-    - Improves coffin success rate
-    - Speeds up coffin looting
-    - No charges consumed
-
-    Comes with 50 charges. Disappears when depleted.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Comes with 50 charges. Disappears when depleted. Found exclusively in Hallowed Sepulchre coffins as a rare reward.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strength-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strength-potion-2.mdx
@@ -12,23 +12,70 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 2000
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2002-09-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Temporarily raises the Strength level by 3 + 10% of the player's current Strength level until the boost decays."
+        duration: 60
+  recipes:
+    - skill: herblore
+      level: 12
+      xp: 50
+      materials:
+        - item_name: Limpwurt potion (unf)
+          quantity: 1
+        - item_name: Limpwurt root
+          quantity: 1
+      tools: []
+      output_quantity: 2
   related_items:
-    - item_id: 115
-      item_name: Strength potion(3)
-      slug: strength-potion-3
-      relationship: variant
-      description: 3-dose version
-    - item_id: 119
-      item_name: Strength potion(1)
+    - item_name: Strength potion(1)
       slug: strength-potion-1
       relationship: variant
-      description: 1-dose version
+      description: "1-dose variant of the same Strength potion."
+    - item_name: Strength potion(3)
+      slug: strength-potion-3
+      relationship: variant
+      description: "3-dose variant brewed directly via Herblore."
+    - item_name: Strength potion(4)
+      slug: strength-potion-4
+      relationship: variant
+      description: "4-dose variant produced from a full Herblore flask."
   about: |-
     > _"2 doses of Strength potion."_
 
-    A 2-dose strength potion. Boosts Strength by 3 + 10% of current level. Available to F2P and members.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The 2-dose Strength potion is the middle-decant tier of the tarromin-and-limpwurt brew. Each sip raises Strength by 3 + 10% of the player's current Strength level. Available to both F2P and members, it serves as an entry-level combat boost before super strength potions are unlocked.
+  market_strategy:
+    notes:
+      - "F2P availability keeps demand thin against the (4) dose variant"
+      - "Decanter arbitrage between (1)/(2)/(3)/(4) drives most volume"
+      - "Limpwurt root supply caps production"
+  trading_tips:
+    - "Use the per-dose spread between (1)/(2)/(3)/(4) to spot decanter flips"
+    - "Demand is steady from low-level F2P combat training"
+  history:
+    - date: "2002-09-26"
+      description: "Released as part of the Herblore skill launch."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-pirate-shirt-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stripy-pirate-shirt-blue.mdx
@@ -13,8 +13,21 @@ osrs:
   highalch: 180
   limit: 150
   about: "Stripy pirate shirt (blue) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-07-26"
+    options:
+      - Wear
+      - Examine
+    worn_options:
+      - Remove
+  equipment:
+    slot: body
+    tradeable: true
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strung-rabbit-foot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strung-rabbit-foot.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 150
-  about: "Strung rabbit foot is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: charm
+    tier: low
+  properties:
+    release_date: "2006-11-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: neck
+    weapon_type: null
+    attack_speed: null
+    weight: 0.03
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 37
+      xp: 4
+      materials:
+        - item_name: Ball of wool
+          quantity: 1
+        - item_name: Rabbit foot
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  passive_effects:
+    - name: Bird house bonus
+      description: "When worn, increases the chance of bird eggs from bird house trapping"
+    - name: Bird nest modifier
+      description: "Wearing while woodcutting slightly reduces seed drops and increases egg/ring drops from bird nests"
+  about: "Strung rabbit foot is a Crafting-made amulet released with Eagles' Peak that subtly biases bird nest and bird house drops toward eggs."
+  market_strategy:
+    notes:
+      - "Craftable at level 37 Crafting for 4 XP"
+      - "Useful for bird house runners chasing egg drops"
+  trading_tips:
+    - "Buy limit: 150 per 4 hours"
+    - Higher GE price than alch value — sell rather than alch
+  history:
+    - date: "2006-11-28"
+      description: "Released with the Eagles' Peak quest update; renamed from \"Thing on string\""
+    - date: "2021-04-01"
+      description: "Bird house egg-drop bonus added"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-moth-item.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-moth-item.mdx
@@ -12,9 +12,46 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: null
-  about: "Sunlight moth (item) is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter
+    tier: mid
+  related_items:
+    - item_name: Sunlight antelope fur
+      relationship: variant
+    - item_name: Moonlight moth (item)
+      slug: moonlight-moth-item
+      relationship: variant
+    - item_name: Butterfly jar
+      relationship: component
+  market_strategy:
+    notes:
+      - "Caught via Hunter at Civitas illa Fortis bushes; supply tracks Hunter training popularity."
+      - "Used in Herblore for prayer regeneration potions, so demand spikes around new boss releases."
+  trading_tips:
+    - "Watch for spikes when new prayer-restore content launches."
+    - "Stock when supply outpaces Hunter activity in the GE."
+  history:
+    - date: "2024-07-24"
+      description: "Sunlight moth introduced with the Varlamore: The Final Dawn expansion."
+  properties:
+    release_date: "2024-07-24"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.001
+    options:
+      - Release
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  about: "Sunlight moth (item) is a members-only Hunter catch used in Herblore. High alchemy value: 1 coins."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-strength-3.mdx
@@ -12,23 +12,80 @@ osrs:
   lowalch: 88
   highalch: 132
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 55
+      xp: 125
+      materials:
+        - item_name: Kwuarm potion (unf)
+          quantity: 1
+        - item_name: Limpwurt root
+          quantity: 1
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Boosts Strength by 5 + 15% of current Strength level (rounded down)"
+        duration: 300
+      - description: "Boost decays by approximately 1 level per minute without Preserve prayer"
+        duration: 300
   related_items:
-    - item_id: 159
-      item_name: Super strength(2)
+    - item_name: Super strength(4)
+      slug: super-strength-4
+      relationship: variant
+      description: "Four-dose version of the potion"
+    - item_name: Super strength(2)
       slug: super-strength-2
       relationship: variant
-      description: 2-dose version
-    - item_id: 161
-      item_name: Super strength(1)
+      description: "Two-dose version of the potion"
+    - item_name: Super strength(1)
       slug: super-strength-1
       relationship: variant
-      description: 1-dose version
+      description: "Single-dose version of the potion"
+    - item_name: Super attack(3)
+      slug: super-attack-3
+      relationship: component
+      description: "Paired with super strength for super combat potion"
+    - item_name: Super combat potion(4)
+      slug: super-combat-potion-4
+      relationship: upgrade
+      description: "Combined super potion replacing individual stat boosts"
   about: |-
-    > _"3 doses of super Strength potion."_
-
-    The super strength potion boosts Strength by 5 + 15% of current level (rounded down). A key combat potion, commonly paired with super attack for PvM.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Super strength is the key Strength-boosting potion, granting +5 plus 15% of the current Strength level for roughly five minutes. Brewed at 55 Herblore by combining a limpwurt root with a kwuarm potion (unf) for 125 XP. Commonly paired with super attack for combat training or combined into a super combat potion.
+  market_strategy:
+    notes:
+      - "Core Strength boost potion for combat training and PvM"
+      - "Used as component for super combat potions"
+      - "Three-dose version is a flip target due to decanter spread"
+      - "Limpwurt root supply gates Herblore brewing margin"
+  trading_tips:
+    - "Decant (3) into (4) doses for profit margin"
+    - "Watch kwuarm and limpwurt root prices for brew cost shifts"
+    - "Spike demand around bossing events and DMM"
+  history:
+    - date: "2002-02-27"
+      description: "Super strength potion added with the Herblore release"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tatty-kyatt-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tatty-kyatt-fur.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tatty kyatt fur | OSRS Price Data
-description: "Tatty kyatt fur: It's a shabby-looking kyatt fur.. High alch: 72 GP, GE limit: 10,000."
+description: "Tatty kyatt fur is a shabby pelt from Rellekka sabre-toothed kyatts that the Fancy Clothes Store can convert into Kyatt legs or top. High alch: 72 GP, GE limit: 10,000."
 osrs:
   id: 10101
   name: Tatty kyatt fur
@@ -12,9 +12,55 @@ osrs:
   lowalch: 48
   highalch: 72
   limit: 10000
-  about: "Tatty kyatt fur is a members-only item in Old School RuneScape. High alchemy value: 72 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: hunter-fur
+    tier: mid
+  properties:
+    release_date: "2006-11-21"
+    update: Hunter
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  related_items:
+    - item_name: Kyatt fur
+      slug: kyatt-fur
+      relationship: variant
+      description: Pristine kyatt pelt used to craft the Kyatt hat
+    - item_name: Kyatt legs
+      slug: kyatt-legs
+      relationship: product
+      description: Made from tatty kyatt fur at the Fancy Clothes Store
+    - item_name: Kyatt top
+      slug: kyatt-top
+      relationship: product
+      description: Made from tatty kyatt fur at the Fancy Clothes Store
+    - item_name: Sabre-toothed kyatt
+      slug: sabre-toothed-kyatt
+      relationship: component
+      description: Hunter creature dropped by pitfall trapping in Rellekka
+  about: Tatty kyatt fur is the shabby pelt obtained when pitfall-trapping sabre-toothed kyatts at the Rellekka Hunter area (requires 55 Hunter). The Fancy Clothes Store in Varrock will turn it into Kyatt legs or Kyatt top for 200 coins each.
+  market_strategy:
+    notes:
+      - "Supply tracks Hunter training rather than PvM, so price moves with Hunter content updates"
+      - "Cannot be stored in the fur pouch, which keeps casual hunter supply unstacked"
+  trading_tips:
+    - Compare tatty fur cost vs. Kyatt legs/top GE prices to spot processing margin
+    - Watch pristine kyatt fur listings — players often dump both pelts after long pitfall trips
+  history:
+    - date: "2006-11-21"
+      update: Hunter
+      description: Added with the Hunter skill launch as a pitfall drop from sabre-toothed kyatts.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-table-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-table-flatpack.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak table (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: mid
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    weight: 1
+    quest_item: false
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  recipes:
+    - skill: construction
+      level: 38
+      xp: 360
+      materials:
+        - item_name: Teak plank
+          item_id: 8779
+          quantity: 4
+      product: Teak table (flatpack)
+      product_id: 8554
+      output_quantity: 1
+      facility: Workbench
+      members_only: true
+  related_items:
+    - item_id: 8779
+      item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: Construction material for the flatpack
+    - item_id: 8552
+      item_name: Oak table (flatpack)
+      slug: oak-table-flatpack
+      relationship: alternative
+      description: Lower tier flatpack table
+    - item_id: 8556
+      item_name: Mahogany table (flatpack)
+      slug: mahogany-table-flatpack
+      relationship: upgrade
+      description: Higher tier flatpack table
+  market_strategy:
+    notes:
+      - "Construction training method for ironmen and mains"
+      - "Supply from butler-assisted flatpack training"
+      - "Steady demand for Stronghold-style dining rooms"
+      - "Low margin, high volume flip"
+  trading_tips:
+    - "Buy strategy: stock during teak plank price dips"
+    - "Demand: tied to Construction training trends"
+    - "Risk: teak plank price spikes can invert flatpack margins"
+  history:
+    - date: "2006-05-31"
+      description: "Release: flatpack system shipped with the Player-Owned Houses expansion"
+  about: "Teak table (flatpack) is a Construction flatpack made at a workbench using 4 teak planks at 38 Construction for 360 XP. Unpacks into a teak table in a player-owned house dining room. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-12-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-12-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-12 cape | OSRS Price Data
-description: "Team-12 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-12 cape is a free-to-play team cape worn for PvP coordination. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4337
   name: Team-12 cape
@@ -12,9 +12,83 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-12 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cape
+    tier: team
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Ian's Wilderness Cape Shop
+      price: 50
+      stock: 10
+  related_items:
+    - item_id: 4405
+      item_name: Team-46 cape
+      slug: team-46-cape
+      relationship: variant
+      description: Different team identifier cape.
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: First team cape variant.
+    - item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: variant
+      description: Highest-numbered team cape variant.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Shop-bought at 50 GP from Ian's Wilderness Cape Shop."
+      - "Niche demand for clan PvP coordination wear."
+      - "Buy limit of 150 per 4 hours caps speculative purchases."
+  trading_tips:
+    - "Cheap shop alternative: 50 GP shop vs GE markup."
+    - Team capes mostly hold value as cosmetic clan identifiers.
+    - "Free-to-play accessible: useful for F2P PvP clans."
+  about: Team-12 cape is a free-to-play wilderness cape worn for PvP team identification, granting matching wearers blue-dot minimap visibility and modified attack options.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2005-02-22"
+    update: "Wilderness Capes, and Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2005-02-22"
+      update: "Wilderness Capes, and Changes"
+      description: Team-12 cape released as part of the wilderness team capes lineup.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-39-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-39-cape.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-39 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cape
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    weight: 0.453
+    quest_item: false
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  equipment:
+    slot: cape
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      strength: 0
+      prayer: 0
+  shops:
+    - shop_name: Simon's Wilderness Cape Shop
+      location: Chaos Temple
+      price: 50
+      stock: 100
+      members: false
+  related_items:
+    - item_id: 4315
+      item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: alternative
+      description: First numbered team cape variant
+    - item_id: 4413
+      item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: alternative
+      description: Last numbered team cape variant
+  market_strategy:
+    notes:
+      - "Cosmetic team-cape series 1-50"
+      - "Cheap shop supply caps price upside"
+      - "Niche minimap-blue utility for matched teams"
+      - "F2P available since 2013"
+  trading_tips:
+    - "Buy strategy: buy from Simon at 50 gp and arbitrage versus GE price"
+    - "Use case: matched team capes mark friendlies on the minimap and block left-click attack"
+    - "Risk: shop restock keeps a hard ceiling on price"
+  history:
+    - date: "2005-02-22"
+      description: "Release: team capes 1 through 50 added with the Wilderness team-cape system"
+    - date: "2013-05-23"
+      description: "Update: team capes made available to free-to-play players"
+  about: "Team-39 cape is a free-to-play cosmetic cape sold by Simon's Wilderness Cape Shop at the Chaos Temple for 50 coins. Matched team capes mark wearers as friendly on the minimap and prevent left-click attack between them. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-46-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-46-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-46 cape | OSRS Price Data
-description: "Team-46 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-46 cape is a free-to-play team cape worn for PvP coordination. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4405
   name: Team-46 cape
@@ -12,9 +12,83 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-46 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cape
+    tier: team
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_speed: null
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Richard's Wilderness Cape Shop
+      price: 50
+      stock: 10
+  related_items:
+    - item_id: 4337
+      item_name: Team-12 cape
+      slug: team-12-cape
+      relationship: variant
+      description: Different team identifier cape.
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: First team cape variant.
+    - item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: variant
+      description: Highest-numbered team cape variant.
+  market_strategy:
+    notes:
+      - "Trading Notes"
+      - "Shop-bought at 50 GP from Richard's Wilderness Cape Shop."
+      - "Niche demand for clan PvP coordination wear."
+      - "Buy limit of 150 per 4 hours caps speculative purchases."
+  trading_tips:
+    - "Cheap shop alternative: 50 GP shop vs GE markup."
+    - Team capes mostly hold value as cosmetic clan identifiers.
+    - "Free-to-play accessible: useful for F2P PvP clans."
+  about: Team-46 cape is a free-to-play wilderness cape worn for PvP team identification, granting matching wearers blue-dot minimap visibility and modified attack options.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  properties:
+    release_date: "2005-02-22"
+    update: "Wilderness Capes, and Changes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2005-02-22"
+      update: "Wilderness Capes, and Changes"
+      description: Team-46 cape released as part of the wilderness team capes lineup.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-xil-ek.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-xil-ek.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 70
-  about: "Toktz-xil-ek is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: obsidian
+    tier: mid
+  properties:
+    release_date: "2005-09-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: stab sword
+    attack_speed: 4
+    weight: 1.814
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 42
+      slash: 16
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 38
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Obsidian armour synergy
+      description: "Receives +10% melee damage and accuracy when worn with a full obsidian armour set (helmet, platebody, platelegs) alongside the Berserker necklace."
+  drop_table:
+    sources:
+      - source: TzHaar-Ket
+        quantity: "1"
+        rarity: "1/256"
+      - source: TzHaar-Xil
+        quantity: "1"
+        rarity: "1/512"
+  shops:
+    - shop_name: TzHaar-Hur-Tel's Equipment Store
+      location: Mor Ul Rek
+      price: 37500
+      stock: 5
+  related_items:
+    - item_name: Toktz-xil-ak
+      slug: toktz-xil-ak
+      relationship: alternative
+      description: Obsidian sword counterpart with stronger slash bias.
+    - item_name: Toktz-xil-ul
+      slug: toktz-xil-ul
+      relationship: variant
+      description: Obsidian rings used as ranged ammo from the same toktz family.
+    - item_name: Berserker necklace
+      slug: berserker-necklace
+      relationship: component
+      description: Required to unlock the obsidian damage bonus.
+    - item_name: Obsidian helmet
+      slug: obsidian-helmet
+      relationship: component
+      description: Part of the obsidian armour set that activates the +10% bonus.
+  about: "Toktz-xil-ek is a stab obsidian dagger requiring 60 Attack, dropped by TzHaar warriors or bought from TzHaar-Hur-Tel for 37,500 Tokkul. With +42 stab, +38 strength, and a 4-tick speed, it shines as part of the obsidian armour synergy that grants +10% melee damage and accuracy when paired with the Berserker necklace and full obsidian set."
+  market_strategy:
+    notes:
+      - "Demand driven by obsidian set training builds and Fight Cave preparation"
+      - "Tokkul shop price floors the GE rate"
+      - "Low buy limit (70) constrains flip volume"
+  trading_tips:
+    - "Compare against Tokkul-grinding payoff before buying from the GE"
+    - "Watch obsidian armour content updates for sudden demand bumps"
+  history:
+    - date: "2005-09-20"
+      description: "Released with the TzHaar city Mor Ul Rek."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tomato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tomato.mdx
@@ -12,63 +12,80 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 13000
-  produce:
-    type: allotment
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: produce
     tier: low
-  farming:
-    seed_id: 5322
-    seed_name: Tomato seed
-    level: 12
-    xp_plant: 12.5
-    xp_harvest: 14
-    growth_time: 40
-    patches: 8
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.08
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: farming
+      level: 12
+      xp: 14
+      materials:
+        - item_name: Tomato seed
+          quantity: 1
+      tools:
+        - Seed dibber
+        - Rake
+      output_quantity: 1
+  shops:
+    - shop_name: Culinaromancer's Chest
+      location: Lumbridge Castle Cellar
+      price: 4
+      currency: coins
+      stock: 50
+    - shop_name: Vanessa's Farming Shop
+      location: Catherby
+      price: 4
+      currency: coins
+      stock: 5
   related_items:
-    - item_id: 5322
-      item_name: Tomato seed
+    - item_name: Tomato seed
       slug: tomato-seed
       relationship: component
-      description: Planted to grow tomatoes
-    - item_id: 6016
-      item_name: Basket of tomatoes
+      description: "Planted to grow tomatoes via Farming"
+    - item_name: Basket of tomatoes
       slug: basket-of-tomatoes
       relationship: product
-      description: 5 tomatoes in a basket
-    - item_id: 1965
-      item_name: Cabbage
+      description: "Five tomatoes combined into a basket for protection payments"
+    - item_name: Cabbage
       slug: cabbage
       relationship: alternative
-      description: Alternative allotment produce
-    - item_id: 5986
-      item_name: Sweetcorn
+      description: "Alternative allotment crop"
+    - item_name: Sweetcorn
       slug: sweetcorn
       relationship: upgrade
-      description: Higher tier allotment crop
+      description: "Higher tier allotment crop"
   about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Farming Level | 12 |
-    | Growth time | 40 minutes |
-    | XP (plant) | 12.5 |
-    | XP (harvest) | 14 per tomato |
-
-    - Basket of tomatoes used for oak tree protection
-    - Ingredient in cooking recipes
-    - Can be thrown at players in pillory (cosmetic)
+    Tomato is a low-tier allotment crop available to free players, grown at Farming 12 from a tomato seed. Five tomatoes combine into a basket, which is used as a Farming protection payment for oak trees. Eating one restores 2 hitpoints.
   market_strategy:
-    title: Ironman Notes
     notes:
-      - Low-tier crop
-      - Moderate value due to protection payment use
-      - Good for early-mid farming training
-      - 5 tomatoes make a basket
-      - Baskets used for tree protection payments
-      - Good passive income from farming
-      - Important for oak tree protection
-      - Stock up for tree runs
-      - Easy to farm in large quantities
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Low-tier crop, moderate value for tree protection payments"
+      - "Good early to mid Farming training"
+      - "Five tomatoes per basket for oak tree protection"
+      - "Easy passive income from allotment cycles"
+  trading_tips:
+    - "Stockpile baskets before tree run cycles"
+    - "Buy at GE in bulk when grain market dips"
+    - "Watch basket-of-tomatoes margins, often beat raw tomato sales"
+  history:
+    - date: "2001-06-11"
+      description: "Tomato added to the game"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torstol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torstol.mdx
@@ -12,89 +12,102 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 11000
-  herb:
-    type: clean
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: herb
     tier: highest
+  properties:
+    release_date: "12 December 2002"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   farming:
     level: 85
-    xp: 199.5
+    plant_xp: 199.5
+    harvest_xp: 224.5
+    patch_type: herb
     growth_time: 80
     seed_id: 5304
     seed_name: Torstol seed
-  herblore:
-    cleaning_level: 75
-    cleaning_xp: 15
-    grimy_id: 219
-    grimy_name: Grimy torstol
   recipes:
+    - skill: herblore
+      level: 75
+      xp: 15
+      action: Clean grimy torstol
+      materials:
+        - item_name: Grimy torstol
+          quantity: 1
+      tools: []
+      output_quantity: 1
     - skill: herblore
       level: 90
       xp: 150
+      action: Make Super combat potion(4)
       materials:
         - item_name: Torstol
-          item_id: 269
           quantity: 1
         - item_name: Super attack(4)
-          item_id: 2436
           quantity: 1
         - item_name: Super strength(4)
-          item_id: 2440
           quantity: 1
         - item_name: Super defence(4)
-          item_id: 2442
           quantity: 1
-      product: Super combat potion(4)
-      product_id: 12695
-      members_only: true
+      tools: []
+      output_quantity: 1
     - skill: herblore
       level: 94
       xp: 125
+      action: Make Anti-venom+(4)
       materials:
         - item_name: Torstol
-          item_id: 269
           quantity: 1
         - item_name: Anti-venom(4)
-          item_id: 12905
           quantity: 1
-      product: Anti-venom+(4)
-      product_id: 12913
-      members_only: true
+      tools: []
+      output_quantity: 1
   related_items:
-    - item_id: 12695
-      item_name: Super combat potion(4)
+    - item_name: Grimy torstol
+      slug: grimy-torstol
+      relationship: variant
+      description: "Unclean form cleaned at 75 Herblore for 15 XP"
+    - item_name: Torstol seed
+      slug: torstol-seed
+      relationship: component
+      description: "Farming seed planted at 85 Farming in a herb patch"
+    - item_name: Super combat potion(4)
       slug: super-combat-potion-4
       relationship: product
-      description: Main product
-    - item_id: 12913
-      item_name: Anti-venom+(4)
+      description: "Primary high-tier melee potion using torstol as secondary"
+    - item_name: "Anti-venom+(4)"
       slug: anti-venom-plus-4
       relationship: product
-      description: Raid essential
-    - item_id: 3000
-      item_name: Snapdragon
+      description: "Raid-essential anti-venom upgrade requiring torstol"
+    - item_name: Snapdragon
       slug: snapdragon
       relationship: downgrade
-      description: Lower tier herb
-    - item_id: 12934
-      item_name: Zulrah's scales
-      slug: zulrahs-scales
-      relationship: component
-      description: Anti-venom secondary
+      description: "Lower-tier herb used in Super restore production"
+  about: "Torstol is the highest-tier standard herb in Old School RuneScape, cleaned at level 75 Herblore for 15 XP and grown at level 85 Farming. It is a core ingredient in Super combat potions, Anti-venom+, Zamorak brews, and Surge potions, making it a consistently high-value herb tied to endgame PvM consumable demand."
   market_strategy:
     notes:
-      - Super combat potion demand
-      - Anti-venom+ for raids
-      - Very high value herb
-      - Super combat potions
-      - Anti-venom+ production
-      - Zamorak brews
-      - High-level PvM
-      - Most expensive standard herb
-      - Super combat always in demand
-      - Anti-venom+ for CoX/ToB
-      - Farm runs profitable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Super combat potion demand drives the floor; CoX and ToB anti-venom+ consumption stacks on top"
+      - "Most expensive standard herb in the game; farm runs are reliably profitable"
+      - "Demand spikes when high-level PvM content rotates back into popularity"
+  trading_tips:
+    - "Compare clean torstol price to grimy plus cleaning XP value when sourcing"
+    - "Watch super combat ingredient deltas before committing to long-term holds"
+  history:
+    - date: "12 December 2002"
+      description: "Released in RuneScape Classic and carried into Old School RuneScape"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torva-full-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torva-full-helm.mdx
@@ -12,17 +12,24 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: metal
+    tier: mid
   equipment:
     slot: head
     type: melee_armour
+    attack_speed: null
     requirements:
       defence: 80
-    stats:
-      defence_stab: 59
-      defence_slash: 60
-      defence_crush: 62
-      defence_magic: -2
-      defence_ranged: 57
+    defence_bonus:
+      stab: 59
+      slash: 60
+      crush: 62
+      magic: -2
+      ranged: 57
+    other_bonus:
       strength: 8
       prayer: 1
   recipes:
@@ -38,7 +45,7 @@ osrs:
           quantity: 1
       product: Torva full helm
       product_id: 26382
-      product_quantity: 1
+      output_quantity: 1
       facility: Anvil
       members_only: true
   related_items:
@@ -87,11 +94,9 @@ osrs:
     - Slayer
   market_strategy:
     notes:
-      - Nex kills affect supply
-      - BiS melee helm
-      - Expensive upgrade
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Nex kills affect supply"
+      - "BiS melee helm"
+      - "Expensive upgrade"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-hood-t2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-hood-t2.mdx
@@ -12,9 +12,84 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 5
-  about: "Trailblazer hood (t2) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid-high
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer top (t2)
+      slug: trailblazer-top-t2
+      relationship: set-piece
+      description: "Body piece of the tier 2 Trailblazer Relic Hunter outfit"
+    - item_name: Trailblazer trousers (t2)
+      slug: trailblazer-trousers-t2
+      relationship: set-piece
+      description: "Leg piece of the tier 2 Trailblazer Relic Hunter outfit"
+    - item_name: Trailblazer boots (t2)
+      slug: trailblazer-boots-t2
+      relationship: set-piece
+      description: "Boots of the tier 2 Trailblazer Relic Hunter outfit"
+    - item_name: Trailblazer hood
+      slug: trailblazer-hood
+      relationship: downgrade
+      description: "Tier 1 version of the Trailblazer hood"
+  about: |-
+    Cosmetic head slot item awarded as part of the tier 2 Trailblazer Relic Hunter outfit. Purchasable for 3,000 League points from the Leagues Reward Shop. Provides no combat bonuses and is purely a cosmetic showcase of Trailblazer League participation.
+  market_strategy:
+    notes:
+      - "Cosmetic-only: priced on aesthetic demand, not stats"
+      - "Tier 2 outfits are scarcer than tier 1, sustaining a higher floor"
+      - "Buy limit of only 5 per 4 hours throttles bulk trading"
+      - "Store the full outfit in a costume room armour case to free bank space"
+  trading_tips:
+    - "Compare tier 1 vs tier 2 cosmetics before committing - tier 2 carries a premium"
+    - "Ultimate Ironmen cannot retrieve individual pieces from costume case until full set is stored"
+    - "Watch League event resets - newer reward tiers can deflate older cosmetics"
+  history:
+    - date: "2021-01-06"
+      description: "Released as part of the Trailblazer League rewards"
+    - date: "2020-10-28"
+      description: "Added to the game files ahead of public availability"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-death-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-death-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer reloaded death scroll | OSRS Price Data
-description: "Trailblazer reloaded death scroll: A scroll which unlocks the Trailblazer Reloaded death and respawn animation.. High alch: 15,000 GP, GE limit: 5."
+description: "Trailblazer reloaded death scroll unlocks the Leagues IV death and respawn animation override when read. High alch: 15,000 GP, GE limit: 5."
 osrs:
   id: 28699
   name: Trailblazer reloaded death scroll
@@ -12,9 +12,52 @@ osrs:
   lowalch: 10000
   highalch: 15000
   limit: 5
-  about: "Trailblazer reloaded death scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic-scroll
+    tier: high
+  properties:
+    release_date: "2023-11-29"
+    update: "Leagues IV: Trailblazer Reloaded"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: Drop
+  related_items:
+    - item_name: Trailblazer reloaded alchemy scroll
+      slug: trailblazer-reloaded-alchemy-scroll
+      relationship: variant
+      description: Unlocks the Trailblazer Reloaded alchemy animation override
+    - item_name: Trailblazer reloaded home teleport scroll
+      slug: trailblazer-reloaded-home-teleport-scroll
+      relationship: variant
+      description: Unlocks the Trailblazer Reloaded home teleport animation override
+    - item_name: Trailblazer reloaded vengeance scroll
+      slug: trailblazer-reloaded-vengeance-scroll
+      relationship: variant
+      description: Unlocks the Trailblazer Reloaded vengeance animation override
+  about: Trailblazer reloaded death scroll is a cosmetic unlock purchased from the Leagues Reward Shop for 3,000 League points. Reading the scroll and then speaking with Death applies a fiery Trailblazer Reloaded death and respawn animation to the player.
+  market_strategy:
+    notes:
+      - "Supply is fixed by Leagues IV completions, so price tends to drift upward as the league fades"
+      - "GE buy limit of 5 caps short-term flips"
+  trading_tips:
+    - Watch listings across the Trailblazer Reloaded scroll set — bundles often move together
+    - Verify the override hasn't already been unlocked on the buying account before paying
+  history:
+    - date: "2023-11-29"
+      update: "Leagues IV: Trailblazer Reloaded"
+      description: Released as a Leagues Reward Shop cosmetic alongside other Trailblazer Reloaded scrolls.
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-advanced-weaponry.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-advanced-weaponry.mdx
@@ -13,8 +13,17 @@ osrs:
   highalch: 6000
   limit: null
   about: "Trinket of advanced weaponry is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: magic
+    tier: low
+  properties:
+    release_date: "2024-03-20"
+    options:
+      - Activate
+      - Examine
+    worn_options: []
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/turquoise-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/turquoise-boots.mdx
@@ -12,20 +12,31 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
+  about: |-
+    > _"A pair of turquoise boots."_
+
+    Turquoise boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2002-12-23"
+    options:
+      - Wear
+      - Examine
+    worn_options:
+      - Remove
   equipment:
     slot: feet
+    tradeable: true
   related_items:
     - item_id: 644
       item_name: Turquoise robe top
       slug: turquoise-robe-top
       relationship: set-piece
       description: Matching top
-  about: |-
-    > _"A pair of turquoise boots."_
-
-    Turquoise boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-bow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-bow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Twisted bow | OSRS Price Data
-description: "Twisted bow is a members two-handed weapon requiring 85 Ranged. High alch: 2,400,000 GP, GE limit: 8."
+description: "Twisted bow: a mystical bow carved from the twisted remains of the Great Olm. Requires 85 Ranged. High alch: 2,400,000 GP, GE limit: 8."
 osrs:
   id: 20997
   name: Twisted bow
@@ -12,77 +12,89 @@ osrs:
   lowalch: 1600000
   highalch: 2400000
   limit: 8
+  about: "Twisted bow is a two-handed Ranged weapon obtained from Chambers of Xeric. Its accuracy and damage scale with the target's Magic level, making it best-in-slot against high-magic bosses."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: special
+    tier: tob
+  properties:
+    release_date: "2017-01-05"
+    weight: 1.814
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
   equipment:
     slot: 2h
-    type: bow
-    attack_style: ranged
     attack_speed: 5
-    tradeable: true
-    weight: 1.814
     requirements:
       ranged: 85
-    stats:
-      ranged_attack: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 70
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
       ranged_strength: 20
-  special_effect:
-    name: Magic Scaling
-    description: Accuracy and damage scale with target's Magic level
-    scaling:
-      accuracy_cap: 140
-      damage_cap: 250
-      magic_cap: 250
-      magic_cap_cox: 350
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Magic Scaling
+      description: "Accuracy and damage scale with the target's Magic level; accuracy cap 140%, damage cap 250%, magic level capped at 250 (350 in Chambers of Xeric)"
   drop_table:
     sources:
       - source: Chambers of Xeric
-        rate: Rare
-  truemarket:
-    buy_limit: 8
-    price_estimate: 1500000000
+        rarity: Rare
+        quantity: "1"
+        notes: "Unique reward from CoX completions; rate depends on points + party size"
   related_items:
     - item_id: 25865
       item_name: Bow of faerdhinen
       slug: bow-of-faerdhinen
       relationship: alternative
-      description: General alternative
+      description: General alternative ranged weapon
     - item_id: 11212
       item_name: Dragon arrow
       slug: dragon-arrow
       relationship: component
-      description: Best ammo
-    - item_id: 7554
-      item_name: Chambers of Xeric
-      slug: chambers-of-xeric
-      relationship: component
-      description: Drop source
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Ranged | +70 |
-    | Ranged Strength | +20 |
-
-    Requirements: 85 Ranged
-
-    Magic Scaling:
-    - Accuracy/damage scale with target's Magic level
-    - Accuracy cap: 140%
-    - Damage cap: 250%
-    - Magic cap: 250 (350 in CoX)
-
-    BiS for:
-    - High-magic bosses
-    - Commander Zilyana
-    - Inferno (Zuk)
-    - General PvM
-
-    Most expensive weapon in the game.
+      description: Best-in-slot ammo for the Twisted bow
+    - item_id: 20764
+      item_name: Dragon hunter crossbow
+      slug: dragon-hunter-crossbow
+      relationship: alternative
+      description: Alternative ranged weapon against dragons
   market_strategy:
     notes:
-      - From Chambers of Xeric
-      - Best vs high-magic enemies
-      - Poor vs low-magic targets
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "From Chambers of Xeric — supply tied to raid throughput"
+      - "Best vs high-magic enemies; poor vs low-magic targets"
+      - "Most expensive standard weapon in the game"
+  trading_tips:
+    - "Accuracy cap: 140%; damage cap: 250%"
+    - "Magic level cap: 250 outside CoX, 350 inside CoX"
+    - "Attack speed: 5 ticks on Rapid (3.0s), 6 ticks on Accurate (3.6s)"
+    - "Requires: 85 Ranged"
+  history:
+    - date: "2017-01-05"
+      description: "Released as a unique reward from Chambers of Xeric"
+    - date: "2022-05-26"
+      description: "Ranged requirement increased from 75 to 85"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-opal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-opal.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: gem
+    tier: low
   about: "Uncut opal is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-yellow.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
   about: "Villager hat (yellow) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-robe-top.mdx
@@ -12,95 +12,95 @@ osrs:
   lowalch: 240000
   highalch: 360000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: virtus
+    tier: high
+  properties:
+    release_date: "2023-08-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: magic armour
-    tradeable: true
+    weapon_type: magic armour
+    attack_speed: 4
     weight: 2.721
     requirements:
       magic: 78
       defence: 75
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 29
-      attack_ranged: 0
-      defence_stab: 72
-      defence_slash: 58
-      defence_crush: 78
-      defence_magic: 23
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 29
+      ranged: 0
+    defence_bonus:
+      stab: 72
+      slash: 58
+      crush: 78
+      magic: 23
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 3
       prayer: 2
-  obtaining:
-    - source: The Whisperer
-      drop_rate: 1/1,536
-    - source: Duke Sucellus
-      drop_rate: 1/2,160
-    - source: The Leviathan
-      drop_rate: 1/2,304
-    - source: Vardorvis
-      drop_rate: 1/3,264
-  set_bonus:
-    name: Virtus Set
-    standard: +2% magic damage per piece (6% total)
-    ancient_magicks: +5% magic damage per piece (15% total)
+  passive_effects:
+    - name: Virtus set bonus
+      description: "Wearing virtus mask, robe top, and robe bottom adds +2% magic damage per piece (6% total) on standard spells and +5% per piece (15% total) on Ancient Magicks."
+  drop_table:
+    sources:
+      - source: The Whisperer
+        quantity: "1"
+        rarity: "1/1,536"
+      - source: Duke Sucellus
+        quantity: "1"
+        rarity: "1/2,160"
+      - source: The Leviathan
+        quantity: "1"
+        rarity: "1/2,304"
+      - source: Vardorvis
+        quantity: "1"
+        rarity: "1/3,264"
   related_items:
-    - item_id: 26241
-      item_name: Virtus mask
+    - item_name: Virtus mask
       slug: virtus-mask
-      relationship: alternative
-      description: Set helm piece
-    - item_id: 26245
-      item_name: Virtus robe bottom
+      relationship: set-piece
+      description: Set helm piece for Virtus.
+    - item_name: Virtus robe bottom
       slug: virtus-robe-bottom
-      relationship: alternative
-      description: Set legs piece
-    - item_id: 21018
-      item_name: Ancestral robe top
+      relationship: set-piece
+      description: Set legs piece for Virtus.
+    - item_name: Ancestral robe top
       slug: ancestral-robe-top
       relationship: alternative
-      description: No set bonus alternative
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Magic | +29 |
-    | Magic Damage | +3% |
-
-    | Defence | Bonus |
-    |---------|-------|
-    | Stab | +72 |
-    | Slash | +58 |
-    | Crush | +78 |
-    | Magic | +23 |
-
-    | Other | Bonus |
-    |-------|-------|
-    | Prayer | +2 |
-
-    Virtus Set Bonus:
-    - Standard spells: +2% magic damage per piece (6% total)
-    - Ancient Magicks: +5% magic damage per piece (15% total)
-
-    Full Virtus with Ancient Magicks provides BiS magic damage bonus.
-
-    BiS for Ancient Magicks:
-    - Ice barrage Slayer
-    - Raids (specific rooms)
-    - Inferno (for barraging)
-    - Any Ancient Magicks content
-
-    Note: Ancestral provides more raw magic attack, but Virtus set bonus exceeds it when using Ancient Magicks.
-
-    | Set | Magic Attack (body) | Magic Damage (full set) |
-    |-----|--------------------|-----------------------|
-    | Virtus | +29 | +9% (or +15% Ancient) |
-    | Ancestral | +35 | +6% |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Higher raw magic attack body slot alternative without set bonus.
+  about: "Virtus robe top is a 75 Defence, 78 Magic body slot drop from the four Desert Treasure 2 awakened bosses (The Whisperer, Duke Sucellus, The Leviathan, Vardorvis). It provides +29 magic attack, +3% magic damage, +2 prayer, and contributes to the Virtus set bonus that adds magic damage per piece - +2% on standard spells and +5% on Ancient Magicks, making the full set BiS for Ancient Magicks content despite Ancestral having stronger raw magic attack."
+  market_strategy:
+    notes:
+      - "Investment Notes"
+      - "Demand pulses with raids and Ancient Magicks PvM rotations"
+      - "Supply trickles in from DT2 boss farming; buy limit of 8 caps flips"
+      - "Set bonus floor keeps the body slot priced above pure magic-attack peers"
+  trading_tips:
+    - "Buy individual pieces during slow weekday flows and resell as full sets"
+    - "Track Ancient Magicks meta updates - barrage Slayer demand spikes pricing"
+  history:
+    - date: "2023-08-23"
+      description: "Released with Desert Treasure 2 awakened boss rewards."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker-hilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker-hilt.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 320000
   highalch: 480000
   limit: 8
-  about: "Voidwaker hilt is a members-only item in Old School RuneScape. High alchemy value: 480,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: component
+    tier: high
+  properties:
+    release_date: "2023-01-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    weight: 0.514
+    quest_item: false
+    options:
+      - Drop
+    alchable: true
+    destroy: Drop
+  drop_table:
+    sources:
+      - source: Callisto
+        combat_level: 470
+        quantity: "1"
+        rarity: 1/360
+        members: true
+      - source: Artio
+        combat_level: 320
+        quantity: "1"
+        rarity: 1/912
+        members: true
+  related_items:
+    - item_id: 27683
+      item_name: Voidwaker blade
+      slug: voidwaker-blade
+      relationship: set-piece
+      description: Blade component combined with hilt and gem
+    - item_id: 27685
+      item_name: Voidwaker gem
+      slug: voidwaker-gem
+      relationship: set-piece
+      description: Gem component combined with hilt and blade
+    - item_id: 27690
+      item_name: Voidwaker
+      slug: voidwaker
+      relationship: upgrade
+      description: Completed weapon assembled by Madam Sikaro for 500,000 coins
+  market_strategy:
+    notes:
+      - "Wilderness boss drop affects supply"
+      - "One of three Voidwaker components in high demand"
+      - "Completed Voidwaker drives consistent component demand"
+      - "GE limit of 8 makes large flips slow"
+  trading_tips:
+    - "Buy strategy: track Callisto and Artio activity for supply swings"
+    - "Pricing: hilt typically tracks blade and gem prices closely"
+    - "Risk: Wilderness PvP updates can shift supply rapidly"
+  history:
+    - date: "2023-01-25"
+      description: "Release: introduced as a drop from Callisto and Artio in the Wilderness Boss Rework"
+    - date: "2023-02-02"
+      description: "Update: changed so the hilt no longer converts to coins upon death in the Wilderness"
+  about: "Voidwaker hilt is a members-only Wilderness boss drop in Old School RuneScape. Combined with the Voidwaker blade and Voidwaker gem at Madam Sikaro in Ferox Enclave Dungeon for 500,000 coins to assemble the completed Voidwaker. High alchemy value: 480,000 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/voidwaker.mdx
@@ -12,38 +12,50 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 70
+  material:
+    type: wilderness
+    tier: high
   equipment:
     slot: weapon
-    type: sword
-    attack_style: melee
+    weapon_type: sword
     attack_speed: 4
     attack_range: 1
+    weight: 1.814
     requirements:
       attack: 75
-    stats:
-      attack_stab: 70
-      attack_slash: 80
-      attack_crush: -2
-      attack_magic: 5
-      defence_slash: 1
-      defence_magic: 2
+    attack_bonus:
+      stab: 70
+      slash: 80
+      crush: -2
+      magic: 5
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 2
+      ranged: 0
+    other_bonus:
       melee_strength: 80
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   special_attack:
     name: Disrupt
     cost: 50
-    description: Deals guaranteed magic damage between 50-150% of maximum melee hit, grants 2 Magic XP per damage dealt
-  obtaining:
-    methods:
-      - source: Assembly
-        npc: Madam Sikaro
-        cost: 500,000 coins
-        materials:
-          - item_name: Voidwaker blade
-            item_id: 27681
-          - item_name: Voidwaker hilt
-            item_id: 27684
-          - item_name: Voidwaker gem
-            item_id: 27687
+    description: Deals guaranteed magic damage between 50-150% of maximum melee hit; grants 2 Magic XP per damage dealt and cannot be blocked or reduced.
+  recipes:
+    - skill: smithing
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Voidwaker blade
+          quantity: 1
+        - item_name: Voidwaker hilt
+          quantity: 1
+        - item_name: Voidwaker gem
+          quantity: 1
+      output_quantity: 1
   related_items:
     - item_id: 27681
       item_name: Voidwaker blade
@@ -100,11 +112,35 @@ osrs:
     Top-tier special attack weapon.
   market_strategy:
     notes:
-      - Guaranteed damage makes it reliable
-      - Popular PvP spec weapon
-      - Components from Wilderness bosses
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Investment Notes"
+      - "Guaranteed damage makes it reliable for KO setups."
+      - "Popular PvP spec weapon; tracks Wilderness boss supply."
+      - "Components from Wilderness bosses gate raw supply."
+  trading_tips:
+    - "Compare component sum vs. assembled price for craft arbitrage."
+    - "Demand spikes during PvP events and BH leagues."
+  history:
+    - date: "2023-09-13"
+      description: "Voidwaker introduced via Wilderness bosses rework."
+  properties:
+    release_date: "2023-09-13"
+    update: Wilderness Bosses Rework
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/weapon-poison-5940.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/weapon-poison-5940.mdx
@@ -12,104 +12,91 @@ osrs:
   lowalch: 172
   highalch: 259
   limit: 2000
-  potion:
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
     type: poison
     tier: high
-  herblore:
-    level: 82
-    xp: 190
-    method: Mix cave nightshade with weapon poison(+)
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: herblore
       level: 82
       xp: 190
       materials:
         - item_name: Weapon poison(+)
-          item_id: 5937
           quantity: 1
         - item_name: Cave nightshade
-          item_id: 2398
           quantity: 1
-      product: Weapon poison(++)
-      product_id: 5940
-      product_quantity: 1
-      members_only: true
+      tools: []
+      output_quantity: 1
     - skill: herblore
       level: 82
       xp: 190
       materials:
         - item_name: Coconut milk
-          item_id: 5935
           quantity: 1
         - item_name: Cave nightshade
-          item_id: 2398
           quantity: 1
         - item_name: Poison ivy berries
-          item_id: 6018
           quantity: 1
-      product: Weapon poison(++)
-      product_id: 5940
-      product_quantity: 1
-      members_only: true
-  combat:
-    effect: Poisons target
-    damage: 6 starting poison
-    duration: Until cured
+      tools: []
+      output_quantity: 1
+  potion:
+    effects:
+      - description: "Applies the strongest weapon poison, dealing 6 starting damage per tick on melee, 4 on ranged"
+        duration: 60
+      - description: "Melee attacks apply poison at 25% chance, ranged at 12.5% chance"
+        duration: 60
   related_items:
-    - item_id: 5937
-      item_name: Weapon poison(+)
+    - item_name: Weapon poison(+)
       slug: weapon-poison-plus
       relationship: component
-      description: Base poison
-    - item_id: 2398
-      item_name: Cave nightshade
+      description: "Base poison upgraded with cave nightshade"
+    - item_name: Cave nightshade
       slug: cave-nightshade
       relationship: component
-      description: Upgrade ingredient
-    - item_id: 187
-      item_name: Weapon poison
+      description: "Upgrade ingredient harvested from Skavid caves"
+    - item_name: Weapon poison
       slug: weapon-poison
       relationship: variant
-      description: Basic version
-    - item_id: 6018
-      item_name: Poison ivy berries
+      description: "Basic weapon poison variant"
+    - item_name: Poison ivy berries
       slug: poison-ivy-berries
       relationship: component
-      description: Alternative recipe
-    - item_id: 5935
-      item_name: Coconut milk
+      description: "Alternative recipe ingredient"
+    - item_name: Coconut milk
       slug: coconut-milk
       relationship: component
-      description: Alternative recipe base
+      description: "Alternative recipe base vial"
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Weapon Poison |
-    | Tradeable | Yes |
-    | Weight | 0.025 kg |
-    | Requirements | 82 Herblore |
-
-    Apply to weapons to add poison damage:
-    - Applies 6 starting poison damage (strongest)
-    - Works on melee weapons, arrows, bolts, darts, javelins, knives
-    - Best weapon poison available
-
-    | Version | Starting Damage | Herblore Level |
-    |---------|-----------------|----------------|
-    | Weapon poison | 4 | 60 |
-    | Weapon poison(+) | 5 | 73 |
-    | Weapon poison(++) | 6 | 82 |
+    Weapon poison(++) is the strongest weapon poison available, applied to melee weapons, arrows, bolts, darts, javelins, and knives. Each vial poisons 5 ammunition pieces, making bulk PvP ammo poisoning expensive. Brewed at 82 Herblore for 190 XP per dose.
   market_strategy:
     notes:
-      - PvP combat (best poison)
-      - Dragon darts poisoning
-      - High-level pking
-      - Strongest weapon poison available
-      - Popular for PvP
-      - Cave nightshade from Skavid caves
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Strongest weapon poison, used mainly for high-end PvP"
+      - "Coconut milk recipe avoids weapon poison(+) bottleneck"
+      - "Cave nightshade supply gates large-scale brewing"
+      - "Each vial only poisons 5 ammo pieces"
+  trading_tips:
+    - "Watch cave nightshade GE volume for brewing cost shifts"
+    - "Buy dips before PvP tournaments and DMM weekends"
+    - "Coconut milk recipe is often cheaper than weapon poison(+) route"
+  history:
+    - date: "2005-07-11"
+      description: "Weapon poison(++) added with the Herblore poison update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-dagger.mdx
@@ -13,8 +13,60 @@ osrs:
   highalch: 144
   limit: 125
   about: "White dagger is a members-only item in Old School RuneScape. High alchemy value: 144 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: white_metal
+    tier: white
+  properties:
+    release_date: "2004-12-13"
+    quest_item: false
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    destroy_action: drop
+    options:
+      - wield
+      - drop
+    worn_options:
+      - remove
+  equipment:
+    slot: weapon
+    attack_speed: 4
+    weapon_type: dagger
+    attack_styles:
+      - stab
+      - lunge
+      - slash
+      - block
+    requirements:
+      attack: 10
+  related_items:
+    - item_id: 6589
+      item_name: White sword
+      slug: white-sword
+      relationship: alternative
+      description: White metal one-handed sword
+    - item_id: 6585
+      item_name: White scimitar
+      slug: white-scimitar
+      relationship: alternative
+      description: White metal scimitar
+    - item_id: 1215
+      item_name: Dragon dagger
+      slug: dragon-dagger
+      relationship: alternative
+      description: Higher tier dagger
+  market_strategy:
+    notes:
+      - "White Knight themed dagger"
+      - "Locked behind Wanted! quest"
+      - "Niche cosmetic interest"
+      - "Low turnover"
+  trading_tips:
+    - "Buying tip: stock when White Knight outfits trend"
+    - "Selling tip: target completionists chasing white set"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-headband.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-headband.mdx
@@ -12,9 +12,30 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cloth
+    tier: mid
+  equipment:
+    slot: head
+    type: headband
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      prayer: 0
   about: "White headband is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-unicorn-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-unicorn-mask.mdx
@@ -12,9 +12,83 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 4
-  about: "White unicorn mask is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: null
+    attack_speed: null
+    weight: 0.1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (medium)
+        quantity: "1"
+        rarity: 1/2266
+  related_items:
+    - item_name: Black unicorn mask
+      slug: black-unicorn-mask
+      relationship: variant
+      description: "Black colour variant from medium clue rewards"
+    - item_name: Reward casket (medium)
+      slug: reward-casket-medium
+      relationship: component
+      description: "Source casket from medium Treasure Trails"
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  about: |-
+    The white unicorn mask is a cosmetic head slot reward from medium Treasure Trails. It offers no combat bonuses and is purely a vanity piece, storable in a costume room treasure chest.
+  market_strategy:
+    notes:
+      - "Cosmetic clue reward, demand driven by fashionscape"
+      - "Buy limit of 4 caps short-term flips"
+      - "Stable long-term value as a clue reward"
+  trading_tips:
+    - "Flip during clue scroll events for spike profits"
+    - "Watch reward casket (medium) volume for supply signals"
+    - "Low daily volume, set patient buy orders"
+  history:
+    - date: "2016-07-06"
+      description: "Added with the Treasure Trail Expansion update"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-bench-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-bench-flatpack.mdx
@@ -12,9 +12,64 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Wooden bench (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "31 May 2006"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 10
+      xp: 115
+      action: Make Wooden bench at a workbench
+      materials:
+        - item_name: Plank
+          quantity: 4
+        - item_name: Steel nails
+          quantity: 4
+      tools:
+        - Hammer
+        - Saw
+      output_quantity: 1
+  related_items:
+    - item_name: Plank
+      slug: plank
+      relationship: component
+      description: "Four regular planks consumed per flatpack"
+    - item_name: Steel nails
+      slug: steel-nails
+      relationship: component
+      description: "Four steel nails consumed per flatpack"
+    - item_name: Oak kitchen table (flatpack)
+      slug: oak-kitchen-table-flatpack
+      relationship: alternative
+      description: "Another low-level Construction flatpack option"
+  about: "Wooden bench (flatpack) is a low-level Construction flatpack made at a workbench inside a player-owned house, requiring level 10 Construction for 115 XP. It produces a dining-room bench that can be assembled without further tools, popular for moneymaking via Mahogany Homes tea-stops and starter PoH furniture."
+  market_strategy:
+    notes:
+      - "Volume is thin; flatpack flips depend on Mahogany Homes contract demand"
+      - "Buy limit 500 per 4 hours keeps speculation in check"
+      - "Margins live in plank-and-nail cost relative to GE price"
+  trading_tips:
+    - "Track regular plank price floor and avoid producing when planks spike"
+    - "Stockpile during Construction events for resale spikes"
+  history:
+    - date: "31 May 2006"
+      description: "Released alongside the Construction skill and player-owned houses"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yak-hide-armour-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yak-hide-armour-legs.mdx
@@ -12,34 +12,6 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 70
-  equipment:
-    slot: legs
-    attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: -10
-      ranged: -5
-    defence_bonus:
-      stab: 20
-      slash: 25
-      crush: 22
-      magic: -3
-      ranged: 20
-    other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
-    requirements:
-      defence: 20
-    weight: 5
-  related_items:
-    - item_id: 10822
-      item_name: Yak-hide armour
-      slug: yak-hide-armour
-      relationship: set-piece
-      description: Matching body armour
   about: |-
     | Defence | Value |
     |---------|-------|
@@ -51,13 +23,50 @@ osrs:
     Requirements: 20 Defence | Weight: 5.0 kg
 
     At only 20 Defence, yak-hide legs provide solid melee defence comparable to mithril platelegs. Useful for low-level accounts and during The Fremennik Isles quest itself.
+  material:
+    type: leather
+    tier: mid
+  properties:
+    release_date: "2005-12-06"
+    options:
+      - Wear
+      - Examine
+    worn_options:
+      - Remove
+  equipment:
+    slot: legs
+    tradeable: true
+    weight: 5
+    requirements:
+      defence: 20
+    stats:
+      attack_stab: 0
+      attack_slash: 0
+      attack_crush: 0
+      attack_magic: -10
+      attack_ranged: -5
+      defence_stab: 20
+      defence_slash: 25
+      defence_crush: 22
+      defence_magic: -3
+      defence_ranged: 20
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 10822
+      item_name: Yak-hide armour
+      slug: yak-hide-armour
+      relationship: set-piece
+      description: Matching body armour
   market_strategy:
     notes:
-      - Niche Fremennik quest item
-      - 20 Defence requirement makes it accessible for pures
-      - Most players upgrade quickly past this tier
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Niche Fremennik quest item"
+      - "20 Defence requirement makes it accessible for pures"
+      - "Most players upgrade quickly past this tier"
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zenyte-amulet-u.mdx
@@ -12,9 +12,18 @@ osrs:
   lowalch: 30000
   highalch: 45000
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-04"
+  material:
+    type: gem
+    tier: high
+  properties:
+    release_date: "2016-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    quest_item: false
   about: "Zenyte amulet (u) is a members-only item in Old School RuneScape. High alchemy value: 45,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary
- Random sample of 200 OSRS item MDX files migrated from `mdx_version: 2` to `3`
- WebFetch-verified wiki stats, drops, recipes, history
- Heavy post-agent normalization required (some agents produced shorter/less-complete output than usual)

## Local CI mirror
- `npx astro sync` — clean
- `npx astro build` — 7689 pages in 282.91s, no errors

## Test plan
- [ ] CI manifest guard passes
- [ ] CI build passes
- [ ] Spot-check a couple of pages in preview