### PR TITLE
fix(ci): unhang irc-gateway docker test by pre-installing playwright + cache

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -160,6 +160,7 @@ jobs:
             nx_project: ${{ steps.resolve.outputs.nx_project }}
             source_path: ${{ steps.resolve.outputs.source_path }}
             external_publish: ${{ steps.resolve.outputs.external_publish }}
+            install_playwright: ${{ steps.resolve.outputs.install_playwright }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -193,6 +194,13 @@ jobs:
                   echo "source_path=$(echo "$ENTRY" | jq -r '.source_path // empty')"          >> "$GITHUB_OUTPUT"
                   echo "external_publish=$(echo "$ENTRY" | jq -c '.external_publish // empty')" >> "$GITHUB_OUTPUT"
 
+                  E2E_NAME=$(echo "$ENTRY" | jq -r '.e2e_name // empty')
+                  case "$E2E_NAME" in
+                    irc) PW=true ;;
+                    *)   PW=false ;;
+                  esac
+                  echo "install_playwright=${PW}" >> "$GITHUB_OUTPUT"
+
     # ---------------------------------------------------------------------------
     # Test — builds the app image, tags as ci-{sha} in GHCR, runs e2e tests.
     # Skipped for apps that have no e2e suite (e.g. kilobase).
@@ -214,7 +222,7 @@ jobs:
             project: ${{ needs.config.outputs.e2e_name }}
             runner: ${{ needs.config.outputs.runner }}
             image: ${{ needs.config.outputs.image }}
-            install_playwright: false
+            install_playwright: ${{ needs.config.outputs.install_playwright == 'true' }}
             version_source: ${{ needs.config.outputs.version_source }}
             version_target: ${{ needs.config.outputs.version_target }}
 

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -127,24 +127,42 @@ jobs:
               with:
                   enable-cache: false
 
-            - name: Install Playwright Browsers
+            - name: Resolve Playwright version
               if: ${{ inputs.install_playwright }}
+              id: playwright-version
+              run: |
+                  VER=$(node -e "console.log(require('./node_modules/playwright/package.json').version)" 2>/dev/null || echo "unknown")
+                  echo "version=${VER}" >> "$GITHUB_OUTPUT"
+                  echo "Resolved Playwright version: ${VER}"
+
+            - name: Cache Playwright browsers
+              if: ${{ inputs.install_playwright }}
+              id: playwright-cache
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-chromium-webkit
+                  restore-keys: |
+                      ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+                      ${{ runner.os }}-playwright-
+
+            - name: Install Playwright Browsers
+              if: ${{ inputs.install_playwright && steps.playwright-cache.outputs.cache-hit != 'true' }}
               timeout-minutes: 15
               env:
                   UV_THREADPOOL_SIZE: '16'
               run: pnpm exec playwright install --with-deps chromium webkit
 
-            # VALKEY_PASSWORD is injected into the runner container's
-            # process env by the actions-runner-controller values.yaml
-            # (sourced from the valkey-sccache-credentials Secret synced
-            # by ExternalSecret). It auto-inherits into `run:` steps,
-            # so no explicit env entry needed — axum-kbve's container:ci
-            # command picks it up via `${VALKEY_PASSWORD:+--secret ...}`
-            # and only attaches the build secret when present.
+            - name: Install Playwright OS deps (cache hit)
+              if: ${{ inputs.install_playwright && steps.playwright-cache.outputs.cache-hit == 'true' }}
+              timeout-minutes: 10
+              run: pnpm exec playwright install-deps chromium webkit
+
             - name: Nx e2e ${{ inputs.project }}
               env:
                   BUILDKIT_PROGRESS: plain
                   INPUT_GITHUB_TOKEN: ${{ github.token }}
+                  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ inputs.install_playwright && '1' || '' }}
               run: pnpm nx e2e ${{ inputs.project }} --configuration=ci --no-cloud --output-style=stream
 
             - name: Mark test passed


### PR DESCRIPTION
## Why

[Run 27053598231](https://github.com/KBVE/kbve/actions/runs/27053598231/job/79853556612) sat for 3 hours and got killed by the 180-minute job cap. Last log line before the dead air:

\`\`\`
[irc] NX  Ensuring Playwright is installed.
[irc] Downloading Chrome for Testing 147.0.7727.15 (playwright chromium v1217) from https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip
\`\`\`

The hang is **inside** \`pnpm nx e2e irc\` — the \`@nx/playwright:playwright\` executor auto-installs chromium on first run, and \`cdn.playwright.dev\` returns a stalled TCP connection sometimes (no client-side timeout, so it just sits forever).

We had \`install_playwright: false\` in \`ci-docker.yml\`, so the workflow-level \"Install Playwright Browsers\" step (which **does** have a 15-minute timeout) was being skipped — the executor's silent retry took over and burned the whole job slot.

## What changed

- **\`ci-docker.yml\`**: derive \`install_playwright\` from \`e2e_name\` in the config job. Only \`irc\` is true today; everything else stays false. Flows through to \`docker-test-app.yml\`.
- **\`docker-test-app.yml\`**:
  - Restore \`~/.cache/ms-playwright\` from \`actions/cache\` keyed by the resolved Playwright version. Cache hit ⇒ skip the chromium/webkit download, only run \`playwright install-deps\` for apt packages. Cache miss ⇒ run the full install under the existing 15-minute timeout, so a stuck CDN fails fast instead of consuming the entire job.
  - Set \`PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1\` on the \`pnpm nx e2e ...\` step when we already pre-installed browsers, so the Nx executor's \"Ensuring Playwright is installed\" doesn't fire a second download from inside the job.

## Test plan

- [ ] Re-run the irc-gateway docker dispatch on this branch
- [ ] First run: \"Install Playwright Browsers\" step runs (cache miss), under 15-minute cap. If \`cdn.playwright.dev\` is healthy, finishes in 1-2 minutes
- [ ] Subsequent runs: cache hit — only \`install-deps\` runs (~30s); zero chromium downloads
- [ ] \`pnpm nx e2e irc --configuration=ci\` does NOT log \`Ensuring Playwright is installed.\` (skip env var honored)
- [ ] Other docker app tests (memes, cryptothrone, etc.) skip Playwright install entirely — no regression