### PR TITLE
fix(kube): wire chuckrpg + cityvote into Cilium Gateway

### DIFF
--- a/apps/kube/chuckrpg/manifest/kustomization.yaml
+++ b/apps/kube/chuckrpg/manifest/kustomization.yaml
@@ -1,10 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: cityvote
+namespace: chuckrpg
 
 resources:
-    - cityvote-serviceaccount.yaml
-    - cityvote-deployment.yaml
+    - namespace.yaml
+    - serviceaccount.yaml
+    - configmap.yaml
+    - deployment.yaml
     - httproute.yaml
     - certificate.yaml
     - reference-grant.yaml

--- a/apps/kube/cityvote/manifest/certificate.yaml
+++ b/apps/kube/cityvote/manifest/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: cityvote-tls
+    namespace: cityvote
+spec:
+    secretName: cityvote-tls
+    dnsNames:
+        - cityvote.com
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+        group: cert-manager.io

--- a/apps/kube/cityvote/manifest/httproute.yaml
+++ b/apps/kube/cityvote/manifest/httproute.yaml
@@ -14,6 +14,8 @@ spec:
               - path:
                     type: PathPrefix
                     value: /
+          timeouts:
+              backendRequest: 3600s
           backendRefs:
               - name: cityvote-service
                 port: 4321

--- a/apps/kube/cityvote/manifest/reference-grant.yaml
+++ b/apps/kube/cityvote/manifest/reference-grant.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+    name: allow-gateway-tls
+    namespace: cityvote
+spec:
+    from:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          namespace: kbve
+    to:
+        - group: ''
+          kind: Secret

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -156,7 +156,21 @@ spec:
                   - kind: Secret
                     group: ''
                     name: chuckrpg-api-tls
-                    namespace: rows
+                    namespace: chuckrpg
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-cityvote
+          protocol: HTTPS
+          port: 443
+          hostname: cityvote.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: cityvote-tls
+                    namespace: cityvote
           allowedRoutes:
               namespaces:
                   from: All


### PR DESCRIPTION
## Summary

Follow-up to #11551 (ingress-nginx drop). Finishes wiring `chuckrpg.com`, `api.chuckrpg.com`, and `cityvote.com` through the Cilium `kbve-gateway`.

### Fixes
- **kbve-gateway**: `https-chuckrpg-api` listener referenced `chuckrpg-api-tls` in `namespace: rows` — secret doesn't exist there. Corrected to `chuckrpg` ns where `certificate.yaml` mints it. Was almost certainly the reason `api.chuckrpg.com` was still 5xxing through Envoy.
- **kbve-gateway**: added `https-cityvote` listener for `cityvote.com` (was missing entirely).

### Adds
- `apps/kube/chuckrpg/manifest/kustomization.yaml` — directory mode was applying resources in undefined order; now namespace → SA → configmap → deployment → httproute → cert → reference-grant.
- `apps/kube/cityvote/manifest/certificate.yaml` — `letsencrypt-http` cert for `cityvote.com` (mirrors cryptothrone pattern).
- `apps/kube/cityvote/manifest/reference-grant.yaml` — allows `kbve` ns Gateway to read `cityvote-tls` Secret.
- `apps/kube/cityvote/manifest/httproute.yaml` — `backendRequest: 3600s` because cityvote.com carries WebSocket traffic and default Envoy ~15s timeout kills sessions (matches `kbve.com/ws`, `cryptothrone`).
- `apps/kube/cityvote/manifest/kustomization.yaml` — registers new cert + reference-grant.

### Cloudflare DNS (manual, post-merge)
All three hostnames must resolve to the Cilium gateway VIP before HTTP-01 issuance can complete:
- `chuckrpg.com` CNAME → `gateway.kbve.com` (or A `142.132.206.71`)
- `api.chuckrpg.com` CNAME → `gateway.kbve.com`
- `cityvote.com` CNAME → `gateway.kbve.com`

Per `MIGRATION.md` Wave 3, do not split apex+www across listeners with one SAN cert — single listener per cert.

## Test plan

- [ ] After merge to main + ArgoCD sync, verify Gateway shows new listeners `Programmed=True`, `ResolvedRefs=True`.
- [ ] Confirm Certificates `chuckrpg-tls`, `chuckrpg-api-tls`, `cityvote-tls` reach `Ready=True` (requires Cloudflare DNS update).
- [ ] `curl -kI https://chuckrpg.com`, `https://api.chuckrpg.com`, `https://cityvote.com` from outside the cluster return 200.
- [ ] WebSocket on `cityvote.com` survives >1 min (timeout no longer kills it).
- [ ] `hubble observe --namespace chuckrpg --label app=chuckrpg` shows traffic landing on the right service.