### PR TITLE
fix(edge-e2e): pre-warm fn routes in globalSetup (closes #11808)

### DIFF
--- a/apps/kbve/edge-e2e/e2e/globalSetup.ts
+++ b/apps/kbve/edge-e2e/e2e/globalSetup.ts
@@ -1,5 +1,26 @@
-import { waitForReady } from './helpers/http';
+import { waitForReady, warmRoutes } from './helpers/http';
+
+const ROUTES_TO_WARM = [
+	'/health',
+	'/meme',
+	'/discordsh',
+	'/user-vault',
+	'/guild-vault',
+	'/vault-reader',
+	'/argo',
+	'/logs',
+	'/ows',
+	'/forum',
+	'/mc',
+	'/irc',
+	'/gh-webhook',
+	'/gh-backfill',
+	'/gh-admin',
+	'/discord-bootstrap',
+	'/discord-bot',
+];
 
 export async function setup() {
 	await waitForReady();
+	await warmRoutes(ROUTES_TO_WARM);
 }

--- a/apps/kbve/edge-e2e/e2e/helpers/http.ts
+++ b/apps/kbve/edge-e2e/e2e/helpers/http.ts
@@ -3,6 +3,9 @@ const EDGE_PORT = Number(process.env['EDGE_PORT'] ?? 9100);
 const DEFAULT_READY_TIMEOUT_MS = Number(
 	process.env['EDGE_READY_TIMEOUT_MS'] ?? 90_000,
 );
+const DEFAULT_WARM_TIMEOUT_MS = Number(
+	process.env['EDGE_WARM_TIMEOUT_MS'] ?? 45_000,
+);
 
 export const BASE_URL = `http://${EDGE_HOST}:${EDGE_PORT}`;
 
@@ -26,4 +29,32 @@ export async function waitForReady(
 	throw new Error(
 		`Edge runtime not ready at ${BASE_URL} after ${timeoutMs}ms`,
 	);
+}
+
+export async function warmRoute(
+	path: string,
+	timeoutMs = DEFAULT_WARM_TIMEOUT_MS,
+): Promise<void> {
+	const url = `${BASE_URL}${path.startsWith('/') ? path : `/${path}`}`;
+	const deadline = Date.now() + timeoutMs;
+	while (Date.now() < deadline) {
+		try {
+			const res = await fetch(url, {
+				method: 'OPTIONS',
+				signal: AbortSignal.timeout(5_000),
+			});
+			if (res.status > 0) return;
+		} catch {
+			// keep retrying
+		}
+		await new Promise((r) => setTimeout(r, 500));
+	}
+	throw new Error(`Edge route ${url} did not warm within ${timeoutMs}ms`);
+}
+
+export async function warmRoutes(
+	paths: string[],
+	timeoutMs = DEFAULT_WARM_TIMEOUT_MS,
+): Promise<void> {
+	await Promise.all(paths.map((p) => warmRoute(p, timeoutMs)));
 }


### PR DESCRIPTION
Closes #11808.

## Root cause

Supabase edge-runtime spawns a fresh Deno worker per fn path on the FIRST request. Worker boot takes seconds. Run #27027767274 shows:

- `✓ should reject token_name with special characters` — 13ms (warm)
- `✓ should reject token_name shorter than 3 chars` — 5ms (warm)
- `✗ should reject token_name with uppercase chars` — **30003ms** (cold — first hit to /user-vault in the spec)

The "uppercase" test is first in the spec, hits a cold /user-vault worker, and the 30s vitest `testTimeout` fires before the worker comes up. Adjacent tests then pass instantly against the now-warm worker.

`waitForReady()` in `globalSetup` only pings the root (`/`) → main router. Per-fn workers stay cold.

## Fix

| File | Change |
|---|---|
| `e2e/helpers/http.ts` | New `warmRoute(path)` + `warmRoutes(paths[])` helpers — fire OPTIONS (skips JWT in main router) and poll until any non-zero status. 45s default timeout (`EDGE_WARM_TIMEOUT_MS`). |
| `e2e/globalSetup.ts` | After `waitForReady()`, calls `warmRoutes` for every registered fn — `/health, /meme, /discordsh, /user-vault, /guild-vault, /vault-reader, /argo, /logs, /ows, /forum, /mc, /irc, /gh-webhook, /gh-backfill, /gh-admin, /discord-bootstrap, /discord-bot`. Runs concurrently via `Promise.all` → total warm time = max single-worker boot, not sum. |

No spec changes needed — every spec inherits warm workers via globalSetup.

## Test plan
- [x] `npx tsc --noEmit -p apps/kbve/edge-e2e/tsconfig.json` — clean
- [ ] CI run on this branch — hardening.spec.ts uppercase test passes in <100ms instead of timing out
- [ ] No other spec regresses (warm helpers are additive)

## Why OPTIONS

main router's `serve()` short-circuits OPTIONS before the JWT check (line 64: `req.method !== "OPTIONS" && VERIFY_JWT`). Worker boot still triggers via the route dispatch. No real auth needed to warm.