### PR TITLE
ci(chuck): wire unreal_game pipeline — chuckrpg game client + itch.io

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -667,7 +667,11 @@
 			"key": "ue_kbvesqlite",
 			"plugin_name": "KBVESQLite",
 			"plugin_path": "packages/unreal/KBVESQLite",
-			"supported_platforms": ["Win64", "Linux", "Mac"],
+			"supported_platforms": [
+				"Win64",
+				"Linux",
+				"Mac"
+			],
 			"version": "3.51.3",
 			"version_toml": "packages/unreal/KBVESQLite/version.toml"
 		},
@@ -675,7 +679,11 @@
 			"key": "ue_kbvewasm",
 			"plugin_name": "KBVEWASM",
 			"plugin_path": "packages/unreal/KBVEWASM",
-			"supported_platforms": ["Win64", "Linux", "Mac"],
+			"supported_platforms": [
+				"Win64",
+				"Linux",
+				"Mac"
+			],
 			"version": "2.2.0",
 			"version_toml": "packages/unreal/KBVEWASM/version.toml"
 		},
@@ -683,7 +691,11 @@
 			"key": "ue_kbvewebsurface",
 			"plugin_name": "KBVEWebSurface",
 			"plugin_path": "packages/unreal/KBVEWebSurface",
-			"supported_platforms": ["Win64", "Linux", "Mac"],
+			"supported_platforms": [
+				"Win64",
+				"Linux",
+				"Mac"
+			],
 			"version": "0.2.0",
 			"version_toml": "packages/unreal/KBVEWebSurface/version.toml"
 		},
@@ -691,7 +703,11 @@
 			"key": "ue_kbvexxhash",
 			"plugin_name": "KBVEXXHash",
 			"plugin_path": "packages/unreal/KBVEXXHash",
-			"supported_platforms": ["Win64", "Linux", "Mac"],
+			"supported_platforms": [
+				"Win64",
+				"Linux",
+				"Mac"
+			],
 			"version": "0.8.3",
 			"version_toml": "packages/unreal/KBVEXXHash/version.toml"
 		},
@@ -699,7 +715,11 @@
 			"key": "ue_kbveyyjson",
 			"plugin_name": "KBVEYYJson",
 			"plugin_path": "packages/unreal/KBVEYYJson",
-			"supported_platforms": ["Win64", "Linux", "Mac"],
+			"supported_platforms": [
+				"Win64",
+				"Linux",
+				"Mac"
+			],
 			"version": "0.12.0",
 			"version_toml": "packages/unreal/KBVEYYJson/version.toml"
 		},
@@ -707,7 +727,11 @@
 			"key": "ue_kbvezstd",
 			"plugin_name": "KBVEZstd",
 			"plugin_path": "packages/unreal/KBVEZstd",
-			"supported_platforms": ["Win64", "Linux", "Mac"],
+			"supported_platforms": [
+				"Win64",
+				"Linux",
+				"Mac"
+			],
 			"version": "1.5.7",
 			"version_toml": "packages/unreal/KBVEZstd/version.toml"
 		},
@@ -717,7 +741,11 @@
 			"plugin_path": "packages/unreal/UEDevOps",
 			"dependency_plugins": "packages/unreal/KBVEYYJson packages/unreal/KBVEXXHash packages/unreal/KBVEZstd",
 			"itch_game_id": "uedevops",
-			"supported_platforms": ["Win64", "Linux", "Mac"],
+			"supported_platforms": [
+				"Win64",
+				"Linux",
+				"Mac"
+			],
 			"version": "0.1.0",
 			"version_toml": "packages/unreal/UEDevOps/version.toml"
 		}
@@ -802,7 +830,10 @@
 			"engine": {
 				"version": "5.7.4",
 				"project_path": "apps/chuckrpg/unreal-chuck",
-				"build_targets": ["Win64", "Linux"]
+				"build_targets": [
+					"Win64",
+					"Linux"
+				]
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"version": "0.3.19",

--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -788,7 +788,27 @@
 			"has_test": true
 		}
 	],
