### PR TITLE
fix(kubevirt/autologon): enable .NET strong crypto + TLS 1.2 SChannel

### DIFF
--- a/apps/kube/kubevirt/autologon/configmap.yaml
+++ b/apps/kube/kubevirt/autologon/configmap.yaml
@@ -10,12 +10,15 @@
 #     4. Disable Server Manager auto-start
 #     5. Disable inactivity-lock group policy
 #
-#   Build-time bootstrap (steps 8–11)
-#     8. NTP — pin pool.ntp.org + force resync so TLS chains validate
-#     9. Machine HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars routed
-#        through gluetun-builder-egress for long-lived downloads
-#    10. WinHTTP proxy + bypass list (winget / VS Installer / .NET)
-#    11. Chocolatey proxy (if choco is installed)
+#   Build-time bootstrap (steps 8–11c)
+#     8.   NTP — pin pool.ntp.org + force resync so TLS chains validate
+#     9.   Machine HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars routed
+#          through gluetun-builder-egress for long-lived downloads
+#    10.   WinHTTP proxy + bypass list (winget / VS Installer / .NET)
+#    11a.  .NET strong-crypto + SystemDefaultTlsVersions so .NET 4.x
+#          (choco.exe et al) negotiates TLS 1.2/1.3 instead of TLS 1.0
+#    11b.  SCHANNEL TLS 1.2 client enabled OS-wide
+#    11c.  Chocolatey proxy (if choco is installed)
 #
 # The admin password is injected as ADMIN_PASSWORD env var from a Secret —
 # it never appears in this ConfigMap or anywhere in the repo.
@@ -281,7 +284,26 @@ data:
             'netsh winhttp set proxy proxy-server="gluetun-builder-egress.angelscript.svc.cluster.local:8888" bypass-list="*.svc.cluster.local;*.cluster.local;<local>" | Out-Null; Write-Output done' \
             || FAILED=1
 
-        # ── Step 11: Chocolatey proxy (if installed) ──
+        # ── Step 11a: .NET strong crypto / TLS 1.2 system-wide ──
+        # Windows Server defaults to .NET TLS 1.0/1.1 which Chocolatey
+        # and most modern HTTPS endpoints have dropped. Symptom is
+        # `choco install` failing with "An error occurred while
+        # sending the request" against community.chocolatey.org. The
+        # SchUseStrongCrypto + SystemDefaultTlsVersions registry keys
+        # tell every .NET 4.x app on the box (including choco.exe) to
+        # negotiate TLS 1.2/1.3 via the OS default selector.
+        run_ps "Enable .NET strong crypto (TLS 1.2/1.3)" \
+            '$paths = @("HKLM:\SOFTWARE\Microsoft\.NETFramework\v4.0.30319", "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319"); foreach ($p in $paths) { if (-not (Test-Path $p)) { New-Item -Path $p -Force | Out-Null }; Set-ItemProperty -Path $p -Name SchUseStrongCrypto -Value 1 -Type DWord -Force; Set-ItemProperty -Path $p -Name SystemDefaultTlsVersions -Value 1 -Type DWord -Force }; Write-Output done' \
+            || FAILED=1
+
+        # ── Step 11b: Enable TLS 1.2 client at SCHANNEL level ──
+        # Belt-and-suspenders for OS-level WinHTTP / SChannel handlers
+        # so the TLS 1.2 ClientHello is allowed even before .NET asks.
+        run_ps "Enable TLS 1.2 SCHANNEL client" \
+            '$p = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client"; if (-not (Test-Path $p)) { New-Item -Path $p -Force | Out-Null }; Set-ItemProperty -Path $p -Name Enabled -Value 1 -Type DWord -Force; Set-ItemProperty -Path $p -Name DisabledByDefault -Value 0 -Type DWord -Force; Write-Output done' \
+            || FAILED=1
+
+        # ── Step 11c: Chocolatey proxy (if installed) ──
         # choco has its own config file; pointing it at the same
         # gluetun proxy makes `choco install` survive >5 minute
         # downloads. Skip cleanly when choco isn't installed yet


### PR DESCRIPTION
## Summary
Even after the NTP + proxy bootstrap from #11776, \`choco install python\` on \`windows-builder\` still fails with:

\`\`\`
Unable to load the service index for source 'https://community.chocolatey.org/api/v2/':
An error occurred while sending the request.
\`\`\`

Windows Server defaults to .NET 4.x TLS 1.0/1.1, which \`community.chocolatey.org\` dropped years ago. The handshake gets refused before HTTP is even spoken, so the error reads like a generic transport failure with no SSL hint. The same install works on local Windows boxes because they have either patched .NET defaults or the strong-crypto reg keys already set by an MDM/group policy.

## Changes
Two new idempotent bootstrap steps that run every CronJob tick:

- **11a.** \`SchUseStrongCrypto\` + \`SystemDefaultTlsVersions = 1\` at \`HKLM:\\SOFTWARE\\Microsoft\\.NETFramework\\v4.0.30319\` and the \`Wow6432Node\` mirror. Tells every .NET 4.x process (including \`choco.exe\` and the VS Installer) to use the OS default cipher selector, which on Windows Server 2019+ picks TLS 1.2/1.3.
- **11b.** SCHANNEL \`TLS 1.2\\Client\\Enabled = 1\` / \`DisabledByDefault = 0\`. Belt-and-suspenders for OS-level WinHTTP and any non-.NET client that talks straight to SChannel.

The existing chocolatey proxy step shifts to **11c**.

Reference: https://docs.chocolatey.org/en-us/troubleshooting#im-getting-tls-issues

## Test plan
- [ ] After ArgoCD syncs and the next CronJob tick lands on a Running VM, \`kubectl logs -n angelscript -l component=vm-autologon\` reports \`OK\` for both \"Enable .NET strong crypto (TLS 1.2/1.3)\" and \"Enable TLS 1.2 SCHANNEL client\".
- [ ] Inside the VM: \`Get-ItemProperty 'HKLM:\\SOFTWARE\\Microsoft\\.NETFramework\\v4.0.30319' | Select-Object SchUseStrongCrypto, SystemDefaultTlsVersions\` shows \`1, 1\`.
- [ ] After a reboot, \`choco install python -y\` completes end-to-end without the \"An error occurred while sending the request\" failure.
- [ ] \`[Net.ServicePointManager]::SecurityProtocol\` in a fresh PowerShell session now includes \`Tls12\` / \`Tls13\` without manual override.