### PR TITLE
fix(arc-runner): bake webkit+firefox; workflow skips install when baked

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -54,7 +54,7 @@
 		{
 			"key": "arc_runner",
 			"app_name": "arc-runner",
-			"version": "0.1.3",
+			"version": "0.1.4",
 			"version_toml": "packages/docker/arc-runner/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx",
 			"source_path": "packages/docker/arc-runner",

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -191,8 +191,54 @@ jobs:
                   echo "version=${VER}" >> "$GITHUB_OUTPUT"
                   echo "Resolved Playwright version: ${VER}"
 
-            - name: Cache Playwright browsers
+            # Detect whether the runner image has already baked the browsers
+            # this project needs at /opt/ms-playwright (arc-runner does — see
+            # packages/docker/arc-runner/Dockerfile). When every requested
+            # browser is present, skip both the workflow cache and the
+            # install step entirely — the install was the failure mode that
+            # broke every e2e (#11849 / #11853): cdn.playwright.dev stalls
+            # turned a 14-minute chromium download into a 15- (then 25-)
+            # minute timeout. Pre-baked = zero network in the critical
+            # path. Falls back to the legacy cache + install dance on a
+            # github-hosted runner where /opt/ms-playwright isn't there.
+            - name: Check baked Playwright browsers
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' }}
+              id: baked-playwright
+              env:
+                  REQ_BROWSERS: ${{ steps.detect-playwright.outputs.browsers }}
+              run: |
+                  set -euo pipefail
+                  BAKE_DIR="${PLAYWRIGHT_BROWSERS_PATH:-/opt/ms-playwright}"
+                  MISSING=""
+                  if [ ! -d "$BAKE_DIR" ]; then
+                    echo "No baked browsers at ${BAKE_DIR} — falling back to install"
+                    echo "all_present=false" >> "$GITHUB_OUTPUT"
+                    echo "missing=${REQ_BROWSERS}" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+                  for b in $REQ_BROWSERS; do
+                    case "$b" in
+                      chromium) glob="${BAKE_DIR}/chromium-"*/chrome-linux*/chrome ;;
+                      webkit)   glob="${BAKE_DIR}/webkit-"*/pw_run.sh ;;
+                      firefox)  glob="${BAKE_DIR}/firefox-"*/firefox/firefox ;;
+                      *)        glob="${BAKE_DIR}/${b}-"* ;;
+                    esac
+                    if compgen -G "$glob" >/dev/null; then
+                      echo "  ${b}: baked"
+                    else
+                      echo "  ${b}: missing"
+                      MISSING="${MISSING:+$MISSING }${b}"
+                    fi
+                  done
+                  if [ -z "$MISSING" ]; then
+                    echo "all_present=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "all_present=false" >> "$GITHUB_OUTPUT"
+                    echo "missing=${MISSING}" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Cache Playwright browsers
+              if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.baked-playwright.outputs.all_present != 'true' }}
               id: playwright-cache
               uses: actions/cache@v5
               with:
@@ -203,14 +249,15 @@ jobs:
                       ${{ runner.os }}-playwright-
 
             - name: Install Playwright Browsers
-              if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
+              if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.baked-playwright.outputs.all_present != 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
               timeout-minutes: 40
               env:
                   UV_THREADPOOL_SIZE: '16'
+                  MISSING: ${{ steps.baked-playwright.outputs.missing || steps.detect-playwright.outputs.browsers }}
               run: |
                   set -euo pipefail
                   for try in 1 2 3; do
-                    if pnpm exec playwright install --with-deps ${{ steps.detect-playwright.outputs.browsers }}; then
+                    if pnpm exec playwright install --with-deps ${MISSING}; then
                       echo "playwright install succeeded on attempt ${try}"
                       exit 0
                     fi
@@ -221,7 +268,7 @@ jobs:
                   exit 1
 
             - name: Install Playwright OS deps (cache hit)
-              if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
+              if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.baked-playwright.outputs.all_present != 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
               timeout-minutes: 10
               run: pnpm exec playwright install-deps ${{ steps.detect-playwright.outputs.browsers }}
 

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -155,14 +155,6 @@ jobs:
                     echo "Playwright OFF"
                     exit 0
                   fi
