### PR TITLE
fix(ci): retry Playwright install + raise timeout to 40m (axum-kbve)

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -204,10 +204,21 @@ jobs:
 
             - name: Install Playwright Browsers
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
-              timeout-minutes: 25
+              timeout-minutes: 40
               env:
                   UV_THREADPOOL_SIZE: '16'
-              run: pnpm exec playwright install --with-deps ${{ steps.detect-playwright.outputs.browsers }}
+              run: |
+                  set -euo pipefail
+                  for try in 1 2 3; do
+                    if pnpm exec playwright install --with-deps ${{ steps.detect-playwright.outputs.browsers }}; then
+                      echo "playwright install succeeded on attempt ${try}"
+                      exit 0
+                    fi
+                    echo "::warning::playwright install attempt ${try} failed; retrying in 15s"
+                    sleep 15
+                  done
+                  echo "::error::playwright install failed after 3 attempts"
+                  exit 1
 
             - name: Install Playwright OS deps (cache hit)
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}


### PR DESCRIPTION
## Summary
Follow-up to #11854. Closes #11853. The prior PR auto-detected which browsers each project actually drives and bumped \`Install Playwright Browsers\` timeout 15→25 min, which unblocks the chromium-only projects (irc-gateway, memes, etc.) but is still tight for **astro-kbve-e2e** — it legitimately needs chromium + webkit + mobile-chrome + mobile-safari.

Run [#27059433148](https://github.com/KBVE/kbve/actions/runs/27059433148) burned 14.5 minutes on chromium alone before timing out:

\`\`\`
10:11:06 Downloading Chrome for Testing 147.0.7727.15 (playwright chromium v1217) from https://cdn.playwright.dev/builds/cft/147.0.7727.15/linux64/chrome-linux64.zip
10:25:34 ##[error]The action 'Install Playwright Browsers' has timed out after 15 minutes.
\`\`\`

## Fix
- \`timeout-minutes\`: 25 → 40 on the cold-cache install step.
- Wrap the install in a 3-attempt retry with a 15-second gap. A stalled \`cdn.playwright.dev\` TCP session usually doesn't recover; killing it and reopening picks a healthier path.
- Cache-hit \`install-deps\`-only step left at 10 minutes — that path doesn't download binaries.

## Why not pre-bake browsers in the runner image
That's the proper long-term answer (and would zero out this whole step), but it touches the arc-runner image build and rollout — out of scope for an issue-resolve PR. Tracking separately.

## Test plan
- [ ] CI - Docker / axum-kbve green on this PR
- [ ] Successive cache-hit runs still complete \`install-deps\` under 10 minutes
- [ ] First retry attempt logs visible when the CDN flakes