### PR TITLE
feat(cryptothrone): Supabase auth + v0.1.6

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
+++ b/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
@@ -29,6 +29,10 @@ export default defineConfig({
 					label: 'Guides',
 					items: [{ autogenerate: { directory: 'guides' } }],
 				},
+				{
+					label: 'Account',
+					items: [{ autogenerate: { directory: 'auth' } }],
+				},
 			],
 		}),
 		react(),
@@ -36,6 +40,9 @@ export default defineConfig({
 	],
 	vite: {
 		plugins: [tailwindcss()],
+		resolve: {
+			dedupe: ['react', 'react-dom', 'react/jsx-runtime'],
+		},
 		build: {
 			chunkSizeWarningLimit: 1200,
 			rollupOptions: {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/AstroCallback.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/AstroCallback.astro
@@ -1,0 +1,41 @@
+---
+import ReactAuthCallback from './ReactAuthCallback';
+---
+
+<ReactAuthCallback client:only="react" />
+
+<style is:global>
+	.ct-auth-status {
+		max-width: 500px;
+		margin: 3rem auto;
+		text-align: center;
+	}
+
+	.ct-status-message {
+		font-size: 1.25rem;
+		color: var(--sl-color-white);
+		margin-top: 1rem;
+	}
+
+	.ct-status-sub {
+		color: var(--sl-color-gray-3);
+		font-size: 0.9rem;
+		margin-top: 0.5rem;
+	}
+
+	.ct-spinner {
+		width: 40px;
+		height: 40px;
+		margin: 0 auto;
+		border: 3px solid var(--sl-color-hairline-light);
+		border-top-color: var(--sl-color-text-accent);
+		border-radius: 50%;
+		animation: ct-spin 0.8s linear infinite;
+	}
+
+	@keyframes ct-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/AstroLogin.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/AstroLogin.astro
@@ -1,0 +1,144 @@
+---
+import ReactLoginButtons from './ReactLoginButtons';
+---
+
+<div class="ct-auth-container">
+	<div class="ct-auth-content">
+		<h2>Enter the Throne</h2>
+		<p class="ct-auth-desc">
+			Sign in to save your progress, claim your seat, and compete on the
+			leaderboards.
+		</p>
+
+		<ReactLoginButtons client:load />
+
+		<div class="ct-auth-info">
+			<p>
+				By signing in, you agree to our Terms of Service and Privacy
+				Policy.
+			</p>
+		</div>
+	</div>
+</div>
+
+<style is:global>
+	.ct-auth-container {
+		max-width: 500px;
+		margin: 2rem auto;
+		padding: 2rem 1rem;
+	}
+
+	.ct-auth-content {
+		text-align: center;
+	}
+
+	.ct-auth-content h2 {
+		font-family: var(--sl-font);
+		color: var(--sl-color-white);
+		margin-bottom: 1rem;
+	}
+
+	.ct-auth-desc {
+		color: var(--sl-color-gray-2);
+		margin-bottom: 2rem;
+		line-height: 1.6;
+	}
+
+	.ct-auth-buttons {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		margin-bottom: 2rem;
+		min-height: 120px;
+	}
+
+	.ct-auth-btn {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		padding: 0.875rem 1.5rem;
+		border: 1px solid var(--sl-color-hairline-light);
+		border-radius: 4px;
+		font-size: 1rem;
+		font-weight: 500;
+		cursor: pointer;
+		transition: all 0.2s;
+	}
+
+	.ct-auth-btn:hover:not(:disabled) {
+		transform: translateY(-2px);
+		box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+	}
+
+	.ct-auth-btn:disabled {
+		opacity: 0.6;
+		cursor: not-allowed;
+	}
+
+	.ct-auth-btn--github {
+		background: #24292e;
+		color: white;
+	}
+
+	.ct-auth-btn--github:hover:not(:disabled) {
+		background: #2f363d;
+	}
+
+	.ct-auth-btn--discord {
+		background: #5865f2;
+		color: white;
+	}
+
+	.ct-auth-btn--discord:hover:not(:disabled) {
+		background: #4752c4;
+	}
+
+	.ct-auth-icon {
+		width: 20px;
+		height: 20px;
+	}
+
+	.ct-auth-info {
+		color: var(--sl-color-gray-3);
+		font-size: 0.875rem;
+	}
+
+	.ct-auth-info p {
+		margin: 0;
+	}
+
+	.ct-auth-status {
+		max-width: 500px;
+		margin: 3rem auto;
+		text-align: center;
+	}
+
+	.ct-status-message {
+		font-size: 1.25rem;
+		color: var(--sl-color-white);
+		margin-top: 1rem;
+	}
+
+	.ct-status-sub {
+		color: var(--sl-color-gray-3);
+		font-size: 0.9rem;
+		margin-top: 0.5rem;
+	}
+
+	.ct-spinner {
+		width: 40px;
+		height: 40px;
+		margin: 0 auto;
+		border: 3px solid var(--sl-color-hairline-light);
+		border-top-color: var(--sl-color-text-accent);
+		border-radius: 50%;
+		animation: ct-spin 0.8s linear infinite;
+	}
+
+	@keyframes ct-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/AstroLogout.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/AstroLogout.astro
@@ -1,0 +1,41 @@
+---
+import ReactAuthLogout from './ReactAuthLogout';
+---
+
+<ReactAuthLogout client:only="react" />
+
+<style is:global>
+	.ct-auth-status {
+		max-width: 500px;
+		margin: 3rem auto;
+		text-align: center;
+	}
+
+	.ct-status-message {
+		font-size: 1.25rem;
+		color: var(--sl-color-white);
+		margin-top: 1rem;
+	}
+
+	.ct-status-sub {
+		color: var(--sl-color-gray-3);
+		font-size: 0.9rem;
+		margin-top: 0.5rem;
+	}
+
+	.ct-spinner {
+		width: 40px;
+		height: 40px;
+		margin: 0 auto;
+		border: 3px solid var(--sl-color-hairline-light);
+		border-top-color: var(--sl-color-text-accent);
+		border-radius: 50%;
+		animation: ct-spin 0.8s linear infinite;
+	}
+
+	@keyframes ct-spin {
+		to {
+			transform: rotate(360deg);
+		}
+	}
+</style>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactAuthCallback.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactAuthCallback.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { authBridge, initSupa, getSupa } from '@/lib/supa';
+
+export default function ReactAuthCallback() {
+	const [message, setMessage] = useState('Completing sign-in...');
+	const [subMessage, setSubMessage] = useState('Please wait');
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		const handleCallback = async () => {
+			try {
+				const session = await Promise.race([
+					authBridge.handleCallback(),
+					new Promise<null>((_, reject) =>
+						setTimeout(
+							() => reject(new Error('Auth callback timed out')),
+							10_000,
+						),
+					),
+				]);
+
+				if (session) {
+					await initSupa();
+					const supa = getSupa();
+
+					let workerSession = await supa
+						.getSession()
+						.catch(() => null);
+					if (!workerSession?.session) {
+						await new Promise((r) => setTimeout(r, 300));
+						workerSession = await supa
+							.getSession()
+							.catch(() => null);
+					}
+
+					window.location.href = '/';
+				} else {
+					setIsLoading(false);
+					setMessage('Authentication failed');
+					setSubMessage('Redirecting...');
+					setTimeout(() => {
+						window.location.href = '/';
+					}, 2000);
+				}
+			} catch (error) {
+				console.error('Auth callback error:', error);
+				setIsLoading(false);
+				setMessage('Authentication failed');
+				setSubMessage('Redirecting...');
+				setTimeout(() => {
+					window.location.href = '/';
+				}, 2000);
+			}
+		};
+
+		handleCallback();
+	}, []);
+
+	return (
+		<div className="ct-auth-status">
+			{isLoading && <div className="ct-spinner"></div>}
+			<div className="ct-status-message">{message}</div>
+			<div className="ct-status-sub">{subMessage}</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactAuthLogout.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactAuthLogout.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { authBridge } from '@/lib/supa';
+
+export default function ReactAuthLogout() {
+	const [message, setMessage] = useState('Signing out...');
+	const [subMessage, setSubMessage] = useState('Please wait');
+	const [isLoading, setIsLoading] = useState(true);
+
+	useEffect(() => {
+		const handleLogout = async () => {
+			try {
+				await authBridge.signOut();
+			} catch (err) {
+				console.log('[Logout] signOut skipped:', err);
+			}
+
+			try {
+				await authBridge.destroy();
+			} catch (err) {
+				console.warn('[Logout] destroy error:', err);
+			}
+
+			try {
+				Object.keys(localStorage).forEach((key) => {
+					if (key.includes('supabase') || key.includes('sb-')) {
+						localStorage.removeItem(key);
+					}
+				});
+			} catch (err) {
+				console.warn('[Logout] localStorage cleanup error:', err);
+			}
+
+			setIsLoading(false);
+			setMessage('Signed out successfully');
+			setSubMessage('Returning to the realm...');
+			setTimeout(() => {
+				window.location.href = '/?_=' + Date.now();
+			}, 500);
+		};
+
+		handleLogout();
+	}, []);
+
+	return (
+		<div className="ct-auth-status">
+			{isLoading && <div className="ct-spinner"></div>}
+			<div className="ct-status-message">{message}</div>
+			<div className="ct-status-sub">{subMessage}</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactLoginButtons.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactLoginButtons.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { authBridge } from '@/lib/supa';
+
+export default function ReactLoginButtons() {
+	const [isLoading, setIsLoading] = useState<string | null>(null);
+
+	const handleLogin = async (provider: 'github' | 'discord') => {
+		try {
+			setIsLoading(provider);
+			await authBridge.signInWithOAuth(provider);
+		} catch (error) {
+			console.error(`${provider} sign-in error:`, error);
+			setIsLoading(null);
+		}
+	};
+
+	return (
+		<div className="ct-auth-buttons">
+			<button
+				onClick={() => handleLogin('github')}
+				disabled={isLoading !== null}
+				className="ct-auth-btn ct-auth-btn--github">
+				<svg
+					className="ct-auth-icon"
+					viewBox="0 0 16 16"
+					fill="currentColor"
+					aria-hidden="true">
+					<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+				</svg>
+				{isLoading === 'github'
+					? 'Opening portal...'
+					: 'Sign in with GitHub'}
+			</button>
+
+			<button
+				onClick={() => handleLogin('discord')}
+				disabled={isLoading !== null}
+				className="ct-auth-btn ct-auth-btn--discord">
+				<svg
+					className="ct-auth-icon"
+					viewBox="0 0 16 16"
+					fill="currentColor"
+					aria-hidden="true">
+					<path d="M13.545 2.907a13.227 13.227 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.19 12.19 0 0 0-3.658 0 8.258 8.258 0 0 0-.412-.833.051.051 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.041.041 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032c.001.014.01.028.021.037a13.276 13.276 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019c.308-.42.582-.863.818-1.329a.05.05 0 0 0-.01-.059.051.051 0 0 0-.018-.011 8.875 8.875 0 0 1-1.248-.595.05.05 0 0 1-.02-.066.051.051 0 0 1 .015-.019c.084-.063.168-.129.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.052.052 0 0 1 .053.007c.08.066.164.132.248.195a.051.051 0 0 1-.004.085 8.254 8.254 0 0 1-1.249.594.05.05 0 0 0-.03.03.052.052 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.235 13.235 0 0 0 4.001-2.02.049.049 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.034.034 0 0 0-.02-.019Zm-8.198 7.307c-.789 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612Zm5.316 0c-.788 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612Z" />
+				</svg>
+				{isLoading === 'discord'
+					? 'Opening portal...'
+					: 'Sign in with Discord'}
+			</button>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/index.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/index.ts
@@ -1,0 +1,1 @@
+export { authBridge } from '@/lib/supa';

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/auth/callback.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/auth/callback.mdx
@@ -1,0 +1,15 @@
+---
+title: Callback
+description: Authentication callback
+head:
+  - tag: meta
+    attrs:
+      name: robots
+      content: noindex, nofollow
+sidebar:
+  hidden: true
+---
+
+import AstroCallback from '../../../components/auth/AstroCallback.astro';
+
+<AstroCallback />

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/auth/login.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/auth/login.mdx
@@ -1,0 +1,28 @@
+---
+title: Sign In
+description: Sign in to your CryptoThrone account. Cross-device sync for saves, settings, and updates.
+head:
+  - tag: meta
+    attrs:
+      name: robots
+      content: noindex, nofollow
+sidebar:
+  label: Sign In
+  order: 1
+  attrs:
+    data-auth-visibility: anon
+---
+
+import AstroLogin from '../../../components/auth/AstroLogin.astro';
+
+<AstroLogin />
+
+## Why sign in
+
+- **Cloud saves** — progress and settings sync across every device you play on.
+- **Update notifications** — new builds and major updates surface in your account.
+- **Shared community** — one KBVE account covers CryptoThrone plus Discord / GitHub integrations across all KBVE properties.
+
+## Supported providers
+
+**GitHub** and **Discord** are supported today. We only pull the basics from OAuth — username, email, avatar — nothing else.

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/auth/logout.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/auth/logout.mdx
@@ -1,0 +1,13 @@
+---
+title: Sign Out
+description: Sign out from your CryptoThrone account
+sidebar:
+  label: Sign Out
+  order: 2
+  attrs:
+    data-auth-visibility: auth
+---
+
+import AstroLogout from '../../../components/auth/AstroLogout.astro';
+
+<AstroLogout />

--- a/apps/cryptothrone/astro-cryptothrone/src/lib/supa.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/lib/supa.ts
@@ -1,0 +1,30 @@
+import { AuthBridge, SupabaseGateway, bootAuth } from '@kbve/astro';
+
+export const SUPABASE_URL = 'https://supabase.kbve.com';
+export const SUPABASE_ANON_KEY =
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoiYW5vbiIsImlzcyI6InN1cGFiYXNlIiwiaWF0IjoxNzU1NDAzMjAwLCJleHAiOjE5MTMxNjk2MDB9.oietJI22ZytbghFywvdYMSJp7rcsBdBYbcciJxeGWrg';
+
+export const authBridge = new AuthBridge(SUPABASE_URL, SUPABASE_ANON_KEY);
+
+let _gateway: SupabaseGateway | null = null;
+let _initPromise: Promise<void> | null = null;
+
+export function initSupa(): Promise<void> {
+	if (_initPromise) return _initPromise;
+
+	_gateway = new SupabaseGateway();
+	_initPromise = _gateway
+		.init(SUPABASE_URL, SUPABASE_ANON_KEY)
+		.then(() => bootAuth(_gateway!, authBridge))
+		.catch((e) => {
+			_initPromise = null;
+			throw e;
+		});
+
+	return _initPromise;
+}
+
+export function getSupa(): SupabaseGateway {
+	if (!_gateway) throw new Error('Call initSupa() first');
+	return _gateway;
+}

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -8,6 +8,11 @@
 		"baseUrl": ".",
 		"paths": {
 			"@/*": ["src/*"],
+			"@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
+			"@kbve/astro/components/*": [
+				"../../../packages/npm/astro/src/components/*"
+			],
+			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"]
 		}
 	}

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.5"
+version: "0.1.6"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## What
Wire Supabase auth into astro-cryptothrone, mirroring the `@kbve/astro` pattern already used by astro-rareicon / astro-kbve.

- `src/lib/supa.ts` — `AuthBridge` + `SupabaseGateway` init, GitHub/Discord OAuth
- auth islands: `ReactLoginButtons`, `ReactAuthCallback`, `ReactAuthLogout` + Astro wrappers (`client:only="react"`)
- docs pages `/auth/{login,callback,logout}` under new **Account** sidebar group
- `tsconfig` `@kbve/astro`+`@kbve/droid` path aliases, vite `react` dedupe
- bump CI registry `version: 0.1.5 -> 0.1.6`

## Verify
`astro-cryptothrone:build` green — 7 pages incl. all three auth routes prerendered. IDB-unavailable warning at SSG is expected (in-memory fallback; real IndexedDB in browser).