-                  # Auto-detect which browsers the project's playwright.config.ts
-                  # actually drives. The shared workflow used to install
-                  # `chromium webkit` for every e2e, but every config except
-                  # astro-kbve's only uses chromium — irc-gateway in
-                  # particular kept timing out on the 15-min webkit
-                  # download. Scan the configs under source_path; default to
-                  # chromium when nothing matches so a missing config never
-                  # results in an empty browser list to `playwright install`.
                   ROOT="${{ inputs.source_path }}"
                   BROWSERS=""
                   CFGS=$(find "$ROOT" -maxdepth 6 -type f -name "playwright.config.*" -not -path "*/node_modules/*" 2>/dev/null || true)
@@ -191,16 +183,6 @@ jobs:
                   echo "version=${VER}" >> "$GITHUB_OUTPUT"
                   echo "Resolved Playwright version: ${VER}"
 
-            # Detect whether the runner image has already baked the browsers
-            # this project needs at /opt/ms-playwright (arc-runner does — see
-            # packages/docker/arc-runner/Dockerfile). When every requested
-            # browser is present, skip both the workflow cache and the
-            # install step entirely — the install was the failure mode that
-            # broke every e2e (#11849 / #11853): cdn.playwright.dev stalls
-            # turned a 14-minute chromium download into a 15- (then 25-)
-            # minute timeout. Pre-baked = zero network in the critical
-            # path. Falls back to the legacy cache + install dance on a
-            # github-hosted runner where /opt/ms-playwright isn't there.
             - name: Check baked Playwright browsers
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' }}
               id: baked-playwright

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -12,7 +12,7 @@ tags:
 key: arc_runner
 pipeline: docker
 app_name: arc-runner
-version: "0.1.3"
+version: "0.1.4"
 source_path: packages/docker/arc-runner
 version_toml: packages/docker/arc-runner/version.toml
 runner: ubuntu-latest

--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -1,21 +1,3 @@
-# ============================================================================
-# kbve/arc-runner — Custom GitHub Actions Runner image for arc-runner-set.
-#
-# Layered on top of `ghcr.io/actions/actions-runner` to bake in the tools
-# our workflows install at job runtime today (git-lfs, unzip, jq, xz-utils,
-# gh). Each tool we move into the image removes one apt-get round-trip
-# from every job that pulls a runner — Unity matrix legs in particular
-# install git-lfs three times per workflow run, once per build target.
-#
-# The image is consumed by both the `runner` container and the
-# `init-dind-externals` init container in the arc-runner-set values.yaml.
-# Externals (`/home/runner/externals/`) are inherited from the upstream
-# base image, so the init container keeps working unchanged.
-#
-# Build:
-#   docker build -t ghcr.io/kbve/arc-runner:latest packages/docker/arc-runner/
-# ============================================================================
-
 ARG ACTIONS_RUNNER_VERSION=2.334.0
 ARG KUBECTL_VERSION=1.31.0
 ARG DBMATE_VERSION=2.28.0
@@ -26,24 +8,11 @@ ARG PLAYWRIGHT_VERSION=1.59.1
 FROM --platform=linux/amd64 ghcr.io/actions/actions-runner:${ACTIONS_RUNNER_VERSION} AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/kbve/kbve"
-LABEL org.opencontainers.image.description="KBVE arc-runner-set image — actions-runner + git-lfs/unzip/jq/xz/gh + kubectl/dbmate/envsubst/postgresql-client + node/pnpm/playwright-chromium."
+LABEL org.opencontainers.image.description="KBVE arc-runner-set image — actions-runner + git-lfs/unzip/jq/xz/gh + kubectl/dbmate/envsubst/postgresql-client + node/pnpm/playwright."
 LABEL org.opencontainers.image.licenses="MIT"
 
 USER root
 
