### PR TITLE
release(kasm-void): v0.0.4 — bake Discord via updater_bootstrap at build

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx
@@ -14,7 +14,7 @@ tags:
 key: kasm_void
 pipeline: docker
 app_name: kasm-void
-version: "0.0.3"
+version: "0.0.4"
 source_path: packages/docker/kasm-void
 version_toml: packages/docker/kasm-void/version.toml
 runner: ubuntu-latest

--- a/packages/docker/kasm-void/Dockerfile
+++ b/packages/docker/kasm-void/Dockerfile
@@ -61,6 +61,27 @@ RUN set -eux; \
       mv /dockerstartup/custom_startup.sh /dockerstartup/discord_startup.sh; \
     fi
 
+RUN set -eux; \
+    if [ ! -x /usr/share/discord/Discord ]; then \
+      if [ ! -x /usr/share/discord/updater_bootstrap ]; then \
+        echo "no Discord binary and no updater_bootstrap — upstream base layout unexpected" >&2; \
+        ls -la /usr/share/discord/ >&2; \
+        exit 1; \
+      fi; \
+      DISCORD_APP_HOME=/usr/share/discord/app; \
+      mkdir -p "$DISCORD_APP_HOME"; \
+      /usr/share/discord/updater_bootstrap "$DISCORD_APP_HOME" stable --no-zenity || true; \
+      DISCORD_BIN="$(find "$DISCORD_APP_HOME" -maxdepth 4 -name Discord -type f -perm -u+x 2>/dev/null | sort -V | tail -1)"; \
+      if [ -z "$DISCORD_BIN" ]; then \
+        echo "updater_bootstrap finished but Discord binary not found under $DISCORD_APP_HOME" >&2; \
+        find "$DISCORD_APP_HOME" -maxdepth 4 -ls >&2 || true; \
+        exit 1; \
+      fi; \
+      ln -sf "$DISCORD_BIN" /usr/share/discord/Discord; \
+      chmod -R a+rX /usr/share/discord; \
+    fi; \
+    [ -x /usr/share/discord/Discord ]
+
 COPY custom_startup.sh /dockerstartup/custom_startup.sh
 COPY nav_shim.py /dockerstartup/nav_shim.py
 COPY cloakbrowser.desktop /home/kasm-user/Desktop/cloakbrowser.desktop

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -88,7 +88,8 @@
 					"docker run --rm --entrypoint readlink ghcr.io/kbve/kasm-void:dev -e /usr/share/discord/Discord | grep -q . && echo 'PASS: Discord symlink resolves to a real file'",
 					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'real=$(readlink -e /usr/share/discord/Discord); size=$(stat -c %s \"$real\"); [ \"$size\" -gt 1048576 ] || { echo \"Discord binary suspiciously small: $size bytes ($real)\" >&2; exit 1; }' && echo 'PASS: Discord binary larger than 1 MiB (not a stub)'",
 					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'real=$(readlink -e /usr/share/discord/Discord); missing=$(ldd \"$real\" 2>/dev/null | grep \"not found\" || true); [ -z \"$missing\" ] || { echo \"missing libs: $missing\" >&2; exit 1; }' && echo 'PASS: Discord shared lib deps resolve'",
-					"bash packages/docker/kasm-void/tests/nav-shim-smoke.sh"
+					"bash packages/docker/kasm-void/tests/nav-shim-smoke.sh",
+					"bash packages/docker/kasm-void/tests/full-session-smoke.sh"
 				],
 				"parallel": false
 			}

--- a/packages/docker/kasm-void/project.json
+++ b/packages/docker/kasm-void/project.json
@@ -84,6 +84,10 @@
 					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'touch /tmp/probe && rm /tmp/probe' && echo 'PASS: /tmp writable by uid 1000'",
 					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'command -v python3 && command -v pip3' >/dev/null && echo 'PASS: python3 + pip3 on PATH'",
 					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /dockerstartup/maximize_window.sh && echo 'PASS: upstream maximize_window.sh preserved'",
