### PR TITLE
fix(valkey): allow forgejo/n8n/discordsh ingress for redis→valkey migration

### DIFF
--- a/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
+++ b/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-    name: valkey-allow-arc-runners
+    name: valkey-allow-consumers
     namespace: valkey
 spec:
     podSelector:
@@ -14,6 +14,15 @@ spec:
               - namespaceSelector:
                     matchLabels:
                         kubernetes.io/metadata.name: arc-runners
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: forgejo
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: n8n
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: discordsh
           ports:
               - port: 6379
                 protocol: TCP


### PR DESCRIPTION
After PR #11826 rerouted forgejo/n8n/discordsh to valkey, the existing valkey-allow-arc-runners NetworkPolicy still only allowed arc-runners. forgejo pods come up with the new config, hit the valkey ClusterIP, and timed out:

    cache.Init failed: dial tcp 10.104.209.78:6379: i/o timeout

Rename to valkey-allow-consumers and add forgejo + n8n + discordsh namespaceSelectors.