### PR TITLE
feat(cryptothrone): full-bleed game layout + canonical itemdb + typed laser events

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/itemdb.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/itemdb.ts
@@ -1,0 +1,101 @@
+import rawItemdb from '@kbve/itemdb-data';
+import type { ItemData, ItemAction, ItemRarity } from '../types';
+
+const FLAG_WEAPON = 1 << 0;
+const FLAG_ARMOR = 1 << 1;
+const FLAG_FOOD = 1 << 3;
+const FLAG_DRINK = 1 << 4;
+const FLAG_POTION = 1 << 5;
+const FLAG_QUEST = 1 << 12;
+const FLAG_CONSUMABLE = FLAG_FOOD | FLAG_DRINK | FLAG_POTION;
+
+const BONUS_ALIAS: Record<string, string> = {
+	health: 'hp',
+	mana: 'mp',
+	energy: 'ep',
+};
+
+interface RawItem {
+	ref: string;
+	name: string;
+	description?: string;
+	lore?: string;
+	typeFlags?: number;
+	rarity?: string;
+	img?: string;
+	hasImg?: boolean;
+	weight?: number;
+	durability?: number;
+	consumable?: boolean;
+	bonuses?: Record<string, number>;
+}
+
+function resolveType(flags: number): ItemData['type'] {
+	if (flags & FLAG_WEAPON) return 'weapon';
+	if (flags & FLAG_ARMOR) return 'armor';
+	if (flags & FLAG_CONSUMABLE) return 'consumable';
+	if (flags & FLAG_QUEST) return 'quest';
+	return 'material';
+}
+
+function resolveActions(type: ItemData['type']): ItemAction[] {
+	if (type === 'consumable') return ['use', 'drop', 'inspect'];
+	if (type === 'weapon' || type === 'armor')
+		return ['equip', 'drop', 'inspect'];
+	return ['drop', 'inspect'];
+}
+
+function resolveRarity(raw?: string): ItemRarity {
+	const r = (raw ?? '').replace(/^ITEM_RARITY_/, '').toLowerCase();
+	switch (r) {
+		case 'uncommon':
+		case 'rare':
+		case 'epic':
+		case 'legendary':
+		case 'mythic':
+			return r;
+		default:
+			return 'common';
+	}
+}
+
+function normalizeBonuses(
+	raw?: Record<string, number>,
+): Record<string, number> {
+	const out: Record<string, number> = {};
+	for (const [k, v] of Object.entries(raw ?? {})) {
+		out[BONUS_ALIAS[k] ?? k] = v;
+	}
+	return out;
+}
+
+function adapt(raw: RawItem): ItemData {
+	const flags = raw.typeFlags ?? 0;
+	const type = resolveType(flags);
+	return {
+		id: raw.ref,
+		name: raw.name,
+		type,
+		img: raw.img ?? `/assets/icons/${raw.ref}.png`,
+		description: (raw.description ?? '').trim(),
+		bonuses: normalizeBonuses(raw.bonuses),
+		durability: raw.durability ?? (type === 'consumable' ? 1 : 100),
+		weight: raw.weight ?? 1,
+		actions: resolveActions(type),
+		rarity: resolveRarity(raw.rarity),
+		lore: raw.lore?.trim() || undefined,
+	};
+}
+
+const pool = (rawItemdb as { items?: RawItem[] }).items ?? [];
+const items: ItemData[] = pool.filter((r) => r && r.ref && r.name).map(adapt);
+
+const itemMap = new Map(items.map((i) => [i.id, i]));
+
+export function getItemById(ref: string): ItemData | undefined {
+	return itemMap.get(ref);
+}
+
+export function getAllItems(): ItemData[] {
+	return items;
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/items.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/items.ts
@@ -1,69 +1,34 @@
 import type { ItemData } from '../types';
+import { getAllItems as getCanonicalItems } from './itemdb';
 
-const ITEMS: ItemData[] = [
+const LOCAL_EXTRAS: ItemData[] = [
 	{
-		id: 'item_health_potion',
+		id: 'health-potion',
 		name: 'Health Potion',
 		type: 'consumable',
-		img: '/assets/icons/health_potion.png',
-		description: 'Restores 25 HP',
+		img: '/assets/icons/health-potion.png',
+		description: 'Restores 25 HP.',
 		bonuses: { hp: 25 },
 		durability: 1,
 		weight: 0.5,
 		actions: ['use', 'drop', 'inspect'],
-	},
-	{
-		id: 'item_mana_potion',
-		name: 'Mana Potion',
-		type: 'consumable',
-		img: '/assets/icons/mana_potion.png',
-		description: 'Restores 20 MP',
-		bonuses: { mp: 20 },
-		durability: 1,
-		weight: 0.5,
-		actions: ['use', 'drop', 'inspect'],
-	},
-	{
-		id: 'item_iron_sword',
-		name: 'Iron Sword',
-		type: 'weapon',
-		img: '/assets/icons/iron_sword.png',
-		description: 'A sturdy iron sword',
-		bonuses: { attack: 5 },
-		durability: 100,
-		weight: 3,
-		actions: ['equip', 'drop', 'inspect'],
-	},
-	{
-		id: 'item_salmon',
-		name: 'Salmon',
-		type: 'consumable',
-		img: '/assets/icons/salmon.png',
-		description: 'A fresh salmon. Restores 10 HP.',
-		bonuses: { hp: 10 },
-		durability: 1,
-		weight: 1,
-		actions: ['use', 'drop', 'inspect'],
-	},
-	{
-		id: 'item_blue_shark',
-		name: 'Blue Shark',
-		type: 'consumable',
-		img: '/assets/icons/blue_shark.png',
-		description: 'A rare blue shark. Restores 30 HP.',
-		bonuses: { hp: 30 },
-		durability: 1,
-		weight: 2,
-		actions: ['use', 'drop', 'inspect'],
+		rarity: 'common',
 	},
 ];
 
-const itemMap = new Map(ITEMS.map((i) => [i.id, i]));
+const canonical = getCanonicalItems();
+const canonicalRefs = new Set(canonical.map((i) => i.id));
+const items: ItemData[] = [
+	...canonical,
+	...LOCAL_EXTRAS.filter((extra) => !canonicalRefs.has(extra.id)),
+];
+
+const itemMap = new Map(items.map((i) => [i.id, i]));
 
 export function getItemById(id: string): ItemData | undefined {
 	return itemMap.get(id);
 }
 
 export function getAllItems(): ItemData[] {
-	return ITEMS;
+	return items;
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
@@ -1,0 +1,16 @@
+import type { PlayerStats } from './types';
+
+declare module '@kbve/laser' {
+	interface LaserEventMap {
+		'npc:interact': {
+			npcId: string;
+			npcName: string;
+			actions: string[];
+			coords: { x: number; y: number };
+		};
+		'player:damage': { damage: number };
+		'player:stats': { stats: PlayerStats };
+		'dice:roll': { npcId: string; npcName: string; diceCount: number };
+		'dice:result': { diceValues: number[] };
+	}
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { laserEvents } from '@kbve/laser';
 import type { CharacterEventData, NotificationEventData } from '@kbve/laser';
 import type { GameAction } from './game-store';
+import type { NPCAction } from '../types';
 import type { Dispatch } from 'react';
 
 export function useEventBridge(dispatch: Dispatch<GameAction>) {
@@ -42,86 +43,64 @@ export function useEventBridge(dispatch: Dispatch<GameAction>) {
 		);
 
 		unsubs.push(
-			laserEvents.on(
-				'npc:interact' as keyof typeof laserEvents,
-				((data: {
-					npcId: string;
-					npcName: string;
-					actions: string[];
-					coords: { x: number; y: number };
-				}) => {
-					dispatch({
-						type: 'SET_NPC_INTERACTION',
-						payload: data as any,
-					});
-				}) as any,
-			),
+			laserEvents.on('npc:interact', (data) => {
+				dispatch({
+					type: 'SET_NPC_INTERACTION',
+					payload: {
+						npcId: data.npcId,
+						npcName: data.npcName,
+						actions: data.actions as NPCAction[],
+						coords: data.coords,
+					},
+				});
+			}),
 		);
 
 		unsubs.push(
-			laserEvents.on(
-				'player:damage' as keyof typeof laserEvents,
-				((data: { damage: number }) => {
-					dispatch({
-						type: 'PLAYER_DAMAGE',
-						payload: { damage: Number(data.damage) },
-					});
-				}) as any,
-			),
+			laserEvents.on('player:damage', (data) => {
+				dispatch({
+					type: 'PLAYER_DAMAGE',
+					payload: { damage: Number(data.damage) },
+				});
+			}),
 		);
 
 		unsubs.push(
-			laserEvents.on(
-				'player:stats' as keyof typeof laserEvents,
-				((data: { stats: any }) => {
-					dispatch({
-						type: 'SET_PLAYER_STATS',
-						payload: data.stats,
-					});
-				}) as any,
-			),
+			laserEvents.on('player:stats', (data) => {
+				dispatch({
+					type: 'SET_PLAYER_STATS',
+					payload: data.stats,
+				});
+			}),
 		);
 
 		unsubs.push(
-			laserEvents.on(
-				'dice:roll' as keyof typeof laserEvents,
-				((data: {
-					npcId: string;
-					npcName: string;
-					diceCount: number;
-				}) => {
-					dispatch({
-						type: 'SET_DICE_ROLL',
-						payload: {
-							npcId: data.npcId,
-							npcName: data.npcName,
-							diceCount: data.diceCount,
-							diceValues: [],
-							totalRoll: null,
-							phase: 'rolling',
-						},
-					});
-				}) as any,
-			),
+			laserEvents.on('dice:roll', (data) => {
+				dispatch({
+					type: 'SET_DICE_ROLL',
+					payload: {
+						npcId: data.npcId,
+						npcName: data.npcName,
+						diceCount: data.diceCount,
+						diceValues: [],
+						totalRoll: null,
+						phase: 'rolling',
+					},
+				});
+			}),
 		);
 
 		unsubs.push(
-			laserEvents.on(
-				'dice:result' as keyof typeof laserEvents,
-				((data: { diceValues: number[] }) => {
-					const total = data.diceValues.reduce(
-						(a: number, b: number) => a + b,
-						0,
-					);
-					dispatch({
-						type: 'UPDATE_DICE_VALUES',
-						payload: {
-							diceValues: data.diceValues,
-							totalRoll: total,
-						},
-					});
-				}) as any,
-			),
+			laserEvents.on('dice:result', (data) => {
+				const total = data.diceValues.reduce((a, b) => a + b, 0);
+				dispatch({
+					type: 'UPDATE_DICE_VALUES',
+					payload: {
+						diceValues: data.diceValues,
+						totalRoll: total,
+					},
+				});
+			}),
 		);
 
 		return () => unsubs.forEach((fn) => fn());

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/types.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/types.ts
@@ -23,6 +23,14 @@ export interface PlayerInventory {
 	equipment: Record<EquipmentSlot, string | null>;
 }
 
+export type ItemRarity =
+	| 'common'
+	| 'uncommon'
+	| 'rare'
+	| 'epic'
+	| 'legendary'
+	| 'mythic';
+
 export interface ItemData {
 	id: string;
 	name: string;
@@ -33,6 +41,8 @@ export interface ItemData {
 	durability: number;
 	weight: number;
 	actions: ItemAction[];
+	rarity: ItemRarity;
+	lore?: string;
 }
 
 export type ItemAction = 'use' | 'equip' | 'drop' | 'inspect';

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
@@ -10,7 +10,7 @@ export function StickySidebar() {
 	const dispatch = useGameDispatch();
 
 	return (
-		<div className="fixed top-24 left-3 w-[350px] p-4 bg-zinc-800 text-yellow-400 border border-yellow-300 rounded-lg z-20 transition duration-500 opacity-50 hover:opacity-100 max-h-[80vh] overflow-y-auto">
+		<div className="fixed top-4 left-3 w-[350px] p-4 bg-zinc-800 text-yellow-400 border border-yellow-300 rounded-lg z-20 transition duration-500 opacity-50 hover:opacity-100 max-h-[90vh] overflow-y-auto">
 			<div className="flex gap-2 mb-4">
 				<ToggleButton
 					isCollapsed={settings.isStatsCollapsed}

--- a/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
+++ b/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
@@ -45,21 +45,34 @@
 
 /* ── Game full-bleed layout ── */
 
-/* Lock body scroll and hide footer when the game overlay is active */
+/* Lock body scroll fully when the game overlay is active */
+html:has(.game-fullscreen),
 body:has(.game-fullscreen) {
 	overflow: hidden;
 }
 
+/* Strip every Starlight chrome element so the overlay is truly full-bleed */
+body:has(.game-fullscreen) header,
+body:has(.game-fullscreen) .ct-header,
+body:has(.game-fullscreen) .sidebar,
+body:has(.game-fullscreen) .right-sidebar,
+body:has(.game-fullscreen) starlight-menu-button,
 body:has(.game-fullscreen) footer,
 body:has(.game-fullscreen) .ct-footer {
 	display: none;
 }
 
-/* Full-viewport game overlay — covers Starlight header/hero */
+/* Drop the reserved nav-height gap once the header is gone */
+body:has(.game-fullscreen) .page,
+body:has(.game-fullscreen) .main-frame {
+	padding-top: 0 !important;
+}
+
+/* Full-viewport game overlay — sits above all Starlight chrome */
 .game-fullscreen {
 	position: fixed;
 	inset: 0;
-	z-index: 50;
+	z-index: 9999;
 	background: var(--ct-bg-deep);
 	display: flex;
 	align-items: center;

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -13,7 +13,10 @@
 				"../../../packages/npm/astro/src/components/*"
 			],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
-			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"]
+			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/itemdb-data": [
+				"../../../packages/data/codegen/generated/itemdb-data.json"
+			]
 		}
 	}
 }


### PR DESCRIPTION
## Game page layout
- While `.game-fullscreen` is active, hide Starlight header / sidebar / TOC / footer so the Phaser canvas is truly full-bleed (`not-content` alone didn't strip the header).
- Overlay z-index `50 -> 9999`, full `html`+`body` scroll lock.
- StickySidebar `top-24 -> top-4` now the header is gone.

## ItemDB pickup
- New `data/itemdb.ts` adapts the **canonical generated pool** (`packages/data/codegen/generated/itemdb-data.json`, 180 items) via a `@kbve/itemdb-data` tsconfig alias — game now tracks the shared source instead of a stale 5-item hardcode.
- Maps the new schema: `typeFlags` bitmask → cryptothrone `type`, `rarity` enum, `bonuses` `health/mana/energy` → `hp/mp/ep`.
- `ItemData` gains `rarity` + `lore`; `items.ts` sources canonical and keeps a local `health-potion` fallback (not yet in the canonical DB).

## @kbve/laser
- Augment `LaserEventMap` with cryptothrone game events (`npc:interact`, `player:damage`, `player:stats`, `dice:roll`, `dice:result`).
- Drop every `as any` / `as keyof typeof laserEvents` cast in `useEventBridge`.

## Verify
`astro-cryptothrone:build` green (7 pages), `astro check` 0 errors (2 pre-existing hints unrelated).