-# git-lfs               — Forgejo LFS pulls (rareicon Unity, future chuck UE5).
-# unzip                 — butler installer + generic archive tooling.
-# jq                    — manifest dispatch + workflow shell glue.
-# xz-utils              — Unity / butler / SDK installers ship `.tar.xz`.
-# ca-certs              — explicit pin so HTTPS clients always validate cert chains.
-# curl                  — already present in upstream, included defensively.
-# gh                    — GitHub CLI; several workflows shell out to it.
-# gettext-base          — `envsubst` for k8s manifest rendering.
-# postgresql-client     — `psql` for ci-dbmate-validate's seed-init step.
-# kubectl               — pinned k8s client for ci-dbmate-deploy.
-# dbmate                — pinned migrator. ci-dbmate-validate calls it
-#                          directly; ci-dbmate-deploy uses it via the
-#                          in-cluster Job (image bake = parity).
 ARG KUBECTL_VERSION
 ARG DBMATE_VERSION
 RUN set -eux; \
@@ -71,9 +40,6 @@ RUN set -eux; \
         > /etc/apt/sources.list.d/github-cli.list; \
     apt-get update; \
     apt-get install -y --no-install-recommends gh; \
-    # kubectl + dbmate from official release URLs. We pin via build-arg
-    # and verify with sha256 fetched from the matching release manifest
-    # — covers the supply-chain gap of bare `curl | install`.
     KUBECTL_SHA=$(curl -fsSL "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256"); \
     curl -fsSL -o /tmp/kubectl "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl"; \
     echo "${KUBECTL_SHA}  /tmp/kubectl" | sha256sum -c -; \
@@ -87,31 +53,12 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*; \
     git-lfs install --system; \
     echo 'root ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers; \
-    # Smoke-test every binary so a bad bake fails the build, not the runtime.
     kubectl version --client=true >/dev/null; \
     dbmate --version >/dev/null; \
     psql --version >/dev/null; \
     envsubst --version >/dev/null; \
     protoc --version >/dev/null
 
-# node + pnpm + playwright chromium + webkit + firefox
-#
-# Baked at image-build time so per-job `pnpm exec playwright install` is a
-# no-op cache hit at PLAYWRIGHT_BROWSERS_PATH. Avoids the libuv-threadpool
-# deadlock observed on arc-runner-set when playwright extracts chromium's
-# libwidevinecdm.so onto the pod's overlayfs at runtime, and the
-# cdn.playwright.dev hangs that timed out astro-kbve-e2e at the 15-minute
-# (then 25-minute) workflow timeout when a single chromium download
-# stalled to ~280 KB/s — see #11849 / #11853 / #11854 / #11856.
-#
-# All three engines land here so astro-kbve-e2e's chromium + webkit +
-# mobile-chrome + mobile-safari device list (and every other e2e using
-# any subset of these) is cold-install-free.
-#
-# Keep NODE_VERSION/PNPM_VERSION/PLAYWRIGHT_VERSION in lockstep with
-# package.json + .github/workflows/* (actions/setup-node, pnpm/action-setup,
-# @playwright/test). Mismatch falls back to per-job install and re-opens
-# both the deadlock and the CDN-stall failure mode.
 ARG NODE_VERSION
 ARG PNPM_VERSION
 ARG PLAYWRIGHT_VERSION

--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -94,17 +94,24 @@ RUN set -eux; \
     envsubst --version >/dev/null; \
     protoc --version >/dev/null
 
-# node + pnpm + playwright chromium
+# node + pnpm + playwright chromium + webkit + firefox
 #
 # Baked at image-build time so per-job `pnpm exec playwright install` is a
 # no-op cache hit at PLAYWRIGHT_BROWSERS_PATH. Avoids the libuv-threadpool
 # deadlock observed on arc-runner-set when playwright extracts chromium's
-# libwidevinecdm.so onto the pod's overlayfs at runtime.
+# libwidevinecdm.so onto the pod's overlayfs at runtime, and the
+# cdn.playwright.dev hangs that timed out astro-kbve-e2e at the 15-minute
+# (then 25-minute) workflow timeout when a single chromium download
+# stalled to ~280 KB/s — see #11849 / #11853 / #11854 / #11856.
+#
+# All three engines land here so astro-kbve-e2e's chromium + webkit +
+# mobile-chrome + mobile-safari device list (and every other e2e using
+# any subset of these) is cold-install-free.
 #
 # Keep NODE_VERSION/PNPM_VERSION/PLAYWRIGHT_VERSION in lockstep with
 # package.json + .github/workflows/* (actions/setup-node, pnpm/action-setup,
 # @playwright/test). Mismatch falls back to per-job install and re-opens
