### PR TITLE
feat(unreal/websurface): streamline plugin API for consumer integration (v0.2.0)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -675,7 +675,7 @@
 			"key": "ue_kbvewebsurface",
 			"plugin_name": "KBVEWebSurface",
 			"plugin_path": "packages/unreal/KBVEWebSurface",
-			"version": "0.1.0",
+			"version": "0.2.0",
 			"version_toml": "packages/unreal/KBVEWebSurface/version.toml"
 		},
 		{

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvewebsurface.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvewebsurface.mdx
@@ -13,7 +13,7 @@ key: ue_kbvewebsurface
 pipeline: unreal
 plugin_name: KBVEWebSurface
 plugin_path: packages/unreal/KBVEWebSurface
-version: "0.1.0"
+version: "0.2.0"
 source_path: packages/unreal/KBVEWebSurface
 version_toml: packages/unreal/KBVEWebSurface/version.toml
 author: h0lybyte

--- a/packages/unreal/KBVEWebSurface/Docs/QUICKSTART.md
+++ b/packages/unreal/KBVEWebSurface/Docs/QUICKSTART.md
@@ -22,42 +22,68 @@ Regenerate project files. Restart the editor.
 
 Empty allowlist = allow everything (not recommended).
 
-## 3. Place a flat terminal
+## 3. Drop a terminal
 
-Drop `AKBVEWebSurfaceActor` into the world. In the details panel:
+Place `AKBVEWebTerminalActor` in the world. In the details panel:
 
-- Set `Initial URL` (must pass the allowlist).
-- Set `Draw Size` for screen pixel resolution.
+- `Initial URL` — must pass the allowlist.
+- `Auth Token` (optional) — appended as `#kbve_token=<token>` so the page can hydrate without a separate login round-trip.
+- `Surface → Draw Size` — pixel resolution of the surface.
 
-The actor's child `KBVEWebSurfaceComponent` resolves the embedded `UWebBrowser` named `WebBrowser` inside its `Widget Class` (provide a `WBP_DemoBrowser`-style UMG with a `WebBrowser` widget).
+No UMG `.uasset` required. The plugin's `UKBVEWebSurfaceUserWidget` constructs its `UWebBrowser` root programmatically.
 
-## 4. Place a curved screen
+## 4. Player interaction
 
-Use `UKBVEWebRenderSurfaceComponent` on a curved `StaticMesh`. Assign a material that reads a texture parameter named `ScreenTexture` (override `ScreenTextureParam` to rename). The component creates a render target, binds it to a dynamic material instance, and pipes the embedded browser through it.
-
-## 5. Player interaction
+Attach `UKBVEWebInteractionComponent` to the player pawn or controller. Hover, click, and scroll work out of the box for flat surfaces via Unreal's standard `WidgetInteractionComponent` pipeline. Defaults: 1000 unit reach, world trace, `ECC_Visibility`.
 
 ```cpp
-FHitResult Hit;
-if (UKBVEWebInputRouter::TraceForSurface(Player, 500.f, Hit))
-{
-    const FVector2D Pixel = UKBVEWebInputRouter::HitToWidgetCoord(Hit, FIntPoint(1024, 768));
-    // Forward Pixel to the WebBrowser slot input
-}
+Interaction = CreateDefaultSubobject<UKBVEWebInteractionComponent>(TEXT("WebInteraction"));
+Interaction->SetupAttachment(FollowCamera);
 ```
 
-For UV mapping to work on curved meshes, enable `Project Settings → Physics → Support UV From Hit Results`.
+Bind input actions to `PressPointerKey(EKeys::LeftMouseButton)` / `ReleasePointerKey(...)` / `SendKeyChar(...)` per the standard `UWidgetInteractionComponent` API.
+
+## 5. Curved screen
+
+`UKBVEWebRenderSurfaceComponent` on a curved `StaticMesh`. Assign a material that reads a texture parameter named `ScreenTexture` (override `ScreenTextureParam` to rename). The component creates a render target, binds it to a dynamic material instance, and pipes the embedded browser through it.
+
+For curved-mesh trace input enable `Project Settings → Physics → Support UV From Hit Results` and use `UKBVEWebInputRouter::HitToWidgetCoord` (still available, but flagged deprecated for flat surfaces).
 
 ## 6. JS↔UE bridge
 
-From the web page:
+The bridge is auto-attached when `LoadURL` runs. UFUNCTIONs on `UKBVEWebBridge` become callable from JS as `window.<BridgeName>.<func>`.
+
+From a page:
 
 ```js
-window.kbveBridge.send('inventory.use', JSON.stringify({ slot: 3 }));
+window.kbveBridge.Dispatch('inventory.use', JSON.stringify({ slot: 3 }));
 ```
 
 In UE:
 
 ```cpp
-Bridge->OnMessage.AddDynamic(this, &AMyActor::HandleBridge);
+Surface->GetBridge()->OnMessage.AddDynamic(this, &AMyActor::HandleBridge);
+
+void AMyActor::HandleBridge(FName Channel, const FString& Payload)
+{
+	// Channel = "inventory.use", Payload = the JSON string
+}
 ```
+
+Push UE → JS:
+
+```cpp
+Surface->GetBridge()->Push(TEXT("market.update"), TEXT("{\"orders\":3}"));
+```
+
+The web page listens via `window.kbveBridge.onPush = (channel, payload) => { ... }`.
+
+## 7. Performance rails
+
+All wired into the component by default; tune in the details panel:
+
+- `Max Frame Rate` (default 30) — accumulator-driven `RequestRedraw` cadence.
+- `Pause When Offscreen` (default true) — gates redraw on `WasRecentlyRendered`.
+- `Snapshot Distance` (default 0 / off) — past this distance the surface freezes its last rendered frame and stops ticking the browser.
+
+`UKBVEWebLODManager` auto-registers surfaces on `BeginPlay`. `UKBVEWebSurfacePool` caps concurrent live surfaces (default 8).

--- a/packages/unreal/KBVEWebSurface/README.md
+++ b/packages/unreal/KBVEWebSurface/README.md
@@ -4,14 +4,16 @@ Game-agnostic Unreal Engine plugin for rendering interactive web content onto 3D
 
 ## Features
 
-- `UKBVEWebSurfaceComponent` — flat in-world web panel via `UWidgetComponent`.
+- `UKBVEWebSurfaceComponent` — flat in-world web panel via `UWidgetComponent`. Self-contained; no UMG `.uasset` required.
 - `UKBVEWebRenderSurfaceComponent` — render-to-texture path for curved meshes, holograms, CRT-style screens.
-- `AKBVEWebSurfaceActor` — drop-in actor for terminals and kiosks.
-- `UKBVEWebInputRouter` — line-trace → hit-UV → widget-pixel mapping for player interaction.
-- `UKBVEWebBridge` — typed JS↔UE message bus.
+- `AKBVEWebTerminalActor` — drop-in actor bundling mesh frame + surface + auth-aware load for one-step consumer integration.
+- `AKBVEWebSurfaceActor` — minimal surface-only actor (use when you supply your own framing).
+- `UKBVEWebInteractionComponent` — pre-configured `WidgetInteractionComponent` for flat-surface input.
+- `UKBVEWebBridge` — typed JS↔UE message bus, auto-bound via `UWebBrowser::BindUObject`.
 - `UKBVEWebSurfaceSettings` — URL allow/deny list and project-wide perf defaults.
-- `UKBVEWebLODManager` + `UKBVEWebSurfacePool` — frustum/distance LOD and concurrent-surface cap.
+- `UKBVEWebLODManager` + `UKBVEWebSurfacePool` — frustum/distance LOD and concurrent-surface cap. Components self-register.
 - Pluggable `IKBVEWebBackend` — default CEF backend, drop-in alternates (Ultralight, WebUI) ship as separate plugins.
+- `UKBVEWebInputRouter` — raw UV→pixel helper for curved meshes (deprecated for flat surfaces; superseded by `UKBVEWebInteractionComponent`).
 
 ## Engine
 

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Actors/KBVEWebTerminalActor.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Actors/KBVEWebTerminalActor.cpp
@@ -1,0 +1,36 @@
+#include "Actors/KBVEWebTerminalActor.h"
+
+#include "Components/KBVEWebSurfaceComponent.h"
+#include "Components/StaticMeshComponent.h"
+
+AKBVEWebTerminalActor::AKBVEWebTerminalActor()
+{
+	PrimaryActorTick.bCanEverTick = false;
+
+	Root = CreateDefaultSubobject<USceneComponent>(TEXT("Root"));
+	RootComponent = Root;
+
+	Frame = CreateDefaultSubobject<UStaticMeshComponent>(TEXT("Frame"));
+	Frame->SetupAttachment(Root);
+	Frame->SetCollisionProfileName(TEXT("BlockAllDynamic"));
+
+	Surface = CreateDefaultSubobject<UKBVEWebSurfaceComponent>(TEXT("Surface"));
+	Surface->SetupAttachment(Frame);
+	Surface->SetRelativeLocation(FVector(2.f, 0.f, 0.f));
+}
+
+void AKBVEWebTerminalActor::BeginPlay()
+{
+	Super::BeginPlay();
+	if (Surface && !InitialURL.IsEmpty())
+	{
+		if (AuthToken.IsEmpty())
+		{
+			Surface->LoadURL(InitialURL);
+		}
+		else
+		{
+			Surface->LoadURLWithFragmentToken(InitialURL, AuthToken);
+		}
+	}
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Bridge/KBVEWebBridge.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Bridge/KBVEWebBridge.cpp
@@ -2,20 +2,53 @@
 
 #include "WebBrowser.h"
 
-void UKBVEWebBridge::Receive(FName Channel, const FString& Payload)
+void UKBVEWebBridge::BindTo(UWebBrowser* Browser, FName BindName)
 {
-	OnMessage.Broadcast(Channel, Payload);
+	if (!Browser || BindName.IsNone())
+	{
+		return;
+	}
+	if (BoundBrowser.IsValid() && BoundBrowser.Get() == Browser && BoundName == BindName)
+	{
+		return;
+	}
+	Browser->BindUObject(BindName.ToString(), this, /*bIsPermanent=*/true);
+	BoundBrowser = Browser;
+	BoundName = BindName;
 }
 
-void UKBVEWebBridge::Send(UWebBrowser* Browser, FName Channel, const FString& Payload)
+void UKBVEWebBridge::UnbindFrom(UWebBrowser* Browser, FName BindName)
 {
-	if (!Browser)
+	if (!Browser || BindName.IsNone())
+	{
+		return;
+	}
+	Browser->UnbindUObject(BindName.ToString(), this, /*bIsPermanent=*/true);
+	if (BoundBrowser.Get() == Browser && BoundName == BindName)
+	{
+		BoundBrowser = nullptr;
+		BoundName = NAME_None;
+	}
+}
+
+void UKBVEWebBridge::Push(FName Channel, const FString& Payload)
+{
+	UWebBrowser* Browser = BoundBrowser.Get();
+	if (!Browser || BoundName.IsNone())
 	{
 		return;
 	}
 	const FString Script = FString::Printf(
-		TEXT("window.kbveBridge && window.kbveBridge.onMessage && window.kbveBridge.onMessage('%s', %s);"),
+		TEXT("window.%s && window.%s.onPush && window.%s.onPush('%s', %s);"),
+		*BoundName.ToString(),
+		*BoundName.ToString(),
+		*BoundName.ToString(),
 		*Channel.ToString(),
 		*Payload);
 	Browser->ExecuteJavascript(Script);
+}
+
+void UKBVEWebBridge::Dispatch(const FString& Channel, const FString& Payload)
+{
+	OnMessage.Broadcast(FName(*Channel), Payload);
 }

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebInteractionComponent.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebInteractionComponent.cpp
@@ -1,0 +1,11 @@
+#include "Components/KBVEWebInteractionComponent.h"
+
+UKBVEWebInteractionComponent::UKBVEWebInteractionComponent()
+{
+	InteractionDistance = 1000.f;
+	InteractionSource = EWidgetInteractionSource::World;
+	bEnableHitTesting = true;
+	bShowDebug = false;
+	TraceChannel = ECC_Visibility;
+	VirtualUserIndex = 0;
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebSurfaceComponent.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Components/KBVEWebSurfaceComponent.cpp
@@ -1,24 +1,41 @@
 #include "Components/KBVEWebSurfaceComponent.h"
 
 #include "KBVEWebSurface.h"
+#include "Bridge/KBVEWebBridge.h"
+#include "Perf/KBVEWebLODManager.h"
 #include "Settings/KBVEWebSurfaceSettings.h"
+#include "Widgets/KBVEWebSurfaceUserWidget.h"
 #include "WebBrowser.h"
 #include "Blueprint/UserWidget.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "GenericPlatform/GenericPlatformHttp.h"
+#include "Kismet/GameplayStatics.h"
 
 UKBVEWebSurfaceComponent::UKBVEWebSurfaceComponent()
 {
-	PrimaryComponentTick.bCanEverTick = false;
+	PrimaryComponentTick.bCanEverTick = true;
 	MaxFrameRate = 30;
 	bPauseWhenOffscreen = true;
 	SnapshotDistance = 0.f;
+	BridgeName = TEXT("kbveBridge");
+
 	SetWidgetSpace(EWidgetSpace::World);
 	SetDrawSize(FVector2D(1024.f, 768.f));
 	SetPivot(FVector2D(0.5f, 0.5f));
+	SetWidgetClass(UKBVEWebSurfaceUserWidget::StaticClass());
 }
 
 void UKBVEWebSurfaceComponent::BeginPlay()
 {
 	Super::BeginPlay();
+	if (UWorld* World = GetWorld())
+	{
+		if (UKBVEWebLODManager* LOD = World->GetSubsystem<UKBVEWebLODManager>())
+		{
+			LOD->Register(this);
+		}
+	}
 	if (!InitialURL.IsEmpty())
 	{
 		LoadURL(InitialURL);
@@ -27,8 +44,61 @@ void UKBVEWebSurfaceComponent::BeginPlay()
 
 void UKBVEWebSurfaceComponent::EndPlay(const EEndPlayReason::Type Reason)
 {
+	if (UWorld* World = GetWorld())
+	{
+		if (UKBVEWebLODManager* LOD = World->GetSubsystem<UKBVEWebLODManager>())
+		{
+			LOD->Unregister(this);
+		}
+	}
 	WebBrowser = nullptr;
+	Bridge = nullptr;
 	Super::EndPlay(Reason);
+}
+
+void UKBVEWebSurfaceComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+	if (SnapshotDistance > 0.f)
+	{
+		const float Dist = DistanceToLocalViewer();
+		if (Dist > 0.f && Dist > SnapshotDistance && State != EKBVEWebSurfaceState::Snapshot)
+		{
+			TransitionTo(EKBVEWebSurfaceState::Snapshot);
+		}
+		else if (Dist > 0.f && Dist <= SnapshotDistance && State == EKBVEWebSurfaceState::Snapshot)
+		{
+			TransitionTo(EKBVEWebSurfaceState::Live);
+		}
+	}
+
+	if (State == EKBVEWebSurfaceState::Snapshot)
+	{
+		return;
+	}
+
+	if (ShouldPauseForOffscreen())
+	{
+		if (State != EKBVEWebSurfaceState::Paused)
+		{
+			TransitionTo(EKBVEWebSurfaceState::Paused);
+		}
+		return;
+	}
+
+	if (State == EKBVEWebSurfaceState::Paused || State == EKBVEWebSurfaceState::Inactive)
+	{
+		TransitionTo(EKBVEWebSurfaceState::Live);
+	}
+
+	const float FrameInterval = 1.f / FMath::Max(1, MaxFrameRate);
+	RedrawAccumulator += DeltaTime;
+	if (RedrawAccumulator >= FrameInterval)
+	{
+		RedrawAccumulator = 0.f;
+		RequestRedraw();
+	}
 }
 
 void UKBVEWebSurfaceComponent::LoadURL(const FString& URL)
@@ -41,8 +111,17 @@ void UKBVEWebSurfaceComponent::LoadURL(const FString& URL)
 	}
 	if (UWebBrowser* Browser = ResolveBrowser())
 	{
+		EnsureBridge();
 		Browser->LoadURL(URL);
 	}
+}
+
+void UKBVEWebSurfaceComponent::LoadURLWithFragmentToken(const FString& URL, const FString& Token)
+{
+	const FString Combined = Token.IsEmpty()
+		? URL
+		: FString::Printf(TEXT("%s#kbve_token=%s"), *URL, *FGenericPlatformHttp::UrlEncode(Token));
+	LoadURL(Combined);
 }
 
 void UKBVEWebSurfaceComponent::ExecuteJavaScript(const FString& Script)
@@ -58,15 +137,69 @@ void UKBVEWebSurfaceComponent::Reload()
 	LoadURL(InitialURL);
 }
 
+UWebBrowser* UKBVEWebSurfaceComponent::GetWebBrowser()
+{
+	return ResolveBrowser();
+}
+
 UWebBrowser* UKBVEWebSurfaceComponent::ResolveBrowser()
 {
 	if (WebBrowser)
 	{
 		return WebBrowser;
 	}
-	if (UUserWidget* HostWidget = GetUserWidgetObject())
+	if (UKBVEWebSurfaceUserWidget* HostWidget = Cast<UKBVEWebSurfaceUserWidget>(GetUserWidgetObject()))
 	{
-		WebBrowser = Cast<UWebBrowser>(HostWidget->GetWidgetFromName(TEXT("WebBrowser")));
+		WebBrowser = HostWidget->Browser;
 	}
 	return WebBrowser;
+}
+
+void UKBVEWebSurfaceComponent::EnsureBridge()
+{
+	if (!Bridge)
+	{
+		Bridge = NewObject<UKBVEWebBridge>(this);
+	}
+	if (WebBrowser && Bridge)
+	{
+		Bridge->BindTo(WebBrowser, BridgeName);
+	}
+}
+
+void UKBVEWebSurfaceComponent::TransitionTo(EKBVEWebSurfaceState NewState)
+{
+	if (State == NewState)
+	{
+		return;
+	}
+	State = NewState;
+	OnStateChanged.Broadcast(NewState);
+}
+
+float UKBVEWebSurfaceComponent::DistanceToLocalViewer() const
+{
+	const UWorld* World = GetWorld();
+	if (!World)
+	{
+		return 0.f;
+	}
+	const APlayerController* PC = UGameplayStatics::GetPlayerController(World, 0);
+	if (!PC)
+	{
+		return 0.f;
+	}
+	FVector ViewLoc;
+	FRotator ViewRot;
+	PC->GetPlayerViewPoint(ViewLoc, ViewRot);
+	return FVector::Dist(ViewLoc, GetComponentLocation());
+}
+
+bool UKBVEWebSurfaceComponent::ShouldPauseForOffscreen() const
+{
+	if (!bPauseWhenOffscreen)
+	{
+		return false;
+	}
+	return !WasRecentlyRendered(0.5f);
 }

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Widgets/KBVEWebSurfaceUserWidget.cpp
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Private/Widgets/KBVEWebSurfaceUserWidget.cpp
@@ -1,0 +1,14 @@
+#include "Widgets/KBVEWebSurfaceUserWidget.h"
+
+#include "Blueprint/WidgetTree.h"
+#include "WebBrowser.h"
+
+TSharedRef<SWidget> UKBVEWebSurfaceUserWidget::RebuildWidget()
+{
+	if (WidgetTree && !WidgetTree->RootWidget)
+	{
+		Browser = WidgetTree->ConstructWidget<UWebBrowser>(UWebBrowser::StaticClass(), TEXT("WebBrowser"));
+		WidgetTree->RootWidget = Browser;
+	}
+	return Super::RebuildWidget();
+}

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Actors/KBVEWebTerminalActor.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Actors/KBVEWebTerminalActor.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "KBVEWebTerminalActor.generated.h"
+
+class UKBVEWebSurfaceComponent;
+class UStaticMeshComponent;
+
+/**
+ * Drop-in interactive terminal. Bundles a backing static mesh frame, a flat
+ * web surface, and the configuration any consumer needs. Designed to be the
+ * one-actor entry point for chuckrpg and other downstream Unreal projects.
+ */
+UCLASS(BlueprintType, Blueprintable, DisplayName = "KBVE Web Terminal")
+class KBVEWEBSURFACE_API AKBVEWebTerminalActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	AKBVEWebTerminalActor();
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "KBVE")
+	TObjectPtr<USceneComponent> Root;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "KBVE")
+	TObjectPtr<UStaticMeshComponent> Frame;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "KBVE")
+	TObjectPtr<UKBVEWebSurfaceComponent> Surface;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Terminal")
+	FString InitialURL;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Terminal")
+	FString AuthToken;
+
+protected:
+	virtual void BeginPlay() override;
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Bridge/KBVEWebBridge.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Bridge/KBVEWebBridge.h
@@ -2,13 +2,23 @@
 
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
+#include "UObject/WeakObjectPtr.h"
 #include "KBVEWebBridge.generated.h"
 
 class UWebBrowser;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FKBVEWebBridgeMessage, FName, Channel, const FString&, Payload);
 
