### PR TITLE
feat(chuck): wire KBVESupabase plugin + login/account/chat UI

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Config/DefaultKBVESupabase.ini
+++ b/apps/chuckrpg/unreal-chuck/Config/DefaultKBVESupabase.ini
@@ -1,0 +1,24 @@
+; KBVESupabase plugin config for ChuckRPG.
+;
+; Fill in ProjectURL + AnonKey before launching. Both can be edited in the
+; editor at: Project Settings → Plugins → KBVE Supabase (changes write back
+; to this file). The anon key is safe to ship — RLS gates the actual access.
+;
+; For local dev, override values via Config/LocalKBVESupabase.ini (gitignored)
+; or via the editor; do NOT commit a personal AnonKey here.
+
+[/Script/KBVESupabase.KBVESupabaseSettings]
+ProjectURL=
+AnonKey=
+bPersistSession=True
+bAutoRefreshOn401=True
+RefreshLeadSeconds=60
+RequestTimeoutSeconds=20
+
+; Chat (irc-gateway) defaults — wss://chat.kbve.com/ws + auto-join #global.
+ChatURL=wss://chat.kbve.com/ws
+bChatRespondToPing=True
+bChatAutoReconnect=True
+ChatReconnectInitialDelaySeconds=2
+ChatReconnectMaxDelaySeconds=60
++ChatAutoJoinChannels=#global

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -15,6 +15,9 @@
 #include "SchuckHotbar.h"
 #include "SchuckHUD.h"
 #include "SchuckInventoryWindow.h"
+#include "SchuckLoginWidget.h"
+#include "SchuckAccountPanel.h"
+#include "SchuckChatPanel.h"
 #include "SchuckPauseMenu.h"
 #include "chuckInventory.h"
 #include "chuckItemDB.h"
@@ -22,6 +25,9 @@
 #include "Engine/GameInstance.h"
 #include "SKBVEDragArrowLayer.h"
 #include "SKBVETooltip.h"
+#include "KBVESupabaseSubsystem.h"
+#include "KBVESupabaseChat.h"
+#include "KBVESupabaseTypes.h"
 
 AchuckCorePlayerController::AchuckCorePlayerController()
 {
@@ -93,13 +99,27 @@ void AchuckCorePlayerController::OnPossess(APawn* InPawn)
 	TooltipWidget = SNew(SKBVETooltip);
 	DragArrowLayer = SNew(SKBVEDragArrowLayer);
 
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		SupabaseSubsystem = GI->GetSubsystem<UKBVESupabaseSubsystem>();
+	}
+
+	LoginWidget   = SNew(SchuckLoginWidget).Subsystem(SupabaseSubsystem);
+	AccountWidget = SNew(SchuckAccountPanel).Subsystem(SupabaseSubsystem);
+	ChatWidget    = SNew(SchuckChatPanel).Subsystem(SupabaseSubsystem);
+
 	if (UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr)
 	{
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), HUDWidget.ToSharedRef(),       5);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), HotbarWidget.ToSharedRef(),    20);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), DragArrowLayer.ToSharedRef(), 29);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), TooltipWidget.ToSharedRef(),  30);
+		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), ChatWidget.ToSharedRef(),     35);
+		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), AccountWidget.ToSharedRef(),  40);
+		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), LoginWidget.ToSharedRef(),    45);
 	}
