### PR TITLE
fix(arc-runner): copy browsers from mcr.microsoft.com/playwright image

### DIFF
--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -5,6 +5,8 @@ ARG NODE_VERSION=24.16.0
 ARG PNPM_VERSION=10.33.0
 ARG PLAYWRIGHT_VERSION=1.59.1
 
+FROM --platform=linux/amd64 mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-jammy AS playwright-src
+
 FROM --platform=linux/amd64 ghcr.io/actions/actions-runner:${ACTIONS_RUNNER_VERSION} AS runtime
 
 LABEL org.opencontainers.image.source="https://github.com/kbve/kbve"
@@ -61,7 +63,6 @@ RUN set -eux; \
 
 ARG NODE_VERSION
 ARG PNPM_VERSION
-ARG PLAYWRIGHT_VERSION
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
 RUN set -eux; \
     cd /tmp; \
@@ -74,13 +75,18 @@ RUN set -eux; \
     ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/npx; \
     rm "node-v${NODE_VERSION}-linux-x64.tar.xz" SHASUMS256.txt; \
     npm install -g "pnpm@${PNPM_VERSION}"; \
-    mkdir -p "${PLAYWRIGHT_BROWSERS_PATH}"; \
-    npx --yes "playwright@${PLAYWRIGHT_VERSION}" install --with-deps chromium webkit firefox; \
-    chmod -R a+rX "${PLAYWRIGHT_BROWSERS_PATH}"; \
     node --version >/dev/null; \
-    pnpm --version >/dev/null; \
-    test -d "${PLAYWRIGHT_BROWSERS_PATH}/chromium-"*/chrome-linux*; \
-    test -d "${PLAYWRIGHT_BROWSERS_PATH}/webkit-"*; \
-    test -d "${PLAYWRIGHT_BROWSERS_PATH}/firefox-"*
+    pnpm --version >/dev/null
+
+ARG PLAYWRIGHT_VERSION
+COPY --from=playwright-src /ms-playwright /opt/ms-playwright
+RUN set -eux; \
+    chmod -R a+rX /opt/ms-playwright; \
+    apt-get update; \
+    npx --yes "playwright@${PLAYWRIGHT_VERSION}" install-deps chromium webkit firefox; \
+    rm -rf /var/lib/apt/lists/*; \
+    test -d /opt/ms-playwright/chromium-*/chrome-linux*; \
+    test -d /opt/ms-playwright/webkit-*; \
+    test -d /opt/ms-playwright/firefox-*
 
 USER runner


### PR DESCRIPTION
## Summary
Follow-up to #11865. That PR baked \`chromium webkit firefox\` by running \`playwright install\` during our image build, which downloaded from \`cdn.playwright.dev\` — the same flaky path that broke every e2e in the first place. The 0.1.4 build run got cancelled mid-stream because the install was hanging.

Switch the bake to a multi-stage \`COPY --from\` against \`mcr.microsoft.com/playwright:v\${PLAYWRIGHT_VERSION}-jammy\`. Microsoft already pre-built \`/ms-playwright\` in their image; we copy it into \`/opt/ms-playwright\` instead of re-downloading. Zero \`cdn.playwright.dev\` traffic at our image build, and Docker Hub's pull path is fronted by a different CDN.

\`install-deps\` still runs locally — the system libs Playwright browsers depend on aren't shipped inside the \`/ms-playwright\` tree, only the browser binaries.

Per [feedback_ride_pending_version](memory/feedback_ride_pending_version.md), MDX stays at \`0.1.4\` — the previous bump never produced a published artifact (run cancelled), so we keep the same version and let CI ship 0.1.4 the first time the build actually succeeds.

## Test plan
- [ ] CI - Docker / arc-runner build completes without hitting \`cdn.playwright.dev\`
- [ ] Resulting \`ghcr.io/kbve/arc-runner:0.1.4\` ships with all three browsers at \`/opt/ms-playwright\`
- [ ] After roll-out, CI - Docker / axum-kbve hits the \`Check baked Playwright browsers\` short-circuit and skips Install / Cache steps entirely