### PR TITLE
feat(unreal/websurface): scaffold game-agnostic WebSurface plugin for Fab

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -3,7 +3,7 @@
 		{
 			"key": "agones_factorio",
 			"app_name": "agones-factorio",
-			"version": "0.0.12",
+			"version": "0.0.13",
 			"version_toml": "apps/agones/factorio/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio.mdx",
 			"source_path": "apps/agones/factorio",
@@ -28,7 +28,7 @@
 		{
 			"key": "agones_factorio_relay",
 			"app_name": "agones-factorio-relay",
-			"version": "0.0.6",
+			"version": "0.0.7",
 			"version_toml": "apps/agones/factorio/relay/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/agones-factorio-relay.mdx",
 			"source_path": "apps/agones/factorio/relay",
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.180",
+			"version": "1.0.182",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -134,7 +134,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.17",
+			"version": "0.1.18",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -148,7 +148,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.34",
+			"version": "0.1.35",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -260,7 +260,7 @@
 		{
 			"key": "kasm_void",
 			"app_name": "kasm-void",
-			"version": "0.0.2",
+			"version": "0.0.4",
 			"version_toml": "packages/docker/kasm-void/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kasm-void.mdx",
 			"source_path": "packages/docker/kasm-void",
@@ -282,7 +282,7 @@
 		{
 			"key": "kubectl",
 			"app_name": "kbve-kubectl",
-			"version": "0.1.2",
+			"version": "0.1.3",
 			"version_toml": "apps/vm/kubectl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx",
 			"version_target": "apps/vm/kubectl/Cargo.toml",
@@ -672,6 +672,13 @@
 			"version_toml": "packages/unreal/KBVEWASM/version.toml"
 		},
 		{
+			"key": "ue_kbvewebsurface",
+			"plugin_name": "KBVEWebSurface",
+			"plugin_path": "packages/unreal/KBVEWebSurface",
+			"version": "0.1.0",
+			"version_toml": "packages/unreal/KBVEWebSurface/version.toml"
+		},
+		{
 			"key": "ue_kbvexxhash",
 			"plugin_name": "KBVEXXHash",
 			"plugin_path": "packages/unreal/KBVEXXHash",
@@ -782,12 +789,12 @@
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
-		"unreal": 6,
+		"unreal": 7,
 		"ue5_server": 2,
 		"unity": 1,
 		"godot": 1,
 		"unreal_game": 0,
 		"bevy_game": 0,
-		"total": 69
+		"total": 70
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvewebsurface.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvewebsurface.mdx
@@ -1,0 +1,66 @@
+---
+title: KBVEWebSurface
+description: |
+    Game-agnostic Unreal Engine plugin for rendering interactive web content onto 3D surfaces — billboards, terminals, kiosks, holograms, in-world dashboards.
+sidebar:
+    label: KBVEWebSurface
+    order: 95
+tags:
+    - unreal
+    - web
+    - ui
+key: ue_kbvewebsurface
+pipeline: unreal
+plugin_name: KBVEWebSurface
+plugin_path: packages/unreal/KBVEWebSurface
+version: "0.1.0"
+source_path: packages/unreal/KBVEWebSurface
+version_toml: packages/unreal/KBVEWebSurface/version.toml
+author: h0lybyte
+license: MIT
+status: beta
+min_engine_version: "5.6"
+supported_platforms:
+    - Win64
+    - Linux
+    - Mac
+---
+
+## Overview
+
+`KBVEWebSurface` renders interactive web content onto Unreal world surfaces. The plugin is game-agnostic and targets reuse across `chuckrpg`, future KBVE titles, and external Fab distribution.
+
+### Surface kinds
+
+- **Flat panel** — `UKBVEWebSurfaceComponent` wraps a `UWidgetComponent` with an embedded UMG `WebBrowser`.
+- **Curved / holographic** — `UKBVEWebRenderSurfaceComponent` pipes the browser through a render target onto an arbitrary mesh + material.
+- **Actor** — `AKBVEWebSurfaceActor` ships as a drop-in for terminals and kiosks.
+
+### Input
+
+`UKBVEWebInputRouter` maps player line traces to widget-pixel coordinates. Hit UVs come from `FindCollisionUV`, so `Support UV From Hit Results` must be enabled on the project.
+
+### Bridge
+
+`UKBVEWebBridge` exposes a typed message bus between embedded JS and Blueprint/C++. Pages call `window.kbveBridge.send(channel, payload)`; the bridge re-broadcasts via `OnMessage`.
+
+### Performance
+
+CEF is expensive. The plugin ships a per-surface frame-rate cap, offscreen pause, snapshot fallback at distance, and a `UKBVEWebSurfacePool` LRU cap on concurrent live surfaces.
+
+### Backend
+
+The default backend wraps Unreal's stock `UWebBrowser` (CEF). Alternate backends (Ultralight, WebUI) plug in via `IKBVEWebBackend` and ship as separate plugins.
+
+### Use cases
+
+- Marketplace / auction house
+- Account, guild, social screens
+- Admin and debug terminals
+- Patch notes, news boards
+- In-world interactive billboards and kiosks
+
+### Anti-use cases
+
+- Combat HUD, health bars, minimap — use Slate/UMG.
+- Per-NPC labels, shop signs, hundreds of world objects — too expensive per surface.

--- a/packages/unreal/KBVEWebSurface/Config/FilterPlugin.ini
+++ b/packages/unreal/KBVEWebSurface/Config/FilterPlugin.ini
@@ -1,0 +1,5 @@
+[FilterPlugin]
+; Additional files packaged with the plugin. Source, Content, Resources, and Config ship by default.
+; Examples:
+;    /README.md
+;    /Docs/...

--- a/packages/unreal/KBVEWebSurface/Docs/PERFORMANCE.md
+++ b/packages/unreal/KBVEWebSurface/Docs/PERFORMANCE.md
@@ -1,0 +1,40 @@
+# Performance
+
+CEF is expensive. Treat live web surfaces as premium content.
+
+## Defaults
+
+- `MaxFrameRate`: 30 fps per surface. Billboards usually fine at 10–15.
+- `bPauseWhenOffscreen`: true. Saves a frame budget when the player isn't looking.
+- `SnapshotDistance`: 0 (off). Set non-zero to fall back to a single baked frame past N units.
+
+## Concurrent cap
+
+`UKBVEWebSurfacePool::MaxConcurrent` caps live surfaces per game instance (default 8). Surfaces past the cap should fall back to snapshot mode (LRU eviction).
+
+Override via `Project Settings → Plugins → KBVE Web Surface → Max Concurrent Surfaces`.
+
+## Recommended budgets
+
+| Surface kind       | Live count | Frame rate | Notes                         |
+| ------------------ | ---------- | ---------- | ----------------------------- |
+| Player UI terminal | 1–2        | 30–60      | Active interaction            |
+| Hub kiosks         | 4–8        | 15–30      | Pause offscreen               |
+| Billboards         | 0          | snapshot   | One-time bake, no live render |
+| Combat HUD         | 0          | n/a        | Use Slate/UMG instead         |
+
+## Use Slate/UMG, not webview, for
+
+- Health bars, combat HUD
+- Inventory during gameplay
+- Quest tracker, minimap
+- Anything ticking every frame
+
+## Use webview for
+
+- Marketplace / auction house
+- Account / guild / social screens
+- Admin and debug panels
+- Patch notes / news boards
+- Interactive in-world terminals
+- Crafting and mail

--- a/packages/unreal/KBVEWebSurface/Docs/QUICKSTART.md
+++ b/packages/unreal/KBVEWebSurface/Docs/QUICKSTART.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+## 1. Enable the plugin
+
+Drop `KBVEWebSurface` into your project's `Plugins/` folder, or reference it via `AdditionalPluginDirectories` in `.uproject`:
+
+```json
+{
+	"Plugins": [{ "Name": "KBVEWebSurface", "Enabled": true }],
+	"AdditionalPluginDirectories": ["../path/to/packages/unreal"]
+}
+```
+
+Regenerate project files. Restart the editor.
+
+## 2. Configure the URL allowlist
+
+`Project Settings → Plugins → KBVE Web Surface`:
+
+- `Allowed URL Prefixes`: e.g. `https://kbve.com/`, `http://127.0.0.1:3000/`
+- `Blocked URL Prefixes`: e.g. `file://`, `chrome://`
+
+Empty allowlist = allow everything (not recommended).
+
+## 3. Place a flat terminal
+
+Drop `AKBVEWebSurfaceActor` into the world. In the details panel:
+
+- Set `Initial URL` (must pass the allowlist).
+- Set `Draw Size` for screen pixel resolution.
+
+The actor's child `KBVEWebSurfaceComponent` resolves the embedded `UWebBrowser` named `WebBrowser` inside its `Widget Class` (provide a `WBP_DemoBrowser`-style UMG with a `WebBrowser` widget).
+
+## 4. Place a curved screen
+
+Use `UKBVEWebRenderSurfaceComponent` on a curved `StaticMesh`. Assign a material that reads a texture parameter named `ScreenTexture` (override `ScreenTextureParam` to rename). The component creates a render target, binds it to a dynamic material instance, and pipes the embedded browser through it.
+
+## 5. Player interaction
+
+```cpp
+FHitResult Hit;
+if (UKBVEWebInputRouter::TraceForSurface(Player, 500.f, Hit))
+{
+    const FVector2D Pixel = UKBVEWebInputRouter::HitToWidgetCoord(Hit, FIntPoint(1024, 768));
+    // Forward Pixel to the WebBrowser slot input
+}
+```
+
+For UV mapping to work on curved meshes, enable `Project Settings → Physics → Support UV From Hit Results`.
+
+## 6. JS↔UE bridge
+
+From the web page:
+
+```js
+window.kbveBridge.send('inventory.use', JSON.stringify({ slot: 3 }));
+```
+
+In UE:
+
+```cpp
+Bridge->OnMessage.AddDynamic(this, &AMyActor::HandleBridge);
+```

--- a/packages/unreal/KBVEWebSurface/KBVEWebSurface.uplugin
+++ b/packages/unreal/KBVEWebSurface/KBVEWebSurface.uplugin
@@ -1,0 +1,35 @@
+{
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "0.1.0",
+	"FriendlyName": "KBVE Web Surface",
+	"Description": "Game-agnostic plugin for rendering interactive web content onto 3D surfaces — billboards, terminals, kiosks, holograms, in-world dashboards.",
+	"Category": "Web",
+	"CreatedBy": "KBVE",
+	"CreatedByURL": "https://kbve.com",
+	"DocsURL": "https://kbve.com/docs/unreal/web-surface",
+	"SupportURL": "https://github.com/KBVE/kbve/issues",
+	"CanContainContent": true,
+	"IsBetaVersion": true,
+	"IsExperimentalVersion": false,
+	"Installed": false,
+	"EnabledByDefault": false,
+	"Modules": [
+		{
+			"Name": "KBVEWebSurface",
+			"Type": "Runtime",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": ["Win64", "Mac", "Linux"]
+		},
+		{
+			"Name": "KBVEWebSurfaceEditor",
+			"Type": "Editor",
+			"LoadingPhase": "Default",
+			"PlatformAllowList": ["Win64", "Mac", "Linux"]
+		}
+	],
+	"Plugins": [
+		{ "Name": "WebBrowserWidget", "Enabled": true },
+		{ "Name": "WebBrowser", "Enabled": true }
+	]
+}

--- a/packages/unreal/KBVEWebSurface/LICENSE
+++ b/packages/unreal/KBVEWebSurface/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 KBVE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/unreal/KBVEWebSurface/README.md
+++ b/packages/unreal/KBVEWebSurface/README.md
@@ -1,0 +1,31 @@
+# KBVE Web Surface
+
+Game-agnostic Unreal Engine plugin for rendering interactive web content onto 3D surfaces — billboards, terminals, kiosks, holograms, in-world dashboards.
+
+## Features
+
+- `UKBVEWebSurfaceComponent` — flat in-world web panel via `UWidgetComponent`.
+- `UKBVEWebRenderSurfaceComponent` — render-to-texture path for curved meshes, holograms, CRT-style screens.
+- `AKBVEWebSurfaceActor` — drop-in actor for terminals and kiosks.
+- `UKBVEWebInputRouter` — line-trace → hit-UV → widget-pixel mapping for player interaction.
+- `UKBVEWebBridge` — typed JS↔UE message bus.
+- `UKBVEWebSurfaceSettings` — URL allow/deny list and project-wide perf defaults.
+- `UKBVEWebLODManager` + `UKBVEWebSurfacePool` — frustum/distance LOD and concurrent-surface cap.
+- Pluggable `IKBVEWebBackend` — default CEF backend, drop-in alternates (Ultralight, WebUI) ship as separate plugins.
+
+## Engine
+
+- Unreal Engine 5.6
+- Win64, Mac, Linux
+
+## Quick start
+
+See [Docs/QUICKSTART.md](Docs/QUICKSTART.md).
+
+## Performance
+
+See [Docs/PERFORMANCE.md](Docs/PERFORMANCE.md).
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/KBVEWebSurface.Build.cs
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/KBVEWebSurface.Build.cs
@@ -1,0 +1,32 @@
+using UnrealBuildTool;
+
+public class KBVEWebSurface : ModuleRules
+{
+	public KBVEWebSurface(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+		IWYUSupport = IWYUSupport.Full;
+		bUseUnity = false;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"UMG",
+			"Slate",
+			"SlateCore",
+			"WebBrowserWidget",
+			"WebBrowser",
+			"DeveloperSettings",
+			"InputCore"
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"Projects",
+			"RenderCore",
+			"RHI"
+		});
+	}
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Actors/KBVEWebSurfaceActor.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Actors/KBVEWebSurfaceActor.cpp
@@ -1,0 +1,10 @@
+#include "Actors/KBVEWebSurfaceActor.h"
+
+#include "Components/KBVEWebSurfaceComponent.h"
+
+AKBVEWebSurfaceActor::AKBVEWebSurfaceActor()
+{
+	PrimaryActorTick.bCanEverTick = false;
+	WebSurface = CreateDefaultSubobject<UKBVEWebSurfaceComponent>(TEXT("WebSurface"));
+	RootComponent = WebSurface;
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Backend/KBVEWebBackend_CEF.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Backend/KBVEWebBackend_CEF.cpp
@@ -1,0 +1,45 @@
+#include "Backend/KBVEWebBackend_CEF.h"
+
+#include "WebBrowser.h"
+
+FKBVEWebBackend_CEF::FKBVEWebBackend_CEF(UWebBrowser* InBrowser)
+	: BrowserRef(InBrowser)
+{
+}
+
+FName FKBVEWebBackend_CEF::GetBackendId() const
+{
+	return TEXT("CEF");
+}
+
+bool FKBVEWebBackend_CEF::LoadURL(const FString& URL)
+{
+	if (UWebBrowser* B = BrowserRef.Get())
+	{
+		B->LoadURL(URL);
+		return true;
+	}
+	return false;
+}
+
+void FKBVEWebBackend_CEF::ExecuteJavaScript(const FString& Script)
+{
+	if (UWebBrowser* B = BrowserRef.Get())
+	{
+		B->ExecuteJavascript(Script);
+	}
+}
+
+void FKBVEWebBackend_CEF::Tick(float DeltaSeconds)
+{
+}
+
+void FKBVEWebBackend_CEF::SetFrameRateCap(int32 Fps)
+{
+	FrameRateCap = Fps;
+}
+
+bool FKBVEWebBackend_CEF::IsValid() const
+{
+	return BrowserRef.IsValid();
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Bridge/KBVEWebBridge.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Bridge/KBVEWebBridge.cpp
@@ -1,0 +1,21 @@
+#include "Bridge/KBVEWebBridge.h"
+
+#include "WebBrowser.h"
+
+void UKBVEWebBridge::Receive(FName Channel, const FString& Payload)
+{
+	OnMessage.Broadcast(Channel, Payload);
+}
+
+void UKBVEWebBridge::Send(UWebBrowser* Browser, FName Channel, const FString& Payload)
+{
+	if (!Browser)
+	{
+		return;
+	}
+	const FString Script = FString::Printf(
+		TEXT("window.kbveBridge && window.kbveBridge.onMessage && window.kbveBridge.onMessage('%s', %s);"),
+		*Channel.ToString(),
+		*Payload);
+	Browser->ExecuteJavascript(Script);
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebRenderSurfaceComponent.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebRenderSurfaceComponent.cpp
@@ -1,0 +1,78 @@
+#include "Components/KBVEWebRenderSurfaceComponent.h"
+
+#include "KBVEWebSurface.h"
+#include "Settings/KBVEWebSurfaceSettings.h"
+#include "Engine/TextureRenderTarget2D.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "WebBrowser.h"
+#include "Blueprint/UserWidget.h"
+
+UKBVEWebRenderSurfaceComponent::UKBVEWebRenderSurfaceComponent()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+	Resolution = FIntPoint(1024, 768);
+	ScreenTextureParam = TEXT("ScreenTexture");
+	MaxFrameRate = 30;
+}
+
+void UKBVEWebRenderSurfaceComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	EnsureRenderTarget();
+	BindMaterial();
+	if (!InitialURL.IsEmpty())
+	{
+		LoadURL(InitialURL);
+	}
+}
+
+void UKBVEWebRenderSurfaceComponent::EndPlay(const EEndPlayReason::Type Reason)
+{
+	WebBrowser = nullptr;
+	ScreenMID = nullptr;
+	RenderTarget = nullptr;
+	HostWidget = nullptr;
+	Super::EndPlay(Reason);
+}
+
+void UKBVEWebRenderSurfaceComponent::LoadURL(const FString& URL)
+{
+	const UKBVEWebSurfaceSettings* Settings = GetDefault<UKBVEWebSurfaceSettings>();
+	if (Settings && !Settings->IsURLAllowed(URL))
+	{
+		UE_LOG(LogKBVEWebSurface, Warning, TEXT("URL '%s' blocked by allowlist."), *URL);
+		return;
+	}
+	if (WebBrowser)
+	{
+		WebBrowser->LoadURL(URL);
+	}
+}
+
+void UKBVEWebRenderSurfaceComponent::EnsureRenderTarget()
+{
+	if (RenderTarget)
+	{
+		return;
+	}
+	RenderTarget = NewObject<UTextureRenderTarget2D>(this);
+	RenderTarget->RenderTargetFormat = RTF_RGBA8;
+	RenderTarget->InitAutoFormat(Resolution.X, Resolution.Y);
+	RenderTarget->UpdateResourceImmediate(true);
+}
+
+void UKBVEWebRenderSurfaceComponent::BindMaterial()
+{
+	if (!RenderTarget)
+	{
+		return;
+	}
+	if (GetMaterial(0))
+	{
+		ScreenMID = CreateAndSetMaterialInstanceDynamic(0);
+		if (ScreenMID)
+		{
+			ScreenMID->SetTextureParameterValue(ScreenTextureParam, RenderTarget);
+		}
+	}
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebSurfaceComponent.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebSurfaceComponent.cpp
@@ -1,0 +1,72 @@
+#include "Components/KBVEWebSurfaceComponent.h"
+
+#include "KBVEWebSurface.h"
+#include "Settings/KBVEWebSurfaceSettings.h"
+#include "WebBrowser.h"
+#include "Blueprint/UserWidget.h"
+
+UKBVEWebSurfaceComponent::UKBVEWebSurfaceComponent()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+	MaxFrameRate = 30;
+	bPauseWhenOffscreen = true;
+	SnapshotDistance = 0.f;
+	SetWidgetSpace(EWidgetSpace::World);
+	SetDrawSize(FVector2D(1024.f, 768.f));
+	SetPivot(FVector2D(0.5f, 0.5f));
+}
+
+void UKBVEWebSurfaceComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	if (!InitialURL.IsEmpty())
+	{
+		LoadURL(InitialURL);
+	}
+}
+
+void UKBVEWebSurfaceComponent::EndPlay(const EEndPlayReason::Type Reason)
+{
+	WebBrowser = nullptr;
+	Super::EndPlay(Reason);
+}
+
+void UKBVEWebSurfaceComponent::LoadURL(const FString& URL)
+{
+	const UKBVEWebSurfaceSettings* Settings = GetDefault<UKBVEWebSurfaceSettings>();
+	if (Settings && !Settings->IsURLAllowed(URL))
+	{
+		UE_LOG(LogKBVEWebSurface, Warning, TEXT("URL '%s' blocked by allowlist."), *URL);
+		return;
+	}
+	if (UWebBrowser* Browser = ResolveBrowser())
+	{
+		Browser->LoadURL(URL);
+	}
+}
+
+void UKBVEWebSurfaceComponent::ExecuteJavaScript(const FString& Script)
+{
+	if (UWebBrowser* Browser = ResolveBrowser())
+	{
+		Browser->ExecuteJavascript(Script);
+	}
+}
+
+void UKBVEWebSurfaceComponent::Reload()
+{
+	LoadURL(InitialURL);
+}
+
+UWebBrowser* UKBVEWebSurfaceComponent::ResolveBrowser()
+{
+	if (WebBrowser)
+	{
+		return WebBrowser;
+	}
+	if (UUserWidget* HostWidget = GetUserWidgetObject())
+	{
+		WebBrowser = Cast<UWebBrowser>(HostWidget->GetWidgetFromName(TEXT("WebBrowser")));
+	}
+	return WebBrowser;
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Input/KBVEWebInputRouter.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Input/KBVEWebInputRouter.cpp
@@ -1,0 +1,40 @@
+#include "Input/KBVEWebInputRouter.h"
+
+#include "GameFramework/Actor.h"
+#include "Engine/World.h"
+#include "Camera/CameraComponent.h"
+#include "Kismet/GameplayStatics.h"
+#include "Components/PrimitiveComponent.h"
+
+FVector2D UKBVEWebInputRouter::HitToWidgetCoord(const FHitResult& Hit, FIntPoint WidgetSize)
+{
+	FVector2D UV = FVector2D::ZeroVector;
+	if (Hit.GetComponent())
+	{
+		UGameplayStatics::FindCollisionUV(Hit, 0, UV);
+	}
+	return FVector2D(UV.X * WidgetSize.X, UV.Y * WidgetSize.Y);
+}
+
+bool UKBVEWebInputRouter::TraceForSurface(AActor* Instigator, float MaxDistance, FHitResult& OutHit)
+{
+	if (!Instigator)
+	{
+		return false;
+	}
+	UWorld* World = Instigator->GetWorld();
+	if (!World)
+	{
+		return false;
+	}
+	UCameraComponent* Cam = Instigator->FindComponentByClass<UCameraComponent>();
+	if (!Cam)
+	{
+		return false;
+	}
+	const FVector Start = Cam->GetComponentLocation();
+	const FVector End = Start + Cam->GetForwardVector() * MaxDistance;
+	FCollisionQueryParams Params(SCENE_QUERY_STAT(KBVEWebSurfaceTrace), true, Instigator);
+	Params.bReturnFaceIndex = true;
+	return World->LineTraceSingleByChannel(OutHit, Start, End, ECC_Visibility, Params);
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/KBVEWebSurface.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/KBVEWebSurface.cpp
@@ -1,0 +1,17 @@
+#include "KBVEWebSurface.h"
+
+#define LOCTEXT_NAMESPACE "FKBVEWebSurfaceModule"
+
+DEFINE_LOG_CATEGORY(LogKBVEWebSurface);
+
+void FKBVEWebSurfaceModule::StartupModule()
+{
+}
+
+void FKBVEWebSurfaceModule::ShutdownModule()
+{
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FKBVEWebSurfaceModule, KBVEWebSurface)

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Perf/KBVEWebLODManager.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Perf/KBVEWebLODManager.cpp
@@ -1,0 +1,35 @@
+#include "Perf/KBVEWebLODManager.h"
+
+#include "Components/KBVEWebSurfaceComponent.h"
+
+void UKBVEWebLODManager::Tick(float DeltaTime)
+{
+	for (int32 i = Surfaces.Num() - 1; i >= 0; --i)
+	{
+		if (!Surfaces[i].IsValid())
+		{
+			Surfaces.RemoveAtSwap(i);
+		}
+	}
+}
+
+TStatId UKBVEWebLODManager::GetStatId() const
+{
+	RETURN_QUICK_DECLARE_CYCLE_STAT(UKBVEWebLODManager, STATGROUP_Tickables);
+}
+
+void UKBVEWebLODManager::Register(UKBVEWebSurfaceComponent* Surface)
+{
+	if (Surface)
+	{
+		Surfaces.AddUnique(Surface);
+	}
+}
+
+void UKBVEWebLODManager::Unregister(UKBVEWebSurfaceComponent* Surface)
+{
+	Surfaces.RemoveAll([Surface](const TWeakObjectPtr<UKBVEWebSurfaceComponent>& W)
+	{
+		return W.Get() == Surface;
+	});
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Perf/KBVEWebSurfacePool.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Perf/KBVEWebSurfacePool.cpp
@@ -1,0 +1,25 @@
+#include "Perf/KBVEWebSurfacePool.h"
+
+#include "Components/KBVEWebSurfaceComponent.h"
+
+bool UKBVEWebSurfacePool::RequestLiveSlot(UKBVEWebSurfaceComponent* Surface)
+{
+	if (!Surface)
+	{
+		return false;
+	}
+	if (Live.Num() >= MaxConcurrent && Live.Num() > 0)
+	{
+		Live.RemoveAt(0);
+	}
+	Live.Add(Surface);
+	return true;
+}
+
+void UKBVEWebSurfacePool::Release(UKBVEWebSurfaceComponent* Surface)
+{
+	Live.RemoveAll([Surface](const TWeakObjectPtr<UKBVEWebSurfaceComponent>& W)
+	{
+		return W.Get() == Surface;
+	});
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Settings/KBVEWebSurfaceSettings.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Settings/KBVEWebSurfaceSettings.cpp
@@ -1,0 +1,24 @@
+#include "Settings/KBVEWebSurfaceSettings.h"
+
+bool UKBVEWebSurfaceSettings::IsURLAllowed(const FString& URL) const
+{
+	for (const FString& Blocked : BlockedURLPrefixes)
+	{
+		if (URL.StartsWith(Blocked))
+		{
+			return false;
+		}
+	}
+	if (AllowedURLPrefixes.Num() == 0)
+	{
+		return true;
+	}
+	for (const FString& Allowed : AllowedURLPrefixes)
+	{
+		if (URL.StartsWith(Allowed))
+		{
+			return true;
+		}
+	}
+	return false;
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Tests/KBVEWebSurfaceSettingsTests.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Tests/KBVEWebSurfaceSettingsTests.cpp
@@ -1,0 +1,40 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Misc/AutomationTest.h"
+#include "Settings/KBVEWebSurfaceSettings.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FKBVEWebSurfaceAllowlistTest,
+	"KBVE.WebSurface.Settings.Allowlist",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKBVEWebSurfaceAllowlistTest::RunTest(const FString& Parameters)
+{
+	UKBVEWebSurfaceSettings* Settings = NewObject<UKBVEWebSurfaceSettings>();
+	Settings->AllowedURLPrefixes = { TEXT("https://kbve.com/"), TEXT("http://127.0.0.1:") };
+	Settings->BlockedURLPrefixes = { TEXT("file://"), TEXT("chrome://") };
+
+	TestTrue("kbve.com allowed", Settings->IsURLAllowed(TEXT("https://kbve.com/foo")));
+	TestTrue("loopback allowed", Settings->IsURLAllowed(TEXT("http://127.0.0.1:3000/hud")));
+	TestFalse("evil.com blocked (not in allowlist)", Settings->IsURLAllowed(TEXT("https://evil.com/")));
+	TestFalse("file:// blocked by deny", Settings->IsURLAllowed(TEXT("file:///etc/passwd")));
+	TestFalse("chrome:// blocked by deny", Settings->IsURLAllowed(TEXT("chrome://settings")));
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FKBVEWebSurfaceEmptyAllowlistTest,
+	"KBVE.WebSurface.Settings.EmptyAllowlist",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FKBVEWebSurfaceEmptyAllowlistTest::RunTest(const FString& Parameters)
+{
+	UKBVEWebSurfaceSettings* Settings = NewObject<UKBVEWebSurfaceSettings>();
+	Settings->BlockedURLPrefixes = { TEXT("file://") };
+
+	TestTrue("anything allowed when allowlist empty", Settings->IsURLAllowed(TEXT("https://example.com")));
+	TestFalse("denylist still wins over empty allowlist", Settings->IsURLAllowed(TEXT("file:///x")));
+	return true;
+}
+
+#endif

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Actors/KBVEWebSurfaceActor.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Actors/KBVEWebSurfaceActor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "KBVEWebSurfaceActor.generated.h"
+
+class UKBVEWebSurfaceComponent;
+
+/** Drop-in actor pairing a flat web surface with a default scene root. */
+UCLASS(BlueprintType, Blueprintable, DisplayName = "KBVE Web Surface Actor")
+class KBVEWEBSURFACE_API AKBVEWebSurfaceActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	AKBVEWebSurfaceActor();
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "KBVE")
+	TObjectPtr<UKBVEWebSurfaceComponent> WebSurface;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Backend/IKBVEWebBackend.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Backend/IKBVEWebBackend.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+/** Abstract web rendering backend. Default impl wraps Unreal's CEF UWebBrowser. */
+class KBVEWEBSURFACE_API IKBVEWebBackend
+{
+public:
+	virtual ~IKBVEWebBackend() = default;
+
+	virtual FName GetBackendId() const = 0;
+	virtual bool LoadURL(const FString& URL) = 0;
+	virtual void ExecuteJavaScript(const FString& Script) = 0;
+	virtual void Tick(float DeltaSeconds) = 0;
+	virtual void SetFrameRateCap(int32 Fps) = 0;
+	virtual bool IsValid() const = 0;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Backend/KBVEWebBackend_CEF.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Backend/KBVEWebBackend_CEF.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Backend/IKBVEWebBackend.h"
+#include "UObject/WeakObjectPtr.h"
+
+class UWebBrowser;
+
+/** Default backend wrapping Unreal's stock CEF-based UWebBrowser. */
+class KBVEWEBSURFACE_API FKBVEWebBackend_CEF : public IKBVEWebBackend
+{
+public:
+	explicit FKBVEWebBackend_CEF(UWebBrowser* InBrowser);
+
+	virtual FName GetBackendId() const override;
+	virtual bool LoadURL(const FString& URL) override;
+	virtual void ExecuteJavaScript(const FString& Script) override;
+	virtual void Tick(float DeltaSeconds) override;
+	virtual void SetFrameRateCap(int32 Fps) override;
+	virtual bool IsValid() const override;
+
+private:
+	TWeakObjectPtr<UWebBrowser> BrowserRef;
+	int32 FrameRateCap = 30;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Bridge/KBVEWebBridge.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Bridge/KBVEWebBridge.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "KBVEWebBridge.generated.h"
+
+class UWebBrowser;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FKBVEWebBridgeMessage, FName, Channel, const FString&, Payload);
+
+/** Typed JS↔UE message bus. Web pages publish via window.kbveBridge.send(channel, payload). */
+UCLASS(BlueprintType)
+class KBVEWEBSURFACE_API UKBVEWebBridge : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(BlueprintAssignable, Category = "KBVE|WebSurface|Bridge")
+	FKBVEWebBridgeMessage OnMessage;
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Bridge")
+	void Receive(FName Channel, const FString& Payload);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Bridge")
+	void Send(UWebBrowser* Browser, FName Channel, const FString& Payload);
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebRenderSurfaceComponent.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebRenderSurfaceComponent.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/StaticMeshComponent.h"
+#include "KBVEWebRenderSurfaceComponent.generated.h"
+
+class UTextureRenderTarget2D;
+class UMaterialInstanceDynamic;
+class UWebBrowser;
+class UUserWidget;
+
+/** Render-to-texture web surface for curved/holographic/billboard meshes. */
+UCLASS(ClassGroup = (KBVE), meta = (BlueprintSpawnableComponent), DisplayName = "KBVE Web Render Surface")
+class KBVEWEBSURFACE_API UKBVEWebRenderSurfaceComponent : public UStaticMeshComponent
+{
+	GENERATED_BODY()
+
+public:
+	UKBVEWebRenderSurfaceComponent();
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebRenderSurface")
+	FString InitialURL;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebRenderSurface")
+	FIntPoint Resolution;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebRenderSurface")
+	FName ScreenTextureParam;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebRenderSurface|Perf", meta = (ClampMin = "1", ClampMax = "120"))
+	int32 MaxFrameRate;
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebRenderSurface")
+	void LoadURL(const FString& URL);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebRenderSurface")
+	UTextureRenderTarget2D* GetRenderTarget() const { return RenderTarget; }
+
+protected:
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type Reason) override;
+
+private:
+	UPROPERTY(Transient)
+	TObjectPtr<UTextureRenderTarget2D> RenderTarget;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UMaterialInstanceDynamic> ScreenMID;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UUserWidget> HostWidget;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UWebBrowser> WebBrowser;
+
+	void EnsureRenderTarget();
+	void BindMaterial();
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebSurfaceComponent.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebSurfaceComponent.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/WidgetComponent.h"
+#include "KBVEWebSurfaceComponent.generated.h"
+
+class UWebBrowser;
+
+/** Flat in-world web surface backed by a UMG WebBrowser widget. */
+UCLASS(ClassGroup = (KBVE), meta = (BlueprintSpawnableComponent), DisplayName = "KBVE Web Surface")
+class KBVEWEBSURFACE_API UKBVEWebSurfaceComponent : public UWidgetComponent
+{
+	GENERATED_BODY()
+
+public:
+	UKBVEWebSurfaceComponent();
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface")
+	FString InitialURL;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Perf", meta = (ClampMin = "0", ClampMax = "120"))
+	int32 MaxFrameRate;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Perf")
+	bool bPauseWhenOffscreen;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Perf", meta = (ClampMin = "0"))
+	float SnapshotDistance;
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface")
+	void LoadURL(const FString& URL);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface")
+	void ExecuteJavaScript(const FString& Script);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface")
+	void Reload();
+
+protected:
+	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type Reason) override;
+
+private:
+	UPROPERTY(Transient)
+	TObjectPtr<UWebBrowser> WebBrowser;
+
+	UWebBrowser* ResolveBrowser();
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Input/KBVEWebInputRouter.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Input/KBVEWebInputRouter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "Engine/HitResult.h"
+#include "KBVEWebInputRouter.generated.h"
+
+/** Maps line trace hits on a web surface into 2D widget-pixel coordinates. */
+UCLASS(BlueprintType)
+class KBVEWEBSURFACE_API UKBVEWebInputRouter : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Input")
+	static FVector2D HitToWidgetCoord(const FHitResult& Hit, FIntPoint WidgetSize);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Input")
+	static bool TraceForSurface(class AActor* Instigator, float MaxDistance, FHitResult& OutHit);
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/KBVEWebSurface.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/KBVEWebSurface.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Modules/ModuleManager.h"
+
+DECLARE_LOG_CATEGORY_EXTERN(LogKBVEWebSurface, Log, All);
+
+class FKBVEWebSurfaceModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Perf/KBVEWebLODManager.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Perf/KBVEWebLODManager.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "KBVEWebLODManager.generated.h"
+
+class UKBVEWebSurfaceComponent;
+
+/** World subsystem applying frustum/distance LOD across active web surfaces. */
+UCLASS()
+class KBVEWEBSURFACE_API UKBVEWebLODManager : public UTickableWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Tick(float DeltaTime) override;
+	virtual TStatId GetStatId() const override;
+
+	void Register(UKBVEWebSurfaceComponent* Surface);
+	void Unregister(UKBVEWebSurfaceComponent* Surface);
+
+private:
+	UPROPERTY(Transient)
+	TArray<TWeakObjectPtr<UKBVEWebSurfaceComponent>> Surfaces;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Perf/KBVEWebSurfacePool.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Perf/KBVEWebSurfacePool.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "KBVEWebSurfacePool.generated.h"
+
+class UKBVEWebSurfaceComponent;
+
+/** Caps concurrent live web surfaces. Over-cap surfaces fall back to snapshot mode. */
+UCLASS(Config = Game)
+class KBVEWEBSURFACE_API UKBVEWebSurfacePool : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, Config, Category = "KBVE")
+	int32 MaxConcurrent = 8;
+
+	bool RequestLiveSlot(UKBVEWebSurfaceComponent* Surface);
+	void Release(UKBVEWebSurfaceComponent* Surface);
+
+private:
+	UPROPERTY(Transient)
+	TArray<TWeakObjectPtr<UKBVEWebSurfaceComponent>> Live;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Settings/KBVEWebSurfaceSettings.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Settings/KBVEWebSurfaceSettings.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "KBVEWebSurfaceSettings.generated.h"
+
+/** Project-wide config for KBVE Web Surface plugin. */
+UCLASS(config = Game, defaultconfig, meta = (DisplayName = "KBVE Web Surface"))
+class KBVEWEBSURFACE_API UKBVEWebSurfaceSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, Config, Category = "Security")
+	TArray<FString> AllowedURLPrefixes;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Security")
+	TArray<FString> BlockedURLPrefixes;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Perf", meta = (ClampMin = "1", ClampMax = "120"))
+	int32 DefaultFrameRate = 30;
+
+	UPROPERTY(EditAnywhere, Config, Category = "Perf", meta = (ClampMin = "1"))
+	int32 MaxConcurrentSurfaces = 8;
+
+	bool IsURLAllowed(const FString& URL) const;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurfaceEditor/KBVEWebSurfaceEditor.Build.cs
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurfaceEditor/KBVEWebSurfaceEditor.Build.cs
@@ -1,0 +1,29 @@
+using UnrealBuildTool;
+
+public class KBVEWebSurfaceEditor : ModuleRules
+{
+	public KBVEWebSurfaceEditor(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+		IWYUSupport = IWYUSupport.Full;
+		bUseUnity = false;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"UnrealEd",
+			"KBVEWebSurface"
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"Slate",
+			"SlateCore",
+			"EditorStyle",
+			"PropertyEditor",
+			"ToolMenus"
+		});
+	}
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurfaceEditor/Private/KBVEWebSurfaceEditor.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurfaceEditor/Private/KBVEWebSurfaceEditor.cpp
@@ -1,0 +1,15 @@
+#include "KBVEWebSurfaceEditor.h"
+
+#define LOCTEXT_NAMESPACE "FKBVEWebSurfaceEditorModule"
+
+void FKBVEWebSurfaceEditorModule::StartupModule()
+{
+}
+
+void FKBVEWebSurfaceEditorModule::ShutdownModule()
+{
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FKBVEWebSurfaceEditorModule, KBVEWebSurfaceEditor)

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurfaceEditor/Public/KBVEWebSurfaceEditor.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurfaceEditor/Public/KBVEWebSurfaceEditor.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Modules/ModuleManager.h"
+
+class FKBVEWebSurfaceEditorModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/packages/unreal/KBVEWebSurface/version.toml
+++ b/packages/unreal/KBVEWebSurface/version.toml
@@ -1,0 +1,2 @@
+version = "0.1.0"
+publish = false


### PR DESCRIPTION
## Summary

- New `packages/unreal/KBVEWebSurface` plugin — game-agnostic, not consumed by chuckrpg yet. Intended for standalone Fab release.
- Flat `UKBVEWebSurfaceComponent` (UWidgetComponent) + curved `UKBVEWebRenderSurfaceComponent` (render-to-texture).
- `UKBVEWebInputRouter` for line-trace → UV → widget-pixel mapping.
- `UKBVEWebBridge` typed JS↔UE message bus.
- `UKBVEWebSurfaceSettings` URL allow/deny list.
- `UKBVEWebLODManager` + `UKBVEWebSurfacePool` for frustum/distance LOD and concurrent-surface cap.
- `IKBVEWebBackend` abstraction with default CEF impl; alt backends (Ultralight, WebUI) plug in as separate plugins later.
- Editor module skeleton (empty placeholder) + automation tests for the allowlist.
- MDX project entry `apps/kbve/astro-kbve/src/content/docs/project/kbvewebsurface.mdx` + regenerated `.github/ci-dispatch-manifest.json` (now 70 tracked items).

## Out of scope

- Demo content (`Content/Demo/*.uasset`) — needs binary assets created in-editor.
- Ultralight backend addon plugin.
- Snapshot/billboard pre-bake mode (Phase 5 of the roadmap).
- chuckrpg integration — deferred until plugin stabilizes.

## Test plan

- [ ] `utils-unreal-plugin-cicd.yml` matrix build (Linux, UE 5.6) succeeds against `packages/unreal/KBVEWebSurface`.
- [ ] Allowlist automation tests pass under `KBVE.WebSurface.Settings.*`.
- [ ] Drop `AKBVEWebSurfaceActor` into a sandbox map, point `Initial URL` at `https://kbve.com/`, verify rendering.
- [ ] Verify `UKBVEWebInputRouter::HitToWidgetCoord` returns expected pixel on a flat plane (requires `Support UV From Hit Results` enabled).