### PR TITLE
feat(kbve-kubectl,factorio): watchdog recovery for Unhealthy GS + 2m rotator cadence

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.183",
+			"version": "1.0.184",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -282,7 +282,7 @@
 		{
 			"key": "kubectl",
 			"app_name": "kbve-kubectl",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"version_toml": "apps/vm/kubectl/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx",
 			"version_target": "apps/vm/kubectl/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -77,7 +77,7 @@ The image is pinned in three manifests today, all kept in sync by the `deploymen
 |---|---|---|
 | `apps/kube/kubevirt/autologon/job.yaml` | KubeVirt Windows autologon setup | One-shot Job, kubectl + virtctl |
 | `apps/kube/kubevirt/runner/job.yaml` | KubeVirt runner orchestration | One-shot Job, kubectl + virtctl |
-| `apps/kube/agones/factorio/manifests/rotation-cronjob.yaml` | Factorio GameServer image rotator | CronJob every 5 min, invokes `kbve-kubectl rotate-gameserver` to compare `gs.spec.image` vs `pod.spec.image` and delete the GameServer on drift so ArgoCD selfHeal recreates from the new spec |
+| `apps/kube/agones/factorio/manifests/rotation-cronjob.yaml` | Factorio GameServer rotator + watchdog | CronJob every 2 min, invokes `kbve-kubectl rotate-gameserver` to (a) compare `gs.spec.image` vs `pod.spec.image` and delete the GameServer on drift, and (b) detect `state=Unhealthy` with a missing pod and delete the stuck GameServer so ArgoCD selfHeal recreates from the spec |
 
 When a new behavior needs to land across all rotator and KubeVirt jobs (RCON-aware save-flush probes, Agones SDK Health calls, retry-with-backoff, ConfigMap-driven rotation policy), extend the Rust CLI in `apps/vm/kubectl/src/`, bump `version.toml`, and every manifest above auto-bumps via the post-publish sync.
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kubectl.mdx
@@ -13,7 +13,7 @@ tags:
 key: kubectl
 pipeline: docker
 app_name: kbve-kubectl
-version: "0.1.3"
+version: "0.1.4"
 source_path: apps/vm/kubectl
 version_toml: apps/vm/kubectl/version.toml
 version_target: apps/vm/kubectl/Cargo.toml

--- a/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
+++ b/apps/kube/agones/factorio/manifests/rotation-cronjob.yaml
@@ -4,7 +4,7 @@ metadata:
     name: factorio-rotator
     namespace: factorio
 spec:
-    schedule: '*/5 * * * *'
+    schedule: '*/2 * * * *'
     concurrencyPolicy: Forbid
     successfulJobsHistoryLimit: 1
     failedJobsHistoryLimit: 3

--- a/apps/vm/kubectl/src/main.rs
+++ b/apps/vm/kubectl/src/main.rs
@@ -437,8 +437,38 @@ async fn cmd_rotate_gameserver(
 
     tracing::info!("desired={desired} running={running} state={state}");
 
-    if desired.is_empty() || running.is_empty() {
-        tracing::info!("missing gs or pod — nothing to rotate");
+    if desired.is_empty() {
+        tracing::info!("missing gs — nothing to rotate");
+        return ExitCode::SUCCESS;
+    }
+
+    let timeout_arg = format!("--timeout={delete_timeout}s");
+    let wrapper_timeout = Duration::from_secs(delete_timeout.saturating_add(30));
+    let delete_args = [
+        "-n",
+        namespace,
+        "delete",
+        &gs_ref,
+        &timeout_arg,
+        "--ignore-not-found",
+    ];
+
+    if state == "Unhealthy" && running.is_empty() {
+        tracing::warn!("gs Unhealthy with no pod — recovering by deleting gs");
+        return match kubectl_output_with_timeout(&delete_args, wrapper_timeout).await {
+            Ok(_) => {
+                tracing::info!("delete sent; ArgoCD selfHeal will recreate from {desired}");
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                tracing::error!("recovery delete failed: {e}");
+                ExitCode::FAILURE
+            }
+        };
+    }
+
+    if running.is_empty() {
+        tracing::info!("missing pod (state={state}) — nothing to rotate");
         return ExitCode::SUCCESS;
     }
     if desired == running {
@@ -452,21 +482,7 @@ async fn cmd_rotate_gameserver(
 
     tracing::info!("image drift detected: {running} -> {desired}; rotating");
 
-    let timeout_arg = format!("--timeout={delete_timeout}s");
-    let wrapper_timeout = Duration::from_secs(delete_timeout.saturating_add(30));
-    match kubectl_output_with_timeout(
-        &[
-            "-n",
-            namespace,
-            "delete",
-            &gs_ref,
-            &timeout_arg,
-            "--ignore-not-found",
-        ],
-        wrapper_timeout,
-    )
-    .await
-    {
+    match kubectl_output_with_timeout(&delete_args, wrapper_timeout).await {
         Ok(_) => {
             tracing::info!("delete sent; ArgoCD selfHeal will recreate from {desired}");
             ExitCode::SUCCESS


### PR DESCRIPTION
## Context

Earlier today the factorio GameServer hit \`state=Unhealthy\` with no pod backing it (likely a Cilium agent restart on the node knocked the pod out of network, Agones marked it Unhealthy, pod was cleaned up). \`gs/factorio\` then sat stuck — Agones does not auto-respawn pods for Unhealthy GS (no ReplicaSet), and the rotator only acted on image drift, so it logged \`missing gs or pod — nothing to rotate\` and walked away. Manual \`kubectl delete gs/factorio\` was needed to let ArgoCD selfHeal recreate it.

## Summary

- **\`rotate-gameserver\` now doubles as a watchdog.** New branch: when \`gs.status.state == \"Unhealthy\"\` AND the pod is missing, the rotator deletes the GameServer so ArgoCD selfHeal recreates it from spec. The drift-rotation path is unchanged.
- **Cadence bumped \`*/5\` → \`*/2\`** so unhealthy-pod outages are detected within 2 min instead of 5.
- **kubectl.mdx** documents the rotator's expanded role as \"rotator + watchdog\".

## Test plan

- [x] \`cargo check\` + \`cargo clippy -- -D warnings\` clean
- [ ] CI publishes \`kbve-kubectl\` 0.1.4 → \`rotation-cronjob.yaml\` image pin auto-bumps via \`deployment_yamls\`
- [ ] Manual: \`kubectl delete pod factorio -n factorio\`, wait 2 min, confirm rotator log shows \`gs Unhealthy with no pod — recovering\` and ArgoCD respawns