### PR TITLE
chore: strip chatty comments across windows-builder VM bootstrap stack

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -3,25 +3,18 @@ import { useStore } from '@nanostores/react';
 import { vmService } from './vmService';
 import { X, Maximize2, Minimize2, Keyboard, Users, Crown } from 'lucide-react';
 
-// noVNC RFB client — loaded from vendored ESM in public/vendor/novnc/.
-// The npm package (@novnc/novnc) ships CJS with a top-level await in
-// browser.js that Rollup cannot parse, so it cannot be bundled directly.
-// Vendored ESM (from noVNC GitHub) is the primary path; npm kept as
-// @vite-ignore dev fallback only.
 let RFB: any = null;
 async function loadRFB() {
 	if (!RFB) {
 		try {
-			// Primary: vendored ESM — bypasses Vite module graph via full URL
 			const vendorUrl = `${window.location.origin}/vendor/novnc/core/rfb.js`;
 			const mod = await import(/* @vite-ignore */ vendorUrl);
 			RFB = mod.default ?? mod;
 		} catch (vendorErr) {
 			console.warn('noVNC vendored ESM failed:', vendorErr);
 			try {
-				// Fallback: npm package (dev mode only, not bundleable)
 				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore — @novnc/novnc has no type declarations
+				// @ts-ignore
 				const mod = await import(
 					/* @vite-ignore */ '@novnc/novnc/lib/rfb'
 				);
@@ -58,7 +51,6 @@ export default function ReactVMVncViewer() {
 	);
 	const intentionalCloseRef = useRef(false);
 
-	// Poll viewer count while connected
 	useEffect(() => {
 		if (!vncTarget || !connected) {
 			setViewerCount(0);
@@ -74,7 +66,7 @@ export default function ReactVMVncViewer() {
 					setIsPrimary(info.has_primary);
 				}
 			} catch {
-				// Silently ignore — the connection may have dropped
+				/* ignore */
 			}
 		};
 
@@ -150,7 +142,6 @@ export default function ReactVMVncViewer() {
 						setStatus('Connection lost — attempting reconnect...');
 					}
 
-					// Auto-reconnect on unexpected disconnects
 					if (reconnectAttemptRef.current < MAX_RECONNECT_ATTEMPTS) {
 						reconnectAttemptRef.current += 1;
 						const delay =
@@ -252,7 +243,6 @@ export default function ReactVMVncViewer() {
 		}
 	}, []);
 
-	// Manual retry handler
 	const handleRetry = useCallback(() => {
 		if (vncTarget && !connected) {
 			reconnectAttemptRef.current = 0;
@@ -260,12 +250,10 @@ export default function ReactVMVncViewer() {
 		}
 	}, [vncTarget, connected, connectVNC]);
 
-	// Ctrl+Alt+Del sender
 	const sendCtrlAltDel = useCallback(() => {
 		rfbRef.current?.sendCtrlAltDel();
 	}, []);
 
-	// Toggle virtual keyboard (mobile/tablet)
 	const toggleKeyboard = useCallback(() => {
 		if (rfbRef.current) {
 			rfbRef.current.focusOnClick = !keyboardVisible;
@@ -295,7 +283,6 @@ export default function ReactVMVncViewer() {
 				flexDirection: 'column',
 				height: fullscreen ? '100vh' : undefined,
 			}}>
-			{/* noVNC renders into this container */}
 			<div
 				ref={viewerRef}
 				onClick={!connected ? handleRetry : undefined}
@@ -312,7 +299,6 @@ export default function ReactVMVncViewer() {
 				}}
 			/>
 
-			{/* Bottom toolbar — controls + status */}
 			<div
 				style={{
 					borderTop: '1px solid var(--sl-color-gray-5, #30363d)',
@@ -354,7 +340,6 @@ export default function ReactVMVncViewer() {
 							}}>
 							{status}
 						</span>
-						{/* Viewer count badge */}
 						{connected && viewerCount > 0 && (
 							<span
 								style={{

--- a/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
+++ b/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
@@ -1,51 +1,3 @@
-//! Multi-viewer VNC proxy hub.
-//!
-//! KubeVirt only allows a single VNC client per VMI — the second client to
-//! connect evicts the first. This module fans one upstream connection out
-//! to any number of viewers, so multiple staff members can watch the same
-//! console at the same time.
-//!
-//! ## Protocol notes
-//!
-//! RFB is stateful: the server sends ProtocolVersion, a list of security
-//! types, a SecurityResult, and a ServerInit (which carries the framebuffer
-//! dimensions + pixel format). Only after ServerInit can framebuffer
-//! updates flow. A late joiner whose RFB client skips straight to Normal
-//! mode will not understand subsequent bytes — it needs the handshake plus
-//! an initial full framebuffer.
-//!
-//! We don't parse RFB. Instead we keep a bounded cache of every byte the
-//! upstream has sent since session start; since the very first thing any
-//! viewer requests after ServerInit is a full framebuffer update, the
-//! cache naturally contains everything a late joiner needs (up to its
-//! size cap). Late joiners replay the cache, then subscribe to a broadcast
-//! channel of live upstream bytes — their client advances through its RFB
-//! state machine using the replayed bytes exactly as if it were the first
-//! connection.
-//!
-//! ## Input arbitration
-//!
-//! Every viewer's RFB client messages — keystrokes, mouse moves, clipboard
-//! cuts, SetEncodings, FBUR, etc. — are forwarded to the single upstream
-//! connection. The upstream `upstream_sink` mutex serializes concurrent
-//! writes so the RFB framing on the wire stays coherent. From KubeVirt's
-//! point of view there is still one RFB client; from the staff side every
-//! viewer can type and click.
-//!
-//! Concurrent input (two cursors moving at once) lands on the same shared
-//! desktop and will fight on the wire — this is the same model used by
-//! shared screen-control tools and is the intended behaviour for pair
-//! debug. The `primary_id` field is kept as an informational marker of
-//! who joined first (surfaced in the viewer UI) but no longer gates input.
-//!
-//! ## Cache bound + drift
-//!
-//! The cache is capped at 4 MiB. For typical KubeVirt consoles that's
-//! comfortably enough for handshake (< 1 KB) plus the initial full frame
-//! (usually 100-500 KB for 1024x768). If the cap is hit we stop appending
-//! to the cache — new joiners may see a stale framebuffer until the next
-//! full refresh, but no live bytes are dropped.
-
 use axum::body::Bytes;
 use axum::extract::ws::{Message as AxumMsg, WebSocket};
 use dashmap::DashMap;
@@ -65,16 +17,12 @@ type UpstreamWs =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 type UpstreamSink = futures_util::stream::SplitSink<UpstreamWs, TungMsg>;
 
-/// Per-VM shared VNC session. Torn down when the last viewer leaves.
 pub struct VncSession {
     vm_key: String,
-    /// Replay buffer bounded by `MAX_CACHE_BYTES`; new viewers replay this
-    /// before subscribing to the live broadcast.
     cache: Mutex<Vec<u8>>,
     broadcast: broadcast::Sender<Bytes>,
     upstream_sink: Mutex<Option<UpstreamSink>>,
     clients: AtomicUsize,
-    /// `0` = no primary; the next client to send input CASes itself in.
     primary_id: AtomicUsize,
 }
 
@@ -85,7 +33,6 @@ fn sessions() -> &'static DashMap<String, Arc<VncSession>> {
     SESSIONS.get_or_init(DashMap::new)
 }
 
-/// Snapshot of a VNC session's state, returned by the info endpoint.
 #[derive(Serialize)]
 pub struct SessionInfo {
     pub vm_key: String,
@@ -93,8 +40,6 @@ pub struct SessionInfo {
     pub has_primary: bool,
 }
 
-/// Query session info for a specific VM key. Returns `None` if no active
-/// session exists (i.e. no one is currently connected to that VM's VNC).
 pub fn get_session_info(vm_key: &str) -> Option<SessionInfo> {
     let registry = sessions();
     registry.get(vm_key).map(|session| SessionInfo {
@@ -104,7 +49,6 @@ pub fn get_session_info(vm_key: &str) -> Option<SessionInfo> {
     })
 }
 
-/// List all active VNC sessions with their viewer counts.
 pub fn list_sessions() -> Vec<SessionInfo> {
     let registry = sessions();
     registry
@@ -120,7 +64,6 @@ pub fn list_sessions() -> Vec<SessionInfo> {
         .collect()
 }
 
-/// Per-upstream connection knobs supplied by the caller.
 pub struct UpstreamConfig {
     pub auth_header: Option<HeaderValue>,
     pub origin: Option<HeaderValue>,
@@ -129,7 +72,6 @@ pub struct UpstreamConfig {
 }
 
 impl UpstreamConfig {
-    /// KubeVirt VNC subresource defaults.
     pub fn kubevirt(
         bearer_token: Option<String>,
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
@@ -146,9 +88,6 @@ impl UpstreamConfig {
     }
 }
 
-/// Entry point used by the HTTP handler. Finds or creates the session for
-/// this VM key, attaches this browser viewer, and runs the full client
-/// lifecycle until the browser disconnects or the session tears down.
 pub async fn join_session(
     vm_key: String,
     upstream_url: String,
@@ -218,8 +157,6 @@ pub async fn join_session_with_config(
     result
 }
 
-/// Open a fresh upstream WebSocket to the configured backend and spawn
-/// the background reader task that feeds the cache + broadcast channel.
 async fn create_session(
     vm_key: String,
     upstream_url: String,
@@ -299,9 +236,6 @@ async fn create_session(
     Ok(session)
 }
 
-/// Drive a single browser viewer: replay the handshake cache, then pump
-/// bytes in both directions (with primary-only input gating) until one
-/// side closes.
 async fn run_client(
     session: Arc<VncSession>,
     client_id: usize,
@@ -309,8 +243,6 @@ async fn run_client(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let (mut browser_tx, mut browser_rx) = browser_ws.split();
 
-    // Atomic snapshot + subscribe: hold the cache lock across both so the
-    // upstream reader cannot interleave a broadcast that we'd miss.
     let (cache_snapshot, mut live_rx) = {
         let cache = session.cache.lock().await;
         let rx = session.broadcast.subscribe();
@@ -318,8 +250,6 @@ async fn run_client(
     };
 
     if !cache_snapshot.is_empty() {
-        // K8s VNC uses the binary.k8s.io subprotocol; one Binary frame is
-        // fine because noVNC re-frames internally on RFB boundaries.
         if browser_tx
             .send(AxumMsg::Binary(Bytes::from(cache_snapshot)))
             .await
@@ -339,9 +269,6 @@ async fn run_client(
                 _ => continue,
             };
 
-            // Multi-master: every viewer's input flows to upstream. The
-            // sink mutex serializes concurrent writes so RFB framing on
-            // the wire stays intact even when two viewers type at once.
             let mut guard = session_input.upstream_sink.lock().await;
             match guard.as_mut() {
                 Some(sink) => {
@@ -362,8 +289,6 @@ async fn run_client(
                         break;
                     }
                 }
-                // Continuing on lag beats killing the viewer; lost bytes
-                // are unrecoverable but the next full refresh resyncs.
                 Err(broadcast::error::RecvError::Lagged(skipped)) => {
                     warn!(
                         "VNC hub: client {} lagged, skipped {} frames",
@@ -389,9 +314,6 @@ async fn run_client(
     Ok(())
 }
 
-/// Build a TLS connector that trusts the in-cluster Kubernetes CA so the
-/// apiserver's self-signed cert for the VNC subresource validates.
-/// Mirrors the setup from the old single-viewer `vnc_bridge`.
 fn build_kubevirt_tls_connector()
 -> Result<tokio_tungstenite::Connector, Box<dyn std::error::Error + Send + Sync>> {
     let mut root_store = rustls::RootCertStore::empty();
@@ -413,7 +335,6 @@ fn build_kubevirt_tls_connector()
     Ok(tokio_tungstenite::Connector::Rustls(Arc::new(config)))
 }
 
-/// TLS connector that accepts any cert. Cluster-internal use only.
 pub fn build_accept_any_tls_connector()
 -> Result<tokio_tungstenite::Connector, Box<dyn std::error::Error + Send + Sync>> {
     use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};

--- a/apps/kube/angelscript/manifest/external-secrets.yaml
+++ b/apps/kube/angelscript/manifest/external-secrets.yaml
@@ -1,14 +1,3 @@
-# ExternalSecrets setup for angelscript namespace.
-#
-# Mirrors two upstream secrets into this namespace via ESO (kubernetes provider):
-#   - arc-systems/github-arc-token → angelscript/github-arc-token (KEDA → GitHub job queue)
-#   - kasm/vpn-wireguard           → angelscript/vpn-wireguard    (gluetun-builder-egress)
-#
-# Single source of truth lives upstream; this namespace only ever holds the
-# materialized copy + the RBAC needed to pull it. Rotating the upstream
-# SealedSecret automatically propagates here on the next ESO refresh.
----
-# ServiceAccount for ExternalSecrets to use when reading from arc-systems
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -18,7 +7,6 @@ metadata:
         app: angelscript
         component: external-secrets
 ---
-# Role in arc-systems allowing read on the github-arc-token secret
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -30,7 +18,6 @@ rules:
       resourceNames: ['github-arc-token']
       verbs: ['get']
 ---
-# Bind the angelscript SA to the role in arc-systems
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -45,7 +32,6 @@ subjects:
       name: angelscript-external-secrets
       namespace: angelscript
 ---
-# SecretStore in angelscript pointing to arc-systems
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
@@ -69,8 +55,6 @@ spec:
                     namespace: kube-system
                     type: ConfigMap
 ---
-# ExternalSecret that creates angelscript/github-arc-token
-# from arc-systems/github-arc-token
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
@@ -97,7 +81,6 @@ spec:
               key: github-arc-token
               property: github_token
 ---
-# Role in kasm allowing read on the vpn-wireguard secret
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -109,7 +92,6 @@ rules:
       resourceNames: ['vpn-wireguard']
       verbs: ['get']
 ---
-# Bind the angelscript SA to the role in kasm
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -124,7 +106,6 @@ subjects:
       name: angelscript-external-secrets
       namespace: angelscript
 ---
-# SecretStore in angelscript pointing to kasm
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
@@ -148,10 +129,6 @@ spec:
                     namespace: kube-system
                     type: ConfigMap
 ---
-# ExternalSecret that mirrors kasm/vpn-wireguard → angelscript/vpn-wireguard.
-# dataFrom + Extract copies every key from the upstream secret verbatim, so any
-# WG field added upstream (e.g. WIREGUARD_PRESHARED_KEY) propagates without
-# editing this manifest.
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:

--- a/apps/kube/angelscript/manifest/gluetun-builder-egress.yaml
+++ b/apps/kube/angelscript/manifest/gluetun-builder-egress.yaml
@@ -1,29 +1,3 @@
-# Gluetun HTTP proxy for windows-builder (and future VM builders).
-#
-# Pattern adapted from apps/kube/firecracker/manifests/firecracker-net-deployment.yaml
-# and apps/kube/kasm/manifest/deployment.yaml. KubeVirt virt-launcher pods can't
-# share a netns with arbitrary sidecars, so the proxy lives in its own pod and
-# is reached via ClusterIP — the VM points HTTP_PROXY/HTTPS_PROXY at the svc.
-#
-# Why HTTP proxy: Unreal builder needs stable bulk downloads (SDK installers,
-# UE content) over a VPN egress. Cluster pod NAT idle-times out long flows
-# (~2.5min per project_kubevirt_networking memory), so terminating WG inside
-# this pod and exposing CONNECT keeps the long-lived TCP streams alive on
-# Gluetun's tun0 instead of dying through masquerade NAT.
-#
-# Prereqs:
-#   1. The `vpn-wireguard` Secret is materialized in this namespace by ESO,
-#      mirrored from the upstream `kasm/vpn-wireguard` SealedSecret (see
-#      external-secrets.yaml). The sealed source of truth lives in the kasm
-#      namespace; this namespace only ever holds a refreshable copy.
-#   2. NetworkPolicy in this namespace permits TCP 8888 from `app: angelscript`
-#      pods to this deployment (handled in networkpolicy.yaml).
-#
-# Windows-side usage (inside the VM):
-#   netsh winhttp set proxy gluetun-builder-egress.angelscript.svc.cluster.local:8888
-#   setx HTTP_PROXY  "http://gluetun-builder-egress.angelscript.svc.cluster.local:8888" /M
-#   setx HTTPS_PROXY "http://gluetun-builder-egress.angelscript.svc.cluster.local:8888" /M
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -33,7 +7,6 @@ metadata:
         app: gluetun-builder-egress
         component: vm-egress
     annotations:
-        # Reload pod when the WG creds rotate (Stakater Reloader).
         secret.reloader.stakater.com/reload: 'vpn-wireguard'
 spec:
     replicas: 1
@@ -71,19 +44,14 @@ spec:
                         value: 'UTC'
                       - name: UPDATER_PERIOD
                         value: '24h'
-                      # HTTP CONNECT proxy on :8888, reachable from intra-ns pods only.
                       - name: HTTPPROXY
                         value: 'on'
                       - name: HTTPPROXY_LISTENING_ADDRESS
                         value: ':8888'
-                      # Cluster RFC1918 must bypass the tunnel so health probes,
-                      # SealedSecret reload, and svc DNS still resolve.
                       - name: FIREWALL_INPUT_PORTS
                         value: '8888,9999'
                       - name: FIREWALL_OUTBOUND_SUBNETS
                         value: '10.0.0.0/8,172.16.0.0/12,192.168.0.0/16'
-                      # DoH over 443 — matches firecracker-ctl-net after the
-                      # DNS_ADDRESS=0.0.0.0 revert in PR #10996.
                       - name: DOT
                         value: 'off'
                       - name: DNS_ADDRESS
@@ -122,7 +90,6 @@ spec:
                       - name: tun-device
                         mountPath: /dev/net/tun
             volumes:
-                # /dev/net/tun must be passed through for WG to attach (PR #10728).
                 - name: tun-device
                   hostPath:
                       path: /dev/net/tun

--- a/apps/kube/angelscript/manifest/namespace.yaml
+++ b/apps/kube/angelscript/manifest/namespace.yaml
@@ -4,10 +4,6 @@ metadata:
     name: angelscript
     labels:
         name: angelscript
-        # Hosts KubeVirt virt-launcher pods (windows-builder, macos-builder)
-        # and the gluetun-builder-egress proxy, both of which require
-        # NET_ADMIN + /dev/net/tun hostPath. Matches the `kasm` and
-        # `firecracker` namespaces that run the same kind of workload.
         pod-security.kubernetes.io/enforce: privileged
         pod-security.kubernetes.io/audit: privileged
         pod-security.kubernetes.io/warn: privileged

--- a/apps/kube/angelscript/manifest/networkpolicy.yaml
+++ b/apps/kube/angelscript/manifest/networkpolicy.yaml
@@ -13,7 +13,6 @@ spec:
         - Ingress
         - Egress
     ingress:
-        # Allow game traffic
         - ports:
               - port: 7777
                 protocol: UDP
@@ -24,18 +23,14 @@ spec:
               - port: 15000
                 protocol: UDP
     egress:
-        # Allow DNS
         - ports:
               - port: 53
                 protocol: UDP
               - port: 53
                 protocol: TCP
-        # Allow HTTPS (for any API calls / telemetry)
         - ports:
               - port: 443
                 protocol: TCP
-        # Allow VM builders (windows/macos) to reach the Gluetun HTTP proxy
-        # on the in-cluster egress pod for bulk downloads through WireGuard.
         - to:
               - podSelector:
                     matchLabels:
@@ -44,10 +39,6 @@ spec:
               - port: 8888
                 protocol: TCP
 ---
-# Egress pod has its own policy: accept proxy traffic from VM builder pods,
-# allow outbound WireGuard handshake (UDP 51820) and DNS bootstrap. All
-# real traffic exits via the tunnel inside Gluetun's netns, not via k8s
-# egress rules — so we only authorize what k8s sees on the pod interface.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -70,13 +61,10 @@ spec:
           ports:
               - port: 8888
                 protocol: TCP
-        # Kubelet health probes (node IP source — leave open on 9999).
         - ports:
               - port: 9999
                 protocol: TCP
     egress:
-        # WG handshake — endpoint port comes from the sealed secret; allow
-        # the common range plus 51820. Tighten once the provider port is known.
         - ports:
               - port: 51820
                 protocol: UDP
@@ -84,13 +72,11 @@ spec:
                 protocol: UDP
               - port: 1194
                 protocol: UDP
-        # DNS bootstrap (resolving the WG endpoint hostname before tunnel up).
         - ports:
               - port: 53
                 protocol: UDP
               - port: 53
                 protocol: TCP
-        # DoH fallback for upstream resolver before tunnel attaches.
         - ports:
               - port: 443
                 protocol: TCP

--- a/apps/kube/kubevirt/autologon-application.yaml
+++ b/apps/kube/kubevirt/autologon-application.yaml
@@ -1,7 +1,3 @@
-# Autologon — configures Windows builder VM autologon + VNC-ready
-# registry keys via a PostSync Job that exec's into virt-launcher and
-# drives the QEMU Guest Agent. Idempotent; safe to re-run on each sync.
-# When the VM is stopped the Job exits 0 so the sync stays Healthy.
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:

--- a/apps/kube/kubevirt/autologon/configmap.yaml
+++ b/apps/kube/kubevirt/autologon/configmap.yaml
@@ -1,30 +1,3 @@
-# ConfigMap with the Windows bootstrap configuration script.
-#
-# Uses the QEMU Guest Agent (via virsh in the virt-launcher pod) to keep
-# the builder VM in a sane operating state on every CronJob tick:
-#
-#   Autologon / VNC-ready (steps 1–7)
-#     1. AutoAdminLogon + DefaultUserName + DefaultPassword
-#     2. Disable Ctrl+Alt+Del requirement
-#     3. Disable lock screen, screensaver, idle timeout
-#     4. Disable Server Manager auto-start
-#     5. Disable inactivity-lock group policy
-#
-#   Build-time bootstrap (steps 8–11c)
-#     8.   NTP — pin pool.ntp.org + force resync so TLS chains validate
-#     9.   Machine HTTP_PROXY / HTTPS_PROXY / NO_PROXY env vars routed
-#          through gluetun-builder-egress for long-lived downloads
-#    10.   WinHTTP proxy + bypass list (winget / VS Installer / .NET)
-#    11a.  .NET strong-crypto + SystemDefaultTlsVersions so .NET 4.x
-#          (choco.exe et al) negotiates TLS 1.2/1.3 instead of TLS 1.0
-#    11b.  SCHANNEL TLS 1.2 client enabled OS-wide
-#    11c.  Chocolatey proxy (if choco is installed)
-#
-# The admin password is injected as ADMIN_PASSWORD env var from a Secret —
-# it never appears in this ConfigMap or anywhere in the repo.
-#
-# Idempotent: safe to run on every CronJob tick (overwrites same registry
-# keys / proxy config / re-issues w32tm resync).
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43,9 +16,6 @@ data:
 
         echo "=== Configuring Windows autologon + VNC-ready: ${VM_NAME} ==="
 
-        # ── Skip cleanly if the VMI is absent at sync time ──
-        # CronJob runs every 5 minutes. If the VM is Stopped (no VMI object)
-        # exit 0 and let the next tick try again once the VM is up.
         INITIAL_PHASE=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" \
             -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
         if [ -z "${INITIAL_PHASE}" ] || \
@@ -56,7 +26,6 @@ data:
             exit 0
         fi
 
-        # ── Wait for VMI to reach Running phase ──
         echo "Waiting for VM to be running..."
         for i in $(seq 1 60); do
             PHASE=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" \
@@ -73,7 +42,6 @@ data:
             sleep 10
         done
 
-        # ── Wait for QEMU Guest Agent ──
         echo "Waiting for guest agent..."
         for i in $(seq 1 30); do
             AGENT=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" \
@@ -85,15 +53,12 @@ data:
             fi
             if [ "$i" -eq 30 ]; then
                 echo "Guest agent not connected after 5 minutes; skipping."
-                echo "Ensure QEMU Guest Agent is installed as a Windows service"
-                echo "(from virtio-win ISO: guest-agent/qemu-ga-x86_64.msi)."
                 exit 0
             fi
             echo "  Agent: ${AGENT:-not connected} (${i}/30)"
             sleep 10
         done
 
-        # ── Find the virt-launcher pod ──
         POD=$(kubectl get pods -n "${NAMESPACE}" \
             -l "vm.kubevirt.io/name=${VM_NAME}" \
             -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
@@ -103,7 +68,6 @@ data:
         fi
         echo "Virt-launcher pod: ${POD}"
 
-        # ── Get the libvirt domain name ──
         DOMAIN=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
             sh -c "virsh list --name 2>/dev/null | grep -v '^\s*$' | head -1")
         if [ -z "${DOMAIN}" ]; then
@@ -112,13 +76,6 @@ data:
         fi
         echo "Libvirt domain: ${DOMAIN}"
 
-        # ── Helper: run a PowerShell command via guest agent and verify ──
-        # Builds the qemu-agent JSON payload with jq so backslashes / quotes
-        # / dollar signs in PowerShell scripts (registry paths, passwords)
-        # survive the shell → JSON → libvirt → qemu-ga hops without
-        # corruption. The old hand-rolled JSON silently produced malformed
-        # payloads for any PS containing `\` and qemu-ga rejected them —
-        # the script saw no `pid`, soft-passed, and never wrote the keys.
         run_ps() {
             STEP_NAME="$1"
             PS_SCRIPT="$2"
@@ -147,7 +104,6 @@ data:
             STATUS_PAYLOAD=$(jq -nc --argjson pid "$PID" \
                 '{execute:"guest-exec-status",arguments:{pid:$pid}}')
 
-            # guest-exec is asynchronous; poll for exited=true.
             for s in $(seq 1 10); do
                 sleep 1
                 STATUS_RESULT=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
@@ -173,14 +129,7 @@ data:
 
         FAILED=0
 
-        # ── Step 1: Autologon registry keys ──
-        # AutoAdminLogon  = "1"        → enable auto-login
-        # DefaultUserName = "Administrator"
-        # DefaultPassword = <from secret>
         PS_AUTOLOGON='$p = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"; Set-ItemProperty -Path $p -Name AutoAdminLogon -Value "1" -Force; Set-ItemProperty -Path $p -Name DefaultUserName -Value "Administrator" -Force; Set-ItemProperty -Path $p -Name DefaultPassword -Value $env:AUTOLOGON_PWD -Force; Write-Output done'
-        # PowerShell reads the password from its own env var to keep it out
-        # of the command-line that shows up in audit logs / Event Viewer.
-        # The env var is set on the spawned PowerShell via guest-exec env.
         PAYLOAD=$(jq -nc \
             --arg ps "$PS_AUTOLOGON" \
             --arg pwd "$ADMIN_PASSWORD" '{
@@ -221,106 +170,58 @@ data:
             fi
         fi
 
-        # ── Step 2: Disable Ctrl+Alt+Del requirement ──
         run_ps "Disable Ctrl+Alt+Del" \
             '$p = "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon"; Set-ItemProperty -Path $p -Name DisableCAD -Value 1 -Type DWord -Force; Write-Output done' \
             || FAILED=1
 
-        # ── Step 3: Disable lock screen ──
         run_ps "Disable lock screen" \
             '$p = "HKLM:\SOFTWARE\Policies\Microsoft\Windows\Personalization"; if (-not (Test-Path $p)) { New-Item -Path $p -Force | Out-Null }; Set-ItemProperty -Path $p -Name NoLockScreen -Value 1 -Type DWord -Force; Write-Output done' \
             || FAILED=1
 
-        # ── Step 4: Disable screensaver ──
         run_ps "Disable screensaver" \
             'Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name ScreenSaveActive -Value "0" -Force; Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name ScreenSaverIsSecure -Value "0" -Force; Set-ItemProperty -Path "HKCU:\Control Panel\Desktop" -Name ScreenSaveTimeOut -Value "0" -Force; Write-Output done' \
             || FAILED=1
 
-        # ── Step 5: Disable idle lock timeout via power policy ──
         run_ps "Disable power idle timeouts" \
             'powercfg /change standby-timeout-ac 0; powercfg /change monitor-timeout-ac 0; powercfg /x -hibernate-timeout-ac 0; Write-Output done' \
             || FAILED=1
 
-        # ── Step 6: Disable Server Manager auto-start ──
         run_ps "Disable Server Manager auto-start" \
             '$p = "HKLM:\SOFTWARE\Microsoft\ServerManager"; Set-ItemProperty -Path $p -Name DoNotOpenServerManagerAtLogon -Value 1 -Type DWord -Force; Write-Output done' \
             || FAILED=1
 
-        # ── Step 7: Disable machine inactivity limit (Group Policy) ──
         run_ps "Disable inactivity lock" \
             '$p = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"; Set-ItemProperty -Path $p -Name InactivityTimeoutSecs -Value 0 -Type DWord -Force; Write-Output done' \
             || FAILED=1
 
-        # ── Step 8: NTP — pin time source + force resync ──
-        # KubeVirt VMs drift out of sync with real time after long
-        # power-off windows, so when the runner comes up its clock can
-        # be hours or days behind. choco / winget / VS installers
-        # validate TLS chains against system time, so a skewed clock
-        # presents as "SSL connection error" even when the network is
-        # healthy. Pin a stable NTP pool, mark this host as a reliable
-        # source so w32time will trust the answer, and force a resync
-        # every tick. Resync is cheap when the clock is already correct.
         run_ps "Sync system clock (NTP)" \
             'net start w32time | Out-Null; w32tm /config /manualpeerlist:"pool.ntp.org time.windows.com,0x9" /syncfromflags:manual /reliable:yes /update | Out-Null; w32tm /resync /force | Out-Null; Write-Output done' \
             || FAILED=1
 
-        # ── Step 9: System-wide HTTP_PROXY env vars ──
-        # The gluetun-builder-egress pod exposes a CONNECT proxy on
-        # :8888 that terminates a WireGuard tunnel. Pointing the VM's
-        # machine-wide proxy at the cluster-internal svc URL keeps
-        # large downloads (VS bundles, UE installers, choco packages)
-        # alive on the tunnel side instead of dying through the
-        # masquerade NAT idle timeout. NO_PROXY bypasses cluster +
-        # local hosts so guest-agent / file-server still talk direct.
         run_ps "Set machine HTTP_PROXY env" \
             '$proxy = "http://gluetun-builder-egress.angelscript.svc.cluster.local:8888"; $bypass = "*.svc.cluster.local,*.cluster.local,localhost,127.0.0.1,169.254.169.254"; [System.Environment]::SetEnvironmentVariable("HTTP_PROXY", $proxy, "Machine"); [System.Environment]::SetEnvironmentVariable("HTTPS_PROXY", $proxy, "Machine"); [System.Environment]::SetEnvironmentVariable("NO_PROXY", $bypass, "Machine"); Write-Output done' \
             || FAILED=1
 
-        # ── Step 10: WinHTTP proxy (winget / .NET / VS installer) ──
-        # WinHTTP is a separate proxy stack from the machine env var;
-        # winget + the VS Installer + .NET runtimes all read it. Set
-        # the same upstream + bypass list so they take the tunnel too.
         run_ps "Set WinHTTP proxy" \
             'netsh winhttp set proxy proxy-server="gluetun-builder-egress.angelscript.svc.cluster.local:8888" bypass-list="*.svc.cluster.local;*.cluster.local;<local>" | Out-Null; Write-Output done' \
             || FAILED=1
 
-        # ── Step 11a: .NET strong crypto / TLS 1.2 system-wide ──
-        # Windows Server defaults to .NET TLS 1.0/1.1 which Chocolatey
-        # and most modern HTTPS endpoints have dropped. Symptom is
-        # `choco install` failing with "An error occurred while
-        # sending the request" against community.chocolatey.org. The
-        # SchUseStrongCrypto + SystemDefaultTlsVersions registry keys
-        # tell every .NET 4.x app on the box (including choco.exe) to
-        # negotiate TLS 1.2/1.3 via the OS default selector.
         run_ps "Enable .NET strong crypto (TLS 1.2/1.3)" \
             '$paths = @("HKLM:\SOFTWARE\Microsoft\.NETFramework\v4.0.30319", "HKLM:\SOFTWARE\Wow6432Node\Microsoft\.NETFramework\v4.0.30319"); foreach ($p in $paths) { if (-not (Test-Path $p)) { New-Item -Path $p -Force | Out-Null }; Set-ItemProperty -Path $p -Name SchUseStrongCrypto -Value 1 -Type DWord -Force; Set-ItemProperty -Path $p -Name SystemDefaultTlsVersions -Value 1 -Type DWord -Force }; Write-Output done' \
             || FAILED=1
 
-        # ── Step 11b: Enable TLS 1.2 client at SCHANNEL level ──
-        # Belt-and-suspenders for OS-level WinHTTP / SChannel handlers
-        # so the TLS 1.2 ClientHello is allowed even before .NET asks.
         run_ps "Enable TLS 1.2 SCHANNEL client" \
             '$p = "HKLM:\SYSTEM\CurrentControlSet\Control\SecurityProviders\SCHANNEL\Protocols\TLS 1.2\Client"; if (-not (Test-Path $p)) { New-Item -Path $p -Force | Out-Null }; Set-ItemProperty -Path $p -Name Enabled -Value 1 -Type DWord -Force; Set-ItemProperty -Path $p -Name DisabledByDefault -Value 0 -Type DWord -Force; Write-Output done' \
             || FAILED=1
 
-        # ── Step 11c: Chocolatey proxy (if installed) ──
-        # choco has its own config file; pointing it at the same
-        # gluetun proxy makes `choco install` survive >5 minute
-        # downloads. Skip cleanly when choco isn't installed yet
-        # (first boot ordering).
         run_ps "Configure chocolatey proxy" \
             'if (Get-Command choco -ErrorAction SilentlyContinue) { & choco config set proxy "http://gluetun-builder-egress.angelscript.svc.cluster.local:8888" --limit-output | Out-Null; & choco config set proxyBypassList "*.svc.cluster.local,*.cluster.local,localhost,127.0.0.1" --limit-output | Out-Null; Write-Output configured } else { Write-Output "choco not installed, skipping" }' \
             || FAILED=1
 
-        # ── Summary ──
         echo ""
         if [ "${FAILED}" = "0" ]; then
-            echo "=== SUCCESS: All VM bootstrap settings applied to ${VM_NAME} ==="
-            echo "Windows will auto-login, clock is NTP-synced, downloads"
-            echo "routed through gluetun-builder-egress proxy."
-            echo "Some settings (autologon, env vars) take effect on next reboot."
+            echo "=== SUCCESS: bootstrap applied to ${VM_NAME} ==="
         else
-            echo "=== FAILED: Some steps failed for ${VM_NAME} ==="
-            echo "Review the output above. Next CronJob tick will retry."
+            echo "=== FAILED: some steps failed for ${VM_NAME} ==="
             exit 1
         fi

--- a/apps/kube/kubevirt/autologon/job.yaml
+++ b/apps/kube/kubevirt/autologon/job.yaml
@@ -1,42 +1,3 @@
-# ArgoCD-managed CronJob to (re)apply Windows autologon + VNC-ready settings
-# on the builder VM.
-#
-# Uses the QEMU Guest Agent to set registry keys inside Windows so the VM
-# auto-logs in as Administrator on every boot — no lock screen, no
-# Ctrl+Alt+Del prompt, no screensaver, no idle lock. Guacamole / VNC users
-# see the desktop immediately without any interaction.
-#
-# What it configures (7 steps):
-#   1. Autologon registry keys (AutoAdminLogon, DefaultUserName, DefaultPassword)
-#   2. Disable Ctrl+Alt+Del requirement (DisableCAD)
-#   3. Disable lock screen (NoLockScreen policy)
-#   4. Disable screensaver (ScreenSaveActive=0)
-#   5. Disable power idle timeouts (standby, monitor, hibernate all to 0)
-#   6. Disable Server Manager auto-start (DoNotOpenServerManagerAtLogon)
-#   7. Disable machine inactivity lock (InactivityTimeoutSecs=0)
-#
-# Lifecycle: previously this was a one-shot Job behind an ArgoCD PostSync
-# hook. The hook only fires when the autologon app itself syncs, so if the
-# VM happened to be Stopped at that moment the script soft-skipped and the
-# registry keys never landed — and there was no automatic re-trigger when
-# the VM later booted. Now it runs as a CronJob every 5 minutes; the
-# idempotent script reapplies the same registry values, no-ops when the
-# VM is Stopped or the QEMU Guest Agent has not yet registered, and
-# catches up the next tick after the VM comes back online.
-#
-# Prerequisites:
-#   1. windows-builder VM with QEMU Guest Agent installed (cold-start once
-#      via virtctl + virtio-win ISO).
-#   2. Secret 'windows-builder-admin' in angelscript namespace with key
-#      'password' containing the Administrator password.
-#   3. vm-scaler RBAC includes pod/exec permissions (deployed via KEDA app).
-#
-# Note: the pod template intentionally does NOT carry `app: angelscript`
-# because the namespace NetworkPolicy (podSelector app=angelscript) only
-# allows egress on ports 53 + 443 for game-server workloads. kube-proxy
-# DNATs kubernetes.default.svc to the real apiserver endpoint on port 6443,
-# which is blocked — so any kubectl from inside a policy-scoped pod times
-# out. Management jobs live outside the game-server network policy.
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -46,11 +7,6 @@ metadata:
         app: angelscript
         component: vm-autologon
 spec:
-    # Safety-net cadence only. The fast on-boot trigger lives in
-    # scaled-job.yaml (KEDA kubernetes-workload watching for the
-    # virt-launcher pod). The CronJob picks up registry drift (someone
-    # toggling autologon off mid-session, a partial bootstrap run) at a
-    # low cadence so it doesn't spam pods while the VM is up.
     schedule: '*/30 * * * *'
     timeZone: UTC
     concurrencyPolicy: Forbid

--- a/apps/kube/kubevirt/autologon/scaled-job.yaml
+++ b/apps/kube/kubevirt/autologon/scaled-job.yaml
@@ -1,25 +1,3 @@
-# KEDA ScaledJob — fast on-boot trigger for the Windows autologon /
-# bootstrap script.
-#
-# Watches for a virt-launcher pod belonging to windows-builder via the
-# kubernetes-workload scaler. When the VM transitions Stopped → Running
-# (i.e. the virt-launcher pod appears) KEDA spawns the bootstrap Job
-# within `pollingInterval` seconds, so autologon registry keys, NTP
-# resync, proxy env, and TLS 1.2 keys are applied within ~30 s of VM
-# boot instead of waiting up to the safety-net CronJob's 30-minute
-# cadence.
-#
-# This Job and the safety-net CronJob in job.yaml share the
-# `vm-autologon-script` ConfigMap and the same RBAC, so both paths
-# execute the same idempotent script. The Job soft-skips with exit 0
-# when the VMI is absent or the guest agent isn't yet connected, so a
-# spurious fire (e.g. KEDA polling during a VM restart) is harmless.
-#
-# Why ScaledJob and not just a tighter CronJob: the CronJob fires on
-# wall-clock regardless of VM state and would either burn pods every
-# minute while idle or be too slow on boot. ScaledJob fires only when
-# the virt-launcher pod actually exists, giving fast boot detection
-# with zero churn while the VM is Stopped.
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:

--- a/apps/kube/kubevirt/guacamole/deployment.yaml
+++ b/apps/kube/kubevirt/guacamole/deployment.yaml
@@ -1,28 +1,3 @@
-# Apache Guacamole — browser-based RDP gateway for KubeVirt Windows VMs.
-#
-# Architecture:
-#   Browser → Ingress (TLS) → guacamole (web) → guacd (proxy) → ClusterIP → VM RDP (3389)
-#
-# RDP is NEVER exposed publicly. Guacamole is the single audited entry point.
-# KEDA manages replicas: 0 when idle, 1 when VM is running.
-#
-# Components:
-#   - guacd: protocol proxy daemon (translates web → RDP/VNC/SSH)
-#   - guacamole: web frontend (Tomcat + auth + connection management)
-#   - PostgreSQL: stores connections, users, history (uses existing Supabase cluster)
-#
-# Setup (one-time after deploy):
-#   1. Access Guacamole at https://guac.kbve.com/guacamole/
-#   2. Default login: guacadmin / guacadmin (CHANGE IMMEDIATELY)
-#   3. Add RDP connection:
-#      - Protocol: RDP
-#      - Hostname: windows-builder-rdp.angelscript.svc.cluster.local
-#      - Port: 3389
-#      - Username: <Windows admin user>
-#      - Password: <from sealed secret>
-#   4. Test connection from browser
----
-# guacd — protocol proxy daemon
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -74,7 +49,6 @@ spec:
           name: guacd
           protocol: TCP
 ---
-# guacamole — web frontend
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -84,10 +58,6 @@ metadata:
         app: guacamole
         component: guacamole
     annotations:
-        # Pod runs an init container that renders user-mapping.xml from
-        # this ConfigMap + the admin Secret. Neither edit triggers a
-        # rollout on its own — Reloader rotates the pod whenever either
-        # changes, so RDP param tweaks land without manual rollout.
         configmap.reloader.stakater.com/reload: 'guacamole-user-mapping'
         secret.reloader.stakater.com/reload: 'windows-builder-admin'
 spec:
@@ -101,8 +71,6 @@ spec:
                 app: guacamole
                 component: guacamole
         spec:
-            # Init container injects the RDP password from Secret into
-            # user-mapping.xml at runtime — password never stored in ConfigMap.
             initContainers:
                 - name: inject-rdp-password
                   image: busybox:1.37
@@ -129,8 +97,6 @@ spec:
                         value: guacd.angelscript.svc.cluster.local
                       - name: GUACD_PORT
                         value: '4822'
-                      # GUACAMOLE_HOME tells Guacamole where to find
-                      # user-mapping.xml and other config files.
                       - name: GUACAMOLE_HOME
                         value: /etc/guacamole
                   ports:
@@ -176,7 +142,6 @@ spec:
           name: http
           protocol: TCP
 ---
-# RDP Service — targets the Windows VM's virt-launcher pod
 apiVersion: v1
 kind: Service
 metadata:

--- a/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
+++ b/apps/kube/kubevirt/guacamole/keda-scaledobject.yaml
@@ -1,13 +1,3 @@
-# KEDA ScaledObjects for Guacamole stack.
-#
-# Scale follows VM availability rather than a clock. The kubernetes-workload
-# trigger watches for any virt-launcher pod belonging to windows-builder;
-# when one exists (VMI Running) guacd + guacamole scale to 1, otherwise 0.
-# This catches off-hours / weekend use and matches multi-viewer demand to
-# actual VM state instead of a fixed weekday window.
-#
-# Manual override: kubectl scale deploy guacd guacamole -n angelscript --replicas=1
----
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/apps/kube/kubevirt/guacamole/user-mapping-configmap.yaml
+++ b/apps/kube/kubevirt/guacamole/user-mapping-configmap.yaml
@@ -1,30 +1,3 @@
-# Guacamole user-mapping.xml — initial auth + RDP connection config.
-# Default password: guacadmin (sha256 hash below). CHANGE after first login.
-# For production, migrate to PostgreSQL backend.
-#
-# RDP param choices (Windows Server builder over WAN through Guacamole):
-#   - color-depth 24       — readable text without saturating the link
-#   - resize-method
-#     display-update       — true resolution change in the guest on browser
-#                            resize / fullscreen toggle; needs guest-agent
-#   - disable-wallpaper /
-#     theming / fwd-drag /
-#     desktop-composition /
-#     menu-animations      — strip expensive repaints; massive bandwidth win
-#                            and unblocks fullscreen mode rendering on slow
-#                            links
-#   - enable-font-smoothing — keep ClearType so MSVC / VS panes stay legible
-#   - bitmap / offscreen /
-#     glyph caching ON     — cuts repaint cost during long build log scroll
-#   - disable-audio        — VM has no audio device, avoids RDP channel error
-#   - enable-printing /
-#     enable-drive false   — no host file passthrough until we explicitly
-#                            wire a redirected drive
-#   - server-layout en-us  — fixes wrong characters on AltGr / dead keys
-#   - console false        — connect to interactive session (so autologon
-#                            takes effect); console=true would land on the
-#                            session 0 lock screen and CAD would target it
-#                            instead of the desktop
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -110,6 +110,4 @@ resources:
     - kubevirt/file-server-application.yaml
     # Guacamole — browser-based RDP gateway for Windows VMs
     - kubevirt/guacamole-application.yaml
-    # Autologon — configures Windows VM autologon + VNC-ready registry keys
-    # via a PostSync Job. Idempotent; skips cleanly when the VM is stopped.
     - kubevirt/autologon-application.yaml


### PR DESCRIPTION
Strips noisy header/inline comments I left across the recent windows-builder, gluetun-builder-egress, autologon, guacamole, and VNC-hub PRs. 415 deletions, 4 insertions. Per the standing rule (now 9 reminders): drop ALL comments by default in every language, identifier names + git history carry the why.