### PR TITLE
feat(vnc): single-controller model for shared VNC hub

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -45,15 +45,12 @@ export default function ReactVMVncViewer() {
 	const [keyboardVisible, setKeyboardVisible] = useState(false);
 	const [viewerCount, setViewerCount] = useState(0);
 	const [isPrimary, setIsPrimary] = useState(false);
-	// Stable per-tab id so the control endpoint can target this viewer.
 	const [viewerId] = useState(() =>
 		typeof crypto !== 'undefined' && crypto.randomUUID
 			? crypto.randomUUID()
 			: `v-${Math.random().toString(36).slice(2)}`,
 	);
-	// Whether this tab currently holds input control of the shared session.
 	const [isController, setIsController] = useState(false);
-	// A pending "take control" request inside its grace window, if any.
 	const [pending, setPending] = useState<{
 		requester_viewer_id: string;
 		seconds_remaining: number;
@@ -88,13 +85,10 @@ export default function ReactVMVncViewer() {
 			return;
 		}
 		refreshInfo();
-		// Poll often enough that the grace countdown + control changes feel live.
 		const interval = setInterval(refreshInfo, 2000);
 		return () => clearInterval(interval);
 	}, [vncTarget, connected, refreshInfo]);
 
-	// Mirror control state into noVNC: view-only unless we hold control. This
-	// gates user input client-side; the server enforces it authoritatively too.
 	useEffect(() => {
 		if (rfbRef.current) rfbRef.current.viewOnly = !isController;
 	}, [isController, connected]);