+
+	InitSupabaseBridge();
 
 	if (UGameInstance* GI = GetGameInstance())
 	{
@@ -147,6 +167,24 @@ void AchuckCorePlayerController::OnPossess(APawn* InPawn)
 void AchuckCorePlayerController::OnUnPossess()
 {
 	UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr;
+
+	TearDownSupabaseBridge();
+
+	if (LoginWidget.IsValid())
+	{
+		if (Viewport) Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), LoginWidget.ToSharedRef());
+		LoginWidget.Reset();
+	}
+	if (AccountWidget.IsValid())
+	{
+		if (Viewport) Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), AccountWidget.ToSharedRef());
+		AccountWidget.Reset();
+	}
+	if (ChatWidget.IsValid())
+	{
+		if (Viewport) Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), ChatWidget.ToSharedRef());
+		ChatWidget.Reset();
+	}
 
 	if (TooltipHandleId != 0)
 	{
@@ -361,5 +399,185 @@ void AchuckCorePlayerController::CloseInventory()
 	if (HotbarWidget.IsValid())
 	{
 		HotbarWidget->SetExpanded(false);
+	}
+}
+
+void AchuckCorePlayerController::InitSupabaseBridge()
+{
+	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
+	if (!Sub) return;
+
+	Sub->OnSignedIn.AddDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedIn);
+	Sub->OnSignedOut.AddDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedOut);
+	Sub->OnAuthError.AddDynamic(this, &AchuckCorePlayerController::HandleSupabaseAuthError);
+
+	if (UKBVESupabaseChat* Chat = Sub->GetChat())
+	{
+		Chat->OnConnected.AddDynamic(this, &AchuckCorePlayerController::HandleChatConnected);
+		Chat->OnDisconnected.AddDynamic(this, &AchuckCorePlayerController::HandleChatDisconnected);
+		Chat->OnMessage.AddDynamic(this, &AchuckCorePlayerController::HandleChatMessage);
+	}
+
+	const bool bSignedIn = Sub->IsSignedIn();
+	RefreshAuthOverlayVisibility(bSignedIn);
+	if (bSignedIn)
+	{
+		const FKBVESupabaseUser& U = Sub->GetUser();
+		if (AccountWidget.IsValid())
+		{
+			AccountWidget->SetUsername(U.KbveUsername.IsEmpty() ? U.Id : U.KbveUsername);
+			AccountWidget->SetEmail(U.Email);
+		}
+		if (UKBVESupabaseChat* Chat = Sub->GetChat())
+		{
+			Chat->Connect();
+		}
+	}
+}
+
+void AchuckCorePlayerController::TearDownSupabaseBridge()
+{
+	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
+	if (!Sub) return;
+
+	Sub->OnSignedIn.RemoveDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedIn);
+	Sub->OnSignedOut.RemoveDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedOut);
+	Sub->OnAuthError.RemoveDynamic(this, &AchuckCorePlayerController::HandleSupabaseAuthError);
+
+	if (UKBVESupabaseChat* Chat = Sub->GetChat())
+	{
+		Chat->OnConnected.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatConnected);
+		Chat->OnDisconnected.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatDisconnected);
+		Chat->OnMessage.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatMessage);
+	}
+}
+
+void AchuckCorePlayerController::RefreshAuthOverlayVisibility(bool bSignedIn)
+{
+	if (LoginWidget.IsValid())
+	{
+		LoginWidget->SetVisibility(bSignedIn ? EVisibility::Collapsed : EVisibility::Visible);
+	}
+	if (AccountWidget.IsValid())
+	{
+		AccountWidget->SetVisibility(bSignedIn ? EVisibility::Visible : EVisibility::Collapsed);
+	}
+	if (ChatWidget.IsValid())
+	{
+		ChatWidget->SetVisibility(bSignedIn ? EVisibility::Visible : EVisibility::Collapsed);
+	}
+}
+
+void AchuckCorePlayerController::HandleSupabaseSignedIn(const FKBVESupabaseSession& Session)
+{
+	const FKBVESupabaseUser& U = Session.User;
+
+	if (AccountWidget.IsValid())
+	{
+		AccountWidget->SetUsername(U.KbveUsername.IsEmpty() ? U.Id : U.KbveUsername);
+		AccountWidget->SetEmail(U.Email);
+	}
+	RefreshAuthOverlayVisibility(/*bSignedIn=*/true);
+
+	if (UchuckUIEvents* Bus = UchuckUIEvents::Get(this))
+	{
+		FchuckAuthStatusPayload Payload;
+		Payload.bSignedIn    = true;
+		Payload.UserId       = U.Id;
+		Payload.Email        = U.Email;
+		Payload.KbveUsername = U.KbveUsername;
+		Bus->AuthStatus.Publish(Payload);
+	}
+
+	if (UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get())
+	{
+		if (UKBVESupabaseChat* Chat = Sub->GetChat())
+		{
+			Chat->Connect();
+		}
+	}
+}
+
+void AchuckCorePlayerController::HandleSupabaseSignedOut()
+{
+	RefreshAuthOverlayVisibility(/*bSignedIn=*/false);
+	if (LoginWidget.IsValid())
+	{
+		LoginWidget->SetStatusText(FText::FromString(TEXT("Signed out.")), FLinearColor(0.85f, 0.85f, 0.85f));
+	}
+	if (UchuckUIEvents* Bus = UchuckUIEvents::Get(this))
+	{
+		FchuckAuthStatusPayload Payload;
+		Payload.bSignedIn = false;
+		Bus->AuthStatus.Publish(Payload);
+	}
+}
+
+void AchuckCorePlayerController::HandleSupabaseAuthError(const FKBVESupabaseError& Error)
+{
+	if (LoginWidget.IsValid())
+	{
+		LoginWidget->SetStatusText(FText::FromString(Error.Message), FLinearColor(1.f, 0.4f, 0.3f));
+	}
+	if (UchuckUIEvents* Bus = UchuckUIEvents::Get(this))
+	{
+		FchuckAuthErrorPayload Payload;
+		Payload.HttpStatus = Error.HttpStatus;
+		Payload.Code       = Error.Code;
+		Payload.Message    = Error.Message;
+		Bus->AuthError.Publish(Payload);
+	}
+}
+
+void AchuckCorePlayerController::HandleChatConnected()
+{
+	if (ChatWidget.IsValid())
+	{
+		FchuckChatStatePayload Payload;
+		Payload.bConnected = true;
+		ChatWidget->OnChatStateChanged(Payload);
+	}
+	if (UchuckUIEvents* Bus = UchuckUIEvents::Get(this))
+	{
+		FchuckChatStatePayload Payload;
+		Payload.bConnected = true;
+		Bus->ChatState.Publish(Payload);
+	}
+}
+
+void AchuckCorePlayerController::HandleChatDisconnected(int32 /*StatusCode*/, const FString& /*Reason*/)
+{
+	if (ChatWidget.IsValid())
+	{
+		FchuckChatStatePayload Payload;
+		Payload.bConnected = false;
+		ChatWidget->OnChatStateChanged(Payload);
+	}
+	if (UchuckUIEvents* Bus = UchuckUIEvents::Get(this))
+	{
+		FchuckChatStatePayload Payload;
+		Payload.bConnected = false;
+		Bus->ChatState.Publish(Payload);
+	}
+}
+
+void AchuckCorePlayerController::HandleChatMessage(const FKBVEChatMessage& Message)
+{
+	FchuckChatLinePayload Payload;
+	Payload.Channel  = Message.Channel;
+	Payload.Nick     = Message.Nick;
+	Payload.Sender   = Message.Sender;
+	Payload.Platform = Message.Platform;
+	Payload.Kind     = Message.Kind;
+	Payload.Body     = Message.Body;
+	Payload.bIsEvent = Message.bIsEvent;
+
+	if (ChatWidget.IsValid())
+	{
+		ChatWidget->OnChatLine(Payload);
+	}
+	if (UchuckUIEvents* Bus = UchuckUIEvents::Get(this))
+	{
+		Bus->ChatLine.Publish(Payload);
 	}
 }

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
@@ -9,9 +9,16 @@ class SchuckPauseMenu;
 class SchuckDevOverlay;
 class SchuckHotbar;
 class SchuckInventoryWindow;
