### PR TITLE
feat(unreal): MDX-canonical plugin version flow + UE5-Win engine provisioning

### DIFF
--- a/.github/actions/fetch-ue-plugins/action.yml
+++ b/.github/actions/fetch-ue-plugins/action.yml
@@ -1,0 +1,96 @@
+name: Fetch UE Plugins
+description: Resolve a game's unreal-plugins.lock.json and download matching prebuilt plugin release assets into the project's Plugins dir. Falls back to source for any plugin without a published asset.
+
+inputs:
+    lockfile:
+        description: Path to unreal-plugins.lock.json (beside the .uproject)
+        required: true
+    project_dir:
+        description: Directory containing the .uproject — plugins land in <project_dir>/Plugins
+        required: true
+    platform:
+        description: 'Target platform: Win64 | Linux | Mac'
+        required: true
+    source_root:
+        description: Monorepo root holding packages/unreal/<name> for source fallback
+        required: false
+        default: '.'
+    github_token:
+        description: Token with contents read on the release repo
+        required: true
+
+outputs:
+    prebuilt:
+        description: Space-separated plugin names satisfied by a prebuilt asset
+        value: ${{ steps.fetch.outputs.prebuilt }}
+    source:
+        description: Space-separated plugin names that fell back to source
+        value: ${{ steps.fetch.outputs.source }}
+
+runs:
+    using: composite
+    steps:
+        - name: Fetch plugins
+          id: fetch
+          shell: bash
+          env:
+              GH_TOKEN: ${{ inputs.github_token }}
+              LOCKFILE: ${{ inputs.lockfile }}
+              PROJECT_DIR: ${{ inputs.project_dir }}
+              PLATFORM: ${{ inputs.platform }}
+              SOURCE_ROOT: ${{ inputs.source_root }}
+              REPO: ${{ github.repository }}
+          run: |
+              set -uo pipefail
+
+              if [ ! -f "$LOCKFILE" ]; then
+                  echo "::error::Lockfile not found: $LOCKFILE"
+                  exit 1
+              fi
+
+              ENGINE=$(jq -r '.engine' "$LOCKFILE")
+              if [ -z "$ENGINE" ] || [ "$ENGINE" = "null" ]; then
+                  echo "::error::Lockfile missing 'engine'"
+                  exit 1
+              fi
+
+              PLUGINS_DIR="${PROJECT_DIR}/Plugins"
+              mkdir -p "$PLUGINS_DIR"
+
+              prebuilt=""
+              source=""
+
+              while IFS= read -r entry; do
+                  name=$(echo "$entry" | jq -r '.name')
+                  version=$(echo "$entry" | jq -r '.version')
+                  lower=$(echo "$name" | tr '[:upper:]' '[:lower:]')
+                  if [ "$PLATFORM" = "Win64" ]; then
+                      tag="${lower}-win64-v${version}"
+                  else
+                      tag="${lower}-v${version}"
+                  fi
+                  asset="${name}-${PLATFORM}-UE${ENGINE}-v${version}.zip"
+
+                  echo "::group::${name} v${version} (${PLATFORM}, UE${ENGINE})"
+                  if gh release download "$tag" --repo "$REPO" --pattern "$asset" --dir /tmp/ue-plugins 2>/dev/null; then
+                      unzip -q -o "/tmp/ue-plugins/${asset}" -d "$PLUGINS_DIR"
+                      echo "prebuilt: $asset"
+                      prebuilt="${prebuilt} ${name}"
+                  else
+                      src="${SOURCE_ROOT}/packages/unreal/${name}"
+                      if [ -d "$src" ]; then
+                          cp -r "$src" "${PLUGINS_DIR}/${name}"
+                          rm -rf "${PLUGINS_DIR}/${name}/Binaries" "${PLUGINS_DIR}/${name}/Intermediate"
+                          echo "::warning::No prebuilt ${asset} — copied source from ${src} (will compile)"
+                          source="${source} ${name}"
+                      else
+                          echo "::error::No prebuilt asset ${asset} and no source at ${src}"
+                          echo "::endgroup::"
+                          exit 1
+                      fi
+                  fi
+                  echo "::endgroup::"
+              done < <(jq -c '.plugins[]' "$LOCKFILE")
+
+              echo "prebuilt=${prebuilt# }" >> "$GITHUB_OUTPUT"
+              echo "source=${source# }" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -159,6 +159,20 @@ jobs:
                     is_newer "$local_v" "$pub_v"
                   }
 
