### PR TITLE
fix(dashboard/vm): VNC viewer fullscreen + Astro client-router teardown

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -113,6 +113,9 @@ export default function ReactVMVncViewer() {
 
 		try {
 			const RFBClass = await loadRFB();
+			if (intentionalCloseRef.current || viewerRef.current !== viewerEl) {
+				return;
+			}
 			const rfb = new RFBClass(viewerEl, wsUrl, {
 				wsProtocols: ['binary.k8s.io', 'base64.binary.k8s.io'],
 			});
@@ -196,6 +199,59 @@ export default function ReactVMVncViewer() {
 		};
 	}, [vncTarget, connectVNC, cleanup]);
 
+	useEffect(() => {
+		const teardown = () => {
+			intentionalCloseRef.current = true;
+			cleanup();
+			if (
+				typeof document !== 'undefined' &&
+				document.fullscreenElement === containerRef.current
+			) {
+				document.exitFullscreen().catch(() => undefined);
+			}
+		};
+		document.addEventListener('astro:before-swap', teardown);
+		document.addEventListener('astro:before-preparation', teardown);
+		window.addEventListener('pagehide', teardown);
+		return () => {
+			document.removeEventListener('astro:before-swap', teardown);
+			document.removeEventListener('astro:before-preparation', teardown);
+			window.removeEventListener('pagehide', teardown);
+		};
+	}, [cleanup]);
+
+	useEffect(() => {
+		const onFsChange = () => {
+			const active = document.fullscreenElement === containerRef.current;
+			setFullscreen(active);
+		};
+		document.addEventListener('fullscreenchange', onFsChange);
+		return () =>
+			document.removeEventListener('fullscreenchange', onFsChange);
+	}, []);
+
+	useEffect(() => {
+		if (!rfbRef.current) return;
+		const rafId = requestAnimationFrame(() => {
+			window.dispatchEvent(new Event('resize'));
+		});
+		return () => cancelAnimationFrame(rafId);
+	}, [fullscreen]);
+
+	const toggleFullscreen = useCallback(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		if (document.fullscreenElement === el) {
+			document.exitFullscreen().catch(() => setFullscreen(false));
+			return;
+		}
+		if (typeof el.requestFullscreen === 'function') {
+			el.requestFullscreen().catch(() => setFullscreen((f) => !f));
+		} else {
+			setFullscreen((f) => !f);
+		}
+	}, []);
+
 	// Manual retry handler
 	const handleRetry = useCallback(() => {
 		if (vncTarget && !connected) {
@@ -262,6 +318,9 @@ export default function ReactVMVncViewer() {
 					borderTop: '1px solid var(--sl-color-gray-5, #30363d)',
 					background: 'var(--sl-color-gray-6, #161b22)',
 					flexShrink: 0,
+					pointerEvents: 'auto',
+					position: 'relative',
+					zIndex: 1,
 				}}>
 				<div
 					style={{
@@ -349,7 +408,7 @@ export default function ReactVMVncViewer() {
 							title={
 								fullscreen ? 'Exit fullscreen' : 'Fullscreen'
 							}
-							onClick={() => setFullscreen(!fullscreen)}>
+							onClick={toggleFullscreen}>
 							{fullscreen ? (
 								<Minimize2 size={14} />
 							) : (


### PR DESCRIPTION
## Summary
Two related glitches in the VNC viewer surfaced while a second viewer was joining:

1. **Fullscreen toggle looked broken.** It was a CSS overlay (\`position: fixed\` + \`zIndex: 9999\`) with no resize event fired, so noVNC's \`scaleViewport\` never recomputed and the canvas stayed at the original \`480px\` inside the fullscreen container. The CSS overlay could also lose click priority to noVNC's pointer capture on the canvas, making the Exit-Fullscreen and CAD buttons appear dead.

2. **Astro view transitions leaked the RFB connection across navigations.** \`AstroVMDashboard.astro\` mounts the island with \`client:only=\"react\"\`, but the client router persists DOM through transitions and the React island's \`useEffect\` cleanup did not always run before the user came back to \`/dashboard/vm/\`. The previous RFB instance kept its WebSocket alive, the new mount raced the old one, and toolbar buttons clicked into a stale ref and did nothing.

## Changes
- Toggle the browser Fullscreen API on the container ref, fall back to the CSS overlay only if \`requestFullscreen()\` rejects. Listen for \`fullscreenchange\` so React state tracks the real DOM state (Esc-out, browser-controlled exit).
- Dispatch a \`resize\` event after fullscreen flips so noVNC recomputes \`scaleViewport\` and the canvas fills the new container.
- Mark the toolbar with \`pointerEvents: 'auto'\` + relative \`zIndex\` so noVNC's canvas can't swallow toolbar clicks.
- Tear down the RFB connection on \`astro:before-swap\`, \`astro:before-preparation\`, and \`pagehide\`. Exit fullscreen during teardown to avoid stranded fullscreen state on the next page.
- Guard \`connectVNC\` against an unmount that completes during the async \`loadRFB()\` — if the ref pointer changed or the close flag flipped, bail before constructing a new RFB.

## Test plan
- [ ] Open \`https://kbve.com/dashboard/vm/\`, click Open VNC, hit Fullscreen — desktop fills the screen, Exit Fullscreen works, Esc exits cleanly.
- [ ] In a second browser tab/window, repeat — both viewers see the same desktop (multi-viewer hub), both can fullscreen independently, neither traps clicks.
- [ ] CAD button in fullscreen toolbar sends Ctrl+Alt+Del.
- [ ] Navigate away from \`/dashboard/vm/\` to another dashboard route, then back. Network tab shows the old VNC WS closed before a new one opens; no duplicate sockets.
- [ ] Close the VNC viewer while in fullscreen — page exits fullscreen and disconnects WS cleanly.