### PR TITLE
feat(KBVEUI): toast notification system + top nav bar

### DIFF
--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEToast.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEToast.cpp
@@ -1,0 +1,114 @@
+#include "SKBVEToast.h"
+
+#include "Styling/CoreStyle.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/SOverlay.h"
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+FLinearColor SKBVEToast::LevelColor(EKBVEToastLevel Level)
+{
+	switch (Level)
+	{
+		case EKBVEToastLevel::Success: return FLinearColor(0.25f, 0.78f, 0.38f, 1.f);
+		case EKBVEToastLevel::Warning: return FLinearColor(0.95f, 0.72f, 0.20f, 1.f);
+		case EKBVEToastLevel::Error:   return FLinearColor(0.90f, 0.30f, 0.30f, 1.f);
+		default:                       return FLinearColor(0.30f, 0.62f, 0.95f, 1.f);
+	}
+}
+
+void SKBVEToast::Construct(const FArguments& InArgs)
+{
+	OnDismiss = InArgs._OnDismiss;
+
+	const FLinearColor Accent     = LevelColor(InArgs._Level);
+	const FSlateFontInfo TitleFont = FCoreStyle::GetDefaultFontStyle("Bold", 12);
+	const FSlateFontInfo MsgFont   = FCoreStyle::GetDefaultFontStyle("Regular", 11);
+	const FSlateBrush* WhiteBrush  = FCoreStyle::Get().GetBrush("WhiteBrush");
+
+	TSharedRef<SHorizontalBox> Row = SNew(SHorizontalBox);
+
+	Row->AddSlot()
+	.AutoWidth()
+	[
+		SNew(SBox).WidthOverride(4.f)
+		[
+			SNew(SImage).Image(WhiteBrush).ColorAndOpacity(Accent)
+		]
+	];
+
+	Row->AddSlot()
+	.FillWidth(1.f)
+	.VAlign(VAlign_Center)
+	.Padding(10.f, 8.f, 8.f, 8.f)
+	[
+		SNew(SVerticalBox)
+
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		[
+			SNew(STextBlock)
+			.Text(InArgs._Title)
+			.Font(TitleFont)
+			.ColorAndOpacity(FLinearColor(0.95f, 0.95f, 0.97f, 1.f))
+			.AutoWrapText(true)
+		]
+
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(0.f, 2.f, 0.f, 0.f)
+		[
+			SNew(STextBlock)
+			.Text(InArgs._Message)
+			.Font(MsgFont)
+			.ColorAndOpacity(FLinearColor(0.82f, 0.82f, 0.86f, 0.95f))
+			.AutoWrapText(true)
+		]
+	];
+
+	if (InArgs._bShowClose)
+	{
+		Row->AddSlot()
+		.AutoWidth()
+		.VAlign(VAlign_Top)
+		.Padding(0.f, 4.f, 4.f, 0.f)
+		[
+			SNew(SButton)
+			.OnClicked(this, &SKBVEToast::HandleClose)
+			[
+				SNew(STextBlock)
+				.Text(FText::FromString(TEXT("X")))
+				.Font(FCoreStyle::GetDefaultFontStyle("Bold", 11))
+			]
+		];
+	}
+
+	ChildSlot
+	[
+		SNew(SBox)
+		.WidthOverride(InArgs._Width)
+		[
+			SNew(SOverlay)
+
+			+ SOverlay::Slot()
+			[
+				SNew(SImage)
+				.Image(WhiteBrush)
+				.ColorAndOpacity(FLinearColor(0.05f, 0.06f, 0.08f, 0.95f))
+			]
+
+			+ SOverlay::Slot()
+			[
+				Row
+			]
+		]
+	];
+}
+
+FReply SKBVEToast::HandleClose()
+{
+	OnDismiss.ExecuteIfBound();
+	return FReply::Handled();
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEToastLayer.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEToastLayer.cpp
@@ -1,0 +1,97 @@
+#include "SKBVEToastLayer.h"
+
+#include "Widgets/SBoxPanel.h"
+
+void SKBVEToastLayer::Construct(const FArguments& InArgs)
+{
+	MaxToasts       = FMath::Max(1, InArgs._MaxToasts);
+	DefaultDuration = InArgs._DefaultDuration;
+	ToastWidth      = InArgs._ToastWidth;
+
+	ChildSlot
+	[
+		SAssignNew(Stack, SVerticalBox)
+	];
+}
+
+int32 SKBVEToastLayer::PushToast(const FText& Title, const FText& Message, EKBVEToastLevel Level, float Duration)
+{
+	const float Life = (Duration < 0.f) ? DefaultDuration : Duration;
+	const int32 Id   = NextId++;
+
+	while (Entries.Num() >= MaxToasts)
+	{
+		RemoveEntry(0);
+	}
+
+	TSharedRef<SKBVEToast> Toast = SNew(SKBVEToast)
+		.Title(Title)
+		.Message(Message)
+		.Level(Level)
+		.Width(ToastWidth)
+		.OnDismiss(FSimpleDelegate::CreateSP(this, &SKBVEToastLayer::Dismiss, Id));
+
+	Stack->AddSlot()
+	.AutoHeight()
+	.Padding(0.f, 0.f, 0.f, 6.f)
+	[
+		Toast
+	];
+
+	FEntry Entry;
+	Entry.Id        = Id;
+	Entry.Widget    = Toast;
+	Entry.Remaining = Life;
+	Entry.bExpires  = Life > 0.f;
+	Entries.Add(Entry);
+
+	return Id;
+}
+
+void SKBVEToastLayer::Dismiss(int32 ToastId)
+{
+	const int32 Index = Entries.IndexOfByPredicate([ToastId](const FEntry& E) { return E.Id == ToastId; });
+	if (Index != INDEX_NONE)
+	{
+		RemoveEntry(Index);
+	}
+}
+
+void SKBVEToastLayer::DismissAll()
+{
+	for (int32 i = Entries.Num() - 1; i >= 0; --i)
+	{
+		RemoveEntry(i);
+	}
+}
+
+void SKBVEToastLayer::RemoveEntry(int32 Index)
+{
+	if (!Entries.IsValidIndex(Index))
+	{
+		return;
+	}
+	if (Entries[Index].Widget.IsValid() && Stack.IsValid())
+	{
+		Stack->RemoveSlot(Entries[Index].Widget.ToSharedRef());
+	}
+	Entries.RemoveAt(Index);
+}
+
+void SKBVEToastLayer::Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime)
+{
+	SCompoundWidget::Tick(AllottedGeometry, InCurrentTime, InDeltaTime);
+
+	for (int32 i = Entries.Num() - 1; i >= 0; --i)
+	{
+		if (!Entries[i].bExpires)
+		{
+			continue;
+		}
+		Entries[i].Remaining -= InDeltaTime;
+		if (Entries[i].Remaining <= 0.f)
+		{
+			RemoveEntry(i);
+		}
+	}
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVETopBar.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVETopBar.cpp
@@ -1,0 +1,57 @@
+#include "SKBVETopBar.h"
+
+#include "Styling/CoreStyle.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/SOverlay.h"
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Layout/SBox.h"
+
+void SKBVETopBar::Construct(const FArguments& InArgs)
+{
+	const FSlateBrush* WhiteBrush = FCoreStyle::Get().GetBrush("WhiteBrush");
+	const FSlateColor BgColor = InArgs._BackgroundColor.Get(FSlateColor(FLinearColor(0.04f, 0.05f, 0.07f, 0.95f)));
+
+	ChildSlot
+	[
+		SNew(SBox)
+		.HeightOverride(InArgs._BarHeight)
+		[
+			SNew(SOverlay)
+
+			+ SOverlay::Slot()
+			[
+				SNew(SImage)
+				.Image(WhiteBrush)
+				.ColorAndOpacity(BgColor)
+			]
+
+			+ SOverlay::Slot()
+			.Padding(FMargin(12.f, 0.f))
+			[
+				SNew(SHorizontalBox)
+
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				[
+					InArgs._Left.Widget
+				]
+
+				+ SHorizontalBox::Slot()
+				.FillWidth(1.f)
+				.HAlign(HAlign_Center)
+				.VAlign(VAlign_Center)
+				[
+					InArgs._Center.Widget
+				]
+
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.VAlign(VAlign_Center)
+				[
+					InArgs._Right.Widget
+				]
+			]
+		]
+	];
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVEToast.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVEToast.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Framework/SlateDelegates.h"
+#include "Input/Reply.h"
+
+enum class EKBVEToastLevel : uint8
+{
+	Info,
+	Success,
+	Warning,
+	Error
+};
+
+class KBVEUI_API SKBVEToast : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVEToast)
+		: _Level(EKBVEToastLevel::Info)
+		, _Width(320.f)
+		, _bShowClose(true)
+	{}
+		SLATE_ARGUMENT(EKBVEToastLevel, Level)
+		SLATE_ARGUMENT(float, Width)
+		SLATE_ARGUMENT(bool, bShowClose)
+		SLATE_ATTRIBUTE(FText, Title)
+		SLATE_ATTRIBUTE(FText, Message)
+		SLATE_EVENT(FSimpleDelegate, OnDismiss)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	static FLinearColor LevelColor(EKBVEToastLevel Level);
+
+private:
+	FReply HandleClose();
+
+	FSimpleDelegate OnDismiss;
+};

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVEToastLayer.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVEToastLayer.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "SKBVEToast.h"
+
+class SVerticalBox;
+
+class KBVEUI_API SKBVEToastLayer : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVEToastLayer)
+		: _MaxToasts(6)
+		, _DefaultDuration(4.f)
+		, _ToastWidth(320.f)
+	{}
+		SLATE_ARGUMENT(int32, MaxToasts)
+		SLATE_ARGUMENT(float, DefaultDuration)
+		SLATE_ARGUMENT(float, ToastWidth)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	int32 PushToast(const FText& Title, const FText& Message, EKBVEToastLevel Level = EKBVEToastLevel::Info, float Duration = -1.f);
+	void Dismiss(int32 ToastId);
+	void DismissAll();
+
+	virtual void Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime) override;
+
+private:
+	struct FEntry
+	{
+		int32 Id = 0;
+		TSharedPtr<SWidget> Widget;
+		float Remaining = 0.f;
+		bool bExpires = false;
+	};
+
+	void RemoveEntry(int32 Index);
+
+	TSharedPtr<SVerticalBox> Stack;
+	TArray<FEntry> Entries;
+	int32 NextId = 1;
+	int32 MaxToasts = 6;
+	float DefaultDuration = 4.f;
+	float ToastWidth = 320.f;
+};

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVETopBar.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVETopBar.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "Styling/SlateColor.h"
+
+class KBVEUI_API SKBVETopBar : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SKBVETopBar)
+		: _BarHeight(50.f)
+	{}
+		SLATE_ARGUMENT(float, BarHeight)
+		SLATE_ATTRIBUTE(FSlateColor, BackgroundColor)
+		SLATE_NAMED_SLOT(FArguments, Left)
+		SLATE_NAMED_SLOT(FArguments, Center)
+		SLATE_NAMED_SLOT(FArguments, Right)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+};


### PR DESCRIPTION
## What

Two more game-agnostic KBVEUI Slate widgets (Core + Slate, presentation only). Follows the settings-frame work already merged in #11839.

### Toast system (not hooked in — ready for a future notification system)
- `SKBVEToast` — notification card: Info/Success/Warning/Error accent, title + message, optional close, `LevelColor()` palette.
- `SKBVEToastLayer` — the system: `PushToast` / `Dismiss` / `DismissAll`, capped stack, per-toast auto-expiry via Tick. Game pushes toasts.

### Top nav bar
- `SKBVETopBar` — full-width, fixed height (default 50px), Left/Center/Right named slots for future player-facing info.

## Context
These were originally pushed to the (now-merged) #11839 branch after it merged, so they were orphaned. Re-based cleanly onto current dev here. No new CI wiring — KBVEUI's manifest entry is handled in #11844.

## Not verified
No local UE toolchain — **not compiled**. Needs a UE editor/UAT build pass.