+                  # --- Version gate from a literal local version (unreal: MDX is the lever) ---
+                  check_version_value() {
+                    local local_v="$1" version_toml="$2"
+                    local pub_v="0.0.0" pub_flag="true"
+                    if [ -f "$version_toml" ]; then
+                      pub_flag=$(grep -m1 '^publish' "$version_toml" | sed 's/publish = //' | tr -d ' "' 2>/dev/null || echo "true")
+                    fi
+                    if [ "$pub_flag" = "false" ]; then echo "false"; return; fi
+                    if [ -f "$version_toml" ]; then
+                      pub_v=$(grep -m1 '^version' "$version_toml" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || echo "0.0.0")
+                    fi
+                    is_newer "$local_v" "$pub_v"
+                  }
+
                   # --- Check if alteration key is true ---
                   is_altered() {
                     local key="$1"
@@ -412,13 +426,14 @@ jobs:
                     deps=$(echo "$entry" | jq -r '.dependency_plugins // ""')
                     itch=$(echo "$entry" | jq -r '.itch_game_id // ""')
                     platforms=$(echo "$entry" | jq -r 'if (.supported_platforms // [] | length) > 0 then (.supported_platforms | join(",")) else "Linux" end')
+                    mdx_version=$(echo "$entry" | jq -r '.version')
                     altered=$(is_altered "$key")
                     deploy_itch="false"
                     [ -n "$itch" ] && deploy_itch="true"
                     reason=""
                     if [ "$altered" = "true" ]; then
                       reason="files changed"
-                    elif [ "$(check_version "${path}/${name}.uplugin" "${path}/version.toml")" = "true" ]; then
+                    elif [ "$(check_version_value "$mdx_version" "${path}/version.toml")" = "true" ]; then
                       reason="unpublished version"
                     else
                       echo "  · $name — no changes, version published, skipping"
@@ -436,6 +451,7 @@ jobs:
                         dispatch_publish unreal \
                           --field package_name="$name" \
                           --field unreal_plugin_path="$path" \
+                          --field manifest_version="$mdx_version" \
                           --field deploy_to_itch="$deploy_itch" \
                           --field itch_game_id="$itch" \
                           --field unreal_dependency_plugins="$deps"
@@ -444,7 +460,11 @@ jobs:
                     fi
 
                     # Win64 build (native UE5-Win VM) — GitHub Release only, no itch.
+                    # Linux owns the shared version.toml bump when both build, so the
+                    # Win64 publish skips it; a Win64-only plugin owns it itself.
                     if printf '%s' ",${platforms}," | grep -q ',Win64,'; then
+                      win64_skip_version="false"
+                      printf '%s' ",${platforms}," | grep -q ',Linux,' && win64_skip_version="true"
                       if [ "$(is_publish_running unreal-win64 "$name")" = "true" ]; then
                         echo "  · $name (Win64) — already running ($reason), skipping duplicate"
                         SKIPPED=$((SKIPPED + 1))
@@ -453,7 +473,9 @@ jobs:
                         dispatch_publish unreal-win64 \
                           --field package_name="$name" \
                           --field unreal_plugin_path="$path" \
+                          --field manifest_version="$mdx_version" \
                           --field deploy_to_itch="false" \
+                          --field skip_version_update="$win64_skip_version" \
                           --field unreal_dependency_plugins="$deps"
                         DISPATCHED=$((DISPATCHED + 1))
                       fi

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -67,6 +67,11 @@ on:
                 description: 'Unix timestamp when this was dispatched (queue guard)'
                 required: true
                 type: string
+            skip_version_update:
+                description: 'unreal-win64 only — when true, the Win64 publish does NOT bump version.toml (the Linux publish owns it for multi-platform plugins).'
+                required: false
+                type: boolean
+                default: false
 
 # No workflow-level concurrency — each package fans out independently.
 # Queue guard handles stale deploy protection per-package.
@@ -164,14 +169,15 @@ jobs:
                       fi
                       VTOML="packages/python/${PYPI}/version.toml"
                       ;;
-                    unreal)
-                      UPLUGIN="${{ inputs.unreal_plugin_path }}/${NAME}.uplugin"
-                      LOCAL=$(jq -r '.VersionName' "$UPLUGIN" 2>/dev/null || echo "0.0.0")
-                      VTOML="${{ inputs.unreal_plugin_path }}/version.toml"
-                      ;;
-                    unreal-win64)
-                      UPLUGIN="${{ inputs.unreal_plugin_path }}/${NAME}.uplugin"
-                      LOCAL=$(jq -r '.VersionName' "$UPLUGIN" 2>/dev/null || echo "0.0.0")
+                    unreal | unreal-win64)
+                      # MDX manifest_version is the lever; uplugin VersionName is a
+                      # build-stamped/post-publish-synced mirror, not the source.
+                      MANIFEST_V="${{ inputs.manifest_version }}"
+                      if [ -n "$MANIFEST_V" ] && [ "$MANIFEST_V" != "0.0.0" ]; then
+                        LOCAL="$MANIFEST_V"
+                      else
+                        LOCAL=$(jq -r '.VersionName' "${{ inputs.unreal_plugin_path }}/${NAME}.uplugin" 2>/dev/null || echo "0.0.0")
+                      fi
                       VTOML="${{ inputs.unreal_plugin_path }}/version.toml"
                       ;;
                     *)
@@ -330,6 +336,7 @@ jobs:
             mode: plugin
             plugin_path: ${{ inputs.unreal_plugin_path }}
             plugin_name: ${{ inputs.package_name }}
+            manifest_version: ${{ inputs.manifest_version }}
             ue_image_tag: ${{ matrix.ue_tag }}
             target_platforms: Linux
             deploy_to_itch: ${{ inputs.deploy_to_itch }}
@@ -358,6 +365,8 @@ jobs:
             mode: plugin-win
             plugin_path: ${{ inputs.unreal_plugin_path }}
             plugin_name: ${{ inputs.package_name }}
