### PR TITLE
feat(astro): RSS feed for the KBVE Journal

### DIFF
--- a/apps/kbve/astro-kbve/src/components/navigation/Head.astro
+++ b/apps/kbve/astro-kbve/src/components/navigation/Head.astro
@@ -172,6 +172,13 @@ if (isArticle) {
 <ClientRouter />
 <meta name="view-transition" content="same-origin" />
 
+<link
+	rel="alternate"
+	type="application/rss+xml"
+	title="KBVE Journal"
+	href="https://kbve.com/rss.xml"
+/>
+
 <!-- YouTube hero-bg DNS + TLS warm so the iframe doesn't gate LCP -->
 <link rel="preconnect" href="https://www.youtube.com" crossorigin />
 <link rel="preconnect" href="https://i.ytimg.com" crossorigin />

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -184,6 +184,13 @@ export const collections = {
 				mc_block: McBlockSchema.optional(),
 				'yt-tracks': z.array(z.string()).optional(),
 				'yt-sets': z.array(z.string()).optional(),
+				// Journal post metadata consumed by the RSS feed
+				// (src/pages/rss.xml.ts). Without these the docs schema strips
+				// them from entry.data.
+				date: z.coerce.date().optional(),
+				img: z.string().optional(),
+				category: z.string().optional(),
+				tags: z.array(z.string()).optional(),
 				// Per-page social-meta overrides consumed by
 				// src/components/navigation/Head.astro. Astro silently strips
 				// nested z.object fields imported across zod-package boundaries

--- a/apps/kbve/astro-kbve/src/pages/rss.xml.ts
+++ b/apps/kbve/astro-kbve/src/pages/rss.xml.ts
@@ -1,0 +1,39 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { APIContext } from 'astro';
+
+const SITE = 'https://kbve.com';
+const MAX_ITEMS = 50;
+
+export async function GET(context: APIContext) {
+	const posts = await getCollection(
+		'docs',
+		(entry) =>
+			entry.id.startsWith('journal/') && entry.data.date instanceof Date,
+	);
+
+	const items = posts
+		.sort(
+			(a, b) =>
+				(b.data.date as Date).getTime() -
+				(a.data.date as Date).getTime(),
+		)
+		.slice(0, MAX_ITEMS)
+		.map((entry) => ({
+			title: entry.data.title,
+			description: entry.data.description ?? '',
+			pubDate: entry.data.date as Date,
+			link: `/${entry.id}/`,
+			categories:
+				entry.data.tags ??
+				(entry.data.category ? [entry.data.category] : []),
+		}));
+
+	return rss({
+		title: 'KBVE Journal',
+		description: 'The dev log and daily journal of KBVE — h0lythoughts.',
+		site: context.site?.toString() ?? SITE,
+		items,
+		customData: '<language>en-us</language>',
+	});
+}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"@astrojs/mdx": "^5.0.4",
 		"@astrojs/partytown": "^2.1.7",
 		"@astrojs/react": "^5.0.4",
+		"@astrojs/rss": "^4.0.12",
 		"@astrojs/sitemap": "^3.7.2",
 		"@astrojs/starlight": "^0.39.2",
 		"@astrojs/starlight-tailwind": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
       '@astrojs/react':
         specifier: ^5.0.4
         version: 5.0.4(@types/node@18.19.17)(@types/react-dom@19.1.5(@types/react@19.2.9))(@types/react@19.2.9)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.48.0)(yaml@2.9.0)
+      '@astrojs/rss':
+        specifier: ^4.0.12
+        version: 4.0.18
       '@astrojs/sitemap':
         specifier: ^3.7.2
         version: 3.7.2
@@ -744,6 +747,9 @@ packages:
       '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
       react: ^17.0.2 || ^18.0.0 || ^19.0.0
       react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
+  '@astrojs/rss@4.0.18':
+    resolution: {integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==}
 
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
@@ -16372,6 +16378,12 @@ snapshots:
       - tsx
       - yaml
 
+  '@astrojs/rss@4.0.18':
+    dependencies:
+      fast-xml-parser: 5.8.0
+      piccolore: 0.1.3
+      zod: 4.3.6
+
   '@astrojs/sitemap@3.7.2':
     dependencies:
       sitemap: 9.0.1
@@ -20346,8 +20358,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@nodable/entities@2.1.0':
-    optional: true
+  '@nodable/entities@2.1.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -27818,7 +27829,6 @@ snapshots:
     dependencies:
       path-expression-matcher: 1.5.0
       xml-naming: 0.1.0
-    optional: true
 
   fast-xml-parser@5.8.0:
     dependencies:
@@ -27827,7 +27837,6 @@ snapshots:
       path-expression-matcher: 1.5.0
       strnum: 2.3.0
       xml-naming: 0.1.0
-    optional: true
 
   fastq@1.17.1:
     dependencies:
@@ -32165,8 +32174,7 @@ snapshots:
 
   path-exists@5.0.0: {}
 
-  path-expression-matcher@1.5.0:
-    optional: true
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -34405,8 +34413,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.3.0:
-    optional: true
+  strnum@2.3.0: {}
 
   structured-headers@0.4.1:
     optional: true
@@ -36243,8 +36250,7 @@ snapshots:
 
   xml-name-validator@5.0.0: {}
 
-  xml-naming@0.1.0:
-    optional: true
+  xml-naming@0.1.0: {}
 
   xml-parse-from-string@1.0.1: {}
 


### PR DESCRIPTION
## What

Adds `/rss.xml` for the KBVE Journal (dev log / daily journal) + autodiscovery.

- **`src/pages/rss.xml.ts`** — `@astrojs/rss` endpoint serving the **50 most recent** journal posts, sorted newest-first, each with `pubDate` and `categories` (tags, else category).
- **Schema** — surfaces journal frontmatter (`date`, `img`, `category`, `tags`) on the docs collection; the docs zod schema was silently stripping these from `entry.data`, so the feed couldn't read them.
- **Autodiscovery** — `<link rel=alternate type=application/rss+xml>` in the Head override → feed readers + crawlers find it on every page.
- **Dep** — `@astrojs/rss@^4.0.12` added to root `package.json` (resolved 4.0.18), per the root-deps-only rule.

## Verified
`astro-kbve:build` clean (exit 0, 7702 pages). Parsed `dist/.../rss.xml`:
- valid XML, channel `KBVE Journal`, `language en-us`, 50 items
- newest *June: 01* → `https://kbve.com/journal/06-01/`, sorted descending
- autodiscovery link present in built page heads

## Notes
- Feed capped at 50 (367 posts total) — standard for readers; bump `MAX_ITEMS` if you want a fuller archive feed.
- Journal post URLs derive from entry id (`journal/MM-DD` → `/journal/MM-DD/`).