### PR TITLE
feat(kubevirt/autologon): KEDA ScaledJob fires on VM boot, CronJob drops to 30m

### DIFF
--- a/apps/kube/kubevirt/autologon/job.yaml
+++ b/apps/kube/kubevirt/autologon/job.yaml
@@ -46,7 +46,12 @@ metadata:
         app: angelscript
         component: vm-autologon
 spec:
-    schedule: '*/5 * * * *'
+    # Safety-net cadence only. The fast on-boot trigger lives in
+    # scaled-job.yaml (KEDA kubernetes-workload watching for the
+    # virt-launcher pod). The CronJob picks up registry drift (someone
+    # toggling autologon off mid-session, a partial bootstrap run) at a
+    # low cadence so it doesn't spam pods while the VM is up.
+    schedule: '*/30 * * * *'
     timeZone: UTC
     concurrencyPolicy: Forbid
     successfulJobsHistoryLimit: 1

--- a/apps/kube/kubevirt/autologon/scaled-job.yaml
+++ b/apps/kube/kubevirt/autologon/scaled-job.yaml
@@ -1,0 +1,89 @@
+# KEDA ScaledJob — fast on-boot trigger for the Windows autologon /
+# bootstrap script.
+#
+# Watches for a virt-launcher pod belonging to windows-builder via the
+# kubernetes-workload scaler. When the VM transitions Stopped → Running
+# (i.e. the virt-launcher pod appears) KEDA spawns the bootstrap Job
+# within `pollingInterval` seconds, so autologon registry keys, NTP
+# resync, proxy env, and TLS 1.2 keys are applied within ~30 s of VM
+# boot instead of waiting up to the safety-net CronJob's 30-minute
+# cadence.
+#
+# This Job and the safety-net CronJob in job.yaml share the
+# `vm-autologon-script` ConfigMap and the same RBAC, so both paths
+# execute the same idempotent script. The Job soft-skips with exit 0
+# when the VMI is absent or the guest agent isn't yet connected, so a
+# spurious fire (e.g. KEDA polling during a VM restart) is harmless.
+#
+# Why ScaledJob and not just a tighter CronJob: the CronJob fires on
+# wall-clock regardless of VM state and would either burn pods every
+# minute while idle or be too slow on boot. ScaledJob fires only when
+# the virt-launcher pod actually exists, giving fast boot detection
+# with zero churn while the VM is Stopped.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+    name: vm-autologon-windows-on-boot
+    namespace: angelscript
+    labels:
+        app: angelscript
+        component: vm-autologon
+spec:
+    pollingInterval: 30
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 2
+    maxReplicaCount: 1
+    triggers:
+        - type: kubernetes-workload
+          metadata:
+              podSelector: 'vm.kubevirt.io/name=windows-builder'
+              value: '1'
+    jobTargetRef:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 3
+        ttlSecondsAfterFinished: 600
+        template:
+            metadata:
+                labels:
+                    component: vm-autologon
+            spec:
+                serviceAccountName: vm-scaler
+                restartPolicy: OnFailure
+                securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 10001
+                    runAsGroup: 10001
+                    seccompProfile:
+                        type: RuntimeDefault
+                containers:
+                    - name: autologon
+                      image: ghcr.io/kbve/kubectl:0.1.3
+                      command: ['/bin/sh', '/scripts/autologon.sh']
+                      securityContext:
+                          allowPrivilegeEscalation: false
+                          readOnlyRootFilesystem: true
+                          capabilities:
+                              drop: ['ALL']
+                      env:
+                          - name: VM_NAME
+                            value: windows-builder
+                          - name: NAMESPACE
+                            value: angelscript
+                          - name: ADMIN_PASSWORD
+                            valueFrom:
+                                secretKeyRef:
+                                    name: windows-builder-admin
+                                    key: password
+                      volumeMounts:
+                          - name: script
+                            mountPath: /scripts
+                          - name: tmp
+                            mountPath: /tmp
+                volumes:
+                    - name: script
+                      configMap:
+                          name: vm-autologon-script
+                          defaultMode: 0755
+                    - name: tmp
+                      emptyDir: {}


### PR DESCRIPTION
## Summary
Hybrid trigger for the windows-builder bootstrap script so autologon registry keys, NTP resync, proxy env, and TLS 1.2 keys land seconds after VM boot instead of waiting up to 5 min for the next CronJob tick.

1. **KEDA \`ScaledJob\` \`vm-autologon-windows-on-boot\`** — \`kubernetes-workload\` trigger watching for a \`virt-launcher\` pod with \`vm.kubevirt.io/name=windows-builder\`. When the VM transitions \`Stopped → Running\` the pod appears, KEDA polls within \`pollingInterval: 30\` s, and a fresh bootstrap Job is spawned. Zero churn while the VM is Stopped.
2. **Existing CronJob \`vm-autologon-windows\`** drops from \`*/5\` → \`*/30\`. Stays purely as the drift safety net: catches the rare case where someone manually toggles autologon off mid-session or a previous Job partially failed.

Both Jobs share the same \`vm-autologon-script\` ConfigMap, the same \`vm-scaler\` ServiceAccount, and the same idempotent shell script that soft-skips with \`exit 0\` when the VMI is absent or the guest agent isn't connected. A spurious ScaledJob fire (e.g. KEDA polling during a VM restart) is harmless.

## Test plan
- [ ] After ArgoCD syncs: \`kubectl get scaledjob vm-autologon-windows-on-boot -n angelscript\` reports READY=True, plus the existing \`vm-autologon-windows\` CronJob now shows \`*/30 * * * *\`.
- [ ] With VM Stopped: no new \`vm-autologon-windows-on-boot-*\` Jobs are created over a 5 min window.
- [ ] \`virtctl start windows-builder -n angelscript\` → within ≤30 s, \`kubectl get jobs -n angelscript -l component=vm-autologon\` shows a new ScaledJob-spawned Job. Pod logs print every step \`OK\`.
- [ ] After the first bootstrap pass succeeds and the VM reboots once, VNC console comes up at the Administrator desktop (autologon active).
- [ ] Subsequent ScaledJob fires while the VM stays up are idempotent (registry already set, script re-applies cleanly).
- [ ] Drift test: manually \`Set-ItemProperty AutoAdminLogon -Value 0\` inside the VM. Within 30 min the safety-net CronJob restores it to \`1\`.