+            manifest_version: ${{ inputs.manifest_version }}
+            ue_image_tag: ${{ fromJson(inputs.ue_image_tags)[0] }}
             target_platforms: Win64
             deploy_to_itch: ${{ inputs.deploy_to_itch }}
             itch_username: kbve
@@ -371,7 +380,6 @@ jobs:
     # ---------------------------------------------------------------------------
     # Post-publish — update version.toml after successful publish.
     # Uses the version_gate output to know what version was published.
-    # Unreal handles its own version.toml update inside ci-unreal-build.yml.
     # ---------------------------------------------------------------------------
     update_version_npm:
         name: Update version.toml (npm)
@@ -420,6 +428,38 @@ jobs:
             version: ${{ needs.version_gate.outputs.local_version }}
             version_toml_path: packages/python/${{ inputs.pypi_name }}/version.toml
             version_target_path: ${{ inputs.version_target }}
+
+    update_version_unreal:
+        name: Update version.toml (unreal)
+        needs: [publish_unreal, version_gate]
+        if: always() && needs.publish_unreal.result == 'success' && needs.version_gate.outputs.should_publish == 'true'
+        permissions:
+            contents: write
+            pull-requests: write
+            actions: write
+        uses: KBVE/kbve/.github/workflows/utils-update-version-toml.yml@dev
+        with:
+            package_type: unreal
+            package_name: ${{ inputs.package_name }}
+            version: ${{ needs.version_gate.outputs.local_version }}
+            version_toml_path: ${{ inputs.unreal_plugin_path }}/version.toml
+            version_target_path: ${{ inputs.unreal_plugin_path }}/${{ inputs.package_name }}.uplugin
+
+    update_version_unreal_win64:
+        name: Update version.toml (unreal-win64)
+        needs: [publish_unreal_win64, version_gate]
+        if: always() && needs.publish_unreal_win64.result == 'success' && needs.version_gate.outputs.should_publish == 'true' && inputs.skip_version_update != true
+        permissions:
+            contents: write
+            pull-requests: write
+            actions: write
+        uses: KBVE/kbve/.github/workflows/utils-update-version-toml.yml@dev
+        with:
+            package_type: unreal
+            package_name: ${{ inputs.package_name }}
+            version: ${{ needs.version_gate.outputs.local_version }}
+            version_toml_path: ${{ inputs.unreal_plugin_path }}/version.toml
+            version_target_path: ${{ inputs.unreal_plugin_path }}/${{ inputs.package_name }}.uplugin
 
     # ---------------------------------------------------------------------------
     # Failure Tracker — opens a GitHub issue on any pipeline failure (#8186).

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -831,82 +831,108 @@ jobs:
                   fi
 
     engine_build_windows:
-        name: Engine Build (Windows client)
+        name: Engine Provision (UE5-Win VM)
         needs: [guard, engine_gate]
         if: inputs.mode == 'engine' && needs.guard.outputs.allowed == 'true' && needs.engine_gate.outputs.should_build == 'true' && contains(inputs.platforms, 'windows')
-        runs-on: windows-latest
-        timeout-minutes: 360
+        runs-on: UE5-Win
+        timeout-minutes: 600
         permissions:
             contents: read
+        env:
+            ENGINE_ROOT: C:\UnrealEngine
         steps:
             - name: Audit log
+              shell: pwsh
+              run: Write-Host "::notice::Windows engine provision — ref=${{ inputs.engine_ref }}, version=${{ needs.engine_gate.outputs.version }}, root=$env:ENGINE_ROOT"
+
+            - name: Check existing engine
+              id: check
+              shell: pwsh
               run: |