-/** Typed JS↔UE message bus. Web pages publish via window.kbveBridge.send(channel, payload). */
+/**
+ * Typed JS↔UE message bus. The bridge is bound into a UWebBrowser instance via
+ * UWebBrowser::BindUObject, exposing UFUNCTIONs to JS as window.<BindName>.<func>.
+ *
+ *   // JS
+ *   window.kbveBridge.dispatch('inventory.use', JSON.stringify({ slot: 3 }));
+ *
+ *   // UE
+ *   Bridge->OnMessage.AddDynamic(this, &AMyActor::HandleBridge);
+ */
 UCLASS(BlueprintType)
 class KBVEWEBSURFACE_API UKBVEWebBridge : public UObject
 {
@@ -18,9 +28,16 @@ public:
 	UPROPERTY(BlueprintAssignable, Category = "KBVE|WebSurface|Bridge")
 	FKBVEWebBridgeMessage OnMessage;
 
-	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Bridge")
-	void Receive(FName Channel, const FString& Payload);
+	void BindTo(UWebBrowser* Browser, FName BindName);
+	void UnbindFrom(UWebBrowser* Browser, FName BindName);
 
 	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Bridge")
-	void Send(UWebBrowser* Browser, FName Channel, const FString& Payload);
+	void Push(FName Channel, const FString& Payload);
+
+	UFUNCTION()
+	void Dispatch(const FString& Channel, const FString& Payload);
+
+private:
+	TWeakObjectPtr<UWebBrowser> BoundBrowser;
+	FName BoundName;
 };

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebInteractionComponent.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebInteractionComponent.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/WidgetInteractionComponent.h"
+#include "KBVEWebInteractionComponent.generated.h"
+
+/**
+ * Pre-configured WidgetInteractionComponent for KBVE web surfaces.
+ *
+ * Attach to a player pawn / controller. Forwards mouse + key events to the
+ * 3D widget under the trace cursor. Hover/click/scroll work for flat surfaces
+ * via Unreal's built-in pipeline; no custom UV math required.
+ */
+UCLASS(ClassGroup = (KBVE), meta = (BlueprintSpawnableComponent), DisplayName = "KBVE Web Interaction")
+class KBVEWEBSURFACE_API UKBVEWebInteractionComponent : public UWidgetInteractionComponent
+{
+	GENERATED_BODY()
+
+public:
+	UKBVEWebInteractionComponent();
+};

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebSurfaceComponent.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Components/KBVEWebSurfaceComponent.h
@@ -5,8 +5,20 @@
 #include "KBVEWebSurfaceComponent.generated.h"
 
 class UWebBrowser;
