### PR TITLE
fix(ci-unreal): win-setup runs in Windows PowerShell (UE5-Win has no pwsh)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1505,7 +1505,7 @@ jobs:
         runs-on: UE5-Win
         defaults:
             run:
-                shell: pwsh
+                shell: powershell
         env:
             FILE_SERVER: http://file-server.angelscript.svc:8080
         steps:


### PR DESCRIPTION
## What
Change the `win-setup` job default shell from `pwsh` → `powershell` in `ci-unreal-build.yml`.

## Why
The `windows-builder` / `UE5-Win` VM has Windows PowerShell (`powershell.exe`) but **not** PowerShell 7 (`pwsh`). With `shell: pwsh`, the first step (`System Info`) dies with `pwsh: command not found`, so win-setup can never provision the VM.

Confirmed live: after #11872 unblocked the pipeline (router permissions), the runner picked up the job and failed exactly here. Windows PowerShell 5.1 runs all of win-setup's install steps fine (no PS7-only syntax; the job writes no `$GITHUB_OUTPUT`).

## Follow-up (separate)
The other UE5-Win jobs (game/plugin/engine builds) still use `pwsh` and will need either a staged `pwsh` install via win-setup, or the same shell switch with UTF-8 `$GITHUB_OUTPUT` handling. Tracked in `packages/unreal/PLUGIN_PIPELINE.md`.