-                  echo "::notice::Windows engine build — ref=${{ inputs.engine_ref }}, version=${{ needs.engine_gate.outputs.version }}"
+                  $runuat = Test-Path (Join-Path $env:ENGINE_ROOT 'Engine\Build\BatchFiles\RunUAT.bat')
+                  $marker = Join-Path $env:ENGINE_ROOT '.kbve-engine-ref'
+                  $builtRef = if (Test-Path $marker) { (Get-Content $marker -Raw).Trim() } else { '' }
+                  $force = '${{ inputs.skip_version_gate }}' -eq 'true'
+                  if ($runuat -and ($builtRef -eq '${{ inputs.engine_ref }}') -and (-not $force)) {
+                      Write-Host "Engine already provisioned (ref=$builtRef) — skipping build."
+                      "skip=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                  } else {
+                      Write-Host "Building engine (runuat=$runuat builtRef='$builtRef' force=$force)."
+                      "skip=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+                  }
 
             - name: Verify build tools
+              if: steps.check.outputs.skip != 'true'
               shell: pwsh
               run: |
                   $vsWhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-                  if (Test-Path $vsWhere) {
-                    $vsPath = & $vsWhere -latest -property installationPath
-                    Write-Host "::notice::Visual Studio found at: $vsPath"
-                  } else {
-                    Write-Host "::warning::vswhere not found — MSVC may not be installed"
-                  }
+                  if (-not (Test-Path $vsWhere)) { Write-Host "::error::vswhere not found — run the win-setup task first"; exit 1 }
+                  Write-Host "::notice::VS: $(& $vsWhere -latest -property installationPath)"
+                  git --version
                   git lfs version
 
-            - name: Clone engine source
+            - name: Clone or update engine source
+              if: steps.check.outputs.skip != 'true'
               env:
                   UNITY_PAT: ${{ secrets.UNITY_PAT }}
               shell: pwsh
               run: |
-                  git clone --depth 1 --branch ${{ inputs.engine_ref }} `
-                    "https://x-access-token:${env:UNITY_PAT}@github.com/${{ env.ENGINE_REPO }}.git" `
-                    engine
+                  $url = "https://x-access-token:${env:UNITY_PAT}@github.com/${{ env.ENGINE_REPO }}.git"
+                  if (Test-Path (Join-Path $env:ENGINE_ROOT '.git')) {
+                      Push-Location $env:ENGINE_ROOT
+                      git remote set-url origin $url
+                      git fetch --depth 1 origin '${{ inputs.engine_ref }}'
+                      git checkout -f FETCH_HEAD
+                      git reset --hard FETCH_HEAD
+                      git lfs pull
+                      Pop-Location
+                  } else {
+                      git clone --depth 1 --branch '${{ inputs.engine_ref }}' $url $env:ENGINE_ROOT
+                  }
 
             - name: Run Setup
+              if: steps.check.outputs.skip != 'true'
               shell: pwsh
               run: |
-                  Push-Location engine; .\Setup.bat; Pop-Location
+                  Push-Location $env:ENGINE_ROOT; .\Setup.bat; Pop-Location
 
             - name: Generate project files
+              if: steps.check.outputs.skip != 'true'
               shell: pwsh
               run: |
-                  Push-Location engine; .\GenerateProjectFiles.bat; Pop-Location
+                  Push-Location $env:ENGINE_ROOT; .\GenerateProjectFiles.bat; Pop-Location
 
             - name: Build Editor (Win64)
+              if: steps.check.outputs.skip != 'true'
               shell: pwsh
               run: |
-                  Push-Location engine
+                  Push-Location $env:ENGINE_ROOT
                   .\Engine\Build\BatchFiles\RunUAT.bat BuildTarget `
                     -target=UnrealEditor -platform=Win64 -configuration=Development `
                     -notools -unattended -utf8output
                   Pop-Location
 
-            - name: Package Windows client
+            - name: Mark engine ref
+              if: steps.check.outputs.skip != 'true'
               shell: pwsh
               run: |
-                  $Version = "${{ needs.engine_gate.outputs.version }}"
-                  $OutDir = "angelscript-win64-v${Version}"
-                  New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
-                  Copy-Item -Recurse "engine\Engine\Binaries\Win64\*" "$OutDir\"
-                  Compress-Archive -Path $OutDir -DestinationPath "angelscript-win64-v${Version}.zip"
+                  '${{ inputs.engine_ref }}' | Out-File -FilePath (Join-Path $env:ENGINE_ROOT '.kbve-engine-ref') -Encoding ascii -NoNewline
 
-            - name: Upload Windows artifact
-              uses: actions/upload-artifact@v7
-              with:
-                  name: angelscript-win64-v${{ needs.engine_gate.outputs.version }}
-                  path: angelscript-win64-v${{ needs.engine_gate.outputs.version }}.zip
-                  retention-days: 30
+            - name: Verify engine root
+              shell: pwsh
+              run: |
+                  $runuat = Join-Path $env:ENGINE_ROOT 'Engine\Build\BatchFiles\RunUAT.bat'
+                  if (-not (Test-Path $runuat)) { Write-Host "::error::Engine not provisioned — RunUAT.bat missing at $runuat"; exit 1 }
+                  Write-Host "::notice::Engine ready at $env:ENGINE_ROOT"
 
             - name: Cleanup secrets
               if: always()
               shell: pwsh
               run: |
-                  if (Test-Path "engine\.git") {
-                    Push-Location engine
-                    git remote set-url origin "https://github.com/${{ env.ENGINE_REPO }}.git"
-                    Pop-Location
+                  if (Test-Path (Join-Path $env:ENGINE_ROOT '.git')) {
+                      Push-Location $env:ENGINE_ROOT
+                      git remote set-url origin "https://github.com/${{ env.ENGINE_REPO }}.git"
+                      Pop-Location
                   }
 
     engine_build_mac:
@@ -1021,21 +1047,14 @@ jobs:
 
     engine_release:
         name: Engine GitHub Release
-        needs:
-            [
-                engine_gate,
-                engine_build_windows,
-                engine_build_mac,
-                engine_build_linux,
-            ]
+        needs: [engine_gate, engine_build_mac, engine_build_linux]
         if: |
             inputs.mode == 'engine' &&
             always() &&
             needs.engine_gate.outputs.should_build == 'true' &&
-            (needs.engine_build_windows.result == 'success' || needs.engine_build_windows.result == 'skipped') &&
             (needs.engine_build_mac.result == 'success' || needs.engine_build_mac.result == 'skipped') &&
             (needs.engine_build_linux.result == 'success' || needs.engine_build_linux.result == 'skipped') &&
-            (needs.engine_build_windows.result == 'success' || needs.engine_build_mac.result == 'success' || needs.engine_build_linux.result == 'success')
+            (needs.engine_build_mac.result == 'success' || needs.engine_build_linux.result == 'success')
         runs-on: ubuntu-latest
         timeout-minutes: 15
         permissions:
@@ -1065,7 +1084,6 @@ jobs:
                   ### Artifacts
                   | Platform | Status |
                   |----------|--------|
-                  | Windows x86 | ${{ needs.engine_build_windows.result }} |
                   | Mac x86 | ${{ needs.engine_build_mac.result }} |
                   | Linux Server | ${{ needs.engine_build_linux.result }} |
 
@@ -1150,6 +1168,7 @@ jobs:
             should_release: ${{ steps.compare.outputs.should_release }}
             tag: ${{ steps.compare.outputs.tag }}
             zip_name: ${{ steps.extract.outputs.zip_name }}
+            engine: ${{ steps.extract.outputs.engine }}
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -1159,8 +1178,13 @@ jobs:
               run: |
                   UPLUGIN="${{ inputs.plugin_path }}/${{ inputs.plugin_name }}.uplugin"
                   if [ ! -f "${UPLUGIN}" ]; then echo "::error::Plugin file not found: ${UPLUGIN}"; exit 1; fi
-                  VERSION=$(jq -r '.VersionName' "${UPLUGIN}")
-                  if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then echo "::error::No VersionName in ${UPLUGIN}"; exit 1; fi
+                  MANIFEST_V="${{ inputs.manifest_version }}"
+                  if [ -n "${MANIFEST_V}" ] && [ "${MANIFEST_V}" != "0.0.0" ]; then
+                    VERSION="${MANIFEST_V}"
+                  else
+                    VERSION=$(jq -r '.VersionName' "${UPLUGIN}")
+                  fi
+                  if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then echo "::error::No version resolved for ${UPLUGIN}"; exit 1; fi
 
                   VERSION_TOML="${{ inputs.plugin_path }}/version.toml"
                   if [ -f "${VERSION_TOML}" ]; then
@@ -1169,11 +1193,14 @@ jobs:
                     PUBLISHED="0.0.0"
                   fi
 
-                  if [ "${{ inputs.mode }}" = "plugin-win" ]; then SUFFIX="-Win64"; else SUFFIX=""; fi
+                  if [ "${{ inputs.mode }}" = "plugin-win" ]; then SUFFIX="-Win64"; else SUFFIX="-Linux"; fi
+                  ENGINE=$(printf '%s' "${{ inputs.ue_image_tag }}" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)
+                  [ -z "${ENGINE}" ] && ENGINE="unknown"
                   echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
                   echo "published_version=${PUBLISHED}" >> "$GITHUB_OUTPUT"
-                  echo "zip_name=${{ inputs.plugin_name }}${SUFFIX}-v${VERSION}.zip" >> "$GITHUB_OUTPUT"
-                  echo "::notice::Plugin ${{ inputs.plugin_name }} — uplugin: ${VERSION}, published: ${PUBLISHED}"
+                  echo "engine=${ENGINE}" >> "$GITHUB_OUTPUT"
+                  echo "zip_name=${{ inputs.plugin_name }}${SUFFIX}-UE${ENGINE}-v${VERSION}.zip" >> "$GITHUB_OUTPUT"
+                  echo "::notice::Plugin ${{ inputs.plugin_name }} — uplugin: ${VERSION}, published: ${PUBLISHED}, engine: ${ENGINE}"
 
             - name: Compare versions
               id: compare
@@ -1218,6 +1245,13 @@ jobs:
 
             - name: Checkout repository
               uses: actions/checkout@v6
+
+            - name: Stamp plugin version
+              run: |
+                  UPLUGIN="${{ inputs.plugin_path }}/${{ inputs.plugin_name }}.uplugin"
+                  VERSION="${{ needs.plugin_check.outputs.version }}"
+                  jq --arg v "$VERSION" '.VersionName = $v' "$UPLUGIN" > "$UPLUGIN.tmp" && mv "$UPLUGIN.tmp" "$UPLUGIN"
+                  echo "Stamped $UPLUGIN VersionName=$VERSION"
 
             - name: Login to GHCR
               run: echo "${{ secrets.epic_pat }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -1319,6 +1353,14 @@ jobs:
 
             - name: Checkout repository
               uses: actions/checkout@v6
+
+            - name: Stamp plugin version
+              run: |
+                  $up = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.plugin_path }}' '${{ inputs.plugin_name }}.uplugin'
+                  $json = Get-Content $up -Raw | ConvertFrom-Json
+                  $json.VersionName = '${{ needs.plugin_check.outputs.version }}'
+                  $json | ConvertTo-Json -Depth 20 | Set-Content $up
+                  Write-Host "Stamped $up VersionName=${{ needs.plugin_check.outputs.version }}"
 
             - name: Locate Unreal Engine
               id: engine
