### PR TITLE
fix(kube): swap kubectl image refs to ghcr.io/kbve/kubectl:0.1.3

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -148,7 +148,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.35",
+			"version": "0.1.37",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -292,8 +292,14 @@
 			"e2e_name": "kubectl-e2e",
 			"deployment_yamls": [
 				"apps/kube/kubevirt/autologon/job.yaml",
+				"apps/kube/kubevirt/autologon/scaled-job.yaml",
 				"apps/kube/kubevirt/runner/job.yaml",
-				"apps/kube/agones/factorio/manifests/rotation-cronjob.yaml"
+				"apps/kube/kubevirt/keda/scaled-jobs.yaml",
+				"apps/kube/agones/factorio/manifests/rotation-cronjob.yaml",
+				"apps/kube/namespace/manifests/pod-gc-cronjob.yaml",
+				"apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml",
+				"apps/kube/kilobase/manifests/backup-restore-test.yaml",
+				"apps/kube/kilobase/manifests/backup-watchdog.yaml"
 			],
 			"has_test": true
 		},

--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -21,8 +21,14 @@ runner: arc-runner-set
 image: kbve/kubectl
 deployment_yamls:
     - apps/kube/kubevirt/autologon/job.yaml
+    - apps/kube/kubevirt/autologon/scaled-job.yaml
     - apps/kube/kubevirt/runner/job.yaml
+    - apps/kube/kubevirt/keda/scaled-jobs.yaml
     - apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
+    - apps/kube/namespace/manifests/pod-gc-cronjob.yaml
+    - apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
+    - apps/kube/kilobase/manifests/backup-restore-test.yaml
+    - apps/kube/kilobase/manifests/backup-watchdog.yaml
 has_test: true
 e2e_name: kubectl-e2e
 test_framework: typescript

--- a/apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
+++ b/apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml
@@ -91,7 +91,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: healthcheck
-                          image: registry.k8s.io/kubectl:1.32
+                          image: ghcr.io/kbve/kubectl:0.1.3
                           securityContext:
                               allowPrivilegeEscalation: false
                               readOnlyRootFilesystem: true

--- a/apps/kube/kilobase/manifests/backup-restore-test.yaml
+++ b/apps/kube/kilobase/manifests/backup-restore-test.yaml
@@ -223,7 +223,7 @@ spec:
                     restartPolicy: Never
                     containers:
                         - name: restore-test
-                          image: registry.k8s.io/kubectl:1.32
+                          image: ghcr.io/kbve/kubectl:0.1.3
                           resources:
                               limits:
                                   cpu: 200m

--- a/apps/kube/kilobase/manifests/backup-watchdog.yaml
+++ b/apps/kube/kilobase/manifests/backup-watchdog.yaml
@@ -98,7 +98,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: watchdog
-                          image: registry.k8s.io/kubectl:1.32
+                          image: ghcr.io/kbve/kubectl:0.1.3
                           securityContext:
                               allowPrivilegeEscalation: false
                               readOnlyRootFilesystem: true

--- a/apps/kube/kubevirt/keda/scaled-jobs.yaml
+++ b/apps/kube/kubevirt/keda/scaled-jobs.yaml
@@ -30,7 +30,7 @@ spec:
                 restartPolicy: OnFailure
                 containers:
                     - name: idle-checker
-                      image: registry.k8s.io/kubectl:v1.33.2
+                      image: ghcr.io/kbve/kubectl:0.1.3
                       command: ['/bin/sh', '/scripts/idle-shutdown.sh']
                       env:
                           - name: VM_NAME
@@ -80,7 +80,7 @@ spec:
                 restartPolicy: OnFailure
                 containers:
                     - name: idle-checker
-                      image: registry.k8s.io/kubectl:v1.33.2
+                      image: ghcr.io/kbve/kubectl:0.1.3
                       command: ['/bin/sh', '/scripts/idle-shutdown.sh']
                       env:
                           - name: VM_NAME

--- a/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
+++ b/apps/kube/namespace/manifests/pod-gc-cronjob.yaml
@@ -92,7 +92,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: gc
-                          image: registry.k8s.io/kubectl:1.32
+                          image: ghcr.io/kbve/kubectl:0.1.3
                           securityContext:
                               allowPrivilegeEscalation: false
                               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

\`registry.k8s.io\` has never published a \`kubectl\` image at the tags we were pointing at (\`1.32\`, \`v1.33.2\`). Both resolve to \"image not found\" — every affected cronjob has been silently \`ImagePullBackOff\` since creation. Surfaced today when the cluster re-pulled every image post-recovery.

## Changes

Swap to the existing custom build at \`ghcr.io/kbve/kubectl:0.1.3\` (already canonical for the rest of the repo — these five files were the only stragglers):

- \`apps/kube/namespace/manifests/pod-gc-cronjob.yaml\`
- \`apps/kube/crossplane/providers/s3-healthcheck-cronjob.yaml\`
- \`apps/kube/kubevirt/keda/scaled-jobs.yaml\` (2 occurrences)
- \`apps/kube/kilobase/manifests/backup-restore-test.yaml\`
- \`apps/kube/kilobase/manifests/backup-watchdog.yaml\`

## Test plan

- [ ] After ArgoCD sync: \`kubectl get cronjob -A\` shows no pods stuck on \`registry.k8s.io/kubectl\`.
- [ ] \`backup-restore-test\` next scheduled run lands and reports SUCCEEDED.
- [ ] \`s3-healthcheck-cronjob\` next run completes.