### PR TITLE
feat(astro): enrich SEO signals — Org entity, inLanguage, robots, Article OG

### DIFF
--- a/apps/kbve/astro-kbve/src/components/navigation/Head.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Head.astro
@@ -40,6 +40,23 @@ if (twitterTitle) owned['twitter:title'] = twitterTitle;
 if (twitterDescription) owned['twitter:description'] = twitterDescription;
 if (twitterImage) owned['twitter:image'] = twitterImage;
 
+type JsonLdFm = {
+	disable?: boolean;
+	type?: 'WebPage' | 'Article';
+	image?: string;
+	datePublished?: string;
+	dateModified?: string;
+	author?: string;
+	section?: string;
+	keywords?: string[];
+	breadcrumb?: { name: string; path: string }[];
+	faq?: { question: string; answer: string }[];
+};
+
+const jl = (data.jsonld ?? {}) as JsonLdFm;
+const isArticle = jl.type === 'Article';
+if (isArticle) owned['og:type'] = 'article';
+
 type HeadTag = (typeof head)[number];
 
 function tagKey(t: HeadTag): string | undefined {
@@ -53,7 +70,7 @@ function tagKey(t: HeadTag): string | undefined {
 
 const filteredHead = head.filter((t) => {
 	const key = tagKey(t);
-	return !key || !(key in owned);
+	return !key || (!(key in owned) && key !== 'robots');
 });
 
 const overrideTags: HeadTag[] = Object.entries(owned).map(([key, content]) => {
@@ -66,18 +83,6 @@ const overrideTags: HeadTag[] = Object.entries(owned).map(([key, content]) => {
 	} as HeadTag;
 });
 
-type JsonLdFm = {
-	disable?: boolean;
-	type?: 'WebPage' | 'Article';
-	image?: string;
-	datePublished?: string;
-	dateModified?: string;
-	keywords?: string[];
-	breadcrumb?: { name: string; path: string }[];
-	faq?: { question: string; answer: string }[];
-};
-
-const jl = (data.jsonld ?? {}) as JsonLdFm;
 const pageTitle = typeof data.title === 'string' ? data.title : undefined;
 const pageDescription =
 	typeof data.description === 'string' ? data.description : undefined;
@@ -107,6 +112,31 @@ const jsonLdPayload = jsonLdGraph
 		? { '@context': 'https://schema.org', ...jsonLdGraph[0] }
 		: { '@context': 'https://schema.org', '@graph': jsonLdGraph }
 	: null;
+
+const noindex = data.noindex === true;
+const robotsContent = noindex
+	? 'noindex, nofollow'
+	: 'index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1';
+
+const articleTags: { property: string; content: string }[] = [];
+if (isArticle) {
+	if (jl.datePublished)
+		articleTags.push({
+			property: 'article:published_time',
+			content: jl.datePublished,
+		});
+	if (jl.dateModified)
+		articleTags.push({
+			property: 'article:modified_time',
+			content: jl.dateModified,
+		});
+	if (jl.author)
+		articleTags.push({ property: 'article:author', content: jl.author });
+	if (jl.section)
+		articleTags.push({ property: 'article:section', content: jl.section });
+	for (const tag of jl.keywords ?? [])
+		articleTags.push({ property: 'article:tag', content: tag });
+}
 ---
 
 {
@@ -115,6 +145,9 @@ const jsonLdPayload = jsonLdGraph
 	))
 }
 {overrideTags.map(({ tag: Tag, attrs }) => <Tag {...attrs} />)}
+
+<meta name="robots" content={robotsContent} />
+{articleTags.map((t) => <meta property={t.property} content={t.content} />)}
 
 {
 	jsonLdPayload && (

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -195,6 +195,7 @@ export const collections = {
 				twitterTitle: z.string().optional(),
 				twitterDescription: z.string().optional(),
 				twitterImage: z.string().optional(),
+				noindex: z.boolean().optional(),
 				jsonld: z
 					.object({
 						disable: z.boolean().optional(),
@@ -202,6 +203,8 @@ export const collections = {
 						image: z.string().optional(),
 						datePublished: z.string().optional(),
 						dateModified: z.string().optional(),
+						author: z.string().optional(),
+						section: z.string().optional(),
 						keywords: z.array(z.string()).optional(),
 						breadcrumb: z
 							.array(

--- a/apps/kbve/astro-kbve/src/lib/seo.ts
+++ b/apps/kbve/astro-kbve/src/lib/seo.ts
@@ -3,9 +3,16 @@ import { createSeo } from '@kbve/astro/seo';
 export const seo = createSeo({
 	siteUrl: 'https://kbve.com',
 	name: 'KBVE',
+	alternateName: 'KiloByte Virtual Enterprise',
 	description:
 		'KiloByte Virtual Enterprise — building, shipping, and hosting games and software in the open.',
 	logo: 'https://kbve.com/assets/images/brand/letter_logo.png',
+	logoWidth: 150,
+	logoHeight: 48,
+	email: 'hello@kbve.com',
+	contactType: 'customer support',
+	brand: 'KBVE',
+	inLanguage: 'en',
 	sameAs: [
 		'https://github.com/kbve',
 		'https://discord.gg/kbve',

--- a/packages/npm/astro/src/seo/index.ts
+++ b/packages/npm/astro/src/seo/index.ts
@@ -19,7 +19,15 @@ export interface SeoSiteConfig {
 	siteUrl: string;
 	name: string;
 	logo?: string;
+	logoWidth?: number;
+	logoHeight?: number;
 	description?: string;
+	alternateName?: string;
+	foundingDate?: string;
+	email?: string;
+	contactType?: string;
+	brand?: string;
+	inLanguage?: string;
 	sameAs?: string[];
 }
 
@@ -82,13 +90,21 @@ export const createSeo = (config: SeoSiteConfig): Seo => {
 		url: config.siteUrl,
 		name: config.name,
 		logo: config.logo,
+		logoWidth: config.logoWidth,
+		logoHeight: config.logoHeight,
 		description: config.description,
+		alternateName: config.alternateName,
+		foundingDate: config.foundingDate,
+		email: config.email,
+		contactType: config.contactType,
+		brand: config.brand,
 		sameAs: config.sameAs,
 	});
 	const siteNode = website({
 		url: config.siteUrl,
 		name: config.name,
 		description: config.description,
+		inLanguage: config.inLanguage,
 		publisher: orgNode,
 	});
 
@@ -120,6 +136,7 @@ export const createSeo = (config: SeoSiteConfig): Seo => {
 							datePublished: i.datePublished,
 							dateModified: i.dateModified,
 							keywords: i.keywords,
+							inLanguage: config.inLanguage,
 							publisher: orgNode,
 							isPartOf: siteNode,
 							breadcrumb: crumbId,
@@ -131,6 +148,7 @@ export const createSeo = (config: SeoSiteConfig): Seo => {
 							image: i.image,
 							primaryImageOfPage: i.image ?? config.logo,
 							keywords: i.keywords,
+							inLanguage: config.inLanguage,
 							isPartOf: siteNode,
 							breadcrumb: crumbId,
 							dateModified: i.dateModified,

--- a/packages/npm/astro/src/seo/schema.ts
+++ b/packages/npm/astro/src/seo/schema.ts
@@ -14,25 +14,64 @@ export interface OrgInput {
 	url: string;
 	name: string;
 	logo?: string;
+	logoWidth?: number;
+	logoHeight?: number;
 	description?: string;
+	alternateName?: string;
+	foundingDate?: string;
+	email?: string;
+	contactType?: string;
+	brand?: string;
 	sameAs?: string[];
 }
 
-export const org = (i: OrgInput): SchemaNode => ({
-	'@type': 'Organization',
-	'@id': `${trim(i.url)}/#organization`,
-	name: i.name,
-	url: trim(i.url),
-	...(i.logo ? { logo: i.logo } : {}),
-	...(i.description ? { description: i.description } : {}),
-	...(i.sameAs?.length ? { sameAs: i.sameAs } : {}),
-});
+export const org = (i: OrgInput): SchemaNode => {
+	const base = trim(i.url);
+	const logoId = `${base}/#logo`;
+	const logo =
+		i.logo && i.logoWidth && i.logoHeight
+			? {
+					'@type': 'ImageObject',
+					'@id': logoId,
+					url: i.logo,
+					width: i.logoWidth,
+					height: i.logoHeight,
+				}
+			: i.logo;
+	return {
+		'@type': 'Organization',
+		'@id': `${base}/#organization`,
+		name: i.name,
+		url: base,
+		...(i.alternateName ? { alternateName: i.alternateName } : {}),
+		...(logo
+			? {
+					logo,
+					...(typeof logo === 'object' ? { image: ref(logoId) } : {}),
+				}
+			: {}),
+		...(i.description ? { description: i.description } : {}),
+		...(i.foundingDate ? { foundingDate: i.foundingDate } : {}),
+		...(i.email
+			? {
+					contactPoint: {
+						'@type': 'ContactPoint',
+						email: i.email,
+						contactType: i.contactType ?? 'customer support',
+					},
+				}
+			: {}),
+		...(i.brand ? { brand: { '@type': 'Brand', name: i.brand } } : {}),
+		...(i.sameAs?.length ? { sameAs: i.sameAs } : {}),
+	};
+};
 
 export interface WebSiteInput {
 	url: string;
 	name: string;
 	description?: string;
 	publisher?: SchemaNode | string;
+	inLanguage?: string;
 }
 
 export const website = (i: WebSiteInput): SchemaNode => ({
@@ -41,6 +80,7 @@ export const website = (i: WebSiteInput): SchemaNode => ({
 	url: trim(i.url),
 	name: i.name,
 	...(i.description ? { description: i.description } : {}),
+	...(i.inLanguage ? { inLanguage: i.inLanguage } : {}),
 	...(i.publisher ? { publisher: ref(i.publisher) } : {}),
 });
 
@@ -54,6 +94,7 @@ export interface WebPageInput {
 	primaryImageOfPage?: string;
 	dateModified?: string;
 	keywords?: string[];
+	inLanguage?: string;
 }
 
 export const webPage = (i: WebPageInput): SchemaNode => ({
@@ -67,6 +108,7 @@ export const webPage = (i: WebPageInput): SchemaNode => ({
 		? { primaryImageOfPage: i.primaryImageOfPage }
 		: {}),
 	...(i.keywords?.length ? { keywords: i.keywords } : {}),
+	...(i.inLanguage ? { inLanguage: i.inLanguage } : {}),
 	...(i.isPartOf ? { isPartOf: ref(i.isPartOf) } : {}),
 	...(i.breadcrumb ? { breadcrumb: ref(i.breadcrumb) } : {}),
 	...(i.dateModified ? { dateModified: i.dateModified } : {}),
@@ -219,6 +261,7 @@ export interface ArticleInput {
 	publisher?: SchemaNode | string;
 	isPartOf?: SchemaNode | string;
 	breadcrumb?: SchemaNode | string;
+	inLanguage?: string;
 }
 
 export const article = (i: ArticleInput): SchemaNode => ({
@@ -231,6 +274,7 @@ export const article = (i: ArticleInput): SchemaNode => ({
 	...(i.datePublished ? { datePublished: i.datePublished } : {}),
 	...(i.dateModified ? { dateModified: i.dateModified } : {}),
 	...(i.keywords?.length ? { keywords: i.keywords } : {}),
+	...(i.inLanguage ? { inLanguage: i.inLanguage } : {}),
 	...(i.author ? { author: ref(i.author) } : {}),
 	...(i.publisher ? { publisher: ref(i.publisher) } : {}),
 	...(i.isPartOf ? { isPartOf: ref(i.isPartOf) } : {}),


### PR DESCRIPTION
## What

Round 2 of structured-data work (builds on #11830). Adds the richer signals crawlers reward beyond the base graph.

### Organization → real knowledge-graph entity
- `logo` as `ImageObject` (150×48) + `image` ref to `#logo`
- `contactPoint` (hello@kbve.com)
- `alternateName` (KiloByte Virtual Enterprise), `brand`

### Language + indexing
- `inLanguage` on WebSite + WebPage/Article
- Site-wide `<meta name=robots>`: `index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1` (bigger thumbnails, full snippets)
- Per-page opt-out via `noindex: true` frontmatter

### Article pages
- `og:type=article` override + `article:published_time / modified_time / author / section / tag` OG tags for `jsonld.type: Article`, driven by frontmatter (`author`, `section` added to the `jsonld` block)

### Deliberately skipped
- **SearchAction** (sitelinks search box) — no `/search?q=` route exists; declaring it with no working endpoint is ignored/penalized.

## Verified
`astro-kbve:build` clean (exit 0, 7692 pages). Built `/feature/`:
- Org carries ImageObject logo, contactPoint, brand, alternateName, image ref
- WebSite + WebPage `inLanguage: en`
- single robots meta with max-image-preview:large
- non-article page stays `og:type=website`, zero stray `article:` tags

## Config
KBVE-specific values live in `apps/kbve/astro-kbve/src/lib/seo.ts`; the builders in `@kbve/astro/seo` stay generic.