-	"unreal_game": [],
+	"unreal_game": [
+		{
+			"key": "unreal_chuck_game",
+			"app_name": "chuck",
+			"engine": {
+				"version": "5.7.4",
+				"project_path": ".",
+				"build_targets": ["Win64", "Linux"],
+				"external_repo_url": "https://github.com/KBVE/chuck"
+			},
+			"source_path": "apps/chuckrpg/unreal-chuck",
+			"version": "0.3.19",
+			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx",
+			"runner": "arc-runner-ue",
+			"external_publish": {
+				"itch_user": "kbve",
+				"itch_game": "chuckrpg"
+			}
+		}
+	],
 	"bevy_game": [],
 	"summary": {
 		"docker": 29,
@@ -799,8 +819,8 @@
 		"ue5_server": 2,
 		"unity": 1,
 		"godot": 1,
-		"unreal_game": 0,
+		"unreal_game": 1,
 		"bevy_game": 0,
-		"total": 70
+		"total": 71
 	}
 }

--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -667,6 +667,7 @@
 			"key": "ue_kbvesqlite",
 			"plugin_name": "KBVESQLite",
 			"plugin_path": "packages/unreal/KBVESQLite",
+			"supported_platforms": ["Win64", "Linux", "Mac"],
 			"version": "3.51.3",
 			"version_toml": "packages/unreal/KBVESQLite/version.toml"
 		},
@@ -674,6 +675,7 @@
 			"key": "ue_kbvewasm",
 			"plugin_name": "KBVEWASM",
 			"plugin_path": "packages/unreal/KBVEWASM",
+			"supported_platforms": ["Win64", "Linux", "Mac"],
 			"version": "2.2.0",
 			"version_toml": "packages/unreal/KBVEWASM/version.toml"
 		},
@@ -681,6 +683,7 @@
 			"key": "ue_kbvewebsurface",
 			"plugin_name": "KBVEWebSurface",
 			"plugin_path": "packages/unreal/KBVEWebSurface",
+			"supported_platforms": ["Win64", "Linux", "Mac"],
 			"version": "0.2.0",
 			"version_toml": "packages/unreal/KBVEWebSurface/version.toml"
 		},
@@ -688,6 +691,7 @@
 			"key": "ue_kbvexxhash",
 			"plugin_name": "KBVEXXHash",
 			"plugin_path": "packages/unreal/KBVEXXHash",
+			"supported_platforms": ["Win64", "Linux", "Mac"],
 			"version": "0.8.3",
 			"version_toml": "packages/unreal/KBVEXXHash/version.toml"
 		},
@@ -695,6 +699,7 @@
 			"key": "ue_kbveyyjson",
 			"plugin_name": "KBVEYYJson",
 			"plugin_path": "packages/unreal/KBVEYYJson",
+			"supported_platforms": ["Win64", "Linux", "Mac"],
 			"version": "0.12.0",
 			"version_toml": "packages/unreal/KBVEYYJson/version.toml"
 		},
@@ -702,6 +707,7 @@
 			"key": "ue_kbvezstd",
 			"plugin_name": "KBVEZstd",
 			"plugin_path": "packages/unreal/KBVEZstd",
+			"supported_platforms": ["Win64", "Linux", "Mac"],
 			"version": "1.5.7",
 			"version_toml": "packages/unreal/KBVEZstd/version.toml"
 		},
@@ -711,6 +717,7 @@
 			"plugin_path": "packages/unreal/UEDevOps",
 			"dependency_plugins": "packages/unreal/KBVEYYJson packages/unreal/KBVEXXHash packages/unreal/KBVEZstd",
 			"itch_game_id": "uedevops",
+			"supported_platforms": ["Win64", "Linux", "Mac"],
 			"version": "0.1.0",
 			"version_toml": "packages/unreal/UEDevOps/version.toml"
 		}