+class SchuckLoginWidget;
+class SchuckAccountPanel;
+class SchuckChatPanel;
 class SKBVETooltip;
 class SKBVEDragArrowLayer;
+class UKBVESupabaseSubsystem;
 struct FInputActionValue;
+struct FKBVESupabaseSession;
+struct FKBVESupabaseError;
+struct FKBVEChatMessage;
 
 UCLASS()
 class AchuckCorePlayerController : public AchuckPlayerController
@@ -44,14 +51,38 @@ protected:
 	UPROPERTY(EditDefaultsOnly, Category = "Chuck|Menu")
 	FName MainMenuLevelName = TEXT("L_MainMenu");
 
+	UFUNCTION()
+	void HandleSupabaseSignedIn(const FKBVESupabaseSession& Session);
+	UFUNCTION()
+	void HandleSupabaseSignedOut();
+	UFUNCTION()
+	void HandleSupabaseAuthError(const FKBVESupabaseError& Error);
+	UFUNCTION()
+	void HandleChatConnected();
+	UFUNCTION()
+	void HandleChatDisconnected(int32 StatusCode, const FString& Reason);
+	UFUNCTION()
+	void HandleChatMessage(const FKBVEChatMessage& Message);
+
+	void InitSupabaseBridge();
+	void TearDownSupabaseBridge();
+	void RefreshAuthOverlayVisibility(bool bSignedIn);
+
 private:
 	TSharedPtr<SchuckHUD>             HUDWidget;
 	TSharedPtr<SchuckPauseMenu>       PauseWidget;
 	TSharedPtr<SchuckDevOverlay>      DevOverlayWidget;
 	TSharedPtr<SchuckHotbar>          HotbarWidget;
 	TSharedPtr<SchuckInventoryWindow> InventoryWidget;
+	TSharedPtr<SchuckLoginWidget>     LoginWidget;
+	TSharedPtr<SchuckAccountPanel>    AccountWidget;
+	TSharedPtr<SchuckChatPanel>       ChatWidget;
 	TSharedPtr<SKBVETooltip>          TooltipWidget;
 	TSharedPtr<SKBVEDragArrowLayer>   DragArrowLayer;
+
+	UPROPERTY(Transient)
+	TWeakObjectPtr<UKBVESupabaseSubsystem> SupabaseSubsystem;
+
 	uint64 TooltipHandleId = 0;
 
 	bool        bPendingTooltipShow    = false;

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckEventPayloads.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckEventPayloads.h
@@ -74,3 +74,36 @@ struct FchuckPickupRequestPayload
 	int32             ItemKey = 0;
 	int32             Count   = 1;
 };