@@ -1455,51 +1497,6 @@ jobs:
                   buildChannel: ${{ inputs.itch_channel }}-v${{ needs.plugin_check.outputs.version }}
                   buildNumber: ${{ needs.plugin_check.outputs.version }}
 
-    plugin_update_version:
-        name: Plugin PR version.toml
-        needs:
-            [plugin_check, plugin_build_linux, plugin_build_win, plugin_release]
-        if: |
-            (inputs.mode == 'plugin' || inputs.mode == 'plugin-win') &&
-            always() &&
-            needs.plugin_check.outputs.should_release == 'true' &&
-            (needs.plugin_build_linux.result == 'success' || needs.plugin_build_win.result == 'success')
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        permissions:
-            contents: write
-            pull-requests: write
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v6
-              with:
-                  ref: dev
-
-            - name: Update version.toml
-              run: |
-                  VERSION_TOML="${{ inputs.plugin_path }}/version.toml"
-                  echo 'version = "${{ needs.plugin_check.outputs.version }}"' > "${VERSION_TOML}"
-                  cat "${VERSION_TOML}"
-
-            - name: Create PR
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  PLUGIN="${{ inputs.plugin_name }}"
-                  VERSION="${{ needs.plugin_check.outputs.version }}"
-                  if [ "${{ inputs.mode }}" = "plugin-win" ]; then VARIANT="-win64"; else VARIANT=""; fi
-                  BRANCH="auto/update-${PLUGIN,,}${VARIANT}-version-${VERSION}"
-                  git config user.name "github-actions[bot]"
-                  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                  git checkout -b "${BRANCH}"
-                  git add "${{ inputs.plugin_path }}/version.toml"
-                  git commit -m "chore(${PLUGIN}): update version.toml to ${VERSION} [skip ci]"
-                  git push origin "${BRANCH}"
-                  gh pr create \
-                    --base dev --head "${BRANCH}" \
-                    --title "chore(${PLUGIN}): update version.toml to ${VERSION}" \
-                    --body "Automated post-publish update. ${PLUGIN} v${VERSION} released."
-
     # ════════════════ VM SETUP (Windows / macOS) ════════════════
     win_setup:
         name: Install on UE5-Win
