### PR TITLE
fix(astro-kbve): stabilize forum-tags test against CI timer race (#11754)

### DIFF
--- a/apps/kbve/astro-kbve/src/data/forum-tags.test.ts
+++ b/apps/kbve/astro-kbve/src/data/forum-tags.test.ts
@@ -19,6 +19,13 @@ function jsonResponse(body: unknown, ok = true, status = 200) {
 describe('getForumTopTags', () => {
 	beforeEach(() => {
 		vi.spyOn(console, 'warn').mockImplementation(() => {});
+		// Replace AbortSignal.timeout with a never-aborting signal so the
+		// production code's 5s real-timer can't race vitest's own 5s
+		// testTimeout under heavy CI load. The mock fetch resolves
+		// synchronously anyway, so a real timeout serves no purpose here.
+		vi.spyOn(AbortSignal, 'timeout').mockImplementation(
+			() => new AbortController().signal,
+		);
 	});
 
 	afterEach(() => {


### PR DESCRIPTION
## Summary

Closes #11754. Flaky CI failure on \`astro-kbve:test\` was a timer race in \`src/data/forum-tags.test.ts\`:

- Production \`getForumTopTags\` wraps fetch with \`AbortSignal.timeout(5000)\` so build-time upstream fetches can't hang.
- Default vitest \`testTimeout\` is also 5000 ms.
- Under heavy CI parallelism (cargo + nx + vitest workers in the same job), the real abort timer races vitest's own budget. The "default limit is 12" test landed at exactly 5030 ms in the failing run.

## Fix

Mock \`AbortSignal.timeout\` to return a never-aborting signal for the duration of the describe block. The mock fetch resolves synchronously anyway, so a real 5 s timer serves no purpose — it was the side effect causing the race.

\`\`\`ts
vi.spyOn(AbortSignal, 'timeout').mockImplementation(
    () => new AbortController().signal,
);
\`\`\`

## Verification

- [x] Ran the test file 5× locally — all 8 tests green every run (~12 ms each, down from the flaky 5030 ms)
- [x] Production \`forum-tags.ts\` unchanged; real-world timeout behaviour preserved