### PR TITLE
feat(astro-kbve): dashboard/gameops/mc/lots page consuming /api/v1/mc/lots

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mc/lot/AstroMCLotsShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mc/lot/AstroMCLotsShell.astro
@@ -11,7 +11,36 @@ import './mc-lots.css';
 				Marketplace, owned parcels, in-progress builds, and the
 				schematic catalog for the Minecraft survival backend.
 			</p>
+			<ul class="kbve-mclots-section__legend">
+				<li>
+					<strong>Vacant</strong> — buy any open parcel with credits or
+					khash.
+				</li>
+				<li>
+					<strong>My lots</strong> — your owned + built parcels.
+				</li>
+				<li>
+					<strong>In progress</strong> — jobs the survival worker has queued
+					or is applying right now.
+				</li>
+				<li>
+					<strong>Schematics</strong> — public catalog of build templates
+					and their prices.
+				</li>
+			</ul>
 		</div>
 	</header>
+
+	<noscript>
+		<div class="kbve-mclots__status kbve-mclots__status--auth">
+			This page needs JavaScript to fetch live lot data from
+			<code>/api/v1/mc/lots</code>. Enable scripts to continue.
+		</div>
+	</noscript>
+
+	<div class="kbve-mclots__skeleton" data-mclots-skeleton>
+		<div class="kbve-mclots__status">Loading lot dashboard…</div>
+	</div>
+
 	<MCLotsShell client:only="react" />
 </section>

--- a/apps/kbve/astro-kbve/src/components/mc/lot/AstroMCLotsShell.astro
+++ b/apps/kbve/astro-kbve/src/components/mc/lot/AstroMCLotsShell.astro
@@ -1,0 +1,17 @@
+---
+import MCLotsShell from './MCLotsShell';
+import './mc-lots.css';
+---
+
+<section class="kbve-mclots-section not-content kbve-dashboard-page">
+	<header class="kbve-mclots-section__header">
+		<div>
+			<h1>MC Lots</h1>
+			<p>
+				Marketplace, owned parcels, in-progress builds, and the
+				schematic catalog for the Minecraft survival backend.
+			</p>
+		</div>
+	</header>
+	<MCLotsShell client:only="react" />
+</section>

