### PR TITLE
perf(rareicon): jobify tender-scan prep across all four tender systems

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/DockTenderScanSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/DockTenderScanSystem.cs
@@ -5,7 +5,7 @@ using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Writes <see cref="TenderMultiplier"/>.Value = 1 when any Craftsman-intent unit stands on a Dock's hex; otherwise 0. <see cref="DockProductionSystem"/> reads the multiplier to halve the boat-build cadence while the dock is manned. Mirrors <see cref="FarmTenderScanSystem"/>.</summary>
+    /// <summary>Writes <see cref="TenderMultiplier"/>.Value = 1 when any Craftsman-intent unit stands on a Dock's hex; otherwise 0. <see cref="DockProductionSystem"/> reads the multiplier to halve the boat-build cadence while the dock is manned. Prep scan runs as a parallel IJobEntity into NativeParallelHashSet.ParallelWriter, replacing the prior main-thread foreach.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateAfter(typeof(ProfessionDispatchSystem))]
@@ -17,20 +17,31 @@ namespace RareIcon
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
-            var tendedHexes = new NativeHashSet<int2>(8, Allocator.TempJob);
-            foreach (var (intent, movement) in
-                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<UnitMovement>>())
+            var tendedHexes = new NativeParallelHashSet<int2>(256, Allocator.TempJob);
+
+            var prepHandle = new CollectCraftsmanHexesJob
             {
-                if (intent.ValueRO.Kind != ProfessionKind.Craftsman) continue;
-                tendedHexes.Add(movement.ValueRO.CurrentHex);
-            }
+                Writer = tendedHexes.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
             state.Dependency = new DockTenderJob
             {
-                TendedHexes = tendedHexes.AsReadOnly(),
-            }.ScheduleParallel(state.Dependency);
+                TendedHexes = tendedHexes,
+            }.ScheduleParallel(prepHandle);
 
             state.Dependency = tendedHexes.Dispose(state.Dependency);
+        }
+    }
+
+    [BurstCompile]
+    public partial struct CollectCraftsmanHexesJob : IJobEntity
+    {
+        public NativeParallelHashSet<int2>.ParallelWriter Writer;
+
+        void Execute(in ProfessionIntent intent, in UnitMovement movement)
+        {
+            if (intent.Kind != ProfessionKind.Craftsman) return;
+            Writer.Add(movement.CurrentHex);
         }
     }
 
@@ -38,7 +49,7 @@ namespace RareIcon
     [WithAll(typeof(DockTag))]
     public partial struct DockTenderJob : IJobEntity
     {
-        [ReadOnly] public NativeHashSet<int2>.ReadOnly TendedHexes;
+        [ReadOnly] public NativeParallelHashSet<int2> TendedHexes;
 
         void Execute(in Building building, ref TenderMultiplier tender)
         {

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/FarmTenderScanSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/FarmTenderScanSystem.cs
@@ -5,7 +5,7 @@ using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Writes TenderMultiplier.Value = 1 when any Farmer-intent unit stands on the farm's 7-hex footprint; otherwise 0. ProductionSystem hard-gates new Farm cycles on tender > 0 (no Farmer = no production) and additionally halves the duration when tended, so the worker is required to start a cycle and rewarded for staying through it. Main-thread hex-snapshot + parallel per-farm multiplier writes.</summary>
+    /// <summary>Writes TenderMultiplier.Value = 1 when any Farmer-intent unit stands on the farm's 7-hex footprint; otherwise 0. ProductionSystem hard-gates new Farm cycles on tender > 0 (no Farmer = no production) and additionally halves the duration when tended, so the worker is required to start a cycle and rewarded for staying through it. Prep scan runs as a parallel IJobEntity into NativeParallelHashSet.ParallelWriter, replacing the prior main-thread foreach.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateAfter(typeof(ProfessionDispatchSystem))]
@@ -17,20 +17,31 @@ namespace RareIcon
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
-            var tendedHexes = new NativeHashSet<int2>(16, Allocator.TempJob);
-            foreach (var (intent, movement) in
-                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<UnitMovement>>())
+            var tendedHexes = new NativeParallelHashSet<int2>(256, Allocator.TempJob);
+
+            var prepHandle = new CollectFarmerHexesJob
             {
-                if (intent.ValueRO.Kind != ProfessionKind.Farmer) continue;
-                tendedHexes.Add(movement.ValueRO.CurrentHex);
-            }
+                Writer = tendedHexes.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
             state.Dependency = new FarmTenderJob
             {
-                TendedHexes = tendedHexes.AsReadOnly(),
-            }.ScheduleParallel(state.Dependency);
+                TendedHexes = tendedHexes,
+            }.ScheduleParallel(prepHandle);
 
             state.Dependency = tendedHexes.Dispose(state.Dependency);
+        }
+    }
+
+    [BurstCompile]
+    public partial struct CollectFarmerHexesJob : IJobEntity
+    {
+        public NativeParallelHashSet<int2>.ParallelWriter Writer;
+
+        void Execute(in ProfessionIntent intent, in UnitMovement movement)
+        {
+            if (intent.Kind != ProfessionKind.Farmer) return;
+            Writer.Add(movement.CurrentHex);
         }
     }
 
