### PR TITLE
fix(agents): unblock Save Config + dashboard smoke backfill + auto-install webhooks

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
@@ -205,7 +205,16 @@ export default function ReactAgentBotConfig() {
 		);
 		const allErrors = validateAll(draft);
 		setErrors(allErrors);
-		if (Object.keys(allErrors).length > 0) return;
+		const errorKeys = Object.keys(allErrors) as TextFieldKey[];
+		if (errorKeys.length > 0) {
+			const first = errorKeys[0];
+			const el = refs.current[first];
+			if (el) {
+				el.focus();
+				el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+			}
+			return;
+		}
 		agentsService.patchBotConfigDraft(guildId, draft);
 		setSuccess(null);
 		const r = await agentsService.saveBotConfigDraft(guildId);
@@ -416,11 +425,16 @@ export default function ReactAgentBotConfig() {
 					{serverError && (
 						<span style={errTextLine}>{serverError}</span>
 					)}
+					{anyError && !saving && (
+						<span style={errTextLine}>
+							Fix field errors before saving.
+						</span>
+					)}
 					<button
 						type="submit"
-						disabled={anyError || saving}
+						disabled={saving}
 						style={{
-							...primaryBtn(!anyError && !saving),
+							...primaryBtn(!saving),
 							marginLeft: 'auto',
 						}}>
 						{saving ? (

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -367,12 +367,33 @@ function Step2WebhookConfig({
 	hasWebhook: boolean;
 }) {
 	const url = agentsService.webhookUrlFor(guild.id);
+	const allowlistMap = useStore(agentsService.$repoAllowlistDrafts);
+	const selectedMap = useStore(agentsService.$webhookInstallSelected);
+	const installBusyMap = useStore(agentsService.$webhookInstallBusyFor);
+	const installResultMap = useStore(agentsService.$webhookInstallResults);
+
+	const repos = allowlistMap[guild.id] ?? [];
+	const selectedRepo = selectedMap[guild.id] ?? repos[0] ?? '';
+	const installing = !!installBusyMap[guild.id];
+	const installResult = installResultMap[guild.id] ?? null;
 	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!selectedMap[guild.id] && repos.length > 0) {
+			agentsService.setWebhookInstallSelected(guild.id, repos[0]);
+		}
+	}, [guild.id, repos, selectedMap]);
 
 	async function copy() {
 		const ok = await copyToClipboard(url);
 		setCopied(ok);
 		if (ok) setTimeout(() => setCopied(false), 2500);
+	}
+
+	async function install() {
+		if (!selectedRepo || installing) return;
+		agentsService.setWebhookInstallSelected(guild.id, selectedRepo);
+		await agentsService.installWebhookForGuild(guild.id);
 	}
 
 	return (
@@ -448,6 +469,124 @@ function Step2WebhookConfig({
 					200 in under a second.
 				</li>
 			</ol>
+
+			<div
+				style={{
+					marginTop: '0.85rem',
+					padding: '0.75rem',
+					border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+					borderRadius: 8,
+					background: 'rgba(88,166,255,0.04)',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.5rem',
+				}}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.4rem',
+					}}>
+					<strong style={{ fontSize: '0.85rem' }}>
+						Or auto-install via your PAT
+					</strong>
+				</div>
+				<p style={{ ...mutedText, fontSize: '0.82rem' }}>
+					Uses your stored GitHub PAT (Step 3 must be done first) to
+					POST <code>/repos/&lt;owner&gt;/&lt;repo&gt;/hooks</code>{' '}
+					with the URL and HMAC secret you just stored. Only repos in
+					your allowlist are eligible.
+				</p>
+				{repos.length === 0 ? (
+					<p style={{ ...mutedText, fontStyle: 'italic' }}>
+						Add at least one repo to the allowlist below before
+						auto-installing.
+					</p>
+				) : (
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'stretch',
+							gap: '0.4rem',
+							flexWrap: 'wrap',
+						}}>
+						<select
+							value={selectedRepo}
+							onChange={(e) =>
+								agentsService.setWebhookInstallSelected(
+									guild.id,
+									e.target.value,
+								)
+							}
+							disabled={installing || !hasWebhook}
+							style={{
+								...inputStyle,
+								fontFamily:
+									'var(--sl-font-mono, ui-monospace, monospace)',
+								flex: 1,
+								minWidth: 220,
+								width: 'auto',
+							}}>
+							{repos.map((r) => (
+								<option key={r} value={r}>
+									{r}
+								</option>
+							))}
+						</select>
+						<button
+							type="button"
+							onClick={() => void install()}
+							disabled={
+								installing || !hasWebhook || !selectedRepo
+							}
+							style={primaryBtn}>
+							{installing ? (
+								<Loader2 size={14} style={spinStyle} />
+							) : (
+								<CheckCircle2 size={14} />
+							)}
+							{installing
+								? 'Installing…'
+								: 'Install webhook on repo'}
+						</button>
+					</div>
+				)}
+				{!hasWebhook && repos.length > 0 && (
+					<p style={{ ...mutedText, fontSize: '0.8rem' }}>
+						Finish Step 1 first — the HMAC row must exist in Vault
+						before gh-admin can read it.
+					</p>
+				)}
+				{installResult && !installResult.ok && (
+					<p style={errText}>{installResult.error}</p>
+				)}
+				{installResult && installResult.ok && (
+					<div
+						style={{
+							padding: '0.5rem 0.75rem',
+							borderRadius: 6,
+							background: 'rgba(74,222,128,0.08)',
+							border: '1px solid rgba(74,222,128,0.3)',
+							fontSize: '0.85rem',
+							lineHeight: 1.5,
+						}}>
+						<CheckCircle2
+							size={14}
+							color="#4ade80"
+							style={{ verticalAlign: '-2px', marginRight: 6 }}
+						/>
+						{installResult.alreadyPresent
+							? 'Webhook already present on this repo'
+							: 'Webhook installed'}
+						{installResult.hookId !== null && (
+							<>
+								{' · hook id '}
+								<code>{installResult.hookId}</code>
+							</>
+						)}
+					</div>
+				)}
+			</div>
 		</StepCard>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -322,6 +322,22 @@ class AgentsService {
 		>
 	>({});
 
+	public readonly $webhookInstallSelected = atom<Record<string, string>>({});
+	public readonly $webhookInstallBusyFor = atom<Record<string, boolean>>({});
+	public readonly $webhookInstallResults = atom<
+		Record<
+			string,
+			| {
+					ok: true;
+					installed: boolean;
+					alreadyPresent: boolean;
+					hookId: number | null;
+			  }
+			| { ok: false; error: string }
+			| null
+		>
+	>({});
+
 	// Dedup state — singleton so the cache survives ClientRouter swaps.
 	private initPromise: Promise<void> | null = null;
 	private lastInitAt = 0;
@@ -1176,6 +1192,42 @@ class AgentsService {
 		this.$backfillBusyFor.set(busyDone);
 		const resultsSet = { ...this.$backfillResults.get(), [guildId]: r };
 		this.$backfillResults.set(resultsSet);
+	}
+
+	public setWebhookInstallSelected(guildId: string, repo: string): void {
+		this.$webhookInstallSelected.set({
+			...this.$webhookInstallSelected.get(),
+			[guildId]: repo,
+		});
+	}
+
+	public clearWebhookInstallResult(guildId: string): void {
+		const m = { ...this.$webhookInstallResults.get() };
+		delete m[guildId];
+		this.$webhookInstallResults.set(m);
+	}
+
+	public async installWebhookForGuild(guildId: string): Promise<void> {
+		const repoFull = this.$webhookInstallSelected.get()[guildId] ?? '';
+		const [owner, repo] = repoFull.split('/');
+		if (!owner || !repo) return;
+		const busy = {
+			...this.$webhookInstallBusyFor.get(),
+			[guildId]: true,
+		};
+		this.$webhookInstallBusyFor.set(busy);
+		const resultsClear = { ...this.$webhookInstallResults.get() };
+		delete resultsClear[guildId];
+		this.$webhookInstallResults.set(resultsClear);
+		const r = await this.installRepoWebhook(guildId, owner, repo);
+		const busyDone = { ...this.$webhookInstallBusyFor.get() };
+		delete busyDone[guildId];
+		this.$webhookInstallBusyFor.set(busyDone);
+		const resultsSet = {
+			...this.$webhookInstallResults.get(),
+			[guildId]: r,
+		};
+		this.$webhookInstallResults.set(resultsSet);
 	}
 
 	public async toggleToken(

--- a/apps/kbve/edge/functions/gh-backfill/index.ts
+++ b/apps/kbve/edge/functions/gh-backfill/index.ts
@@ -5,12 +5,24 @@ import {
   extractToken,
   jsonResponse,
   parseJwt,
-  requireServiceRole,
 } from "../_shared/supabase.ts";
 import {
   enforceBodySizeLimit,
   requireJsonContentType,
 } from "../_shared/validators.ts";
+
+interface JwtClaimsLite {
+  role?: string;
+  owned_guilds?: unknown;
+}
+
+function ownsGuild(claims: JwtClaimsLite, serverId: string): boolean {
+  const og = claims.owned_guilds;
+  if (!Array.isArray(og)) return false;
+  return og.some((g) =>
+    typeof g === "string" && /^[0-9]{17,20}$/.test(g) && g === serverId
+  );
+}
 
 interface BackfillRequest {
   owner: string;
@@ -116,9 +128,21 @@ serve(async (req) => {
   } catch {
     return jsonResponse({ error: "authorization required" }, 401);
   }
-  const claims = await parseJwt(token).catch(() => ({}));
-  const denied = requireServiceRole(claims);
-  if (denied) return denied;
+  const claims = (await parseJwt(token).catch(() => ({}))) as JwtClaimsLite;
+  const isServiceRole = claims.role === "service_role";
+  const isUserToken =
+    typeof claims.role === "string" &&
+    claims.role !== "service_role" &&
+    Array.isArray(claims.owned_guilds);
+  if (!isServiceRole && !isUserToken) {
+    return jsonResponse(
+      {
+        error:
+          "Access denied: requires service_role or an authenticated Discord-linked user token",
+      },
+      403,
+    );
+  }
 
   let body: BackfillRequest;
   try {
@@ -147,6 +171,16 @@ serve(async (req) => {
           "guild_id is required and must be a Discord snowflake (17–20 digits). Pass in body or set GH_BACKFILL_DEFAULT_GUILD_ID on the edge deployment.",
       },
       400,
+    );
+  }
+
+  if (!isServiceRole && !ownsGuild(claims, guildId)) {
+    return jsonResponse(
+      {
+        error:
+          "JWT owned_guilds claim does not include this guild_id. Re-bootstrap or sign in with Discord.",
+      },
+      403,
     );
   }
 


### PR DESCRIPTION
Three follow-up bugs on `/dashboard/agents/*` after #11819 landed.

## 1. Save Config silently failed

> the fucking button doesnt work in /dashboard/agents/discordsh/

\`ReactAgentBotConfig\` had \`disabled={anyError || saving}\` on the Save button. Any in-flight field error (partial snowflake, blank max_assignees) silently disabled the button — disabled-state styling was too subtle to distinguish from enabled.

**Fix**
- Drop \`anyError\` from the disabled gate. Only \`saving\` disables now.
- Inline hint next to the button reads "Fix field errors before saving." when validation errors are present.
- \`onSubmit\` always runs: if errors exist, focus + smooth-scroll to the first invalid input. User always gets feedback for the click.

## 2. Smoke backfill returned "Access denied: service_role required"

\`gh-backfill\` used \`requireServiceRole\` exclusively. Dashboard sends user JWTs.

**Fix**
- Dual-mode gate: accept \`service_role\` OR an authenticated user JWT whose \`owned_guilds\` claim contains the target \`guild_id\`. Same auth pattern \`gh-admin\` already uses.
- Allowlist + Vault PAT lookup unchanged — apply to both code paths. A user can only backfill repos in their guild's allowlist with their guild's PAT.

## 3. Step 2 "Configure GitHub webhook" sat at PENDING with no automation

Even though \`gh-admin webhooks.install\` exists end-to-end, Step 2 was just copy-paste instructions.

**Fix**
- New install panel inside Step 2 below the manual list.
- Dropdown of repos from the guild's allowlist; "Install webhook on repo" calls \`installWebhookForGuild\` → \`gh-admin webhooks.install\` which uses the stored PAT + HMAC.
- Result panel shows installed / already-present + hook id, or the gh-admin error verbatim.
- Gated on Step 1 being complete (HMAC row must exist before gh-admin can read it).

### New singletons + helper

\`agentsService\`:
- \`$webhookInstallSelected\` — selected repo per guildId
- \`$webhookInstallBusyFor\` — install in-flight flag
- \`$webhookInstallResults\` — last install outcome
- \`installWebhookForGuild\` — thin wrapper over the existing \`installRepoWebhook\` that owns the singleton state

Same belt-and-suspenders pattern as the rest of #11819.

## Test plan

- [ ] /dashboard/agents/discordsh/: type partial Discord ID into a channel field, click Save. Button fires, focuses the bad field, scrolls to it.
- [ ] Same page: clear max_assignees, click Save. Same focus behavior.
- [ ] Same page: fix all errors, click Save. Save flow runs, success indicator.
- [ ] /dashboard/agents/github/: complete Step 1 + Step 3 (PAT). Step 2 panel shows allowlist dropdown. Click Install. gh-admin runs and reports installed/already-present.
- [ ] Same page: Step 4 smoke-test runs without "Access denied" (uses user JWT now).