+class UKBVEWebBridge;
 
-/** Flat in-world web surface backed by a UMG WebBrowser widget. */
+UENUM(BlueprintType)
+enum class EKBVEWebSurfaceState : uint8
+{
+	Inactive,
+	Live,
+	Paused,
+	Snapshot
+};
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FKBVEWebSurfaceStateChanged, EKBVEWebSurfaceState, NewState);
+
+/** Flat in-world web surface. Self-contained — needs no UMG asset to function. */
 UCLASS(ClassGroup = (KBVE), meta = (BlueprintSpawnableComponent), DisplayName = "KBVE Web Surface")
 class KBVEWEBSURFACE_API UKBVEWebSurfaceComponent : public UWidgetComponent
 {
@@ -18,7 +30,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface")
 	FString InitialURL;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Perf", meta = (ClampMin = "0", ClampMax = "120"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Perf", meta = (ClampMin = "1", ClampMax = "120"))
 	int32 MaxFrameRate;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Perf")
@@ -27,8 +39,17 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Perf", meta = (ClampMin = "0"))
 	float SnapshotDistance;
 
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|WebSurface|Bridge")
+	FName BridgeName;
+
+	UPROPERTY(BlueprintAssignable, Category = "KBVE|WebSurface")
+	FKBVEWebSurfaceStateChanged OnStateChanged;
+
 	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface")
 	void LoadURL(const FString& URL);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface")
