### PR TITLE
perf(rareicon): jobify StatsRegenSystem — Health / Energy / Mana parallel

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/StatsRegenSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/StatsRegenSystem.cs
@@ -1,10 +1,12 @@
 using Unity.Burst;
+using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Ticks Health / Energy / Mana toward Max; Energy regen is scaled by hungerFactor × fatigueFactor so starved or exhausted units don't recover stamina.</summary>
+    /// <summary>Ticks Health / Energy / Mana toward Max; Energy regen is scaled by hungerFactor × fatigueFactor so starved or exhausted units don't recover stamina. Three [BurstCompile] IJobEntity passes run in parallel — RegenHealthJob writes Health + adds DeadTag via EndSimulationEntityCommandBufferSystem ParallelWriter on death, RegenEnergyJob reads Hunger/Fatigue ComponentLookups, RegenManaJob is a straight clamp+add. Previously three main-thread foreach scans iterated every Health/Energy/Mana entity per frame.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct StatsRegenSystem : ISystem
@@ -15,50 +17,90 @@ namespace RareIcon
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
-            float dt = SystemAPI.Time.DeltaTime;
-            var ecb = new EntityCommandBuffer(Unity.Collections.Allocator.Temp);
+            float dt   = SystemAPI.Time.DeltaTime;
+            var   ecb  = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>()
+                                  .CreateCommandBuffer(state.WorldUnmanaged);
+            var   pw   = ecb.AsParallelWriter();
 
-            foreach (var (h, hr, entity) in
-                     SystemAPI.Query<RefRW<Health>, RefRO<HealthRegen>>().WithEntityAccess())
+            var deadLookup    = SystemAPI.GetComponentLookup<DeadTag>(true);
+            var hungerLookup  = SystemAPI.GetComponentLookup<Hunger>(true);
+            var fatigueLookup = SystemAPI.GetComponentLookup<Fatigue>(true);
+
+            var healthHandle = new RegenHealthJob
             {
-                float v = math.clamp(h.ValueRO.Value + hr.ValueRO.PerSecond * dt, 0f, h.ValueRO.Max);
-                h.ValueRW.Value = v;
-                if (v <= 0f && !SystemAPI.HasComponent<DeadTag>(entity))
-                    ecb.AddComponent<DeadTag>(entity);
-            }
+                Dt         = dt,
+                Ecb        = pw,
+                DeadLookup = deadLookup,
+            }.ScheduleParallel(state.Dependency);
 
-            var hungerLookup  = SystemAPI.GetComponentLookup<Hunger>(isReadOnly: true);
-            var fatigueLookup = SystemAPI.GetComponentLookup<Fatigue>(isReadOnly: true);
-
-            foreach (var (e, er, entity) in
-                     SystemAPI.Query<RefRW<Energy>, RefRO<EnergyRegen>>().WithEntityAccess())
+            var energyHandle = new RegenEnergyJob
             {
-                float rate = er.ValueRO.PerSecond;
-                if (rate > 0f)
+                Dt            = dt,
+                HungerLookup  = hungerLookup,
+                FatigueLookup = fatigueLookup,
+            }.ScheduleParallel(state.Dependency);
+
+            var manaHandle = new RegenManaJob
+            {
+                Dt = dt,
+            }.ScheduleParallel(state.Dependency);
+
+            state.Dependency = JobHandle.CombineDependencies(healthHandle, energyHandle, manaHandle);
+        }
+    }
+
+    [BurstCompile]
+    public partial struct RegenHealthJob : IJobEntity
+    {
+        public float                                   Dt;
+        public EntityCommandBuffer.ParallelWriter      Ecb;
+        [ReadOnly] public ComponentLookup<DeadTag>     DeadLookup;
+
+        void Execute([ChunkIndexInQuery] int chunkIndex, Entity entity, ref Health h, in HealthRegen hr)
+        {
+            float v = math.clamp(h.Value + hr.PerSecond * Dt, 0f, h.Max);
+            h.Value = v;
+            if (v <= 0f && !DeadLookup.HasComponent(entity))
+                Ecb.AddComponent<DeadTag>(chunkIndex, entity);
+        }
+    }
+
+    [BurstCompile]
+    public partial struct RegenEnergyJob : IJobEntity
+    {
+        public float Dt;
+        [ReadOnly] public ComponentLookup<Hunger>  HungerLookup;
+        [ReadOnly] public ComponentLookup<Fatigue> FatigueLookup;
+
+        void Execute(Entity entity, ref Energy e, in EnergyRegen er)
+        {
+            float rate = er.PerSecond;
+            if (rate > 0f)
+            {
+                if (HungerLookup.HasComponent(entity))
                 {
-                    if (hungerLookup.HasComponent(entity))
-                    {
-                        var h = hungerLookup[entity];
-                        rate *= math.saturate(1f - (h.Max > 0f ? h.Value / h.Max : 0f));
-                    }
-                    if (fatigueLookup.HasComponent(entity))
-                    {
-                        var f = fatigueLookup[entity];
-                        rate *= math.saturate(1f - (f.Max > 0f ? f.Value / f.Max : 0f));
-                    }
+                    var h = HungerLookup[entity];
+                    rate *= math.saturate(1f - (h.Max > 0f ? h.Value / h.Max : 0f));
                 }
-                e.ValueRW.Value = math.clamp(e.ValueRO.Value + rate * dt, 0f, e.ValueRO.Max);
+                if (FatigueLookup.HasComponent(entity))
+                {
+                    var f = FatigueLookup[entity];
+                    rate *= math.saturate(1f - (f.Max > 0f ? f.Value / f.Max : 0f));
+                }
             }
+            e.Value = math.clamp(e.Value + rate * Dt, 0f, e.Max);
+        }
+    }
 
