### PR TITLE
fix(kubevirt/guacamole): scale guac on VM presence, not weekday clock

### DIFF
--- a/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
@@ -1,7 +1,11 @@
 # KEDA ScaledObjects for Guacamole stack.
 #
-# Guacamole scales to 1 replica when the Windows VM is likely in use
-# (weekdays 06:00–22:00 UTC) and back to 0 outside that window.
+# Scale follows VM availability rather than a clock. The kubernetes-workload
+# trigger watches for any virt-launcher pod belonging to windows-builder;
+# when one exists (VMI Running) guacd + guacamole scale to 1, otherwise 0.
+# This catches off-hours / weekend use and matches multi-viewer demand to
+# actual VM state instead of a fixed weekday window.
+#
 # Manual override: kubectl scale deploy guacd guacamole -n angelscript --replicas=1
 ---
 apiVersion: keda.sh/v1alpha1
@@ -15,18 +19,16 @@ metadata:
 spec:
     scaleTargetRef:
         name: guacd
-    pollingInterval: 300
+    pollingInterval: 30
     cooldownPeriod: 300
     idleReplicaCount: 0
     minReplicaCount: 0
     maxReplicaCount: 1
     triggers:
-        - type: cron
+        - type: kubernetes-workload
           metadata:
-              timezone: UTC
-              start: 0 6 * * 1-5
-              end: 0 22 * * 1-5
-              desiredReplicas: '1'
+              podSelector: 'vm.kubevirt.io/name=windows-builder'
+              value: '1'
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -39,15 +41,13 @@ metadata:
 spec:
     scaleTargetRef:
         name: guacamole
-    pollingInterval: 300
+    pollingInterval: 30
     cooldownPeriod: 300
     idleReplicaCount: 0
     minReplicaCount: 0
     maxReplicaCount: 1
     triggers:
-        - type: cron
+        - type: kubernetes-workload
           metadata:
-              timezone: UTC
-              start: 0 6 * * 1-5
-              end: 0 22 * * 1-5
-              desiredReplicas: '1'
+              podSelector: 'vm.kubevirt.io/name=windows-builder'
+              value: '1'


### PR DESCRIPTION
## Summary
- The \`guacd\` + \`guacamole\` deployments were scaled to 0 outside Mon–Fri 06:00–22:00 UTC by a cron KEDA trigger, so any off-hours / weekend connection through \`kbve.com/dashboard/vm\` got a blank browser tunnel — no backend pod to relay to. Today the second viewer hit this after 22 UTC and saw a blank screen while the first viewer (who connected during the active window) saw a working desktop.
- Swap the cron trigger for KEDA's \`kubernetes-workload\` scaler keyed on the virt-launcher pod that KubeVirt spawns when \`windows-builder\`'s VMI is Running. Guacd + guacamole now scale up whenever the VM is up (regardless of weekday/hour) and back down whenever the VM is Stopped. \`pollingInterval\` drops to 30 s so the spin-up reaction time matches a typical VM start.

## Test plan
- [ ] After ArgoCD syncs: \`kubectl get scaledobject guacd-scaler guacamole-scaler -n angelscript -o jsonpath='{range .items[*]}{.spec.triggers}{\"\\n\"}{end}'\` shows the kubernetes-workload trigger with \`podSelector: 'vm.kubevirt.io/name=windows-builder'\`.
- [ ] With VM Stopped: both deployments stay at 0/0.
- [ ] \`virtctl start windows-builder -n angelscript\` → within ~30 s \`kubectl get deploy guacd guacamole -n angelscript\` reports 1/1.
- [ ] \`virtctl stop windows-builder -n angelscript\` → after \`cooldownPeriod\` both deployments fall back to 0/0.
- [ ] \`kbve.com/dashboard/vm\` Guacamole viewer connects successfully from a second staff browser while the VM is up.