+	void LoadURLWithFragmentToken(const FString& URL, const FString& Token);
 
 	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface")
 	void ExecuteJavaScript(const FString& Script);
@@ -36,13 +57,33 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface")
 	void Reload();
 
+	UFUNCTION(BlueprintPure, Category = "KBVE|WebSurface")
+	UKBVEWebBridge* GetBridge() const { return Bridge; }
+
+	UFUNCTION(BlueprintPure, Category = "KBVE|WebSurface")
+	EKBVEWebSurfaceState GetState() const { return State; }
+
+	UFUNCTION(BlueprintPure, Category = "KBVE|WebSurface")
+	UWebBrowser* GetWebBrowser();
+
 protected:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type Reason) override;
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
 private:
 	UPROPERTY(Transient)
 	TObjectPtr<UWebBrowser> WebBrowser;
 
+	UPROPERTY(Transient)
+	TObjectPtr<UKBVEWebBridge> Bridge;
+
+	EKBVEWebSurfaceState State = EKBVEWebSurfaceState::Inactive;
+	float RedrawAccumulator = 0.f;
+
 	UWebBrowser* ResolveBrowser();
+	void EnsureBridge();
+	void TransitionTo(EKBVEWebSurfaceState NewState);
+	float DistanceToLocalViewer() const;
+	bool ShouldPauseForOffscreen() const;
 };

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Input/KBVEWebInputRouter.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Input/KBVEWebInputRouter.h
@@ -5,16 +5,22 @@
 #include "Engine/HitResult.h"
 #include "KBVEWebInputRouter.generated.h"
 
