### PR TITLE
test(cryptothrone): istanbul coverage gate (80%) + game HUD + axum API e2e

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/a11y.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/a11y.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { ALL_ROUTES, CONTENT_ROUTES } from './helpers/routes';
 
 test.describe('accessibility baseline', () => {

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/api.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/api.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * axum-cryptothrone JSON game API. Only runs against the built server (docker
+ * project) — astro dev has no /api routes. Mirrors the Rust unit-test contract.
+ */
+test.describe('axum game API', () => {
+	test.beforeEach(() => {
+		test.skip(
+			test.info().project.name !== 'docker',
+			'API is served by axum, not astro dev',
+		);
+	});
+
+	test('health check returns OK', async ({ request }) => {
+		const res = await request.get('/health');
+		expect(res.status()).toBe(200);
+		expect(await res.text()).toBe('OK');
+	});
+
+	test('lists all items as JSON', async ({ request }) => {
+		const res = await request.get('/api/v1/items');
+		expect(res.status()).toBe(200);
+		expect(res.headers()['content-type']).toContain('application/json');
+		const items = await res.json();
+		expect(Array.isArray(items)).toBe(true);
+		expect(items.length).toBe(5);
+	});
+
+	test('fetches a known item by id', async ({ request }) => {
+		const res = await request.get('/api/v1/items/health_potion');
+		expect(res.status()).toBe(200);
+		expect((await res.json()).name).toBe('Health Potion');
+	});
+
+	test('unknown item returns 404', async ({ request }) => {
+		const res = await request.get('/api/v1/items/nonexistent');
+		expect(res.status()).toBe(404);
+	});
+
+	test('lists npcs', async ({ request }) => {
+		const res = await request.get('/api/v1/npcs');
+		expect(res.status()).toBe(200);
+		expect((await res.json()).length).toBe(2);
+	});
+
+	test('fetches a known npc by id', async ({ request }) => {
+		const res = await request.get('/api/v1/npcs/npc_barkeep');
+		expect(res.status()).toBe(200);
+		expect((await res.json()).name).toBe('Evee The BarKeep');
+	});
+
+	test('fetches a dialogue with options', async ({ request }) => {
+		const res = await request.get('/api/v1/dialogues/dlg_barkeep_greeting');
+		expect(res.status()).toBe(200);
+		const dialogue = await res.json();
+		expect(dialogue.title).toBe('Greeting');
+		expect(Array.isArray(dialogue.options)).toBe(true);
+	});
+
+	test('speed endpoint responds', async ({ request }) => {
+		const res = await request.get('/api/v1/speed');
+		expect(res.status()).toBe(200);
+		expect((await res.json()).time_ms).toBe(0);
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/auth.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/auth.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { AUTH_ROUTES } from './helpers/routes';
 
 test.describe('astro-cryptothrone auth pages', () => {

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/fixtures.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/fixtures.ts
@@ -1,0 +1,32 @@
+import { test as base } from '@playwright/test';
+import { addCoverageReport } from 'monocart-reporter';
+
+/**
+ * Auto-collects Istanbul coverage (window.__coverage__, injected by
+ * vite-plugin-istanbul when COVERAGE=1) on Chromium and feeds it to
+ * monocart-reporter. Other engines run the same assertions without coverage.
+ */
+export const test = base.extend<{ autoCoverage: void }>({
+	autoCoverage: [
+		async ({ page, browserName }, use) => {
+			await use();
+
+			if (browserName !== 'chromium') return;
+
+			const coverage = await page
+				.evaluate(
+					() =>
+						(window as Window & { __coverage__?: unknown })
+							.__coverage__,
+				)
+				.catch(() => undefined);
+
+			if (coverage) {
+				await addCoverageReport(coverage, test.info());
+			}
+		},
+		{ scope: 'test', auto: true },
+	],
+});
+
+export { expect } from '@playwright/test';

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { supportsWebGL } from './helpers/env';
 
 test.describe('game page layout', () => {

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/home.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/home.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { FOOTER_EXTERNAL_LINKS } from './helpers/routes';
 
 test.describe('homepage hero', () => {

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/interactions.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/interactions.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect } from './fixtures';
+import type { Page } from '@playwright/test';
+import { isMobileViewport } from './helpers/env';
+
+/**
+ * Drives the in-game React HUD through the dev-only `window.__ctEvents` seam
+ * (exposed by GameWindow under import.meta.env.DEV). Exercises the modal/toast
+ * UI + store reducers that idle movement can't reach in headless. Skipped where
+ * the seam is absent (production build served by axum).
+ */
+
+async function emit(page: Page, event: string, payload: unknown) {
+	await page.evaluate(
+		({ event, payload }) => {
+			const w = window as Window & {
+				__ctEvents?: { emit: (e: string, p: unknown) => void };
+			};
+			w.__ctEvents?.emit(event, payload);
+		},
+		{ event, payload },
+	);
+}
+
+test.describe('in-game HUD interactions', () => {
+	test.beforeEach(async ({ page }) => {
+		test.skip(
+			await isMobileViewport(page),
+			'HUD modals are desktop-sized (min-w 700px)',
+		);
+		await page.goto('/game/play/');
+		await expect(
+			page.getByText('Debug Mode', { exact: false }),
+		).toBeVisible({ timeout: 20_000 });
+		const hasSeam = await page
+			.waitForFunction(
+				() =>
+					!!(window as Window & { __ctEvents?: unknown }).__ctEvents,
+				{ timeout: 10_000 },
+			)
+			.then(() => true)
+			.catch(() => false);
+		test.skip(!hasSeam, 'event seam only present in dev build');
+	});
+
+	test('character event opens and closes the dialog', async ({ page }) => {
+		await emit(page, 'char:event', {
+			message: 'A wandering merchant greets you.',
+			character_name: 'Merchant',
+		});
+		await expect(
+			page.getByText('A wandering merchant greets you.'),
+		).toBeVisible();
+		await expect(page.getByText('Merchant').first()).toBeVisible();
+	});
+
+	test('notification surfaces a toast', async ({ page }) => {
+		await emit(page, 'notification', {
+			title: 'Heads Up',
+			message: 'Something happened.',
+			notificationType: 'info',
+		});
+		await expect(page.getByText('Heads Up')).toBeVisible();
+		await expect(page.getByText('Something happened.')).toBeVisible();
+	});
+
+	test('npc interaction opens the action menu with its actions', async ({
+		page,
+	}) => {
+		await emit(page, 'npc:interact', {
+			npcId: 'npc_barkeep',
+			npcName: 'Evee The BarKeep',
+			actions: ['talk', 'trade', 'steal', 'inspect'],
+			coords: { x: 200, y: 200 },
+		});
+		await expect(page.getByText('Evee The BarKeep').first()).toBeVisible();
+		await expect(page.getByRole('button', { name: 'trade' })).toBeVisible();
+	});
+
+	test('trade action emits a toast', async ({ page }) => {
+		await emit(page, 'npc:interact', {
+			npcId: 'npc_barkeep',
+			npcName: 'Evee The BarKeep',
+			actions: ['trade'],
+			coords: { x: 200, y: 200 },
+		});
+		await page.getByRole('button', { name: 'trade' }).click();
+		await expect(page.getByText('Trade').first()).toBeVisible();
+	});
+
+	test('steal action opens the dice-roll modal', async ({ page }) => {
+		await emit(page, 'npc:interact', {
+			npcId: 'npc_barkeep',
+			npcName: 'Evee The BarKeep',
+			actions: ['steal'],
+			coords: { x: 200, y: 200 },
+		});
+		await page.getByRole('button', { name: 'steal' }).click();
+		await expect(page.getByText('Steal Attempt')).toBeVisible();
+	});
+
+	test('talk action opens the dialogue modal', async ({ page }) => {
+		await emit(page, 'npc:interact', {
+			npcId: 'npc_barkeep',
+			npcName: 'Evee The BarKeep',
+			actions: ['talk'],
+			coords: { x: 200, y: 200 },
+		});
+		await page.getByRole('button', { name: 'talk' }).click();
+		await expect(page.locator('.fixed.z-\\[60\\]').first()).toBeVisible();
+	});
+
+	test('direct dice-roll event opens the modal', async ({ page }) => {
+		await emit(page, 'dice:roll', {
+			npcId: 'npc_barkeep',
+			npcName: 'Evee The BarKeep',
+			diceCount: 4,
+		});
+		await expect(page.getByText('Steal Attempt')).toBeVisible();
+	});
+
+	test('rolling the dice resolves to a total', async ({ page }) => {
+		await emit(page, 'dice:roll', {
+			npcId: 'npc_barkeep',
+			npcName: 'Evee The BarKeep',
+			diceCount: 4,
+		});
+		await page.getByRole('button', { name: 'Roll Dice' }).click();
+		await expect(page.getByText(/Total:/)).toBeVisible({
+			timeout: 10_000,
+		});
+	});
+
+	test('dialogue advances when an option is chosen', async ({ page }) => {
+		await emit(page, 'npc:interact', {
+			npcId: 'npc_barkeep',
+			npcName: 'Evee The BarKeep',
+			actions: ['talk'],
+			coords: { x: 200, y: 200 },
+		});
+		await page.getByRole('button', { name: 'talk' }).click();
+		await page
+			.getByRole('button', { name: 'Tell me about Cloud City' })
+			.click();
+		await expect(page.getByText('About Cloud City')).toBeVisible();
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/navigation.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { isMobileViewport } from './helpers/env';
 
 test.describe('primary header navigation (desktop)', () => {

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/responsive.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/responsive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { isMobileViewport } from './helpers/env';
 import { ALL_ROUTES } from './helpers/routes';
 

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/seo.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/seo.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { ALL_ROUTES } from './helpers/routes';
 import { getMeta, getMetaProperty } from './helpers/env';
 

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/server.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/server.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * axum-cryptothrone server behaviour layered on top of the static SSG:
+ * security headers, cache-control, and the askama 404 fallback. Docker-only.
+ */
+test.describe('axum server integration', () => {
+	test.beforeEach(() => {
+		test.skip(
+			test.info().project.name !== 'docker',
+			'server middleware only present in the axum build',
+		);
+	});
+
+	test('applies security headers to responses', async ({ request }) => {
+		const res = await request.get('/');
+		const headers = res.headers();
+		expect(headers['x-content-type-options']).toBe('nosniff');
+		expect(headers['x-frame-options']).toBe('DENY');
+		expect(headers['referrer-policy']).toBe(
+			'strict-origin-when-cross-origin',
+		);
+	});
+
+	test('serves the homepage with a cache-control header', async ({
+		request,
+	}) => {
+		const res = await request.get('/');
+		expect(res.status()).toBe(200);
+		expect(res.headers()['cache-control']).toContain('max-age');
+	});
+
+	test('immutable cache for hashed _astro assets', async ({
+		page,
+		request,
+	}) => {
+		await page.goto('/');
+		const assetHref = await page
+			.locator('link[href*="/_astro/"], script[src*="/_astro/"]')
+			.first()
+			.evaluate(
+				(el) => el.getAttribute('href') ?? el.getAttribute('src') ?? '',
+			)
+			.catch(() => '');
+		test.skip(!assetHref, 'no hashed _astro asset on the page');
+		const res = await request.get(assetHref);
+		expect(res.status()).toBe(200);
+		expect(res.headers()['cache-control']).toContain('immutable');
+	});
+
+	test('askama 404 fallback for unknown routes', async ({ request }) => {
+		const res = await request.get('/definitely-not-a-real-page');
+		expect(res.status()).toBe(404);
+		const body = await res.text();
+		expect(body).toContain('Page Not Found');
+	});
+
+	test('sitemap is generated in the production build', async ({
+		request,
+	}) => {
+		const res = await request.get('/sitemap-index.xml');
+		expect(res.status()).toBe(200);
+		expect(await res.text()).toMatch(/sitemapindex|urlset/);
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/smoke.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/smoke.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import { CONTENT_ROUTES, GAME_ROUTES } from './helpers/routes';
 
 test.describe('astro-cryptothrone smoke tests', () => {

--- a/apps/cryptothrone/astro-cryptothrone-e2e/playwright.config.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/playwright.config.ts
@@ -11,7 +11,41 @@ export default defineConfig({
 	forbidOnly: !!process.env['CI'],
 	retries: process.env['CI'] ? 2 : 0,
 	workers: process.env['CI'] ? 1 : undefined,
-	reporter: 'html',
+	reporter: [
+		['list'],
+		[
+			'monocart-reporter',
+			{
+				name: 'astro-cryptothrone E2E + Coverage',
+				outputFile: './test-results/monocart/index.html',
+				coverage: {
+					sourceFilter: (sourcePath: string) =>
+						sourcePath.includes('src/') &&
+						!sourcePath.includes('.spec.'),
+					reports: [
+						['console-summary'],
+						['html'],
+						['lcovonly', { file: 'lcov.info' }],
+					],
+					onEnd: (results: {
+						summary?: { lines?: { pct?: number } };
+					}) => {
+						const pct = results?.summary?.lines?.pct ?? 0;
+						const min = Number(process.env['COVERAGE_MIN'] ?? '80');
+						if (pct < min) {
+							console.error(
+								`\n✘ Line coverage ${pct}% is below the required ${min}% threshold\n`,
+							);
+							process.exit(1);
+						}
+						console.log(
+							`\n✓ Line coverage ${pct}% meets the ${min}% threshold\n`,
+						);
+					},
+				},
+			},
+		],
+	],
 	use: {
 		trace: 'on-first-retry',
 	},
@@ -58,5 +92,6 @@ export default defineConfig({
 		url: baseURL,
 		reuseExistingServer: !process.env['CI'],
 		timeout: process.env['CI'] ? 600_000 : 120_000,
+		env: { COVERAGE: '1' },
 	},
 });

--- a/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
+++ b/apps/cryptothrone/astro-cryptothrone/astro.config.mjs
@@ -3,6 +3,19 @@ import starlight from '@astrojs/starlight';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
+import istanbul from 'vite-plugin-istanbul';
+
+const coverage = process.env.COVERAGE === '1';
+const coveragePlugins = coverage
+	? [
+			istanbul({
+				include: 'src/**/*.{ts,tsx}',
+				exclude: ['node_modules', '**/*.spec.ts', '**/*.d.ts'],
+				extension: ['.ts', '.tsx'],
+				forceBuildInstrument: false,
+			}),
+		]
+	: [];
 
 export default defineConfig({
 	site: 'https://cryptothrone.com',
@@ -39,7 +52,7 @@ export default defineConfig({
 		sitemap(),
 	],
 	vite: {
-		plugins: [tailwindcss()],
+		plugins: [tailwindcss(), ...coveragePlugins],
 		resolve: {
 			dedupe: ['react', 'react-dom', 'react/jsx-runtime'],
 		},

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -1,7 +1,7 @@
-import { useRef, useCallback, useMemo, memo } from 'react';
+import { useRef, useCallback, useMemo, memo, useEffect } from 'react';
 import Phaser from 'phaser';
 import GridEngine from 'grid-engine';
-import { PhaserGame } from '@kbve/laser';
+import { PhaserGame, laserEvents } from '@kbve/laser';
 import type { PhaserGameRef } from '@kbve/laser';
 import { PreloaderScene } from './scenes/PreloaderScene';
 import { CloudCityScene } from './scenes/CloudCityScene';
@@ -61,6 +61,14 @@ const PhaserCanvas = memo(function PhaserCanvas() {
 function GameUI() {
 	const dispatch = useGameDispatch();
 	useEventBridge(dispatch);
+
+	useEffect(() => {
+		if (import.meta.env.DEV) {
+			(
+				window as Window & { __ctEvents?: typeof laserEvents }
+			).__ctEvents = laserEvents;
+		}
+	}, []);
 
 	return (
 		<>

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
 		"@playform/compress": "^0.2.3",
 		"@axe-core/playwright": "^4.10.2",
 		"@playwright/test": "^1.59.1",
+		"monocart-reporter": "^2.9.19",
+		"vite-plugin-istanbul": "^7.2.0",
 		"@scalar/api-reference": "^1.55.3",
 		"@swc-node/register": "1.11.1",
 		"@swc/core": "1.15.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      monocart-reporter:
+        specifier: ^2.9.19
+        version: 2.11.2
       nanostores:
         specifier: ^1.1.0
         version: 1.1.0
@@ -593,6 +596,9 @@ importers:
       vite-plugin-dts:
         specifier: 4.5.3
         version: 4.5.3(@types/node@18.19.17)(rollup@4.57.1)(typescript@5.9.3)(vite@7.3.1(@types/node@18.19.17)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.32.0)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.48.0)(yaml@2.9.0))
+      vite-plugin-istanbul:
+        specifier: ^7.2.0
+        version: 7.2.1(vite@7.3.1(@types/node@18.19.17)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.32.0)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.48.0)(yaml@2.9.0))
       vite-plugin-top-level-await:
         specifier: ^1.6.0
         version: 1.6.0(@swc/helpers@0.5.21)(rollup@4.57.1)(vite@7.3.1(@types/node@18.19.17)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.32.0)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.48.0)(yaml@2.9.0))
@@ -6715,8 +6721,16 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn-loose@8.5.2:
+    resolution: {integrity: sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==}
+    engines: {node: '>=0.4.0'}
+
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
 
   acorn@8.14.1:
@@ -7817,9 +7831,16 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  console-grid@2.2.4:
+    resolution: {integrity: sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg==}
+
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
+
+  content-disposition@1.0.1:
+    resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
+    engines: {node: '>=18'}
 
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
@@ -8614,6 +8635,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  eight-colors@1.3.3:
+    resolution: {integrity: sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -8936,11 +8960,19 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@4.2.1:
+    resolution: {integrity: sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
+
+  espree@10.4.0:
+    resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -9362,6 +9394,10 @@ packages:
   foreground-child@3.3.0:
     resolution: {integrity: sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==}
     engines: {node: '>=14'}
+
+  foreground-child@4.0.3:
+    resolution: {integrity: sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==}
+    engines: {node: '>=16'}
 
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
@@ -10879,8 +10915,15 @@ packages:
   koa-compose@4.1.0:
     resolution: {integrity: sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw==}
 
+  koa-static-resolver@1.0.6:
+    resolution: {integrity: sha512-ZX5RshSzH8nFn05/vUNQzqw32nEigsPa67AVUr6ZuQxuGdnCcTLcdgr4C81+YbJjpgqKHfacMBd7NmJIbj7fXw==}
+
   koa@3.0.3:
     resolution: {integrity: sha512-MeuwbCoN1daWS32/Ni5qkzmrOtQO2qrnfdxDHjrm6s4b59yG4nexAJ0pTEFyzjLp0pBVO80CZp0vW8Ze30Ebow==}
+    engines: {node: '>= 18'}
+
+  koa@3.2.1:
+    resolution: {integrity: sha512-e7IpWJrnanNUroVK2taAgMxoEZvHLXdQiNjeExSu/DEIWm83jaKGBgb7tLmu2rMYpA027qFB3iLR/k3AVpFRnA==}
     engines: {node: '>= 18'}
 
   kolorist@1.8.0:
@@ -11296,6 +11339,9 @@ packages:
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
+
+  lz-utils@2.1.1:
+    resolution: {integrity: sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q==}
 
   maath@0.10.8:
     resolution: {integrity: sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==}
@@ -11878,6 +11924,17 @@ packages:
     peerDependencies:
       monaco-editor: '>=0.36'
 
+  monocart-coverage-reports@2.12.12:
+    resolution: {integrity: sha512-d9FdUr2dn58Crweon0IE0zVi8r/i4vLvfvb2G7eL5vL5LfrxCB2X6F6qzuiwV6RioA4zbAI//7CYi6LjCvN3zA==}
+    hasBin: true
+
+  monocart-locator@1.0.3:
+    resolution: {integrity: sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g==}
+
+  monocart-reporter@2.11.2:
+    resolution: {integrity: sha512-CMzRSN1QyjbPvQRm7TOc/kTzozKNzwySVI47iajwPnvrkKOtS3P4PV2korNPNE/4uqkhvbzhXjZNjfWT03OT6Q==}
+    hasBin: true
+
   motion-dom@12.34.3:
     resolution: {integrity: sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==}
 
@@ -12056,6 +12113,10 @@ packages:
   node-stream-zip@1.15.0:
     resolution: {integrity: sha512-LN4fydt9TqhZhThkZIVQnF9cwjU3qmUH9h78Mx/K7d3VvfRqqwthLwJEUOEL0QPZ0XQmNN7be5Ggit5+4dq3Bw==}
     engines: {node: '>=0.12.0'}
+
+  nodemailer@8.0.10:
+    resolution: {integrity: sha512-BLFuSth7QtHOkBzyqTehWWyub0NTRDuK2Q2SQfnGLsrJnzyU+Yeh4WpV1eZGuARFj1xQJHIdnTuJZLP+b9R1GQ==}
+    engines: {node: '>=6.0.0'}
 
   nopt@8.1.0:
     resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
@@ -14548,6 +14609,10 @@ packages:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
 
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
+
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
@@ -15305,6 +15370,11 @@ packages:
     peerDependenciesMeta:
       vite:
         optional: true
+
+  vite-plugin-istanbul@7.2.1:
+    resolution: {integrity: sha512-DSPi4ulvYsjnP44sTI5oriNosbM0E6m3uoCxjdxboTtVzxSkFwcDy3/JnSYKebjr+ZToJwVLTms+2CM0rmbbzQ==}
+    peerDependencies:
+      vite: '>=4 <=7'
 
   vite-plugin-monaco-editor@1.1.0:
     resolution: {integrity: sha512-IvtUqZotrRoVqwT0PBBDIZPNraya3BxN/bfcNfnxZ5rkJiGcNtO5eAOWWSgT7zullIAEqQwxMU83yL9J5k7gww==}
@@ -19258,7 +19328,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -24612,7 +24682,15 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-loose@8.5.2:
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.16.0
+
+  acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
 
@@ -26108,9 +26186,13 @@ snapshots:
 
   consola@3.4.2: {}
 
+  console-grid@2.2.4: {}
+
   content-disposition@0.5.4:
     dependencies:
       safe-buffer: 5.2.1
+
+  content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
 
@@ -26884,6 +26966,8 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  eight-colors@1.3.3: {}
+
   ejs@3.1.10:
     dependencies:
       jake: 10.9.2
@@ -27431,6 +27515,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@4.2.1: {}
+
   eslint@8.57.0:
     dependencies:
       '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.0)
@@ -27473,6 +27559,12 @@ snapshots:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  espree@10.4.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
@@ -28013,6 +28105,10 @@ snapshots:
   foreground-child@3.3.0:
     dependencies:
       cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
+  foreground-child@4.0.3:
+    dependencies:
       signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
@@ -29897,7 +29993,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.8.1
 
   jsprim@2.0.2:
     dependencies:
@@ -29962,10 +30058,33 @@ snapshots:
 
   koa-compose@4.1.0: {}
 
+  koa-static-resolver@1.0.6: {}
+
   koa@3.0.3:
     dependencies:
       accepts: 1.3.8
       content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookies: 0.9.1
+      delegates: 1.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      fresh: 0.5.2
+      http-assert: 1.5.0
+      http-errors: 2.0.1
+      koa-compose: 4.1.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      type-is: 2.0.1
+      vary: 1.1.2
+
+  koa@3.2.1:
+    dependencies:
+      accepts: 1.3.8
+      content-disposition: 1.0.1
       content-type: 1.0.5
       cookies: 0.9.1
       delegates: 1.0.0
@@ -30360,6 +30479,8 @@ snapshots:
   luxon@3.5.0: {}
 
   lz-string@1.5.0: {}
+
+  lz-utils@2.1.1: {}
 
   maath@0.10.8(@types/three@0.176.0)(three@0.184.0):
     dependencies:
@@ -31414,7 +31535,7 @@ snapshots:
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mkdirp@0.5.6:
     dependencies:
@@ -31481,6 +31602,34 @@ snapshots:
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
       yaml: 2.8.4
+
+  monocart-coverage-reports@2.12.12:
+    dependencies:
+      acorn: 8.16.0
+      acorn-loose: 8.5.2
+      acorn-walk: 8.3.5
+      commander: 14.0.3
+      console-grid: 2.2.4
+      eight-colors: 1.3.3
+      foreground-child: 4.0.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      lz-utils: 2.1.1
+      monocart-locator: 1.0.3
+
+  monocart-locator@1.0.3: {}
+
+  monocart-reporter@2.11.2:
+    dependencies:
+      console-grid: 2.2.4
+      eight-colors: 1.3.3
+      koa: 3.2.1
+      koa-static-resolver: 1.0.6
+      lz-utils: 2.1.1
+      monocart-coverage-reports: 2.12.12
+      monocart-locator: 1.0.3
+      nodemailer: 8.0.10
 
   motion-dom@12.34.3:
     dependencies:
@@ -31626,6 +31775,8 @@ snapshots:
 
   node-stream-zip@1.15.0:
     optional: true
+
+  nodemailer@8.0.10: {}
 
   nopt@8.1.0:
     dependencies:
@@ -34680,6 +34831,12 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.4
 
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.3
+
   text-decoder@1.2.3:
     dependencies:
       b4a: 1.6.7
@@ -35500,6 +35657,20 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
       - rollup
+      - supports-color
+
+  vite-plugin-istanbul@7.2.1(vite@7.3.1(@types/node@18.19.17)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.32.0)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.48.0)(yaml@2.9.0)):
+    dependencies:
+      '@babel/generator': 7.29.1
+      '@istanbuljs/load-nyc-config': 1.1.0
+      '@types/babel__generator': 7.6.8
+      espree: 10.4.0
+      istanbul-lib-instrument: 6.0.3
+      picocolors: 1.1.1
+      source-map: 0.7.6
+      test-exclude: 7.0.2
+      vite: 7.3.1(@types/node@18.19.17)(jiti@2.7.0)(less@4.1.3)(lightningcss@1.32.0)(sass-embedded@1.85.1)(sass@1.85.1)(stylus@0.64.0)(terser@5.48.0)(yaml@2.9.0)
+    transitivePeerDependencies:
       - supports-color
 
   vite-plugin-monaco-editor@1.1.0(monaco-editor@0.55.1):


### PR DESCRIPTION
Wires up the coverage + axum integration the last suite was missing.

## Coverage (real LoC, gated)
- `vite-plugin-istanbul` instruments `src/**/*.{ts,tsx}` only when `COVERAGE=1` (set on the e2e dev server)
- `monocart-reporter` aggregates `window.__coverage__` from the Chromium project → html + lcov + console-summary
- onEnd gate **fails the run below `COVERAGE_MIN` (default 80%)** — verified: exits 0 at 80, exits 1 at 90
- **Current line coverage: 83.26%** (was effectively 0 — V8-over-astro-dev never resolved the lazy island sources, which is why the earlier attempt couldn't measure it)

## Game HUD interactions (the coverage that got us past 80%)
- dev-only `window.__ctEvents` seam in `GameWindow` (`import.meta.env.DEV`, stripped from the prod/axum build)
- `interactions.spec` drives the real UI: character dialog, toast, action menu → trade/steal/talk, **dice roll-to-result**, **dialogue advance**. Desktop-only (modals are 700px).

## axum-cryptothrone integration (docker project only)
Post-SSG server behaviour that astro dev can't serve, gated to the `docker` project:
- `api.spec` — `/health` + `/api/v1/{items,npcs,dialogues,speed}` JSON contract (mirrors the Rust unit tests, end-to-end over HTTP)
- `server.spec` — security headers, cache-control, immutable `_astro`, **askama 404 fallback**, production sitemap

## Result
Full matrix (Chrome/Firefox/WebKit/Mobile Safari/Mobile Chrome): **313 passed, 122 gated skips, 0 failures**, coverage gate ✓ 83.26%.

Knobs: `COVERAGE_MIN=90 nx run astro-cryptothrone-e2e:e2e` to raise the bar; axum specs run under the docker config against the built image.