### PR TITLE
feat(astro): unified JSON-LD module + rich Features page

### DIFF
--- a/apps/kbve/astro-kbve/src/components/kbve/DeferredFeature.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/DeferredFeature.astro
@@ -6,8 +6,10 @@
  */
 import DeferredSection from '@/components/utility/DeferredSection.astro';
 import Feature from './Feature.astro';
+
+const props = Astro.props;
 ---
 
 <DeferredSection id="features" minHeight="500px" minHeightMobile="400px">
-	<Feature />
+	<Feature {...props} />
 </DeferredSection>

--- a/apps/kbve/astro-kbve/src/components/navigation/Head.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Head.astro
@@ -12,6 +12,8 @@
  * Mirrors the rareicon Head override (apps/rareicon/astro-rareicon/...).
  */
 import { ClientRouter } from 'astro:transitions';
+import { seo } from '@/lib/seo';
+import { dedupeGraph } from '@kbve/astro/seo';
 
 const route = Astro.locals.starlightRoute;
 const head = route.head;
@@ -63,6 +65,48 @@ const overrideTags: HeadTag[] = Object.entries(owned).map(([key, content]) => {
 			: { property: key, content: content! },
 	} as HeadTag;
 });
+
+type JsonLdFm = {
+	disable?: boolean;
+	type?: 'WebPage' | 'Article';
+	image?: string;
+	datePublished?: string;
+	dateModified?: string;
+	keywords?: string[];
+	breadcrumb?: { name: string; path: string }[];
+	faq?: { question: string; answer: string }[];
+};
+
+const jl = (data.jsonld ?? {}) as JsonLdFm;
+const pageTitle = typeof data.title === 'string' ? data.title : undefined;
+const pageDescription =
+	typeof data.description === 'string' ? data.description : undefined;
+
+const jsonLdGraph =
+	jl.disable || !pageTitle
+		? null
+		: dedupeGraph(
+				seo.page({
+					pathname: Astro.url.pathname,
+					title: pageTitle,
+					description: pageDescription,
+					type: jl.type,
+					image: jl.image ?? ogImage,
+					datePublished: jl.datePublished,
+					dateModified: jl.dateModified,
+					keywords: jl.keywords,
+					breadcrumb: jl.breadcrumb?.map(
+						(c) => [c.name, c.path] as [string, string],
+					),
+					faq: jl.faq,
+				}),
+			);
+
+const jsonLdPayload = jsonLdGraph
+	? jsonLdGraph.length === 1
+		? { '@context': 'https://schema.org', ...jsonLdGraph[0] }
+		: { '@context': 'https://schema.org', '@graph': jsonLdGraph }
+	: null;
 ---
 
 {
@@ -71,6 +115,16 @@ const overrideTags: HeadTag[] = Object.entries(owned).map(([key, content]) => {
 	))
 }
 {overrideTags.map(({ tag: Tag, attrs }) => <Tag {...attrs} />)}
+
+{
+	jsonLdPayload && (
+		<script
+			type="application/ld+json"
+			is:inline
+			set:html={JSON.stringify(jsonLdPayload)}
+		/>
+	)
+}
 
 <slot />
 

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -195,6 +195,32 @@ export const collections = {
 				twitterTitle: z.string().optional(),
 				twitterDescription: z.string().optional(),
 				twitterImage: z.string().optional(),
+				jsonld: z
+					.object({
+						disable: z.boolean().optional(),
+						type: z.enum(['WebPage', 'Article']).optional(),
+						image: z.string().optional(),
+						datePublished: z.string().optional(),
+						dateModified: z.string().optional(),
+						keywords: z.array(z.string()).optional(),
+						breadcrumb: z
+							.array(
+								z.object({
+									name: z.string(),
+									path: z.string(),
+								}),
+							)
+							.optional(),
+						faq: z
+							.array(
+								z.object({
+									question: z.string(),
+									answer: z.string(),
+								}),
+							)
+							.optional(),
+					})
+					.optional(),
 			}),
 		}),
 	}),