@@ -38,7 +49,7 @@ namespace RareIcon
     [WithAll(typeof(FarmTag))]
     public partial struct FarmTenderJob : IJobEntity
     {
-        [ReadOnly] public NativeHashSet<int2>.ReadOnly TendedHexes;
+        [ReadOnly] public NativeParallelHashSet<int2> TendedHexes;
 
         void Execute(in Building building, ref TenderMultiplier tender)
         {

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LumbercampTenderScanSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LumbercampTenderScanSystem.cs
@@ -1,11 +1,12 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Writes TenderMultiplier.Value = 1 when any Lumberjack-intent unit stands on a Lumbercamp's footprint *or* is ShelteredInside the camp (Phase B garrison path). Otherwise 0 — LumbercampProductionSystem refuses to start a cycle without a worker. Mirrors FarmTenderScanSystem's shape plus the shelter roster.</summary>
+    /// <summary>Writes TenderMultiplier.Value = 1 when any Lumberjack-intent unit stands on a Lumbercamp's footprint *or* is ShelteredInside the camp (Phase B garrison path). Otherwise 0 — LumbercampProductionSystem refuses to start a cycle without a worker. Prep scans run as parallel IJobEntity passes into NativeParallelHashSet ParallelWriters, replacing the prior pair of main-thread foreach scans.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateAfter(typeof(ProfessionDispatchSystem))]
@@ -17,28 +18,24 @@ namespace RareIcon
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
-            var tendedHexes  = new NativeHashSet<int2>(16, Allocator.TempJob);
-            var tendingHosts = new NativeHashSet<Entity>(16, Allocator.TempJob);
+            var tendedHexes  = new NativeParallelHashSet<int2>(256, Allocator.TempJob);
+            var tendingHosts = new NativeParallelHashSet<Entity>(64, Allocator.TempJob);
 
-            foreach (var (intent, movement) in
-                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<UnitMovement>>().WithNone<ShelteredInside>())
+            var hexHandle = new CollectLumberjackHexesJob
             {
-                if (intent.ValueRO.Kind != ProfessionKind.Lumberjack) continue;
-                tendedHexes.Add(movement.ValueRO.CurrentHex);
-            }
+                Writer = tendedHexes.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
-            foreach (var (intent, sheltered) in
-                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<ShelteredInside>>())
+            var hostHandle = new CollectLumberjackHostsJob
             {
-                if (intent.ValueRO.Kind != ProfessionKind.Lumberjack) continue;
-                tendingHosts.Add(sheltered.ValueRO.Host);
-            }
+                Writer = tendingHosts.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
             state.Dependency = new LumbercampTenderJob
             {
-                TendedHexes  = tendedHexes.AsReadOnly(),
-                TendingHosts = tendingHosts.AsReadOnly(),
-            }.ScheduleParallel(state.Dependency);
+                TendedHexes  = tendedHexes,
+                TendingHosts = tendingHosts,
+            }.ScheduleParallel(JobHandle.CombineDependencies(hexHandle, hostHandle));
 
             state.Dependency = tendedHexes.Dispose(state.Dependency);
             state.Dependency = tendingHosts.Dispose(state.Dependency);
@@ -46,11 +43,36 @@ namespace RareIcon
     }
 
     [BurstCompile]