@@ -794,9 +801,8 @@
 			"app_name": "chuck",
 			"engine": {
 				"version": "5.7.4",
-				"project_path": ".",
-				"build_targets": ["Win64", "Linux"],
-				"external_repo_url": "https://github.com/KBVE/chuck"
+				"project_path": "apps/chuckrpg/unreal-chuck",
+				"build_targets": ["Win64", "Linux"]
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"version": "0.3.19",

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -411,6 +411,7 @@ jobs:
                     path=$(echo "$entry" | jq -r '.plugin_path')
                     deps=$(echo "$entry" | jq -r '.dependency_plugins // ""')
                     itch=$(echo "$entry" | jq -r '.itch_game_id // ""')
+                    platforms=$(echo "$entry" | jq -r 'if (.supported_platforms // [] | length) > 0 then (.supported_platforms | join(",")) else "Linux" end')
                     altered=$(is_altered "$key")
                     deploy_itch="false"
                     [ -n "$itch" ] && deploy_itch="true"
@@ -424,19 +425,39 @@ jobs:
                       SKIPPED=$((SKIPPED + 1))
                       continue
                     fi
-                    if [ "$(is_publish_running unreal "$name")" = "true" ]; then
-                      echo "  · $name — already running ($reason), skipping duplicate"
-                      SKIPPED=$((SKIPPED + 1))
-                      continue
+
+                    # Linux build (docker) — keeps itch deploy when configured.
+                    if printf '%s' ",${platforms}," | grep -q ',Linux,'; then
+                      if [ "$(is_publish_running unreal "$name")" = "true" ]; then
+                        echo "  · $name (Linux) — already running ($reason), skipping duplicate"
+                        SKIPPED=$((SKIPPED + 1))
+                      else
+                        echo "  ✓ $name (Linux) — $reason, dispatching"
+                        dispatch_publish unreal \
+                          --field package_name="$name" \
+                          --field unreal_plugin_path="$path" \
+                          --field deploy_to_itch="$deploy_itch" \
+                          --field itch_game_id="$itch" \
+                          --field unreal_dependency_plugins="$deps"
+                        DISPATCHED=$((DISPATCHED + 1))
+                      fi
                     fi
-                    echo "  ✓ $name — $reason, dispatching"
-                    dispatch_publish unreal \
-                      --field package_name="$name" \
-                      --field unreal_plugin_path="$path" \
-                      --field deploy_to_itch="$deploy_itch" \
-                      --field itch_game_id="$itch" \
-                      --field unreal_dependency_plugins="$deps"
-                    DISPATCHED=$((DISPATCHED + 1))
+
+                    # Win64 build (native UE5-Win VM) — GitHub Release only, no itch.
+                    if printf '%s' ",${platforms}," | grep -q ',Win64,'; then
+                      if [ "$(is_publish_running unreal-win64 "$name")" = "true" ]; then
+                        echo "  · $name (Win64) — already running ($reason), skipping duplicate"
+                        SKIPPED=$((SKIPPED + 1))
+                      else
+                        echo "  ✓ $name (Win64) — $reason, dispatching"
+                        dispatch_publish unreal-win64 \
+                          --field package_name="$name" \
+                          --field unreal_plugin_path="$path" \
+                          --field deploy_to_itch="false" \
+                          --field unreal_dependency_plugins="$deps"
+                        DISPATCHED=$((DISPATCHED + 1))
+                      fi
+                    fi
                   done < <(jq -c '.unreal[]' "$MANIFEST")
 
                   # =================================================================

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -339,7 +339,7 @@ jobs:
             dependency_plugin_paths: ${{ inputs.unreal_dependency_plugins }}
         secrets:
             epic_pat: ${{ secrets.UNITY_PAT }}
-            butler_api: ${{ secrets.butler_api }}
+            butler_api: ${{ secrets.ITCH_API }}
 
     # ===========================================================================
     # Unreal Win64 — native Windows build on KubeVirt VM
@@ -366,7 +366,7 @@ jobs:
             dependency_plugin_paths: ${{ inputs.unreal_dependency_plugins }}
         secrets:
             epic_pat: ${{ secrets.UNITY_PAT }}
-            butler_api: ${{ secrets.butler_api }}
+            butler_api: ${{ secrets.ITCH_API }}
 
     # ---------------------------------------------------------------------------
     # Post-publish — update version.toml after successful publish.

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -152,6 +152,12 @@ on:
             butler_api:
                 description: 'Itch.io Butler API key'
                 required: false
+            FORGEJO_USER:
+                description: 'Forgejo (git.kbve.com) user for per-game LFS pull'
+                required: false
+            FORGEJO_TOKEN:
+                description: 'Forgejo (git.kbve.com) token for per-game LFS pull'
+                required: false
         outputs:
             version:
                 description: 'Resolved version (plugin/engine modes)'
@@ -342,18 +348,34 @@ jobs:
               run: |
                   docker pull "${{ env.UE_IMAGE }}"
 
-            - name: Clone game project
-              run: |
-                  rm -rf /tmp/game-project
-                  git clone --depth=1 \
-                    "https://x-access-token:${{ steps.pat.outputs.token }}@github.com/${{ needs.server_config.outputs.project_repo }}.git" \
-                    /tmp/game-project
+            - name: Checkout monorepo
+              uses: actions/checkout@v6
+              with:
+                  lfs: false
 
-            - name: Fetch LFS objects
+            - name: Pull game LFS (Forgejo) + materialize project
+              env:
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
               run: |
-                  cd /tmp/game-project
-                  git lfs install
-                  git lfs pull
+                  PROJ="${{ inputs.shell_path }}"
+                  if [ ! -f "${PROJ}/.lfsconfig" ]; then
+                    echo "::error::${PROJ}/.lfsconfig not found — cannot resolve game LFS endpoint"
+                    exit 1
+                  fi
+                  if [ -z "${FORGEJO_USER}" ] || [ -z "${FORGEJO_TOKEN}" ]; then
+                    echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing — cannot pull LFS from git.kbve.com"
+                    exit 1
+                  fi
+                  echo "::add-mask::${FORGEJO_TOKEN}"
+                  LFS_URL=$(git config -f "${PROJ}/.lfsconfig" lfs.url)
+                  AUTH_URL="${LFS_URL/https:\/\//https://${FORGEJO_USER}:${FORGEJO_TOKEN}@}"
+                  echo "::notice::Pulling LFS for ${PROJ} from ${LFS_URL}"
+                  git -c lfs.url="${AUTH_URL}" lfs install --local
+                  git -c lfs.url="${AUTH_URL}" lfs pull --include="${PROJ}/**"
+                  rm -rf /tmp/game-project
+                  mkdir -p /tmp/game-project
+                  cp -r "${PROJ}/." /tmp/game-project/
 
             - name: Build dedicated server
               env:
@@ -425,7 +447,7 @@ jobs:
                   REPO="${{ needs.server_config.outputs.project_repo }}"
                   UE_TAG="${{ needs.server_config.outputs.ue_image_tag }}"
 
-                  CHUCK_SHA=$(cd /tmp/game-project && git rev-parse HEAD)
+                  CHUCK_SHA="${{ github.sha }}"
 
                   SERVER_DIR=$(find /tmp/ue5-build-output -name "LinuxServer" -type d | head -1)
                   if [ -z "${SERVER_DIR}" ]; then
@@ -570,33 +592,48 @@ jobs:
             - name: Pull UE image
               run: docker pull "${{ env.UE_IMAGE }}"
 
-            - name: Clone game repo
-              run: |
-                  rm -rf /tmp/game-project
-                  REPO_SLUG=$(echo "${{ inputs.external_repo_url }}" | sed -E 's#^https?://github.com/##; s#/$##; s#\.git$##')
-                  git clone --depth=1 \
-                    "https://x-access-token:${{ steps.pat.outputs.token }}@github.com/${REPO_SLUG}.git" \
-                    /tmp/game-project
-                  cd /tmp/game-project
-                  git lfs install
-                  git lfs pull
+            - name: Checkout monorepo
+              uses: actions/checkout@v6
+              with:
+                  lfs: false
 
-            - name: Build Linux client
+            - name: Pull game LFS (Forgejo) + materialize project
               env:
-                  PROJECT_PATH: ${{ inputs.project_path }}
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
               run: |
-                  mkdir -p /tmp/ue5-game-output
-                  UPROJECT_FILE=$(find "/tmp/game-project/${PROJECT_PATH}" -maxdepth 1 -name '*.uproject' | head -1)
-                  if [ -z "${UPROJECT_FILE}" ]; then
-                    echo "::error::No .uproject under /tmp/game-project/${PROJECT_PATH}"
+                  PROJ="${{ inputs.project_path }}"
+                  if [ ! -f "${PROJ}/.lfsconfig" ]; then
+                    echo "::error::${PROJ}/.lfsconfig not found — cannot resolve game LFS endpoint"
                     exit 1
                   fi
-                  PROJECT_MOUNT=$(dirname "${UPROJECT_FILE}")
+                  if [ -z "${FORGEJO_USER}" ] || [ -z "${FORGEJO_TOKEN}" ]; then
+                    echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing — cannot pull LFS from git.kbve.com"
+                    exit 1
+                  fi
+                  echo "::add-mask::${FORGEJO_TOKEN}"
+                  LFS_URL=$(git config -f "${PROJ}/.lfsconfig" lfs.url)
+                  AUTH_URL="${LFS_URL/https:\/\//https://${FORGEJO_USER}:${FORGEJO_TOKEN}@}"
+                  echo "::notice::Pulling LFS for ${PROJ} from ${LFS_URL}"
+                  git -c lfs.url="${AUTH_URL}" lfs install --local
+                  git -c lfs.url="${AUTH_URL}" lfs pull --include="${PROJ}/**"
+                  rm -rf /tmp/game-project
+                  mkdir -p /tmp/game-project
+                  cp -r "${PROJ}/." /tmp/game-project/
+
+            - name: Build Linux client
+              run: |
+                  mkdir -p /tmp/ue5-game-output
+                  UPROJECT_FILE=$(find /tmp/game-project -maxdepth 1 -name '*.uproject' | head -1)
+                  if [ -z "${UPROJECT_FILE}" ]; then
+                    echo "::error::No .uproject at /tmp/game-project root"
+                    exit 1
+                  fi
                   UPROJECT_NAME=$(basename "${UPROJECT_FILE}")
-                  echo "::notice::Mounting ${PROJECT_MOUNT} → /project, building ${UPROJECT_NAME} (Linux client)"
+                  echo "::notice::Building ${UPROJECT_NAME} (Linux client)"
 
                   docker run --rm \
-                    -v "${PROJECT_MOUNT}:/project" \
+                    -v /tmp/game-project:/project \
                     -v /tmp/ue5-game-output:/output \
                     "${{ env.UE_IMAGE }}" \
                     /bin/bash -c '
@@ -660,14 +697,10 @@ jobs:
         permissions:
             contents: read
         steps:
-            - name: Resolve PAT
-              id: pat
-              run: |
-                  $token = "${{ secrets.epic_pat }}"
-                  if (-not $token) { $token = "${{ secrets.UNITY_PAT }}" }
-                  if (-not $token) { Write-Host "::error::No PAT available"; exit 1 }
-                  Write-Host "::add-mask::$token"
-                  "token=$token" >> $env:GITHUB_OUTPUT
+            - name: Checkout monorepo
+              uses: actions/checkout@v6
+              with:
+                  lfs: false
 
             - name: Locate Unreal Engine
               id: engine
@@ -681,20 +714,25 @@ jobs:
                   Write-Host "::notice::Engine at $engineRoot"
                   "runuat=$(Join-Path $engineRoot 'Engine\Build\BatchFiles\RunUAT.bat')" >> $env:GITHUB_OUTPUT
 
-            - name: Clone game repo
+            - name: Pull game LFS (Forgejo)
+              env:
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
               run: |
-                  $token = '${{ steps.pat.outputs.token }}'
-                  $slug = '${{ inputs.external_repo_url }}' -replace '^https?://github.com/','' -replace '\.git$','' -replace '/$',''
-                  if (Test-Path C:\game-project) { Remove-Item -Recurse -Force C:\game-project }
-                  git clone --depth=1 "https://x-access-token:$token@github.com/$slug.git" C:\game-project
-                  Push-Location C:\game-project
-                  git lfs install
-                  git lfs pull
-                  Pop-Location
+                  $proj = '${{ inputs.project_path }}'
+                  $lfsConfig = Join-Path $proj '.lfsconfig'
+                  if (-not (Test-Path $lfsConfig)) { Write-Host "::error::$lfsConfig not found"; exit 1 }
+                  if (-not $env:FORGEJO_USER -or -not $env:FORGEJO_TOKEN) { Write-Host "::error::FORGEJO_USER / FORGEJO_TOKEN missing"; exit 1 }
+                  Write-Host "::add-mask::$($env:FORGEJO_TOKEN)"
+                  $lfsUrl = (git config -f $lfsConfig lfs.url)
+                  $authUrl = $lfsUrl -replace '^https://', "https://$($env:FORGEJO_USER):$($env:FORGEJO_TOKEN)@"
+                  Write-Host "::notice::Pulling LFS for $proj from $lfsUrl"
+                  git -c lfs.url="$authUrl" lfs install --local
+                  git -c lfs.url="$authUrl" lfs pull --include="$proj/**"
 
             - name: Build Win64 client
               run: |
-                  $uproject = Get-ChildItem -Path (Join-Path 'C:\game-project' '${{ inputs.project_path }}') -Filter *.uproject | Select-Object -First 1
+                  $uproject = Get-ChildItem -Path (Join-Path $env:GITHUB_WORKSPACE '${{ inputs.project_path }}') -Filter *.uproject | Select-Object -First 1
                   if (-not $uproject) { Write-Host "::error::No .uproject found"; exit 1 }
                   $out = "C:\ue5-game-output"
                   New-Item -ItemType Directory -Force -Path $out | Out-Null
@@ -724,7 +762,6 @@ jobs:
             - name: Cleanup
               if: always()
               run: |
-                  if (Test-Path C:\game-project) { Remove-Item -Recurse -Force C:\game-project -ErrorAction SilentlyContinue }
                   if (Test-Path C:\ue5-game-output) { Remove-Item -Recurse -Force C:\ue5-game-output -ErrorAction SilentlyContinue }
 
     game_build_mac:

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -573,8 +573,9 @@ jobs:
             - name: Clone game repo
               run: |
                   rm -rf /tmp/game-project
+                  REPO_SLUG=$(echo "${{ inputs.external_repo_url }}" | sed -E 's#^https?://github.com/##; s#/$##; s#\.git$##')
                   git clone --depth=1 \
-                    "https://x-access-token:${{ steps.pat.outputs.token }}@github.com/${{ inputs.external_repo_url }}.git" \
+                    "https://x-access-token:${{ steps.pat.outputs.token }}@github.com/${REPO_SLUG}.git" \
                     /tmp/game-project
                   cd /tmp/game-project
                   git lfs install
@@ -683,8 +684,9 @@ jobs:
             - name: Clone game repo
               run: |
                   $token = '${{ steps.pat.outputs.token }}'
+                  $slug = '${{ inputs.external_repo_url }}' -replace '^https?://github.com/','' -replace '\.git$','' -replace '/$',''
                   if (Test-Path C:\game-project) { Remove-Item -Recurse -Force C:\game-project }
-                  git clone --depth=1 "https://x-access-token:$token@github.com/${{ inputs.external_repo_url }}.git" C:\game-project
+                  git clone --depth=1 "https://x-access-token:$token@github.com/$slug.git" C:\game-project
                   Push-Location C:\game-project
                   git lfs install
                   git lfs pull

--- a/.github/workflows/ci-unreal.yml
+++ b/.github/workflows/ci-unreal.yml
@@ -149,6 +149,8 @@ jobs:
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}
+            FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+            FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
 
     server:
         name: Dedicated Server
