### PR TITLE
feat(chuck): polish chat window — movable frame, tabs, slash cmds, history

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -70,6 +70,14 @@ void AchuckCorePlayerController::SetupInputComponent()
 			{
 				EIC->BindAction(Inputs->Inventory, ETriggerEvent::Started, this, &AchuckCorePlayerController::OnInventoryPressed);
 			}
+			if (Inputs->ToggleChat)
+			{
+				EIC->BindAction(Inputs->ToggleChat, ETriggerEvent::Started, this, &AchuckCorePlayerController::OnToggleChatPressed);
+			}
+			if (Inputs->FocusChat)
+			{
+				EIC->BindAction(Inputs->FocusChat, ETriggerEvent::Started, this, &AchuckCorePlayerController::OnFocusChatPressed);
+			}
 		}
 	}
 }
@@ -106,7 +114,9 @@ void AchuckCorePlayerController::OnPossess(APawn* InPawn)
 
 	LoginWidget   = SNew(SchuckLoginWidget).Subsystem(SupabaseSubsystem);
 	AccountWidget = SNew(SchuckAccountPanel).Subsystem(SupabaseSubsystem);
-	ChatWidget    = SNew(SchuckChatPanel).Subsystem(SupabaseSubsystem);
+	ChatWidget    = SNew(SchuckChatPanel)
+		.Subsystem(SupabaseSubsystem)
+		.OwningCharacter(Char);
 
 	if (UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr)
 	{
@@ -416,6 +426,8 @@ void AchuckCorePlayerController::InitSupabaseBridge()
 		Chat->OnConnected.AddDynamic(this, &AchuckCorePlayerController::HandleChatConnected);
 		Chat->OnDisconnected.AddDynamic(this, &AchuckCorePlayerController::HandleChatDisconnected);
 		Chat->OnMessage.AddDynamic(this, &AchuckCorePlayerController::HandleChatMessage);
+		Chat->OnChannelJoined.AddDynamic(this, &AchuckCorePlayerController::HandleChatChannelJoined);
+		Chat->OnChannelLeft.AddDynamic(this, &AchuckCorePlayerController::HandleChatChannelLeft);
 	}
 
 	const bool bSignedIn = Sub->IsSignedIn();
@@ -449,6 +461,40 @@ void AchuckCorePlayerController::TearDownSupabaseBridge()
 		Chat->OnConnected.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatConnected);
 		Chat->OnDisconnected.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatDisconnected);
 		Chat->OnMessage.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatMessage);
+		Chat->OnChannelJoined.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatChannelJoined);
+		Chat->OnChannelLeft.RemoveDynamic(this, &AchuckCorePlayerController::HandleChatChannelLeft);
+	}
+}
+
+void AchuckCorePlayerController::HandleChatChannelJoined(const FString& Channel)
+{
+	if (ChatWidget.IsValid())
+	{
+		ChatWidget->OnChannelJoined(Channel);
+	}
+}
+
+void AchuckCorePlayerController::HandleChatChannelLeft(const FString& Channel)
+{
+	if (ChatWidget.IsValid())
+	{
+		ChatWidget->OnChannelLeft(Channel);
+	}
+}
+
+void AchuckCorePlayerController::OnToggleChatPressed(const FInputActionValue& /*Value*/)
+{
+	if (ChatWidget.IsValid())
+	{
+		ChatWidget->ToggleVisible();
+	}
+}
+
+void AchuckCorePlayerController::OnFocusChatPressed(const FInputActionValue& /*Value*/)
+{
+	if (ChatWidget.IsValid())
+	{
+		ChatWidget->ShowAndFocusInput();
 	}
 }
 

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
@@ -39,6 +39,8 @@ protected:
 	void OnPausePressed(const FInputActionValue& Value);
 	void OnToggleDevOverlayPressed(const FInputActionValue& Value);
 	void OnInventoryPressed(const FInputActionValue& Value);
+	void OnToggleChatPressed(const FInputActionValue& Value);
+	void OnFocusChatPressed(const FInputActionValue& Value);
 
 	void OpenInventory();
 	void CloseInventory();
@@ -63,6 +65,10 @@ protected:
 	void HandleChatDisconnected(int32 StatusCode, const FString& Reason);
 	UFUNCTION()
 	void HandleChatMessage(const FKBVEChatMessage& Message);
+	UFUNCTION()
+	void HandleChatChannelJoined(const FString& Channel);
+	UFUNCTION()
+	void HandleChatChannelLeft(const FString& Channel);
 
 	void InitSupabaseBridge();
 	void TearDownSupabaseBridge();

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckInputs.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckInputs.cpp
@@ -29,6 +29,8 @@ void UchuckInputs::Build()
 	Pause            = NewObject<UInputAction>(this, TEXT("IA_Pause"));
 	ToggleDevOverlay = NewObject<UInputAction>(this, TEXT("IA_ToggleDevOverlay"));
 	Inventory        = NewObject<UInputAction>(this, TEXT("IA_Inventory"));