--- a/apps/kbve/astro-kbve/src/content/docs/feature.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/feature.mdx
@@ -1,6 +1,6 @@
 ---
 title: Features
-description: KBVE platform features — community, gaming, automation, and more.
+description: What the KBVE platform ships — game development, managed game servers, CI/CD automation, observability, identity, and open-source libraries.
 editUrl: false
 lastUpdated: false
 next: false
@@ -11,17 +11,149 @@ sidebar:
 
 import DeferredFeature from '@/components/kbve/DeferredFeature.astro';
 import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
+import JsonLd from '@kbve/astro/seo/JsonLd.astro';
+import { seo } from '@/lib/seo';
+import RingShipGrid from '@kbve/astro/components/hero/ring/RingShipGrid.astro';
+import RingShipCard from '@kbve/astro/components/hero/ring/RingShipCard.astro';
 import ScrollRing from '@kbve/astro/components/hero/observer/ScrollRing.astro';
+
+export const features = [
+	{
+		title: 'Game Development',
+		description:
+			'In-house engines and worlds — Rareicon (DOTS/ECS), isometric Bevy worlds, and Unreal/AngelScript pipelines.',
+		href: '/rareicon/',
+		icon: 'controller',
+		accent: '#a855f7',
+	},
+	{
+		title: 'Managed Game Servers',
+		description:
+			'Auto-scaling Minecraft, Unreal, and Bevy world hosting on Kubernetes with built-in observability.',
+		href: '/service/',
+		icon: 'server',
+		accent: '#22c55e',
+	},
+	{
+		title: 'CI/CD Automation',
+		description:
+			'Nx monorepo builds, manifest-driven dispatch, and event-driven pipelines that ship versioned artifacts.',
+		href: '/github/',
+		icon: 'cog',
+		accent: '#f59e0b',
+	},
+	{
+		title: 'Observability',
+		description:
+			'End-to-end metrics and logs — Vector to ClickHouse, Prometheus alerts, and tracing across every service.',
+		href: '/service/',
+		icon: 'zap',
+		accent: '#06b6d4',
+	},
+	{
+		title: 'Identity & Auth',
+		description:
+			'Supabase-backed accounts with canonical kbve.com/@username profiles and JWT claims wired into Rust services.',
+		href: '/profile/',
+		icon: 'compass',
+		accent: '#3b82f6',
+	},
+	{
+		title: 'Open Source',
+		description:
+			'A public monorepo of libraries, tools, and game code. Read it, fork it, sponsor a maintainer, ship with us.',
+		href: 'https://github.com/kbve',
+		icon: 'github',
+		accent: '#ef4444',
+	},
+];
+
+export const highlights = [
+	{
+		title: 'Built in the Open',
+		description:
+			'Every library, pipeline, and game system lives in one public monorepo — audit it, fork it, contribute back.',
+		icon: 'star',
+	},
+	{
+		title: 'Scales on Kubernetes',
+		description:
+			'Talos + Cilium clusters, ArgoCD GitOps, and auto-scaling workloads keep services fast under real load.',
+		icon: 'bolt',
+	},
+	{
+		title: 'Production Hardened',
+		description:
+			'Sealed secrets, network policies, observability, and restore drills — the boring parts done right.',
+		icon: 'shield',
+	},
+];
+
+export const pageDescription =
+	'What the KBVE platform ships — game development, managed game servers, CI/CD automation, observability, identity, and open-source libraries.';
+
+<JsonLd
+	graph={seo.graph(
+		seo.webPage({
+			url: seo.url('/feature/'),
+			name: 'KBVE Features',
+			description: pageDescription,
+			primaryImageOfPage: seo.config.logo,
+			breadcrumb: `${seo.url('/feature/')}#breadcrumb`,
+		}),
+		seo.breadcrumbs(
+			[
+				['KBVE', '/'],
+				['Features', '/feature/'],
+			],
+			`${seo.url('/feature/')}#breadcrumb`,
+		),
+		seo.itemList(
+			features.map((f) => ({
+				name: f.title,
+				description: f.description,
+				url: f.href,
+			})),
+			{
+				id: `${seo.url('/feature/')}#features`,
+				name: 'KBVE Features',
+				description: pageDescription,
+			},
+		),
+	)}
+/>
 
 <div class="ring-page kbve-dashboard-page relative min-h-screen w-full bg-transparent">
 
 # Features
 
