### PR TITLE
fix(ci-unreal): win-setup file-server check exit 0 (curl LASTEXITCODE leak)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1527,6 +1527,7 @@ jobs:
                       Write-Host "::warning::File server unreachable (HTTP $response) — VM cannot reach $env:FILE_SERVER. Install steps skip downloads and rely on pre-installed tools; Verify reports the real state."
                       Add-Content -Path $env:GITHUB_ENV -Value "FS_OK=false"
                   }
+                  exit 0
 
             - name: Install Visual Studio 2022 Build Tools
               timeout-minutes: 30
@@ -1613,6 +1614,7 @@ jobs:
                       try { $r = & $check.Cmd 2>&1; Write-Host "  $($check.Name): $r" }
                       catch { Write-Host "  $($check.Name): NOT INSTALLED" }
                   }
+                  exit 0
 
     mac_setup:
         name: Install on UE5-Mac (STUB)


### PR DESCRIPTION
The resilient win-setup check warns on unreachable file-server but `curl.exe` leaves a non-zero $LASTEXITCODE; GitHub's powershell wrapper then exits with it, failing the step and skipping all install/Verify steps. Add explicit `exit 0` to the reachability check and Verify so the run completes and reports the VM's real tool state.