--- a/apps/kbve/astro-kbve/src/components/mc/lot/MCLotsShell.tsx
+++ b/apps/kbve/astro-kbve/src/components/mc/lot/MCLotsShell.tsx
@@ -1,0 +1,352 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSession } from '@kbve/astro';
+import { MCLotStates } from '../../../../../../../packages/data/codegen/generated/mc_lot-schema';
+import {
+	MCLotApiError,
+	listMyActive,
+	listMyTransitional,
+	listSchematics,
+	listVacant,
+	type MCOwnedLot,
+	type MCSchematic,
+	type MCVacantLot,
+} from './api';
+
+type Tab = 'vacant' | 'active' | 'transitional' | 'schematics';
+
+const TABS: Array<{ key: Tab; label: string }> = [
+	{ key: 'vacant', label: 'Vacant' },
+	{ key: 'active', label: 'My lots' },
+	{ key: 'transitional', label: 'In progress' },
+	{ key: 'schematics', label: 'Schematics' },
+];
+
+const DEFAULT_WORLD = 'minecraft:overworld';
+
+function lotStateLabel(state: number): string {
+	return MCLotStates[state] ?? `state:${state}`;
+}
+
+function fmtChunks(min: number, max: number): string {
+	if (min === max) return `${min}`;
+	return `${min}..${max}`;
+}
+
+function fmtPrice(credits: number, khash: number): string {
+	const parts: string[] = [];
+	if (credits > 0) parts.push(`${credits.toLocaleString()} credits`);
+	if (khash > 0) parts.push(`${khash.toLocaleString()} khash`);
+	return parts.length === 0 ? 'free' : parts.join(' + ');
+}
+
+export function MCLotsShell() {
+	const { ready, authenticated } = useSession();
+	const [tab, setTab] = useState<Tab>('vacant');
+	const [world, setWorld] = useState<string>(DEFAULT_WORLD);
+	const [vacant, setVacant] = useState<MCVacantLot[] | null>(null);
+	const [myActive, setMyActive] = useState<MCOwnedLot[] | null>(null);
+	const [myTrans, setMyTrans] = useState<MCOwnedLot[] | null>(null);
+	const [schematics, setSchematics] = useState<MCSchematic[] | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	// AbortController owns every in-flight request from this component so
+	// fetches that started right before a ClientRouter swap don't land
+	// after teardown and leak state writes into the next page.
+	const abortRef = useRef<AbortController | null>(null);
+
+	const cancelInFlight = useCallback(() => {
+		if (abortRef.current) {
+			abortRef.current.abort();
+			abortRef.current = null;
+		}
+	}, []);
+
+	const refresh = useCallback(
+		async (which: Tab) => {
+			cancelInFlight();
+			const ctrl = new AbortController();
+			abortRef.current = ctrl;
+			setLoading(true);
+			setError(null);
+			try {
+				if (which === 'vacant') {
+					const rows = await listVacant(
+						{ world, limit: 64 },
+						{ signal: ctrl.signal },
+					);
+					if (ctrl.signal.aborted) return;
+					setVacant(rows);
+				} else if (which === 'active') {
+					const rows = await listMyActive(
+						{ world, limit: 64 },
+						{ signal: ctrl.signal },
+					);
+					if (ctrl.signal.aborted) return;
+					setMyActive(rows);
+				} else if (which === 'transitional') {
+					const rows = await listMyTransitional(
+						{ world, limit: 64 },
+						{ signal: ctrl.signal },
+					);
+					if (ctrl.signal.aborted) return;
+					setMyTrans(rows);
+				} else {
+					const rows = await listSchematics(undefined, {
+						signal: ctrl.signal,
+					});
+					if (ctrl.signal.aborted) return;
+					setSchematics(rows);
+				}
+			} catch (e) {
+				if ((e as Error)?.name === 'AbortError') return;
+				setError(
+					e instanceof MCLotApiError ? e.message : 'failed to load',
+				);
+			} finally {
+				if (!ctrl.signal.aborted) setLoading(false);
+				if (abortRef.current === ctrl) abortRef.current = null;
+			}
+		},
+		[cancelInFlight, world],
+	);
+
+	useEffect(() => {
+		if (!ready) return;
+		if (tab !== 'schematics' && !authenticated) return;
+		void refresh(tab);
+		return () => cancelInFlight();
+	}, [ready, authenticated, tab, refresh, cancelInFlight]);
+
+	// Astro ClientRouter swaps don't unmount React islands the same way a
+	// hard reload would. Hook the swap lifecycle so in-flight fetches are
+	// cancelled even when React's useEffect cleanup hasn't run yet.
+	useEffect(() => {
+		const teardown = () => cancelInFlight();
+		document.addEventListener('astro:before-swap', teardown);
+		document.addEventListener('astro:before-preparation', teardown);
+		window.addEventListener('pagehide', teardown);
+		return () => {
+			document.removeEventListener('astro:before-swap', teardown);
+			document.removeEventListener('astro:before-preparation', teardown);
+			window.removeEventListener('pagehide', teardown);
+			cancelInFlight();
+		};
+	}, [cancelInFlight]);
+
+	const requiresAuth = tab !== 'schematics';
+
+	if (!ready) {
+		return <div className="kbve-mclots__status">Loading session…</div>;
+	}
+	if (requiresAuth && !authenticated) {
+		return (
+			<div className="kbve-mclots__status kbve-mclots__status--auth">
+				Sign in to view your lots.
+			</div>
+		);
+	}
+
+	return (
+		<div className="kbve-mclots">
+			<div className="kbve-mclots__bar">
+				<div className="kbve-mclots__tabs" role="tablist">
+					{TABS.map((t) => (
+						<button
+							key={t.key}
+							role="tab"
+							aria-selected={tab === t.key}
+							className={
+								'kbve-mclots__tab' +
+								(tab === t.key
+									? ' kbve-mclots__tab--active'
+									: '')
+							}
+							onClick={() => setTab(t.key)}>
+							{t.label}
+						</button>
+					))}
+				</div>
+				<label className="kbve-mclots__world">
+					<span>World</span>
+					<input
+						type="text"
+						value={world}
+						onChange={(e) => setWorld(e.target.value)}
+						spellCheck={false}
+					/>
+				</label>
+				<button
+					type="button"
+					className="kbve-mclots__refresh"
+					onClick={() => void refresh(tab)}
+					disabled={loading}>
+					{loading ? 'Loading…' : 'Refresh'}
+				</button>
+			</div>
+
+			{error && <div className="kbve-mclots__error">{error}</div>}
+
+			{tab === 'vacant' && (
+				<VacantTable rows={vacant} loading={loading} />
+			)}
+			{tab === 'active' && (
+				<OwnedTable rows={myActive} loading={loading} />
+			)}
+			{tab === 'transitional' && (
+				<OwnedTable rows={myTrans} loading={loading} />
+			)}
+			{tab === 'schematics' && (
+				<SchematicTable rows={schematics} loading={loading} />
+			)}
+		</div>
+	);
+}
+
+function VacantTable({
+	rows,
+	loading,
+}: {
+	rows: MCVacantLot[] | null;
+	loading: boolean;
+}) {
+	const empty = rows !== null && rows.length === 0;
+	const sorted = useMemo(
+		() =>
+			(rows ?? []).slice().sort((a, b) => a.chunk_x_min - b.chunk_x_min),
+		[rows],
+	);
+	if (rows === null && loading) {
+		return <div className="kbve-mclots__status">Loading lots…</div>;
+	}
+	if (empty) {
+		return <div className="kbve-mclots__status">No vacant lots.</div>;
+	}
+	return (
+		<table className="kbve-mclots__table">
+			<thead>
+				<tr>
+					<th>Lot</th>
+					<th>Chunks (x)</th>
+					<th>Chunks (z)</th>
+					<th>Area</th>
+					<th>Anchor Y</th>
+					<th>Price</th>
+				</tr>
+			</thead>
+			<tbody>
+				{sorted.map((r) => (
+					<tr key={r.lot_id}>
+						<td>
+							<code>{r.lot_id}</code>
+						</td>
+						<td>{fmtChunks(r.chunk_x_min, r.chunk_x_max)}</td>
+						<td>{fmtChunks(r.chunk_z_min, r.chunk_z_max)}</td>
+						<td>{r.chunk_area}</td>
+						<td>{r.anchor_y}</td>
+						<td>{fmtPrice(r.price_credits, r.price_khash)}</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	);
+}
+
+function OwnedTable({
+	rows,
+	loading,
+}: {
+	rows: MCOwnedLot[] | null;
+	loading: boolean;
+}) {
+	const empty = rows !== null && rows.length === 0;
+	if (rows === null && loading) {
+		return <div className="kbve-mclots__status">Loading lots…</div>;
+	}
+	if (empty) {
+		return <div className="kbve-mclots__status">No lots.</div>;
+	}
+	return (
+		<table className="kbve-mclots__table">
+			<thead>
+				<tr>
+					<th>Lot</th>
+					<th>State</th>
+					<th>Schematic</th>
+					<th>Chunks (x)</th>
+					<th>Chunks (z)</th>
+					<th>Area</th>
+					<th>Anchor Y</th>
+				</tr>
+			</thead>
+			<tbody>
+				{(rows ?? []).map((r) => (
+					<tr key={r.lot_id}>
+						<td>
+							<code>{r.lot_id}</code>
+						</td>
+						<td>
+							<span
+								className={`kbve-mclots__state kbve-mclots__state--${lotStateLabel(r.state)}`}>
+								{lotStateLabel(r.state)}
+							</span>
+						</td>
+						<td>{r.current_schematic_id ?? '—'}</td>
+						<td>{fmtChunks(r.chunk_x_min, r.chunk_x_max)}</td>
+						<td>{fmtChunks(r.chunk_z_min, r.chunk_z_max)}</td>
+						<td>{r.chunk_area}</td>
+						<td>{r.anchor_y}</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	);
+}
+
+function SchematicTable({
+	rows,
+	loading,
+}: {
+	rows: MCSchematic[] | null;
+	loading: boolean;
+}) {
+	const empty = rows !== null && rows.length === 0;
+	if (rows === null && loading) {
+		return <div className="kbve-mclots__status">Loading catalog…</div>;
+	}
+	if (empty) {
+		return <div className="kbve-mclots__status">No schematics.</div>;
+	}
+	return (
+		<table className="kbve-mclots__table">
+			<thead>
+				<tr>
+					<th>ID</th>
+					<th>Name</th>
+					<th>Category</th>
+					<th>Tier</th>
+					<th>Dimensions</th>
+					<th>Price</th>
+				</tr>
+			</thead>
+			<tbody>
+				{(rows ?? []).map((s) => (
+					<tr key={s.schematic_id}>
+						<td>
+							<code>{s.schematic_id}</code>
+						</td>
+						<td>{s.name}</td>
+						<td>{s.category}</td>
+						<td>{s.tier}</td>
+						<td>
+							{s.dims_x}×{s.dims_y}×{s.dims_z}
+						</td>
+						<td>{fmtPrice(s.price_credits, s.price_khash)}</td>
+					</tr>
+				))}
+			</tbody>
+		</table>
+	);
+}
+
+export default MCLotsShell;

--- a/apps/kbve/astro-kbve/src/components/mc/lot/MCLotsShell.tsx
+++ b/apps/kbve/astro-kbve/src/components/mc/lot/MCLotsShell.tsx
@@ -42,6 +42,7 @@ function fmtPrice(credits: number, khash: number): string {
 export function MCLotsShell() {
 	const { ready, authenticated } = useSession();
 	const [tab, setTab] = useState<Tab>('vacant');
+	const [worldInput, setWorldInput] = useState<string>(DEFAULT_WORLD);
 	const [world, setWorld] = useState<string>(DEFAULT_WORLD);
 	const [vacant, setVacant] = useState<MCVacantLot[] | null>(null);
 	const [myActive, setMyActive] = useState<MCOwnedLot[] | null>(null);
@@ -50,10 +51,13 @@ export function MCLotsShell() {
 	const [error, setError] = useState<string | null>(null);
 	const [loading, setLoading] = useState(false);
 
-	// AbortController owns every in-flight request from this component so
-	// fetches that started right before a ClientRouter swap don't land
-	// after teardown and leak state writes into the next page.
 	const abortRef = useRef<AbortController | null>(null);
+	const worldRef = useRef(world);
+	const mountedRef = useRef(false);
+
+	useEffect(() => {
+		worldRef.current = world;
+	}, [world]);
 
 	const cancelInFlight = useCallback(() => {
 		if (abortRef.current) {
@@ -69,66 +73,88 @@ export function MCLotsShell() {
 			abortRef.current = ctrl;
 			setLoading(true);
 			setError(null);
+			const currentWorld = worldRef.current;
 			try {
 				if (which === 'vacant') {
 					const rows = await listVacant(
-						{ world, limit: 64 },
+						{ world: currentWorld, limit: 64 },
 						{ signal: ctrl.signal },
 					);
-					if (ctrl.signal.aborted) return;
+					if (ctrl.signal.aborted || !mountedRef.current) return;
 					setVacant(rows);
 				} else if (which === 'active') {
 					const rows = await listMyActive(
-						{ world, limit: 64 },
+						{ world: currentWorld, limit: 64 },
 						{ signal: ctrl.signal },
 					);
-					if (ctrl.signal.aborted) return;
+					if (ctrl.signal.aborted || !mountedRef.current) return;
 					setMyActive(rows);
 				} else if (which === 'transitional') {
 					const rows = await listMyTransitional(
-						{ world, limit: 64 },
+						{ world: currentWorld, limit: 64 },
 						{ signal: ctrl.signal },
 					);
-					if (ctrl.signal.aborted) return;
+					if (ctrl.signal.aborted || !mountedRef.current) return;
 					setMyTrans(rows);
 				} else {
 					const rows = await listSchematics(undefined, {
 						signal: ctrl.signal,
 					});
-					if (ctrl.signal.aborted) return;
+					if (ctrl.signal.aborted || !mountedRef.current) return;
 					setSchematics(rows);
 				}
 			} catch (e) {
 				if ((e as Error)?.name === 'AbortError') return;
+				if (!mountedRef.current) return;
 				setError(
 					e instanceof MCLotApiError ? e.message : 'failed to load',
 				);
 			} finally {
-				if (!ctrl.signal.aborted) setLoading(false);
+				if (!ctrl.signal.aborted && mountedRef.current) {
+					setLoading(false);
+				}
 				if (abortRef.current === ctrl) abortRef.current = null;
 			}
 		},
-		[cancelInFlight, world],
+		[cancelInFlight],
 	);
+
+	// Debounce worldInput → world so each keystroke doesn't kick off a fetch.
+	useEffect(() => {
+		if (worldInput === world) return;
+		const t = window.setTimeout(() => setWorld(worldInput), 350);
+		return () => window.clearTimeout(t);
+	}, [worldInput, world]);
 
 	useEffect(() => {
 		if (!ready) return;
 		if (tab !== 'schematics' && !authenticated) return;
 		void refresh(tab);
 		return () => cancelInFlight();
-	}, [ready, authenticated, tab, refresh, cancelInFlight]);
+	}, [ready, authenticated, tab, world, refresh, cancelInFlight]);
 
-	// Astro ClientRouter swaps don't unmount React islands the same way a
-	// hard reload would. Hook the swap lifecycle so in-flight fetches are
-	// cancelled even when React's useEffect cleanup hasn't run yet.
+	// Astro ClientRouter swaps don't always unmount React islands. Hook the
+	// swap + page-lifecycle events so in-flight fetches die even when the
+	// component cleanup hasn't run. mountedRef gates every late setState so
+	// a settle that wins the race after teardown is a no-op.
 	useEffect(() => {
+		mountedRef.current = true;
+		document
+			.querySelectorAll('[data-mclots-skeleton]')
+			.forEach((el) => el.remove());
 		const teardown = () => cancelInFlight();
+		const onHidden = () => {
+			if (document.visibilityState === 'hidden') cancelInFlight();
+		};
 		document.addEventListener('astro:before-swap', teardown);
 		document.addEventListener('astro:before-preparation', teardown);
+		document.addEventListener('visibilitychange', onHidden);
 		window.addEventListener('pagehide', teardown);
 		return () => {
+			mountedRef.current = false;
 			document.removeEventListener('astro:before-swap', teardown);
 			document.removeEventListener('astro:before-preparation', teardown);
+			document.removeEventListener('visibilitychange', onHidden);
 			window.removeEventListener('pagehide', teardown);
 			cancelInFlight();
 		};
@@ -171,8 +197,8 @@ export function MCLotsShell() {
 					<span>World</span>
 					<input
 						type="text"
-						value={world}
-						onChange={(e) => setWorld(e.target.value)}
+						value={worldInput}
+						onChange={(e) => setWorldInput(e.target.value)}
 						spellCheck={false}
 					/>
 				</label>

--- a/apps/kbve/astro-kbve/src/components/mc/lot/api.ts
+++ b/apps/kbve/astro-kbve/src/components/mc/lot/api.ts
@@ -1,0 +1,259 @@
+import { getAccessToken } from '@kbve/astro';
+import {
+	MCSchematicSchema,
+	MCVacantLotSchema,
+	MCOwnedLotSchema,
+	MCViewportLotSchema,
+	MCPurchaseLotResponseSchema,
+	MCBuildIdResponseSchema,
+	MCOkResponseSchema,
+	type MCSchematic,
+	type MCVacantLot,
+	type MCOwnedLot,
+	type MCViewportLot,
+	type MCPurchaseLotResponse,
+	type MCBuildIdResponse,
+	type MCOkResponse,
+} from '../../../../../../../packages/data/codegen/generated/mc_lot-schema';
+import { z } from 'zod';
+
+export class MCLotApiError extends Error {
+	status: number;
+	code?: string;
+	constructor(message: string, status: number, code?: string) {
+		super(message);
+		this.status = status;
+		this.code = code;
+	}
+}
+
+async function parseError(res: Response): Promise<MCLotApiError> {
+	let detail = '';
+	let code: string | undefined;
+	try {
+		const txt = await res.text();
+		try {
+			const parsed = JSON.parse(txt);
+			detail = parsed.message || parsed.error || txt;
+			code = parsed.error;
+		} catch {
+			detail = txt;
+		}
+	} catch {
+		// Body read failure — fall through to statusText.
+	}
+	return new MCLotApiError(detail || res.statusText, res.status, code);
+}
+
+type FetchOpts = {
+	signal?: AbortSignal;
+};
+
+async function publicGet<T>(
+	path: string,
+	schema: z.ZodSchema<T>,
+	opts: FetchOpts = {},
+): Promise<T> {
+	const res = await fetch(path, { signal: opts.signal });
+	if (!res.ok) throw await parseError(res);
+	const data = await res.json();
+	return schema.parse(data);
+}
+
+async function authedFetch<T>(
+	path: string,
+	schema: z.ZodSchema<T>,
+	init: RequestInit & FetchOpts = {},
+): Promise<T> {
+	const token = await getAccessToken();
+	if (!token) {
+		throw new MCLotApiError('not authenticated', 401, 'not_authenticated');
+	}
+	const headers = new Headers(init.headers);
+	headers.set('Authorization', `Bearer ${token}`);
+	if (init.body && !headers.has('Content-Type')) {
+		headers.set('Content-Type', 'application/json');
+	}
+	const res = await fetch(path, {
+		...init,
+		headers,
+		signal: init.signal,
+	});
+	if (!res.ok) throw await parseError(res);
+	if (res.status === 204) return undefined as T;
+	const data = await res.json();
+	return schema.parse(data);
+}
+
+type LotChunkCursor = {
+	world?: string;
+	limit?: number;
+	after_chunk_x?: number | null;
+	after_chunk_z?: number | null;
+	after_lot_id?: string | null;
+};
+
+function buildQuery(
+	params: Record<string, string | number | null | undefined>,
+): string {
+	const usp = new URLSearchParams();
+	for (const [k, v] of Object.entries(params)) {
+		if (v === null || v === undefined || v === '') continue;
+		usp.set(k, String(v));
+	}
+	const s = usp.toString();
+	return s ? `?${s}` : '';
+}
+
+const Schematics = z.array(MCSchematicSchema);
+const VacantLots = z.array(MCVacantLotSchema);
+const OwnedLots = z.array(MCOwnedLotSchema);
+const ViewportLots = z.array(MCViewportLotSchema);
+
+export function listSchematics(
+	category?: string,
+	opts: FetchOpts = {},
+): Promise<MCSchematic[]> {
+	return publicGet(
+		`/api/v1/mc/lots/schematics${buildQuery({ category })}`,
+		Schematics,
+		opts,
+	);
+}
+
+export function listVacant(
+	c: LotChunkCursor = {},
+	opts: FetchOpts = {},
+): Promise<MCVacantLot[]> {
+	return authedFetch(
+		`/api/v1/mc/lots/vacant${buildQuery({
+			world: c.world,
+			limit: c.limit ?? 64,
+			after_chunk_x: c.after_chunk_x,
+			after_chunk_z: c.after_chunk_z,
+			after_lot_id: c.after_lot_id,
+		})}`,
+		VacantLots,
+		opts,
+	);
+}
+
+export function listMyActive(
+	c: LotChunkCursor = {},
+	opts: FetchOpts = {},
+): Promise<MCOwnedLot[]> {
+	return authedFetch(
+		`/api/v1/mc/lots/me/active${buildQuery({
+			world: c.world,
+			limit: c.limit ?? 64,
+			after_chunk_x: c.after_chunk_x,
+			after_chunk_z: c.after_chunk_z,
+			after_lot_id: c.after_lot_id,
+		})}`,
+		OwnedLots,
+		opts,
+	);
+}
+
+export function listMyTransitional(
+	c: LotChunkCursor = {},
+	opts: FetchOpts = {},
+): Promise<MCOwnedLot[]> {
+	return authedFetch(
+		`/api/v1/mc/lots/me/transitional${buildQuery({
+			world: c.world,
+			limit: c.limit ?? 64,
+			after_chunk_x: c.after_chunk_x,
+			after_chunk_z: c.after_chunk_z,
+			after_lot_id: c.after_lot_id,
+		})}`,
+		OwnedLots,
+		opts,
+	);
+}
+
+export function listViewport(
+	q: {
+		world?: string;
+		min_chunk_x: number;
+		max_chunk_x: number;
+		min_chunk_z: number;
+		max_chunk_z: number;
+		state?: number | null;
+		limit?: number;
+	},
+	opts: FetchOpts = {},
+): Promise<MCViewportLot[]> {
+	return authedFetch(
+		`/api/v1/mc/lots/viewport${buildQuery({
+			world: q.world,
+			min_chunk_x: q.min_chunk_x,
+			max_chunk_x: q.max_chunk_x,
+			min_chunk_z: q.min_chunk_z,
+			max_chunk_z: q.max_chunk_z,
+			state: q.state ?? null,
+			limit: q.limit ?? 1000,
+		})}`,
+		ViewportLots,
+		opts,
+	);
+}
+
+export function purchase(
+	body: { lot_id: string; idempotency_key: string },
+	opts: FetchOpts = {},
+): Promise<MCPurchaseLotResponse> {
+	return authedFetch(
+		'/api/v1/mc/lots/me/purchase',
+		MCPurchaseLotResponseSchema,
+		{
+			method: 'POST',
+			body: JSON.stringify(body),
+			signal: opts.signal,
+		},
+	);
+}
+
+export function queueBuild(
+	body: {
+		lot_id: string;
+		schematic_id: string;
+		idempotency_key: string;
+	},
+	opts: FetchOpts = {},
+): Promise<MCBuildIdResponse> {
+	return authedFetch(
+		'/api/v1/mc/lots/me/queue-build',
+		MCBuildIdResponseSchema,
+		{
+			method: 'POST',
+			body: JSON.stringify(body),
+			signal: opts.signal,
+		},
+	);
+}
+
+export function queueDemolish(
+	body: { lot_id: string; idempotency_key: string },
+	opts: FetchOpts = {},
+): Promise<MCBuildIdResponse> {
+	return authedFetch(
+		'/api/v1/mc/lots/me/queue-demolish',
+		MCBuildIdResponseSchema,
+		{
+			method: 'POST',
+			body: JSON.stringify(body),
+			signal: opts.signal,
+		},
+	);
+}
+
+export type {
+	MCSchematic,
+	MCVacantLot,
+	MCOwnedLot,
+	MCViewportLot,
+	MCPurchaseLotResponse,
+	MCBuildIdResponse,
+	MCOkResponse,
+};

--- a/apps/kbve/astro-kbve/src/components/mc/lot/mc-lots.css
+++ b/apps/kbve/astro-kbve/src/components/mc/lot/mc-lots.css
@@ -1,3 +1,19 @@
+.kbve-mclots-section__legend {
+	list-style: disc;
+	margin: 0.5rem 0 0 1.25rem;
+	padding: 0;
+	font-size: 0.92rem;
+	color: var(--sl-color-gray-2);
+}
+
+.kbve-mclots-section__legend li {
+	margin: 0.15rem 0;
+}
+
+.kbve-mclots__skeleton {
+	display: contents;
+}
+
 .kbve-mclots {
 	display: flex;
 	flex-direction: column;

--- a/apps/kbve/astro-kbve/src/components/mc/lot/mc-lots.css
+++ b/apps/kbve/astro-kbve/src/components/mc/lot/mc-lots.css
@@ -1,0 +1,134 @@
+.kbve-mclots {
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	width: 100%;
+}
+
+.kbve-mclots__bar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.75rem 1rem;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.5rem;
+	background: var(--sl-color-bg-nav);
+}
+
+.kbve-mclots__tabs {
+	display: inline-flex;
+	gap: 0.25rem;
+}
+
+.kbve-mclots__tab {
+	background: transparent;
+	border: 1px solid var(--sl-color-gray-5);
+	color: var(--sl-color-white);
+	border-radius: 0.375rem;
+	padding: 0.4rem 0.75rem;
+	font: inherit;
+	cursor: pointer;
+}
+
+.kbve-mclots__tab--active {
+	background: var(--sl-color-accent);
+	color: var(--sl-color-text-invert);
+	border-color: var(--sl-color-accent);
+}
+
+.kbve-mclots__world {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	margin-left: auto;
+}
+
+.kbve-mclots__world input {
+	background: var(--sl-color-bg);
+	color: var(--sl-color-white);
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.375rem;
+	padding: 0.35rem 0.5rem;
+	font: inherit;
+	min-width: 16rem;
+}
+
+.kbve-mclots__refresh {
+	background: var(--sl-color-bg);
+	color: var(--sl-color-white);
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.375rem;
+	padding: 0.4rem 0.85rem;
+	font: inherit;
+	cursor: pointer;
+}
+
+.kbve-mclots__refresh[disabled] {
+	opacity: 0.5;
+	cursor: progress;
+}
+
+.kbve-mclots__status {
+	padding: 1.25rem;
+	text-align: center;
+	color: var(--sl-color-gray-3);
+	border: 1px dashed var(--sl-color-gray-5);
+	border-radius: 0.5rem;
+}
+
+.kbve-mclots__status--auth {
+	color: var(--sl-color-white);
+}
+
+.kbve-mclots__error {
+	padding: 0.75rem 1rem;
+	border-radius: 0.375rem;
+	background: var(--sl-color-red-low);
+	color: var(--sl-color-red-high);
+	border: 1px solid var(--sl-color-red);
+}
+
+.kbve-mclots__table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.92rem;
+}
+
+.kbve-mclots__table th,
+.kbve-mclots__table td {
+	text-align: left;
+	padding: 0.5rem 0.75rem;
+	border-bottom: 1px solid var(--sl-color-gray-6);
+	vertical-align: top;
+}
+
+.kbve-mclots__table th {
+	background: var(--sl-color-bg-nav);
+	font-weight: 600;
+}
+
+.kbve-mclots__state {
+	display: inline-block;
+	padding: 0.15rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.8em;
+	background: var(--sl-color-gray-6);
+	color: var(--sl-color-white);
+}
+
+.kbve-mclots__state--vacant {
+	background: var(--sl-color-gray-5);
+}
+
+.kbve-mclots__state--owned,
+.kbve-mclots__state--built {
+	background: var(--sl-color-green-low);
+	color: var(--sl-color-green-high);
+}
+
+.kbve-mclots__state--under_build,
+.kbve-mclots__state--demolishing {
+	background: var(--sl-color-orange-low);
+	color: var(--sl-color-orange-high);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/mc/lots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/dashboard/gameops/mc/lots.mdx
@@ -1,0 +1,20 @@
+---
+title: MC Lots
+description: |
+    Browse vacant MC parcels, manage owned lots, queue schematic
+    builds, and watch in-progress jobs land on the survival backend.
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: Lots
+    order: 5
+tags:
+    - dashboard
+    - minecraft
+    - mc-lot
+---
+
+import AstroMCLotsShell from '@/components/mc/lot/AstroMCLotsShell.astro';
+
+<AstroMCLotsShell />


### PR DESCRIPTION
## Summary

Light the lot system up on the dashboard. New page at \`/dashboard/gameops/mc/lots\` consumes the deployed \`/api/v1/mc/lots/*\` axum endpoints and validates every response with the Zod schemas from the proto-derived codegen.

### Wiring
\`\`\`
SQL (mc.lot, mc.lot_build_log, ...)
  -> dbmate migration 20260526223407
axum /api/v1/mc/lots/*
  -> typed handlers (LotClient + LotError)
Zod schemas (packages/data/codegen/generated/mc_lot-schema.ts)
  -> proto-derived MCVacantLotSchema / MCOwnedLotSchema / MCSchematicSchema / ...
Astro page (this PR)
  -> components/mc/lot/api.ts (fetch + zod.parse)
  -> components/mc/lot/MCLotsShell.tsx (React island, client:only=react)
\`\`\`

### Tabs
- **Vacant** — marketplace map (\`/api/v1/mc/lots/vacant\`).
- **My lots** — caller's owned lots (\`/api/v1/mc/lots/me/active\`).
- **In progress** — caller's transitional lots (\`/api/v1/mc/lots/me/transitional\`).
- **Schematics** — public catalog (\`/api/v1/mc/lots/schematics\`).

### Astro ClientRouter teardown
KBVE astro-kbve uses ClientRouter; React islands don't re-mount on swap navigation. The island handles cancellation in three layers:

1. \`useRef<AbortController>\` owns every in-flight request. Every refresh cancels the prior one.
2. The data-effect cleanup aborts when tab / world / auth status change.
3. A dedicated effect listens for \`astro:before-swap\`, \`astro:before-preparation\`, and \`pagehide\` so fetches kicked off right before a swap don't land after teardown and leak state writes into the next page.

AbortError is swallowed at the catch site so cancelled requests stay silent.

### Wire-shape notes
- \`state\` / \`action_kind\` come over as i16; \`MCLotStates[state]\` resolves the display label.
- NULL-allowed columns (\`current_schematic_id\`, \`latest_apply_error\`, etc.) are \`.nullable().optional()\` per the codegen config.

## Test plan
- [ ] \`./kbve.sh -nx astro-kbve:build\` produces \`dist/apps/astro-kbve/dashboard/gameops/mc/lots/index.html\` with the \`kbve-mclots\` markup (verified locally).
- [ ] On a deployed instance, the page lists vacant lots without an auth bearer.
- [ ] My lots / In progress tabs return 401 surface (\"Sign in to view your lots\") for anonymous sessions.
- [ ] Swap navigation away from the page while loading does not surface stale data on return.