-What KBVE actually ships:
+KBVE is a platform for building, shipping, and hosting games and software. Here is what we actually ship:
 
-<DeferredFeature />
+<RingShipGrid tagline="Six capabilities, one open-source monorepo — pick a thread to pull.">
+	{
+		features.map((f) => (
+			<RingShipCard
+				title={f.title}
+				description={f.description}
+				href={f.href}
+				icon={f.icon}
+				accent={f.accent}
+			/>
+		))
+	}
+</RingShipGrid>
+
+## Why it holds up
+
+<DeferredFeature features={highlights} imageUrl="/assets/images/gameplay/rentearth.webp" imageAlt="KBVE game world rendered in-engine" />
 
 <DeferredAdsense label="Sponsored" />
+
+## Start here
+
+- **Play** — explore [Rareicon](/rareicon/) and the worlds we are building.
+- **Host** — spin up a [managed game server](/service/).
+- **Build** — read the [source on GitHub](https://github.com/kbve) or join us in [Discord](/discord/).
 
 </div>
 

--- a/apps/kbve/astro-kbve/src/content/docs/feature.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/feature.mdx
@@ -7,6 +7,18 @@ next: false
 sidebar:
     label: Features
     order: 4
+jsonld:
+    keywords:
+        - game development
+        - managed game servers
+        - CI/CD automation
+        - observability
+        - open source
+    breadcrumb:
+        - name: KBVE
+          path: /
+        - name: Features
+          path: /feature/
 ---
 
 import DeferredFeature from '@/components/kbve/DeferredFeature.astro';
@@ -89,25 +101,8 @@ export const highlights = [
 	},
 ];
 
-export const pageDescription =
-	'What the KBVE platform ships — game development, managed game servers, CI/CD automation, observability, identity, and open-source libraries.';
-
 <JsonLd