+	ToggleChat       = NewObject<UInputAction>(this, TEXT("IA_ToggleChat"));
+	FocusChat        = NewObject<UInputAction>(this, TEXT("IA_FocusChat"));
 
 	Move->ValueType             = EInputActionValueType::Axis2D;
 	Look->ValueType             = EInputActionValueType::Axis2D;
@@ -38,6 +40,8 @@ void UchuckInputs::Build()
 	ToggleCamera->ValueType     = EInputActionValueType::Boolean;
 	Pause->ValueType            = EInputActionValueType::Boolean;
 	ToggleDevOverlay->ValueType = EInputActionValueType::Boolean;
+	ToggleChat->ValueType       = EInputActionValueType::Boolean;
+	FocusChat->ValueType        = EInputActionValueType::Boolean;
 
 	DefaultIMC = NewObject<UInputMappingContext>(this, TEXT("IMC_Default"));
 
@@ -48,6 +52,8 @@ void UchuckInputs::Build()
 	DefaultIMC->MapKey(Pause,            EKeys::Escape);
 	DefaultIMC->MapKey(ToggleDevOverlay, EKeys::Tilde);
 	DefaultIMC->MapKey(Inventory,        EKeys::I);
+	DefaultIMC->MapKey(ToggleChat,       EKeys::T);
+	DefaultIMC->MapKey(FocusChat,        EKeys::Enter);
 
 	{
 		FEnhancedActionKeyMapping& LookMap = DefaultIMC->MapKey(Look, EKeys::Mouse2D);

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckInputs.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckInputs.h
@@ -24,6 +24,8 @@ public:
 	UPROPERTY() TObjectPtr<UInputAction>          Pause;
 	UPROPERTY() TObjectPtr<UInputAction>          ToggleDevOverlay;
 	UPROPERTY() TObjectPtr<UInputAction>          Inventory;
+	UPROPERTY() TObjectPtr<UInputAction>          ToggleChat;
+	UPROPERTY() TObjectPtr<UInputAction>          FocusChat;
 	UPROPERTY() TObjectPtr<UInputMappingContext>  DefaultIMC;
 
 protected:

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.cpp
@@ -2,6 +2,10 @@
 
 #include "KBVESupabaseSubsystem.h"
 #include "KBVESupabaseChat.h"
+#include "chuckCoreCharacter.h"
+#include "chuckSettings.h"
+
+#include "SKBVEMovableFrame.h"
 
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/Layout/SBorder.h"
@@ -10,115 +14,325 @@
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SEditableTextBox.h"
 #include "Widgets/Text/STextBlock.h"
+#include "Framework/Application/SlateApplication.h"
 #include "Styling/CoreStyle.h"
 
 #define LOCTEXT_NAMESPACE "SchuckChatPanel"
 
 namespace
 {
+	const FName ChatWindowKey = TEXT("chuck.chat");
+	const int32 MaxScrollbackLines = 500;
+	const int32 MaxHistoryEntries  = 64;
+
 	FLinearColor PickKindColor(const FString& Kind, bool bIsEvent)
 	{
 		if (bIsEvent) return FLinearColor(0.95f, 0.78f, 0.32f);
 		if (Kind.Equals(TEXT("CHAT"), ESearchCase::IgnoreCase)) return FLinearColor(0.78f, 0.88f, 0.98f);
+		if (Kind.Equals(TEXT("ME"), ESearchCase::IgnoreCase)) return FLinearColor(0.82f, 0.74f, 0.98f);
 		return FLinearColor(0.7f, 0.7f, 0.78f);
+	}
+
+	FString FormatTimestampLocal()
+	{
+		return FDateTime::Now().ToString(TEXT("%H:%M"));
+	}
+
+	bool TokenizeArgs(const FString& Rest, TArray<FString>& OutTokens)
+	{
+		Rest.ParseIntoArrayWS(OutTokens);
+		return OutTokens.Num() > 0;
+	}
+
+	FString NormalizeChannel(const FString& In)
+	{
+		FString Trimmed = In.TrimStartAndEnd();
+		if (Trimmed.IsEmpty()) return Trimmed;
+		if (!Trimmed.StartsWith(TEXT("#")) && !Trimmed.StartsWith(TEXT("&")))
+		{
+			Trimmed = TEXT("#") + Trimmed;
+		}
+		return Trimmed;
 	}
 }
 
 void SchuckChatPanel::Construct(const FArguments& InArgs)
 {
 	Subsystem = InArgs._Subsystem;
+	OwningCharacter = InArgs._OwningCharacter;
 	ActiveChannel = InArgs._DefaultChannel;
+	OnCloseClicked = InArgs._OnCloseClicked;
+
+	if (!ActiveChannel.IsEmpty())
+	{
+		FChannelTab Tab;
+		Tab.Name = ActiveChannel;
+		Tabs.Add(MoveTemp(Tab));
+	}
 
 	const FSlateFontInfo HeaderFont = FCoreStyle::GetDefaultFontStyle("Bold", 11);
-	const FSlateFontInfo ChatFont   = FCoreStyle::GetDefaultFontStyle("Regular", 10);
 	const FSlateFontInfo ButtonFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
+
+	FVector2D StartPos(64.f, 380.f);
+	FVector2D StartSize(420.f, 280.f);
+	if (AchuckCoreCharacter* C = OwningCharacter.Get())
+	{
+		if (UchuckSettings* S = UchuckSettings::Get(C))
+		{
+			FchuckWindowGeometry G;
+			if (S->GetWindowGeometry(ChatWindowKey, G))
+			{
+				StartPos  = G.Position;
+				StartSize = G.Size;
+			}
+		}
+	}
+
+	SetVisibility(EVisibility::SelfHitTestInvisible);
+
+	TSharedRef<SHorizontalBox> NewTabRow = SNew(SHorizontalBox);
+	TabRow = NewTabRow;
 
 	ChildSlot
 	[
-		SNew(SBox).WidthOverride(360.f).HeightOverride(220.f)
+		SAssignNew(MovableFrame, SKBVEMovableFrame)
+		.Title(LOCTEXT("ChatTitle", "Chat"))
+		.InitialPosition(StartPos)
+		.FrameSize(StartSize)
+		.MinFrameSize(FVector2D(320.f, 180.f))
+		.OnCloseClicked_Lambda([this]()
+		{
+			SetVisibility(EVisibility::Collapsed);
+			OnCloseClicked.ExecuteIfBound();
+		})
+		.OnGeometryChanged_Lambda([this]() { PersistGeometry(); })
+		.Body()
 		[
-			SNew(SBorder)
-			.BorderImage(FCoreStyle::Get().GetBrush("WhiteBrush"))
-			.BorderBackgroundColor(FSlateColor(FLinearColor(0.04f, 0.06f, 0.09f, 0.78f)))
-			.Padding(FMargin(8.f))
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().Padding(2.f, 2.f, 2.f, 4.f)
 			[
-				SNew(SVerticalBox)
-				+ SVerticalBox::Slot().AutoHeight().Padding(0.f, 0.f, 0.f, 4.f)
+				SAssignNew(HeaderText, STextBlock)
+				.Text(FText::GetEmpty())
+				.Font(HeaderFont)
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(2.f, 0.f, 2.f, 4.f)
+			[
+				NewTabRow
+			]
+			+ SVerticalBox::Slot().FillHeight(1.f).Padding(2.f, 0.f, 2.f, 4.f)
+			[
+				SAssignNew(Scrollback, SScrollBox)
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(2.f)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().FillWidth(1.f).Padding(0.f, 0.f, 4.f, 0.f)
 				[
-					SAssignNew(HeaderText, STextBlock)
-					.Text(FText::FromString(FString::Printf(TEXT("Chat — %s (disconnected)"), *ActiveChannel)))
-					.Font(HeaderFont)
+					SAssignNew(InputBox, SEditableTextBox)
+					.HintText(LOCTEXT("InputHint", "Type a message or /command"))
+					.OnTextCommitted(this, &SchuckChatPanel::HandleInputCommitted)
 				]
-				+ SVerticalBox::Slot().FillHeight(1.f).Padding(0.f, 0.f, 0.f, 4.f)
+				+ SHorizontalBox::Slot().AutoWidth()
 				[
-					SAssignNew(Scrollback, SScrollBox)
-				]
-				+ SVerticalBox::Slot().AutoHeight()
-				[
-					SNew(SHorizontalBox)
-					+ SHorizontalBox::Slot().FillWidth(1.f).Padding(0.f, 0.f, 4.f, 0.f)
+					SNew(SButton)
+					.HAlign(HAlign_Center).VAlign(VAlign_Center)
+					.OnClicked(FOnClicked::CreateSP(this, &SchuckChatPanel::HandleSendClicked))
 					[
-						SAssignNew(InputBox, SEditableTextBox)
-						.HintText(LOCTEXT("InputHint", "Press Enter to send..."))
-						.OnTextCommitted(this, &SchuckChatPanel::HandleInputCommitted)
-					]
-					+ SHorizontalBox::Slot().AutoWidth()
-					[
-						SNew(SButton)
-						.HAlign(HAlign_Center).VAlign(VAlign_Center)
-						.OnClicked(FOnClicked::CreateSP(this, &SchuckChatPanel::HandleSendClicked))
-						[
-							SNew(STextBlock).Text(LOCTEXT("Send", "Send")).Font(ButtonFont)
-						]
+						SNew(STextBlock).Text(LOCTEXT("Send", "Send")).Font(ButtonFont)
 					]
 				]
 			]
 		]
 	];
+
+	RebuildTabs();
+	UpdateHeader();
 }
 
 void SchuckChatPanel::SetActiveChannel(const FString& InChannel)
 {
-	ActiveChannel = InChannel;
-	if (HeaderText.IsValid())
+	const FString Normalized = NormalizeChannel(InChannel);
+	if (Normalized.IsEmpty() || Normalized.Equals(ActiveChannel, ESearchCase::IgnoreCase))
 	{
-		HeaderText->SetText(FText::FromString(FString::Printf(
-			TEXT("Chat — %s (%s)"),
-			*ActiveChannel,
-			bConnected ? TEXT("connected") : TEXT("disconnected"))));
+		return;
 	}
+	ActiveChannel = Normalized;
+
+	for (FChannelTab& Tab : Tabs)
+	{
+		if (Tab.Name.Equals(ActiveChannel, ESearchCase::IgnoreCase))
+		{
+			Tab.bUnread = false;
+			break;
+		}
+	}
+	RefreshTabStyles();
+	UpdateHeader();
 }
 
 void SchuckChatPanel::OnChatStateChanged(const FchuckChatStatePayload& Payload)
 {
 	bConnected = Payload.bConnected;
-	if (HeaderText.IsValid())
-	{
-		HeaderText->SetText(FText::FromString(FString::Printf(
-			TEXT("Chat — %s (%s)"),
-			*ActiveChannel,
-			bConnected ? TEXT("connected") : TEXT("disconnected"))));
-	}
+	UpdateHeader();
 	AppendSystem(bConnected ? TEXT("* connected") : TEXT("* disconnected"));
+}
+
+void SchuckChatPanel::OnChannelJoined(const FString& Channel)
+{
+	const FString Normalized = NormalizeChannel(Channel);
+	if (Normalized.IsEmpty()) return;
+	AddTab(Normalized);
+	if (Tabs.Num() == 1)
+	{
+		ActiveChannel = Normalized;
+	}
+	RebuildTabs();
+	UpdateHeader();
+	AppendSystem(FString::Printf(TEXT("* joined %s"), *Normalized));
+}
+
+void SchuckChatPanel::OnChannelLeft(const FString& Channel)
+{
+	const FString Normalized = NormalizeChannel(Channel);
+	if (Normalized.IsEmpty()) return;
+	RemoveTab(Normalized);
+	if (ActiveChannel.Equals(Normalized, ESearchCase::IgnoreCase))
+	{
+		ActiveChannel = Tabs.Num() > 0 ? Tabs[0].Name : FString();
+	}
+	RebuildTabs();
+	UpdateHeader();
+	AppendSystem(FString::Printf(TEXT("* left %s"), *Normalized));
 }
 
 void SchuckChatPanel::OnChatLine(const FchuckChatLinePayload& Payload)
 {
-	if (!ActiveChannel.IsEmpty() && !Payload.Channel.IsEmpty() && !Payload.Channel.Equals(ActiveChannel, ESearchCase::IgnoreCase))
+	if (Payload.Channel.IsEmpty()) return;
+	if (!ActiveChannel.Equals(Payload.Channel, ESearchCase::IgnoreCase))
 	{
+		MarkChannelUnread(Payload.Channel);
 		return;
 	}
-	AppendLine(Payload.Channel, Payload.Sender.IsEmpty() ? Payload.Nick : Payload.Sender,
+	AppendLine(Payload.Channel,
+		Payload.Sender.IsEmpty() ? Payload.Nick : Payload.Sender,
 		Payload.Kind, Payload.Body, Payload.bIsEvent);
+}
+
+void SchuckChatPanel::MarkChannelUnread(const FString& Channel)
+{
+	for (FChannelTab& Tab : Tabs)
+	{
+		if (Tab.Name.Equals(Channel, ESearchCase::IgnoreCase))
+		{
+			Tab.bUnread = true;
+			RefreshTabStyles();
+			return;
+		}
+	}
+	AddTab(Channel);
+	for (FChannelTab& Tab : Tabs)
+	{
+		if (Tab.Name.Equals(Channel, ESearchCase::IgnoreCase))
+		{
+			Tab.bUnread = true;
+		}
+	}
+	RebuildTabs();
+}
+
+void SchuckChatPanel::AddTab(const FString& Channel)
+{
+	for (const FChannelTab& Tab : Tabs)
+	{
+		if (Tab.Name.Equals(Channel, ESearchCase::IgnoreCase)) return;
+	}
+	FChannelTab T;
+	T.Name = Channel;
+	Tabs.Add(MoveTemp(T));
+}
+
+void SchuckChatPanel::RemoveTab(const FString& Channel)
+{
+	Tabs.RemoveAll([&Channel](const FChannelTab& T)
+	{
+		return T.Name.Equals(Channel, ESearchCase::IgnoreCase);
+	});
+}
+
+void SchuckChatPanel::RebuildTabs()
+{
+	if (!TabRow.IsValid()) return;
+	TabRow->ClearChildren();
+
+	const FSlateFontInfo TabFont = FCoreStyle::GetDefaultFontStyle("Bold", 10);
+
+	for (int32 i = 0; i < Tabs.Num(); ++i)
+	{
+		const FString TabName = Tabs[i].Name;
+		const bool bActive = TabName.Equals(ActiveChannel, ESearchCase::IgnoreCase);
+		const bool bUnread = Tabs[i].bUnread;
+
+		TSharedRef<STextBlock> Label = SNew(STextBlock)
+			.Text(FText::FromString(TabName))
+			.Font(TabFont)
+			.ColorAndOpacity(FSlateColor(bUnread
+				? FLinearColor(0.98f, 0.84f, 0.42f)
+				: (bActive ? FLinearColor::White : FLinearColor(0.7f, 0.74f, 0.82f))));
+
+		TSharedRef<SBorder> Border = SNew(SBorder)
+			.BorderImage(FCoreStyle::Get().GetBrush("WhiteBrush"))
+			.BorderBackgroundColor(FSlateColor(bActive
+				? FLinearColor(0.18f, 0.22f, 0.30f, 0.95f)
+				: FLinearColor(0.08f, 0.10f, 0.14f, 0.75f)))
+			.Padding(FMargin(8.f, 4.f))
+			.OnMouseButtonDown_Lambda([this, TabName](const FGeometry&, const FPointerEvent&) -> FReply
+			{
+				SetActiveChannel(TabName);
+				return FReply::Handled();
+			})
+			[
+				Label
+			];
+
+		Tabs[i].TabBorder = Border;
+		Tabs[i].TabLabel = Label;
+
+		TabRow->AddSlot().AutoWidth().Padding(0.f, 0.f, 4.f, 0.f)
+		[
+			Border
+		];
+	}
+}
+
+void SchuckChatPanel::RefreshTabStyles()
+{
+	for (FChannelTab& Tab : Tabs)
+	{
+		const bool bActive = Tab.Name.Equals(ActiveChannel, ESearchCase::IgnoreCase);
+		if (Tab.TabBorder.IsValid())
+		{
+			Tab.TabBorder->SetBorderBackgroundColor(FSlateColor(bActive
+				? FLinearColor(0.18f, 0.22f, 0.30f, 0.95f)
+				: FLinearColor(0.08f, 0.10f, 0.14f, 0.75f)));
+		}
+		if (Tab.TabLabel.IsValid())
+		{
+			Tab.TabLabel->SetColorAndOpacity(FSlateColor(Tab.bUnread
+				? FLinearColor(0.98f, 0.84f, 0.42f)
+				: (bActive ? FLinearColor::White : FLinearColor(0.7f, 0.74f, 0.82f))));
+		}
+	}
 }
 
 void SchuckChatPanel::AppendLine(const FString& /*Channel*/, const FString& Sender, const FString& Kind, const FString& Body, bool bIsEvent)
 {
 	if (!Scrollback.IsValid()) return;
 
+	const FSlateFontInfo TimeFont = FCoreStyle::GetDefaultFontStyle("Regular", 9);
 	const FSlateFontInfo NickFont = FCoreStyle::GetDefaultFontStyle("Bold", 10);
 	const FSlateFontInfo BodyFont = FCoreStyle::GetDefaultFontStyle("Regular", 10);
 
+	const FString TimeStr = FormatTimestampLocal();
 	const FString NickLine = bIsEvent
 		? FString::Printf(TEXT("[%s] %s"), *Kind, *Sender)
 		: Sender;
@@ -126,6 +340,13 @@ void SchuckChatPanel::AppendLine(const FString& /*Channel*/, const FString& Send
 	Scrollback->AddSlot().Padding(0.f, 1.f)
 	[
 		SNew(SHorizontalBox)
+		+ SHorizontalBox::Slot().AutoWidth().Padding(0.f, 0.f, 6.f, 0.f)
+		[
+			SNew(STextBlock)
+			.Text(FText::FromString(TimeStr))
+			.Font(TimeFont)
+			.ColorAndOpacity(FSlateColor(FLinearColor(0.55f, 0.6f, 0.72f)))
+		]
 		+ SHorizontalBox::Slot().AutoWidth().Padding(0.f, 0.f, 6.f, 0.f)
 		[
 			SNew(STextBlock)
@@ -143,6 +364,10 @@ void SchuckChatPanel::AppendLine(const FString& /*Channel*/, const FString& Send
 		]
 	];
 
+	while (Scrollback->GetChildren()->Num() > MaxScrollbackLines)
+	{
+		Scrollback->RemoveSlot(Scrollback->GetChildren()->GetChildAt(0));
+	}
 	Scrollback->ScrollToEnd();
 }
 
@@ -157,7 +382,177 @@ void SchuckChatPanel::AppendSystem(const FString& Text)
 		.Font(SystemFont)
 		.ColorAndOpacity(FSlateColor(FLinearColor(0.6f, 0.66f, 0.78f)))
 	];
+	while (Scrollback->GetChildren()->Num() > MaxScrollbackLines)
+	{
+		Scrollback->RemoveSlot(Scrollback->GetChildren()->GetChildAt(0));
+	}
 	Scrollback->ScrollToEnd();
+}
+
+void SchuckChatPanel::AppendMe(const FString& Channel, const FString& Sender, const FString& Body)
+{
+	AppendLine(Channel, Sender, TEXT("ME"), TEXT("* ") + Body, /*bIsEvent=*/false);
+}
+
+bool SchuckChatPanel::ExecuteSlashCommand(const FString& InputLine)
+{
+	if (!InputLine.StartsWith(TEXT("/"))) return false;
+
+	const FString WithoutSlash = InputLine.RightChop(1);
+	FString Cmd, Rest;
+	if (!WithoutSlash.Split(TEXT(" "), &Cmd, &Rest))
+	{
+		Cmd = WithoutSlash;
+	}
+	Cmd = Cmd.ToLower();
+
+	UKBVESupabaseSubsystem* Sub = Subsystem.Get();
+	UKBVESupabaseChat* Chat = Sub ? Sub->GetChat() : nullptr;
+
+	if (Cmd == TEXT("join") || Cmd == TEXT("j"))
+	{
+		TArray<FString> Args;
+		if (!TokenizeArgs(Rest, Args))
+		{
+			AppendSystem(TEXT("Usage: /join <channel>"));
+			return true;
+		}
+		const FString Channel = NormalizeChannel(Args[0]);
+		if (Chat) Chat->JoinChannel(Channel);
+		return true;
+	}
+	if (Cmd == TEXT("part") || Cmd == TEXT("leave"))
+	{
+		TArray<FString> Args;
+		const FString Target = TokenizeArgs(Rest, Args) ? NormalizeChannel(Args[0]) : ActiveChannel;
+		FString Reason;
+		for (int32 i = 1; i < Args.Num(); ++i)
+		{
+			if (!Reason.IsEmpty()) Reason += TEXT(' ');
+			Reason += Args[i];
+		}
+		if (Chat) Chat->PartChannel(Target, Reason);
+		return true;
+	}
+	if (Cmd == TEXT("me"))
+	{
+		const FString Body = Rest.TrimStartAndEnd();
+		if (Body.IsEmpty() || ActiveChannel.IsEmpty()) return true;
+		if (Chat)
+		{
+			Chat->SendPrivMsg(ActiveChannel, FString::Printf(TEXT("\x01""ACTION %s\x01"), *Body));
+		}
+		AppendMe(ActiveChannel, TEXT("you"), Body);
+		return true;
+	}
+	if (Cmd == TEXT("msg") || Cmd == TEXT("w") || Cmd == TEXT("whisper"))
+	{
+		FString Target, Body;
+		if (!Rest.Split(TEXT(" "), &Target, &Body))
+		{
+			AppendSystem(TEXT("Usage: /msg <nick> <message>"));
+			return true;
+		}
+		Target = Target.TrimStartAndEnd();
+		Body = Body.TrimStartAndEnd();
+		if (Target.IsEmpty() || Body.IsEmpty())
+		{
+			AppendSystem(TEXT("Usage: /msg <nick> <message>"));
+			return true;
+		}
+		if (Chat) Chat->SendPrivMsg(Target, Body);
+		AppendLine(ActiveChannel, TEXT("you→") + Target, TEXT("CHAT"), Body, /*bIsEvent=*/false);
+		return true;
+	}
+	if (Cmd == TEXT("quit") || Cmd == TEXT("disconnect"))
+	{
+		if (Chat) Chat->Disconnect();
+		return true;
+	}
+	if (Cmd == TEXT("connect") || Cmd == TEXT("reconnect"))
+	{
+		if (Chat) Chat->Connect();
+		return true;
+	}
+	if (Cmd == TEXT("raw"))
+	{
+		const FString Line = Rest.TrimStartAndEnd();
+		if (Chat && !Line.IsEmpty()) Chat->SendRawLine(Line);
+		return true;
+	}
+	if (Cmd == TEXT("clear"))
+	{
+		if (Scrollback.IsValid()) Scrollback->ClearChildren();
+		return true;
+	}
+	if (Cmd == TEXT("help") || Cmd == TEXT("?"))
+	{
+		AppendSystem(TEXT("Commands: /join <chan> /part [chan] [reason] /me <text> /msg <nick> <text> /raw <line> /clear /quit /reconnect /help"));
+		return true;
+	}
+
+	AppendSystem(FString::Printf(TEXT("Unknown command: /%s — try /help"), *Cmd));
+	return true;
+}
+
+void SchuckChatPanel::PushHistory(const FString& Line)
+{
+	if (Line.IsEmpty()) return;
+	if (InputHistory.Num() == 0 || !InputHistory.Last().Equals(Line))
+	{
+		InputHistory.Add(Line);
+		while (InputHistory.Num() > MaxHistoryEntries)
+		{
+			InputHistory.RemoveAt(0, 1, EAllowShrinking::No);
+		}
+	}
+	HistoryCursor = -1;
+	DraftBeforeRecall.Empty();
+}
+
+void SchuckChatPanel::RecallHistoryDirection(int32 Direction)
+{
+	if (!InputBox.IsValid() || InputHistory.Num() == 0) return;
+
+	if (HistoryCursor == -1)
+	{
+		DraftBeforeRecall = InputBox->GetText().ToString();
+		HistoryCursor = InputHistory.Num();
+	}
+
+	HistoryCursor = FMath::Clamp(HistoryCursor + Direction, 0, InputHistory.Num());
+
+	if (HistoryCursor == InputHistory.Num())
+	{
+		InputBox->SetText(FText::FromString(DraftBeforeRecall));
+	}
+	else
+	{
+		InputBox->SetText(FText::FromString(InputHistory[HistoryCursor]));
+	}
+}
+
+FReply SchuckChatPanel::OnKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent)
+{
+	if (InputBox.IsValid() && InputBox->HasKeyboardFocus())
+	{
+		if (InKeyEvent.GetKey() == EKeys::Up)
+		{
+			RecallHistoryDirection(-1);
+			return FReply::Handled();
+		}
+		if (InKeyEvent.GetKey() == EKeys::Down)
+		{
+			RecallHistoryDirection(+1);
+			return FReply::Handled();
+		}
+		if (InKeyEvent.GetKey() == EKeys::Escape)
+		{
+			FSlateApplication::Get().ClearKeyboardFocus(EFocusCause::Cleared);
+			return FReply::Handled();
+		}
+	}
+	return SCompoundWidget::OnKeyDown(MyGeometry, InKeyEvent);
 }
 
 FReply SchuckChatPanel::HandleSendClicked()
@@ -165,7 +560,17 @@ FReply SchuckChatPanel::HandleSendClicked()
 	if (!InputBox.IsValid()) return FReply::Handled();
 	const FString Body = InputBox->GetText().ToString();
 	InputBox->SetText(FText::GetEmpty());
-	if (Body.IsEmpty() || ActiveChannel.IsEmpty()) return FReply::Handled();
+	if (Body.IsEmpty()) return FReply::Handled();
+
+	PushHistory(Body);
+
+	if (Body.StartsWith(TEXT("/")))
+	{
+		ExecuteSlashCommand(Body);
+		return FReply::Handled();
+	}
+
+	if (ActiveChannel.IsEmpty()) return FReply::Handled();
 
 	UKBVESupabaseSubsystem* Sub = Subsystem.Get();
 	if (!Sub) return FReply::Handled();
@@ -181,6 +586,48 @@ void SchuckChatPanel::HandleInputCommitted(const FText& InText, ETextCommit::Typ
 	{
 		HandleSendClicked();
 	}
+}
+
+bool SchuckChatPanel::ToggleVisible()
+{
+	const EVisibility Cur = GetVisibility();
+	const bool bShow = (Cur == EVisibility::Collapsed || Cur == EVisibility::Hidden);
+	SetVisibility(bShow ? EVisibility::SelfHitTestInvisible : EVisibility::Collapsed);
+	if (bShow)
+	{
+		ShowAndFocusInput();
+	}
+	return bShow;
+}
+
+void SchuckChatPanel::ShowAndFocusInput()
+{
+	SetVisibility(EVisibility::SelfHitTestInvisible);
+	if (InputBox.IsValid())
+	{
+		FSlateApplication::Get().SetKeyboardFocus(InputBox, EFocusCause::SetDirectly);
+	}
+}
+
+void SchuckChatPanel::PersistGeometry()
+{
+	if (!MovableFrame.IsValid()) return;
+	AchuckCoreCharacter* C = OwningCharacter.Get();
+	UchuckSettings* S = C ? UchuckSettings::Get(C) : nullptr;
+	if (!S) return;
+	FchuckWindowGeometry G;
+	G.WindowKey = ChatWindowKey;
+	G.Position  = MovableFrame->GetCurrentPosition();
+	G.Size      = MovableFrame->GetCurrentSize();
+	S->SetWindowGeometry(G);
+}
+
+void SchuckChatPanel::UpdateHeader()
+{
+	if (!HeaderText.IsValid()) return;
+	const TCHAR* StateLabel = bConnected ? TEXT("connected") : TEXT("disconnected");
+	const FString Channel = ActiveChannel.IsEmpty() ? TEXT("—") : ActiveChannel;
+	HeaderText->SetText(FText::FromString(FString::Printf(TEXT("%s · %s"), *Channel, StateLabel)));
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.h
@@ -3,18 +3,28 @@
 #include "CoreMinimal.h"
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Framework/SlateDelegates.h"
 #include "Input/Reply.h"
 #include "chuckEventPayloads.h"
 
 class UKBVESupabaseSubsystem;
+class AchuckCoreCharacter;
 class SEditableTextBox;
 class SScrollBox;
+class SHorizontalBox;
+class SBorder;
 class STextBlock;
+class SWidget;
+class SKBVEMovableFrame;
 
 /**
- * Scrollback + input dock for the irc-gateway WebSocket. Listens to the
- * chuck event bus (ChatState / ChatLine) so the widget never touches the
- * Supabase subsystem directly except to send PRIVMSGs.
+ * Chat window for the irc-gateway WebSocket. Wraps SKBVEMovableFrame for
+ * drag / resize / close, persists geometry via UchuckSettings under the
+ * "chuck.chat" key, and renders channel tabs + scrollback + input.
+ *
+ * Bridges the chuck event bus (FchuckChatStatePayload / FchuckChatLinePayload)
+ * onto Slate so the widget never imports UKBVESupabaseSubsystem directly
+ * except to dispatch outbound commands.
  */
 class SchuckChatPanel : public SCompoundWidget
 {
@@ -23,26 +33,71 @@ public:
 		: _DefaultChannel(TEXT("#global"))
 	{}
 		SLATE_ARGUMENT(TWeakObjectPtr<UKBVESupabaseSubsystem>, Subsystem)
+		SLATE_ARGUMENT(TWeakObjectPtr<AchuckCoreCharacter>, OwningCharacter)
 		SLATE_ARGUMENT(FString, DefaultChannel)
+		SLATE_EVENT(FSimpleDelegate, OnCloseClicked)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
 
 	void OnChatStateChanged(const FchuckChatStatePayload& Payload);
 	void OnChatLine(const FchuckChatLinePayload& Payload);
+	void OnChannelJoined(const FString& Channel);
+	void OnChannelLeft(const FString& Channel);
 
 	void SetActiveChannel(const FString& InChannel);
+	const FString& GetActiveChannel() const { return ActiveChannel; }
+
+	bool ToggleVisible();
+	void ShowAndFocusInput();
+
+protected:
+	virtual bool SupportsKeyboardFocus() const override { return true; }
+	virtual FReply OnKeyDown(const FGeometry& MyGeometry, const FKeyEvent& InKeyEvent) override;
 
 private:
+	struct FChannelTab
+	{
+		FString Name;
+		TSharedPtr<SBorder> TabBorder;
+		TSharedPtr<STextBlock> TabLabel;
+		bool bUnread = false;
+	};
+
 	FReply HandleSendClicked();
 	void   HandleInputCommitted(const FText& InText, ETextCommit::Type CommitType);
 	void   AppendLine(const FString& Channel, const FString& Sender, const FString& Kind, const FString& Body, bool bIsEvent);
 	void   AppendSystem(const FString& Text);
+	void   AppendMe(const FString& Channel, const FString& Sender, const FString& Body);
+
+	void   RebuildTabs();
+	void   AddTab(const FString& Channel);
+	void   RemoveTab(const FString& Channel);
+	void   RefreshTabStyles();
+	void   MarkChannelUnread(const FString& Channel);
+
+	bool   ExecuteSlashCommand(const FString& InputLine);
+	void   PushHistory(const FString& Line);
+	void   RecallHistoryDirection(int32 Direction);
+
+	void   PersistGeometry();
+	void   UpdateHeader();
 
 	TWeakObjectPtr<UKBVESupabaseSubsystem> Subsystem;
-	TSharedPtr<SScrollBox> Scrollback;
+	TWeakObjectPtr<AchuckCoreCharacter>    OwningCharacter;
+
+	TSharedPtr<SKBVEMovableFrame> MovableFrame;
+	TSharedPtr<SHorizontalBox>   TabRow;
+	TSharedPtr<SScrollBox>       Scrollback;
 	TSharedPtr<SEditableTextBox> InputBox;
-	TSharedPtr<STextBlock> HeaderText;
+	TSharedPtr<STextBlock>       HeaderText;
+	FSimpleDelegate              OnCloseClicked;
+
+	TArray<FChannelTab> Tabs;
+
+	TArray<FString> InputHistory;
+	int32 HistoryCursor = -1;
+	FString DraftBeforeRecall;
 
 	FString ActiveChannel;
 	bool bConnected = false;


### PR DESCRIPTION
## Summary
- \`SchuckChatPanel\` wrapped in \`SKBVEMovableFrame\` — drag, resize, close. Geometry persists across launches via \`UchuckSettings\` under window key \`chuck.chat\` (same pattern \`SchuckInventoryWindow\` uses).
- Channel tabs above the scrollback: click to switch, active tab highlighted, unread channels flash gold. \`OnChannelJoined\` / \`OnChannelLeft\` from \`UKBVESupabaseChat\` feed the widget via two new UFUNCTION handlers on \`AchuckCorePlayerController\`.
- Slash command parser: \`/join\`, \`/part\`, \`/me\` (CTCP ACTION), \`/msg\`, \`/raw\`, \`/clear\`, \`/quit\`, \`/reconnect\`, \`/help\`.
- Timestamps (HH:MM local), kind-aware nick coloring, body wrap. Scrollback capped at 500 lines.
- Input history (up / down arrow recall, 64 entries, dedup). Esc clears focus.
- New Enhanced Input actions \`IA_ToggleChat\` (T) and \`IA_FocusChat\` (Enter) on \`UchuckInputs\`, bound in \`SetupInputComponent\`.
- \`OwningCharacter\` now threaded into the chat widget so geometry persist can find \`UchuckSettings\` via world context.

## Not in this PR
- Slash command tab-completion.
- User list per channel.
- Mention / highlight rules.
- Localized strings beyond \`LOCTEXT\` defaults.
- KBVEUI Slate buttons instead of raw \`SButton\`.

## Test plan
- [ ] Sign in via login modal. Chat window appears at remembered position/size.
- [ ] Drag the title bar — position persists across editor restarts.
- [ ] Resize from the bottom-right grip — size persists.
- [ ] \`/join #world-events\` — new tab appears, becomes active, header reflects new channel.
- [ ] PRIVMSG arrives on inactive tab — tab name turns gold; clicking it clears the flag.
- [ ] \`/me waves\` — local \"* you waves\" line + CTCP ACTION sent.
- [ ] Up/Down arrow in input cycles through prior messages; Esc clears focus.
- [ ] Press \`T\` — window toggles. Press \`Enter\` — window opens and focuses the input.