### PR TITLE
feat(KBVEUI): settings frame + reusable settings row widgets

### DIFF
--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsComboRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsComboRow.cpp
@@ -1,0 +1,72 @@
+#include "SKBVESettingsComboRow.h"
+
+#include "SKBVESettingsRow.h"
+#include "Styling/CoreStyle.h"
+#include "Widgets/Input/SComboBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+void SKBVESettingsComboRow::Construct(const FArguments& InArgs)
+{
+	OnSelectionChanged = InArgs._OnSelectionChanged;
+
+	for (const FString& Option : InArgs._Options)
+	{
+		Options.Add(MakeShared<FString>(Option));
+	}
+
+	if (Options.IsValidIndex(InArgs._InitialSelection))
+	{
+		CurrentItem = Options[InArgs._InitialSelection];
+	}
+	else if (Options.Num() > 0)
+	{
+		CurrentItem = Options[0];
+	}
+
+	const FSlateFontInfo Font = FCoreStyle::GetDefaultFontStyle("Regular", 11);
+
+	ChildSlot
+	[
+		SNew(SKBVESettingsRow)
+		.LabelWidth(InArgs._LabelWidth)
+		.Label(InArgs._Label)
+		.Hint(InArgs._Hint)
+		.Content
+		[
+			SNew(SComboBox<TSharedPtr<FString>>)
+			.OptionsSource(&Options)
+			.InitiallySelectedItem(CurrentItem)
+			.OnGenerateWidget(this, &SKBVESettingsComboRow::MakeOptionWidget)
+			.OnSelectionChanged(this, &SKBVESettingsComboRow::HandleSelectionChanged)
+			[
+				SNew(STextBlock)
+				.Text(this, &SKBVESettingsComboRow::SelectedText)
+				.Font(Font)
+				.ColorAndOpacity(FLinearColor(0.85f, 0.85f, 0.88f, 0.95f))
+			]
+		]
+	];
+}
+
+TSharedRef<SWidget> SKBVESettingsComboRow::MakeOptionWidget(TSharedPtr<FString> InItem)
+{
+	return SNew(STextBlock)
+		.Text(InItem.IsValid() ? FText::FromString(*InItem) : FText::GetEmpty())
+		.Font(FCoreStyle::GetDefaultFontStyle("Regular", 11));
+}
+
+void SKBVESettingsComboRow::HandleSelectionChanged(TSharedPtr<FString> InItem, ESelectInfo::Type SelectInfo)
+{
+	if (!InItem.IsValid())
+	{
+		return;
+	}
+	CurrentItem = InItem;
+	const int32 Index = Options.IndexOfByKey(InItem);
+	OnSelectionChanged.ExecuteIfBound(*InItem, Index);
+}
+
+FText SKBVESettingsComboRow::SelectedText() const
+{
+	return CurrentItem.IsValid() ? FText::FromString(*CurrentItem) : FText::GetEmpty();
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsFrame.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsFrame.cpp
@@ -1,0 +1,118 @@
+#include "SKBVESettingsFrame.h"
+
+#include "SKBVEMovableFrame.h"
+#include "Styling/CoreStyle.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/SNullWidget.h"
+#include "Widgets/SOverlay.h"
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Layout/SScrollBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+void SKBVESettingsFrame::Construct(const FArguments& InArgs)
+{
+	OnApply  = InArgs._OnApplyClicked;
+	OnReset  = InArgs._OnResetClicked;
+	OnCancel = InArgs._OnCancelClicked;
+
+	const FSlateFontInfo ButtonFont = FCoreStyle::GetDefaultFontStyle("Bold", 11);
+	const FSlateBrush* WhiteBrush   = FCoreStyle::Get().GetBrush("WhiteBrush");
+
+	TSharedRef<SHorizontalBox> Footer = SNew(SHorizontalBox);
+	Footer->AddSlot().FillWidth(1.f)[ SNullWidget::NullWidget ];
+
+	if (InArgs._bShowReset)
+	{
+		Footer->AddSlot().AutoWidth().Padding(6.f, 0.f, 0.f, 0.f)
+		[
+			SNew(SButton)
+			.OnClicked(this, &SKBVESettingsFrame::HandleReset)
+			[ SNew(STextBlock).Text(NSLOCTEXT("KBVEUI", "SettingsReset", "Reset")).Font(ButtonFont) ]
+		];
+	}
+
+	if (InArgs._bShowCancel)
+	{
+		Footer->AddSlot().AutoWidth().Padding(6.f, 0.f, 0.f, 0.f)
+		[
+			SNew(SButton)
+			.OnClicked(this, &SKBVESettingsFrame::HandleCancel)
+			[ SNew(STextBlock).Text(NSLOCTEXT("KBVEUI", "SettingsCancel", "Cancel")).Font(ButtonFont) ]
+		];
+	}
+
+	if (InArgs._bShowApply)
+	{
+		Footer->AddSlot().AutoWidth().Padding(6.f, 0.f, 0.f, 0.f)
+		[
+			SNew(SButton)
+			.OnClicked(this, &SKBVESettingsFrame::HandleApply)
+			[ SNew(STextBlock).Text(NSLOCTEXT("KBVEUI", "SettingsApply", "Apply")).Font(ButtonFont) ]
+		];
+	}
+
+	ChildSlot
+	[
+		SNew(SKBVEMovableFrame)
+		.InitialPosition(InArgs._InitialPosition)
+		.FrameSize(InArgs._FrameSize)
+		.MinFrameSize(InArgs._MinFrameSize)
+		.bResizable(InArgs._bResizable)
+		.Title(InArgs._Title)
+		.OnCloseClicked(InArgs._OnCloseClicked)
+		.Body
+		[
+			SNew(SOverlay)
+
+			+ SOverlay::Slot()
+			[
+				SNew(SImage)
+				.Image(WhiteBrush)
+				.ColorAndOpacity(FLinearColor(0.03f, 0.04f, 0.06f, 0.85f))
+			]
+
+			+ SOverlay::Slot()
+			.Padding(FMargin(14.f))
+			[
+				SNew(SVerticalBox)
+
+				+ SVerticalBox::Slot()
+				.FillHeight(1.f)
+				[
+					SNew(SScrollBox)
+
+					+ SScrollBox::Slot()
+					[
+						InArgs._Rows.Widget
+					]
+				]
+
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				.Padding(0.f, 12.f, 0.f, 0.f)
+				[
+					Footer
+				]
+			]
+		]
+	];
+}
+
+FReply SKBVESettingsFrame::HandleApply()
+{
+	OnApply.ExecuteIfBound();
+	return FReply::Handled();
+}
+
+FReply SKBVESettingsFrame::HandleReset()
+{
+	OnReset.ExecuteIfBound();
+	return FReply::Handled();
+}
+
+FReply SKBVESettingsFrame::HandleCancel()
+{
+	OnCancel.ExecuteIfBound();
+	return FReply::Handled();
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsRow.cpp
@@ -1,0 +1,58 @@
+#include "SKBVESettingsRow.h"
+
+#include "Styling/CoreStyle.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+void SKBVESettingsRow::Construct(const FArguments& InArgs)
+{
+	const FSlateFontInfo LabelFont = FCoreStyle::GetDefaultFontStyle("Regular", 12);
+	const FSlateFontInfo HintFont  = FCoreStyle::GetDefaultFontStyle("Italic", 10);
+
+	ChildSlot
+	[
+		SNew(SHorizontalBox)
+
+		+ SHorizontalBox::Slot()
+		.AutoWidth()
+		.VAlign(VAlign_Center)
+		[
+			SNew(SBox)
+			.WidthOverride(InArgs._LabelWidth)
+			[
+				SNew(SVerticalBox)
+
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				[
+					SNew(STextBlock)
+					.Text(InArgs._Label)
+					.Font(LabelFont)
+					.ColorAndOpacity(InArgs._LabelColor)
+					.AutoWrapText(true)
+				]
+
+				+ SVerticalBox::Slot()
+				.AutoHeight()
+				.Padding(0.f, 2.f, 0.f, 0.f)
+				[
+					SNew(STextBlock)
+					.Text(InArgs._Hint)
+					.Font(HintFont)
+					.ColorAndOpacity(FLinearColor(0.6f, 0.6f, 0.65f, 0.9f))
+					.AutoWrapText(true)
+					.Visibility(EVisibility::SelfHitTestInvisible)
+				]
+			]
+		]
+
+		+ SHorizontalBox::Slot()
+		.FillWidth(1.f)
+		.VAlign(VAlign_Center)
+		.Padding(12.f, 0.f, 0.f, 0.f)
+		[
+			InArgs._Content.Widget
+		]
+	];
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsSliderRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsSliderRow.cpp
@@ -1,0 +1,77 @@
+#include "SKBVESettingsSliderRow.h"
+
+#include "SKBVESettingsRow.h"
+#include "Styling/CoreStyle.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Input/SSlider.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+void SKBVESettingsSliderRow::Construct(const FArguments& InArgs)
+{
+	MinValue       = InArgs._MinValue;
+	MaxValue       = FMath::Max(InArgs._MaxValue, MinValue + KINDA_SMALL_NUMBER);
+	StepSize       = InArgs._StepSize;
+	CurrentValue   = FMath::Clamp(InArgs._Value, MinValue, MaxValue);
+	OnValueChanged = InArgs._OnValueChanged;
+
+	const FSlateFontInfo ValueFont = FCoreStyle::GetDefaultFontStyle("Regular", 11);
+
+	ChildSlot
+	[
+		SNew(SKBVESettingsRow)
+		.LabelWidth(InArgs._LabelWidth)
+		.Label(InArgs._Label)
+		.Hint(InArgs._Hint)
+		.Content
+		[
+			SNew(SHorizontalBox)
+
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.f)
+			.VAlign(VAlign_Center)
+			[
+				SNew(SSlider)
+				.Value(this, &SKBVESettingsSliderRow::Normalized)
+				.OnValueChanged(this, &SKBVESettingsSliderRow::HandleSliderMoved)
+			]
+
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(10.f, 0.f, 0.f, 0.f)
+			[
+				SNew(SBox)
+				.MinDesiredWidth(48.f)
+				[
+					SNew(STextBlock)
+					.Text(this, &SKBVESettingsSliderRow::ValueText)
+					.Font(ValueFont)
+					.ColorAndOpacity(FLinearColor(0.85f, 0.85f, 0.88f, 0.95f))
+					.Justification(ETextJustify::Right)
+				]
+			]
+		]
+	];
+}
+
+float SKBVESettingsSliderRow::Normalized() const
+{
+	return (CurrentValue - MinValue) / (MaxValue - MinValue);
+}
+
+void SKBVESettingsSliderRow::HandleSliderMoved(float InNormalized)
+{
+	float NewValue = MinValue + InNormalized * (MaxValue - MinValue);
+	if (StepSize > 0.f)
+	{
+		NewValue = MinValue + FMath::RoundToFloat((NewValue - MinValue) / StepSize) * StepSize;
+	}
+	CurrentValue = FMath::Clamp(NewValue, MinValue, MaxValue);
+	OnValueChanged.ExecuteIfBound(CurrentValue);
+}
+
+FText SKBVESettingsSliderRow::ValueText() const
+{
+	return FText::AsNumber(CurrentValue);
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsToggleRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsToggleRow.cpp
@@ -1,0 +1,33 @@
+#include "SKBVESettingsToggleRow.h"
+
+#include "SKBVESettingsRow.h"
+#include "Widgets/Input/SCheckBox.h"
+
+void SKBVESettingsToggleRow::Construct(const FArguments& InArgs)
+{
+	OnToggled = InArgs._OnToggled;
+
+	TAttribute<bool> IsChecked = InArgs._IsChecked;
+
+	ChildSlot
+	[
+		SNew(SKBVESettingsRow)
+		.LabelWidth(InArgs._LabelWidth)
+		.Label(InArgs._Label)
+		.Hint(InArgs._Hint)
+		.Content
+		[
+			SNew(SCheckBox)
+			.IsChecked_Lambda([IsChecked]()
+			{
+				return IsChecked.Get(false) ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+			})
+			.OnCheckStateChanged(this, &SKBVESettingsToggleRow::HandleChanged)
+		]
+	];
+}
+
+void SKBVESettingsToggleRow::HandleChanged(ECheckBoxState NewState)
+{
+	OnToggled.ExecuteIfBound(NewState == ECheckBoxState::Checked);
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsComboRow.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsComboRow.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Types/SlateEnums.h"
+
+DECLARE_DELEGATE_TwoParams(FOnKBVESettingSelectionChanged, FString /*Selected*/, int32 /*Index*/);
+
+class KBVEUI_API SKBVESettingsComboRow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVESettingsComboRow)
+		: _LabelWidth(220.f)
+		, _InitialSelection(0)
+	{}
+		SLATE_ARGUMENT(float, LabelWidth)
+		SLATE_ATTRIBUTE(FText, Label)
+		SLATE_ATTRIBUTE(FText, Hint)
+		SLATE_ARGUMENT(TArray<FString>, Options)
+		SLATE_ARGUMENT(int32, InitialSelection)
+		SLATE_EVENT(FOnKBVESettingSelectionChanged, OnSelectionChanged)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedRef<SWidget> MakeOptionWidget(TSharedPtr<FString> InItem);
+	void HandleSelectionChanged(TSharedPtr<FString> InItem, ESelectInfo::Type SelectInfo);
+	FText SelectedText() const;
+
+	TArray<TSharedPtr<FString>> Options;
+	TSharedPtr<FString> CurrentItem;
+
+	FOnKBVESettingSelectionChanged OnSelectionChanged;
+};

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsFrame.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsFrame.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Framework/SlateDelegates.h"
+#include "Input/Reply.h"
+
+class KBVEUI_API SKBVESettingsFrame : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVESettingsFrame)
+		: _InitialPosition(FVector2D(200.f, 180.f))
+		, _FrameSize(FVector2D(640.f, 520.f))
+		, _MinFrameSize(FVector2D(420.f, 320.f))
+		, _bResizable(true)
+		, _bShowApply(true)
+		, _bShowReset(true)
+		, _bShowCancel(true)
+	{}
+		SLATE_ARGUMENT(FVector2D, InitialPosition)
+		SLATE_ARGUMENT(FVector2D, FrameSize)
+		SLATE_ARGUMENT(FVector2D, MinFrameSize)
+		SLATE_ARGUMENT(bool, bResizable)
+		SLATE_ARGUMENT(bool, bShowApply)
+		SLATE_ARGUMENT(bool, bShowReset)
+		SLATE_ARGUMENT(bool, bShowCancel)
+		SLATE_ATTRIBUTE(FText, Title)
+		SLATE_EVENT(FSimpleDelegate, OnApplyClicked)
+		SLATE_EVENT(FSimpleDelegate, OnResetClicked)
+		SLATE_EVENT(FSimpleDelegate, OnCancelClicked)
+		SLATE_EVENT(FSimpleDelegate, OnCloseClicked)
+		SLATE_NAMED_SLOT(FArguments, Rows)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	FReply HandleApply();
+	FReply HandleReset();
+	FReply HandleCancel();
+
+	FSimpleDelegate OnApply;
+	FSimpleDelegate OnReset;
+	FSimpleDelegate OnCancel;
+};

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsRow.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsRow.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Styling/SlateColor.h"
+
+class KBVEUI_API SKBVESettingsRow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVESettingsRow)
+		: _LabelWidth(220.f)
+	{}
+		SLATE_ARGUMENT(float, LabelWidth)
+		SLATE_ATTRIBUTE(FText, Label)
+		SLATE_ATTRIBUTE(FText, Hint)
+		SLATE_ATTRIBUTE(FSlateColor, LabelColor)
+		SLATE_NAMED_SLOT(FArguments, Content)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+};

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsSliderRow.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsSliderRow.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+
+DECLARE_DELEGATE_OneParam(FOnKBVESettingValueChanged, float);
+
+class KBVEUI_API SKBVESettingsSliderRow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVESettingsSliderRow)
+		: _LabelWidth(220.f)
+		, _Value(0.f)
+		, _MinValue(0.f)
+		, _MaxValue(1.f)
+		, _StepSize(0.f)
+	{}
+		SLATE_ARGUMENT(float, LabelWidth)
+		SLATE_ATTRIBUTE(FText, Label)
+		SLATE_ATTRIBUTE(FText, Hint)
+		SLATE_ARGUMENT(float, Value)
+		SLATE_ARGUMENT(float, MinValue)
+		SLATE_ARGUMENT(float, MaxValue)
+		SLATE_ARGUMENT(float, StepSize)
+		SLATE_EVENT(FOnKBVESettingValueChanged, OnValueChanged)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	void HandleSliderMoved(float Normalized);
+	float Normalized() const;
+	FText ValueText() const;
+
+	float MinValue = 0.f;
+	float MaxValue = 1.f;
+	float StepSize = 0.f;
+	float CurrentValue = 0.f;
+
+	FOnKBVESettingValueChanged OnValueChanged;
+};

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsToggleRow.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVESettingsToggleRow.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Styling/SlateTypes.h"
+
+DECLARE_DELEGATE_OneParam(FOnKBVESettingToggled, bool);
+
+class KBVEUI_API SKBVESettingsToggleRow : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVESettingsToggleRow)
+		: _LabelWidth(220.f)
+	{}
+		SLATE_ARGUMENT(float, LabelWidth)
+		SLATE_ATTRIBUTE(FText, Label)
+		SLATE_ATTRIBUTE(FText, Hint)
+		SLATE_ATTRIBUTE(bool, IsChecked)
+		SLATE_EVENT(FOnKBVESettingToggled, OnToggled)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	void HandleChanged(ECheckBoxState NewState);
+
+	FOnKBVESettingToggled OnToggled;
+};


