### PR TITLE
fix(ci): auto-detect Playwright browsers per app to unblock irc-gateway

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -137,28 +137,51 @@ jobs:
               run: |
                   FORCE="${{ inputs.install_playwright }}"
                   if [ "$FORCE" = "true" ]; then
-                    echo "uses_playwright=true" >> "$GITHUB_OUTPUT"
-                    echo "Playwright forced ON via input"
-                    exit 0
-                  fi
-                  if [ "$FORCE" = "false" ]; then
-                    echo "uses_playwright=false" >> "$GITHUB_OUTPUT"
-                    echo "Playwright forced OFF via input"
-                    exit 0
-                  fi
-                  ROOT="${{ inputs.source_path }}"
-                  if [ -z "$ROOT" ] || [ ! -d "$ROOT" ]; then
-                    echo "uses_playwright=false" >> "$GITHUB_OUTPUT"
-                    echo "No source_path provided — defaulting to no Playwright"
-                    exit 0
-                  fi
-                  if grep -rlq '@nx/playwright:playwright' "$ROOT" 2>/dev/null; then
-                    echo "uses_playwright=true" >> "$GITHUB_OUTPUT"
-                    echo "Detected @nx/playwright:playwright executor under ${ROOT}"
+                    USES=true
+                  elif [ "$FORCE" = "false" ]; then
+                    USES=false
                   else
-                    echo "uses_playwright=false" >> "$GITHUB_OUTPUT"
-                    echo "No Playwright executor under ${ROOT}"
+                    ROOT="${{ inputs.source_path }}"
+                    if [ -z "$ROOT" ] || [ ! -d "$ROOT" ]; then
+                      USES=false
+                    elif grep -rlq '@nx/playwright:playwright' "$ROOT" 2>/dev/null; then
+                      USES=true
+                    else
+                      USES=false
+                    fi
                   fi
+                  echo "uses_playwright=${USES}" >> "$GITHUB_OUTPUT"
+                  if [ "$USES" != "true" ]; then
+                    echo "Playwright OFF"
+                    exit 0
+                  fi
+                  # Auto-detect which browsers the project's playwright.config.ts
+                  # actually drives. The shared workflow used to install
+                  # `chromium webkit` for every e2e, but every config except
+                  # astro-kbve's only uses chromium — irc-gateway in
+                  # particular kept timing out on the 15-min webkit
+                  # download. Scan the configs under source_path; default to
+                  # chromium when nothing matches so a missing config never
+                  # results in an empty browser list to `playwright install`.
+                  ROOT="${{ inputs.source_path }}"
+                  BROWSERS=""
+                  CFGS=$(find "$ROOT" -maxdepth 6 -type f -name "playwright.config.*" -not -path "*/node_modules/*" 2>/dev/null || true)
+                  if [ -n "$CFGS" ]; then
+                    add() {
+                      case " $BROWSERS " in
+                        *" $1 "*) ;;
+                        *) BROWSERS="${BROWSERS:+$BROWSERS }$1" ;;
+                      esac
+                    }
+                    if echo "$CFGS" | xargs grep -lqE "devices\['Desktop Chrome'|name: *'chromium|chromium.*channel|name: *'mobile-chrome" 2>/dev/null; then add chromium; fi
+                    if echo "$CFGS" | xargs grep -lqE "devices\['Desktop Safari|name: *'webkit|name: *'mobile-safari" 2>/dev/null; then add webkit; fi
+                    if echo "$CFGS" | xargs grep -lqE "devices\['Desktop Firefox|name: *'firefox" 2>/dev/null; then add firefox; fi
+                  fi
+                  if [ -z "$BROWSERS" ]; then BROWSERS=chromium; fi
+                  KEY=$(echo "$BROWSERS" | tr ' ' '-')
+                  echo "browsers=${BROWSERS}" >> "$GITHUB_OUTPUT"
+                  echo "browsers_key=${KEY}" >> "$GITHUB_OUTPUT"
+                  echo "Playwright ON — browsers: ${BROWSERS}"
 
             - name: Resolve Playwright version
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' }}
@@ -174,22 +197,22 @@ jobs:
               uses: actions/cache@v5
               with:
                   path: ~/.cache/ms-playwright
-                  key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-chromium-webkit
+                  key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ steps.detect-playwright.outputs.browsers_key }}
                   restore-keys: |
                       ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
                       ${{ runner.os }}-playwright-
 
             - name: Install Playwright Browsers
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
-              timeout-minutes: 15
+              timeout-minutes: 25
               env:
                   UV_THREADPOOL_SIZE: '16'
-              run: pnpm exec playwright install --with-deps chromium webkit
+              run: pnpm exec playwright install --with-deps ${{ steps.detect-playwright.outputs.browsers }}
 
             - name: Install Playwright OS deps (cache hit)
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
               timeout-minutes: 10
-              run: pnpm exec playwright install-deps chromium webkit
+              run: pnpm exec playwright install-deps ${{ steps.detect-playwright.outputs.browsers }}
 
             - name: Nx e2e ${{ inputs.project }}
               env:


### PR DESCRIPTION
## Summary
Closes #11849. Every \`irc-gateway\` ci-docker run since 2026-06-05 timed out at the \`Install Playwright Browsers\` step, even though \`axum-kbve\` / \`axum-chuckrpg\` / etc. went green in the same windows. Root cause was the shared workflow downloading webkit unconditionally even though no project except astro-kbve uses it.

## Evidence
- Failed run [#27059162871](https://github.com/KBVE/kbve/actions/runs/27059162871) — \`Install Playwright Browsers\` step \`##[error]The action 'Install Playwright Browsers' has timed out after 15 minutes\` while downloading \`Chrome for Testing 147.0.7727.15 (playwright chromium v1217)\`.
- Workflow ran \`pnpm exec playwright install --with-deps chromium webkit\` for every project with \`@nx/playwright:playwright\` under \`source_path\`.
- Survey of \`playwright.config.*\` across the monorepo:

  | Config | Browsers driven |
  |---|---|
  | apps/irc/irc-e2e | chromium |
  | apps/memes/memes-e2e | chromium |
  | apps/discordsh/discordsh-e2e | chromium |
  | apps/rareicon/astro-rareicon-e2e | chromium |
  | apps/cryptothrone/astro-cryptothrone-e2e | chromium |
  | apps/herbmail/herbmail-e2e | chromium |
  | apps/chuckrpg/astro-chuckrpg-e2e | chromium |
  | **apps/kbve/astro-kbve** | **chromium, webkit, mobile-chrome, mobile-safari** |

## Fix
In [docker-test-app.yml](.github/workflows/docker-test-app.yml) \`Detect Playwright usage\`:
- After the existing \`uses_playwright\` detection, scan the project's \`playwright.config.*\` for the device / project names Playwright uses (\`Desktop Chrome\` / \`name: 'chromium'\` / etc.) and emit a \`browsers\` output (defaults to \`chromium\` when nothing matches).
- Cache key includes the browsers set so chromium-only projects share cache without colliding with webkit projects: \`Linux-playwright-<ver>-chromium\` vs \`Linux-playwright-<ver>-chromium-webkit\`.
- Install command + post-cache \`install-deps\` use the detected set.
- \`timeout-minutes\` on the install step goes from 15 → 25 (belt + suspenders for first-bump downloads after a Playwright version change).

## Test plan
- [ ] CI - Docker / irc-gateway green on this PR
- [ ] CI - Docker / axum-kbve still green (webkit detected via \`devices['Desktop Safari'\` + \`name: 'webkit'\` matchers)
- [ ] Successive runs hit the chromium-only cache key