@@ -1566,6 +1563,15 @@ jobs:
                   if (Get-Command cmake -ErrorAction SilentlyContinue) { Write-Host "CMake already installed: $(cmake --version | Select-Object -First 1)"; exit 0 }
                   curl.exe -o C:\cmake-install.msi "$env:FILE_SERVER/cmake-install.msi"
                   Start-Process msiexec.exe -ArgumentList '/i C:\cmake-install.msi /quiet /norestart ADD_CMAKE_TO_PATH=System' -Wait
+
+            - name: Install Git LFS
+              run: |
+                  git lfs version 2>$null
+                  if ($LASTEXITCODE -eq 0) { git lfs install; Write-Host "Git LFS already installed: $(git lfs version)"; exit 0 }
+                  curl.exe -o C:\git-lfs-install.exe "$env:FILE_SERVER/git-lfs-install.exe"
+                  if (!(Test-Path C:\git-lfs-install.exe)) { Write-Host "::error::Download failed. Stage git-lfs-install.exe on file-server first."; exit 1 }
+                  Start-Process C:\git-lfs-install.exe -ArgumentList '/VERYSILENT /NORESTART' -Wait
+                  git lfs install
 
             - name: Verify Installation
               run: |

--- a/.github/workflows/ci-unreal.yml
+++ b/.github/workflows/ci-unreal.yml
@@ -125,7 +125,11 @@ on:
                 type: boolean
                 default: true
 
-permissions: {}
+permissions:
+    contents: write
+    packages: write
+    issues: write
+    pull-requests: write
 
 jobs:
     game:

--- a/.github/workflows/utils-update-version-toml.yml
+++ b/.github/workflows/utils-update-version-toml.yml
@@ -78,6 +78,9 @@ jobs:
                     *.toml)
                       sed -i "s/^version = .*/version = \"${VERSION}\"/" "$TARGET"
                       ;;
+                    *.uplugin)
+                      jq --arg v "$VERSION" '.VersionName = $v' "$TARGET" > "$TARGET.tmp" && mv "$TARGET.tmp" "$TARGET"
+                      ;;
                     *.json)
                       jq --arg v "$VERSION" '.version = $v' "$TARGET" > "$TARGET.tmp" && mv "$TARGET.tmp" "$TARGET"
                       ;;

--- a/apps/chuckrpg/unreal-chuck/unreal-plugins.lock.json.example
+++ b/apps/chuckrpg/unreal-chuck/unreal-plugins.lock.json.example
@@ -1,0 +1,8 @@
+{
+	"engine": "5.7.4",
+	"plugins": [
+		{ "name": "KBVEZstd", "version": "1.5.7" },
+		{ "name": "KBVEYYJson", "version": "0.12.0" },
+		{ "name": "UEDevOps", "version": "0.1.0" }
+	]
+}

--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -140,6 +140,20 @@
 				"cwd": "{workspaceRoot}"
 			}
 		},