+
+// Auth-domain payloads: bridge KBVESupabase delegates onto the chuck event bus
+// so UI widgets do not need a direct reference to the subsystem.
+struct FchuckAuthStatusPayload
+{
+	bool    bSignedIn = false;
+	FString UserId;
+	FString Email;
+	FString KbveUsername;
+};
+
+struct FchuckAuthErrorPayload
+{
+	int32   HttpStatus = 0;
+	FString Code;
+	FString Message;
+};
+
+struct FchuckChatStatePayload
+{
+	bool bConnected = false;
+};
+
+struct FchuckChatLinePayload
+{
+	FString Channel;
+	FString Nick;
+	FString Sender;
+	FString Platform;
+	FString Kind;
+	FString Body;
+	bool    bIsEvent = false;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckUIEvents.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckUIEvents.h
@@ -30,4 +30,9 @@ public:
 	TKBVEChannel<FchuckDamageReceivedPayload>  DamageReceived;
 	TKBVEChannel<FchuckTooltipPayload>         Tooltip;
 	TKBVEChannel<FchuckItemConsumedPayload>    ItemConsumed;
+
+	TKBVEChannel<FchuckAuthStatusPayload>      AuthStatus;
+	TKBVEChannel<FchuckAuthErrorPayload>       AuthError;
+	TKBVEChannel<FchuckChatStatePayload>       ChatState;
+	TKBVEChannel<FchuckChatLinePayload>        ChatLine;
 };

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckAccountPanel.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckAccountPanel.cpp
@@ -1,0 +1,84 @@
+#include "SchuckAccountPanel.h"
+
+#include "KBVESupabaseSubsystem.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/SOverlay.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Styling/CoreStyle.h"
+
+#define LOCTEXT_NAMESPACE "SchuckAccountPanel"
+
+void SchuckAccountPanel::Construct(const FArguments& InArgs)
+{
+	Subsystem = InArgs._Subsystem;
+
+	const FSlateFontInfo NickFont = FCoreStyle::GetDefaultFontStyle("Bold", 13);
+	const FSlateFontInfo EmailFont = FCoreStyle::GetDefaultFontStyle("Regular", 9);
+	const FSlateFontInfo ButtonFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+
+	ChildSlot
+	[
+		SNew(SBorder)
+		.BorderImage(FCoreStyle::Get().GetBrush("WhiteBrush"))
+		.BorderBackgroundColor(FSlateColor(FLinearColor(0.04f, 0.06f, 0.09f, 0.85f)))
+		.Padding(FMargin(10.f, 6.f))
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center).Padding(0.f, 0.f, 10.f, 0.f)
+			[
+				SNew(SVerticalBox)
+				+ SVerticalBox::Slot().AutoHeight()
+				[
+					SAssignNew(UsernameText, STextBlock).Text(LOCTEXT("Unknown", "—")).Font(NickFont)
+				]
+				+ SVerticalBox::Slot().AutoHeight()
+				[
+					SAssignNew(EmailText, STextBlock)
+					.Text(FText::GetEmpty())
+					.Font(EmailFont)
+					.ColorAndOpacity(FSlateColor(FLinearColor(0.7f, 0.74f, 0.82f)))
+				]
+			]
+			+ SHorizontalBox::Slot().AutoWidth().VAlign(VAlign_Center)
+			[
+				SNew(SButton)
+				.HAlign(HAlign_Center).VAlign(VAlign_Center)
+				.OnClicked(FOnClicked::CreateSP(this, &SchuckAccountPanel::HandleSignOut))
+				[
+					SNew(STextBlock).Text(LOCTEXT("SignOut", "Sign Out")).Font(ButtonFont)
+				]
+			]
+		]
+	];
+}
+
+void SchuckAccountPanel::SetUsername(const FString& InUsername)
+{
+	if (UsernameText.IsValid())
+	{
+		UsernameText->SetText(InUsername.IsEmpty() ? LOCTEXT("Guest", "Guest") : FText::FromString(InUsername));
+	}
+}
+
+void SchuckAccountPanel::SetEmail(const FString& InEmail)
+{
+	if (EmailText.IsValid())
+	{
+		EmailText->SetText(FText::FromString(InEmail));
+	}
+}
+
+FReply SchuckAccountPanel::HandleSignOut()
+{
+	if (UKBVESupabaseSubsystem* Sub = Subsystem.Get())
+	{
+		Sub->SignOut(/*bAlsoRevokeServerSide=*/true);
+	}
+	return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckAccountPanel.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckAccountPanel.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Input/Reply.h"
+
+class UKBVESupabaseSubsystem;
+class STextBlock;
+
+/** Small overlay tile in the corner — shows the active KBVE username and a sign-out affordance. */
+class SchuckAccountPanel : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SchuckAccountPanel) {}
+		SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	void SetUsername(const FString& InUsername);
+	void SetEmail(const FString& InEmail);
+
+private:
+	FReply HandleSignOut();
+
+	TWeakObjectPtr<UKBVESupabaseSubsystem> Subsystem;
+	TSharedPtr<STextBlock> UsernameText;
+	TSharedPtr<STextBlock> EmailText;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckLoginWidget.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckLoginWidget.cpp
@@ -1,0 +1,223 @@
+#include "SchuckLoginWidget.h"
+
+#include "ChuckUIStyle.h"
+#include "KBVESupabaseSubsystem.h"
+#include "KBVESupabaseTypes.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/SOverlay.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Styling/CoreStyle.h"
+
+#define LOCTEXT_NAMESPACE "SchuckLoginWidget"
+
+namespace
+{
+	const TCHAR* OAuthLabels[] = { TEXT("Discord"), TEXT("GitHub"), TEXT("Google") };
+	EKBVESupabaseOAuthProvider OAuthProviders[] = {
+		EKBVESupabaseOAuthProvider::Discord,
+		EKBVESupabaseOAuthProvider::GitHub,
+		EKBVESupabaseOAuthProvider::Google,
+	};
+
+	TSharedRef<SWidget> MakeFieldRow(const FText& Label, TSharedRef<SEditableTextBox> Box, const FSlateFontInfo& Font)
+	{
+		return SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 4.f, 0.f, 2.f)
+			[
+				SNew(STextBlock).Text(Label).Font(Font).ColorAndOpacity(FSlateColor(FLinearColor(0.78f, 0.85f, 0.95f)))
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 6.f)
+			[
+				Box
+			];
+	}
+}
+
+void SchuckLoginWidget::Construct(const FArguments& InArgs)
+{
+	Subsystem = InArgs._Subsystem;
+
+	const FSlateFontInfo TitleFont = FCoreStyle::GetDefaultFontStyle("Bold", 22);
+	const FSlateFontInfo LabelFont = FCoreStyle::GetDefaultFontStyle("Regular", 11);
+	const FSlateFontInfo ButtonFont = FCoreStyle::GetDefaultFontStyle("Bold", 12);
+	const FSlateFontInfo StatusFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+
+	EmailBox = SNew(SEditableTextBox).HintText(LOCTEXT("EmailHint", "you@example.com"));
+	PasswordBox = SNew(SEditableTextBox).IsPassword(true).HintText(LOCTEXT("PasswordHint", "password"));
+
+	TSharedRef<SHorizontalBox> OAuthRow = SNew(SHorizontalBox);
+	for (int32 i = 0; i < UE_ARRAY_COUNT(OAuthLabels); ++i)
+	{
+		const int32 Idx = i;
+		OAuthRow->AddSlot().FillWidth(1.f).Padding(4.f, 0.f)
+		[
+			SNew(SButton)
+			.HAlign(HAlign_Center).VAlign(VAlign_Center)
+			.OnClicked(FOnClicked::CreateSP(this, &SchuckLoginWidget::HandleOAuth, Idx))
+			[
+				SNew(STextBlock).Text(FText::FromString(OAuthLabels[Idx])).Font(ButtonFont)
+			]
+		];
+	}
+
+	ChildSlot
+	[
+		SNew(SOverlay)
+		+ SOverlay::Slot().HAlign(HAlign_Center).VAlign(VAlign_Center)
+		[
+			SNew(SBorder)
+			.BorderImage(FCoreStyle::Get().GetBrush("WhiteBrush"))
+			.BorderBackgroundColor(FSlateColor(FLinearColor(0.06f, 0.08f, 0.11f, 0.96f)))
+			.Padding(FMargin(24.f))
+			[
+				SNew(SBox).WidthOverride(420.f)
+				[
+					SNew(SVerticalBox)
+					+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center).Padding(0.f, 0.f, 0.f, 12.f)
+					[
+						SNew(STextBlock).Text(LOCTEXT("Title", "Sign in to ChuckRPG")).Font(TitleFont)
+					]
+					+ SVerticalBox::Slot().AutoHeight()
+					[
+						MakeFieldRow(LOCTEXT("EmailLabel", "Email"), EmailBox.ToSharedRef(), LabelFont)
+					]
+					+ SVerticalBox::Slot().AutoHeight()
+					[
+						MakeFieldRow(LOCTEXT("PasswordLabel", "Password"), PasswordBox.ToSharedRef(), LabelFont)
+					]
+					+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 8.f, 0.f, 4.f)
+					[
+						SNew(SHorizontalBox)
+						+ SHorizontalBox::Slot().FillWidth(1.f).Padding(0.f, 0.f, 4.f, 0.f)
+						[
+							SNew(SButton)
+							.HAlign(HAlign_Center).VAlign(VAlign_Center)
+							.OnClicked(FOnClicked::CreateSP(this, &SchuckLoginWidget::HandleSignIn))
+							[
+								SNew(STextBlock).Text(LOCTEXT("SignIn", "Sign In")).Font(ButtonFont)
+							]
+						]
+						+ SHorizontalBox::Slot().FillWidth(1.f).Padding(4.f, 0.f, 0.f, 0.f)
+						[
+							SNew(SButton)
+							.HAlign(HAlign_Center).VAlign(VAlign_Center)
+							.OnClicked(FOnClicked::CreateSP(this, &SchuckLoginWidget::HandleSignUp))
+							[
+								SNew(STextBlock).Text(LOCTEXT("SignUp", "Sign Up")).Font(ButtonFont)
+							]
+						]
+					]
+					+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 12.f, 0.f, 4.f)
+					[
+						SNew(STextBlock)
+						.Text(LOCTEXT("OAuth", "or continue with"))
+						.Font(LabelFont)
+						.ColorAndOpacity(FSlateColor(FLinearColor(0.6f, 0.66f, 0.78f)))
+						.Justification(ETextJustify::Center)
+					]
+					+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 8.f)
+					[
+						OAuthRow
+					]
+					+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center).Padding(0.f, 0.f, 0.f, 4.f)
+					[
+						SNew(SButton)
+						.HAlign(HAlign_Center).VAlign(VAlign_Center)
+						.OnClicked(FOnClicked::CreateSP(this, &SchuckLoginWidget::HandleAnonymous))
+						[
+							SNew(STextBlock).Text(LOCTEXT("Anon", "Play as Guest")).Font(LabelFont)
+						]
+					]
+					+ SVerticalBox::Slot().AutoHeight().HAlign(HAlign_Center).Padding(0.f, 6.f, 0.f, 0.f)
+					[
+						SAssignNew(StatusText, STextBlock)
+						.Text(FText::GetEmpty())
+						.Font(StatusFont)
+						.ColorAndOpacity(FSlateColor(FLinearColor(0.85f, 0.85f, 0.85f)))
+					]
+				]
+			]
+		]
+	];
+}
+
+void SchuckLoginWidget::SetStatusText(const FText& InText, const FLinearColor& InColor)
+{
+	if (StatusText.IsValid())
+	{
+		StatusText->SetText(InText);
+		StatusText->SetColorAndOpacity(FSlateColor(InColor));
+	}
+}
+
+void SchuckLoginWidget::SetBusy(bool bInBusy)
+{
+	bBusy = bInBusy;
+	SetVisibility(bInBusy ? EVisibility::HitTestInvisible : EVisibility::Visible);
+}
+
+FReply SchuckLoginWidget::HandleSignIn()
+{
+	if (bBusy) return FReply::Handled();
+	UKBVESupabaseSubsystem* Sub = Subsystem.Get();
+	if (!Sub) return FReply::Handled();
+	const FString Email = EmailBox->GetText().ToString();
+	const FString Password = PasswordBox->GetText().ToString();
+	if (Email.IsEmpty() || Password.IsEmpty())
+	{
+		SetStatusText(LOCTEXT("MissingFields", "Email and password required"), FLinearColor(1.f, 0.4f, 0.3f));
+		return FReply::Handled();
+	}
+	SetStatusText(LOCTEXT("SigningIn", "Signing in..."), FLinearColor(0.85f, 0.85f, 0.85f));
+	Sub->SignInWithPassword(Email, Password);
+	return FReply::Handled();
+}
+
+FReply SchuckLoginWidget::HandleSignUp()
+{
+	if (bBusy) return FReply::Handled();
+	UKBVESupabaseSubsystem* Sub = Subsystem.Get();
+	if (!Sub) return FReply::Handled();
+	const FString Email = EmailBox->GetText().ToString();
+	const FString Password = PasswordBox->GetText().ToString();
+	if (Email.IsEmpty() || Password.IsEmpty())
+	{
+		SetStatusText(LOCTEXT("MissingFields", "Email and password required"), FLinearColor(1.f, 0.4f, 0.3f));
+		return FReply::Handled();
+	}
+	SetStatusText(LOCTEXT("SigningUp", "Creating account..."), FLinearColor(0.85f, 0.85f, 0.85f));
+	Sub->SignUpWithPassword(Email, Password);
+	return FReply::Handled();
+}
+
+FReply SchuckLoginWidget::HandleOAuth(int32 ProviderIndex)
+{
+	if (bBusy) return FReply::Handled();
+	UKBVESupabaseSubsystem* Sub = Subsystem.Get();
+	if (!Sub) return FReply::Handled();
+	if (ProviderIndex < 0 || ProviderIndex >= static_cast<int32>(UE_ARRAY_COUNT(OAuthProviders)))
+	{
+		return FReply::Handled();
+	}
+	SetStatusText(LOCTEXT("OpeningBrowser", "Opening browser..."), FLinearColor(0.85f, 0.85f, 0.85f));
+	Sub->StartOAuthSignIn(OAuthProviders[ProviderIndex], FString());
+	return FReply::Handled();
+}
+
+FReply SchuckLoginWidget::HandleAnonymous()
+{
+	if (bBusy) return FReply::Handled();
+	UKBVESupabaseSubsystem* Sub = Subsystem.Get();
+	if (!Sub) return FReply::Handled();
+	SetStatusText(LOCTEXT("Anonymous", "Creating guest session..."), FLinearColor(0.85f, 0.85f, 0.85f));
+	Sub->SignInAnonymously();
+	return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckLoginWidget.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckLoginWidget.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Input/Reply.h"
+
+class UKBVESupabaseSubsystem;
+class SEditableTextBox;
+class STextBlock;
+
+/**
+ * Modal login panel. Sign-in / sign-up / OAuth bootstrap (Discord, GitHub,
+ * Google) hooked straight to UKBVESupabaseSubsystem. Auth state changes are
+ * surfaced via the chuck event bus (FchuckAuthStatusPayload), so this widget
+ * just drives the subsystem and renders status text.
+ */
+class SchuckLoginWidget : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SchuckLoginWidget) {}
+		SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	void SetStatusText(const FText& InText, const FLinearColor& InColor);
+	void SetBusy(bool bBusy);
+
+private:
+	FReply HandleSignIn();
+	FReply HandleSignUp();
+	FReply HandleOAuth(int32 ProviderIndex);
+	FReply HandleAnonymous();
+
+	TWeakObjectPtr<UKBVESupabaseSubsystem> Subsystem;
+	TSharedPtr<SEditableTextBox> EmailBox;
+	TSharedPtr<SEditableTextBox> PasswordBox;
+	TSharedPtr<STextBlock>       StatusText;
+	bool bBusy = false;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.cpp
@@ -1,0 +1,186 @@
+#include "SchuckChatPanel.h"
+
+#include "KBVESupabaseSubsystem.h"
+#include "KBVESupabaseChat.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Styling/CoreStyle.h"
+
+#define LOCTEXT_NAMESPACE "SchuckChatPanel"
+
+namespace
+{
+	FLinearColor PickKindColor(const FString& Kind, bool bIsEvent)
+	{
+		if (bIsEvent) return FLinearColor(0.95f, 0.78f, 0.32f);
+		if (Kind.Equals(TEXT("CHAT"), ESearchCase::IgnoreCase)) return FLinearColor(0.78f, 0.88f, 0.98f);
+		return FLinearColor(0.7f, 0.7f, 0.78f);
+	}
+}
+
+void SchuckChatPanel::Construct(const FArguments& InArgs)
+{
+	Subsystem = InArgs._Subsystem;
+	ActiveChannel = InArgs._DefaultChannel;
+
+	const FSlateFontInfo HeaderFont = FCoreStyle::GetDefaultFontStyle("Bold", 11);
+	const FSlateFontInfo ChatFont   = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+	const FSlateFontInfo ButtonFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+
+	ChildSlot
+	[
+		SNew(SBox).WidthOverride(360.f).HeightOverride(220.f)
+		[
+			SNew(SBorder)
+			.BorderImage(FCoreStyle::Get().GetBrush("WhiteBrush"))
+			.BorderBackgroundColor(FSlateColor(FLinearColor(0.04f, 0.06f, 0.09f, 0.78f)))
+			.Padding(FMargin(8.f))
+			[
+				SNew(SVerticalBox)
+				+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 4.f)
+				[
+					SAssignNew(HeaderText, STextBlock)
+					.Text(FText::FromString(FString::Printf(TEXT("Chat — %s (disconnected)"), *ActiveChannel)))
+					.Font(HeaderFont)
+				]
+				+ SVerticalBox::Slot().FillHeight(1.f).Padding(0.f, 0.f, 0.f, 4.f)
+				[
+					SAssignNew(Scrollback, SScrollBox)
+				]
+				+ SVerticalBox::Slot().AutoHeight()
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot().FillWidth(1.f).Padding(0.f, 0.f, 4.f, 0.f)
+					[
+						SAssignNew(InputBox, SEditableTextBox)
+						.HintText(LOCTEXT("InputHint", "Press Enter to send..."))
+						.OnTextCommitted(this, &SchuckChatPanel::HandleInputCommitted)
+					]
+					+ SHorizontalBox::Slot().AutoWidth()
+					[
+						SNew(SButton)
+						.HAlign(HAlign_Center).VAlign(VAlign_Center)
+						.OnClicked(FOnClicked::CreateSP(this, &SchuckChatPanel::HandleSendClicked))
+						[
+							SNew(STextBlock).Text(LOCTEXT("Send", "Send")).Font(ButtonFont)
+						]
+					]
+				]
+			]
+		]
+	];
+}
+
+void SchuckChatPanel::SetActiveChannel(const FString& InChannel)
+{
+	ActiveChannel = InChannel;
+	if (HeaderText.IsValid())
+	{
+		HeaderText->SetText(FText::FromString(FString::Printf(
+			TEXT("Chat — %s (%s)"),
+			*ActiveChannel,
+			bConnected ? TEXT("connected") : TEXT("disconnected"))));
+	}
+}
+
+void SchuckChatPanel::OnChatStateChanged(const FchuckChatStatePayload& Payload)
+{
+	bConnected = Payload.bConnected;
+	if (HeaderText.IsValid())
+	{
+		HeaderText->SetText(FText::FromString(FString::Printf(
+			TEXT("Chat — %s (%s)"),
+			*ActiveChannel,
+			bConnected ? TEXT("connected") : TEXT("disconnected"))));
+	}
+	AppendSystem(bConnected ? TEXT("* connected") : TEXT("* disconnected"));
+}
+
+void SchuckChatPanel::OnChatLine(const FchuckChatLinePayload& Payload)
+{
+	if (!ActiveChannel.IsEmpty() && !Payload.Channel.IsEmpty() && !Payload.Channel.Equals(ActiveChannel, ESearchCase::IgnoreCase))
+	{
+		return;
+	}
+	AppendLine(Payload.Channel, Payload.Sender.IsEmpty() ? Payload.Nick : Payload.Sender,
+		Payload.Kind, Payload.Body, Payload.bIsEvent);
+}
+
+void SchuckChatPanel::AppendLine(const FString& /*Channel*/, const FString& Sender, const FString& Kind, const FString& Body, bool bIsEvent)
+{
+	if (!Scrollback.IsValid()) return;
+
+	const FSlateFontInfo NickFont = FCoreStyle::GetDefaultFontStyle("Bold", 10);
+	const FSlateFontInfo BodyFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+
+	const FString NickLine = bIsEvent
+		? FString::Printf(TEXT("[%s] %s"), *Kind, *Sender)
+		: Sender;
+
+	Scrollback->AddSlot().Padding(0.f, 1.f)
+	[
+		SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot().AutoWidth().Padding(0.f, 0.f, 6.f, 0.f)
+		[
+			SNew(STextBlock)
+			.Text(FText::FromString(NickLine + TEXT(":")))
+			.Font(NickFont)
+			.ColorAndOpacity(FSlateColor(PickKindColor(Kind, bIsEvent)))
+		]
+		+ SHorizontalBox::Slot().FillWidth(1.f)
+		[
+			SNew(STextBlock)
+			.Text(FText::FromString(Body))
+			.Font(BodyFont)
+			.AutoWrapText(true)
+			.ColorAndOpacity(FSlateColor(FLinearColor(0.95f, 0.95f, 0.96f)))
+		]
+	];
+
+	Scrollback->ScrollToEnd();
+}
+
+void SchuckChatPanel::AppendSystem(const FString& Text)
+{
+	if (!Scrollback.IsValid()) return;
+	const FSlateFontInfo SystemFont = FCoreStyle::GetDefaultFontStyle("Italic", 9);
+	Scrollback->AddSlot().Padding(0.f, 1.f)
+	[
+		SNew(STextBlock)
+		.Text(FText::FromString(Text))
+		.Font(SystemFont)
+		.ColorAndOpacity(FSlateColor(FLinearColor(0.6f, 0.66f, 0.78f)))
+	];
+	Scrollback->ScrollToEnd();
+}
+
+FReply SchuckChatPanel::HandleSendClicked()
+{
+	if (!InputBox.IsValid()) return FReply::Handled();
+	const FString Body = InputBox->GetText().ToString();
+	InputBox->SetText(FText::GetEmpty());
+	if (Body.IsEmpty() || ActiveChannel.IsEmpty()) return FReply::Handled();
+
+	UKBVESupabaseSubsystem* Sub = Subsystem.Get();
+	if (!Sub) return FReply::Handled();
+	UKBVESupabaseChat* Chat = Sub->GetChat();
+	if (!Chat) return FReply::Handled();
+	Chat->SendPrivMsg(ActiveChannel, Body);
+	return FReply::Handled();
+}
+
+void SchuckChatPanel::HandleInputCommitted(const FText& InText, ETextCommit::Type CommitType)
+{
+	if (CommitType == ETextCommit::OnEnter)
+	{
+		HandleSendClicked();
+	}
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Input/Reply.h"
+#include "chuckEventPayloads.h"
+
+class UKBVESupabaseSubsystem;
+class SEditableTextBox;
+class SScrollBox;
+class STextBlock;
+
+/**
+ * Scrollback + input dock for the irc-gateway WebSocket. Listens to the
+ * chuck event bus (ChatState / ChatLine) so the widget never touches the
+ * Supabase subsystem directly except to send PRIVMSGs.
+ */
+class SchuckChatPanel : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SchuckChatPanel)
+		: _DefaultChannel(TEXT("#global"))
+	{}
+		SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)
+		SLATE_ARGUMENT(FString, DefaultChannel)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	void OnChatStateChanged(const FchuckChatStatePayload& Payload);
+	void OnChatLine(const FchuckChatLinePayload& Payload);
+
+	void SetActiveChannel(const FString& InChannel);
+
+private:
+	FReply HandleSendClicked();
+	void   HandleInputCommitted(const FText& InText, ETextCommit::Type CommitType);
+	void   AppendLine(const FString& Channel, const FString& Sender, const FString& Kind, const FString& Body, bool bIsEvent);
+	void   AppendSystem(const FString& Text);
+
+	TWeakObjectPtr<UKBVESupabaseSubsystem> Subsystem;
+	TSharedPtr<SScrollBox> Scrollback;
+	TSharedPtr<SEditableTextBox> InputBox;
+	TSharedPtr<STextBlock> HeaderText;
+
+	FString ActiveChannel;
+	bool bConnected = false;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/chuck.Build.cs
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/chuck.Build.cs
@@ -35,7 +35,8 @@ public class chuck : ModuleRules
 			"KBVEXXHash",
 			"KBVEULID",
 			"KBVEUI",
