### PR TITLE
fix(agents): Step 2 GitHub wizard flips to DONE + verify-on-mount

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -388,6 +388,11 @@ function Step2WebhookConfig({
 		}
 	}, [guild.id, repos, selectedMap]);
 
+	useEffect(() => {
+		if (!hasWebhook || !selectedRepo) return;
+		void agentsService.verifyWebhookInstall(guild.id, selectedRepo);
+	}, [guild.id, hasWebhook, selectedRepo]);
+
 	async function copy() {
 		const ok = await copyToClipboard(url);
 		setCopied(ok);
@@ -405,11 +410,21 @@ function Step2WebhookConfig({
 		await agentsService.pingWebhookForGuild(guild.id);
 	}
 
+	const installedOk =
+		!!installResult &&
+		installResult.ok &&
+		(installResult.installed || installResult.alreadyPresent);
+	const step2Status: StepStatus = !hasWebhook
+		? 'todo'
+		: installedOk
+			? 'done'
+			: 'pending';
+
 	return (
 		<StepCard
 			n={2}
 			title="Configure the GitHub webhook"
-			status={hasWebhook ? 'pending' : 'todo'}
+			status={step2Status}
 			disabled={!hasWebhook}>
 			<p style={mutedText}>
 				Copy the per-guild webhook URL, then create a new webhook on the

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -1261,6 +1261,30 @@ class AgentsService {
 		});
 	}
 
+	public async verifyWebhookInstall(
+		guildId: string,
+		repoFull: string,
+	): Promise<void> {
+		const [owner, repo] = repoFull.split('/');
+		if (!owner || !repo) return;
+		const cur = this.$webhookInstallResults.get()[guildId];
+		if (cur && cur.ok && (cur.installed || cur.alreadyPresent)) return;
+		const r = await this.listRepoWebhooks(guildId, owner, repo);
+		if (!r.ok) return;
+		const kbveHook = r.hooks.find((h) => h.is_kbve);
+		if (!kbveHook) return;
+		const resultsSet = {
+			...this.$webhookInstallResults.get(),
+			[guildId]: {
+				ok: true as const,
+				installed: false,
+				alreadyPresent: true,
+				hookId: kbveHook.id,
+			},
+		};
+		this.$webhookInstallResults.set(resultsSet);
+	}
+
 	public async toggleToken(
 		tokenId: string,
 		isActive: boolean,


### PR DESCRIPTION
> being stuck in pending? just want to be sure.

Yes — Step 2 status was hard-coded:
\`\`\`tsx
status={hasWebhook ? 'pending' : 'todo'}
\`\`\`
No 'done' branch existed, so even after #11843's auto-install panel reported success, the chip stayed at PENDING.

## Fix

**Three states**:
\`\`\`tsx
!hasWebhook                                   → 'todo'
hasWebhook + no install confirmed             → 'pending'
hasWebhook + install reported or verified ok  → 'done'
\`\`\`

**\`installedOk\`** derives done-ness from the singleton \`installResult\` so a successful install during the current session immediately upgrades the chip.

**Verify-on-mount** (\`verifyWebhookInstall\` in agentsService): when \`hasWebhook\` is true and a repo is selected, call \`listRepoWebhooks\` for that repo. If any hook has \`is_kbve=true\`, populate the singleton with \`alreadyPresent=true\` + the discovered hook id. Means Step 2 also reads as DONE after a full page reload (the singleton resets but the GitHub-side hook persists, so we re-discover via gh-admin).

Guarded so it never overwrites a fresh in-session install result.

## Test plan

- [ ] /dashboard/agents/github/, fresh guild with no kbve hook yet: Step 2 reads TODO. Complete Step 1 → reads PENDING. Click Install → flips to DONE.
- [ ] Full page reload: Step 2 still reads DONE (verify-on-mount discovers the existing hook via webhooks.list).
- [ ] Switch dropdown to a different allowlist repo that has no kbve hook: chip stays DONE (we don't downgrade once installed) — known limitation, since the singleton is per-guild not per-repo. Future work if needed.