### PR TITLE
chore(cilium): upgrade 1.18.0 → 1.19.4

### DIFF
--- a/apps/kube/cilium/application.yaml
+++ b/apps/kube/cilium/application.yaml
@@ -7,7 +7,7 @@ spec:
     project: default
     sources:
         - repoURL: https://helm.cilium.io
-          targetRevision: 1.18.0
+          targetRevision: 1.19.4
           chart: cilium
           helm:
               releaseName: cilium

--- a/apps/kube/cilium/manifests/lb-ipam.yaml
+++ b/apps/kube/cilium/manifests/lb-ipam.yaml
@@ -1,4 +1,4 @@
-apiVersion: cilium.io/v2alpha1
+apiVersion: cilium.io/v2
 kind: CiliumLoadBalancerIPPool
 metadata:
     name: public-ip-pool


### PR DESCRIPTION
## Summary

Unstick the HTTP-01 ACME pipeline. Cilium 1.18.0 gateway controller has a bug where HTTPRoute backendRefs to cert-manager's NodePort solver Service never populate Envoy endpoints — CiliumEnvoyConfig backendServices ports = null, Envoy returns 404 content-length:0 on the ACME path even when the route is correctly attached and Accepted=True. \`cityvote-tls\` and \`memes-cert\` have been stuck on this for 14+ days.

## Changes

- \`apps/kube/cilium/application.yaml\`: Helm chart \`targetRevision: 1.18.0\` → \`1.19.4\` (5 patch releases deep into current stable minor).
- \`apps/kube/cilium/manifests/lb-ipam.yaml\`: \`CiliumLoadBalancerIPPool\` apiVersion \`v2alpha1\` → \`v2\`. Cluster already stores at v2; 1.19 removes the v2alpha1 alias. \`CiliumL2AnnouncementPolicy\` stays v2alpha1 (still alpha as of 1.19).

## Upgrade flow (ArgoCD handles)

1. ArgoCD picks up new chart version, renders new manifests.
2. CRDs upgrade first (Helm pre-install ordering).
3. cilium-operator Deployment rolls (1 replica, brief LB IPAM gap).
4. cilium agent DaemonSet rolls (1 node, ~10s networking blip per node during eBPF program reload).
5. cilium-envoy DaemonSet rolls (filter chains regenerate from CEC).

Single-node cluster → all four hit one node sequentially. Expect ~30s of intermittent traffic disruption during the agent reload.

## Compatibility

- **Talos v1.13.0 / kernel 6.18.24** — well above Cilium 1.19's 4.19+ requirement.
- **Kubernetes 1.33.2** — within Cilium 1.19 support matrix.
- **WireGuard encryption** — preserved across upgrade, keys auto-rotated.
- **Existing values.yaml** — no deprecated fields (kubeProxyReplacement boolean still accepted, gatewayAPI subfields stable, l2announcements unchanged).

## Test plan

After dev→main release + ArgoCD sync:

- [ ] \`kubectl -n kube-system get pods\` — cilium agent + operator + envoy on 1.19.4 image tag, all Running.
- [ ] \`cilium status\` healthy.
- [ ] \`kubectl get certificate -A | grep False\` — empty (cityvote-tls + memes-cert flip Ready=True).
- [ ] \`curl -I https://cityvote.com\` returns 200 from CF edge.
- [ ] \`curl -I https://meme.sh\` still returns 200.
- [ ] WireGuard intact: \`kubectl exec ds/cilium -- cilium encrypt status\` shows WG up.
- [ ] All existing HTTPRoutes still Programmed=True on kbve-gateway.

## Rollback

If upgrade fails:
1. Revert this PR.
2. ArgoCD reconciles back to 1.18.0 chart.
3. Cilium components downgrade automatically (operator may need manual restart if CRD storage versions clash — revert lb-ipam.yaml apiVersion too).

If networking fully borks, apply \`apps/kube/cilium/patches/cilium-rollback.yaml\` to Talos machine config to re-enable flannel + kube-proxy as last-resort recovery path.