### PR DESCRIPTION
## What

Game-agnostic KBVEUI Slate widgets (Core + Slate only, no game state, all wiring via delegates/slots). Presentation library — matches existing `SKBVE*` conventions.

### Settings frame
| Class | Role |
|-------|------|
| `SKBVESettingsRow` | label (+hint) + caller `Content` slot (the reused atom) |
| `SKBVESettingsFrame` | self-contained window (embeds `SKBVEMovableFrame`) + scrollable `Rows` + Apply/Reset/Cancel footer delegates |
| `SKBVESettingsToggleRow` / `SliderRow` / `ComboRow` | row helpers — one delegate per value |

### Toast system (not hooked in — ready for a future notification system)
| Class | Role |
|-------|------|
| `SKBVEToast` | single notification card — Info/Success/Warning/Error accent, title + message, optional close |
| `SKBVEToastLayer` | the system: `PushToast` / `Dismiss` / `DismissAll`, capped stack, per-toast auto-expiry via Tick |

### Top nav bar
| Class | Role |
|-------|------|
| `SKBVETopBar` | full-width fixed-height bar (default 50px) with Left/Center/Right named slots for future player-facing info |

## Scope
**Source only.** KBVEUI's CI wiring (version.toml + ci-registry MDX + manifest) lives in #11844. Merge **this PR first**, then #11844, so the plugin build has source.

## Not verified
No local UE toolchain — **not compiled**. Needs a UE editor/UAT build pass.