### PR TITLE
fix(agents): promote BotConfig + RepoAllowlist drafts to singleton — survives ClientRouter swap

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
@@ -35,7 +35,10 @@ import ReactAgentBotInstall from './ReactAgentBotInstall';
 		<div class="agent-stack">
 			<ReactAgentSetupStatus client:only="react" />
 			<ReactAgentBotInstall client:only="react" />
-			<ReactAgentBotConfig client:only="react" />
+			<ReactAgentBotConfig
+				client:only="react"
+				transition:persist="agents-bot-config"
+			/>
 			<ReactAgentDiscordsh client:only="react" />
 		</div>
 	</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
@@ -39,7 +39,10 @@ import ReactAgentRepoAllowlist from './ReactAgentRepoAllowlist';
 		</header>
 
 		<div class="agent-stack">
-			<ReactAgentRepoAllowlist client:only="react" />
+			<ReactAgentRepoAllowlist
+				client:only="react"
+				transition:persist="agents-repo-allowlist"
+			/>
 			<ReactAgentGithubWizard client:only="react" />
 		</div>
 	</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
@@ -43,7 +43,10 @@ import ReactAgentRepoAllowlist from './ReactAgentRepoAllowlist';
 				client:only="react"
 				transition:persist="agents-repo-allowlist"
 			/>
-			<ReactAgentGithubWizard client:only="react" />
+			<ReactAgentGithubWizard
+				client:only="react"
+				transition:persist="agents-github-wizard"
+			/>
 		</div>
 	</div>
 </section>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
@@ -1,76 +1,17 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import { Loader2, RefreshCw, Save, Settings2 } from 'lucide-react';
-import { agentsService, type DiscordshConfig } from './agentsService';
+import {
+	agentsService,
+	emptyBotConfigFormDraft,
+	type BotConfigFormDraft,
+} from './agentsService';
 import { styles } from './dashboard-ui';
 
 const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
 const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
 
