### PR TITLE
feat(edge,agents): discord-bootstrap edge fn + frontend cache fallback (P5.8b + P5.8c)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -39,15 +39,74 @@ export interface AgentTokenRow {
 
 const DISCORD_API_BASE = 'https://discord.com/api/v10';
 const GUILD_VAULT_URL = `${SUPABASE_URL}/functions/v1/guild-vault`;
+const DISCORD_BOOTSTRAP_URL = `${SUPABASE_URL}/functions/v1/discord-bootstrap`;
+const GUILDS_CACHE_KEY = 'kbve:agents:owned_guilds_cache:v1';
+const GUILDS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface CachedGuildsBlob {
+	user_id: string;
+	guilds: DiscordGuild[];
+	cached_at: number;
+}
+
+function parseJwtPayload(jwt: string): Record<string, unknown> | null {
+	try {
+		const parts = jwt.split('.');
+		if (parts.length < 2) return null;
+		const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+		const padded = b64 + '==='.slice((b64.length + 3) % 4);
+		const json = atob(padded);
+		return JSON.parse(json) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+function extractJwtOwnedGuildIds(jwt: string): string[] {
+	const payload = parseJwtPayload(jwt);
+	if (!payload || !Array.isArray(payload.owned_guilds)) return [];
+	return payload.owned_guilds.filter(
+		(g): g is string => typeof g === 'string' && /^[0-9]{17,20}$/.test(g),
+	);
+}
+
+function loadCachedGuilds(userId: string): DiscordGuild[] | null {
+	try {
+		const raw = localStorage.getItem(GUILDS_CACHE_KEY);
+		if (!raw) return null;
+		const blob = JSON.parse(raw) as CachedGuildsBlob;
+		if (blob.user_id !== userId) return null;
+		if (Date.now() - blob.cached_at > GUILDS_CACHE_TTL_MS) return null;
+		if (!Array.isArray(blob.guilds)) return null;
+		return blob.guilds;
+	} catch {
+		return null;
+	}
+}
+
+function saveCachedGuilds(userId: string, guilds: DiscordGuild[]): void {
+	try {
+		const blob: CachedGuildsBlob = {
+			user_id: userId,
+			guilds,
+			cached_at: Date.now(),
+		};
+		localStorage.setItem(GUILDS_CACHE_KEY, JSON.stringify(blob));
+	} catch {
+		// non-fatal
+	}
+}
 
 class AgentsService {
 	public readonly $authState = atom<AuthState>('loading');
 	public readonly $accessToken = atom<string | null>(null);
 	public readonly $providerToken = atom<string | null>(null);
+	public readonly $userId = atom<string | null>(null);
 
 	public readonly $guilds = atom<DiscordGuild[]>([]);
 	public readonly $guildsLoading = atom<boolean>(false);
 	public readonly $guildsError = atom<string | null>(null);
+	public readonly $guildsStale = atom<boolean>(false);
 
 	public readonly $selectedGuildId = atom<string | null>(null);
 
@@ -69,6 +128,10 @@ class AgentsService {
 
 			this.$accessToken.set(session.access_token as string);
 
+			const jwtPayload = parseJwtPayload(session.access_token as string);
+			const userId = (jwtPayload?.sub as string | undefined) ?? null;
+			if (userId) this.$userId.set(userId);
+
 			const sessionProviderToken =
 				(session as { provider_token?: string | null } | null)
 					?.provider_token ?? null;
@@ -80,17 +143,94 @@ class AgentsService {
 				providerToken = authBridge.getDiscordProviderToken();
 			}
 
-			if (!providerToken) {
-				this.$authState.set('discord_reauth_required');
+			if (providerToken) {
+				this.$providerToken.set(providerToken);
+				this.$authState.set('authenticated');
+
+				// Fire the bootstrap edge fn so the JWT hook picks up
+				// fresh owned_guilds on the next mint. Best-effort; a
+				// failure here doesn't block the page.
+				void this.bootstrapDiscord(providerToken);
+				await this.loadOwnedGuilds();
 				return;
 			}
 
-			this.$providerToken.set(providerToken);
-			this.$authState.set('authenticated');
+			// No provider_token. Fall back to JWT claim IDs + cached
+			// guild metadata; mark guild list stale so the UI can show
+			// a banner. Mutations remain disabled until the user
+			// re-OAuths (the mutation paths already gate on
+			// $providerToken being set).
+			const cached = userId ? loadCachedGuilds(userId) : null;
+			const jwtIds = extractJwtOwnedGuildIds(
+				session.access_token as string,
+			);
+			const jwtSet = new Set(jwtIds);
 
-			await this.loadOwnedGuilds();
+			if (cached && cached.length > 0) {
+				const filtered =
+					jwtIds.length > 0
+						? cached.filter((g) => jwtSet.has(g.id))
+						: cached;
+				this.$guilds.set(filtered);
+				this.$guildsStale.set(true);
+				this.$authState.set('authenticated');
+				if (filtered.length === 1) {
+					this.selectGuild(filtered[0].id);
+				}
+				return;
+			}
+
+			if (jwtIds.length > 0) {
+				// JWT claim present but no cached names — render as
+				// ID-only placeholders. UI can prompt re-sign-in to
+				// hydrate names from Discord.
+				this.$guilds.set(
+					jwtIds.map((id) => ({
+						id,
+						name: `Guild #${id.slice(-6)}`,
+						icon: null,
+						owner: true,
+						permissions: '0',
+					})),
+				);
+				this.$guildsStale.set(true);
+				this.$authState.set('authenticated');
+				if (jwtIds.length === 1) this.selectGuild(jwtIds[0]);
+				return;
+			}
+
+			// No provider_token, no JWT claim, no cache — truly need
+			// Discord re-auth to make progress.
+			this.$authState.set('discord_reauth_required');
 		} catch {
 			this.$authState.set('unauthenticated');
+		}
+	}
+
+	private async bootstrapDiscord(providerToken: string): Promise<void> {
+		const accessToken = this.$accessToken.get();
+		if (!accessToken) return;
+		try {
+			const resp = await fetch(DISCORD_BOOTSTRAP_URL, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify({ provider_token: providerToken }),
+			});
+			if (!resp.ok) {
+				// Non-fatal: the JWT claim path + Discord-live path
+				// both still work. Just log so dev tools shows it.
+				const text = await resp.text();
+				console.warn(
+					'[agentsService] discord-bootstrap returned',
+					resp.status,
+					text.slice(0, 200),
+				);
+			}
+		} catch (e) {
+			console.warn('[agentsService] discord-bootstrap threw:', e);
 		}
 	}
 
@@ -107,8 +247,14 @@ class AgentsService {
 			});
 
 			if (resp.status === 401) {
-				this.$authState.set('discord_reauth_required');
+				// provider_token expired/invalid. Don't blank the page —
+				// flip $providerToken null + mark stale; UI keeps the
+				// JWT-claim / cached guild list and mutation buttons
+				// disable themselves via their existing
+				// !providerToken guards. User re-OAuth refreshes
+				// names + re-enables mutations.
 				this.$providerToken.set(null);
+				this.$guildsStale.set(true);
 				try {
 					const { authBridge } =
 						await import('@/components/auth/AuthBridge');
@@ -117,7 +263,7 @@ class AgentsService {
 					// non-fatal
 				}
 				this.$guildsError.set(
-					'Discord session expired. Re-sign-in required.',
+					'Discord session expired — guild list may be stale. Sign in with Discord to refresh.',
 				);
 				return;
 			}
@@ -127,12 +273,17 @@ class AgentsService {
 				this.$guildsError.set(
 					`Discord API ${resp.status}: ${body.slice(0, 200)}`,
 				);
+				this.$guildsStale.set(true);
 				return;
 			}
 
 			const allGuilds = (await resp.json()) as DiscordGuild[];
 			const owned = allGuilds.filter((g) => g.owner === true);
 			this.$guilds.set(owned);
+			this.$guildsStale.set(false);
+
+			const userId = this.$userId.get();
+			if (userId) saveCachedGuilds(userId, owned);
 
 			if (owned.length === 1) {
 				this.selectGuild(owned[0].id);
@@ -143,6 +294,7 @@ class AgentsService {
 					? e.message
 					: 'Failed to load Discord guilds',
 			);
+			this.$guildsStale.set(true);
 		} finally {
 			this.$guildsLoading.set(false);
 		}

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.34"
+version: "0.1.35"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/discord-bootstrap/index.ts
+++ b/apps/kbve/edge/functions/discord-bootstrap/index.ts
@@ -1,0 +1,268 @@
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { corsHeaders } from "../_shared/cors.ts";
+import {
+  enforceBodySizeLimit,
+  requireJsonContentType,
+} from "../_shared/validators.ts";
+import {
+  createServiceClient,
+  extractToken,
+  jsonResponse,
+  parseJwt,
+  requireUserToken,
+} from "../_shared/supabase.ts";
+
+// ---------------------------------------------------------------------------
+// discord-bootstrap edge fn (P5.8b)
+//
+// Called by the browser once after a successful Discord OAuth sign-in (or
+// after JWT refresh). Reads the Discord provider_token from the request
+// body, calls Discord's /users/@me + /users/@me/guilds, cross-checks the
+// Discord ID against auth.identities (the OAuth-linked identity for this
+// user), filters to owner-only guilds, and upserts the result into
+// profile.discord_bootstrap_cache via the SECURITY DEFINER RPC. The
+// custom_access_token_hook then picks up the freshly cached owned_guilds
+// on the next JWT mint and embeds it as a JWT claim.
+//
+// Why the body carries provider_token instead of the edge fn fetching it
+// from auth.identities directly: Supabase auth doesn't persist
+// provider_tokens server-side by default. The client holds them
+// (localStorage stash via AuthBridge) and forwards them here.
+//
+// Auth model
+//   - User's Supabase JWT in Authorization header (verified by gateway).
+//   - provider_token in body (NOT a Supabase token — Discord access token).
+//   - Cross-check: Discord ID returned by the provider_token MUST match
+//     auth.identities.provider_id for this user_id. Prevents a holder of
+//     someone else's Discord token from injecting that user's guilds into
+//     their own kbve bootstrap cache.
+// ---------------------------------------------------------------------------
+
+const DISCORD_API_BASE = "https://discord.com/api/v10";
+const MAX_GUILDS_FETCHED = 200; // Discord platform cap
+
+interface DiscordUser {
+  id: string;
+}
+
+interface DiscordGuild {
+  id: string;
+  owner: boolean;
+}
+
+function validateProviderToken(token: unknown): Response | null {
+  if (!token || typeof token !== "string" || token.trim().length < 10) {
+    return jsonResponse(
+      { error: "provider_token is required (Discord access token)" },
+      400,
+    );
+  }
+  if (token.length > 4000) {
+    return jsonResponse(
+      { error: "provider_token exceeds reasonable length" },
+      400,
+    );
+  }
+  return null;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return jsonResponse({ error: "Only POST is allowed" }, 405);
+  }
+
+  const ctErr = requireJsonContentType(req);
+  if (ctErr) return ctErr;
+
+  let userId: string;
+  try {
+    const token = extractToken(req);
+    const claims = await parseJwt(token);
+    const denied = requireUserToken(claims);
+    if (denied) return denied;
+    if (!claims.sub || typeof claims.sub !== "string") {
+      return jsonResponse({ error: "JWT is missing sub claim" }, 401);
+    }
+    userId = claims.sub;
+  } catch (e) {
+    console.error("discord-bootstrap: auth failed:", e);
+    return jsonResponse({ error: "Authentication failed" }, 401);
+  }
+
+  const sizeErr = enforceBodySizeLimit(req);
+  if (sizeErr) return sizeErr;
+
+  let providerToken: string;
+  try {
+    const body = await req.json();
+    const ptErr = validateProviderToken(body.provider_token);
+    if (ptErr) return ptErr;
+    providerToken = (body.provider_token as string).trim();
+  } catch (_) {
+    return jsonResponse({ error: "Invalid JSON body" }, 400);
+  }
+
+  // 1. Discord /users/@me → get the canonical Discord ID
+  let discordUserId: string;
+  try {
+    const meRes = await fetch(`${DISCORD_API_BASE}/users/@me`, {
+      headers: { Authorization: `Bearer ${providerToken}` },
+    });
+    if (meRes.status === 401) {
+      return jsonResponse(
+        { error: "Discord provider_token rejected (401)" },
+        401,
+      );
+    }
+    if (meRes.status === 429) {
+      return jsonResponse(
+        { error: "Discord API rate limited" },
+        429,
+      );
+    }
+    if (!meRes.ok) {
+      console.error("discord-bootstrap: /users/@me failed:", meRes.status);
+      return jsonResponse(
+        { error: "Failed to verify Discord identity" },
+        502,
+      );
+    }
+    const me = (await meRes.json()) as DiscordUser;
+    if (!me.id || typeof me.id !== "string" || !/^[0-9]{17,20}$/.test(me.id)) {
+      return jsonResponse(
+        { error: "Discord returned malformed user id" },
+        502,
+      );
+    }
+    discordUserId = me.id;
+  } catch (e) {
+    console.error("discord-bootstrap: /users/@me threw:", e);
+    return jsonResponse({ error: "Failed to call Discord" }, 502);
+  }
+
+  // 2. Cross-check: Discord ID must match this user's linked Discord
+  //    identity in auth.identities. Closes the "attacker presents a
+  //    stolen Discord token but signs in as themselves" gap.
+  const supabase = createServiceClient();
+  {
+    const { data, error } = await supabase
+      .schema("auth")
+      .from("identities")
+      .select("provider_id")
+      .eq("user_id", userId)
+      .eq("provider", "discord")
+      .maybeSingle();
+    if (error) {
+      console.error(
+        "discord-bootstrap: auth.identities lookup failed:",
+        error.message,
+      );
+      return jsonResponse(
+        { error: "Failed to verify linked Discord identity" },
+        500,
+      );
+    }
+    if (!data) {
+      return jsonResponse(
+        { error: "No Discord identity linked to this kbve account" },
+        403,
+      );
+    }
+    if (data.provider_id !== discordUserId) {
+      console.warn(
+        "discord-bootstrap: provider_id mismatch",
+        { expected: data.provider_id, got: discordUserId, userId },
+      );
+      return jsonResponse(
+        {
+          error:
+            "provider_token belongs to a different Discord identity than the one linked to this kbve account",
+        },
+        403,
+      );
+    }
+  }
+
+  // 3. Discord /users/@me/guilds → filter to owner-only
+  let ownedGuildIds: string[];
+  try {
+    const gRes = await fetch(`${DISCORD_API_BASE}/users/@me/guilds`, {
+      headers: { Authorization: `Bearer ${providerToken}` },
+    });
+    if (gRes.status === 401) {
+      return jsonResponse(
+        { error: "Discord provider_token rejected (401)" },
+        401,
+      );
+    }
+    if (gRes.status === 429) {
+      return jsonResponse(
+        { error: "Discord API rate limited" },
+        429,
+      );
+    }
+    if (!gRes.ok) {
+      console.error(
+        "discord-bootstrap: /users/@me/guilds failed:",
+        gRes.status,
+      );
+      return jsonResponse(
+        { error: "Failed to fetch Discord guilds" },
+        502,
+      );
+    }
+    const raw = (await gRes.json()) as DiscordGuild[];
+    if (!Array.isArray(raw)) {
+      return jsonResponse(
+        { error: "Discord returned malformed guilds payload" },
+        502,
+      );
+    }
+    ownedGuildIds = raw
+      .slice(0, MAX_GUILDS_FETCHED)
+      .filter((g) =>
+        g && typeof g.id === "string" &&
+        /^[0-9]{17,20}$/.test(g.id) && g.owner === true
+      )
+      .map((g) => g.id);
+  } catch (e) {
+    console.error("discord-bootstrap: /users/@me/guilds threw:", e);
+    return jsonResponse({ error: "Failed to call Discord" }, 502);
+  }
+
+  // 4. Upsert via the RPC. The RPC dedups + first-seen-orders + caps
+  //    at 50 internally, so we pass the raw owned list. Filtering above
+  //    is defensive only.
+  const { error: rpcError } = await supabase.rpc(
+    "service_upsert_discord_bootstrap_cache",
+    {
+      p_user_id: userId,
+      p_discord_provider_id: discordUserId,
+      p_owned_guilds: ownedGuildIds,
+    },
+  );
+  if (rpcError) {
+    console.error(
+      "discord-bootstrap: service_upsert RPC failed:",
+      rpcError.message,
+    );
+    // SQLSTATE 22023 = validation failure from the RPC; map to 400.
+    const status = rpcError.code === "22023" ? 400 : 500;
+    return jsonResponse(
+      { error: "Failed to upsert bootstrap cache", detail: rpcError.message },
+      status,
+    );
+  }
+
+  // Report back: counts only, not the raw guild list (browser will pick
+  // it up via the JWT claim on the next mint anyway).
+  return jsonResponse({
+    success: true,
+    discord_user_id: discordUserId,
+    owned_guild_count: ownedGuildIds.length,
+    capped_at: 50,
+  });
+});

--- a/apps/kbve/edge/functions/main/index.ts
+++ b/apps/kbve/edge/functions/main/index.ts
@@ -160,6 +160,7 @@ serve(async (req: Request) => {
   const FUNCTION_ENV: Record<string, string[]> = {
     discordsh: ["HCAPTCHA_SECRET"],
     argo: ["ARGOCD_UPSTREAM_URL", "ARGOCD_AUTH_TOKEN"],
+    "discord-bootstrap": [],
     "guild-vault": [],
     "user-vault": [],
     "vault-reader": [],


### PR DESCRIPTION
## Summary

Closes the agents-dashboard "Discord session expired" dead-end. Adds the **server-side bootstrap** that populates the JWT `owned_guilds` claim (consumed by the v2 hook from #11488), and makes the **frontend degrade gracefully** so the page never blanks just because `provider_token` aged out of the Supabase session.

Vertical slice — both halves shipped together so the cache flow works end-to-end on land. Edge image bumped 0.1.34 → 0.1.35 via MDX.

## P5.8b — `discord-bootstrap` edge fn

Browser POSTs `{ provider_token }` with its Supabase JWT in `Authorization`. Edge fn:
1. Verifies the JWT (gateway-level via `VERIFY_JWT`) + extracts `user_id` from `sub`
2. Calls Discord `/users/@me` → canonical Discord ID
3. **Cross-checks against `auth.identities`** — `provider='discord'`, `user_id=JWT.sub` — `provider_id` must match. Closes the "holder of a stolen Discord token presents it under their own kbve JWT" forgery gap
4. Calls Discord `/users/@me/guilds`, filters to `owner === true` + snowflake regex, slices to Discord platform cap
5. Calls `profile.service_upsert_discord_bootstrap_cache` RPC via service_role — the RPC dedups + first-seen orders + caps at 50 internally
6. Returns counts only (success / discord_user_id / owned_guild_count); never returns the raw guild list

Wired into the main router's FUNCTION_ENV (no extra secrets; SHARED_ENV covers Supabase + JWT).

## P5.8c — `agentsService` graceful degradation

**Three-tier fallback** in `initAuth` instead of blanking the page:

| Tier | Trigger | Behaviour |
|---|---|---|
| 1 | `provider_token` present | Fire bootstrap (non-blocking) + live Discord call (existing behaviour) |
| 2 | No `provider_token`, localStorage cache hit | Intersect cache with JWT-claim IDs; flip `$guildsStale = true`; stay `authenticated` |
| 3 | No `provider_token`, no cache, JWT claim has IDs | Render ID-only placeholder objects (`Guild #<last6>`); flip `$guildsStale = true`; stay `authenticated` |
| 4 | Truly nothing | Fall back to existing `discord_reauth_required` state |

**`loadOwnedGuilds` on Discord 401**: flips `$providerToken = null` + `$guildsStale = true` but **stays `authenticated`**. Mutation paths already gate on `$providerToken` being set, so they surface a clean "re-sign-in to edit" error without forcing the user off the page.

**localStorage cache** (`kbve:agents:owned_guilds_cache:v1`, 7-day TTL, keyed by `user_id`) holds the last successful Discord response with names + icons, so the next session-without-provider-token can still render real guild names.

**New atoms**: `$userId`, `$guildsStale`.

## Test plan

- [x] `npx tsc --noEmit -p apps/kbve/astro-kbve/tsconfig.json` — no new errors
- [x] Smoke targets from #11753 (`nx run data-sql:smoke-vanilla` + `smoke-kilobase`) still pass (no SQL changes here)
- [ ] **Manual end-to-end** (requires Discord OAuth against a real account):
  - Sign in fresh with Discord → bootstrap fires → next JWT refresh shows `owned_guilds` claim populated → agents dashboard renders guild picker
  - Clear `localStorage.kbve_discord_provider_token` (simulate session aging) → reload → page still renders guild picker (cache fallback) with stale banner / disabled mutations
  - Clear localStorage entirely + use an existing JWT (still valid claim) → page renders ID-only placeholders
  - Wait > 1h for JWT refresh, fresh JWT carries updated `owned_guilds` claim
- [ ] **Edge fn smoke** (deferred — needs a real Discord token to hit `/users/@me` + `/users/@me/guilds`)

## Not in this PR (follow-ups)

- `$guildsStale` banner UI (polish; existing `discord_reauth_required` CTA still reachable for the truly-stuck case)
- pgTAP test for `service_upsert_discord_bootstrap_cache` canonicalisation (CI follow-up; standing across all 12 review rounds of #11488)

Part of #11362.