@@ -144,8 +138,6 @@ export default function ReactVMVncViewer() {
 			rfb.showDotCursor = true;
 			rfb.qualityLevel = 6;
 			rfb.compressionLevel = 2;
-			// Start view-only; the info poll flips this on once we're confirmed
-			// as the controller (the first viewer is auto-promoted server-side).
 			rfb.viewOnly = true;
 
 			rfb.addEventListener('connect', () => {
@@ -436,7 +428,12 @@ export default function ReactVMVncViewer() {
 							</span>
 						)}
 					</div>
-					<div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 4,
+						}}>
 						{connected && (
 							<span
 								style={{
@@ -457,7 +454,9 @@ export default function ReactVMVncViewer() {
 						{connected && !isController && (
 							<button
 								onClick={takeControl}
-								disabled={pending?.requester_viewer_id === viewerId}
+								disabled={
+									pending?.requester_viewer_id === viewerId
+								}
 								title="Request control of this VM"
 								style={controlBtnStyle(false)}>
 								{pending?.requester_viewer_id === viewerId

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactVMVncViewer.tsx
@@ -45,35 +45,59 @@ export default function ReactVMVncViewer() {
 	const [keyboardVisible, setKeyboardVisible] = useState(false);
 	const [viewerCount, setViewerCount] = useState(0);
 	const [isPrimary, setIsPrimary] = useState(false);
+	// Stable per-tab id so the control endpoint can target this viewer.
+	const [viewerId] = useState(() =>
+		typeof crypto !== 'undefined' && crypto.randomUUID
+			? crypto.randomUUID()
+			: `v-${Math.random().toString(36).slice(2)}`,
+	);
+	// Whether this tab currently holds input control of the shared session.
+	const [isController, setIsController] = useState(false);
+	// A pending "take control" request inside its grace window, if any.
+	const [pending, setPending] = useState<{
+		requester_viewer_id: string;
+		seconds_remaining: number;
+	} | null>(null);
 	const reconnectAttemptRef = useRef(0);
 	const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
 		null,
 	);
 	const intentionalCloseRef = useRef(false);
 
+	const refreshInfo = useCallback(async () => {
+		if (!vncTarget) return;
+		try {
+			const info = await vmService.getVNCSessionInfo(vncTarget);
+			if (info) {
+				setViewerCount(info.viewers);
+				setIsPrimary(info.has_primary);
+				setIsController(info.controller_viewer_id === viewerId);
+				setPending(info.pending);
+			}
+		} catch {
+			/* ignore */
+		}
+	}, [vncTarget, viewerId]);
+
 	useEffect(() => {
 		if (!vncTarget || !connected) {
 			setViewerCount(0);
 			setIsPrimary(false);
+			setIsController(false);
+			setPending(null);
 			return;
 		}
-
-		const pollViewerCount = async () => {
-			try {
-				const info = await vmService.getVNCSessionInfo(vncTarget);
-				if (info) {
-					setViewerCount(info.viewers);
-					setIsPrimary(info.has_primary);
-				}
-			} catch {
-				/* ignore */
-			}
-		};
-
-		pollViewerCount();
-		const interval = setInterval(pollViewerCount, 5000);
+		refreshInfo();
+		// Poll often enough that the grace countdown + control changes feel live.
+		const interval = setInterval(refreshInfo, 2000);
 		return () => clearInterval(interval);
-	}, [vncTarget, connected]);
+	}, [vncTarget, connected, refreshInfo]);
+
+	// Mirror control state into noVNC: view-only unless we hold control. This
+	// gates user input client-side; the server enforces it authoritatively too.
+	useEffect(() => {
+		if (rfbRef.current) rfbRef.current.viewOnly = !isController;
+	}, [isController, connected]);
 
 	const cleanup = useCallback(() => {
 		if (reconnectTimerRef.current) {
@@ -88,6 +112,8 @@ export default function ReactVMVncViewer() {
 		setStatus('Disconnected');
 		setViewerCount(0);
 		setIsPrimary(false);
+		setIsController(false);
+		setPending(null);
 	}, []);
 
 	const connectVNC = useCallback(async (target: string) => {
@@ -96,7 +122,7 @@ export default function ReactVMVncViewer() {
 
 		viewerEl.innerHTML = '';
 
-		const wsUrl = vmService.getVNCWebSocketURL(target);
+		const wsUrl = vmService.getVNCWebSocketURL(target, viewerId);
 		setStatus(
 			reconnectAttemptRef.current > 0
 				? `Reconnecting (${reconnectAttemptRef.current}/${MAX_RECONNECT_ATTEMPTS})...`
@@ -118,6 +144,9 @@ export default function ReactVMVncViewer() {
 			rfb.showDotCursor = true;
 			rfb.qualityLevel = 6;
 			rfb.compressionLevel = 2;
+			// Start view-only; the info poll flips this on once we're confirmed
+			// as the controller (the first viewer is auto-promoted server-side).
+			rfb.viewOnly = true;
 
 			rfb.addEventListener('connect', () => {
 				setConnected(true);
@@ -271,6 +300,24 @@ export default function ReactVMVncViewer() {
 		}
 	}, [vncTarget, connected, connectVNC]);
 
+	const takeControl = useCallback(async () => {
+		if (!vncTarget) return;
+		await vmService.vncControl(vncTarget, 'take', viewerId);
+		refreshInfo();
+	}, [vncTarget, viewerId, refreshInfo]);
+
+	const releaseControl = useCallback(async () => {
+		if (!vncTarget) return;
+		await vmService.vncControl(vncTarget, 'release', viewerId);
+		refreshInfo();
+	}, [vncTarget, viewerId, refreshInfo]);
+
+	const denyControl = useCallback(async () => {
+		if (!vncTarget) return;
+		await vmService.vncControl(vncTarget, 'deny', viewerId);
+		refreshInfo();
+	}, [vncTarget, viewerId, refreshInfo]);
+
 	const sendCtrlAltDel = useCallback(() => {
 		rfbRef.current?.sendCtrlAltDel();
 	}, []);
@@ -389,8 +436,44 @@ export default function ReactVMVncViewer() {
 							</span>
 						)}
 					</div>
-					<div style={{ display: 'flex', gap: 4 }}>
+					<div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
 						{connected && (
+							<span
+								style={{
+									fontSize: '0.6rem',
+									fontWeight: 700,
+									letterSpacing: 0.3,
+									padding: '2px 6px',
+									borderRadius: 4,
+									textTransform: 'uppercase',
+									background: isController
+										? 'rgba(34, 197, 94, 0.15)'
+										: 'rgba(139, 148, 158, 0.15)',
+									color: isController ? '#22c55e' : '#8b949e',
+								}}>
+								{isController ? 'Controlling' : 'View only'}
+							</span>
+						)}
+						{connected && !isController && (
+							<button
+								onClick={takeControl}
+								disabled={pending?.requester_viewer_id === viewerId}
+								title="Request control of this VM"
+								style={controlBtnStyle(false)}>
+								{pending?.requester_viewer_id === viewerId
+									? `Requesting… ${pending?.seconds_remaining ?? ''}s`
+									: 'Take control'}
+							</button>
+						)}
+						{connected && isController && (
+							<button
+								onClick={releaseControl}
+								title="Release control (become view-only)"
+								style={controlBtnStyle(false)}>
+								Release
+							</button>
+						)}
+						{connected && isController && (
 							<>
 								<ToolbarButton
 									title="Send Ctrl+Alt+Del"
@@ -432,6 +515,35 @@ export default function ReactVMVncViewer() {
 						</ToolbarButton>
 					</div>
 				</div>
+				{connected &&
+					isController &&
+					pending &&
+					pending.requester_viewer_id !== viewerId && (
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								justifyContent: 'space-between',
+								gap: 8,
+								padding: '0.4rem 1rem',
+								borderTop:
+									'1px solid var(--sl-color-gray-5, #30363d)',
+								background: 'rgba(245, 158, 11, 0.12)',
+								fontSize: '0.7rem',
+								color: '#f59e0b',
+							}}>
+							<span>
+								Another viewer is requesting control —
+								transferring in {pending.seconds_remaining}s
+							</span>
+							<button
+								onClick={denyControl}
+								title="Deny the control request"
+								style={controlBtnStyle(true)}>
+								Deny
+							</button>
+						</div>
+					)}
 				<div
 					style={{
 						padding: '0.25rem 1rem 0.4rem',
@@ -448,6 +560,19 @@ export default function ReactVMVncViewer() {
 			</div>
 		</div>
 	);
+}
+
+function controlBtnStyle(danger: boolean): React.CSSProperties {
+	return {
+		fontSize: '0.65rem',
+		fontWeight: 600,
+		padding: '3px 8px',
+		borderRadius: 4,
+		cursor: 'pointer',
+		border: `1px solid ${danger ? 'rgba(239, 68, 68, 0.4)' : 'var(--sl-color-gray-5, #30363d)'}`,
+		background: danger ? 'rgba(239, 68, 68, 0.15)' : 'transparent',
+		color: danger ? '#ef4444' : 'var(--sl-color-text, #e6edf3)',
+	};
 }
 
 function ToolbarButton({

--- a/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
@@ -747,19 +747,25 @@ class VMService {
 		this.$guacTarget.set(null);
 	}
 
-	public getVNCWebSocketURL(name: string): string {
+	public getVNCWebSocketURL(name: string, viewerId?: string): string {
 		// Dedicated VNC WebSocket bridge — axum handles auth + upstream relay.
 		// Browser WebSocket API cannot set custom headers, so pass JWT as
 		// query param. The backend accepts ?access_token= for WS auth.
+		// viewer_id is a stable per-tab id so the control endpoint can target
+		// this specific viewer (take/release control).
 		const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const token = this.$accessToken.get() ?? '';
-		return `${proto}//${window.location.host}/dashboard/vm/vnc/${name}?access_token=${token}`;
+		const vid = viewerId ? `&viewer_id=${encodeURIComponent(viewerId)}` : '';
+		return `${proto}//${window.location.host}/dashboard/vm/vnc/${name}?access_token=${token}${vid}`;
 	}
 
 	public async getVNCSessionInfo(name: string): Promise<{
 		vm_key: string;
 		viewers: number;
 		has_primary: boolean;
+		controller_viewer_id: string | null;
+		viewers_list: { viewer_id: string; is_controller: boolean }[];
+		pending: { requester_viewer_id: string; seconds_remaining: number } | null;
 	} | null> {
 		const token = this.$accessToken.get();
 		if (!token) return null;
@@ -773,9 +779,44 @@ class VMService {
 				vm_key: string;
 				viewers: number;
 				has_primary: boolean;
+				controller_viewer_id: string | null;
+				viewers_list: { viewer_id: string; is_controller: boolean }[];
+				pending: {
+					requester_viewer_id: string;
+					seconds_remaining: number;
+				} | null;
 			};
 		} catch {
 			return null;
+		}
+	}
+
+	// Take / release / deny control of a shared VNC session. `action`:
+	// 'take' opens a 5s grace request (or grants immediately if uncontrolled),
+	// 'release' drops control to view-only, 'deny' (controller only) cancels a
+	// pending takeover. Returns true if the backend accepted the action.
+	public async vncControl(
+		name: string,
+		action: 'take' | 'release' | 'deny',
+		viewerId: string,
+	): Promise<boolean> {
+		const token = this.$accessToken.get();
+		if (!token) return false;
+		try {
+			const resp = await fetch(
+				`/dashboard/vm/vnc-control/${name}?access_token=${token}`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ action, viewer_id: viewerId }),
+					signal: AbortSignal.timeout(5000),
+				},
+			);
+			if (!resp.ok) return false;
+			const data = (await resp.json()) as { ok?: boolean };
+			return data.ok === true;
+		} catch {
+			return false;
 		}
 	}
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/vmService.ts
@@ -748,14 +748,11 @@ class VMService {
 	}
 
 	public getVNCWebSocketURL(name: string, viewerId?: string): string {
-		// Dedicated VNC WebSocket bridge — axum handles auth + upstream relay.
-		// Browser WebSocket API cannot set custom headers, so pass JWT as
-		// query param. The backend accepts ?access_token= for WS auth.
-		// viewer_id is a stable per-tab id so the control endpoint can target
-		// this specific viewer (take/release control).
 		const proto = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
 		const token = this.$accessToken.get() ?? '';
-		const vid = viewerId ? `&viewer_id=${encodeURIComponent(viewerId)}` : '';
+		const vid = viewerId
+			? `&viewer_id=${encodeURIComponent(viewerId)}`
+			: '';
 		return `${proto}//${window.location.host}/dashboard/vm/vnc/${name}?access_token=${token}${vid}`;
 	}
 
@@ -765,7 +762,10 @@ class VMService {
 		has_primary: boolean;
 		controller_viewer_id: string | null;
 		viewers_list: { viewer_id: string; is_controller: boolean }[];
-		pending: { requester_viewer_id: string; seconds_remaining: number } | null;
+		pending: {
+			requester_viewer_id: string;
+			seconds_remaining: number;
+		} | null;
 	} | null> {
 		const token = this.$accessToken.get();
 		if (!token) return null;
@@ -791,10 +791,6 @@ class VMService {
 		}
 	}
 
-	// Take / release / deny control of a shared VNC session. `action`:
-	// 'take' opens a 5s grace request (or grants immediately if uncontrolled),
-	// 'release' drops control to view-only, 'deny' (controller only) cancels a
-	// pending takeover. Returns true if the backend accepted the action.
 	public async vncControl(
 		name: string,
 		action: 'take' | 'release' | 'deny',

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -628,6 +628,10 @@ fn router(state: AppState) -> Router {
             axum::routing::get(super::proxy::kubevirt_vnc_info_handler),
         )
         .route(
+            "/dashboard/vm/vnc-control/{name}",
+            axum::routing::post(super::proxy::kubevirt_vnc_control_handler),
+        )
+        .route(
             "/dashboard/vm/vnc-sessions",
             axum::routing::get(super::proxy::kubevirt_vnc_sessions_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -968,14 +968,9 @@ pub async fn kubevirt_vnc_handler(
         kubevirt.upstream, VM_NAMESPACE, vm_name
     );
     let upstream_token = kubevirt.upstream_token.clone();
-    // VM_NAMESPACE is hardcoded to angelscript; parameterise once another
-    // VM namespace lands.
     let vm_key = format!("{VM_NAMESPACE}/{vm_name}");
-    // Browser-supplied stable id used to correlate this viewer with its
-    // control-plane HTTP requests (take/release control).
     let viewer_id = query_param(query.as_deref(), "viewer_id");
 
-    // vnc_hub shares a single upstream connection across every viewer.
     ws.protocols(["binary.k8s.io", "base64.binary.k8s.io"])
         .on_upgrade(move |browser_ws| async move {
             if let Err(e) = super::vnc_hub::join_session(
@@ -992,17 +987,12 @@ pub async fn kubevirt_vnc_handler(
         })
 }
 
-/// Extract a single query-string parameter value (no percent-decoding —
-/// callers use it for opaque ids like a UUID viewer_id).
 fn query_param(query: Option<&str>, key: &str) -> Option<String> {
-    query?.split('&').find_map(|pair| {
-        let (k, v) = pair.split_once('=')?;
-        (k == key).then(|| v.to_string())
-    })
+    url::form_urlencoded::parse(query?.as_bytes())
+        .find(|(k, _)| k == key)
+        .map(|(_, v)| v.into_owned())
 }
 
-/// POST /dashboard/vm/vnc-control/{name} — take / release / deny control of a
-/// shared VNC session. Body: {"action":"take|release|deny","viewer_id":"..."}.
 pub async fn kubevirt_vnc_control_handler(
     Path(vm_name): Path<String>,
     req: Request<Body>,
@@ -1019,22 +1009,34 @@ pub async fn kubevirt_vnc_control_handler(
     let body_bytes = match axum::body::to_bytes(req.into_body(), 4096).await {
         Ok(b) => b,
         Err(_) => {
-            return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "invalid body"})))
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({"error": "invalid body"})),
+            )
                 .into_response();
         }
     };
     let payload: serde_json::Value = match serde_json::from_slice(&body_bytes) {
         Ok(v) => v,
         Err(_) => {
-            return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "invalid JSON"})))
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({"error": "invalid JSON"})),
+            )
                 .into_response();
         }
     };
 
     let action = payload.get("action").and_then(|v| v.as_str()).unwrap_or("");
-    let viewer_id = payload.get("viewer_id").and_then(|v| v.as_str()).unwrap_or("");
+    let viewer_id = payload
+        .get("viewer_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
     if viewer_id.is_empty() {
-        return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "missing viewer_id"})))
+        return (
+            StatusCode::BAD_REQUEST,
+            axum::Json(json!({"error": "missing viewer_id"})),
+        )
             .into_response();
     }
 
@@ -1044,7 +1046,10 @@ pub async fn kubevirt_vnc_control_handler(
         "release" => super::vnc_hub::release_control(&vm_key, viewer_id),
         "deny" => super::vnc_hub::deny_control(&vm_key, viewer_id),
         _ => {
-            return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "unknown action"})))
+            return (
+                StatusCode::BAD_REQUEST,
+                axum::Json(json!({"error": "unknown action"})),
+            )
                 .into_response();
         }
     };

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -971,16 +971,85 @@ pub async fn kubevirt_vnc_handler(
     // VM_NAMESPACE is hardcoded to angelscript; parameterise once another
     // VM namespace lands.
     let vm_key = format!("{VM_NAMESPACE}/{vm_name}");
+    // Browser-supplied stable id used to correlate this viewer with its
+    // control-plane HTTP requests (take/release control).
+    let viewer_id = query_param(query.as_deref(), "viewer_id");
 
     // vnc_hub shares a single upstream connection across every viewer.
     ws.protocols(["binary.k8s.io", "base64.binary.k8s.io"])
         .on_upgrade(move |browser_ws| async move {
-            if let Err(e) =
-                super::vnc_hub::join_session(vm_key, upstream_url, upstream_token, browser_ws).await
+            if let Err(e) = super::vnc_hub::join_session(
+                vm_key,
+                upstream_url,
+                upstream_token,
+                viewer_id,
+                browser_ws,
+            )
+            .await
             {
                 warn!("VNC hub error for {vm_name}: {e}");
             }
         })
+}
+
+/// Extract a single query-string parameter value (no percent-decoding —
+/// callers use it for opaque ids like a UUID viewer_id).
+fn query_param(query: Option<&str>, key: &str) -> Option<String> {
+    query?.split('&').find_map(|pair| {
+        let (k, v) = pair.split_once('=')?;
+        (k == key).then(|| v.to_string())
+    })
+}
+
+/// POST /dashboard/vm/vnc-control/{name} — take / release / deny control of a
+/// shared VNC session. Body: {"action":"take|release|deny","viewer_id":"..."}.
+pub async fn kubevirt_vnc_control_handler(
+    Path(vm_name): Path<String>,
+    req: Request<Body>,
+) -> Response {
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(|q| q.to_string());
+
+    if let Err(resp) =
+        require_dashboard_view_with_query(&headers, query.as_deref(), "VNC-Control").await
+    {
+        return resp;
+    }
+
+    let body_bytes = match axum::body::to_bytes(req.into_body(), 4096).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "invalid body"})))
+                .into_response();
+        }
+    };
+    let payload: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(_) => {
+            return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "invalid JSON"})))
+                .into_response();
+        }
+    };
+
+    let action = payload.get("action").and_then(|v| v.as_str()).unwrap_or("");
+    let viewer_id = payload.get("viewer_id").and_then(|v| v.as_str()).unwrap_or("");
+    if viewer_id.is_empty() {
+        return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "missing viewer_id"})))
+            .into_response();
+    }
+
+    let vm_key = format!("{VM_NAMESPACE}/{vm_name}");
+    let ok = match action {
+        "take" => super::vnc_hub::request_control(&vm_key, viewer_id),
+        "release" => super::vnc_hub::release_control(&vm_key, viewer_id),
+        "deny" => super::vnc_hub::deny_control(&vm_key, viewer_id),
+        _ => {
+            return (StatusCode::BAD_REQUEST, axum::Json(json!({"error": "unknown action"})))
+                .into_response();
+        }
+    };
+
+    axum::Json(json!({"ok": ok})).into_response()
 }
 
 const VM_NAMESPACE: &str = "angelscript";
