### PR TITLE
perf(slate): disable tick on idle UI widgets

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckAccountPanel.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckAccountPanel.cpp
@@ -20,6 +20,7 @@
 
 void SchuckAccountPanel::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	Subsystem = InArgs._Subsystem;
 
 	const FSlateFontInfo NickFont   = FCoreStyle::GetDefaultFontStyle("Bold", 13);

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckLoginWidget.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Auth/SchuckLoginWidget.cpp
@@ -41,6 +41,7 @@ namespace
 
 void SchuckLoginWidget::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	Subsystem = InArgs._Subsystem;
 
 	const FSlateFontInfo TitleFont = FCoreStyle::GetDefaultFontStyle("Bold", 22);

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Chat/SchuckChatPanel.cpp
@@ -58,6 +58,7 @@ namespace
 
 void SchuckChatPanel::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	Subsystem = InArgs._Subsystem;
 	OwningCharacter = InArgs._OwningCharacter;
 	ActiveChannel = InArgs._DefaultChannel;

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Inventory/SchuckEquipmentPanel.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Inventory/SchuckEquipmentPanel.cpp
@@ -66,6 +66,7 @@ namespace
 
 void SchuckEquipmentPanel::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	Character   = InArgs._OwningCharacter;
 	SelectedKey = InArgs._SelectedKey;
 

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Inventory/SchuckItemInfo.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/Inventory/SchuckItemInfo.cpp
@@ -9,6 +9,7 @@
 
 void SchuckItemInfo::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	Character   = InArgs._OwningCharacter;
 	SelectedKey = InArgs._SelectedKey;
 

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckLoadingPanel.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckLoadingPanel.cpp
@@ -9,6 +9,7 @@
 
 void SchuckLoadingPanel::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	SetVisibility(EVisibility::HitTestInvisible);
 
 	ChildSlot

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckMainMenu.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckMainMenu.cpp
@@ -12,6 +12,7 @@
 
 void SchuckMainMenu::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	OnPlay = InArgs._OnPlayClicked;
 	OnQuit = InArgs._OnQuitClicked;
 

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckPauseMenu.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckPauseMenu.cpp
@@ -14,6 +14,7 @@
 
 void SchuckPauseMenu::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	OnResume     = InArgs._OnResumeClicked;
 	OnQuitToMenu = InArgs._OnQuitToMenuClicked;
 	OnQuit       = InArgs._OnQuitClicked;