-			"KBVEEvents"
+			"KBVEEvents",
+			"KBVESupabase"
 		});
 
 
@@ -48,6 +49,8 @@ public class chuck : ModuleRules
 			"chuck/UI",
 			"chuck/UI/HUD",
 			"chuck/UI/Inventory",
+			"chuck/UI/Auth",
+			"chuck/UI/Chat",
 			"chuck/Variant_Platforming",
 			"chuck/Variant_Platforming/Animation",
 			"chuck/Variant_Combat",

--- a/apps/chuckrpg/unreal-chuck/chuck.uproject
+++ b/apps/chuckrpg/unreal-chuck/chuck.uproject
@@ -84,6 +84,10 @@
 		{
 			"Name": "KBVEROWS",
 			"Enabled": false
+		},
+		{
+			"Name": "KBVESupabase",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
## Summary
- Enable KBVESupabase in \`chuck.uproject\` and \`chuck.Build.cs\`.
- Scaffold \`Config/DefaultKBVESupabase.ini\` (ProjectURL + AnonKey left blank — fill via Project Settings).
- Add auth + chat channels (\`AuthStatus\`, \`AuthError\`, \`ChatState\`, \`ChatLine\`) to the chuck event bus.
- New Slate widgets:
  - \`SchuckLoginWidget\` — email/password sign-in + sign-up, OAuth (Discord / GitHub / Google) via loopback PKCE, \`Play as Guest\` (anonymous), inline status text.
  - \`SchuckAccountPanel\` — kbve_username + email + Sign Out tile.
  - \`SchuckChatPanel\` — scrollback + input, filters by active channel (\`#global\` default), sends PRIVMSGs via \`Sb->GetChat()->SendPrivMsg\`.
- \`AchuckCorePlayerController::OnPossess\` mounts the three widgets (z 35 chat / 40 account / 45 login), grabs \`UKBVESupabaseSubsystem\`, and binds dynamic delegates that flip overlay visibility, publish to the chuck event bus, and auto-Connect the chat WS on sign-in. \`OnUnPossess\` cleans up.

## Not in this PR
- Real Supabase ProjectURL / AnonKey (kept blank — local fill).
- Slash-command parsing, channel switcher, scrollback persistence.
- HUD chrome / themed buttons via KBVEUI Slate primitives (uses raw \`SButton\` / \`SEditableTextBox\` for now).
- Bind toggle key for chat / account panels.

## Test plan
- [ ] In editor, fill Project Settings → Plugins → KBVE Supabase → ProjectURL + AnonKey, launch \`L_Open_World\` (or main play map).
- [ ] On possess, login modal appears at top z-order; chat + account hidden.
- [ ] Sign-in with valid creds → modal disappears, account tile shows \`kbve_username\` + email, chat panel reads \`Chat — #global (connected)\` once WS connects.
- [ ] Send a PRIVMSG in chat input → message echoes back into the scrollback when the gateway replays it.
- [ ] OAuth button opens system browser via loopback PKCE → after auth, session is restored + same widgets settle in signed-in state.
- [ ] \`Sign Out\` in account tile → modal re-appears, chat hides + closes WS.