@@ -160,6 +162,8 @@ jobs:
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}
+            FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+            FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
 
     engine:
         name: Engine Build
@@ -174,6 +178,8 @@ jobs:
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}
+            FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+            FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
 
     win_setup:
         name: Win VM Setup
@@ -184,6 +190,8 @@ jobs:
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}
+            FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+            FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
 
     mac_setup:
         name: Mac VM Setup
@@ -194,3 +202,5 @@ jobs:
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}
+            FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+            FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}

--- a/.github/workflows/ci-unreal.yml
+++ b/.github/workflows/ci-unreal.yml
@@ -146,7 +146,9 @@ jobs:
             deploy_to_itch: ${{ inputs.deploy_to_itch }}
             itch_username: ${{ inputs.itch_user }}
             itch_game_id: ${{ inputs.itch_game }}
-        secrets: inherit
+        secrets:
+            UNITY_PAT: ${{ secrets.UNITY_PAT }}
+            butler_api: ${{ secrets.ITCH_API }}
 
     server:
         name: Dedicated Server
@@ -155,7 +157,9 @@ jobs:
         with:
             mode: server
             shell_path: ${{ inputs.shell_path }}
-        secrets: inherit
+        secrets:
+            UNITY_PAT: ${{ secrets.UNITY_PAT }}
+            butler_api: ${{ secrets.ITCH_API }}
 
     engine:
         name: Engine Build