+    [WithNone(typeof(ShelteredInside))]
+    public partial struct CollectLumberjackHexesJob : IJobEntity
+    {
+        public NativeParallelHashSet<int2>.ParallelWriter Writer;
+
+        void Execute(in ProfessionIntent intent, in UnitMovement movement)
+        {
+            if (intent.Kind != ProfessionKind.Lumberjack) return;
+            Writer.Add(movement.CurrentHex);
+        }
+    }
+
+    [BurstCompile]
+    public partial struct CollectLumberjackHostsJob : IJobEntity
+    {
+        public NativeParallelHashSet<Entity>.ParallelWriter Writer;
+
+        void Execute(in ProfessionIntent intent, in ShelteredInside sheltered)
+        {
+            if (intent.Kind != ProfessionKind.Lumberjack) return;
+            Writer.Add(sheltered.Host);
+        }
+    }
+
+    [BurstCompile]
     [WithAll(typeof(LumbercampTag))]
     public partial struct LumbercampTenderJob : IJobEntity
     {
-        [ReadOnly] public NativeHashSet<int2>.ReadOnly   TendedHexes;
-        [ReadOnly] public NativeHashSet<Entity>.ReadOnly TendingHosts;
+        [ReadOnly] public NativeParallelHashSet<int2>   TendedHexes;
+        [ReadOnly] public NativeParallelHashSet<Entity> TendingHosts;
 
         void Execute(Entity entity, in Building building, ref TenderMultiplier tender)
         {
@@ -59,7 +81,7 @@ namespace RareIcon
         }
     }
 
-    /// <summary>Writes TenderMultiplier.Value = 1 when any Miner-intent unit stands on a Mining Pit's footprint *or* is ShelteredInside the pit (Phase B garrison path). Otherwise 0 — MiningPitProductionSystem refuses to start a cycle without a worker.</summary>
+    /// <summary>Writes TenderMultiplier.Value = 1 when any Miner-intent unit stands on a Mining Pit's footprint *or* is ShelteredInside the pit (Phase B garrison path). Otherwise 0 — MiningPitProductionSystem refuses to start a cycle without a worker. Prep scans run as parallel IJobEntity passes into NativeParallelHashSet ParallelWriters, replacing the prior pair of main-thread foreach scans.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateAfter(typeof(ProfessionDispatchSystem))]
@@ -71,28 +93,24 @@ namespace RareIcon
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
-            var tendedHexes  = new NativeHashSet<int2>(16, Allocator.TempJob);
-            var tendingHosts = new NativeHashSet<Entity>(16, Allocator.TempJob);
+            var tendedHexes  = new NativeParallelHashSet<int2>(256, Allocator.TempJob);
+            var tendingHosts = new NativeParallelHashSet<Entity>(64, Allocator.TempJob);
 
-            foreach (var (intent, movement) in
-                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<UnitMovement>>().WithNone<ShelteredInside>())
+            var hexHandle = new CollectMinerHexesJob
             {
-                if (intent.ValueRO.Kind != ProfessionKind.Miner) continue;
-                tendedHexes.Add(movement.ValueRO.CurrentHex);
-            }
+                Writer = tendedHexes.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
-            foreach (var (intent, sheltered) in
-                     SystemAPI.Query<RefRO<ProfessionIntent>, RefRO<ShelteredInside>>())
+            var hostHandle = new CollectMinerHostsJob
             {
-                if (intent.ValueRO.Kind != ProfessionKind.Miner) continue;
-                tendingHosts.Add(sheltered.ValueRO.Host);
-            }
+                Writer = tendingHosts.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
             state.Dependency = new MiningPitTenderJob
             {
-                TendedHexes  = tendedHexes.AsReadOnly(),
-                TendingHosts = tendingHosts.AsReadOnly(),
-            }.ScheduleParallel(state.Dependency);
+                TendedHexes  = tendedHexes,
+                TendingHosts = tendingHosts,
+            }.ScheduleParallel(JobHandle.CombineDependencies(hexHandle, hostHandle));
 
             state.Dependency = tendedHexes.Dispose(state.Dependency);
             state.Dependency = tendingHosts.Dispose(state.Dependency);
@@ -100,11 +118,36 @@ namespace RareIcon
     }
 
     [BurstCompile]
