### PR TITLE
fix(agents,edge): surface SQLSTATE on guild-vault errors + drop delete-then-add upsert

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -674,18 +674,10 @@ class AgentsService {
 	public async setRepoAllowlist(
 		repos: string[],
 	): Promise<{ ok: true } | { ok: false; error: string }> {
-		const tokens = this.$tokens.get();
-		const existing = tokens.find((t) => t.service === 'github_repos');
-		const value = JSON.stringify({ repos });
-
-		if (existing) {
-			const r = await this.deleteToken(existing.token_id);
-			if (!r.ok) return { ok: false, error: r.error };
-		}
 		const r = await this.addToken({
 			tokenName: 'github-repos',
 			service: 'github_repos',
-			tokenValue: value,
+			tokenValue: JSON.stringify({ repos }),
 			description:
 				'Per-guild repo allowlist consumed by gh-webhook and gh-backfill',
 		});
@@ -714,18 +706,10 @@ class AgentsService {
 	public async setBotConfig(
 		config: DiscordshConfig,
 	): Promise<{ ok: true } | { ok: false; error: string }> {
-		const tokens = this.$tokens.get();
-		const existing = tokens.find((t) => t.service === 'discordsh_config');
-		const value = JSON.stringify(config);
-
-		if (existing) {
-			const r = await this.deleteToken(existing.token_id);
-			if (!r.ok) return { ok: false, error: r.error };
-		}
 		const r = await this.addToken({
 			tokenName: 'discordsh-config',
 			service: 'discordsh_config',
-			tokenValue: value,
+			tokenValue: JSON.stringify(config),
 			description:
 				'Per-guild DiscordSH bot config (channels, defaults, toggles)',
 		});
@@ -785,10 +769,18 @@ class AgentsService {
 				};
 			}
 			if (!resp.ok) {
-				const errMsg =
-					(body as { error?: string } | null)?.error ??
-					`HTTP ${resp.status}`;
-				return { ok: false, error: errMsg };
+				const b = body as {
+					error?: string;
+					sqlstate?: string | null;
+					hint?: string | null;
+					context?: string | null;
+				} | null;
+				const parts: string[] = [];
+				parts.push(b?.error ?? `HTTP ${resp.status}`);
+				if (b?.sqlstate) parts.push(`sqlstate=${b.sqlstate}`);
+				if (b?.hint) parts.push(`hint=${b.hint}`);
+				if (b?.context) parts.push(`context=${b.context}`);
+				return { ok: false, error: parts.join(' · ') };
 			}
 			return { ok: true, body };
 		} catch (e) {

--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.35"
+version: "0.1.36"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json

--- a/apps/kbve/edge/functions/_shared/validators.ts
+++ b/apps/kbve/edge/functions/_shared/validators.ts
@@ -145,13 +145,18 @@ export function requireJsonContentType(req: Request): Response | null {
  * Logs the real error server-side, returns a generic message to the client.
  */
 export function safeRpcError(
-  error: { message: string },
+  error: { message: string; code?: string; hint?: string; details?: string },
   context: string,
   status = 400,
 ): Response {
-  console.error(`${context}:`, error.message);
+  console.error(`${context}:`, error.message, error.code ?? "", error.hint ?? "");
   return jsonResponse(
-    { error: "Operation failed. Please try again or contact support." },
+    {
+      error: "Operation failed. Please try again or contact support.",
+      sqlstate: error.code ?? null,
+      hint: error.hint ?? null,
+      context,
+    },
     status,
   );
 }

--- a/apps/kbve/edge/functions/discord-bootstrap/index.ts
+++ b/apps/kbve/edge/functions/discord-bootstrap/index.ts
@@ -236,7 +236,7 @@ serve(async (req) => {
   // 4. Upsert via the RPC. The RPC dedups + first-seen-orders + caps
   //    at 50 internally, so we pass the raw owned list. Filtering above
   //    is defensive only.
-  const { error: rpcError } = await supabase.rpc(
+  const { error: rpcError } = await supabase.schema("profile").rpc(
     "service_upsert_discord_bootstrap_cache",
     {
       p_user_id: userId,

--- a/apps/kbve/edge/functions/guild-vault/tokens.ts
+++ b/apps/kbve/edge/functions/guild-vault/tokens.ts
@@ -68,7 +68,7 @@ const handlers: Record<string, Handler> = {
     if (ownerErr) return ownerErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_set_guild_token", {
+    const { data, error } = await supabase.schema("discordsh").rpc("service_set_guild_token", {
       p_owner_id: userId,
       p_server_id: server_id as string,
       p_service: service as string,
@@ -113,7 +113,7 @@ const handlers: Record<string, Handler> = {
     if (ownerErr) return ownerErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_list_guild_tokens", {
+    const { data, error } = await supabase.schema("discordsh").rpc("service_list_guild_tokens", {
       p_owner_id: userId,
       p_server_id: server_id as string,
     });
@@ -147,7 +147,7 @@ const handlers: Record<string, Handler> = {
     if (ownerErr) return ownerErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc(
+    const { data, error } = await supabase.schema("discordsh").rpc(
       "service_delete_guild_token",
       {
         p_owner_id: userId,
@@ -202,7 +202,7 @@ const handlers: Record<string, Handler> = {
     if (ownerErr) return ownerErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc(
+    const { data, error } = await supabase.schema("discordsh").rpc(
       "service_toggle_guild_token_status",
       {
         p_owner_id: userId,

--- a/apps/kbve/edge/functions/mc/character.ts
+++ b/apps/kbve/edge/functions/mc/character.ts
@@ -80,7 +80,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_save_character", {
+    const { data, error } = await supabase.schema("mc").rpc("service_save_character", {
       p_character: character,
     });
 
@@ -103,7 +103,7 @@ const handlers: Record<string, Handler> = {
     if (serverErr) return serverErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_load_character", {
+    const { data, error } = await supabase.schema("mc").rpc("service_load_character", {
       p_player_uuid: player_uuid as string,
       p_server_id: server_id as string,
     });
@@ -141,7 +141,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_add_experience", {
+    const { data, error } = await supabase.schema("mc").rpc("service_add_experience", {
       p_player_uuid: player_uuid as string,
       p_server_id: server_id as string,
       p_xp_amount: xp,

--- a/apps/kbve/edge/functions/mc/container.ts
+++ b/apps/kbve/edge/functions/mc/container.ts
@@ -46,7 +46,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_save_container", {
+    const { data, error } = await supabase.schema("mc").rpc("service_save_container", {
       p_container: container,
       p_server_id: server_id as string,
     });
@@ -70,7 +70,7 @@ const handlers: Record<string, Handler> = {
     if (serverErr) return serverErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_load_container", {
+    const { data, error } = await supabase.schema("mc").rpc("service_load_container", {
       p_container_id: container_id as string,
       p_server_id: server_id as string,
     });

--- a/apps/kbve/edge/functions/mc/player.ts
+++ b/apps/kbve/edge/functions/mc/player.ts
@@ -36,7 +36,7 @@ const handlers: Record<string, Handler> = {
     if (serverErr) return serverErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_save_player", {
+    const { data, error } = await supabase.schema("mc").rpc("service_save_player", {
       p_snapshot: snapshot,
     });
 
@@ -59,7 +59,7 @@ const handlers: Record<string, Handler> = {
     if (serverErr) return serverErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_load_player", {
+    const { data, error } = await supabase.schema("mc").rpc("service_load_player", {
       p_player_uuid: player_uuid as string,
       p_server_id: server_id as string,
     });

--- a/apps/kbve/edge/functions/mc/skill.ts
+++ b/apps/kbve/edge/functions/mc/skill.ts
@@ -101,7 +101,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_save_skill_tree", {
+    const { data, error } = await supabase.schema("mc").rpc("service_save_skill_tree", {
       p_skill_tree: skill_tree,
     });
 
@@ -124,7 +124,7 @@ const handlers: Record<string, Handler> = {
     if (serverErr) return serverErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_load_skill_tree", {
+    const { data, error } = await supabase.schema("mc").rpc("service_load_skill_tree", {
       p_player_uuid: player_uuid as string,
       p_server_id: server_id as string,
     });
@@ -179,7 +179,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_add_skill_xp", {
+    const { data, error } = await supabase.schema("mc").rpc("service_add_skill_xp", {
       p_player_uuid: player_uuid as string,
       p_server_id: server_id as string,
       p_skill_id: skill_id as string,

--- a/apps/kbve/edge/functions/mc/transfer.ts
+++ b/apps/kbve/edge/functions/mc/transfer.ts
@@ -39,7 +39,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_record_transfers", {
+    const { data, error } = await supabase.schema("mc").rpc("service_record_transfers", {
       p_batch: batch,
     });
 
@@ -66,7 +66,7 @@ const handlers: Record<string, Handler> = {
     const offset = Math.max(rawOffset, 0);
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc(
+    const { data, error } = await supabase.schema("mc").rpc(
       "service_get_transfer_history",
       {
         p_player_uuid: player_uuid as string,

--- a/apps/kbve/edge/functions/meme/admin.ts
+++ b/apps/kbve/edge/functions/meme/admin.ts
@@ -169,7 +169,7 @@ const handlers: Record<string, Handler> = {
     // --- Suspenders: let the DB RPC + table constraints do their job ---
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_create_meme", {
+    const { data, error } = await supabase.schema("meme").rpc("service_create_meme", {
       p_author_id: author_id as string,
       p_asset_url: asset_url as string,
       p_title: (title as string) ?? null,

--- a/apps/kbve/edge/functions/meme/comment.ts
+++ b/apps/kbve/edge/functions/meme/comment.ts
@@ -36,7 +36,7 @@ const handlers: Record<string, Handler> = {
     if (cursorErr) return cursorErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_fetch_comments", {
+    const { data, error } = await supabase.schema("meme").rpc("service_fetch_comments", {
       p_meme_id: meme_id as string,
       p_limit: safeLimit,
       p_cursor: (cursor as string) ?? null,
@@ -68,7 +68,7 @@ const handlers: Record<string, Handler> = {
     if (cursorErr) return cursorErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_fetch_replies", {
+    const { data, error } = await supabase.schema("meme").rpc("service_fetch_replies", {
       p_parent_id: parent_id as string,
       p_limit: safeLimit,
       p_cursor: (cursor as string) ?? null,
@@ -104,7 +104,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_create_comment", {
+    const { data, error } = await supabase.schema("meme").rpc("service_create_comment", {
       p_user_id: userId,
       p_meme_id: meme_id as string,
       p_body: (commentBody as string).trim(),
@@ -127,7 +127,7 @@ const handlers: Record<string, Handler> = {
     if (idErr) return idErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_delete_comment", {
+    const { data, error } = await supabase.schema("meme").rpc("service_delete_comment", {
       p_user_id: userId,
       p_comment_id: comment_id as string,
     });

--- a/apps/kbve/edge/functions/meme/feed.ts
+++ b/apps/kbve/edge/functions/meme/feed.ts
@@ -50,7 +50,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_fetch_feed", {
+    const { data, error } = await supabase.schema("meme").rpc("service_fetch_feed", {
       p_limit: safeLimit,
       p_cursor: (cursor as string) ?? null,
       p_tag: (tag as string) ?? null,
@@ -75,7 +75,7 @@ const handlers: Record<string, Handler> = {
     if (memeErr) return memeErr;
 
     const supabase = createServiceClient();
-    const { error } = await supabase.rpc("service_increment_view", {
+    const { error } = await supabase.schema("meme").rpc("service_increment_view", {
       p_meme_id: meme_id as string,
     });
 
@@ -92,7 +92,7 @@ const handlers: Record<string, Handler> = {
     if (memeErr) return memeErr;
 
     const supabase = createServiceClient();
-    const { error } = await supabase.rpc("service_increment_share", {
+    const { error } = await supabase.schema("meme").rpc("service_increment_share", {
       p_meme_id: meme_id as string,
     });
 

--- a/apps/kbve/edge/functions/meme/follow.ts
+++ b/apps/kbve/edge/functions/meme/follow.ts
@@ -35,7 +35,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_follow", {
+    const { data, error } = await supabase.schema("meme").rpc("service_follow", {
       p_follower_id: userId,
       p_following_id: following_id as string,
     });
@@ -56,7 +56,7 @@ const handlers: Record<string, Handler> = {
     if (idErr) return idErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_unfollow", {
+    const { data, error } = await supabase.schema("meme").rpc("service_unfollow", {
       p_follower_id: userId,
       p_following_id: following_id as string,
     });

--- a/apps/kbve/edge/functions/meme/profile.ts
+++ b/apps/kbve/edge/functions/meme/profile.ts
@@ -28,7 +28,7 @@ const handlers: Record<string, Handler> = {
     if (idErr) return idErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_get_profile", {
+    const { data, error } = await supabase.schema("meme").rpc("service_get_profile", {
       p_user_id: user_id as string,
     });
 
@@ -106,7 +106,7 @@ const handlers: Record<string, Handler> = {
     }
 
     const supabase = createServiceClient();
-    const { error } = await supabase.rpc("service_upsert_profile", {
+    const { error } = await supabase.schema("meme").rpc("service_upsert_profile", {
       p_user_id: userId,
       p_display_name: (display_name as string) ?? null,
       p_avatar_url: (avatar_url as string) ?? null,
@@ -133,7 +133,7 @@ const handlers: Record<string, Handler> = {
     if (cursorErr) return cursorErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_get_user_memes", {
+    const { data, error } = await supabase.schema("meme").rpc("service_get_user_memes", {
       p_user_id: user_id as string,
       p_limit: safeLimit,
       p_cursor: (cursor as string) ?? null,

--- a/apps/kbve/edge/functions/meme/reaction.ts
+++ b/apps/kbve/edge/functions/meme/reaction.ts
@@ -31,7 +31,7 @@ const handlers: Record<string, Handler> = {
     if (reactionErr) return reactionErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_react", {
+    const { data, error } = await supabase.schema("meme").rpc("service_react", {
       p_user_id: userId,
       p_meme_id: meme_id as string,
       p_reaction: Number(reaction),
@@ -53,7 +53,7 @@ const handlers: Record<string, Handler> = {
     if (memeErr) return memeErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_unreact", {
+    const { data, error } = await supabase.schema("meme").rpc("service_unreact", {
       p_user_id: userId,
       p_meme_id: meme_id as string,
     });

--- a/apps/kbve/edge/functions/meme/report.ts
+++ b/apps/kbve/edge/functions/meme/report.ts
@@ -35,7 +35,7 @@ const handlers: Record<string, Handler> = {
     if (detailErr) return detailErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_report_meme", {
+    const { data, error } = await supabase.schema("meme").rpc("service_report_meme", {
       p_reporter_id: userId,
       p_meme_id: meme_id as string,
       p_reason: Number(reason),

--- a/apps/kbve/edge/functions/meme/save.ts
+++ b/apps/kbve/edge/functions/meme/save.ts
@@ -27,7 +27,7 @@ const handlers: Record<string, Handler> = {
     if (memeErr) return memeErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_save_meme", {
+    const { data, error } = await supabase.schema("meme").rpc("service_save_meme", {
       p_user_id: userId,
       p_meme_id: meme_id as string,
     });
@@ -48,7 +48,7 @@ const handlers: Record<string, Handler> = {
     if (memeErr) return memeErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc("service_unsave_meme", {
+    const { data, error } = await supabase.schema("meme").rpc("service_unsave_meme", {
       p_user_id: userId,
       p_meme_id: meme_id as string,
     });

--- a/apps/kbve/edge/functions/meme/user.ts
+++ b/apps/kbve/edge/functions/meme/user.ts
@@ -27,7 +27,7 @@ const handlers: Record<string, Handler> = {
     if (idsErr) return idsErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc(
+    const { data, error } = await supabase.schema("meme").rpc(
       "service_get_user_reactions",
       {
         p_user_id: userId,
@@ -52,7 +52,7 @@ const handlers: Record<string, Handler> = {
     if (idsErr) return idsErr;
 
     const supabase = createServiceClient();
-    const { data, error } = await supabase.rpc(
+    const { data, error } = await supabase.schema("meme").rpc(
       "service_get_user_saves",
       {
         p_user_id: userId,


### PR DESCRIPTION
## What user hit

Setting KBVE/kbve repo on \`/dashboard/agents/github/\` step 1 → toast \`"Operation failed. Please try again or contact support."\` with zero info to debug.

## Root causes

1. **\`safeRpcError\` swallows everything** — SQLSTATE, hint, and context all logged server-side only. User sees a generic string and can't even open a useful support ticket.
2. **\`setRepoAllowlist\` + \`setBotConfig\` did delete-then-add** instead of using \`service_set_guild_token\`'s built-in \`ON CONFLICT (server_id, service, token_name) DO UPDATE\`. Two network round-trips with a failure window: if delete succeeded but add failed (e.g. provider_token expired between calls), guild ends up with **no row at all** — actively destructive.

## Fix

| File | Change |
|---|---|
| \`edge/functions/_shared/validators.ts\` | \`safeRpcError\` now returns \`sqlstate\` + \`hint\` + \`context\` alongside the generic message. Server log gains code+hint too. |
| \`astro-kbve/.../agentsService.ts\` (\`callGuildVault\`) | Concatenates surfaced error to \`"… · sqlstate=XXX · context=guild_vault_rpc"\` so user + reviewer + support can see exactly what failed. |
| \`astro-kbve/.../agentsService.ts\` (\`setRepoAllowlist\` + \`setBotConfig\`) | Removed delete-then-add. Single \`addToken\` call now relies on the RPC's existing \`ON CONFLICT … DO UPDATE\` upsert. Atomic. No failure window. |
| \`edge.mdx\` | 0.1.35 → 0.1.36 (touched edge fn). |

## Why no info-leak risk

SQLSTATE codes (\`23505\`, \`22023\`, \`23514\`, etc.) are public Postgres-defined. \`hint\` from Postgres is meant for caller consumption. \`context\` is our own static string (\`"guild_vault_rpc"\`). Actual error \`message\` still logged server-side only — that's where DB internals could leak.

## Test plan
- [ ] Retry repo allowlist set for KBVE/kbve. Two outcomes:
  - Success → upsert went through; "Operation failed" gone
  - Still fails → toast now carries the SQLSTATE; paste it back here and we'll map it to a real fix
- [ ] Existing rate-limit / validation false-returns (e.g. "Rate limit: max 10 tokens per guild") still surface their original message via the \`success: false\` path (untouched by this PR)