### PR TITLE
fix(kyverno): grant background-controller Secret RBAC for valkey-auth sync

### DIFF
--- a/apps/kube/valkey/manifests/kustomization.yaml
+++ b/apps/kube/valkey/manifests/kustomization.yaml
@@ -5,4 +5,5 @@ resources:
     - valkey-auth-sealedsecret.yaml
     - valkey-networkpolicy.yaml
     - valkey-sccache-rbac.yaml
+    - valkey-auth-sync-rbac.yaml
     - valkey-auth-sync-policy.yaml

--- a/apps/kube/valkey/manifests/valkey-auth-sync-rbac.yaml
+++ b/apps/kube/valkey/manifests/valkey-auth-sync-rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+    name: kyverno:valkey-auth-sync
+    labels:
+        rbac.kyverno.io/aggregate-to-admission-controller: 'true'
+        rbac.kyverno.io/aggregate-to-background-controller: 'true'
+        rbac.kyverno.io/aggregate-to-reports-controller: 'true'
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'list', 'watch', 'create', 'update', 'patch', 'delete']


### PR DESCRIPTION
## Summary

PR #11826 added a Kyverno ClusterPolicy \`sync-valkey-auth\` that clones \`valkey/valkey-auth\` into forgejo/n8n/discordsh. The admission webhook rejects it because Kyverno's controllers don't have the required Secret RBAC:

\`\`\`
admission webhook \"validate-policy.kyverno.svc\" denied the request:
path: spec.rules[0].generate..:
system:serviceaccount:kyverno:kyverno-admission-controller
requires permissions list,get for resource v1/Secret in namespace forgejo
\`\`\`

Result: ClusterPolicy stuck \`OutOfSync\`, \`valkey-auth\` Secret never generated in the consumer namespaces, forgejo/n8n/discordsh pods stuck in \`CreateContainerConfigError\` waiting on the Secret. \`git.kbve.com\` still down.

## Fix

\`apps/kube/valkey/manifests/valkey-auth-sync-rbac.yaml\` (new) — ClusterRole with three aggregation labels (\`admission-controller\`, \`background-controller\`, \`reports-controller\`) granting Secret read+write cluster-wide. Kyverno picks this up automatically via its native aggregation.

## Test plan

After ArgoCD sync:
- [ ] \`kubectl get clusterpolicy sync-valkey-auth\` shows Ready.
- [ ] \`kubectl get secret valkey-auth -A\` returns valkey/forgejo/n8n/discordsh entries.
- [ ] forgejo pod flips from CreateContainerConfigError → Running.
- [ ] git.kbve.com returns 200.