-interface FormState {
-	default_repo: string;
-	claim_channel_id: string;
-	forum_channel_id: string;
-	noticeboard_channel_id: string;
-	taskboard_channel_id: string;
-	max_assignees: string;
-	mirror_pr_events: boolean;
-	active: boolean;
-}
-
-function emptyForm(): FormState {
-	return {
-		default_repo: '',
-		claim_channel_id: '',
-		forum_channel_id: '',
-		noticeboard_channel_id: '',
-		taskboard_channel_id: '',
-		max_assignees: '2',
-		mirror_pr_events: true,
-		active: true,
-	};
-}
-
-function configToForm(c: DiscordshConfig): FormState {
-	const base = emptyForm();
-	return {
-		default_repo: c.default_repo ?? base.default_repo,
-		claim_channel_id: c.claim_channel_id ?? base.claim_channel_id,
-		forum_channel_id: c.forum_channel_id ?? base.forum_channel_id,
-		noticeboard_channel_id:
-			c.noticeboard_channel_id ?? base.noticeboard_channel_id,
-		taskboard_channel_id:
-			c.taskboard_channel_id ?? base.taskboard_channel_id,
-		max_assignees:
-			typeof c.max_assignees === 'number'
-				? String(c.max_assignees)
-				: base.max_assignees,
-		mirror_pr_events:
-			typeof c.mirror_pr_events === 'boolean'
-				? c.mirror_pr_events
-				: base.mirror_pr_events,
-		active: typeof c.active === 'boolean' ? c.active : base.active,
-	};
-}
-
-function formToConfig(f: FormState): DiscordshConfig {
-	const cfg: DiscordshConfig = {
-		mirror_pr_events: f.mirror_pr_events,
-		active: f.active,
-	};
-	if (f.default_repo.trim()) cfg.default_repo = f.default_repo.trim();
-	if (f.claim_channel_id.trim())
-		cfg.claim_channel_id = f.claim_channel_id.trim();
-	if (f.forum_channel_id.trim())
-		cfg.forum_channel_id = f.forum_channel_id.trim();
-	if (f.noticeboard_channel_id.trim())
-		cfg.noticeboard_channel_id = f.noticeboard_channel_id.trim();
-	if (f.taskboard_channel_id.trim())
-		cfg.taskboard_channel_id = f.taskboard_channel_id.trim();
-	const max = parseInt(f.max_assignees, 10);
-	if (!Number.isNaN(max) && max > 0) cfg.max_assignees = max;
-	return cfg;
-}
+type FormState = BotConfigFormDraft;
 
 function fieldError(
 	value: string,
@@ -95,30 +36,43 @@ function fieldError(
 export default function ReactAgentBotConfig() {
 	const guildId = useStore(agentsService.$selectedGuildId);
 	const guilds = useStore(agentsService.$guilds);
+	const drafts = useStore(agentsService.$botConfigDrafts);
+	const savingMap = useStore(agentsService.$botConfigSavingFor);
+	const errorsMap = useStore(agentsService.$botConfigErrors);
+	const loadedMap = useStore(agentsService.$botConfigLoadedFor);
 
-	const [form, setForm] = useState<FormState>(emptyForm);
 	const [loading, setLoading] = useState(false);
-	const [saving, setSaving] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [success, setSuccess] = useState<string | null>(null);
 
-	const load = useCallback(async () => {
-		if (!guildId) return;
-		setLoading(true);
-		setError(null);
-		setSuccess(null);
-		const r = await agentsService.getBotConfig();
-		setLoading(false);
-		if (!r.ok) {
-			setError(r.error);
-			return;
-		}
-		setForm(configToForm(r.config));
-	}, [guildId]);
+	const form: FormState = guildId
+		? (drafts[guildId] ?? emptyBotConfigFormDraft())
+		: emptyBotConfigFormDraft();
+	const saving = guildId ? !!savingMap[guildId] : false;
+	const error = guildId ? (errorsMap[guildId] ?? null) : null;
+	const loaded = guildId ? !!loadedMap[guildId] : false;
+
+	const load = useCallback(
+		async (force = false) => {
+			if (!guildId) return;
+			setLoading(true);
+			setSuccess(null);
+			await agentsService.ensureBotConfigLoaded(guildId, force);
+			setLoading(false);
+		},
+		[guildId],
+	);
 
 	useEffect(() => {
-		void load();
-	}, [load]);
+		if (guildId && !loaded) {
+			void load();
+		}
+	}, [guildId, loaded, load]);
+
+	useEffect(() => {
+		if (!success) return;
+		const t = setTimeout(() => setSuccess(null), 2500);
+		return () => clearTimeout(t);
+	}, [success]);
 
 	if (!guildId) {
 		return (
@@ -156,23 +110,17 @@ export default function ReactAgentBotConfig() {
 	const anyError = Object.values(errors).some((e) => e !== null);
 
 	async function save() {
-		if (anyError || saving) return;
-		setSaving(true);
-		setError(null);
+		if (!guildId || anyError || saving) return;
 		setSuccess(null);
-		const cfg = formToConfig(form);
-		const r = await agentsService.setBotConfig(cfg);
-		setSaving(false);
-		if (!r.ok) {
-			setError(r.error);
-			return;
-		}
-		setSuccess('Saved.');
-		setTimeout(() => setSuccess(null), 2500);
+		const r = await agentsService.saveBotConfigDraft(guildId);
+		if (r.ok) setSuccess('Saved.');
 	}
 
 	function patch<K extends keyof FormState>(k: K, v: FormState[K]) {
-		setForm((prev) => ({ ...prev, [k]: v }));
+		if (!guildId) return;
+		agentsService.patchBotConfigDraft(guildId, {
+			[k]: v,
+		} as Partial<FormState>);
 	}
 
 	return (
@@ -201,7 +149,7 @@ export default function ReactAgentBotConfig() {
 				)}
 				<button
 					type="button"
-					onClick={() => void load()}
+					onClick={() => void load(true)}
 					disabled={loading || saving}
 					style={refreshBtn(loading || saving)}
 					aria-label="Refresh">

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useState } from 'react';
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type FocusEvent,
+	type FormEvent,
+} from 'react';
 import { useStore } from '@nanostores/react';
 import { Loader2, RefreshCw, Save, Settings2 } from 'lucide-react';
 import {
@@ -11,45 +19,123 @@ import { styles } from './dashboard-ui';
 const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
 const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
 
-type FormState = BotConfigFormDraft;
+type TextFieldKey =
+	| 'default_repo'
+	| 'claim_channel_id'
+	| 'forum_channel_id'
+	| 'noticeboard_channel_id'
+	| 'taskboard_channel_id'
+	| 'max_assignees';
 
-function fieldError(
-	value: string,
-	kind: 'snowflake' | 'repo' | 'int',
-	required = false,
-): string | null {
-	const trimmed = value.trim();
-	if (!trimmed) return required ? 'Required' : null;
-	if (kind === 'snowflake' && !SNOWFLAKE_RE.test(trimmed)) {
-		return 'Must be a Discord snowflake (17–20 digits)';
-	}
-	if (kind === 'repo' && !REPO_RE.test(trimmed)) {
-		return 'Must be owner/repo';
-	}
-	if (kind === 'int') {
-		const n = parseInt(trimmed, 10);
+type BoolFieldKey = 'mirror_pr_events' | 'active';
+
+type Errors = Partial<Record<TextFieldKey, string>>;
+
+function validateField(k: TextFieldKey, raw: string): string | null {
+	const v = raw.trim();
+	if (k === 'max_assignees') {
+		if (!v) return 'Required';
+		const n = parseInt(v, 10);
 		if (Number.isNaN(n) || n < 1 || n > 10) return 'Must be 1–10';
+		return null;
 	}
-	return null;
+	if (!v) return null;
+	if (k === 'default_repo') {
+		return REPO_RE.test(v) ? null : 'Must be owner/repo';
+	}
+	return SNOWFLAKE_RE.test(v)
+		? null
+		: 'Must be a Discord snowflake (17–20 digits)';
+}
+
+function readForm(
+	refs: Record<TextFieldKey, HTMLInputElement | null>,
+	mirror: boolean,
+	active: boolean,
+): BotConfigFormDraft {
+	const get = (k: TextFieldKey) => refs[k]?.value ?? '';
+	return {
+		default_repo: get('default_repo'),
+		claim_channel_id: get('claim_channel_id'),
+		forum_channel_id: get('forum_channel_id'),
+		noticeboard_channel_id: get('noticeboard_channel_id'),
+		taskboard_channel_id: get('taskboard_channel_id'),
+		max_assignees: get('max_assignees'),
+		mirror_pr_events: mirror,
+		active,
+	};
+}
+
+function validateAll(draft: BotConfigFormDraft): Errors {
+	const errs: Errors = {};
+	const keys: TextFieldKey[] = [
+		'default_repo',
+		'claim_channel_id',
+		'forum_channel_id',
+		'noticeboard_channel_id',
+		'taskboard_channel_id',
+		'max_assignees',
+	];
+	for (const k of keys) {
+		const e = validateField(k, draft[k] as string);
+		if (e) errs[k] = e;
+	}
+	return errs;
 }
 
 export default function ReactAgentBotConfig() {
 	const guildId = useStore(agentsService.$selectedGuildId);
 	const guilds = useStore(agentsService.$guilds);
-	const drafts = useStore(agentsService.$botConfigDrafts);
 	const savingMap = useStore(agentsService.$botConfigSavingFor);
 	const errorsMap = useStore(agentsService.$botConfigErrors);
 	const loadedMap = useStore(agentsService.$botConfigLoadedFor);
 
 	const [loading, setLoading] = useState(false);
 	const [success, setSuccess] = useState<string | null>(null);
+	const [errors, setErrors] = useState<Errors>({});
+	const [, setRev] = useState(0);
 
-	const form: FormState = guildId
-		? (drafts[guildId] ?? emptyBotConfigFormDraft())
-		: emptyBotConfigFormDraft();
 	const saving = guildId ? !!savingMap[guildId] : false;
-	const error = guildId ? (errorsMap[guildId] ?? null) : null;
+	const serverError = guildId ? (errorsMap[guildId] ?? null) : null;
 	const loaded = guildId ? !!loadedMap[guildId] : false;
+
+	const refs = useRef<Record<TextFieldKey, HTMLInputElement | null>>({
+		default_repo: null,
+		claim_channel_id: null,
+		forum_channel_id: null,
+		noticeboard_channel_id: null,
+		taskboard_channel_id: null,
+		max_assignees: null,
+	});
+	const mirrorRef = useRef<boolean>(true);
+	const activeRef = useRef<boolean>(true);
+	const initialDraftRef = useRef<BotConfigFormDraft>(
+		emptyBotConfigFormDraft(),
+	);
+
+	const hydrate = useCallback(
+		(force: boolean) => {
+			if (!guildId) return;
+			const snapshot =
+				agentsService.$botConfigDrafts.get()[guildId] ??
+				emptyBotConfigFormDraft();
+			initialDraftRef.current = snapshot;
+			mirrorRef.current = snapshot.mirror_pr_events;
+			activeRef.current = snapshot.active;
+			(Object.keys(refs.current) as TextFieldKey[]).forEach((k) => {
+				const el = refs.current[k];
+				if (
+					el &&
+					(force || el.value === '' || el.value !== snapshot[k])
+				) {
+					el.value = snapshot[k] as string;
+				}
+			});
+			setErrors(validateAll(snapshot));
+			setRev((r) => r + 1);
+		},
+		[guildId],
+	);
 
 	const load = useCallback(
 		async (force = false) => {
@@ -58,21 +144,79 @@ export default function ReactAgentBotConfig() {
 			setSuccess(null);
 			await agentsService.ensureBotConfigLoaded(guildId, force);
 			setLoading(false);
+			hydrate(true);
 		},
-		[guildId],
+		[guildId, hydrate],
 	);
 
 	useEffect(() => {
-		if (guildId && !loaded) {
+		if (!guildId) return;
+		if (loaded) {
+			hydrate(false);
+		} else {
 			void load();
 		}
-	}, [guildId, loaded, load]);
+	}, [guildId, loaded, load, hydrate]);
 
 	useEffect(() => {
 		if (!success) return;
 		const t = setTimeout(() => setSuccess(null), 2500);
 		return () => clearTimeout(t);
 	}, [success]);
+
+	function commitToDraft() {
+		if (!guildId) return;
+		const cur = readForm(
+			refs.current,
+			mirrorRef.current,
+			activeRef.current,
+		);
+		agentsService.patchBotConfigDraft(guildId, cur);
+	}
+
+	function onFieldBlur(k: TextFieldKey) {
+		return (_: FocusEvent<HTMLInputElement>) => {
+			const v = refs.current[k]?.value ?? '';
+			const err = validateField(k, v);
+			setErrors((prev) => {
+				const next = { ...prev };
+				if (err) next[k] = err;
+				else delete next[k];
+				return next;
+			});
+			commitToDraft();
+		};
+	}
+
+	function onBoolChange(k: BoolFieldKey, v: boolean) {
+		if (k === 'mirror_pr_events') mirrorRef.current = v;
+		else activeRef.current = v;
+		commitToDraft();
+		setRev((r) => r + 1);
+	}
+
+	async function onSubmit(e: FormEvent<HTMLFormElement>) {
+		e.preventDefault();
+		if (!guildId || saving) return;
+		const draft = readForm(
+			refs.current,
+			mirrorRef.current,
+			activeRef.current,
+		);
+		const allErrors = validateAll(draft);
+		setErrors(allErrors);
+		if (Object.keys(allErrors).length > 0) return;
+		agentsService.patchBotConfigDraft(guildId, draft);
+		setSuccess(null);
+		const r = await agentsService.saveBotConfigDraft(guildId);
+		if (r.ok) setSuccess('Saved.');
+	}
+
+	const anyError = useMemo(() => Object.keys(errors).length > 0, [errors]);
+	const guild = useMemo(
+		() => guilds.find((g) => g.id === guildId),
+		[guilds, guildId],
+	);
 
 	if (!guildId) {
 		return (
@@ -91,37 +235,7 @@ export default function ReactAgentBotConfig() {
 		);
 	}
 
-	const guild = guilds.find((g) => g.id === guildId);
-
-	const errors = {
-		default_repo: fieldError(form.default_repo, 'repo'),
-		claim_channel_id: fieldError(form.claim_channel_id, 'snowflake'),
-		forum_channel_id: fieldError(form.forum_channel_id, 'snowflake'),
-		noticeboard_channel_id: fieldError(
-			form.noticeboard_channel_id,
-			'snowflake',
-		),
-		taskboard_channel_id: fieldError(
-			form.taskboard_channel_id,
-			'snowflake',
-		),
-		max_assignees: fieldError(form.max_assignees, 'int', true),
-	};
-	const anyError = Object.values(errors).some((e) => e !== null);
-
-	async function save() {
-		if (!guildId || anyError || saving) return;
-		setSuccess(null);
-		const r = await agentsService.saveBotConfigDraft(guildId);
-		if (r.ok) setSuccess('Saved.');
-	}
-
-	function patch<K extends keyof FormState>(k: K, v: FormState[K]) {
-		if (!guildId) return;
-		agentsService.patchBotConfigDraft(guildId, {
-			[k]: v,
-		} as Partial<FormState>);
-	}
+	const d = initialDraftRef.current;
 
 	return (
 		<section style={styles.sectionBorder}>
@@ -161,7 +275,9 @@ export default function ReactAgentBotConfig() {
 				</button>
 			</header>
 
-			<div
+			<form
+				onSubmit={onSubmit}
+				autoComplete="off"
 				style={{
 					padding: '0.85rem 1rem',
 					display: 'flex',
@@ -176,72 +292,83 @@ export default function ReactAgentBotConfig() {
 					required).
 				</p>
 
-				<Field
+				<TextField
 					label="Default repository"
 					hint="Used by /gh shortcuts when no repo argument is supplied. Format: owner/repo."
-					error={errors.default_repo}>
-					<input
-						type="text"
-						value={form.default_repo}
-						placeholder="KBVE/kbve"
-						onChange={(e) => patch('default_repo', e.target.value)}
-						style={mono}
-						spellCheck={false}
-					/>
-				</Field>
-
-				<ChannelField
+					name="default_repo"
+					defaultValue={d.default_repo}
+					placeholder="KBVE/kbve"
+					inputRef={(el) => (refs.current.default_repo = el)}
+					onBlur={onFieldBlur('default_repo')}
+					error={errors.default_repo}
+					fontMono
+				/>
+				<TextField
 					label="Claim channel"
 					hint="Channel that /gh claim posts confirmations to."
-					value={form.claim_channel_id}
+					name="claim_channel_id"
+					defaultValue={d.claim_channel_id}
+					placeholder="Discord snowflake"
+					inputRef={(el) => (refs.current.claim_channel_id = el)}
+					onBlur={onFieldBlur('claim_channel_id')}
 					error={errors.claim_channel_id}
-					onChange={(v) => patch('claim_channel_id', v)}
+					fontMono
 				/>
-
-				<ChannelField
+				<TextField
 					label="Forum channel"
 					hint="Forum channel where issue threads are created (P2 of #11262)."
-					value={form.forum_channel_id}
+					name="forum_channel_id"
+					defaultValue={d.forum_channel_id}
+					placeholder="Discord snowflake"
+					inputRef={(el) => (refs.current.forum_channel_id = el)}
+					onBlur={onFieldBlur('forum_channel_id')}
 					error={errors.forum_channel_id}
-					onChange={(v) => patch('forum_channel_id', v)}
+					fontMono
 				/>
-
-				<ChannelField
+				<TextField
 					label="Notice board channel"
 					hint="Channel for /github noticeboard embeds."
-					value={form.noticeboard_channel_id}
+					name="noticeboard_channel_id"
+					defaultValue={d.noticeboard_channel_id}
+					placeholder="Discord snowflake"
+					inputRef={(el) =>
+						(refs.current.noticeboard_channel_id = el)
+					}
+					onBlur={onFieldBlur('noticeboard_channel_id')}
 					error={errors.noticeboard_channel_id}
-					onChange={(v) => patch('noticeboard_channel_id', v)}
+					fontMono
 				/>
-
-				<ChannelField
+				<TextField
 					label="Task board channel"
 					hint="Channel for /github taskboard embeds."
-					value={form.taskboard_channel_id}
+					name="taskboard_channel_id"
+					defaultValue={d.taskboard_channel_id}
+					placeholder="Discord snowflake"
+					inputRef={(el) => (refs.current.taskboard_channel_id = el)}
+					onBlur={onFieldBlur('taskboard_channel_id')}
 					error={errors.taskboard_channel_id}
-					onChange={(v) => patch('taskboard_channel_id', v)}
+					fontMono
 				/>
-
-				<Field
+				<TextField
 					label="Max assignees per claim"
 					hint="Refuse /gh claim once an issue already has this many GitHub assignees."
-					error={errors.max_assignees}>
-					<input
-						type="number"
-						value={form.max_assignees}
-						min={1}
-						max={10}
-						onChange={(e) => patch('max_assignees', e.target.value)}
-						style={{ ...input, width: 100 }}
-					/>
-				</Field>
+					name="max_assignees"
+					defaultValue={d.max_assignees}
+					placeholder="2"
+					inputRef={(el) => (refs.current.max_assignees = el)}
+					onBlur={onFieldBlur('max_assignees')}
+					error={errors.max_assignees}
+					inputMode="numeric"
+					pattern="[0-9]*"
+					maxWidth={100}
+				/>
 
 				<label style={toggleRow}>
 					<input
 						type="checkbox"
-						checked={form.mirror_pr_events}
+						defaultChecked={d.mirror_pr_events}
 						onChange={(e) =>
-							patch('mirror_pr_events', e.target.checked)
+							onBoolChange('mirror_pr_events', e.target.checked)
 						}
 					/>
 					<span>
@@ -256,30 +383,46 @@ export default function ReactAgentBotConfig() {
 				<label style={toggleRow}>
 					<input
 						type="checkbox"
-						checked={form.active}
-						onChange={(e) => patch('active', e.target.checked)}
+						defaultChecked={d.active}
+						onChange={(e) =>
+							onBoolChange('active', e.target.checked)
+						}
 					/>
 					<span>
 						<strong>Active</strong>
 						<span style={subtle}>
-							Mute the bot for this guild without removing it.
-							When false, slash commands no-op and webhook events
-							are dropped.
+							Master switch. Disable to temporarily silence the
+							bot for this guild without deleting the config row.
 						</span>
 					</span>
 				</label>
 
-				{error && <p style={errText}>{error}</p>}
-				{success && (
-					<p style={{ ...muted, color: '#4ade80' }}>{success}</p>
-				)}
-
-				<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.6rem',
+						marginTop: '0.4rem',
+					}}>
+					{success && (
+						<span
+							style={{
+								color: '#4ade80',
+								fontSize: '0.82rem',
+							}}>
+							{success}
+						</span>
+					)}
+					{serverError && (
+						<span style={errTextLine}>{serverError}</span>
+					)}
 					<button
-						type="button"
-						onClick={() => void save()}
+						type="submit"
 						disabled={anyError || saving}
-						style={primaryBtn(!anyError && !saving)}>
+						style={{
+							...primaryBtn(!anyError && !saving),
+							marginLeft: 'auto',
+						}}>
 						{saving ? (
 							<Loader2 size={14} style={spinIcon} />
 						) : (
@@ -288,59 +431,81 @@ export default function ReactAgentBotConfig() {
 						{saving ? 'Saving…' : 'Save config'}
 					</button>
 				</div>
-			</div>
+			</form>
 		</section>
 	);
 }
 
-function Field({
-	label,
-	hint,
-	error,
-	children,
-}: {
+interface TextFieldProps {
 	label: string;
 	hint?: string;
-	error?: string | null;
-	children: React.ReactNode;
-}) {
+	name: string;
+	defaultValue: string;
+	placeholder?: string;
+	inputRef: (el: HTMLInputElement | null) => void;
+	onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+	error?: string;
+	fontMono?: boolean;
+	inputMode?: 'text' | 'numeric';
+	pattern?: string;
+	maxWidth?: number;
+}
+
+function TextField(props: TextFieldProps) {
+	const {
+		label,
+		hint,
+		name,
+		defaultValue,
+		placeholder,
+		inputRef,
+		onBlur,
+		error,
+		fontMono,
+		inputMode,
+		pattern,
+		maxWidth,
+	} = props;
 	return (
 		<label
 			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
 			<span style={fieldLabel}>{label}</span>
-			{children}
+			<input
+				ref={inputRef}
+				name={name}
+				defaultValue={defaultValue}
+				placeholder={placeholder}
+				onBlur={onBlur}
+				autoComplete="off"
+				spellCheck={false}
+				inputMode={inputMode}
+				pattern={pattern}
+				style={{
+					...inputStyle,
+					...(fontMono ? mono : null),
+					...(maxWidth ? { width: maxWidth } : null),
+				}}
+			/>
 			{hint && !error && <span style={subtle}>{hint}</span>}
 			{error && <span style={errText}>{error}</span>}
 		</label>
 	);
 }
 
-function ChannelField({
-	label,
-	hint,
-	value,
-	error,
-	onChange,
-}: {
-	label: string;
-	hint?: string;
-	value: string;
-	error: string | null;
-	onChange: (v: string) => void;
-}) {
-	return (
-		<Field label={label} hint={hint} error={error}>
-			<input
-				type="text"
-				value={value}
-				placeholder="Discord snowflake"
-				onChange={(e) => onChange(e.target.value)}
-				style={mono}
-				spellCheck={false}
-			/>
-		</Field>
-	);
-}
+const inputStyle: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	boxSizing: 'border-box',
+	width: '100%',
+};
+
+const mono: React.CSSProperties = {
+	fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
+};
 
 const muted: React.CSSProperties = {
 	margin: 0,
@@ -368,37 +533,18 @@ const errText: React.CSSProperties = {
 	fontSize: '0.78rem',
 };
 
-const input: React.CSSProperties = {
-	background: 'rgba(255,255,255,0.04)',
-	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
-	borderRadius: 6,
-	color: 'var(--sl-color-white, #fff)',
-	padding: '0.5rem 0.65rem',
-	fontSize: '0.9rem',
-	boxSizing: 'border-box',
+const errTextLine: React.CSSProperties = {
+	color: '#f87171',
+	fontSize: '0.78rem',
 };
 
-const mono: React.CSSProperties = {
-	...input,
-	fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
-	width: '100%',
+const toggleRow: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'flex-start',
+	gap: '0.6rem',
+	fontSize: '0.85rem',
+	color: 'var(--sl-color-gray-2, #c2c5cc)',
 };
-
-function primaryBtn(enabled: boolean): React.CSSProperties {
-	return {
-		display: 'inline-flex',
-		alignItems: 'center',
-		gap: '0.4rem',
-		padding: '0.5rem 1rem',
-		borderRadius: 8,
-		border: 'none',
-		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
-		color: '#0d1117',
-		fontWeight: 600,
-		cursor: enabled ? 'pointer' : 'not-allowed',
-		fontSize: '0.9rem',
-	};
-}
 
 function refreshBtn(busy: boolean): React.CSSProperties {
 	return {
@@ -416,15 +562,21 @@ function refreshBtn(busy: boolean): React.CSSProperties {
 	};
 }
 
-const toggleRow: React.CSSProperties = {
-	display: 'flex',
-	alignItems: 'flex-start',
-	gap: '0.55rem',
-	padding: '0.5rem 0.7rem',
-	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
-	borderRadius: 8,
-	background: 'rgba(255,255,255,0.02)',
-};
+function primaryBtn(enabled: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+		padding: '0.5rem 0.95rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
+		color: '#0d1117',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		fontSize: '0.85rem',
+	};
+}
 
 const spinIcon: React.CSSProperties = {
 	animation: 'spin 1s linear infinite',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	AlertTriangle,
@@ -191,8 +191,11 @@ function WizardBody({ guild, tokens }: WizardBodyProps) {
 
 			<Step1Webhook guild={guild} existing={existingWebhook} />
 			<Step2WebhookConfig guild={guild} hasWebhook={!!existingWebhook} />
-			<Step3Pat existing={existingPat} />
-			<Step4SmokeBackfill ready={!!existingWebhook && !!existingPat} />
+			<Step3Pat guildId={guild.id} existing={existingPat} />
+			<Step4SmokeBackfill
+				guildId={guild.id}
+				ready={!!existingWebhook && !!existingPat}
+			/>
 		</div>
 	);
 }
@@ -204,38 +207,39 @@ function Step1Webhook({
 	guild: DiscordGuild;
 	existing: AgentTokenRow | null;
 }) {
-	const [secret, setSecret] = useState<string | null>(null);
+	const draftsMap = useStore(agentsService.$webhookDrafts);
+	const savingMap = useStore(agentsService.$webhookSavingFor);
+	const errorsMap = useStore(agentsService.$webhookErrors);
+
+	const secret = draftsMap[guild.id] ?? null;
+	const busy = !!savingMap[guild.id];
+	const error = errorsMap[guild.id] ?? null;
+
 	const [reveal, setReveal] = useState(false);
-	const [busy, setBusy] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
 
 	const stored = !!existing;
 
+	useEffect(() => {
+		setReveal(false);
+		setCopied(false);
+	}, [guild.id]);
+
 	async function generate() {
-		setSecret(genHex(32));
+		agentsService.setWebhookDraft(guild.id, genHex(32));
 		setReveal(true);
 		setCopied(false);
-		setError(null);
+		agentsService.clearWebhookError(guild.id);
 	}
 
 	async function save() {
 		if (!secret) return;
-		setBusy(true);
-		setError(null);
-		const r = await agentsService.addToken({
-			tokenName: WEBHOOK_TOKEN_NAME,
-			service: WEBHOOK_SERVICE,
-			tokenValue: secret,
-			description: `GitHub webhook HMAC for guild ${guild.id}`,
-		});
-		setBusy(false);
-		if (!r.ok) {
-			setError(r.error);
-			return;
-		}
-		setSecret(null);
-		setReveal(false);
+		const r = await agentsService.saveWebhookDraft(
+			guild.id,
+			WEBHOOK_TOKEN_NAME,
+			`GitHub webhook HMAC for guild ${guild.id}`,
+		);
+		if (r.ok) setReveal(false);
 	}
 
 	async function copy() {
@@ -448,54 +452,59 @@ function Step2WebhookConfig({
 	);
 }
 
-function Step3Pat({ existing }: { existing: AgentTokenRow | null }) {
-	const [pat, setPat] = useState('');
-	const [validating, setValidating] = useState(false);
-	const [storing, setStoring] = useState(false);
-	const [error, setError] = useState<string | null>(null);
-	const [validated, setValidated] = useState<{
-		login: string;
-		scopes: string[];
-		tokenType: string;
-	} | null>(null);
+function Step3Pat({
+	guildId,
+	existing,
+}: {
+	guildId: string;
+	existing: AgentTokenRow | null;
+}) {
+	const draftsMap = useStore(agentsService.$patDrafts);
+	const validatedMap = useStore(agentsService.$patValidatedFor);
+	const validatingMap = useStore(agentsService.$patValidatingFor);
+	const savingMap = useStore(agentsService.$patSavingFor);
+	const errorsMap = useStore(agentsService.$patErrors);
+
+	const validating = !!validatingMap[guildId];
+	const storing = !!savingMap[guildId];
+	const error = errorsMap[guildId] ?? null;
+	const validated = validatedMap[guildId] ?? null;
+	const draftPat = draftsMap[guildId] ?? '';
+
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const [hasInput, setHasInput] = useState<boolean>(draftPat.length > 0);
 
 	const stored = !!existing;
 
+	useEffect(() => {
+		if (!inputRef.current) return;
+		const snap = agentsService.$patDrafts.get()[guildId] ?? '';
+		if (inputRef.current.value !== snap) inputRef.current.value = snap;
+		setHasInput(snap.length > 0);
+	}, [guildId]);
+
+	function onPatBlur(_: FocusEvent<HTMLInputElement>) {
+		const v = inputRef.current?.value ?? '';
+		agentsService.setPatDraft(guildId, v);
+	}
+
+	function onPatInput() {
+		const v = inputRef.current?.value ?? '';
+		setHasInput(v.length > 0);
+	}
+
 	async function validate() {
-		setValidating(true);
-		setError(null);
-		setValidated(null);
-		const r = await agentsService.validateGithubPat(pat);
-		setValidating(false);
-		if (!r.ok) {
-			setError(r.error);
-			return;
-		}
-		setValidated({
-			login: r.login,
-			scopes: r.scopes,
-			tokenType: r.tokenType,
-		});
+		const v = inputRef.current?.value ?? '';
+		agentsService.setPatDraft(guildId, v);
+		await agentsService.validatePatForGuild(guildId);
 	}
 
 	async function save() {
-		setStoring(true);
-		setError(null);
-		const r = await agentsService.addToken({
-			tokenName: PAT_TOKEN_NAME,
-			service: PAT_SERVICE,
-			tokenValue: pat,
-			description: validated
-				? `GitHub PAT for ${validated.login}`
-				: 'GitHub PAT',
-		});
-		setStoring(false);
-		if (!r.ok) {
-			setError(r.error);
-			return;
-		}
-		setPat('');
-		setValidated(null);
+		const v = inputRef.current?.value ?? '';
+		agentsService.setPatDraft(guildId, v);
+		const r = await agentsService.savePatForGuild(guildId, PAT_TOKEN_NAME);
+		if (r.ok && inputRef.current) inputRef.current.value = '';
+		if (r.ok) setHasInput(false);
 	}
 
 	return (
@@ -525,9 +534,11 @@ function Step3Pat({ existing }: { existing: AgentTokenRow | null }) {
 						endpoint before storing it.
 					</p>
 					<input
+						ref={inputRef}
 						type="password"
-						value={pat}
-						onChange={(e) => setPat(e.target.value)}
+						defaultValue={draftPat}
+						onBlur={onPatBlur}
+						onInput={onPatInput}
 						placeholder="ghp_… or github_pat_…"
 						style={{
 							...inputStyle,
@@ -546,7 +557,7 @@ function Step3Pat({ existing }: { existing: AgentTokenRow | null }) {
 						<button
 							type="button"
 							onClick={validate}
-							disabled={!pat || validating}
+							disabled={!hasInput || validating}
 							style={secondaryBtn}>
 							{validating ? (
 								<Loader2 size={14} style={spinStyle} />
@@ -620,38 +631,71 @@ function Step3Pat({ existing }: { existing: AgentTokenRow | null }) {
 	);
 }
 
-function Step4SmokeBackfill({ ready }: { ready: boolean }) {
-	const [owner, setOwner] = useState('');
-	const [repo, setRepo] = useState('');
-	const [busy, setBusy] = useState(false);
-	const [result, setResult] = useState<
-		| {
-				ok: true;
-				upserted: number;
-				pages: number;
-				rateLimitRemaining: number | null;
-		  }
-		| { ok: false; error: string }
-		| null
-	>(null);
+function Step4SmokeBackfill({
+	guildId,
+	ready,
+}: {
+	guildId: string;
+	ready: boolean;
+}) {
+	const draftsMap = useStore(agentsService.$backfillDrafts);
+	const busyMap = useStore(agentsService.$backfillBusyFor);
+	const resultsMap = useStore(agentsService.$backfillResults);
 
-	const ownerOk = GITHUB_OWNER_RE.test(owner);
-	const repoOk = GITHUB_REPO_RE.test(repo);
-	const canRun = ready && ownerOk && repoOk && !busy;
+	const draft = draftsMap[guildId] ?? { owner: '', repo: '' };
+	const busy = !!busyMap[guildId];
+	const result = resultsMap[guildId] ?? null;
+
+	const ownerRef = useRef<HTMLInputElement | null>(null);
+	const repoRef = useRef<HTMLInputElement | null>(null);
+	const [draftValid, setDraftValid] = useState<boolean>(
+		GITHUB_OWNER_RE.test(draft.owner) && GITHUB_REPO_RE.test(draft.repo),
+	);
+
+	useEffect(() => {
+		const snap = agentsService.$backfillDrafts.get()[guildId] ?? {
+			owner: '',
+			repo: '',
+		};
+		if (ownerRef.current && ownerRef.current.value !== snap.owner) {
+			ownerRef.current.value = snap.owner;
+		}
+		if (repoRef.current && repoRef.current.value !== snap.repo) {
+			repoRef.current.value = snap.repo;
+		}
+		setDraftValid(
+			GITHUB_OWNER_RE.test(snap.owner) && GITHUB_REPO_RE.test(snap.repo),
+		);
+	}, [guildId]);
+
+	function refreshValid() {
+		const o = ownerRef.current?.value ?? '';
+		const r = repoRef.current?.value ?? '';
+		setDraftValid(GITHUB_OWNER_RE.test(o) && GITHUB_REPO_RE.test(r));
+	}
+
+	function commitOwner() {
+		agentsService.patchBackfillDraft(guildId, {
+			owner: ownerRef.current?.value ?? '',
+		});
+		refreshValid();
+	}
+
+	function commitRepo() {
+		agentsService.patchBackfillDraft(guildId, {
+			repo: repoRef.current?.value ?? '',
+		});
+		refreshValid();
+	}
+
+	const canRun = ready && draftValid && !busy;
 
 	async function run() {
 		if (!canRun) return;
-		setBusy(true);
-		setResult(null);
-		const r = await agentsService.runBackfill({
-			owner,
-			repo,
-			state: 'open',
-			maxPages: 1,
-			perPage: 30,
-		});
-		setBusy(false);
-		setResult(r);
+		const o = ownerRef.current?.value ?? '';
+		const r = repoRef.current?.value ?? '';
+		agentsService.patchBackfillDraft(guildId, { owner: o, repo: r });
+		await agentsService.runBackfillForGuild(guildId);
 	}
 
 	return (
@@ -673,20 +717,26 @@ function Step4SmokeBackfill({ ready }: { ready: boolean }) {
 					gap: '0.4rem',
 				}}>
 				<input
+					ref={ownerRef}
 					placeholder="owner (e.g. KBVE)"
-					value={owner}
-					onChange={(e) => setOwner(e.target.value)}
+					defaultValue={draft.owner}
+					onBlur={commitOwner}
+					onInput={refreshValid}
 					disabled={!ready}
 					style={inputStyle}
 					spellCheck={false}
+					autoComplete="off"
 				/>
 				<input
+					ref={repoRef}
 					placeholder="repo (e.g. kbve)"
-					value={repo}
-					onChange={(e) => setRepo(e.target.value)}
+					defaultValue={draft.repo}
+					onBlur={commitRepo}
+					onInput={refreshValid}
 					disabled={!ready}
 					style={inputStyle}
 					spellCheck={false}
+					autoComplete="off"
 				/>
 			</div>
 			<button
@@ -732,7 +782,7 @@ function Step4SmokeBackfill({ ready }: { ready: boolean }) {
 					)}
 					<div style={{ marginTop: '0.35rem' }}>
 						<a
-							href={`https://github.com/${owner}/${repo}/settings/hooks`}
+							href={`https://github.com/${draft.owner}/${draft.repo}/settings/hooks`}
 							target="_blank"
 							rel="noopener">
 							<ExternalLink

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useState } from 'react';
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type FormEvent,
+} from 'react';
 import { useStore } from '@nanostores/react';
 import { GitBranch, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react';
 import { agentsService } from './agentsService';
@@ -15,7 +21,9 @@ export default function ReactAgentRepoAllowlist() {
 	const loadedMap = useStore(agentsService.$repoAllowlistLoadedFor);
 
 	const [loading, setLoading] = useState(false);
-	const [draft, setDraft] = useState('');
+	const [draftValid, setDraftValid] = useState(false);
+	const [draftRaw, setDraftRaw] = useState('');
+	const draftRef = useRef<HTMLInputElement | null>(null);
 
 	const repos = guildId ? (draftsMap[guildId] ?? []) : [];
 	const saving = guildId ? !!savingMap[guildId] : false;
@@ -39,8 +47,16 @@ export default function ReactAgentRepoAllowlist() {
 	}, [guildId, loaded, load]);
 
 	useEffect(() => {
-		setDraft('');
+		if (draftRef.current) draftRef.current.value = '';
+		setDraftRaw('');
+		setDraftValid(false);
 	}, [guildId]);
+
+	function onDraftInput() {
+		const v = draftRef.current?.value ?? '';
+		setDraftRaw(v);
+		setDraftValid(REPO_RE.test(v) && !repos.includes(v));
+	}
 
 	if (!guildId) {
 		return (
@@ -60,27 +76,34 @@ export default function ReactAgentRepoAllowlist() {
 	}
 
 	const guild = guilds.find((g) => g.id === guildId);
-	const draftOk = REPO_RE.test(draft) && !repos.includes(draft);
+	const draftOk = draftValid && !saving;
 
-	async function add() {
-		if (!guildId || !draftOk || saving) return;
-		const next = [...repos, draft];
+	async function add(e?: FormEvent<HTMLFormElement>) {
+		e?.preventDefault();
+		if (!guildId || saving) return;
+		const v = draftRef.current?.value?.trim() ?? '';
+		if (!REPO_RE.test(v) || repos.includes(v)) return;
+		const prev = repos;
+		const next = [...repos, v];
 		agentsService.patchRepoAllowlistDraft(guildId, next);
 		const r = await agentsService.saveRepoAllowlistDraft(guildId);
 		if (r.ok) {
-			setDraft('');
+			if (draftRef.current) draftRef.current.value = '';
+			setDraftRaw('');
+			setDraftValid(false);
 		} else {
-			agentsService.patchRepoAllowlistDraft(guildId, repos);
+			agentsService.patchRepoAllowlistDraft(guildId, prev);
 		}
 	}
 
 	async function remove(repo: string) {
 		if (!guildId || saving) return;
+		const prev = repos;
 		const next = repos.filter((r) => r !== repo);
 		agentsService.patchRepoAllowlistDraft(guildId, next);
 		const r = await agentsService.saveRepoAllowlistDraft(guildId);
 		if (!r.ok) {
-			agentsService.patchRepoAllowlistDraft(guildId, repos);
+			agentsService.patchRepoAllowlistDraft(guildId, prev);
 		}
 	}
 
@@ -189,17 +212,20 @@ export default function ReactAgentRepoAllowlist() {
 					</ul>
 				)}
 
-				<div
+				<form
+					onSubmit={(e) => void add(e)}
+					autoComplete="off"
 					style={{
 						display: 'flex',
 						gap: '0.4rem',
 						alignItems: 'stretch',
 					}}>
 					<input
+						ref={draftRef}
 						type="text"
-						value={draft}
+						defaultValue=""
 						placeholder="owner/repo (e.g. KBVE/kbve)"
-						onChange={(e) => setDraft(e.target.value)}
+						onInput={onDraftInput}
 						style={{
 							...inputStyle,
 							fontFamily:
@@ -207,12 +233,12 @@ export default function ReactAgentRepoAllowlist() {
 							flex: 1,
 						}}
 						spellCheck={false}
+						autoComplete="off"
 					/>
 					<button
-						type="button"
-						onClick={() => void add()}
-						disabled={!draftOk || saving}
-						style={primaryBtn(draftOk && !saving)}>
+						type="submit"
+						disabled={!draftOk}
+						style={primaryBtn(draftOk)}>
 						{saving ? (
 							<Loader2 size={14} style={spinIcon} />
 						) : (
@@ -220,8 +246,8 @@ export default function ReactAgentRepoAllowlist() {
 						)}
 						{saving ? 'Saving…' : 'Add'}
 					</button>
-				</div>
-				{draft.length > 0 && !REPO_RE.test(draft) && (
+				</form>
+				{draftRaw.length > 0 && !REPO_RE.test(draftRaw) && (
 					<p style={errText}>
 						Expected <code>owner/repo</code> matching GitHub's name
 						rules.

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
@@ -9,32 +9,38 @@ const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
 export default function ReactAgentRepoAllowlist() {
 	const guildId = useStore(agentsService.$selectedGuildId);
 	const guilds = useStore(agentsService.$guilds);
+	const draftsMap = useStore(agentsService.$repoAllowlistDrafts);
+	const savingMap = useStore(agentsService.$repoAllowlistSavingFor);
+	const errorsMap = useStore(agentsService.$repoAllowlistErrors);
+	const loadedMap = useStore(agentsService.$repoAllowlistLoadedFor);
 
-	const [repos, setRepos] = useState<string[]>([]);
 	const [loading, setLoading] = useState(false);
-	const [error, setError] = useState<string | null>(null);
 	const [draft, setDraft] = useState('');
-	const [saving, setSaving] = useState(false);
 
-	const load = useCallback(async () => {
-		if (!guildId) {
-			setRepos([]);
-			return;
-		}
-		setLoading(true);
-		setError(null);
-		const r = await agentsService.getRepoAllowlist();
-		setLoading(false);
-		if (!r.ok) {
-			setError(r.error);
-			return;
-		}
-		setRepos(r.repos);
-	}, [guildId]);
+	const repos = guildId ? (draftsMap[guildId] ?? []) : [];
+	const saving = guildId ? !!savingMap[guildId] : false;
+	const error = guildId ? (errorsMap[guildId] ?? null) : null;
+	const loaded = guildId ? !!loadedMap[guildId] : false;
+
+	const load = useCallback(
+		async (force = false) => {
+			if (!guildId) return;
+			setLoading(true);
+			await agentsService.ensureRepoAllowlistLoaded(guildId, force);
+			setLoading(false);
+		},
+		[guildId],
+	);
 
 	useEffect(() => {
-		void load();
-	}, [load]);
+		if (guildId && !loaded) {
+			void load();
+		}
+	}, [guildId, loaded, load]);
+
+	useEffect(() => {
+		setDraft('');
+	}, [guildId]);
 
 	if (!guildId) {
 		return (
@@ -57,31 +63,25 @@ export default function ReactAgentRepoAllowlist() {
 	const draftOk = REPO_RE.test(draft) && !repos.includes(draft);
 
 	async function add() {
-		if (!draftOk) return;
-		setSaving(true);
-		setError(null);
+		if (!guildId || !draftOk || saving) return;
 		const next = [...repos, draft];
-		const r = await agentsService.setRepoAllowlist(next);
-		setSaving(false);
-		if (!r.ok) {
-			setError(r.error);
-			return;
+		agentsService.patchRepoAllowlistDraft(guildId, next);
+		const r = await agentsService.saveRepoAllowlistDraft(guildId);
+		if (r.ok) {
+			setDraft('');
+		} else {
+			agentsService.patchRepoAllowlistDraft(guildId, repos);
 		}
-		setRepos(next);
-		setDraft('');
 	}
 
 	async function remove(repo: string) {
-		setSaving(true);
-		setError(null);
+		if (!guildId || saving) return;
 		const next = repos.filter((r) => r !== repo);
-		const r = await agentsService.setRepoAllowlist(next);
-		setSaving(false);
+		agentsService.patchRepoAllowlistDraft(guildId, next);
+		const r = await agentsService.saveRepoAllowlistDraft(guildId);
 		if (!r.ok) {
-			setError(r.error);
-			return;
+			agentsService.patchRepoAllowlistDraft(guildId, repos);
 		}
-		setRepos(next);
 	}
 
 	return (
@@ -110,7 +110,7 @@ export default function ReactAgentRepoAllowlist() {
 				)}
 				<button
 					type="button"
-					onClick={() => void load()}
+					onClick={() => void load(true)}
 					disabled={loading || saving}
 					style={refreshBtn(loading || saving)}
 					aria-label="Refresh">

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -289,6 +289,39 @@ class AgentsService {
 	);
 	public readonly $repoAllowlistLoadedFor = atom<Record<string, boolean>>({});
 
+	public readonly $webhookDrafts = atom<Record<string, string | null>>({});
+	public readonly $webhookSavingFor = atom<Record<string, boolean>>({});
+	public readonly $webhookErrors = atom<Record<string, string | null>>({});
+
+	public readonly $patDrafts = atom<Record<string, string>>({});
+	public readonly $patValidatedFor = atom<
+		Record<
+			string,
+			{ login: string; scopes: string[]; tokenType: string } | null
+		>
+	>({});
+	public readonly $patValidatingFor = atom<Record<string, boolean>>({});
+	public readonly $patSavingFor = atom<Record<string, boolean>>({});
+	public readonly $patErrors = atom<Record<string, string | null>>({});
+
+	public readonly $backfillDrafts = atom<
+		Record<string, { owner: string; repo: string }>
+	>({});
+	public readonly $backfillBusyFor = atom<Record<string, boolean>>({});
+	public readonly $backfillResults = atom<
+		Record<
+			string,
+			| {
+					ok: true;
+					upserted: number;
+					pages: number;
+					rateLimitRemaining: number | null;
+			  }
+			| { ok: false; error: string }
+			| null
+		>
+	>({});
+
 	// Dedup state — singleton so the cache survives ClientRouter swaps.
 	private initPromise: Promise<void> | null = null;
 	private lastInitAt = 0;
@@ -966,6 +999,183 @@ class AgentsService {
 			this.$repoAllowlistErrors.set(errs2);
 		}
 		return r;
+	}
+
+	public setWebhookDraft(guildId: string, secret: string | null): void {
+		const m = { ...this.$webhookDrafts.get() };
+		if (secret === null) delete m[guildId];
+		else m[guildId] = secret;
+		this.$webhookDrafts.set(m);
+	}
+
+	public clearWebhookError(guildId: string): void {
+		const m = { ...this.$webhookErrors.get() };
+		delete m[guildId];
+		this.$webhookErrors.set(m);
+	}
+
+	public async saveWebhookDraft(
+		guildId: string,
+		tokenName: string,
+		description: string,
+	): Promise<{ ok: true; tokenId: string } | { ok: false; error: string }> {
+		const secret = this.$webhookDrafts.get()[guildId];
+		if (!secret) return { ok: false, error: 'No secret to save' };
+		const saving = { ...this.$webhookSavingFor.get(), [guildId]: true };
+		this.$webhookSavingFor.set(saving);
+		const errs = { ...this.$webhookErrors.get(), [guildId]: null };
+		this.$webhookErrors.set(errs);
+		const r = await this.addToken({
+			tokenName,
+			service: 'github_webhook',
+			tokenValue: secret,
+			description,
+		});
+		const savingDone = { ...this.$webhookSavingFor.get() };
+		delete savingDone[guildId];
+		this.$webhookSavingFor.set(savingDone);
+		if (r.ok) {
+			this.setWebhookDraft(guildId, null);
+		} else {
+			const errs2 = {
+				...this.$webhookErrors.get(),
+				[guildId]: r.error,
+			};
+			this.$webhookErrors.set(errs2);
+		}
+		return r;
+	}
+
+	public setPatDraft(guildId: string, pat: string): void {
+		const m = { ...this.$patDrafts.get(), [guildId]: pat };
+		this.$patDrafts.set(m);
+		const validated = { ...this.$patValidatedFor.get() };
+		if (validated[guildId]) {
+			delete validated[guildId];
+			this.$patValidatedFor.set(validated);
+		}
+	}
+
+	public clearPatState(guildId: string): void {
+		const drafts = { ...this.$patDrafts.get() };
+		delete drafts[guildId];
+		this.$patDrafts.set(drafts);
+		const validated = { ...this.$patValidatedFor.get() };
+		delete validated[guildId];
+		this.$patValidatedFor.set(validated);
+		const errs = { ...this.$patErrors.get() };
+		delete errs[guildId];
+		this.$patErrors.set(errs);
+	}
+
+	public async validatePatForGuild(
+		guildId: string,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const pat = this.$patDrafts.get()[guildId] ?? '';
+		if (!pat) return { ok: false, error: 'No PAT entered' };
+		const validating = {
+			...this.$patValidatingFor.get(),
+			[guildId]: true,
+		};
+		this.$patValidatingFor.set(validating);
+		const errs = { ...this.$patErrors.get(), [guildId]: null };
+		this.$patErrors.set(errs);
+		const validatedClear = { ...this.$patValidatedFor.get() };
+		delete validatedClear[guildId];
+		this.$patValidatedFor.set(validatedClear);
+		const r = await this.validateGithubPat(pat);
+		const validatingDone = { ...this.$patValidatingFor.get() };
+		delete validatingDone[guildId];
+		this.$patValidatingFor.set(validatingDone);
+		if (!r.ok) {
+			const errs2 = { ...this.$patErrors.get(), [guildId]: r.error };
+			this.$patErrors.set(errs2);
+			return r;
+		}
+		const validatedSet = {
+			...this.$patValidatedFor.get(),
+			[guildId]: {
+				login: r.login,
+				scopes: r.scopes,
+				tokenType: r.tokenType,
+			},
+		};
+		this.$patValidatedFor.set(validatedSet);
+		return { ok: true };
+	}
+
+	public async savePatForGuild(
+		guildId: string,
+		tokenName: string,
+	): Promise<{ ok: true; tokenId: string } | { ok: false; error: string }> {
+		const pat = this.$patDrafts.get()[guildId] ?? '';
+		if (!pat) return { ok: false, error: 'No PAT entered' };
+		const validated = this.$patValidatedFor.get()[guildId] ?? null;
+		const saving = { ...this.$patSavingFor.get(), [guildId]: true };
+		this.$patSavingFor.set(saving);
+		const errs = { ...this.$patErrors.get(), [guildId]: null };
+		this.$patErrors.set(errs);
+		const r = await this.addToken({
+			tokenName,
+			service: 'github',
+			tokenValue: pat,
+			description: validated
+				? `GitHub PAT for ${validated.login}`
+				: 'GitHub PAT',
+		});
+		const savingDone = { ...this.$patSavingFor.get() };
+		delete savingDone[guildId];
+		this.$patSavingFor.set(savingDone);
+		if (r.ok) {
+			this.clearPatState(guildId);
+		} else {
+			const errs2 = { ...this.$patErrors.get(), [guildId]: r.error };
+			this.$patErrors.set(errs2);
+		}
+		return r;
+	}
+
+	public patchBackfillDraft(
+		guildId: string,
+		partial: Partial<{ owner: string; repo: string }>,
+	): void {
+		const drafts = this.$backfillDrafts.get();
+		const cur = drafts[guildId] ?? { owner: '', repo: '' };
+		this.$backfillDrafts.set({
+			...drafts,
+			[guildId]: { ...cur, ...partial },
+		});
+	}
+
+	public clearBackfillResult(guildId: string): void {
+		const m = { ...this.$backfillResults.get() };
+		delete m[guildId];
+		this.$backfillResults.set(m);
+	}
+
+	public async runBackfillForGuild(guildId: string): Promise<void> {
+		const draft = this.$backfillDrafts.get()[guildId] ?? {
+			owner: '',
+			repo: '',
+		};
+		if (!draft.owner || !draft.repo) return;
+		const busy = { ...this.$backfillBusyFor.get(), [guildId]: true };
+		this.$backfillBusyFor.set(busy);
+		const resultsClear = { ...this.$backfillResults.get() };
+		delete resultsClear[guildId];
+		this.$backfillResults.set(resultsClear);
+		const r = await this.runBackfill({
+			owner: draft.owner,
+			repo: draft.repo,
+			state: 'open',
+			maxPages: 1,
+			perPage: 30,
+		});
+		const busyDone = { ...this.$backfillBusyFor.get() };
+		delete busyDone[guildId];
+		this.$backfillBusyFor.set(busyDone);
+		const resultsSet = { ...this.$backfillResults.get(), [guildId]: r };
+		this.$backfillResults.set(resultsSet);
 	}
 
 	public async toggleToken(

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -27,6 +27,71 @@ export interface DiscordshConfig {
 	active?: boolean;
 }
 
+export interface BotConfigFormDraft {
+	default_repo: string;
+	claim_channel_id: string;
+	forum_channel_id: string;
+	noticeboard_channel_id: string;
+	taskboard_channel_id: string;
+	max_assignees: string;
+	mirror_pr_events: boolean;
+	active: boolean;
+}
+
+export function emptyBotConfigFormDraft(): BotConfigFormDraft {
+	return {
+		default_repo: '',
+		claim_channel_id: '',
+		forum_channel_id: '',
+		noticeboard_channel_id: '',
+		taskboard_channel_id: '',
+		max_assignees: '2',
+		mirror_pr_events: true,
+		active: true,
+	};
+}
+
+export function botConfigToFormDraft(c: DiscordshConfig): BotConfigFormDraft {
+	const base = emptyBotConfigFormDraft();
+	return {
+		default_repo: c.default_repo ?? base.default_repo,
+		claim_channel_id: c.claim_channel_id ?? base.claim_channel_id,
+		forum_channel_id: c.forum_channel_id ?? base.forum_channel_id,
+		noticeboard_channel_id:
+			c.noticeboard_channel_id ?? base.noticeboard_channel_id,
+		taskboard_channel_id:
+			c.taskboard_channel_id ?? base.taskboard_channel_id,
+		max_assignees:
+			typeof c.max_assignees === 'number'
+				? String(c.max_assignees)
+				: base.max_assignees,
+		mirror_pr_events:
+			typeof c.mirror_pr_events === 'boolean'
+				? c.mirror_pr_events
+				: base.mirror_pr_events,
+		active: typeof c.active === 'boolean' ? c.active : base.active,
+	};
+}
+
+export function botConfigFromFormDraft(f: BotConfigFormDraft): DiscordshConfig {
+	const cfg: DiscordshConfig = {
+		mirror_pr_events: f.mirror_pr_events,
+		active: f.active,
+	};
+	if (f.default_repo.trim()) cfg.default_repo = f.default_repo.trim();
+	if (f.claim_channel_id.trim())
+		cfg.claim_channel_id = f.claim_channel_id.trim();
+	if (f.forum_channel_id.trim())
+		cfg.forum_channel_id = f.forum_channel_id.trim();
+	if (f.noticeboard_channel_id.trim())
+		cfg.noticeboard_channel_id = f.noticeboard_channel_id.trim();
+	if (f.taskboard_channel_id.trim())
+		cfg.taskboard_channel_id = f.taskboard_channel_id.trim();
+	const max = parseInt(f.max_assignees, 10);
+	if (!Number.isNaN(max) && max > 0) cfg.max_assignees = max;
+	return cfg;
+}
+
 export interface AgentTokenRow {
 	token_id: string;
 	token_name: string;
@@ -209,6 +274,20 @@ class AgentsService {
 	public readonly $tokens = atom<AgentTokenRow[]>([]);
 	public readonly $tokensLoading = atom<boolean>(false);
 	public readonly $tokensError = atom<string | null>(null);
+
+	public readonly $botConfigDrafts = atom<Record<string, BotConfigFormDraft>>(
+		{},
+	);
+	public readonly $botConfigSavingFor = atom<Record<string, boolean>>({});
+	public readonly $botConfigErrors = atom<Record<string, string | null>>({});
+	public readonly $botConfigLoadedFor = atom<Record<string, boolean>>({});
+
+	public readonly $repoAllowlistDrafts = atom<Record<string, string[]>>({});
+	public readonly $repoAllowlistSavingFor = atom<Record<string, boolean>>({});
+	public readonly $repoAllowlistErrors = atom<Record<string, string | null>>(
+		{},
+	);
+	public readonly $repoAllowlistLoadedFor = atom<Record<string, boolean>>({});
 
 	// Dedup state — singleton so the cache survives ClientRouter swaps.
 	private initPromise: Promise<void> | null = null;
@@ -734,6 +813,159 @@ class AgentsService {
 		});
 		if (!r.ok) return { ok: false, error: r.error };
 		return { ok: true };
+	}
+
+	public hydrateBotConfigDraft(guildId: string, cfg: DiscordshConfig): void {
+		const drafts = this.$botConfigDrafts.get();
+		this.$botConfigDrafts.set({
+			...drafts,
+			[guildId]: botConfigToFormDraft(cfg),
+		});
+		const loaded = this.$botConfigLoadedFor.get();
+		this.$botConfigLoadedFor.set({ ...loaded, [guildId]: true });
+	}
+
+	public patchBotConfigDraft(
+		guildId: string,
+		patch: Partial<BotConfigFormDraft>,
+	): void {
+		const drafts = this.$botConfigDrafts.get();
+		const cur = drafts[guildId] ?? emptyBotConfigFormDraft();
+		this.$botConfigDrafts.set({
+			...drafts,
+			[guildId]: { ...cur, ...patch },
+		});
+	}
+
+	public clearBotConfigDraft(guildId: string): void {
+		const drafts = { ...this.$botConfigDrafts.get() };
+		delete drafts[guildId];
+		this.$botConfigDrafts.set(drafts);
+		const loaded = { ...this.$botConfigLoadedFor.get() };
+		delete loaded[guildId];
+		this.$botConfigLoadedFor.set(loaded);
+	}
+
+	public async ensureBotConfigLoaded(
+		guildId: string,
+		force = false,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		if (!force && this.$botConfigLoadedFor.get()[guildId]) {
+			return { ok: true };
+		}
+		const r = await this.getBotConfig();
+		if (!r.ok) {
+			const errs = { ...this.$botConfigErrors.get() };
+			errs[guildId] = r.error;
+			this.$botConfigErrors.set(errs);
+			return r;
+		}
+		this.hydrateBotConfigDraft(guildId, r.config);
+		const errs = { ...this.$botConfigErrors.get() };
+		errs[guildId] = null;
+		this.$botConfigErrors.set(errs);
+		return { ok: true };
+	}
+
+	public async saveBotConfigDraft(
+		guildId: string,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const drafts = this.$botConfigDrafts.get();
+		const draft = drafts[guildId];
+		if (!draft) {
+			return { ok: false, error: 'No draft loaded yet' };
+		}
+		const saving = { ...this.$botConfigSavingFor.get(), [guildId]: true };
+		this.$botConfigSavingFor.set(saving);
+		const errs = { ...this.$botConfigErrors.get(), [guildId]: null };
+		this.$botConfigErrors.set(errs);
+		const r = await this.setBotConfig(botConfigFromFormDraft(draft));
+		const savingDone = { ...this.$botConfigSavingFor.get() };
+		delete savingDone[guildId];
+		this.$botConfigSavingFor.set(savingDone);
+		if (!r.ok) {
+			const errs2 = {
+				...this.$botConfigErrors.get(),
+				[guildId]: r.error,
+			};
+			this.$botConfigErrors.set(errs2);
+		}
+		return r;
+	}
+
+	public hydrateRepoAllowlistDraft(guildId: string, repos: string[]): void {
+		const drafts = this.$repoAllowlistDrafts.get();
+		this.$repoAllowlistDrafts.set({ ...drafts, [guildId]: repos });
+		const loaded = this.$repoAllowlistLoadedFor.get();
+		this.$repoAllowlistLoadedFor.set({ ...loaded, [guildId]: true });
+	}
+
+	public patchRepoAllowlistDraft(guildId: string, repos: string[]): void {
+		const drafts = this.$repoAllowlistDrafts.get();
+		this.$repoAllowlistDrafts.set({ ...drafts, [guildId]: repos });
+	}
+
+	public clearRepoAllowlistDraft(guildId: string): void {
+		const drafts = { ...this.$repoAllowlistDrafts.get() };
+		delete drafts[guildId];
+		this.$repoAllowlistDrafts.set(drafts);
+		const loaded = { ...this.$repoAllowlistLoadedFor.get() };
+		delete loaded[guildId];
+		this.$repoAllowlistLoadedFor.set(loaded);
+	}
+
+	public async ensureRepoAllowlistLoaded(
+		guildId: string,
+		force = false,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		if (!force && this.$repoAllowlistLoadedFor.get()[guildId]) {
+			return { ok: true };
+		}
+		const r = await this.getRepoAllowlist();
+		if (!r.ok) {
+			const errs = {
+				...this.$repoAllowlistErrors.get(),
+				[guildId]: r.error,
+			};
+			this.$repoAllowlistErrors.set(errs);
+			return r;
+		}
+		this.hydrateRepoAllowlistDraft(guildId, r.repos);
+		const errs = { ...this.$repoAllowlistErrors.get(), [guildId]: null };
+		this.$repoAllowlistErrors.set(errs);
+		return { ok: true };
+	}
+
+	public async saveRepoAllowlistDraft(
+		guildId: string,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const drafts = this.$repoAllowlistDrafts.get();
+		const repos = drafts[guildId];
+		if (!repos) {
+			return { ok: false, error: 'No draft loaded yet' };
+		}
+		const saving = {
+			...this.$repoAllowlistSavingFor.get(),
+			[guildId]: true,
+		};
+		this.$repoAllowlistSavingFor.set(saving);
+		const errs = {
+			...this.$repoAllowlistErrors.get(),
+			[guildId]: null,
+		};
+		this.$repoAllowlistErrors.set(errs);
+		const r = await this.setRepoAllowlist(repos);
+		const savingDone = { ...this.$repoAllowlistSavingFor.get() };
+		delete savingDone[guildId];
+		this.$repoAllowlistSavingFor.set(savingDone);
+		if (!r.ok) {
+			const errs2 = {
+				...this.$repoAllowlistErrors.get(),
+				[guildId]: r.error,
+			};
+			this.$repoAllowlistErrors.set(errs2);
+		}
+		return r;
 	}
 
 	public async toggleToken(


### PR DESCRIPTION
## What user reported

> Both `/dashboard/agents/discordsh/` and `/dashboard/agents/github/` have elements that break randomly, like the "Save Config" button sometimes just does not work. It does not make sense why they break either.

## Root cause — 3 systemic bugs

`<ClientRouter />` is site-wide. React 19.2 islands with `client:only="react"` **re-mount on every nav swap**. Every component that stored form state, saving flags, or error messages in `useState` was vulnerable:

1. **Form drafts lived in useState.** ClientRouter swap → re-mount → `useState` resets → typed edits vanish. The mount also re-runs `load()` which writes the server's last-saved value back into the form. Looks like "save did nothing".
2. **Saving flag (`setSaving(true)`) lived in component state.** Mid-save, swap re-mounts → new component renders with `saving=false` → button is clickable again → user clicks "Save" thinking nothing happened. Original save is still in-flight; two saves race.
3. **`setSaving(false)` / `setError(...)` fire after the await.** If the component unmounted during the await (swap during save), React 19 drops the state silently. User sees no success indicator.

## Fix — belt-and-suspenders persistence

Five layers per field. Any one failing, the next catches.

| Layer | What | Survives |
|---|---|---|
| 1 | `<input>` DOM value | intra-page interaction |
| 2 | `transition:persist` on the island | Astro `<ClientRouter />` swap (DOM + React tree preserved) |
| 3 | `useRef` inside the React tree | re-render churn |
| 4 | nanostore draft atom (on blur / submit) | re-mount, cross-component reads, cross-tab if we add storage events |
| 5 | server vault row | reload, other devices |

### Tier 0 — Singleton draft state (`72e519bdb`)

Promoted draft + saving + error state to nanostore atoms keyed by guildId. Module-scoped → survives every re-mount.

| Atom | Type | Owns |
|---|---|---|
| `$botConfigDrafts` | `Record<guildId, BotConfigFormDraft>` | per-guild form state |
| `$botConfigSavingFor` | `Record<guildId, boolean>` | in-flight save flag |
| `$botConfigErrors` | `Record<guildId, string\|null>` | last save error |
| `$botConfigLoadedFor` | `Record<guildId, boolean>` | hydrated yet? |
| `$repoAllowlistDrafts` | `Record<guildId, string[]>` | per-guild allowlist |
| `$repoAllowlistSavingFor` | `Record<guildId, boolean>` | |
| `$repoAllowlistErrors` | `Record<guildId, string\|null>` | |
| `$repoAllowlistLoadedFor` | `Record<guildId, boolean>` | |

New service methods: `hydrateBotConfigDraft`, `patchBotConfigDraft`, `ensureBotConfigLoaded`, `saveBotConfigDraft`, plus the four repo-allowlist counterparts. New `BotConfigFormDraft` interface stores raw string fields separate from the parsed `DiscordshConfig` — avoids the "type \"1\", delete back to empty, snap to default" UX bug.

### Tier 1 — Uncontrolled inputs + useRef + transition:persist (`9f04b9bec`)

User asked: *"at what point does it need to use react? ... we could easily utilize useRef for the html dom right"*. Right — the form inputs do not need React per-keystroke.

**`ReactAgentBotConfig.tsx`**
- Replaced controlled `value=`/`onChange=` with uncontrolled `defaultValue=` + per-field `useRef`.
- Single `<form onSubmit={...}>` wraps the fields; the imperative "Save config" button became a `type="submit"`.
- Per-field `onBlur` runs `validateField` + writes the current value into the singleton draft via `patchBotConfigDraft`. Errors update only on blur or submit attempt — not on keystroke.
- Boolean toggles (`mirror_pr_events` / `active`) use `defaultChecked` + uncontrolled handlers stored in `mirrorRef`/`activeRef`.
- `hydrate(force)` snapshots the singleton draft into refs as defaultValues. If `loaded[guildId]` is already true, uses the cached snapshot without an extra network round-trip.
- Subscribes only to `savingMap`, `errorsMap`, `loadedMap` — **does not re-render on every keystroke**.

**`ReactAgentRepoAllowlist.tsx`**
- Add-repo input is uncontrolled (`defaultValue=""` + `useRef`).
- `onInput` updates `draftValid` + `draftRaw` scalars so the Add button enable-state and inline hint re-render without forcing the input to re-render.
- List still reads from singleton `$repoAllowlistDrafts` via `useStore` so changes from elsewhere (e.g. P6 webhook auto-install) flow through.
- Add/remove handlers snapshot the prior list, patch optimistically, save, revert on failure.

**Astro wrappers**
- `AstroAgentDiscordsh.astro`: `<ReactAgentBotConfig transition:persist="agents-bot-config" />`
- `AstroAgentGithubWizard.astro`: `<ReactAgentRepoAllowlist transition:persist="agents-repo-allowlist" />`

### Tier 2 — GithubWizard step-state singletons (`b5809160c`)

User: *"take advantage of the fact that we are already here right"*. Extends the same pattern to the four-step provider wizard so every form-bearing island under `/dashboard/agents/` has the same resilience.

**New per-guildId atoms in `agentsService`**
- `$webhookDrafts` — generated HMAC secret, pre-save (Step 1)
- `$webhookSavingFor`, `$webhookErrors`
- `$patDrafts` — typed PAT, pre-save (Step 3)
- `$patValidatedFor` — `{ login, scopes, tokenType } | null`
- `$patValidatingFor`, `$patSavingFor`, `$patErrors`
- `$backfillDrafts` — `{ owner, repo }` (Step 4)
- `$backfillBusyFor`, `$backfillResults`

**New service methods**
- `setWebhookDraft` / `clearWebhookError` / `saveWebhookDraft`
- `setPatDraft` / `clearPatState` / `validatePatForGuild` / `savePatForGuild`
- `patchBackfillDraft` / `clearBackfillResult` / `runBackfillForGuild`

**ReactAgentGithubWizard step refactor**
- **Step1Webhook**: secret + saving + error read from singleton. Generate writes draft; Save invokes `saveWebhookDraft` (clears the draft on success). `reveal`/`copied` stay local (transient UI only).
- **Step3Pat**: PAT input uncontrolled (`defaultValue` + `useRef` + `onBlur` → `setPatDraft`). Validate + Save read the ref directly so the most recent typed value always wins regardless of whether blur fired. Validation + saving + error live in singletons keyed by guildId. The validated `{ login, scopes, tokenType }` panel survives swaps.
- **Step4SmokeBackfill**: `owner` / `repo` inputs uncontrolled (refs + `onBlur` → `patchBackfillDraft`). Busy + result live in singletons — a swap mid-backfill returns to the same step with the spinner still visible and the eventual result still displayed once it resolves.

**Astro wrapper**
- `AstroAgentGithubWizard.astro`: `<ReactAgentGithubWizard transition:persist="agents-github-wizard" />` so the entire wizard tree survives nav swaps too.

## What this does NOT touch

- **`ReactAgentBotInstall`, `ReactAgentSetupStatus`, `ReactAgentDiscordsh`** — read-side islands; the post-#11779 dedup + cache work in agentsService already covers their re-mount cost.

## Test plan

- [x] `npx tsc --noEmit -p apps/kbve/astro-kbve/tsconfig.json` — no new errors in dashboard files
- [ ] Manual: open `/dashboard/agents/discordsh/`, edit `forum_channel_id`, swap to `/dashboard/agents/github/` and back. Edits should persist (Layer 1 + 2 hold it pre-blur; Layer 4 holds it post-blur).
- [ ] Click Save, immediately swap to `/github/`, swap back. Save spinner should still be visible until completion; success/error reflects the actual result.
- [ ] Repo allowlist: type "owner/repo", click Add. Swap mid-add. New row should appear when save completes regardless of which page you're on.
- [ ] GitHub wizard Step 1: generate HMAC, swap pages, swap back. Secret still revealed in the input.
- [ ] GitHub wizard Step 3: paste PAT, click Validate, swap pages while the validate is in-flight. Validating spinner should still be visible on return; validated panel should appear once the call resolves.
- [ ] GitHub wizard Step 4: type owner+repo, click Run, swap pages mid-backfill. Result block should appear on return.

Related to #11779 (initAuth dedup), #11796 (sqlstate surface), #11802 (P6 onboarding).