-            foreach (var (m, mr) in
-                     SystemAPI.Query<RefRW<Mana>, RefRO<ManaRegen>>())
-            {
-                float v = m.ValueRO.Value + mr.ValueRO.PerSecond * dt;
-                m.ValueRW.Value = math.clamp(v, 0f, m.ValueRO.Max);
-            }
+    [BurstCompile]
+    public partial struct RegenManaJob : IJobEntity
+    {
+        public float Dt;
 
-            ecb.Playback(state.EntityManager);
-            ecb.Dispose();
+        void Execute(ref Mana m, in ManaRegen mr)
+        {
+            float v = m.Value + mr.PerSecond * Dt;
+            m.Value = math.clamp(v, 0f, m.Max);
         }
     }
 }


### PR DESCRIPTION
Continues the per-system parallelization arc.

## Was

`StatsRegenSystem` ran three main-thread foreach scans every frame:

| Scan | Components | Per-iteration work |
|---|---|---|
| Health | `Health` + `HealthRegen` | clamp + `ecb.AddComponent<DeadTag>` when ≤ 0 |
| Energy | `Energy` + `EnergyRegen` | clamp with Hunger/Fatigue lookup scale |
| Mana | `Mana` + `ManaRegen` | clamp |

At 100k units that's three 100k-iteration scans on the main thread **every frame**. Each iteration is simple math but the cost compounds.

## Now

Three `[BurstCompile] IJobEntity` passes scheduled in parallel:

```csharp
var healthHandle = new RegenHealthJob { … }.ScheduleParallel(state.Dependency);
var energyHandle = new RegenEnergyJob { … }.ScheduleParallel(state.Dependency);
var manaHandle   = new RegenManaJob   { … }.ScheduleParallel(state.Dependency);
state.Dependency = JobHandle.CombineDependencies(healthHandle, energyHandle, manaHandle);
```

- **`RegenHealthJob`**: `ref Health` + `in HealthRegen` + `[ChunkIndexInQuery] int chunkIndex` for `EntityCommandBuffer.ParallelWriter` so `DeadTag` adds are thread-safe under deterministic playback ordering. `DeadLookup` ReadOnly so we don't re-add the tag.
- **`RegenEnergyJob`**: `ref Energy` + `in EnergyRegen` + ReadOnly `Hunger` + `Fatigue` ComponentLookups. Same `hungerFactor × fatigueFactor` formula as before.
- **`RegenManaJob`**: `ref Mana` + `in ManaRegen`. Trivial straight clamp.

ECB pulled from `EndSimulationEntityCommandBufferSystem` singleton, `AsParallelWriter()`. `ChunkIndexInQuery` on the death path keeps `DeadTag` adds ordered the same way the prior main-thread `ecb.Playback` would have.

## Behaviour preserved

- Identical clamp formulas across all three regens.
- Identical Hunger/Fatigue factor scaling in Energy regen.
- Identical `DeadTag` promotion on the ≤ 0 transition.

## Test plan

- [ ] Burst compiles `RegenHealthJob` + `RegenEnergyJob` + `RegenManaJob` clean.
- [ ] No safety errors with `ENABLE_UNITY_COLLECTIONS_CHECKS` on the shared parallel ECB writer.
- [ ] Health/Energy/Mana regen rates match pre-PR under same `dt`.
- [ ] DeadTag still applied exactly once when Health drops to 0 (chunkIndex ordering keeps playback deterministic).
- [ ] Frame-time delta at 1k / 10k / 100k units: main-thread `StatsRegenSystem` time should drop noticeably.
- [ ] Energy regen still scales correctly with Hunger / Fatigue (no double-application, no missing scale).

## Roadmap

Original dispatch optimization roadmap (#11716) closed. This PR is part of the broader pattern — same shape applied to next-most-impactful per-frame system. Future candidates: `LumbercampTenderScanSystem` (4 main-thread foreach), other per-tick simulation systems.