+					"docker run --rm --entrypoint test ghcr.io/kbve/kasm-void:dev -x /usr/share/discord/Discord && echo 'PASS: Discord binary executable'",
+					"docker run --rm --entrypoint readlink ghcr.io/kbve/kasm-void:dev -e /usr/share/discord/Discord | grep -q . && echo 'PASS: Discord symlink resolves to a real file'",
+					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'real=$(readlink -e /usr/share/discord/Discord); size=$(stat -c %s \"$real\"); [ \"$size\" -gt 1048576 ] || { echo \"Discord binary suspiciously small: $size bytes ($real)\" >&2; exit 1; }' && echo 'PASS: Discord binary larger than 1 MiB (not a stub)'",
+					"docker run --rm --entrypoint bash ghcr.io/kbve/kasm-void:dev -c 'real=$(readlink -e /usr/share/discord/Discord); missing=$(ldd \"$real\" 2>/dev/null | grep \"not found\" || true); [ -z \"$missing\" ] || { echo \"missing libs: $missing\" >&2; exit 1; }' && echo 'PASS: Discord shared lib deps resolve'",
 					"bash packages/docker/kasm-void/tests/nav-shim-smoke.sh"
 				],
 				"parallel": false

--- a/packages/docker/kasm-void/tests/full-session-smoke.sh
+++ b/packages/docker/kasm-void/tests/full-session-smoke.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="${IMAGE:-ghcr.io/kbve/kasm-void:dev}"
+NAME="kasm-void-fullboot-$$"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-120}"
+
+cleanup() {
+  docker rm -f "$NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+dump_and_die() {
+  echo "FAIL: $1" >&2
+  echo "--- docker ps -a (kasm) ---" >&2
+  docker ps -a --filter "name=$NAME" >&2 || true
+  echo "--- ps inside container ---" >&2
+  docker exec "$NAME" bash -c 'ps -eo pid,user,etime,comm,args 2>/dev/null | grep -iE "discord|electron|chrome|cloak|nav_shim|kasmvnc|Xvnc|xvfb" | grep -v grep' >&2 || true
+  echo "--- /tmp/discord.log tail ---" >&2
+  docker exec "$NAME" bash -c 'tail -30 /tmp/discord.log 2>/dev/null' >&2 || true
+  echo "--- /tmp/cloakbrowser.log tail ---" >&2
+  docker exec "$NAME" bash -c 'tail -20 /tmp/cloakbrowser.log 2>/dev/null' >&2 || true
+  echo "--- container stdout (tail) ---" >&2
+  docker logs --tail 80 "$NAME" 2>&1 >&2 || true
+  exit 1
+}
+
+docker run -d --rm \
+  --name "$NAME" \
+  --shm-size=512m \
+  -e VNC_PW=kbve-smoke-test \
+  -e URL_LAUNCHER_TOKEN=kbve-smoke-token \
+  "$IMAGE" >/dev/null
+
+deadline=$(( $(date +%s) + BOOT_TIMEOUT ))
+discord_ok=0; cloak_ok=0; nav_ok=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if [ "$nav_ok" = "0" ] && docker exec "$NAME" bash -c 'curl -fsS http://127.0.0.1:9998/healthz' >/dev/null 2>&1; then
+    nav_ok=1
+  fi
+  if [ "$cloak_ok" = "0" ] && docker exec "$NAME" pgrep -f '/opt/cloakbrowser/chrome' >/dev/null 2>&1; then
+    cloak_ok=1
+  fi
+  if [ "$discord_ok" = "0" ] && docker exec "$NAME" pgrep -x Discord >/dev/null 2>&1; then
+    discord_ok=1
+  fi
+  if [ "$nav_ok" = "1" ] && [ "$cloak_ok" = "1" ] && [ "$discord_ok" = "1" ]; then
+    break
+  fi
+  sleep 2
+done
+
+[ "$nav_ok"     = "1" ] || dump_and_die "nav_shim /healthz never came up within ${BOOT_TIMEOUT}s"
+[ "$cloak_ok"   = "1" ] || dump_and_die "cloakbrowser process never appeared within ${BOOT_TIMEOUT}s"
+[ "$discord_ok" = "1" ] || dump_and_die "Discord process never appeared within ${BOOT_TIMEOUT}s"
+
+discord_etime=$(docker exec "$NAME" bash -c "ps -o etimes= -p \$(pgrep -x Discord | head -1) 2>/dev/null | tr -d ' '")
+[ -n "$discord_etime" ] && [ "$discord_etime" -ge 3 ] \
+  || dump_and_die "Discord PID appeared but exited immediately (etime=${discord_etime:-unknown}s)"
+
+echo "PASS: full kasm session boots nav_shim + cloakbrowser + Discord"
+echo "      Discord etime ${discord_etime}s under PID 1 = kasm-init"