+    [WithNone(typeof(ShelteredInside))]
+    public partial struct CollectMinerHexesJob : IJobEntity
+    {
+        public NativeParallelHashSet<int2>.ParallelWriter Writer;
+
+        void Execute(in ProfessionIntent intent, in UnitMovement movement)
+        {
+            if (intent.Kind != ProfessionKind.Miner) return;
+            Writer.Add(movement.CurrentHex);
+        }
+    }
+
+    [BurstCompile]
+    public partial struct CollectMinerHostsJob : IJobEntity
+    {
+        public NativeParallelHashSet<Entity>.ParallelWriter Writer;
+
+        void Execute(in ProfessionIntent intent, in ShelteredInside sheltered)
+        {
+            if (intent.Kind != ProfessionKind.Miner) return;
+            Writer.Add(sheltered.Host);
+        }
+    }
+
+    [BurstCompile]
     [WithAll(typeof(MiningPitTag))]
     public partial struct MiningPitTenderJob : IJobEntity
     {
-        [ReadOnly] public NativeHashSet<int2>.ReadOnly   TendedHexes;
-        [ReadOnly] public NativeHashSet<Entity>.ReadOnly TendingHosts;
+        [ReadOnly] public NativeParallelHashSet<int2>   TendedHexes;
+        [ReadOnly] public NativeParallelHashSet<Entity> TendingHosts;
 
         void Execute(Entity entity, in Building building, ref TenderMultiplier tender)
         {


### PR DESCRIPTION
Continues the per-system parallelization arc. Same pattern as #11743 / #11751 / #11758, applied to the four `*TenderScanSystem`s that each ran a main-thread foreach prep before scheduling their per-building tender job.

## Was

Four tender-scan systems each ran a main-thread foreach over `ProfessionIntent + UnitMovement` (and `ShelteredInside` for Lumbercamp + MiningPit) to filter-by-Kind into a `NativeHashSet`. At 100k units that's 4–6 × 100k iterations across these systems **every frame**, even though the produced sets are tiny (a handful of matching units).

| System | Filter Kind | Prep scans |
|---|---|---|
| [FarmTenderScanSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/FarmTenderScanSystem.cs) | Farmer | 1 |
| [DockTenderScanSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/DockTenderScanSystem.cs) | Craftsman | 1 |
| [LumbercampTenderScanSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LumbercampTenderScanSystem.cs) | Lumberjack | 2 (hex + shelter host) |
| [MiningPitTenderScanSystem](apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LumbercampTenderScanSystem.cs) | Miner | 2 (hex + shelter host) |

## Now

Each prep scan becomes a `[BurstCompile] IJobEntity` that filters in-job and writes to `NativeParallelHashSet<>.ParallelWriter`. Tender job depends on the prep handle(s), reads the set as `[ReadOnly]`.

```
FarmTenderScanSystem
  CollectFarmerHexesJob → FarmTenderJob (chained dependency)

DockTenderScanSystem
  CollectCraftsmanHexesJob → DockTenderJob

LumbercampTenderScanSystem
  ( CollectLumberjackHexesJob [WithNone(ShelteredInside)]
  ‖ CollectLumberjackHostsJob )
        → LumbercampTenderJob

MiningPitTenderScanSystem
  ( CollectMinerHexesJob [WithNone(ShelteredInside)]
  ‖ CollectMinerHostsJob )
        → MiningPitTenderJob
```

## Container change

`NativeHashSet<T>` → `NativeParallelHashSet<T>` since the `AsParallelWriter` pattern requires the parallel variant. Same `Contains()` API in the consumer tender jobs, no downstream contract changes. Initial capacity bumped from 8/16 → 64/256 to avoid resize spikes under sparse write contention.

## Behaviour preserved

- Identical filter predicates per system (`intent.Kind == Farmer/Craftsman/Lumberjack/Miner`).
- Same `Contains()` semantics in each tender job.
- Same Farm 7-hex footprint Contains loop.
- Same `TendedHexes.Contains(root) || TendingHosts.Contains(entity)` shape in Lumbercamp / MiningPit.
- `TenderMultiplier` write semantics unchanged.

`state.Dependency` chains prep → tender job → set Dispose so container lifetime stays tied to job completion without main-thread syncs.

## Test plan

- [ ] Burst compiles every new `Collect*Job` + tender job clean.
- [ ] No safety errors with `ENABLE_UNITY_COLLECTIONS_CHECKS` on `NativeParallelHashSet.ParallelWriter` flow.
- [ ] `TenderMultiplier` flips correctly when a worker steps onto / off a Farm, Dock, Lumbercamp, MiningPit hex.
- [ ] Lumbercamp + MiningPit garrison-shelter path: sheltering a Lumberjack / Miner inside a camp / pit still flips its `TenderMultiplier` to 1.
- [ ] Frame-time delta at 1k / 10k / 100k units: main-thread time for these four systems should drop noticeably (work moved off main thread; total worker time roughly equal).

## Future follow-up

These four systems all scan the same `ProfessionIntent + UnitMovement` query 4× per frame, just with different Kind filters. A natural next refactor: one shared `TenderPrePassSystem` that scans once and populates 4 hex sets + 2 host sets via per-kind ParallelWriters into a singleton, then each tender system reads its slice. Skipped for this PR to keep scope tight; landing the per-system jobification first.