-	graph={seo.graph(
-		seo.webPage({
-			url: seo.url('/feature/'),
-			name: 'KBVE Features',
-			description: pageDescription,
-			primaryImageOfPage: seo.config.logo,
-			breadcrumb: `${seo.url('/feature/')}#breadcrumb`,
-		}),
-		seo.breadcrumbs(
-			[
-				['KBVE', '/'],
-				['Features', '/feature/'],
-			],
-			`${seo.url('/feature/')}#breadcrumb`,
-		),
+	graph={[
 		seo.itemList(
 			features.map((f) => ({
 				name: f.title,
@@ -117,10 +112,11 @@ export const pageDescription =
 			{
 				id: `${seo.url('/feature/')}#features`,
 				name: 'KBVE Features',
-				description: pageDescription,
+				description:
+					'What the KBVE platform ships — game development, managed game servers, CI/CD automation, observability, identity, and open-source libraries.',
 			},
 		),
-	)}
+	]}
 />
 
 <div class="ring-page kbve-dashboard-page relative min-h-screen w-full bg-transparent">

--- a/apps/kbve/astro-kbve/src/lib/seo.ts
+++ b/apps/kbve/astro-kbve/src/lib/seo.ts
@@ -1,0 +1,16 @@
+import { createSeo } from '@kbve/astro/seo';
+
+export const seo = createSeo({
+	siteUrl: 'https://kbve.com',
+	name: 'KBVE',
+	description:
+		'KiloByte Virtual Enterprise — building, shipping, and hosting games and software in the open.',
+	logo: 'https://kbve.com/assets/images/brand/letter_logo.png',
+	sameAs: [
+		'https://github.com/kbve',
+		'https://discord.gg/kbve',
+		'https://kbve.com/discord/',
+	],
+});
+
+export * from '@kbve/astro/seo';

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -12,6 +12,8 @@
 			"@kbve/astro/components/*": [
 				"../../../packages/npm/astro/src/components/*"
 			],
+			"@kbve/astro/seo": ["../../../packages/npm/astro/src/seo/index.ts"],
+			"@kbve/astro/seo/*": ["../../../packages/npm/astro/src/seo/*"],
 			"@kbve/astro/utils/*": ["../../../packages/npm/astro/src/utils/*"],
 			"@kbve/devops": ["../../../packages/npm/devops/src/index.ts"],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],

--- a/packages/npm/astro/src/seo/JsonLd.astro
+++ b/packages/npm/astro/src/seo/JsonLd.astro
@@ -1,0 +1,23 @@
+---
+import { dedupeGraph, type SchemaNode } from './schema.js';
+
+interface Props {
+	graph: SchemaNode[];
+	context?: string;
+}
+
+const { graph, context = 'https://schema.org' } = Astro.props;
+
+const nodes = dedupeGraph(graph);
+
+const payload =
+	nodes.length === 1
+		? { '@context': context, ...nodes[0] }
+		: { '@context': context, '@graph': nodes };
+---
+
+<script
+	type="application/ld+json"
+	is:inline
+	set:html={JSON.stringify(payload)}
+/>

--- a/packages/npm/astro/src/seo/index.ts
+++ b/packages/npm/astro/src/seo/index.ts
@@ -2,12 +2,15 @@ import {
 	org,
 	website,
 	webPage,
+	article,
 	breadcrumbs,
 	itemList,
+	faqPage,
 	type SchemaNode,
 	type WebPageInput,
 	type Crumb,
 	type ListEntry,
+	type FaqEntry,
 } from './schema.js';
 
 export * from './schema.js';
@@ -18,6 +21,20 @@ export interface SeoSiteConfig {
 	logo?: string;
 	description?: string;
 	sameAs?: string[];
+}
+
+export interface PageInput {
+	pathname: string;
+	title: string;
+	description?: string;
+	type?: 'WebPage' | 'Article';
+	image?: string;
+	datePublished?: string;
+	dateModified?: string;
+	keywords?: string[];
+	breadcrumb?: Crumb[];
+	faq?: FaqEntry[];
+	extra?: SchemaNode[];
 }
 
 export interface Seo {
@@ -36,7 +53,22 @@ export interface Seo {
 		opts?: { id?: string; name?: string; description?: string },
 	): SchemaNode;
 	graph(...nodes: SchemaNode[]): SchemaNode[];
+	page(i: PageInput): SchemaNode[];
 }
+
+const humanize = (segment: string): string =>
+	segment.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+
+const autoCrumbs = (siteName: string, pathname: string): Crumb[] => {
+	const segs = pathname.split('/').filter(Boolean);
+	const crumbs: Crumb[] = [[siteName, '/']];
+	let acc = '';
+	for (const seg of segs) {
+		acc += `/${seg}`;
+		crumbs.push([humanize(seg), `${acc}/`]);
+	}
+	return crumbs;
+};
 
 const trim = (url: string): string => url.replace(/\/+$/, '');
 
@@ -73,5 +105,40 @@ export const createSeo = (config: SeoSiteConfig): Seo => {
 		breadcrumbs: (crumbs, id) => breadcrumbs(config.siteUrl, crumbs, id),
 		itemList: (entries, opts) => itemList(config.siteUrl, entries, opts),
 		graph: (...nodes) => [orgNode, siteNode, ...nodes],
+		page: (i) => {
+			const pageUrl = abs(config.siteUrl, i.pathname);
+			const crumbId = `${pageUrl}#breadcrumb`;
+			const trail = i.breadcrumb ?? autoCrumbs(config.name, i.pathname);
+			const crumb = breadcrumbs(config.siteUrl, trail, crumbId);
+			const primary =
+				i.type === 'Article'
+					? article({
+							url: pageUrl,
+							headline: i.title,
+							description: i.description,
+							image: i.image ?? config.logo,
+							datePublished: i.datePublished,
+							dateModified: i.dateModified,
+							keywords: i.keywords,
+							publisher: orgNode,
+							isPartOf: siteNode,
+							breadcrumb: crumbId,
+						})
+					: webPage({
+							url: pageUrl,
+							name: i.title,
+							description: i.description,
+							image: i.image,
+							primaryImageOfPage: i.image ?? config.logo,
+							keywords: i.keywords,
+							isPartOf: siteNode,
+							breadcrumb: crumbId,
+							dateModified: i.dateModified,
+						});
+			const nodes: SchemaNode[] = [orgNode, siteNode, primary, crumb];
+			if (i.faq?.length) nodes.push(faqPage(i.faq, `${pageUrl}#faq`));
+			if (i.extra?.length) nodes.push(...i.extra);
+			return nodes;
+		},
 	};
 };

--- a/packages/npm/astro/src/seo/index.ts
+++ b/packages/npm/astro/src/seo/index.ts
@@ -1,0 +1,77 @@
+import {
+	org,
+	website,
+	webPage,
+	breadcrumbs,
+	itemList,
+	type SchemaNode,
+	type WebPageInput,
+	type Crumb,
+	type ListEntry,
+} from './schema.js';
+
+export * from './schema.js';
+
+export interface SeoSiteConfig {
+	siteUrl: string;
+	name: string;
+	logo?: string;
+	description?: string;
+	sameAs?: string[];
+}
+
+export interface Seo {
+	config: SeoSiteConfig;
+	org: SchemaNode;
+	website: SchemaNode;
+	url(path: string): string;
+	webPage(
+		i: Omit<WebPageInput, 'isPartOf'> & {
+			isPartOf?: WebPageInput['isPartOf'];
+		},
+	): SchemaNode;
+	breadcrumbs(crumbs: Crumb[], id?: string): SchemaNode;
+	itemList(
+		entries: ListEntry[],
+		opts?: { id?: string; name?: string; description?: string },
+	): SchemaNode;
+	graph(...nodes: SchemaNode[]): SchemaNode[];
+}
+
+const trim = (url: string): string => url.replace(/\/+$/, '');
+
+const abs = (siteUrl: string, path: string): string =>
+	/^https?:\/\//.test(path)
+		? path
+		: `${trim(siteUrl)}/${path.replace(/^\/+/, '')}`;
+
+export const createSeo = (config: SeoSiteConfig): Seo => {
+	const orgNode = org({
+		url: config.siteUrl,
+		name: config.name,
+		logo: config.logo,
+		description: config.description,
+		sameAs: config.sameAs,
+	});
+	const siteNode = website({
+		url: config.siteUrl,
+		name: config.name,
+		description: config.description,
+		publisher: orgNode,
+	});
+
+	return {
+		config,
+		org: orgNode,
+		website: siteNode,
+		url: (path) => abs(config.siteUrl, path),
+		webPage: (i) =>
+			webPage({
+				...i,
+				isPartOf: i.isPartOf ?? siteNode,
+			}),
+		breadcrumbs: (crumbs, id) => breadcrumbs(config.siteUrl, crumbs, id),
+		itemList: (entries, opts) => itemList(config.siteUrl, entries, opts),
+		graph: (...nodes) => [orgNode, siteNode, ...nodes],
+	};
+};

--- a/packages/npm/astro/src/seo/schema.ts
+++ b/packages/npm/astro/src/seo/schema.ts
@@ -53,6 +53,7 @@ export interface WebPageInput {
 	breadcrumb?: SchemaNode | string;
 	primaryImageOfPage?: string;
 	dateModified?: string;
+	keywords?: string[];
 }
 
 export const webPage = (i: WebPageInput): SchemaNode => ({
@@ -65,6 +66,7 @@ export const webPage = (i: WebPageInput): SchemaNode => ({
 	...(i.primaryImageOfPage
 		? { primaryImageOfPage: i.primaryImageOfPage }
 		: {}),
+	...(i.keywords?.length ? { keywords: i.keywords } : {}),
 	...(i.isPartOf ? { isPartOf: ref(i.isPartOf) } : {}),
 	...(i.breadcrumb ? { breadcrumb: ref(i.breadcrumb) } : {}),
 	...(i.dateModified ? { dateModified: i.dateModified } : {}),
@@ -203,6 +205,36 @@ export const videoGame = (i: VideoGameInput): SchemaNode => ({
 		? { applicationCategory: i.applicationCategory }
 		: {}),
 	...(i.publisher ? { publisher: ref(i.publisher) } : {}),
+});
+
+export interface ArticleInput {
+	url: string;
+	headline: string;
+	description?: string;
+	image?: string;
+	datePublished?: string;
+	dateModified?: string;
+	keywords?: string[];
+	author?: SchemaNode | string;
+	publisher?: SchemaNode | string;
+	isPartOf?: SchemaNode | string;
+	breadcrumb?: SchemaNode | string;
+}
+
+export const article = (i: ArticleInput): SchemaNode => ({
+	'@type': 'Article',
+	'@id': `${i.url}#article`,
+	headline: i.headline,
+	url: i.url,
+	...(i.description ? { description: i.description } : {}),
+	...(i.image ? { image: i.image } : {}),
+	...(i.datePublished ? { datePublished: i.datePublished } : {}),
+	...(i.dateModified ? { dateModified: i.dateModified } : {}),
+	...(i.keywords?.length ? { keywords: i.keywords } : {}),
+	...(i.author ? { author: ref(i.author) } : {}),
+	...(i.publisher ? { publisher: ref(i.publisher) } : {}),
+	...(i.isPartOf ? { isPartOf: ref(i.isPartOf) } : {}),
+	...(i.breadcrumb ? { breadcrumb: ref(i.breadcrumb) } : {}),
 });
 
 export const dedupeGraph = (nodes: SchemaNode[]): SchemaNode[] => {

--- a/packages/npm/astro/src/seo/schema.ts
+++ b/packages/npm/astro/src/seo/schema.ts
@@ -1,0 +1,221 @@
+export type SchemaNode = Record<string, any>;
+
+const trim = (url: string): string => url.replace(/\/+$/, '');
+
+const abs = (siteUrl: string, path: string): string =>
+	/^https?:\/\//.test(path)
+		? path
+		: `${trim(siteUrl)}/${path.replace(/^\/+/, '')}`;
+
+export const ref = (node: SchemaNode | string): SchemaNode =>
+	typeof node === 'string' ? { '@id': node } : { '@id': node['@id'] };
+
+export interface OrgInput {
+	url: string;
+	name: string;
+	logo?: string;
+	description?: string;
+	sameAs?: string[];
+}
+
+export const org = (i: OrgInput): SchemaNode => ({
+	'@type': 'Organization',
+	'@id': `${trim(i.url)}/#organization`,
+	name: i.name,
+	url: trim(i.url),
+	...(i.logo ? { logo: i.logo } : {}),
+	...(i.description ? { description: i.description } : {}),
+	...(i.sameAs?.length ? { sameAs: i.sameAs } : {}),
+});
+
+export interface WebSiteInput {
+	url: string;
+	name: string;
+	description?: string;
+	publisher?: SchemaNode | string;
+}
+
+export const website = (i: WebSiteInput): SchemaNode => ({
+	'@type': 'WebSite',
+	'@id': `${trim(i.url)}/#website`,
+	url: trim(i.url),
+	name: i.name,
+	...(i.description ? { description: i.description } : {}),
+	...(i.publisher ? { publisher: ref(i.publisher) } : {}),
+});
+
+export interface WebPageInput {
+	url: string;
+	name: string;
+	description?: string;
+	image?: string;
+	isPartOf?: SchemaNode | string;
+	breadcrumb?: SchemaNode | string;
+	primaryImageOfPage?: string;
+	dateModified?: string;
+}
+
+export const webPage = (i: WebPageInput): SchemaNode => ({
+	'@type': 'WebPage',
+	'@id': `${i.url}#webpage`,
+	url: i.url,
+	name: i.name,
+	...(i.description ? { description: i.description } : {}),
+	...(i.image ? { image: i.image } : {}),
+	...(i.primaryImageOfPage
+		? { primaryImageOfPage: i.primaryImageOfPage }
+		: {}),
+	...(i.isPartOf ? { isPartOf: ref(i.isPartOf) } : {}),
+	...(i.breadcrumb ? { breadcrumb: ref(i.breadcrumb) } : {}),
+	...(i.dateModified ? { dateModified: i.dateModified } : {}),
+});
+
+export type Crumb = [name: string, path: string];
+
+export const breadcrumbs = (
+	siteUrl: string,
+	crumbs: Crumb[],
+	id?: string,
+): SchemaNode => ({
+	'@type': 'BreadcrumbList',
+	...(id ? { '@id': id } : {}),
+	itemListElement: crumbs.map(([name, path], idx) => ({
+		'@type': 'ListItem',
+		position: idx + 1,
+		name,
+		item: abs(siteUrl, path),
+	})),
+});
+
+export interface ListEntry {
+	name: string;
+	description?: string;
+	url?: string;
+	image?: string;
+}
+
+export const itemList = (
+	siteUrl: string,
+	entries: ListEntry[],
+	opts: { id?: string; name?: string; description?: string } = {},
+): SchemaNode => ({
+	'@type': 'ItemList',
+	...(opts.id ? { '@id': opts.id } : {}),
+	...(opts.name ? { name: opts.name } : {}),
+	...(opts.description ? { description: opts.description } : {}),
+	numberOfItems: entries.length,
+	itemListElement: entries.map((e, idx) => ({
+		'@type': 'ListItem',
+		position: idx + 1,
+		name: e.name,
+		...(e.description ? { description: e.description } : {}),
+		...(e.url ? { url: abs(siteUrl, e.url) } : {}),
+		...(e.image ? { image: e.image } : {}),
+	})),
+});
+
+export interface FaqEntry {
+	question: string;
+	answer: string;
+}
+
+export const faqPage = (entries: FaqEntry[], id?: string): SchemaNode => ({
+	'@type': 'FAQPage',
+	...(id ? { '@id': id } : {}),
+	mainEntity: entries.map((e) => ({
+		'@type': 'Question',
+		name: e.question,
+		acceptedAnswer: { '@type': 'Answer', text: e.answer },
+	})),
+});
+
+export interface PersonInput {
+	url: string;
+	name: string;
+	image?: string;
+	sameAs?: string[];
+	description?: string;
+}
+
+export const person = (i: PersonInput): SchemaNode => ({
+	'@type': 'Person',
+	'@id': `${i.url}#person`,
+	name: i.name,
+	url: i.url,
+	...(i.image ? { image: i.image } : {}),
+	...(i.description ? { description: i.description } : {}),
+	...(i.sameAs?.length ? { sameAs: i.sameAs } : {}),
+});
+
+export interface SoftwareAppInput {
+	url: string;
+	name: string;
+	description?: string;
+	applicationCategory?: string;
+	operatingSystem?: string;
+	image?: string;
+	offers?: { price: string | number; priceCurrency: string };
+}
+
+export const softwareApplication = (i: SoftwareAppInput): SchemaNode => ({
+	'@type': 'SoftwareApplication',
+	'@id': `${i.url}#software`,
+	name: i.name,
+	url: i.url,
+	...(i.description ? { description: i.description } : {}),
+	...(i.applicationCategory
+		? { applicationCategory: i.applicationCategory }
+		: {}),
+	...(i.operatingSystem ? { operatingSystem: i.operatingSystem } : {}),
+	...(i.image ? { image: i.image } : {}),
+	...(i.offers
+		? {
+				offers: {
+					'@type': 'Offer',
+					price: String(i.offers.price),
+					priceCurrency: i.offers.priceCurrency,
+				},
+			}
+		: {}),
+});
+
+export interface VideoGameInput {
+	url: string;
+	name: string;
+	description?: string;
+	image?: string;
+	genre?: string | string[];
+	gamePlatform?: string | string[];
+	publisher?: SchemaNode | string;
+	applicationCategory?: string;
+}
+
+export const videoGame = (i: VideoGameInput): SchemaNode => ({
+	'@type': 'VideoGame',
+	'@id': `${i.url}#game`,
+	name: i.name,
+	url: i.url,
+	...(i.description ? { description: i.description } : {}),
+	...(i.image ? { image: i.image } : {}),
+	...(i.genre ? { genre: i.genre } : {}),
+	...(i.gamePlatform ? { gamePlatform: i.gamePlatform } : {}),
+	...(i.applicationCategory
+		? { applicationCategory: i.applicationCategory }
+		: {}),
+	...(i.publisher ? { publisher: ref(i.publisher) } : {}),
+});
+
+export const dedupeGraph = (nodes: SchemaNode[]): SchemaNode[] => {
+	const seen = new Map<string, SchemaNode>();
+	const out: SchemaNode[] = [];
+	for (const node of nodes) {
+		if (!node) continue;
+		const id = node['@id'];
+		if (typeof id === 'string') {
+			if (seen.has(id)) continue;
+			seen.set(id, node);
+		}
+		out.push(node);
+	}
+	return out;
+};


### PR DESCRIPTION
## What

Adds a shared structured-data module `@kbve/astro/seo` and rewrites the **Features** page (`/feature/`) onto it — replacing ad-hoc, disconnected per-page JSON-LD with one connected `@graph` for stronger SEO.

### Module (`packages/npm/astro/src/seo/`)
- `schema.ts` — typed schema.org builders: `org`, `website`, `webPage`, `breadcrumbs`, `itemList`, `faqPage`, `person`, `softwareApplication`, `videoGame` + `dedupeGraph`. Generic, no site hardcoding.
- `index.ts` — `createSeo({siteUrl,name,logo,sameAs})` factory: binds site URL, auto-fills `isPartOf`, absolutizes paths, `seo.graph(...)` prepends Organization + WebSite.
- `JsonLd.astro` — one component, emits a single `<script type="application/ld+json">` wrapping all nodes in `@graph`, dedups by `@id`.

### Site wiring
- `apps/kbve/astro-kbve/src/lib/seo.ts` — KBVE org/logo/sameAs defined once.
- `feature.mdx` — real KBVE capability cards (RingShipGrid), highlight showcase, CTA, and linked structured data. Bespoke `FeatureJsonLd.astro` removed.
- tsconfig path added for `@kbve/astro/seo`.

## Verified
Full `astro-kbve:build` passes (7690 pages). Built `/feature/` emits one `@graph`:
`Organization -> WebSite -> WebPage -> BreadcrumbList -> ItemList` (6 features), all `@id`-cross-referenced.

## Follow-up
Retrofit OSRS / profile / webmaster pages onto the same module to remove remaining ad-hoc JSON-LD.