+		"sync:unreal": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "node apps/kbve/astro-kbve/scripts/sync-unreal-uplugin.mjs",
+				"cwd": "{workspaceRoot}"
+			}
+		},
+		"sync:unreal:check": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "node apps/kbve/astro-kbve/scripts/sync-unreal-uplugin.mjs --check",
+				"cwd": "{workspaceRoot}"
+			}
+		},
 		"sync:mapdb": {
 			"executor": "nx:run-commands",
 			"inputs": [

--- a/apps/kbve/astro-kbve/scripts/sync-unreal-uplugin.mjs
+++ b/apps/kbve/astro-kbve/scripts/sync-unreal-uplugin.mjs
@@ -1,0 +1,49 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const REGISTRY = 'dist/apps/astro-kbve/api/ci-registry.json';
+const checkOnly = process.argv.includes('--check');
+
+if (!existsSync(REGISTRY)) {
+	console.error(`Build output not found: ${REGISTRY} — run astro-kbve:build first`);
+	process.exit(1);
+}
+
+const registry = JSON.parse(readFileSync(REGISTRY, 'utf8'));
+const plugins = registry.unreal ?? [];
+
+const drift = [];
+let written = 0;
+
+for (const plugin of plugins) {
+	const { plugin_name, plugin_path, version } = plugin;
+	if (!plugin_name || !plugin_path || !version) continue;
+
+	const upluginPath = `${plugin_path}/${plugin_name}.uplugin`;
+	if (!existsSync(upluginPath)) {
+		console.warn(`Missing .uplugin: ${upluginPath}`);
+		continue;
+	}
+
+	const uplugin = JSON.parse(readFileSync(upluginPath, 'utf8'));
+	if (uplugin.VersionName === version) continue;
+
+	drift.push(`${plugin_name}: uplugin=${uplugin.VersionName} mdx=${version}`);
+
+	if (!checkOnly) {
+		uplugin.VersionName = version;
+		writeFileSync(upluginPath, JSON.stringify(uplugin, null, '\t') + '\n');
+		written++;
+	}
+}
+
+if (checkOnly) {
+	if (drift.length) {
+		console.error('uplugin VersionName drift from MDX version:');
+		for (const line of drift) console.error(`  ${line}`);
+		console.error('Run: npx nx run astro-kbve:sync:unreal');
+		process.exit(1);
+	}
+	console.log(`All ${plugins.length} uplugin VersionNames match MDX.`);
+} else {
+	console.log(`Synced ${written} uplugin VersionName(s) from MDX (${plugins.length} plugins checked).`);
+}

--- a/packages/unreal/PLUGIN_PIPELINE.md
+++ b/packages/unreal/PLUGIN_PIPELINE.md
@@ -1,0 +1,114 @@
+# Unreal Plugin Pipeline
+
+How KBVE Unreal plugins version, build, publish, and (future) get consumed by game builds.
+
+## Source of truth
+
+MDX `version:` is the single lever. Bump it and nothing else — every other
+version field is derived. The page lives at
+`apps/kbve/astro-kbve/src/content/docs/project/<plugin>.mdx` and carries the
+CI registry frontmatter (`key`, `pipeline: unreal`, `plugin_name`,
+`plugin_path`, `version`, `supported_platforms`).
+
+| File                             | Role                                               | Who writes it                                                  |
+| -------------------------------- | -------------------------------------------------- | -------------------------------------------------------------- |
+| MDX `version:`                   | lever — the only thing a human bumps               | human (release PR)                                             |
+| manifest `version`               | what the dispatcher + publish gate compare against | `astro-kbve:build` from MDX                                    |
+| `<plugin>.uplugin` `VersionName` | embedded in the packaged plugin                    | stamped at build time; synced into source by the post-build PR |
+| `version.toml` `version`         | published marker — last version shipped            | post-build PR                                                  |
+
+The dispatcher gates on the **manifest `version`** (from MDX), not the
+`.uplugin`. So the `.uplugin` VersionName is allowed to lag MDX between a bump
+and its publish — that drift is normal, not an error. `version.toml` is the
+published marker and is never pre-synced; the build fires only while MDX >
+`version.toml`.
+
+## Release flow
+
+1. Bump MDX `version:` (e.g. `1.5.7` → `1.5.8`). That is the entire human edit.
+2. Merge to dev → release PR dev→main.
+3. On push to main, `ci-main.yml` reads `.github/ci-dispatch-manifest.json`,
+   sees manifest `version` > `version.toml`, and dispatches `ci-publish.yml`
+   once per platform in `supported_platforms`:
+    - `unreal` → Linux (`arc-runner-ue`, docker)
+    - `unreal-win64` → Win64 (`UE5-Win` KubeVirt VM)
+      The MDX version rides along as `manifest_version`.
+4. The build stamps the `.uplugin` `VersionName` with `manifest_version` before
+   `BuildPlugin`, then packages and uploads a GitHub Release asset named with
+   platform + engine + version:
+   `KBVEZstd-Linux-UE5.7.4-v1.5.8.zip`, `KBVEZstd-Win64-UE5.7.4-v1.5.8.zip`.
+5. Post-build: `ci-publish.yml` opens ONE auto-PR via
+   `utils-update-version-toml.yml` that bumps **both** `version.toml` and the
+   source `.uplugin` `VersionName` to the published version. For multi-platform
+   plugins the Linux publish owns this PR and Win64 skips it
+   (`skip_version_update`, set by the dispatcher). A Win64-only plugin owns it.
+
+`npx nx run astro-kbve:sync:unreal` exists as a manual tool to bulk-resync every
+`.uplugin` VersionName from MDX (e.g. after backfilling versions); it is not part
+of the release path.
+
+## Win64 prerequisites
+
+`UE5-Win` is a single self-hosted KubeVirt VM (`windows-builder`, `angelscript`
+namespace, runner group `KBVE`), started by KEDA when a job queues for that
+label. It needs three provisioning layers, in order, before a plugin builds:
+
+1. **VM online** — KEDA boots it on a queued `UE5-Win` job (or start manually).
+2. **Toolchain** — the `win-setup` task (`ci-unreal.yml`) installs VS BuildTools,
+   Python, .NET, DirectX, CMake, and Git LFS from `file-server` (which must be
+   scaled to `replicas=1`). Idempotent — every step skips if already present.
+   `win-setup` does NOT install the engine.
+3. **Engine** — the `engine` task with `platforms: windows` builds the
+   AngelScript engine (`KBVE/UnrealEngine-Angelscript`) in place at
+   `C:\UnrealEngine` on the VM (`engine_build_windows`, runs on `UE5-Win`). It is
+   a source build, persisted on the VM disk (not released as an artifact), and is
+   idempotent: it skips the multi-hour rebuild when `C:\UnrealEngine` already
+   holds the requested `engine_ref` (tracked by a `.kbve-engine-ref` marker).
+   Force a rebuild with `skip_version_gate: true`. First provision:
+   dispatch the `engine` task, `platforms: windows`, `skip_version_gate: true`.
+
+Plugins are stock-UE compatible, but building them against the same AngelScript
+engine the game ships on keeps the toolchain identical. The plugin-win build's
+"Locate Unreal Engine" finds `C:\UnrealEngine` automatically.
+
+## Future: prebuilt binary distribution to game builds
+
+Game builds currently do not consume these plugins. When wired, the goal is for
+a game build to pull prebuilt plugin binaries (`.so` / `.dll` / `.dylib`) instead
+of compiling each plugin from source — faster builds.
+
+Mechanism (scaffolded, not yet active):
+
+- Each game pins the plugins it consumes in `unreal-plugins.lock.json` beside its
+  `.uproject`:
+
+    ```json
+    {
+    	"engine": "5.7.4",
+    	"plugins": [
+    		{ "name": "KBVEZstd", "version": "1.5.8" },
+    		{ "name": "UEDevOps", "version": "0.1.0" }
+    	]
+    }
+    ```
+
+- `.github/actions/fetch-ue-plugins` reads the lockfile, resolves the build
+  platform + engine, downloads the matching release asset
+  (`<name>-<platform>-UE<engine>-v<version>.zip`) into `<project>/Plugins/`, and
+  falls back to a source build if the asset is missing.
+- UE skips compiling a plugin whose `Binaries/` already match the engine +
+  platform, so prebuilt assets cut game build time.
+
+### Open items before activation
+
+- Mac (`.dylib`) plugin builds — no `macos-builder` VM provisioned; engine
+  provision + plugin-mac jobs are stubs.
+- Win64 asset engine version: `plugin_check` derives engine from `ue_image_tag`,
+  but the VM builds against `C:\UnrealEngine` (the AngelScript engine). The asset
+  name engine field should be sourced from the VM's actual engine, not the image
+  tag passed for naming.
+- Engine-version matrix: `ci-publish.yml` passes `ue_image_tags` as a JSON
+  array but plugin builds consume a single tag; multi-engine fan-out is not wired.
+- Lockfile resolver + source-build fallback need integration into the game build
+  jobs in `ci-unreal-build.yml`.
+- A consumer registry / checksum so game builds verify the asset they pulled.


### PR DESCRIPTION
## Summary
Makes MDX `version:` the single release lever for UE plugins (Model B), wires Win64 builds onto the `UE5-Win` VM, provisions the AngelScript engine onto that VM, and fixes the router permissions that broke the entire consolidated UE pipeline.

## Why
The #11822 consolidation set `ci-unreal.yml` to `permissions: {}`. Reusable jobs request `contents`/`packages`/`issues`/`pull-requests`, and GitHub validates the whole reusable at startup — so **every** UE dispatch (win-setup/engine/plugin/game) hit `startup_failure` and never ran. This grants the union at the router top level.

## Version flow (Model B)
- Dispatcher (`ci-main`) + `ci-publish` gate on the **manifest version** (from MDX), not the `.uplugin` VersionName.
- The plugin build **stamps** the `.uplugin` VersionName from `manifest_version` before `BuildPlugin`.
- One post-build auto-PR (`utils-update-version-toml`) bumps **both** `version.toml` and the source `.uplugin`; Linux owns it for multi-platform plugins (`skip_version_update`), Win64-only owns its own.
- Removed the inline double-PR `plugin_update_version` job.
- New `sync:unreal` target + `sync-unreal-uplugin.mjs` for manual bulk resync.

## Engine provisioning
- `engine_build_windows` retargeted `windows-latest` → `UE5-Win`; source build persisted at `C:\UnrealEngine` (no artifact), idempotent via `.kbve-engine-ref`.
- Decoupled from `engine_release`.
- `win-setup` installs Git LFS.

## Binary-dist groundwork
- Engine version in plugin release asset names.
- `fetch-ue-plugins` composite action + per-game `unreal-plugins.lock.json` format.
- `packages/unreal/PLUGIN_PIPELINE.md` documents the full flow.

## Notes / follow-ups
- First win64 build needs a chosen plugin with `publish = true` + initialized `version.toml` (all leaf plugins are currently `publish = false`).
- VM provisioning order: VM online → `win-setup` → `engine` (platforms=windows, skip_version_gate=true).
- Win64 asset engine field still derives from `ue_image_tag`; should source from the VM's actual engine (tracked in the doc's open items).