### PR TITLE
feat(cryptothrone): bitecs ECS layer + quadtree proximity + tilemap polish

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -28,6 +28,7 @@ const PhaserCanvas = memo(function PhaserCanvas() {
 			height: 600,
 			scenes: [PreloaderScene, CloudCityScene],
 			backgroundColor: '#1a1a2e',
+			pixelArt: true,
 			plugins: {
 				scene: [
 					{

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/components.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/components.ts
@@ -1,0 +1,15 @@
+export const MAX_ENTITIES = 1024;
+
+export const Position = {
+	x: [] as number[],
+	y: [] as number[],
+};
+
+export const Health = {
+	hp: new Float32Array(MAX_ENTITIES),
+	maxHp: new Float32Array(MAX_ENTITIES),
+};
+
+export const PlayerTag: Record<string, never> = {};
+export const NpcTag: Record<string, never> = {};
+export const MonsterTag: Record<string, never> = {};

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/systems.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/systems.ts
@@ -1,0 +1,35 @@
+import { queryInRange, nearestInRange } from '@kbve/laser';
+import type { GameWorld } from './world';
+import { Position, MonsterTag } from './components';
+
+export function monstersNearPlayer(
+	world: GameWorld,
+	playerEid: number,
+	radius: number,
+): number[] {
+	return [
+		...queryInRange(
+			world,
+			[Position, MonsterTag],
+			Position,
+			Position.x[playerEid],
+			Position.y[playerEid],
+			radius,
+		),
+	];
+}
+
+export function nearestMonster(
+	world: GameWorld,
+	playerEid: number,
+	radius: number,
+): number | null {
+	return nearestInRange(
+		world,
+		[Position, MonsterTag],
+		Position,
+		Position.x[playerEid],
+		Position.y[playerEid],
+		radius,
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/world.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/world.ts
@@ -1,0 +1,47 @@
+import { createWorld, addEntity, addComponent, query } from '@kbve/laser';
+import type { World } from '@kbve/laser';
+import { Position, Health, PlayerTag, NpcTag, MonsterTag } from './components';
+
+export type GameWorld = World;
+
+export function createGameWorld(): GameWorld {
+	return createWorld();
+}
+
+function spawn(
+	world: GameWorld,
+	tag: Record<string, never>,
+	x: number,
+	y: number,
+	hp: number,
+): number {
+	const eid = addEntity(world);
+	addComponent(world, eid, Position);
+	addComponent(world, eid, Health);
+	addComponent(world, eid, tag);
+	Position.x[eid] = x;
+	Position.y[eid] = y;
+	Health.hp[eid] = hp;
+	Health.maxHp[eid] = hp;
+	return eid;
+}
+
+export function spawnPlayer(world: GameWorld, x: number, y: number): number {
+	return spawn(world, PlayerTag, x, y, 100);
+}
+
+export function spawnNpc(world: GameWorld, x: number, y: number): number {
+	return spawn(world, NpcTag, x, y, 30);
+}
+
+export function spawnMonster(world: GameWorld, x: number, y: number): number {
+	return spawn(world, MonsterTag, x, y, 10);
+}
+
+export function players(world: GameWorld): Iterable<number> {
+	return query(world, [Position, PlayerTag]);
+}
+
+export function monsters(world: GameWorld): Iterable<number> {
+	return query(world, [Position, MonsterTag]);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
@@ -12,5 +12,10 @@ declare module '@kbve/laser' {
 		'player:stats': { stats: PlayerStats };
 		'dice:roll': { npcId: string; npcName: string; diceCount: number };
 		'dice:result': { diceValues: number[] };
+		'monster:nearby': {
+			count: number;
+			nearestEid: number;
+			distance: number;
+		};
 	}
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -2,6 +2,7 @@ import { Scene } from 'phaser';
 import {
 	Quadtree,
 	PlayerController,
+	SideMap,
 	laserEvents,
 	getBirdNum,
 	isBird,
@@ -10,12 +11,24 @@ import {
 	createBirdAnimation,
 } from '@kbve/laser';
 import type { Bounds2D, Range, CharacterEventData } from '@kbve/laser';
+import {
+	createGameWorld,
+	spawnPlayer,
+	spawnNpc,
+	spawnMonster,
+	type GameWorld,
+} from '../ecs/world';
+import { Position } from '../ecs/components';
+import { monstersNearPlayer, nearestMonster } from '../ecs/systems';
 
 interface PositionChangeEvent {
 	charId: string;
 	exitTile: { x: number; y: number };
 	enterTile: { x: number; y: number };
 }
+
+const MAP_SCALE = 3;
+const AGGRO_RADIUS = 4;
 
 export class CloudCityScene extends Scene {
 	private npcSprite: Phaser.GameObjects.Sprite | undefined;
@@ -25,6 +38,12 @@ export class CloudCityScene extends Scene {
 	private quadtree: Quadtree;
 	private playerController: PlayerController | undefined;
 
+	private world!: GameWorld;
+	private playerEid = -1;
+	private spriteByEid = new SideMap<Phaser.GameObjects.Sprite>();
+	private eidByChar = new Map<string, number>();
+	private monsterNearby = false;
+
 	constructor() {
 		super({ key: 'CloudCity' });
 		const bounds: Bounds2D = { xMin: 0, xMax: 50, yMin: 0, yMax: 50 };
@@ -33,19 +52,31 @@ export class CloudCityScene extends Scene {
 
 	create() {
 		const tilemap = this.make.tilemap({ key: 'cloud-city-map-large' });
-		tilemap.addTilesetImage('cloud_tileset', 'cloud-city-tiles');
+		const tileset = tilemap.addTilesetImage(
+			'cloud_tileset',
+			'cloud-city-tiles',
+		);
 
 		for (let i = 0; i < tilemap.layers.length; i++) {
-			const layer = tilemap.createLayer(i, 'cloud_tileset', 0, 0);
+			const layer = tileset
+				? tilemap.createLayer(i, tileset, 0, 0)
+				: null;
 			if (layer) {
-				layer.scale = 3;
+				layer.setScale(MAP_SCALE);
+				layer.setDepth(i);
 			}
 		}
 
+		const worldWidth = tilemap.widthInPixels * MAP_SCALE;
+		const worldHeight = tilemap.heightInPixels * MAP_SCALE;
+		this.cameras.main.setBounds(0, 0, worldWidth, worldHeight);
+
 		const playerSprite = this.add.sprite(0, 0, 'player');
+		playerSprite.setDepth(tilemap.layers.length);
 		playerSprite.scale = 1.5;
 
 		this.npcSprite = this.add.sprite(0, 0, 'monks');
+		this.npcSprite.setDepth(tilemap.layers.length);
 		this.npcSprite.scale = 1.5;
 
 		this.cameras.main.startFollow(playerSprite, true);
@@ -58,6 +89,9 @@ export class CloudCityScene extends Scene {
 		this.monsterBirdSprites = createBirdSprites(this);
 		this.monsterBirdShadows = createShadowSprites(this);
 		this.anims.staggerPlay('bird', this.monsterBirdSprites, 100);
+		const entityDepth = tilemap.layers.length;
+		this.monsterBirdShadows.forEach((s) => s.setDepth(entityDepth));
+		this.monsterBirdSprites.forEach((s) => s.setDepth(entityDepth + 1));
 
 		const gridEngineConfig = {
 			characters: [
@@ -102,6 +136,8 @@ export class CloudCityScene extends Scene {
 			{ tileSize: 48, joystick: true },
 		);
 
+		this.initEcs(playerSprite);
+
 		this.gridEngine.moveRandomly('npc', 1500, 3);
 
 		for (let i = 0; i < 10; i++) {
@@ -111,6 +147,11 @@ export class CloudCityScene extends Scene {
 		this.gridEngine
 			.positionChangeStarted()
 			.subscribe(({ charId, enterTile }: PositionChangeEvent) => {
+				const eid = this.eidByChar.get(charId);
+				if (eid !== undefined) {
+					Position.x[eid] = enterTile.x;
+					Position.y[eid] = enterTile.y;
+				}
 				if (isBird(charId)) {
 					this.gridEngine.moveTo(
 						'monster_bird_shadow_' + getBirdNum(charId),
@@ -118,6 +159,58 @@ export class CloudCityScene extends Scene {
 					);
 				}
 			});
+	}
+
+	private initEcs(playerSprite: Phaser.GameObjects.Sprite) {
+		this.world = createGameWorld();
+
+		this.playerEid = spawnPlayer(this.world, 5, 12);
+		this.spriteByEid.set(this.playerEid, playerSprite);
+		this.eidByChar.set('player', this.playerEid);
+
+		if (this.npcSprite) {
+			const npcEid = spawnNpc(this.world, 4, 10);
+			this.spriteByEid.set(npcEid, this.npcSprite);
+			this.eidByChar.set('npc', npcEid);
+		}
+
+		this.monsterBirdSprites.forEach((sprite, i) => {
+			const eid = spawnMonster(this.world, 7, 7 + i);
+			this.spriteByEid.set(eid, sprite);
+			this.eidByChar.set('monster_bird_' + i, eid);
+		});
+	}
+
+	private updateProximity() {
+		if (this.playerEid < 0) return;
+
+		const near = monstersNearPlayer(
+			this.world,
+			this.playerEid,
+			AGGRO_RADIUS,
+		);
+
+		if (near.length > 0 && !this.monsterNearby) {
+			this.monsterNearby = true;
+			const nearest = nearestMonster(
+				this.world,
+				this.playerEid,
+				AGGRO_RADIUS,
+			);
+			const dx =
+				Position.x[nearest ?? this.playerEid] -
+				Position.x[this.playerEid];
+			const dy =
+				Position.y[nearest ?? this.playerEid] -
+				Position.y[this.playerEid];
+			laserEvents.emit('monster:nearby', {
+				count: near.length,
+				nearestEid: nearest ?? -1,
+				distance: Math.round(Math.hypot(dx, dy)),
+			});
+		} else if (near.length === 0) {
+			this.monsterNearby = false;
+		}
 	}
 
 	private loadRanges() {
@@ -182,5 +275,6 @@ export class CloudCityScene extends Scene {
 
 	update() {
 		this.playerController?.handleMovement();
+		this.updateProximity();
 	}
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
@@ -24,6 +24,22 @@ export function useEventBridge(dispatch: Dispatch<GameAction>) {
 		);
 
 		unsubs.push(
+			laserEvents.on('monster:nearby', (data) => {
+				dispatch({
+					type: 'ADD_NOTIFICATION',
+					payload: {
+						title: 'Danger',
+						message:
+							data.count > 1
+								? `${data.count} monsters lurk nearby!`
+								: 'A monster lurks nearby!',
+						type: 'warning',
+					},
+				});
+			}),
+		);
+
+		unsubs.push(
 			laserEvents.on('notification', (data: NotificationEventData) => {
 				const type =
 					(data.notificationType as


### PR DESCRIPTION
## ECS migration (@kbve/laser bitecs)
Introduces a bitecs sim layer alongside grid-engine (grid-engine stays the movement/animation driver; ECS is the data + spatial layer, mirroring the kbve TowerDefense/Runner pattern).
- `ecs/components.ts` — `Position`/`Health` SoA + `Player`/`Npc`/`Monster` tags
- `ecs/world.ts` — `createGameWorld` + `spawnPlayer/Npc/Monster` + player/monster queries
- `ecs/systems.ts` — `monstersNearPlayer`/`nearestMonster` via laser `queryInRange`/`nearestInRange`
- `CloudCityScene` spawns ECS entities, binds `eid -> sprite` with `SideMap`, syncs `Position` from grid-engine `positionChangeStarted`

## Spatial / quadtree
- proximity system fires a typed `monster:nearby` event when a monster crosses `AGGRO_RADIUS` (edge-triggered)
- `useEventBridge` surfaces it as a warning toast
- existing interaction `Quadtree` (well/sign/building/tombstone range zones) retained

## Tilemap rendering
- capture the tileset handle, give each layer an explicit depth, set camera bounds to the real map size (50×50 @ 3×)
- entity sprites depth-sorted above tile layers
- `pixelArt` config so the 16px tiles stay crisp at 3× scale

## Verify
`astro check` 0 errors (2 pre-existing hints), `astro-cryptothrone:build` green (7 pages). ECS/proximity is client-runtime — not exercised by SSG prerender, so worth a quick in-browser smoke before merge.