@@ -1003,8 +1072,15 @@ pub async fn kubevirt_vnc_info_handler(
     let vm_key = format!("{VM_NAMESPACE}/{vm_name}");
     match super::vnc_hub::get_session_info(&vm_key) {
         Some(info) => axum::Json(info).into_response(),
-        None => axum::Json(json!({"vm_key": vm_key, "viewers": 0, "has_primary": false}))
-            .into_response(),
+        None => axum::Json(json!({
+            "vm_key": vm_key,
+            "viewers": 0,
+            "has_primary": false,
+            "controller_viewer_id": null,
+            "viewers_list": [],
+            "pending": null
+        }))
+        .into_response(),
     }
 }
 
@@ -1301,6 +1377,7 @@ async fn kasm_ws_handler(
                 session_key,
                 upstream_url.clone(),
                 config,
+                None,
                 browser_ws,
             )
             .await

--- a/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
+++ b/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
@@ -25,25 +25,12 @@ pub struct VncSession {
     broadcast: broadcast::Sender<Bytes>,
     upstream_sink: Mutex<Option<UpstreamSink>>,
     clients: AtomicUsize,
-    /// client_id of the single viewer allowed to send input upstream
-    /// (`0` = nobody). The first viewer to join gets it automatically;
-    /// everyone else is view-only. Control only transfers through the timed
-    /// "take control" flow — never opportunistically — which also keeps late
-    /// joiners' RFB handshake bytes out of the live upstream stream.
     controller_id: AtomicUsize,
-    /// client_id -> browser-supplied viewer_id, so the (separate) control
-    /// HTTP requests can target a specific connection, and so the dashboard
-    /// can list viewers + identify the controller.
     clients_map: DashMap<usize, String>,
-    /// In-flight "take control" request inside its 5s grace window, if any.
     pending: StdMutex<Option<PendingControl>>,
-    /// Bumped on every request/deny so a stale grace timer no-ops.
     pending_gen: AtomicU64,
 }
 