-/** Maps line trace hits on a web surface into 2D widget-pixel coordinates. */
-UCLASS(BlueprintType)
+/**
+ * Maps line trace hits on a web surface into 2D widget-pixel coordinates.
+ *
+ * Prefer UKBVEWebInteractionComponent for flat surfaces. This helper remains
+ * useful when raw UV math is needed for curved meshes; that path will fold
+ * into UKBVEWebRenderSurfaceComponent in a future release.
+ */
+UCLASS(BlueprintType, meta = (DeprecatedNode, DeprecationMessage = "Use UKBVEWebInteractionComponent for flat surfaces."))
 class KBVEWEBSURFACE_API UKBVEWebInputRouter : public UObject
 {
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Input")
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Input", meta = (DeprecatedFunction, DeprecationMessage = "Use UKBVEWebInteractionComponent for flat surfaces."))
 	static FVector2D HitToWidgetCoord(const FHitResult& Hit, FIntPoint WidgetSize);
 
-	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Input")
+	UFUNCTION(BlueprintCallable, Category = "KBVE|WebSurface|Input", meta = (DeprecatedFunction, DeprecationMessage = "Use UKBVEWebInteractionComponent for flat surfaces."))
 	static bool TraceForSurface(class AActor* Instigator, float MaxDistance, FHitResult& OutHit);
 };

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Widgets/KBVEWebSurfaceUserWidget.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Widgets/KBVEWebSurfaceUserWidget.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "KBVEWebSurfaceUserWidget.generated.h"
+
+class UWebBrowser;
+
+/** Code-only UMG widget that hosts a single UWebBrowser as its root. */
+UCLASS()
+class KBVEWEBSURFACE_API UKBVEWebSurfaceUserWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(BlueprintReadOnly, Category = "KBVE|WebSurface", meta = (BindWidgetOptional))
+	TObjectPtr<UWebBrowser> Browser;
+
+protected:
+	virtual TSharedRef<SWidget> RebuildWidget() override;
+};


