### PR TITLE
fix(kubevirt): autologon Job → CronJob so it catches the VM whenever it boots

### DIFF
--- a/apps/kube/kubevirt/autologon/job.yaml
+++ b/apps/kube/kubevirt/autologon/job.yaml
@@ -1,5 +1,5 @@
-# ArgoCD-managed Job to configure Windows autologon + VNC-ready settings on
-# the builder VM.
+# ArgoCD-managed CronJob to (re)apply Windows autologon + VNC-ready settings
+# on the builder VM.
 #
 # Uses the QEMU Guest Agent to set registry keys inside Windows so the VM
 # auto-logs in as Administrator on every boot — no lock screen, no
@@ -15,14 +15,14 @@
 #   6. Disable Server Manager auto-start (DoNotOpenServerManagerAtLogon)
 #   7. Disable machine inactivity lock (InactivityTimeoutSecs=0)
 #
-# Lifecycle: ArgoCD treats this as a Sync hook. Each sync of the autologon
-# app deletes the previous completed Job (BeforeHookCreation) and creates a
-# fresh one. The script is idempotent — re-running just rewrites the same
-# registry keys.
-#
-# If the VM is stopped at sync time the script exits 0 without configuring
-# anything, so the sync stays Healthy. The next sync triggered after the
-# VM comes back online will reapply the settings.
+# Lifecycle: previously this was a one-shot Job behind an ArgoCD PostSync
+# hook. The hook only fires when the autologon app itself syncs, so if the
+# VM happened to be Stopped at that moment the script soft-skipped and the
+# registry keys never landed — and there was no automatic re-trigger when
+# the VM later booted. Now it runs as a CronJob every 5 minutes; the
+# idempotent script reapplies the same registry values, no-ops when the
+# VM is Stopped or the QEMU Guest Agent has not yet registered, and
+# catches up the next tick after the VM comes back online.
 #
 # Prerequisites:
 #   1. windows-builder VM with QEMU Guest Agent installed (cold-start once
@@ -31,10 +31,6 @@
 #      'password' containing the Administrator password.
 #   3. vm-scaler RBAC includes pod/exec permissions (deployed via KEDA app).
 #
-# The settings persist across reboots — the Job only needs to land once
-# successfully per VM lifecycle, but Argo will keep retrying on each sync
-# until that happens.
-#
 # Note: the pod template intentionally does NOT carry `app: angelscript`
 # because the namespace NetworkPolicy (podSelector app=angelscript) only
 # allows egress on ports 53 + 443 for game-server workloads. kube-proxy
@@ -42,64 +38,65 @@
 # which is blocked — so any kubectl from inside a policy-scoped pod times
 # out. Management jobs live outside the game-server network policy.
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
     name: vm-autologon-windows
     namespace: angelscript
     labels:
         app: angelscript
         component: vm-autologon
-    annotations:
-        # PostSync so the autologon Job runs after every successful sync of
-        # the autologon app itself (e.g. when the script ConfigMap or the
-        # Job spec changes). BeforeHookCreation deletes the prior completed
-        # Job before recreating, sidestepping the immutable-Job-spec error.
-        argocd.argoproj.io/hook: PostSync
-        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
-    backoffLimit: 3
-    ttlSecondsAfterFinished: 86400
-    template:
-        metadata:
-            labels:
-                component: vm-autologon
+    schedule: '*/5 * * * *'
+    timeZone: UTC
+    concurrencyPolicy: Forbid
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 2
+    startingDeadlineSeconds: 180
+    jobTemplate:
         spec:
-            serviceAccountName: vm-scaler
-            restartPolicy: OnFailure
-            securityContext:
-                runAsNonRoot: true
-                runAsUser: 10001
-                runAsGroup: 10001
-                seccompProfile:
-                    type: RuntimeDefault
-            containers:
-                - name: autologon
-                  image: ghcr.io/kbve/kubectl:0.1.3
-                  command: ['/bin/sh', '/scripts/autologon.sh']
-                  securityContext:
-                      allowPrivilegeEscalation: false
-                      readOnlyRootFilesystem: true
-                      capabilities:
-                          drop: ['ALL']
-                  env:
-                      - name: VM_NAME
-                        value: windows-builder
-                      - name: NAMESPACE
-                        value: angelscript
-                      - name: ADMIN_PASSWORD
-                        valueFrom:
-                            secretKeyRef:
-                                name: windows-builder-admin
-                                key: password
-                  volumeMounts:
-                      - name: script
-                        mountPath: /scripts
-                      - name: tmp
-                        mountPath: /tmp
-            volumes:
-                - name: script
-                  configMap:
-                      name: vm-autologon-script
-                      defaultMode: 0755
-                - name: tmp
-                  emptyDir: {}
+            backoffLimit: 3
+            ttlSecondsAfterFinished: 3600
+            template:
+                metadata:
+                    labels:
+                        component: vm-autologon
+                spec:
+                    serviceAccountName: vm-scaler
+                    restartPolicy: OnFailure
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 10001
+                        runAsGroup: 10001
+                        seccompProfile:
+                            type: RuntimeDefault
+                    containers:
+                        - name: autologon
+                          image: ghcr.io/kbve/kubectl:0.1.3
+                          command: ['/bin/sh', '/scripts/autologon.sh']
+                          securityContext:
+                              allowPrivilegeEscalation: false
+                              readOnlyRootFilesystem: true
+                              capabilities:
+                                  drop: ['ALL']
+                          env:
+                              - name: VM_NAME
+                                value: windows-builder
+                              - name: NAMESPACE
+                                value: angelscript
+                              - name: ADMIN_PASSWORD
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: windows-builder-admin
+                                        key: password
+                          volumeMounts:
+                              - name: script
+                                mountPath: /scripts
+                              - name: tmp
+                                mountPath: /tmp
+                    volumes:
+                        - name: script
+                          configMap:
+                              name: vm-autologon-script
+                              defaultMode: 0755
+                        - name: tmp
+                          emptyDir: {}


### PR DESCRIPTION
## Summary
- The PostSync hook variant from #11623 only fired when the autologon ArgoCD app itself synced. On 2026-06-02 it ran once with \`windows-builder\` Stopped, the script soft-skipped, and the keys never landed. With no automatic re-trigger when the VM later booted, VNC still drops users at the Windows lock screen.
- Reframes the workload as a CronJob (every 5 minutes, \`concurrencyPolicy: Forbid\`). The same idempotent script runs on a schedule, no-ops while the VM is Stopped or the QEMU Guest Agent has not registered yet, and catches up the next tick after the VM comes back online. ArgoCD still owns the CronJob declaratively; cadence is decoupled from sync events.
- Confirmed in-cluster evidence: \`kubectl get app kubevirt-autologon\` shows Synced/Healthy/Succeeded with no Job or pod present, \`kubectl get vm windows-builder -n angelscript\` reports \`Stopped\` (\`runStrategy: Manual\`), and the existing \`vm-autologon-script\` ConfigMap is still mounted by every future Job spawned by the CronJob.

## Test plan
- [ ] ArgoCD syncs and replaces the old Job with the new CronJob; \`kubectl get cronjob vm-autologon-windows -n angelscript\` shows \`*/5 * * * *\`.
- [ ] First scheduled run while VM is Stopped: pod logs print \"VM not running (phase=absent), skipping autologon configuration\" and exits 0.
- [ ] Start the VM with \`virtctl start windows-builder -n angelscript\`, wait for \`AgentConnected\`, then within ~5 minutes the next CronJob run reports all 7 steps green.
- [ ] Reboot Windows (\`virtctl restart\` or shutdown from inside) and verify the VNC console comes up straight to the Administrator desktop without a lock screen or CAD prompt.
- [ ] After a successful apply, subsequent CronJob runs continue to report all-green idempotently with no churn or alerts.