### PR TITLE
feat(vnc-hub): multi-master input — every viewer can type and click

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
+++ b/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
@@ -25,12 +25,18 @@
 //!
 //! ## Input arbitration
 //!
-//! Only one viewer at a time is allowed to write to upstream (the
-//! "primary"). Observer input is dropped on the floor — their RFB client's
-//! handshake responses go nowhere, which is fine because the upstream is
-//! already past handshake. If the primary disconnects, the next observer
-//! that sends a message opportunistically becomes the new primary via
-//! CAS on the `primary_id` field.
+//! Every viewer's RFB client messages — keystrokes, mouse moves, clipboard
+//! cuts, SetEncodings, FBUR, etc. — are forwarded to the single upstream
+//! connection. The upstream `upstream_sink` mutex serializes concurrent
+//! writes so the RFB framing on the wire stays coherent. From KubeVirt's
+//! point of view there is still one RFB client; from the staff side every
+//! viewer can type and click.
+//!
+//! Concurrent input (two cursors moving at once) lands on the same shared
+//! desktop and will fight on the wire — this is the same model used by
+//! shared screen-control tools and is the intended behaviour for pair
+//! debug. The `primary_id` field is kept as an informational marker of
+//! who joined first (surfaced in the viewer UI) but no longer gates input.
 //!
 //! ## Cache bound + drift
 //!
@@ -333,23 +339,9 @@ async fn run_client(
                 _ => continue,
             };
 
-            // Opportunistic primary CAS — observers fall through to drop.
-            let primary = session_input.primary_id.load(Ordering::Relaxed);
-            let may_write = if primary == client_id {
-                true
-            } else if primary == 0 {
-                session_input
-                    .primary_id
-                    .compare_exchange(0, client_id, Ordering::Relaxed, Ordering::Relaxed)
-                    .is_ok()
-            } else {
-                false
-            };
-
-            if !may_write {
-                continue;
-            }
-
+            // Multi-master: every viewer's input flows to upstream. The
+            // sink mutex serializes concurrent writes so RFB framing on
+            // the wire stays intact even when two viewers type at once.
             let mut guard = session_input.upstream_sink.lock().await;
             match guard.as_mut() {
                 Some(sink) => {


### PR DESCRIPTION
## Summary
Until now the VNC hub gated browser → upstream writes on a \`primary_id\` CAS: only the first viewer to send a message could write to the KubeVirt VNC stream, and every other viewer was a passive observer with its RFB client messages dropped on the floor. A second staff member joining the same desktop saw a frozen framebuffer once the cache replay finished — their own FBUR requests never reached upstream, so no fresh frames flowed until the primary nudged the cursor (the symptom Fudster saw earlier today).

Drop the gate. Every viewer's bytes — keystrokes, mouse moves, clipboard cuts, SetEncodings, FBUR, etc. — go straight to the single upstream \`upstream_sink\`. The sink mutex still serializes concurrent writes so RFB framing on the wire stays coherent. From KubeVirt's point of view there is still one RFB client; from the staff side every viewer is now a writer.

Side effect: observer joins no longer need a synthetic FBUR injected by the proxy. Their own noVNC client sends one as part of its normal handshake and the response broadcasts to every viewer.

\`primary_id\` survives as an informational marker (who joined first) — surfaced via \`SessionInfo\` for the viewer-count badge and the crown icon in the toolbar. It no longer authorizes anything. Concurrent input from two viewers will fight on the wire (the shared-screen pair-debug model); coordinate verbally.

## Test plan
- [ ] Two staff members open \`https://kbve.com/dashboard/vm/\` against the same VM. Both see the desktop come up live, no frozen frame on the second viewer.
- [ ] First viewer types — second viewer sees the keystrokes land.
- [ ] Second viewer types — first viewer sees them too.
- [ ] Both move the cursor at once — cursor jumps between positions (expected pair-debug behaviour, not a bug).
- [ ] Both viewers can send Ctrl+Alt+Del; either one's CAD reaches Windows.
- [ ] First viewer disconnects, second remains — second can still control the desktop (no \"primary left\" deadlock).
- [ ] Viewer count badge in the toolbar still reports the correct number of attached clients.