### PR DESCRIPTION
## Summary

Phase 1 streamlining of `packages/unreal/KBVEWebSurface` to make it drop-in for `chuckrpg` and any future Unreal project. Closes the gaps that would have forced consumers to wire bespoke glue around the v0.1.0 scaffold.

### What changed

- **No UMG asset required.** New code-only `UKBVEWebSurfaceUserWidget` builds its `UWebBrowser` root in `RebuildWidget`. `UKBVEWebSurfaceComponent` defaults its `WidgetClass` to it.
- **Perf rails are real.** `TickComponent` drives a `MaxFrameRate` accumulator → `RequestRedraw`, gates redraw on `WasRecentlyRendered` when `bPauseWhenOffscreen`, and freezes the last rendered frame past `SnapshotDistance`. Emits `OnStateChanged` (Inactive / Live / Paused / Snapshot).
- **LOD manager auto-registers.** Components register on `BeginPlay`, unregister on `EndPlay`. Consumers don't have to remember.
- **Auth helper.** `LoadURLWithFragmentToken(URL, Token)` appends `#kbve_token=<encoded>` so kbve.com pages can hydrate from the fragment without a separate login round-trip (avoids cookie cross-origin headaches).
- **Bridge via `BindUObject`.** `UKBVEWebBridge::BindTo` exposes UFUNCTIONs to JS as `window.<BridgeName>.<Func>`. `Push()` retains the JS-side fanout. Bridge auto-binds on `LoadURL`.
- **`UKBVEWebInteractionComponent`** — pre-configured `WidgetInteractionComponent` so consumers get hover/click/scroll on flat surfaces without inventing input plumbing.
- **`AKBVEWebTerminalActor`** — one-actor drop-in bundling mesh frame + surface + auth-aware load. Intended as the default consumer entry point.
- **`UKBVEWebInputRouter` deprecated for flat surfaces** (still useful for curved-mesh raw UV math until the render surface absorbs that path).

### Out of scope

- Curved-mesh input mapping into the render surface — next.
- Snapshot mode currently freezes the existing widget RT (no separate baked texture yet). Sufficient for perf, full pre-bake later.
- Ultralight backend addon.
- chuckrpg consumer — separate follow-up PR.

### Test plan

- [ ] `utils-unreal-plugin-cicd.yml` matrix build (Linux, UE 5.6) succeeds for `packages/unreal/KBVEWebSurface`.
- [ ] Allowlist automation tests still pass (`KBVE.WebSurface.Settings.*`).
- [ ] Drop `AKBVEWebTerminalActor` in a sandbox map, point `Initial URL` at `https://kbve.com/`, verify rendering with no extra setup.
- [ ] Attach `UKBVEWebInteractionComponent` to a pawn, verify hover + click work against the flat surface.
- [ ] Walk past `SnapshotDistance`, confirm surface state transitions to Snapshot (no browser tick).
- [ ] Trigger a `window.kbveBridge.Dispatch("test", "{}")` call from a page, confirm `OnMessage` fires in UE.