-/// A "take control" request waiting out its grace period. The current
-/// controller may deny it before `deadline`; otherwise the grace timer
-/// promotes `requester_id` to controller.
 struct PendingControl {
     requester_id: usize,
     requester_viewer_id: String,
@@ -76,12 +63,9 @@ pub struct PendingInfo {
 pub struct SessionInfo {
     pub vm_key: String,
     pub viewers: usize,
-    /// viewer_id of the current controller, if any.
     pub controller_viewer_id: Option<String>,
-    /// `true` while someone holds control — kept for dashboard back-compat.
     pub has_primary: bool,
     pub viewers_list: Vec<ViewerInfo>,
-    /// Set while a "take control" request is in its grace window.
     pub pending: Option<PendingInfo>,
 }
 
@@ -102,14 +86,15 @@ fn build_session_info(session: &VncSession) -> SessionInfo {
     let pending = session
         .pending
         .lock()
-        .ok()
-        .and_then(|p| p.as_ref().map(|pc| PendingInfo {
+        .expect("vnc pending mutex poisoned")
+        .as_ref()
+        .map(|pc| PendingInfo {
             requester_viewer_id: pc.requester_viewer_id.clone(),
             seconds_remaining: pc
                 .deadline
                 .saturating_duration_since(Instant::now())
                 .as_secs(),
-        }));
+        });
     SessionInfo {
         vm_key: session.vm_key.clone(),
         viewers: session.clients.load(Ordering::Relaxed),
@@ -122,7 +107,9 @@ fn build_session_info(session: &VncSession) -> SessionInfo {
 
 pub fn get_session_info(vm_key: &str) -> Option<SessionInfo> {
     let registry = sessions();
-    registry.get(vm_key).map(|session| build_session_info(&session))
+    registry
+        .get(vm_key)
+        .map(|session| build_session_info(&session))
 }
 
 pub fn list_sessions() -> Vec<SessionInfo> {
@@ -133,10 +120,6 @@ pub fn list_sessions() -> Vec<SessionInfo> {
         .collect()
 }
 
-/// A viewer requests control. If nobody holds control (or the requester
-/// already does) it's granted immediately; otherwise a 5s grace window opens
-/// during which the current controller may `deny_control`. Returns `false`
-/// if the session or viewer_id is unknown.
 pub fn request_control(vm_key: &str, viewer_id: &str) -> bool {
     let Some(session) = sessions().get(vm_key).map(|s| s.clone()) else {
         return false;
@@ -153,9 +136,7 @@ pub fn request_control(vm_key: &str, viewer_id: &str) -> bool {
     let current = session.controller_id.load(Ordering::Relaxed);
     if current == 0 || current == requester_id {
         session.controller_id.store(requester_id, Ordering::Relaxed);
-        if let Ok(mut p) = session.pending.lock() {
-            *p = None;
-        }
+        *session.pending.lock().expect("vnc pending mutex poisoned") = None;
         info!(
             "VNC hub: {} control granted immediately to client {}",
             session.vm_key, requester_id
@@ -164,14 +145,12 @@ pub fn request_control(vm_key: &str, viewer_id: &str) -> bool {
     }
 
     let generation = session.pending_gen.fetch_add(1, Ordering::Relaxed) + 1;
-    if let Ok(mut p) = session.pending.lock() {
-        *p = Some(PendingControl {
-            requester_id,
-            requester_viewer_id: viewer_id.to_string(),
-            deadline: Instant::now() + CONTROL_GRACE,
-            generation,
-        });
-    }
+    *session.pending.lock().expect("vnc pending mutex poisoned") = Some(PendingControl {
+        requester_id,
+        requester_viewer_id: viewer_id.to_string(),
+        deadline: Instant::now() + CONTROL_GRACE,
+        generation,
+    });
     info!(
         "VNC hub: {} client {} requested control — {}s grace",
         session.vm_key,
@@ -182,28 +161,28 @@ pub fn request_control(vm_key: &str, viewer_id: &str) -> bool {
     let session_timer = session.clone();
     tokio::spawn(async move {
         tokio::time::sleep(CONTROL_GRACE).await;
-        if let Ok(mut p) = session_timer.pending.lock() {
-            if let Some(pc) = p.as_ref() {
-                if pc.generation == generation
-                    && session_timer.clients_map.contains_key(&pc.requester_id)
-                {
-                    session_timer
-                        .controller_id
-                        .store(pc.requester_id, Ordering::Relaxed);
-                    info!(
-                        "VNC hub: {} control transferred to client {} (grace elapsed)",
-                        session_timer.vm_key, pc.requester_id
-                    );
-                    *p = None;
-                }
+        let mut p = session_timer
+            .pending
+            .lock()
+            .expect("vnc pending mutex poisoned");
+        if let Some(pc) = p.as_ref() {
+            if pc.generation == generation
+                && session_timer.clients_map.contains_key(&pc.requester_id)
+            {
+                session_timer
+                    .controller_id
+                    .store(pc.requester_id, Ordering::Relaxed);
+                info!(
+                    "VNC hub: {} control transferred to client {} (grace elapsed)",
+                    session_timer.vm_key, pc.requester_id
+                );
+                *p = None;
             }
         }
     });
     true
 }
 
-/// The current controller denies a pending request (cancels the takeover).
-/// Only the controller may deny. Returns `false` if not allowed / no session.
 pub fn deny_control(vm_key: &str, viewer_id: &str) -> bool {
     let Some(session) = sessions().get(vm_key).map(|s| s.clone()) else {
         return false;
@@ -217,17 +196,12 @@ pub fn deny_control(vm_key: &str, viewer_id: &str) -> bool {
     if !is_controller {
         return false;
     }
-    // Bump the generation so the in-flight grace timer no-ops, then clear.
     session.pending_gen.fetch_add(1, Ordering::Relaxed);
-    if let Ok(mut p) = session.pending.lock() {
-        *p = None;
-    }
+    *session.pending.lock().expect("vnc pending mutex poisoned") = None;
     info!("VNC hub: {} pending control request denied", session.vm_key);
     true
 }
 
-/// The controller releases control, becoming a viewer (controller -> none).
-/// Only the controller may release. Returns `false` if not allowed.
 pub fn release_control(vm_key: &str, viewer_id: &str) -> bool {
     let Some(session) = sessions().get(vm_key).map(|s| s.clone()) else {
         return false;
@@ -289,7 +263,6 @@ pub async fn join_session_with_config(
     browser_ws: WebSocket,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client_id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
-    // Fall back to a server id if the browser didn't supply a viewer_id.
     let viewer_id = viewer_id.unwrap_or_else(|| format!("c{client_id}"));
     let registry = sessions();
 
@@ -313,7 +286,6 @@ pub async fn join_session_with_config(
     session.clients_map.insert(client_id, viewer_id.clone());
     let prior = session.clients.fetch_add(1, Ordering::Relaxed);
     if prior == 0 {
-        // First viewer drives the real upstream handshake and gets control.
         session.controller_id.store(client_id, Ordering::Relaxed);
         info!(
             "VNC hub: {} opened — client {} (viewer {}) is controller",
@@ -331,12 +303,9 @@ pub async fn join_session_with_config(
 
     let result = run_client(session.clone(), client_id, browser_ws).await;
 
-    // Cleanup: drop from the client map and hand off control if we held it.
     session.clients_map.remove(&client_id);
     if session.controller_id.load(Ordering::Relaxed) == client_id {
-        // Promote any remaining viewer so framebuffer requests keep flowing;
-        // otherwise control falls to nobody.
-        let next = session.clients_map.iter().next().map(|e| *e.key());
+        let next = session.clients_map.iter().map(|e| *e.key()).min();
         session
             .controller_id
             .store(next.unwrap_or(0), Ordering::Relaxed);
@@ -468,10 +437,6 @@ async fn run_client(
                 _ => continue,
             };
 
-            // Only the controller may write upstream. View-only clients have
-            // their input dropped here — crucially including a late joiner's
-            // RFB handshake bytes, which would otherwise corrupt the live
-            // upstream stream and reset everyone's connection.
             if session_input.controller_id.load(Ordering::Relaxed) != client_id {
                 continue;
             }

--- a/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
+++ b/apps/kbve/axum-kbve/src/transport/vnc_hub.rs
@@ -3,8 +3,10 @@ use axum::extract::ws::{Message as AxumMsg, WebSocket};
 use dashmap::DashMap;
 use futures_util::{SinkExt, StreamExt};
 use serde::Serialize;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, broadcast};
 use tokio_tungstenite::tungstenite::http::HeaderValue;
 use tokio_tungstenite::tungstenite::{Message as TungMsg, client::IntoClientRequest};
@@ -23,8 +25,33 @@ pub struct VncSession {
     broadcast: broadcast::Sender<Bytes>,
     upstream_sink: Mutex<Option<UpstreamSink>>,
     clients: AtomicUsize,
-    primary_id: AtomicUsize,
+    /// client_id of the single viewer allowed to send input upstream
+    /// (`0` = nobody). The first viewer to join gets it automatically;
+    /// everyone else is view-only. Control only transfers through the timed
+    /// "take control" flow — never opportunistically — which also keeps late
+    /// joiners' RFB handshake bytes out of the live upstream stream.
+    controller_id: AtomicUsize,
+    /// client_id -> browser-supplied viewer_id, so the (separate) control
+    /// HTTP requests can target a specific connection, and so the dashboard
+    /// can list viewers + identify the controller.
+    clients_map: DashMap<usize, String>,
+    /// In-flight "take control" request inside its 5s grace window, if any.
+    pending: StdMutex<Option<PendingControl>>,
+    /// Bumped on every request/deny so a stale grace timer no-ops.
+    pending_gen: AtomicU64,
 }
+
+/// A "take control" request waiting out its grace period. The current
+/// controller may deny it before `deadline`; otherwise the grace timer
+/// promotes `requester_id` to controller.
+struct PendingControl {
+    requester_id: usize,
+    requester_viewer_id: String,
+    deadline: Instant,
+    generation: u64,
+}
+
+const CONTROL_GRACE: Duration = Duration::from_secs(5);
 
 static SESSIONS: OnceLock<DashMap<String, Arc<VncSession>>> = OnceLock::new();
 static NEXT_CLIENT_ID: AtomicUsize = AtomicUsize::new(1);
@@ -34,34 +61,189 @@ fn sessions() -> &'static DashMap<String, Arc<VncSession>> {
 }
 
 #[derive(Serialize)]
+pub struct ViewerInfo {
+    pub viewer_id: String,
+    pub is_controller: bool,
+}
+
+#[derive(Serialize)]
+pub struct PendingInfo {
+    pub requester_viewer_id: String,
+    pub seconds_remaining: u64,
+}
+
+#[derive(Serialize)]
 pub struct SessionInfo {
     pub vm_key: String,
     pub viewers: usize,
+    /// viewer_id of the current controller, if any.
+    pub controller_viewer_id: Option<String>,
+    /// `true` while someone holds control — kept for dashboard back-compat.
     pub has_primary: bool,
+    pub viewers_list: Vec<ViewerInfo>,
+    /// Set while a "take control" request is in its grace window.
+    pub pending: Option<PendingInfo>,
+}
+
+fn build_session_info(session: &VncSession) -> SessionInfo {
+    let controller_id = session.controller_id.load(Ordering::Relaxed);
+    let controller_viewer_id = session
+        .clients_map
+        .get(&controller_id)
+        .map(|v| v.value().clone());
+    let viewers_list = session
+        .clients_map
+        .iter()
+        .map(|e| ViewerInfo {
+            viewer_id: e.value().clone(),
+            is_controller: *e.key() == controller_id,
+        })
+        .collect();
+    let pending = session
+        .pending
+        .lock()
+        .ok()
+        .and_then(|p| p.as_ref().map(|pc| PendingInfo {
+            requester_viewer_id: pc.requester_viewer_id.clone(),
+            seconds_remaining: pc
+                .deadline
+                .saturating_duration_since(Instant::now())
+                .as_secs(),
+        }));
+    SessionInfo {
+        vm_key: session.vm_key.clone(),
+        viewers: session.clients.load(Ordering::Relaxed),
+        controller_viewer_id,
+        has_primary: controller_id != 0,
+        viewers_list,
+        pending,
+    }
 }
 
 pub fn get_session_info(vm_key: &str) -> Option<SessionInfo> {
     let registry = sessions();
-    registry.get(vm_key).map(|session| SessionInfo {
-        vm_key: session.vm_key.clone(),
-        viewers: session.clients.load(Ordering::Relaxed),
-        has_primary: session.primary_id.load(Ordering::Relaxed) != 0,
-    })
+    registry.get(vm_key).map(|session| build_session_info(&session))
 }
 
 pub fn list_sessions() -> Vec<SessionInfo> {
     let registry = sessions();
     registry
         .iter()
-        .map(|entry| {
-            let session = entry.value();
-            SessionInfo {
-                vm_key: session.vm_key.clone(),
-                viewers: session.clients.load(Ordering::Relaxed),
-                has_primary: session.primary_id.load(Ordering::Relaxed) != 0,
-            }
-        })
+        .map(|entry| build_session_info(entry.value()))
         .collect()
+}
+
+/// A viewer requests control. If nobody holds control (or the requester
+/// already does) it's granted immediately; otherwise a 5s grace window opens
+/// during which the current controller may `deny_control`. Returns `false`
+/// if the session or viewer_id is unknown.
+pub fn request_control(vm_key: &str, viewer_id: &str) -> bool {
+    let Some(session) = sessions().get(vm_key).map(|s| s.clone()) else {
+        return false;
+    };
+    let Some(requester_id) = session
+        .clients_map
+        .iter()
+        .find(|e| e.value() == viewer_id)
+        .map(|e| *e.key())
+    else {
+        return false;
+    };
+
+    let current = session.controller_id.load(Ordering::Relaxed);
+    if current == 0 || current == requester_id {
+        session.controller_id.store(requester_id, Ordering::Relaxed);
+        if let Ok(mut p) = session.pending.lock() {
+            *p = None;
+        }
+        info!(
+            "VNC hub: {} control granted immediately to client {}",
+            session.vm_key, requester_id
+        );
+        return true;
+    }
+
+    let generation = session.pending_gen.fetch_add(1, Ordering::Relaxed) + 1;
+    if let Ok(mut p) = session.pending.lock() {
+        *p = Some(PendingControl {
+            requester_id,
+            requester_viewer_id: viewer_id.to_string(),
+            deadline: Instant::now() + CONTROL_GRACE,
+            generation,
+        });
+    }
+    info!(
+        "VNC hub: {} client {} requested control — {}s grace",
+        session.vm_key,
+        requester_id,
+        CONTROL_GRACE.as_secs()
+    );
+
+    let session_timer = session.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(CONTROL_GRACE).await;
+        if let Ok(mut p) = session_timer.pending.lock() {
+            if let Some(pc) = p.as_ref() {
+                if pc.generation == generation
+                    && session_timer.clients_map.contains_key(&pc.requester_id)
+                {
+                    session_timer
+                        .controller_id
+                        .store(pc.requester_id, Ordering::Relaxed);
+                    info!(
+                        "VNC hub: {} control transferred to client {} (grace elapsed)",
+                        session_timer.vm_key, pc.requester_id
+                    );
+                    *p = None;
+                }
+            }
+        }
+    });
+    true
+}
+
+/// The current controller denies a pending request (cancels the takeover).
+/// Only the controller may deny. Returns `false` if not allowed / no session.
+pub fn deny_control(vm_key: &str, viewer_id: &str) -> bool {
+    let Some(session) = sessions().get(vm_key).map(|s| s.clone()) else {
+        return false;
+    };
+    let controller_id = session.controller_id.load(Ordering::Relaxed);
+    let is_controller = session
+        .clients_map
+        .get(&controller_id)
+        .map(|v| v.value() == viewer_id)
+        .unwrap_or(false);
+    if !is_controller {
+        return false;
+    }
+    // Bump the generation so the in-flight grace timer no-ops, then clear.
+    session.pending_gen.fetch_add(1, Ordering::Relaxed);
+    if let Ok(mut p) = session.pending.lock() {
+        *p = None;
+    }
+    info!("VNC hub: {} pending control request denied", session.vm_key);
+    true
+}
+
+/// The controller releases control, becoming a viewer (controller -> none).
+/// Only the controller may release. Returns `false` if not allowed.
+pub fn release_control(vm_key: &str, viewer_id: &str) -> bool {
+    let Some(session) = sessions().get(vm_key).map(|s| s.clone()) else {
+        return false;
+    };
+    let controller_id = session.controller_id.load(Ordering::Relaxed);
+    let is_controller = session
+        .clients_map
+        .get(&controller_id)
+        .map(|v| v.value() == viewer_id)
+        .unwrap_or(false);
+    if !is_controller {
+        return false;
+    }
+    session.controller_id.store(0, Ordering::Relaxed);
+    info!("VNC hub: {} controller released control", session.vm_key);
+    true
 }
 
 pub struct UpstreamConfig {
@@ -92,19 +274,23 @@ pub async fn join_session(
     vm_key: String,
     upstream_url: String,
     upstream_token: Option<String>,
+    viewer_id: Option<String>,
     browser_ws: WebSocket,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let config = UpstreamConfig::kubevirt(upstream_token)?;
-    join_session_with_config(vm_key, upstream_url, config, browser_ws).await
+    join_session_with_config(vm_key, upstream_url, config, viewer_id, browser_ws).await
 }
 
 pub async fn join_session_with_config(
     vm_key: String,
     upstream_url: String,
     config: UpstreamConfig,
+    viewer_id: Option<String>,
     browser_ws: WebSocket,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let client_id = NEXT_CLIENT_ID.fetch_add(1, Ordering::Relaxed);
+    // Fall back to a server id if the browser didn't supply a viewer_id.
+    let viewer_id = viewer_id.unwrap_or_else(|| format!("c{client_id}"));
     let registry = sessions();
 
     let session = {
@@ -124,26 +310,36 @@ pub async fn join_session_with_config(
         }
     };
 
+    session.clients_map.insert(client_id, viewer_id.clone());
     let prior = session.clients.fetch_add(1, Ordering::Relaxed);
     if prior == 0 {
-        session.primary_id.store(client_id, Ordering::Relaxed);
+        // First viewer drives the real upstream handshake and gets control.
+        session.controller_id.store(client_id, Ordering::Relaxed);
         info!(
-            "VNC hub: {} opened — client {} is primary",
-            session.vm_key, client_id
+            "VNC hub: {} opened — client {} (viewer {}) is controller",
+            session.vm_key, client_id, viewer_id
         );
     } else {
         info!(
-            "VNC hub: {} client {} joined as observer ({} total)",
+            "VNC hub: {} client {} (viewer {}) joined as view-only ({} total)",
             session.vm_key,
             client_id,
+            viewer_id,
             prior + 1
         );
     }
 
     let result = run_client(session.clone(), client_id, browser_ws).await;
 
-    if session.primary_id.load(Ordering::Relaxed) == client_id {
-        session.primary_id.store(0, Ordering::Relaxed);
+    // Cleanup: drop from the client map and hand off control if we held it.
+    session.clients_map.remove(&client_id);
+    if session.controller_id.load(Ordering::Relaxed) == client_id {
+        // Promote any remaining viewer so framebuffer requests keep flowing;
+        // otherwise control falls to nobody.
+        let next = session.clients_map.iter().next().map(|e| *e.key());
+        session
+            .controller_id
+            .store(next.unwrap_or(0), Ordering::Relaxed);
     }
     let remaining = session.clients.fetch_sub(1, Ordering::Relaxed) - 1;
     if remaining == 0 {
@@ -194,7 +390,10 @@ async fn create_session(
         broadcast: broadcast_tx,
         upstream_sink: Mutex::new(Some(upstream_tx)),
         clients: AtomicUsize::new(0),
-        primary_id: AtomicUsize::new(0),
+        controller_id: AtomicUsize::new(0),
+        clients_map: DashMap::new(),
+        pending: StdMutex::new(None),
+        pending_gen: AtomicU64::new(0),
     });
 
     {
@@ -268,6 +467,14 @@ async fn run_client(
                 Ok(AxumMsg::Close(_)) | Err(_) => break,
                 _ => continue,
             };
+
+            // Only the controller may write upstream. View-only clients have
+            // their input dropped here — crucially including a late joiner's
+            // RFB handshake bytes, which would otherwise corrupt the live
+            // upstream stream and reset everyone's connection.
+            if session_input.controller_id.load(Ordering::Relaxed) != client_id {
+                continue;
+            }
 
             let mut guard = session_input.upstream_sink.lock().await;
             match guard.as_mut() {


### PR DESCRIPTION
## Problem
Second viewers couldn't connect to a shared VNC session — they'd sit on "Waiting for VNC connection…" while the first viewer stayed fine.

## Root cause
The June-4 `feat(vnc-hub): multi-master input` change removed the input gating, so **every** viewer's bytes were forwarded to the single shared upstream — including each late joiner's RFB **handshake**. KubeVirt's upstream is already past handshake, so those bytes corrupted the stream and triggered `Connection reset without closing handshake`, tearing down the session.

## Fix — single-controller model
- **Server (`vnc_hub`)**: only the controller's input reaches upstream. First viewer is auto-controller; everyone else is view-only (their input — incl. handshake — is dropped). Control transfers via a **timed "take control"** request (5s grace the current controller can **deny**) or **release**. Auto-promotes a remaining viewer if the controller leaves.
- New `POST /dashboard/vm/vnc-control/{name}` endpoint (take/release/deny) + `viewer_id` correlation. `vnc-info` now reports controller, viewer list, and any pending request.
- **Frontend**: per-tab `viewer_id`, noVNC `viewOnly` synced to control state, **Take control / Release / Deny** buttons + grace countdown.

## Verification
- `cargo check -p axum-kbve` (rustc 1.94) passes clean.
- Frontend type-check deferred to CI (worktree has no node_modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)