### PR TITLE
fix(redis): swap Bitnami image registry to bitnamilegacy mirror

### DIFF
--- a/apps/kube/redis/manifests/values.yaml
+++ b/apps/kube/redis/manifests/values.yaml
@@ -12,6 +12,23 @@ architecture: standalone
 commonAnnotations:
     reloader.stakater.com/auto: 'true'
 
+global:
+    security:
+        allowInsecureImages: true
+
+image:
+    registry: docker.io
+    repository: bitnamilegacy/redis
+
+metrics:
+    enabled: true
+    serviceMonitor:
+        enabled: true
+        namespace: redis
+    image:
+        registry: docker.io
+        repository: bitnamilegacy/redis-exporter
+
 auth:
     enabled: true
     existingSecret: redis-auth
@@ -33,12 +50,6 @@ master:
         limits:
             memory: '512Mi'
             cpu: '500m'
-
-metrics:
-    enabled: true
-    serviceMonitor:
-        enabled: true
-        namespace: redis
 
 # Network policy to allow cluster-wide access
 networkPolicy:


### PR DESCRIPTION
## Summary

\`redis-master-0\` has been \`ImagePullBackOff\` for 140+ min since post-recovery re-pull. Cause: Bitnami deprecated their free image distribution in Aug 2025 and is rolling-deleting tags from \`docker.io/bitnami/*\`. \`bitnami/redis:8.0.3-debian-12-r1\` + \`bitnami/redis-exporter:1.74.0-debian-12-r2\` (pinned by chart 21.2.13) are gone.

Downstream impact: forgejo CrashLoopBackOff (cache.Init failing on Redis dial — \`git.kbve.com\` 521 from CF). Other consumers of the cluster-wide Redis affected too.

## Changes

\`apps/kube/redis/manifests/values.yaml\`:
- \`global.security.allowInsecureImages: true\` (Bitnami chart 21.x opt-in for non-canonical registries)
- \`image.repository: bitnamilegacy/redis\`
- \`metrics.image.repository: bitnamilegacy/redis-exporter\`

Bitnami still mirrors deleted tags at \`docker.io/bitnamilegacy/*\` during the deprecation window — same digests, just different namespace. Verified both tags exist:
- \`docker.io/bitnamilegacy/redis:8.0.3-debian-12-r1\` ✓
- \`docker.io/bitnamilegacy/redis-exporter:1.74.0-debian-12-r2\` ✓

Removed the duplicate \`metrics:\` block that was left over after merging the registry override.

## Test plan

- [ ] After ArgoCD sync: \`redis-master-0\` 2/2 Running.
- [ ] \`kubectl exec -n forgejo deploy/forgejo -- nc -zv redis-master.redis.svc.cluster.local 6379\` succeeds.
- [ ] forgejo pod flips to Running (cache.Init passes).
- [ ] \`https://git.kbve.com\` returns 200 from CF edge.
- [ ] discordsh-bot also recovers (depends on Redis per its pod spec).

## Out of scope (follow-up)

Long-term move off the Bitnami chart — pick upstream Redis chart or redis-operator. The legacy mirror is a deprecation window, not a destination.