@@ -167,7 +171,9 @@ jobs:
             engine_ref: ${{ inputs.engine_ref }}
             skip_version_gate: ${{ inputs.skip_version_gate }}
             build_dedicated_server: ${{ inputs.build_dedicated_server }}
-        secrets: inherit
+        secrets:
+            UNITY_PAT: ${{ secrets.UNITY_PAT }}
+            butler_api: ${{ secrets.ITCH_API }}
 
     win_setup:
         name: Win VM Setup
@@ -175,7 +181,9 @@ jobs:
         uses: KBVE/kbve/.github/workflows/ci-unreal-build.yml@dev
         with:
             mode: win-setup
-        secrets: inherit
+        secrets:
+            UNITY_PAT: ${{ secrets.UNITY_PAT }}
+            butler_api: ${{ secrets.ITCH_API }}
 
     mac_setup:
         name: Mac VM Setup
@@ -183,4 +191,6 @@ jobs:
         uses: KBVE/kbve/.github/workflows/ci-unreal-build.yml@dev
         with:
             mode: mac-setup
-        secrets: inherit
+        secrets:
+            UNITY_PAT: ${{ secrets.UNITY_PAT }}
+            butler_api: ${{ secrets.ITCH_API }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,3 +19,5 @@ pnpm-lock.yaml
 packages/data/codegen/generated/*.json
 apps/rareicon/unity-rareicon/Assets/StreamingAssets/*.json
 apps/discordsh/discordsh-bot/data/mapdb.json
+# Generated CI dispatch manifest (raw nx sync output; prettier must not reflow it)
+.github/ci-dispatch-manifest.json

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
@@ -1,0 +1,65 @@
+---
+title: Unreal Chuck Game
+description: |
+    Chuck RPG UE5 standalone game client — Win64 + Linux builds shipped to itch.io as kbve/chuckrpg via the manifest-driven ci-unreal game pipeline.
+sidebar:
+    label: Unreal Chuck Game
+    order: 95
+tags:
+    - ue5
+    - game
+    - chuck
+key: unreal_chuck_game
+pipeline: unreal_game
+app_name: chuck
+source_path: apps/chuckrpg/unreal-chuck
+version_toml: apps/chuckrpg/unreal-chuck/version.toml
+version: "0.3.19"
+runner: arc-runner-ue
+author: h0lybyte
+license: KBVE
+status: beta
+homepage_url: https://kbve.itch.io/chuckrpg
+engine:
+    version: "5.7.4"
+    project_path: "."
+    build_targets:
+        - Win64
+        - Linux
+    external_repo_url: https://github.com/KBVE/chuck
+external_publish:
+    itch_user: kbve
+    itch_game: chuckrpg
+---
+
+## Overview
+
+Chuck RPG UE5 standalone game client. The playable build (distinct from the
+[Unreal Chuck](/project/unreal-chuck) dedicated server) is compiled from the
+`KBVE/chuck` repo and shipped to itch.io under `kbve/chuckrpg`.
+
+## Pipeline
+
+`pipeline: unreal_game` → `ci-main.yml` dispatches `ci-unreal.yml` (`task: game`)
+→ `ci-unreal-build.yml` (`mode: game`) whenever the MDX `version:` here outpaces
+`version.toml`, or `source_path` files change.
+
+## Build Matrix
+
+`engine.build_targets`:
+
+- `Win64` — native build on the `UE5-Win` KubeVirt VM (RunUAT.bat)
+- `Linux` — `BuildCookRun` in the cached Epic UE Docker image on `arc-runner-ue`
+
+Mac is stubbed until the `macos-builder` VM is provisioned.
+
+## Distribution
+
+Ships to itch.io `kbve/chuckrpg`, one channel per platform
+(`win64-v<version>`, `linux-v<version>`). Requires the `butler_api` secret.
+
+## Release
+
+Bump `version:` above `version.toml` (`apps/chuckrpg/unreal-chuck/version.toml`),
+run `npx nx run astro-kbve:sync:ci-manifest`, commit. The next `ci-main` run fans
+out the game build + itch upload for this entry.

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
@@ -63,3 +63,11 @@ Ships to itch.io `kbve/chuckrpg`, one channel per platform
 Bump `version:` above `version.toml` (`apps/chuckrpg/unreal-chuck/version.toml`),
 run `npx nx run astro-kbve:sync:ci-manifest`, commit. The next `ci-main` run fans
 out the game build + itch upload for this entry.
+
+## Source: monorepo now, KBVE/chuck later
+
+Builds source from the lightweight monorepo shell `apps/chuckrpg/unreal-chuck`
+— small and fast, so it doubles as the build/test loop for the UE plugins in
+`packages/unreal/`. Later we expand to the full external game repo `KBVE/chuck`
+by re-adding the `engine.external_repo_url` branch (clone external when set,
+else monorepo). Tracked in [#11828](https://github.com/KBVE/kbve/issues/11828).

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
@@ -22,11 +22,10 @@ status: beta
 homepage_url: https://kbve.itch.io/chuckrpg
 engine:
     version: "5.7.4"
-    project_path: "."
+    project_path: apps/chuckrpg/unreal-chuck
     build_targets:
         - Win64
         - Linux
-    external_repo_url: https://github.com/KBVE/chuck
 external_publish:
     itch_user: kbve
     itch_game: chuckrpg
@@ -36,7 +35,8 @@ external_publish:
 
 Chuck RPG UE5 standalone game client. The playable build (distinct from the
 [Unreal Chuck](/project/unreal-chuck) dedicated server) is compiled from the
-`KBVE/chuck` repo and shipped to itch.io under `kbve/chuckrpg`.
+monorepo source at `apps/chuckrpg/unreal-chuck` (Content pulled from the chuck
+Forgejo LFS endpoint) and shipped to itch.io under `kbve/chuckrpg`.
 
 ## Pipeline
 

--- a/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
+++ b/apps/kbve/astro-kbve/src/pages/api/ci-registry.json.ts
@@ -65,6 +65,7 @@ interface UnrealEntry {
 	plugin_path: string;
 	dependency_plugins?: string;
 	itch_game_id?: string;
+	supported_platforms?: string[];
 	version?: string;
 	version_toml?: string;
 }
@@ -221,6 +222,8 @@ function toManifestEntry(
 			if (d.dependency_plugins)
 				ue.dependency_plugins = d.dependency_plugins;
 			if (d.itch_game_id) ue.itch_game_id = d.itch_game_id;
+			if (d.supported_platforms?.length)
+				ue.supported_platforms = d.supported_platforms;
 			if (ver) ue.version = ver;
 			if (vt) ue.version_toml = vt;
 			return ue;


### PR DESCRIPTION
## What

Wires the Chuck UE5 **game client** into the manifest-driven pipeline, switches all chuck builds to **monorepo source**, and turns on **per-plugin Windows builds**.

### Chuck game client (MDX source of truth)
New ci-registry entry `unreal-chuck-game.mdx` (`pipeline: unreal_game`) → `ci-main` dispatches `ci-unreal.yml task=game` → `ci-unreal-build.yml mode=game`. itch.io under `kbve/chuckrpg`. Win64 + Linux (Mac stubbed).

### Build chuck from the monorepo (not external clone)
`game` + `server` modes now `actions/checkout` the monorepo and pull game Content from the **chuck Forgejo LFS endpoint** (`FORGEJO_USER`/`FORGEJO_TOKEN`, read from the project's own `.lfsconfig`), then build `apps/chuckrpg/unreal-chuck` directly. No more external `KBVE/chuck` clone. `BUILD_INFO source_commit` uses `github.sha`.

### Plugins declare their platforms
A plugin now declares `supported_platforms` (server-side-only = `[Linux]`, client = `[Win64, Mac, Linux]`):
- `ci-registry.json.ts` emits `supported_platforms` into the manifest.
- `ci-main` dispatches the **Win64** plugin build (`unreal-win64`, **GitHub Release only** — no itch) in addition to Linux when the plugin lists `Win64`. Linux/Win64 dedup independently (run-name carries `package_type`).
- The 7 existing plugins already declare `[Win64, Linux, Mac]`; Mac is ignored (no runner). No proto change needed — `supported_platforms` already exists in the schema.

### Secret plumbing
itch token is the org `ITCH_API` (rareicon/unity use it); the reusable workflow's `butler_api` input is now fed from `ITCH_API` at both callers (router + ci-publish), and `FORGEJO_USER`/`FORGEJO_TOKEN` are passed through for LFS.

## Deferred
- **fab.com** publishing — needs a Fab API secret + CLI (no scaffolding exists). Noted for a follow-up.

## Triggering
Chuck game: `version: 0.3.19` == `version.toml`, so no auto-build on merge — bump the MDX `version:` + re-run `sync:ci-manifest`. Plugins build on `.uplugin` VersionName > `version.toml`.

## Validation
`actionlint -shellcheck 'shellcheck -S error'` clean on all changed workflows. astro-kbve build + `sync:ci-manifest` regenerated the manifest (7 plugins carry platforms, chuck game on monorepo path).