### PR TITLE
fix(cert-manager): migrate ACME HTTP-01 solvers to Cilium gateway

### DIFF
--- a/apps/kube/cert-manager/manifests/cluster-issuer.yaml
+++ b/apps/kube/cert-manager/manifests/cluster-issuer.yaml
@@ -9,45 +9,51 @@ spec:
         privateKeySecretRef:
             name: letsencrypt-http-private-key
         solvers:
+            # All solvers use the Cilium kbve-gateway HTTP listener for
+            # ACME HTTP-01 challenges. ingress-nginx was removed in
+            # PR #11551; the old nginx solver template silently created
+            # Ingress resources that no controller picked up, so every
+            # cert that hit a renewal afterwards landed back on the
+            # placeholder "Kubernetes Ingress Controller Fake Certificate"
+            # — which is what Cloudflare 526 on cryptothrone.com surfaced.
+
             # --- Solver 1: KBVE.COM domains ---
             - selector:
                   dnsZones:
                       - kbve.com
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 
             # --- Solver 2: DISCORD.SH domains ---
             - selector:
                   dnsZones:
                       - discord.sh
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 
             # --- Solver 3: HERBMAIL.COM domains ---
             - selector:
                   dnsZones:
                       - herbmail.com
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 
             # --- Solver 4: MEME.SH domains ---
-            # Migrated to Cilium Gateway HTTPRoute solver post-Phase-2 cutover.
-            # meme.sh CNAME -> gateway.kbve.com (.71); nginx no longer serves it.
             - selector:
                   dnsZones:
                       - meme.sh
@@ -64,42 +70,48 @@ spec:
                   dnsZones:
                       - cryptothrone.com
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 
             # --- Solver 6: CHUCKRPG.COM domains ---
-            # Stays on the nginx solver until the Cilium gateway VIP (.71)
-            # is reachable from Let's Encrypt; until then nginx-on-.74 is
-            # the only path that completes HTTP-01.
             - selector:
                   dnsZones:
                       - chuckrpg.com
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 
             # --- Solver 7: RAREICON.COM domains ---
-            # Stays on the nginx solver until the Cilium gateway VIP (.71)
-            # is reachable from Let's Encrypt; until then nginx-on-.74 is
-            # the only path that completes HTTP-01.
             - selector:
                   dnsZones:
                       - rareicon.com
               http01:
-                  ingress:
-                      ingressClassName: nginx
-                      ingressTemplate:
-                          metadata:
-                              annotations:
-                                  cert-manager.io/http01-ingress-path-type: 'Prefix'
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
+
+            # --- Solver 8: CITYVOTE.COM domains ---
+            - selector:
+                  dnsZones:
+                      - cityvote.com
+              http01:
+                  gatewayHTTPRoute:
+                      parentRefs:
+                          - name: kbve-gateway
+                            namespace: kbve
+                            kind: Gateway
+                            group: gateway.networking.k8s.io
 ---
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer


### PR DESCRIPTION
## Summary

cryptothrone.com (and every other LE-issued cert) is back on the placeholder \`Kubernetes Ingress Controller Fake Certificate\` after the nginx drop in #11551 — Cloudflare Full(Strict) returns HTTP 526 against the broken origin.

Root cause: six of seven \`letsencrypt-http\` ClusterIssuer solvers still reference \`ingressClassName: nginx\`. cert-manager keeps creating Ingress objects, no controller picks them up, ACME HTTP-01 never serves the challenge token, renewals fail silently.

## Changes

\`apps/kube/cert-manager/manifests/cluster-issuer.yaml\`:
- Solvers 1, 2, 3, 5, 6, 7 (kbve.com, discord.sh, herbmail.com, cryptothrone.com, chuckrpg.com, rareicon.com) → \`gatewayHTTPRoute\` pointing at \`kbve-gateway\` in \`kbve\` ns (matches solver 4 / meme.sh which was migrated in #11551).
- New solver 8 for \`cityvote.com\` so the Certificate added in #11787 has a matching solver and can actually issue.
- Drop stale "stays on nginx until .71 is reachable" notes — that was the pre-cutover state.

The kbve-gateway HTTP listener already has \`allowedRoutes.namespaces.from: All\`, so cert-manager's HTTPRoutes attach cleanly from every namespace.

## Cloudflare check (manual)

For each apex (cryptothrone.com, chuckrpg.com, api.chuckrpg.com, cityvote.com, kbve.com, discord.sh, herbmail.com, meme.sh, rareicon.com):
- Confirm "Always Use HTTPS" or page rules don't 301 \`/.well-known/acme-challenge/\` before it reaches origin :80.
- Cloudflare normally auto-allows ACME challenges through, but worth verifying for the long-stuck zones.

## Test plan

- [ ] After dev→main release + ArgoCD sync, \`kubectl get certificate -A\` shows previously stuck certs flip to \`Ready=True\`.
- [ ] \`echo | openssl s_client -servername cryptothrone.com -connect 142.132.206.71:443\` returns a Let's Encrypt cert (not Acme Co fake cert).
- [ ] \`curl -I https://cryptothrone.com\` returns 200 (not CF 526).
- [ ] Same for chuckrpg.com, api.chuckrpg.com, cityvote.com.
- [ ] \`kubectl get challenge -A\` empty (no stuck pending challenges).