### PR TITLE
fix(agents): rate-limit smoke backfill + new webhooks.ping for direct Step 2 testing

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -371,11 +371,15 @@ function Step2WebhookConfig({
 	const selectedMap = useStore(agentsService.$webhookInstallSelected);
 	const installBusyMap = useStore(agentsService.$webhookInstallBusyFor);
 	const installResultMap = useStore(agentsService.$webhookInstallResults);
+	const pingBusyMap = useStore(agentsService.$webhookPingBusyFor);
+	const pingResultMap = useStore(agentsService.$webhookPingResults);
 
 	const repos = allowlistMap[guild.id] ?? [];
 	const selectedRepo = selectedMap[guild.id] ?? repos[0] ?? '';
 	const installing = !!installBusyMap[guild.id];
 	const installResult = installResultMap[guild.id] ?? null;
+	const pinging = !!pingBusyMap[guild.id];
+	const pingResult = pingResultMap[guild.id] ?? null;
 	const [copied, setCopied] = useState(false);
 
 	useEffect(() => {
@@ -394,6 +398,11 @@ function Step2WebhookConfig({
 		if (!selectedRepo || installing) return;
 		agentsService.setWebhookInstallSelected(guild.id, selectedRepo);
 		await agentsService.installWebhookForGuild(guild.id);
+	}
+
+	async function ping() {
+		if (!selectedRepo || pinging) return;
+		await agentsService.pingWebhookForGuild(guild.id);
 	}
 
 	return (
@@ -583,6 +592,43 @@ function Step2WebhookConfig({
 								{' · hook id '}
 								<code>{installResult.hookId}</code>
 							</>
+						)}
+					</div>
+				)}
+				{installResult && installResult.ok && hasWebhook && (
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: '0.5rem',
+							flexWrap: 'wrap',
+						}}>
+						<button
+							type="button"
+							onClick={() => void ping()}
+							disabled={pinging || !selectedRepo}
+							style={secondaryBtn}
+							title="Tells GitHub to redeliver a `ping` event to your gh-webhook URL. Server enforces 30s cooldown + 10 pings/hour per repo.">
+							{pinging ? (
+								<Loader2 size={14} style={spinStyle} />
+							) : (
+								<PlayCircle size={14} />
+							)}
+							{pinging ? 'Pinging…' : 'Send test ping'}
+						</button>
+						{pingResult && pingResult.ok && (
+							<span
+								style={{
+									fontSize: '0.82rem',
+									color: '#4ade80',
+								}}>
+								Ping sent · hook{' '}
+								<code>{pingResult.hookId}</code>. Check Recent
+								Deliveries on GitHub for the 200.
+							</span>
+						)}
+						{pingResult && !pingResult.ok && (
+							<span style={errText}>{pingResult.error}</span>
 						)}
 					</div>
 				)}

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -337,6 +337,15 @@ class AgentsService {
 			| null
 		>
 	>({});
+	public readonly $webhookPingBusyFor = atom<Record<string, boolean>>({});
+	public readonly $webhookPingResults = atom<
+		Record<
+			string,
+			| { ok: true; hookId: number; at: number }
+			| { ok: false; error: string }
+			| null
+		>
+	>({});
 
 	// Dedup state — singleton so the cache survives ClientRouter swaps.
 	private initPromise: Promise<void> | null = null;
@@ -1230,6 +1239,28 @@ class AgentsService {
 		this.$webhookInstallResults.set(resultsSet);
 	}
 
+	public async pingWebhookForGuild(guildId: string): Promise<void> {
+		const repoFull = this.$webhookInstallSelected.get()[guildId] ?? '';
+		const [owner, repo] = repoFull.split('/');
+		if (!owner || !repo) return;
+		const busy = {
+			...this.$webhookPingBusyFor.get(),
+			[guildId]: true,
+		};
+		this.$webhookPingBusyFor.set(busy);
+		const r = await this.pingRepoWebhook(guildId, owner, repo);
+		const busyDone = { ...this.$webhookPingBusyFor.get() };
+		delete busyDone[guildId];
+		this.$webhookPingBusyFor.set(busyDone);
+		const result = r.ok
+			? { ok: true as const, hookId: r.hookId, at: Date.now() }
+			: { ok: false as const, error: r.error };
+		this.$webhookPingResults.set({
+			...this.$webhookPingResults.get(),
+			[guildId]: result,
+		});
+	}
+
 	public async toggleToken(
 		tokenId: string,
 		isActive: boolean,
@@ -1431,6 +1462,32 @@ class AgentsService {
 			installed: !!r.data.installed,
 			alreadyPresent: !!r.data.already_present,
 			hookId: r.data.hook_id ?? null,
+		};
+	}
+
+	public async pingRepoWebhook(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<
+		| { ok: true; hookId: number; url: string }
+		| { ok: false; error: string; retryAfterMs?: number }
+	> {
+		const r = await this.callJson<{
+			pinged: boolean;
+			hook_id: number;
+			url: string;
+		}>(GH_ADMIN_URL, {
+			command: 'webhooks.ping',
+			server_id: guildId,
+			owner,
+			repo,
+		});
+		if (!r.ok) return { ok: false, error: r.error };
+		return {
+			ok: true,
+			hookId: r.data.hook_id,
+			url: r.data.url,
 		};
 	}
 

--- a/apps/kbve/edge/functions/gh-admin/index.ts
+++ b/apps/kbve/edge/functions/gh-admin/index.ts
@@ -186,6 +186,115 @@ async function handleList(
   return jsonResponse({ expected_url: expectedUrl, hooks });
 }
 
+const PING_COOLDOWN_MS = 30_000;
+const PING_RATE_WINDOW_MS = 60 * 60 * 1000;
+const PING_RATE_MAX = 10;
+const pingCooldown = new Map<string, number>();
+const pingHistory = new Map<string, number[]>();
+
+function checkPingRateLimit(
+  userSub: string,
+  serverId: string,
+  owner: string,
+  repo: string,
+): { ok: true } | { ok: false; retryAfterMs: number; reason: string } {
+  const cdKey = `${userSub}:${serverId}`;
+  const now = Date.now();
+  const last = pingCooldown.get(cdKey) ?? 0;
+  if (now - last < PING_COOLDOWN_MS) {
+    return {
+      ok: false,
+      retryAfterMs: PING_COOLDOWN_MS - (now - last),
+      reason: "cooldown",
+    };
+  }
+  const histKey = `${userSub}:${serverId}:${owner}/${repo}`;
+  const hist = (pingHistory.get(histKey) ?? []).filter(
+    (t) => now - t < PING_RATE_WINDOW_MS,
+  );
+  if (hist.length >= PING_RATE_MAX) {
+    return {
+      ok: false,
+      retryAfterMs: PING_RATE_WINDOW_MS - (now - hist[0]),
+      reason: "hourly_limit",
+    };
+  }
+  hist.push(now);
+  pingHistory.set(histKey, hist);
+  pingCooldown.set(cdKey, now);
+  return { ok: true };
+}
+
+async function handlePing(
+  serverId: string,
+  owner: string,
+  repo: string,
+): Promise<Response> {
+  const pat = await fetchGuildSecret(serverId, "github");
+  if (!pat) {
+    return jsonResponse(
+      { error: "No GitHub PAT stored for this guild" },
+      400,
+    );
+  }
+  const list = await githubCallback(
+    "GET",
+    `/repos/${owner}/${repo}/hooks`,
+    pat,
+  );
+  if (list.status === 401 || list.status === 403) {
+    return jsonResponse(
+      { error: "GitHub PAT unauthorized for this repo" },
+      403,
+    );
+  }
+  if (list.status === 404) {
+    return jsonResponse(
+      { error: "Repo not found or PAT lacks access" },
+      404,
+    );
+  }
+  if (list.status < 200 || list.status >= 300 || !Array.isArray(list.body)) {
+    return jsonResponse(
+      { error: "GitHub API error listing hooks", status: list.status },
+      502,
+    );
+  }
+  const expectedUrl = `${SUPABASE_URL}/functions/v1/gh-webhook/${serverId}`;
+  const kbveHook = (list.body as GithubHook[]).find(
+    (h) => h.config?.url === expectedUrl,
+  );
+  if (!kbveHook) {
+    return jsonResponse(
+      {
+        error:
+          "No kbve webhook found on this repo — run webhooks.install first",
+      },
+      404,
+    );
+  }
+  const ping = await githubCallback(
+    "POST",
+    `/repos/${owner}/${repo}/hooks/${kbveHook.id}/pings`,
+    pat,
+  );
+  if (ping.status < 200 || ping.status >= 300) {
+    return jsonResponse(
+      {
+        error: "GitHub ping failed",
+        status: ping.status,
+        detail: ping.body,
+      },
+      502,
+    );
+  }
+  return jsonResponse({
+    pinged: true,
+    hook_id: kbveHook.id,
+    url: expectedUrl,
+  });
+}
+
 async function handleInstall(
   serverId: string,
   owner: string,
@@ -382,11 +491,34 @@ serve(async (req) => {
       return await handleInstall(serverId, owner, repo);
     case "webhooks.list":
       return await handleList(serverId, owner, repo);
+    case "webhooks.ping": {
+      const userSub = typeof claims.sub === "string" ? claims.sub : "";
+      if (!userSub) {
+        return jsonResponse(
+          { error: "Authenticated user token missing sub claim" },
+          401,
+        );
+      }
+      const rate = checkPingRateLimit(userSub, serverId, owner, repo);
+      if (!rate.ok) {
+        return jsonResponse(
+          {
+            error:
+              rate.reason === "cooldown"
+                ? `Wait ${Math.ceil(rate.retryAfterMs / 1000)}s between pings`
+                : `Hourly ping limit of ${PING_RATE_MAX} per repo exceeded — retry in ${Math.ceil(rate.retryAfterMs / 60_000)}m`,
+            retry_after_ms: rate.retryAfterMs,
+          },
+          429,
+        );
+      }
+      return await handlePing(serverId, owner, repo);
+    }
     default:
       return jsonResponse(
         {
           error:
-            'command required (one of: "webhooks.install", "webhooks.list")',
+            'command required (one of: "webhooks.install", "webhooks.list", "webhooks.ping")',
         },
         400,
       );

--- a/apps/kbve/edge/functions/gh-backfill/index.ts
+++ b/apps/kbve/edge/functions/gh-backfill/index.ts
@@ -14,6 +14,7 @@ import {
 interface JwtClaimsLite {
   role?: string;
   owned_guilds?: unknown;
+  sub?: string;
 }
 
 function ownsGuild(claims: JwtClaimsLite, serverId: string): boolean {
@@ -22,6 +23,44 @@ function ownsGuild(claims: JwtClaimsLite, serverId: string): boolean {
   return og.some((g) =>
     typeof g === "string" && /^[0-9]{17,20}$/.test(g) && g === serverId
   );
+}
+
+const USER_SMOKE_COOLDOWN_MS = 15_000;
+const USER_SMOKE_WINDOW_MS = 60 * 60 * 1000;
+const USER_SMOKE_MAX_PER_HOUR = 20;
+const USER_SMOKE_PER_PAGE_CAP = 30;
+const USER_SMOKE_MAX_PAGES_CAP = 1;
+const userSmokeCooldown = new Map<string, number>();
+const userSmokeHistory = new Map<string, number[]>();
+
+function checkUserSmokeRateLimit(
+  userSub: string,
+  guildId: string,
+): { ok: true } | { ok: false; retryAfterMs: number; reason: string } {
+  const cdKey = `${userSub}:${guildId}`;
+  const now = Date.now();
+  const last = userSmokeCooldown.get(cdKey) ?? 0;
+  if (now - last < USER_SMOKE_COOLDOWN_MS) {
+    return {
+      ok: false,
+      retryAfterMs: USER_SMOKE_COOLDOWN_MS - (now - last),
+      reason: "cooldown",
+    };
+  }
+  const hist = (userSmokeHistory.get(cdKey) ?? []).filter(
+    (t) => now - t < USER_SMOKE_WINDOW_MS,
+  );
+  if (hist.length >= USER_SMOKE_MAX_PER_HOUR) {
+    return {
+      ok: false,
+      retryAfterMs: USER_SMOKE_WINDOW_MS - (now - hist[0]),
+      reason: "hourly_limit",
+    };
+  }
+  hist.push(now);
+  userSmokeHistory.set(cdKey, hist);
+  userSmokeCooldown.set(cdKey, now);
+  return { ok: true };
 }
 
 interface BackfillRequest {
@@ -160,8 +199,8 @@ serve(async (req) => {
     return jsonResponse({ error: "state must be open|closed|all" }, 400);
   }
 
-  const perPage = Math.min(Math.max(body.per_page ?? DEFAULT_PER_PAGE, 1), 100);
-  const maxPages = Math.min(Math.max(body.max_pages ?? DEFAULT_MAX_PAGES, 1), 50);
+  let perPage = Math.min(Math.max(body.per_page ?? DEFAULT_PER_PAGE, 1), 100);
+  let maxPages = Math.min(Math.max(body.max_pages ?? DEFAULT_MAX_PAGES, 1), 50);
 
   const guildId = (body.guild_id ?? Deno.env.get("GH_BACKFILL_DEFAULT_GUILD_ID") ?? "").trim();
   if (!SNOWFLAKE_RE.test(guildId)) {
@@ -182,6 +221,31 @@ serve(async (req) => {
       },
       403,
     );
+  }
+
+  if (!isServiceRole) {
+    const userSub = typeof claims.sub === "string" ? claims.sub : "";
+    if (!userSub) {
+      return jsonResponse(
+        { error: "Authenticated user token missing sub claim" },
+        401,
+      );
+    }
+    const rate = checkUserSmokeRateLimit(userSub, guildId);
+    if (!rate.ok) {
+      return jsonResponse(
+        {
+          error:
+            rate.reason === "cooldown"
+              ? `Wait ${Math.ceil(rate.retryAfterMs / 1000)}s between smoke runs`
+              : `Hourly smoke-test limit of ${USER_SMOKE_MAX_PER_HOUR} per guild exceeded — retry in ${Math.ceil(rate.retryAfterMs / 60_000)}m`,
+          retry_after_ms: rate.retryAfterMs,
+        },
+        429,
+      );
+    }
+    perPage = Math.min(perPage, USER_SMOKE_PER_PAGE_CAP);
+    maxPages = Math.min(maxPages, USER_SMOKE_MAX_PAGES_CAP);
   }
 
   const sb = createServiceClient();


### PR DESCRIPTION
Follow-up to #11843 / #11857.

> shouldn't there be a better way to test it? i see there is the smoke test but we had that issue with role locked to service_role? hmm for the smoke test, we should have a rate limit and make sure that they own the said server before we let them actually run that smoke test right

## 1. gh-backfill — per-user rate limit + tighter caps

ownsGuild + allowlist were already in #11843. Adds defense-in-depth for the user-JWT path (service_role cron caller untouched):

- 15s cooldown per (user, guild)
- 20 runs/hour per (user, guild)
- Force \`max_pages ≤ 1\` and \`per_page ≤ 30\` for user JWTs (server-side clamp). Service_role keeps full caps.
- 429 with \`retry_after_ms\` so the dashboard can show a sensible message.

In-memory per-edge-instance — stops the practical attack (single tab loop). Distributed quota = SQL counter, deferred until we see abuse.

## 2. gh-admin — new webhooks.ping command

The existing "test" path was gh-backfill smoke, which exercises the PAT + upsert RPC but does **not** fire the webhook. For Step 2 verification you want the actual webhook delivery.

\`handlePing(serverId, owner, repo)\`:
- Fetch PAT from vault
- \`GET /repos/{owner}/{repo}/hooks\` → find the hook whose \`config.url\` matches our edge URL
- \`POST /repos/{owner}/{repo}/hooks/{id}/pings\` → GitHub re-delivers the \`ping\` event to our gh-webhook URL
- Returns \`{ pinged: true, hook_id, url }\`

Rate-limited: 30s cooldown + 10 pings/hour per (user, repo).

## 3. Step 2 UI — "Send test ping" button

After install (or after verify-on-mount discovers the kbve hook), Step 2 shows a "Send test ping" button. Calls \`webhooks.ping\`. Result links the user to GitHub's Recent Deliveries to confirm the 200. 429s surface verbatim.

\`agentsService\`:
- \`$webhookPingBusyFor\`, \`$webhookPingResults\` — per-guild singletons
- \`pingRepoWebhook\` — gh-admin client
- \`pingWebhookForGuild\` — singleton wrapper

## Test plan

- [ ] Step 4 smoke: spam the button. After the first run, get a 429 "Wait Xs between smoke runs". After 20 runs in an hour, get "Hourly smoke-test limit … exceeded".
- [ ] Step 4 smoke: bypass dashboard, curl with \`max_pages: 50\`. Server clamps to 1 for user JWT.
- [ ] Step 2: install webhook → "Send test ping" appears. Click → "Ping sent" message. Open GitHub repo settings → Webhooks → Recent Deliveries → see a fresh \`ping\` event with 200.
- [ ] Step 2: spam ping. Second click within 30s → 429 verbatim message.