--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/SGitInstallerPanel.cpp
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/SGitInstallerPanel.cpp
@@ -17,6 +17,7 @@
 
 void SGitInstallerPanel::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	InitializeRegistry();
 
 	ChildSlot

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEHotbar.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEHotbar.cpp
@@ -5,6 +5,7 @@
 
 void SKBVEHotbar::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	const int32 SlotCount = FMath::Max(1, InArgs._SlotCount);
 	const float Gap = InArgs._SlotGap;
 	const float Bottom = InArgs._BottomPadding;

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEInfoPanel.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEInfoPanel.cpp
@@ -10,6 +10,7 @@
 
 void SKBVEInfoPanel::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	IconSize     = InArgs._IconSize;
 	HasContent   = InArgs._HasContent;
 	OnPaintIcon  = InArgs._OnPaintIcon;

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEMovableFrame.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEMovableFrame.cpp
@@ -73,6 +73,7 @@ namespace
 
 void SKBVEMovableFrame::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	Position                   = InArgs._InitialPosition;
 	FrameSize                  = InArgs._FrameSize;
 	MinFrameSize               = InArgs._MinFrameSize;

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsComboRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsComboRow.cpp
@@ -7,6 +7,7 @@
 
 void SKBVESettingsComboRow::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	OnSelectionChanged = InArgs._OnSelectionChanged;
 
 	for (const FString& Option : InArgs._Options)

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsFrame.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsFrame.cpp
@@ -12,6 +12,7 @@
 
 void SKBVESettingsFrame::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	OnApply  = InArgs._OnApplyClicked;
 	OnReset  = InArgs._OnResetClicked;
 	OnCancel = InArgs._OnCancelClicked;

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsRow.cpp
@@ -7,6 +7,7 @@
 
 void SKBVESettingsRow::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	const FSlateFontInfo LabelFont = FCoreStyle::GetDefaultFontStyle("Regular", 12);
 	const FSlateFontInfo HintFont  = FCoreStyle::GetDefaultFontStyle("Italic", 10);
 

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsSliderRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsSliderRow.cpp
@@ -9,6 +9,7 @@
 
 void SKBVESettingsSliderRow::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	MinValue       = InArgs._MinValue;
 	MaxValue       = FMath::Max(InArgs._MaxValue, MinValue + KINDA_SMALL_NUMBER);
 	StepSize       = InArgs._StepSize;

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsToggleRow.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVESettingsToggleRow.cpp
@@ -5,6 +5,7 @@
 
 void SKBVESettingsToggleRow::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	OnToggled = InArgs._OnToggled;
 
 	TAttribute<bool> IsChecked = InArgs._IsChecked;

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEToast.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEToast.cpp
@@ -21,6 +21,7 @@ FLinearColor SKBVEToast::LevelColor(EKBVEToastLevel Level)
 
 void SKBVEToast::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	OnDismiss = InArgs._OnDismiss;
 
 	const FLinearColor Accent     = LevelColor(InArgs._Level);

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVETopBar.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVETopBar.cpp
@@ -8,6 +8,7 @@
 
 void SKBVETopBar::Construct(const FArguments& InArgs)
 {
+	SetCanTick(false);
 	const FSlateBrush* WhiteBrush = FCoreStyle::Get().GetBrush("WhiteBrush");
 	const FSlateColor BgColor = InArgs._BackgroundColor.Get(FSlateColor(FLinearColor(0.04f, 0.05f, 0.07f, 0.95f)));
 


### PR DESCRIPTION
## What

Audited all Slate (`SWidget`) UI for per-frame paint/tick cost. First pass: the safe, broad win — `SetCanTick(false)` on every **idle** widget.

Slate widgets default `bCanTick = true`, so even widgets with no `Tick()` override are walked and ticked every frame. Added `SetCanTick(false)` to the `Construct()` of 19 idle widgets:

- **KBVEUI:** MovableFrame, Hotbar, InfoPanel, Toast, TopBar, SettingsFrame, SettingsRow, ToggleRow, SliderRow, ComboRow
- **KBVELibGit:** SGitInstallerPanel
- **chuck:** MainMenu, PauseMenu, LoadingPanel, ChatPanel, AccountPanel, LoginWidget, ItemInfo, EquipmentPanel

**Left as-is** (essential `Tick`): SchuckHUD, SchuckHotbar (anim), SchuckDevOverlay, SKBVEToastLayer (expiry), SKBVEDragArrowLayer (drag anim), SchuckInventoryWindow (poll). Widgets already calling `SetCanTick` unchanged.

No behavior change — tick and paint/attribute-eval are independent; this only stops the no-op tick walk.

## Deferred (tracked separately — needs editor profiling)
- **SchuckHUD** — 6 bound `TAttribute` lambdas (HP/MP/EP + pulsing) repaint the stat bars every frame. Split static (HP/MP) from volatile (pulsing EP) behind `SInvalidationPanel`. Highest-cost item.
- **SKBVEMovableFrame / SKBVETooltip** — `SCanvas` position/size lambdas make the subtree volatile; wrap body in `SInvalidationPanel`, invalidate only on geometry change.
- **SKBVEDragArrowLayer** — 48-point Bézier rebuilt every paint while dragging; cache when endpoints unchanged.
- **SchuckInventoryWindow** — per-frame `SelectedKey` validation; make event-driven on inventory change.

## Not verified
No local UE toolchain — **not compiled**. Mechanical one-liner per Construct; needs a UE build pass.