### PR DESCRIPTION
## Summary
0.0.3 finally published to GHCR (\`:0.0.3\`, \`:latest\`, \`:main\` all present), kasm-vpn rolled out and reached READY. CloakBrowser came up clean, but **Discord never appears in-session** and inside the pod \`/tmp/discord.log\` is a wall of:

\`\`\`
Maximum number of clients reached
Cannot open display.
\`\`\`

\`ps\` inside the workspace shows nav_shim + chrome (cloak) + many \`bash /dockerstartup/maximize_window.sh\` zombies and a single \`bash /dockerstartup/discord_startup.sh\` — **no Discord/Electron process anywhere**.

## Root cause
Upstream \`kasmweb/discord:1.18.0-rolling-daily\` has stopped shipping the Discord binary itself. \`/usr/share/discord/\` now contains only:

\`\`\`
discord.desktop
discord.png
postinst.sh
updater_bootstrap   ← downloader, not Discord
\`\`\`

The pinned \`discord_startup.sh\` from the same image still references the hard-coded \`START_COMMAND=/usr/share/discord/Discord\`, so its inner \`while true; sleep 1\` supervisor loop is spawning \`bash maximize_window.sh & /usr/share/discord/Discord &\` every second forever — Discord exits immediately (\`No such file or directory\`), maximize_window forks off another X client, and within ~30s the X server hits its default 256-client cap. From there nothing new can attach to \`:1\` and the whole session degrades (which is also why fresh Discord launches log \`Cannot open display.\`).

## Fix
Add a Dockerfile \`RUN\` that pre-installs Discord at build time using upstream's own bootstrap and symlinks the discovered binary into the legacy hard-coded path that \`discord_startup.sh\` still expects:

\`\`\`Dockerfile
RUN set -eux; \\
    if [ ! -x /usr/share/discord/Discord ]; then \\
      [ -x /usr/share/discord/updater_bootstrap ] || { ls -la /usr/share/discord/ >&2; exit 1; }; \\
      mkdir -p /usr/share/discord/app; \\
      /usr/share/discord/updater_bootstrap /usr/share/discord/app stable --no-zenity || true; \\
      DISCORD_BIN="\$(find /usr/share/discord/app -maxdepth 4 -name Discord -type f -perm -u+x | sort -V | tail -1)"; \\
      [ -n "\$DISCORD_BIN" ] || { find /usr/share/discord/app -maxdepth 4 -ls >&2; exit 1; }; \\
      ln -sf "\$DISCORD_BIN" /usr/share/discord/Discord; \\
      chmod -R a+rX /usr/share/discord; \\
    fi; \\
    [ -x /usr/share/discord/Discord ]
\`\`\`

Guards:
- Only runs when \`/usr/share/discord/Discord\` is missing — older base tags that still bundle the binary keep working without re-downloading.
- Fails loudly with a directory listing when \`updater_bootstrap\` is also gone, so any future base-layout shift surfaces a clear error in CI instead of a green publish that wedges the session.
- \`find … -perm -u+x | sort -V | tail -1\` picks the highest version directory the bootstrap unpacks, so multi-install roots stay deterministic.

\`discord_startup.sh\`'s chromium-flag args (\`--no-sandbox --disable-gpu --disable-dev-shm-usage --user-agent="…"\`) are kept as-is — they're all valid Electron switches and removing them risks the very "kicked off" pattern the deployment was guarding against.

## Files
- \`packages/docker/kasm-void/Dockerfile\` — RUN block above
- \`apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx\` — \`version: "0.0.4"\`

\`version.toml\` and \`apps/kube/kasm/manifest/deployment.yaml\` are deliberately not touched — they're synced automatically by the post-publish atom PR after the 0.0.4 publish run lands.

## Test plan
- [ ] CI \`Validate Dev→Main PR\` green; \`kasm-void:test\` still passes (existing e2e doesn't exercise Discord launch, so the Dockerfile RUN failing the build is the canary)
- [ ] After \`CI - Docker / kasm-void\` ships 0.0.4 and the post-publish atom PR lands deployment manifest bump, scale kasm-vpn to 1 and confirm Discord window renders alongside CloakBrowser
- [ ] \`/tmp/discord.log\` no longer spams "Maximum number of clients reached"