-# the deadlock.
+# both the deadlock and the CDN-stall failure mode.
 ARG NODE_VERSION
 ARG PNPM_VERSION
 ARG PLAYWRIGHT_VERSION
@@ -121,10 +128,12 @@ RUN set -eux; \
     rm "node-v${NODE_VERSION}-linux-x64.tar.xz" SHASUMS256.txt; \
     npm install -g "pnpm@${PNPM_VERSION}"; \
     mkdir -p "${PLAYWRIGHT_BROWSERS_PATH}"; \
-    npx --yes "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium; \
+    npx --yes "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium webkit firefox; \
     chmod -R a+rX "${PLAYWRIGHT_BROWSERS_PATH}"; \
     node --version >/dev/null; \
     pnpm --version >/dev/null; \
-    test -d "${PLAYWRIGHT_BROWSERS_PATH}/chromium-"*/chrome-linux*
+    test -d "${PLAYWRIGHT_BROWSERS_PATH}/chromium-"*/chrome-linux*; \
+    test -d "${PLAYWRIGHT_BROWSERS_PATH}/webkit-"*; \
+    test -d "${PLAYWRIGHT_BROWSERS_PATH}/firefox-"*
 
 USER runner


### PR DESCRIPTION
## Summary
Real fix for the recurring Playwright-installs-from-CDN-stall failure mode (#11849, #11853, #11854, #11856). arc-runner already pre-baked chromium at \`/opt/ms-playwright\` with \`PLAYWRIGHT_BROWSERS_PATH\` wired in the image, but the shared workflow ignored that path — every cache-miss run re-downloaded chromium from \`cdn.playwright.dev\`, plus the webkit + firefox that the bake didn't cover.

## Two halves

### Half 1 — bake the full browser set in arc-runner

[packages/docker/arc-runner/Dockerfile](packages/docker/arc-runner/Dockerfile) now installs \`chromium webkit firefox\` instead of just \`chromium\`. \`mobile-chrome\` and \`mobile-safari\` are config-only (they use the chromium and webkit engines), so this covers astro-kbve-e2e's full device matrix plus every other current e2e. \`--with-deps\` brings in apt deps too, so post-deploy runs are zero-network.

Bumps arc-runner MDX \`0.1.3\` → \`0.1.4\`. CI builds the image, post-publish atom PR rolls the values.yaml image tag.

### Half 2 — workflow checks the bake before downloading

[.github/workflows/docker-test-app.yml](.github/workflows/docker-test-app.yml) gets a new \`Check baked Playwright browsers\` step before the cache step:

- Probes \`$PLAYWRIGHT_BROWSERS_PATH\` (defaults to \`/opt/ms-playwright\`) for each requested browser using format-specific globs (chromium → \`chrome-linux/chrome\`, webkit → \`pw_run.sh\`, firefox → \`firefox/firefox\`).
- If every requested browser is present: emit \`all_present=true\`, skip both cache and install steps.
- If any are missing: emit \`missing=<list>\` and feed it to the install step, which only fetches what's actually missing.
- Falls back to the legacy cache + retry install on github-hosted runners (\`ubuntu-latest\`) where \`/opt/ms-playwright\` isn't there.

## Backwards compatibility
Workflow runs against \`@main\`, so this merges to dev and lands on main on the next release PR. While arc-runner is still at 0.1.3:
- chromium check: present → step skipped (immediate win)
- webkit / firefox checks: missing → falls through to the existing install (no regression vs. status quo)

Once arc-runner 0.1.4 is rolled to the cluster, all three browser checks pass and the install step becomes a no-op.

## Test plan
- [ ] CI - Docker / arc-runner builds the new image
- [ ] After 0.1.4 rolls out, CI - Docker / axum-kbve green with \`Check baked Playwright browsers\` reporting \`chromium: baked / webkit: baked / firefox: baked\` and Install/Cache steps skipped
- [ ] CI - Docker / irc-gateway, memes, discordsh, etc. (chromium-only) skip Install on either 0.1.3 or 0.1.4
- [ ] github-hosted-runner e2e (any) still installs via the legacy path