### PR TITLE
feat(chuck): wire KBVEUI top bar + toasts + settings frame into the HUD

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -27,6 +27,16 @@
 #include "Engine/GameInstance.h"
 #include "SKBVEDragArrowLayer.h"
 #include "SKBVETooltip.h"
+#include "SKBVESettingsFrame.h"
+#include "SKBVESettingsToggleRow.h"
+#include "SKBVESettingsSliderRow.h"
+#include "SKBVETopBar.h"
+#include "SchuckToastHost.h"
+#include "Engine/Engine.h"
+#include "GameFramework/GameUserSettings.h"
+#include "Styling/CoreStyle.h"
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
 #include "chuckNoise.h"
 #include "chuckTerrainStreamer.h"
 #include "KBVESupabaseSubsystem.h"
@@ -148,6 +158,36 @@ void AchuckCorePlayerController::OnPossess(APawn* InPawn)
 	HotbarWidget = SNew(SchuckHotbar).OwningCharacter(Char);
 	TooltipWidget = SNew(SKBVETooltip);
 	DragArrowLayer = SNew(SKBVEDragArrowLayer);
+	ToastHostWidget = SNew(SchuckToastHost).OwningCharacter(Char);
+
+	const FSlateFontInfo TopBarFont = FCoreStyle::GetDefaultFontStyle("Bold", 12);
+	TopBarWidget = SNew(SKBVETopBar)
+		.BarHeight(50.f)
+		.Left
+		[
+			SNew(STextBlock)
+			.Font(TopBarFont)
+			.ColorAndOpacity(FLinearColor(0.92f, 0.92f, 0.95f, 1.f))
+			.Text_Lambda([this]()
+			{
+				return FText::FromString(BarPlayerName.IsEmpty() ? TEXT("Guest") : BarPlayerName);
+			})
+		]
+		.Right
+		[
+			SNew(STextBlock)
+			.Font(TopBarFont)
+			.Text_Lambda([this]()
+			{
+				return bBarOnline
+					? NSLOCTEXT("chuck", "BarOnline", "Online")
+					: NSLOCTEXT("chuck", "BarOffline", "Offline");
+			})
+			.ColorAndOpacity_Lambda([this]()
+			{
+				return bBarOnline ? FLinearColor(0.30f, 0.80f, 0.40f, 1.f) : FLinearColor(0.6f, 0.6f, 0.65f, 1.f);
+			})
+		];
 
 	if (UGameInstance* GI = GetGameInstance())
 	{
@@ -170,10 +210,12 @@ void AchuckCorePlayerController::OnPossess(APawn* InPawn)
 
 	if (UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr)
 	{
+		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), TopBarWidget.ToSharedRef(),     6);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), HUDWidget.ToSharedRef(),       5);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), HotbarWidget.ToSharedRef(),    20);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), DragArrowLayer.ToSharedRef(), 29);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), TooltipWidget.ToSharedRef(),  30);
+		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), ToastHostWidget.ToSharedRef(),32);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), ChatWidget.ToSharedRef(),     35);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), AccountWidget.ToSharedRef(),  40);
 	}
@@ -274,6 +316,22 @@ void AchuckCorePlayerController::OnUnPossess()
 		if (Viewport) Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), HUDWidget.ToSharedRef());
 		HUDWidget.Reset();
 	}
+	if (ToastHostWidget.IsValid())
+	{
+		if (Viewport) Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), ToastHostWidget.ToSharedRef());
+		ToastHostWidget.Reset();
+	}
+	if (TopBarWidget.IsValid())
+	{
+		if (Viewport) Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), TopBarWidget.ToSharedRef());
+		TopBarWidget.Reset();
+	}
+	if (SettingsWidget.IsValid())
+	{
+		if (Viewport) Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), SettingsWidget.ToSharedRef());
+		SettingsWidget.Reset();
+		SetUiFlag(EUiFlag::Settings, false);
+	}
 	Super::OnUnPossess();
 }
 
@@ -305,6 +363,7 @@ void AchuckCorePlayerController::PauseGame()
 
 	PauseWidget = SNew(SchuckPauseMenu)
 		.OnResumeClicked    (FSimpleDelegate::CreateUObject(this, &AchuckCorePlayerController::ResumeGame))
+		.OnSettingsClicked  (FSimpleDelegate::CreateUObject(this, &AchuckCorePlayerController::OpenSettings))
 		.OnQuitToMenuClicked(FSimpleDelegate::CreateUObject(this, &AchuckCorePlayerController::QuitToMainMenu))
 		.OnQuitClicked      (FSimpleDelegate::CreateUObject(this, &AchuckCorePlayerController::QuitGame));
 
@@ -339,6 +398,113 @@ void AchuckCorePlayerController::ResumeGame()
 	SetPause(false);
 	SetInputMode(FInputModeGameOnly());
 	bShowMouseCursor = false;
+}
+
+void AchuckCorePlayerController::OpenSettings()
+{
+	if (SettingsWidget.IsValid())
+	{
+		return;
+	}
+	UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr;
+	if (!Viewport)
+	{
+		return;
+	}
+
+	UGameUserSettings* GUS = GEngine ? GEngine->GetGameUserSettings() : nullptr;
+	const float ResScale = GUS ? GUS->GetResolutionScaleNormalized() * 100.f : 100.f;
+
+	SettingsWidget = SNew(SKBVESettingsFrame)
+		.Title(NSLOCTEXT("chuck", "SettingsTitle", "Settings"))
+		.bShowReset(false)
+		.OnCloseClicked (FSimpleDelegate::CreateUObject(this, &AchuckCorePlayerController::CloseSettings))
+		.OnCancelClicked(FSimpleDelegate::CreateUObject(this, &AchuckCorePlayerController::CloseSettings))
+		.OnApplyClicked (FSimpleDelegate::CreateLambda([]()
+		{
+			if (UGameUserSettings* S = GEngine ? GEngine->GetGameUserSettings() : nullptr)
+			{
+				S->ApplySettings(false);
+				S->SaveSettings();
+			}
+		}))
+		.Rows
+		[
+			SNew(SVerticalBox)
+
+			+ SVerticalBox::Slot()
+			.AutoHeight()
+			.Padding(0.f, 0.f, 0.f, 8.f)
+			[
+				SNew(SKBVESettingsToggleRow)
+				.Label(NSLOCTEXT("chuck", "VSync", "V-Sync"))
+				.IsChecked_Lambda([]()
+				{
+					UGameUserSettings* S = GEngine ? GEngine->GetGameUserSettings() : nullptr;
+					return S && S->IsVSyncEnabled();
+				})
+				.OnToggled_Lambda([](bool bOn)
+				{
+					if (UGameUserSettings* S = GEngine ? GEngine->GetGameUserSettings() : nullptr)
+					{
+						S->SetVSyncEnabled(bOn);
+					}
+				})
+			]
+
+			+ SVerticalBox::Slot()
+			.AutoHeight()
+			[
+				SNew(SKBVESettingsSliderRow)
+				.Label(NSLOCTEXT("chuck", "ResScale", "Resolution Scale"))
+				.MinValue(50.f)
+				.MaxValue(100.f)
+				.StepSize(5.f)
+				.Value(ResScale)
+				.OnValueChanged_Lambda([](float Pct)
+				{
+					if (UGameUserSettings* S = GEngine ? GEngine->GetGameUserSettings() : nullptr)
+					{
+						S->SetResolutionScaleNormalized(Pct / 100.f);
+					}
+				})
+			]
+		];
+
+	Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), SettingsWidget.ToSharedRef(), 22);
+	SetUiFlag(EUiFlag::Settings, true);
+
+	FInputModeUIOnly Mode;
+	Mode.SetWidgetToFocus(SettingsWidget);
+	Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+	SetInputMode(Mode);
+	bShowMouseCursor = true;
+}
+
+void AchuckCorePlayerController::CloseSettings()
+{
+	if (SettingsWidget.IsValid())
+	{
+		if (UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr)
+		{
+			Viewport->RemoveViewportWidgetForPlayer(GetLocalPlayer(), SettingsWidget.ToSharedRef());
+		}
+		SettingsWidget.Reset();
+	}
+	SetUiFlag(EUiFlag::Settings, false);
+
+	if (HasUiFlag(EUiFlag::Pause) && PauseWidget.IsValid())
+	{
+		FInputModeUIOnly Mode;
+		Mode.SetWidgetToFocus(PauseWidget);
+		Mode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+		SetInputMode(Mode);
+		bShowMouseCursor = true;
+	}
+	else
+	{
+		RefreshUiMouseMode();
+	}
 }
 
 void AchuckCorePlayerController::QuitToMainMenu()
@@ -623,6 +789,8 @@ void AchuckCorePlayerController::HandleSupabaseSignedIn(const FKBVESupabaseSessi
 {
 	const FKBVESupabaseUser& U = Session.User;
 
+	BarPlayerName = U.KbveUsername.IsEmpty() ? U.Email : U.KbveUsername;
+
 	if (AccountWidget.IsValid())
 	{
 		AccountWidget->SetUsername(U.KbveUsername.IsEmpty() ? U.Id : U.KbveUsername);
@@ -651,6 +819,9 @@ void AchuckCorePlayerController::HandleSupabaseSignedIn(const FKBVESupabaseSessi
 
 void AchuckCorePlayerController::HandleSupabaseSignedOut()
 {
+	BarPlayerName.Empty();
+	bBarOnline = false;
+
 	if (UchuckUIEvents* Bus = UchuckUIEvents::Get(this))
 	{
 		FchuckAuthStatusPayload Payload;
@@ -683,6 +854,8 @@ void AchuckCorePlayerController::HandleSupabaseAuthError(const FKBVESupabaseErro
 
 void AchuckCorePlayerController::HandleChatConnected()
 {
+	bBarOnline = true;
+
 	if (ChatWidget.IsValid())
 	{
 		FchuckChatStatePayload Payload;
@@ -699,6 +872,8 @@ void AchuckCorePlayerController::HandleChatConnected()
 
 void AchuckCorePlayerController::HandleChatDisconnected(int32 /*StatusCode*/, const FString& /*Reason*/)
 {
+	bBarOnline = false;
+
 	if (ChatWidget.IsValid())
 	{
 		FchuckChatStatePayload Payload;

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
@@ -14,6 +14,9 @@ class SchuckAccountPanel;
 class SchuckChatPanel;
 class SKBVETooltip;
 class SKBVEDragArrowLayer;
+class SKBVESettingsFrame;
+class SKBVETopBar;
+class SchuckToastHost;
 class UKBVESupabaseSubsystem;
 struct FInputActionValue;
 struct FKBVESupabaseSession;
@@ -47,6 +50,8 @@ protected:
 
 	void PauseGame();
 	void ResumeGame();
+	void OpenSettings();
+	void CloseSettings();
 	void QuitToMainMenu();
 	void QuitGame();
 
@@ -88,6 +93,12 @@ private:
 	TSharedPtr<SchuckChatPanel>       ChatWidget;
 	TSharedPtr<SKBVETooltip>          TooltipWidget;
 	TSharedPtr<SKBVEDragArrowLayer>   DragArrowLayer;
+	TSharedPtr<SKBVESettingsFrame>    SettingsWidget;
+	TSharedPtr<SKBVETopBar>           TopBarWidget;
+	TSharedPtr<SchuckToastHost>       ToastHostWidget;
+
+	FString BarPlayerName;
+	bool    bBarOnline = false;
 
 	UPROPERTY(Transient)
 	TWeakObjectPtr<UKBVESupabaseSubsystem> SupabaseSubsystem;

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/HUD/SchuckToastHost.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/HUD/SchuckToastHost.cpp
@@ -1,0 +1,81 @@
+#include "SchuckToastHost.h"
+
+#include "chuckCoreCharacter.h"
+#include "chuckEventPayloads.h"
+#include "chuckUIEvents.h"
+#include "SKBVEToastLayer.h"
+#include "Widgets/Layout/SBox.h"
+
+#define LOCTEXT_NAMESPACE "SchuckToastHost"
+
+void SchuckToastHost::Construct(const FArguments& InArgs)
+{
+	SetCanTick(false);
+	Character = InArgs._OwningCharacter;
+
+	ChildSlot
+	.HAlign(HAlign_Right)
+	.VAlign(VAlign_Top)
+	.Padding(FMargin(0.f, 64.f, 16.f, 0.f))
+	[
+		SAssignNew(ToastLayer, SKBVEToastLayer)
+		.MaxToasts(5)
+		.DefaultDuration(4.f)
+	];
+
+	BindToEventBus();
+}
+
+SchuckToastHost::~SchuckToastHost()
+{
+	AchuckCoreCharacter* C = Character.Get();
+	if (UchuckUIEvents* Bus = C ? UchuckUIEvents::Get(C) : nullptr)
+	{
+		Bus->ItemConsumed.Unsubscribe(ItemConsumedHandle);
+		Bus->AuthStatus.Unsubscribe(AuthStatusHandle);
+		Bus->AuthError.Unsubscribe(AuthErrorHandle);
+	}
+}
+
+void SchuckToastHost::BindToEventBus()
+{
+	AchuckCoreCharacter* C = Character.Get();
+	UchuckUIEvents* Bus = C ? UchuckUIEvents::Get(C) : nullptr;
+	if (!Bus)
+	{
+		return;
+	}
+
+	ItemConsumedHandle = Bus->ItemConsumed.Subscribe(C, [this](const FchuckItemConsumedPayload& P)
+	{
+		if (!ToastLayer.IsValid())
+		{
+			return;
+		}
+		const FText Msg = (P.HealHP > 0.f)
+			? FText::Format(LOCTEXT("ItemHealFmt", "+{0} HP"), FText::AsNumber(FMath::RoundToInt(P.HealHP)))
+			: LOCTEXT("ItemUsed", "Item used");
+		ToastLayer->PushToast(LOCTEXT("ItemConsumedTitle", "Consumed"), Msg, EKBVEToastLevel::Success);
+	});
+
+	AuthStatusHandle = Bus->AuthStatus.Subscribe(C, [this](const FchuckAuthStatusPayload& P)
+	{
+		if (!ToastLayer.IsValid() || !P.bSignedIn)
+		{
+			return;
+		}
+		const FString Name = P.KbveUsername.IsEmpty() ? P.Email : P.KbveUsername;
+		ToastLayer->PushToast(LOCTEXT("SignedInTitle", "Signed in"), FText::FromString(Name), EKBVEToastLevel::Info);
+	});
+
+	AuthErrorHandle = Bus->AuthError.Subscribe(C, [this](const FchuckAuthErrorPayload& P)
+	{
+		if (!ToastLayer.IsValid())
+		{
+			return;
+		}
+		ToastLayer->PushToast(LOCTEXT("AuthErrTitle", "Auth error"), FText::FromString(P.Message), EKBVEToastLevel::Error);
+	});
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/HUD/SchuckToastHost.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/HUD/SchuckToastHost.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "KBVEEvents.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+
+class AchuckCoreCharacter;
+class SKBVEToastLayer;
+
+class SchuckToastHost : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SchuckToastHost) {}
+		SLATE_ARGUMENT(TWeakObjectPtr<AchuckCoreCharacter>, OwningCharacter)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+	virtual ~SchuckToastHost() override;
+
+private:
+	void BindToEventBus();
+
+	TWeakObjectPtr<AchuckCoreCharacter> Character;
+	TSharedPtr<SKBVEToastLayer> ToastLayer;
+
+	FKBVEEventHandle ItemConsumedHandle;
+	FKBVEEventHandle AuthStatusHandle;
+	FKBVEEventHandle AuthErrorHandle;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckPauseMenu.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckPauseMenu.cpp
@@ -16,6 +16,7 @@ void SchuckPauseMenu::Construct(const FArguments& InArgs)
 {
 	SetCanTick(false);
 	OnResume     = InArgs._OnResumeClicked;
+	OnSettings   = InArgs._OnSettingsClicked;
 	OnQuitToMenu = InArgs._OnQuitToMenuClicked;
 	OnQuit       = InArgs._OnQuitClicked;
 
@@ -83,6 +84,16 @@ void SchuckPauseMenu::Construct(const FArguments& InArgs)
 							.Padding(Style.GetMargin(FChuckUIStyle::FKeys::Button_SlotPadding))
 							[
 								BuildMenuButton(
+									LOCTEXT("Settings", "Settings"),
+									FOnClicked::CreateSP(this, &SchuckPauseMenu::HandleSettings),
+									ButtonFont)
+							]
+
+							+ SVerticalBox::Slot()
+							.AutoHeight()
+							.Padding(Style.GetMargin(FChuckUIStyle::FKeys::Button_SlotPadding))
+							[
+								BuildMenuButton(
 									LOCTEXT("QuitToMenu", "Main Menu"),
 									FOnClicked::CreateSP(this, &SchuckPauseMenu::HandleQuitToMenu),
 									ButtonFont)
@@ -126,6 +137,12 @@ TSharedRef<SWidget> SchuckPauseMenu::BuildMenuButton(
 FReply SchuckPauseMenu::HandleResume()
 {
 	OnResume.ExecuteIfBound();
+	return FReply::Handled();
+}
+
+FReply SchuckPauseMenu::HandleSettings()
+{
+	OnSettings.ExecuteIfBound();
 	return FReply::Handled();
 }
 

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckPauseMenu.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckPauseMenu.h
@@ -11,6 +11,7 @@ class SchuckPauseMenu : public SCompoundWidget
 public:
 	SLATE_BEGIN_ARGS(SchuckPauseMenu) {}
 		SLATE_EVENT(FSimpleDelegate, OnResumeClicked)
+		SLATE_EVENT(FSimpleDelegate, OnSettingsClicked)
 		SLATE_EVENT(FSimpleDelegate, OnQuitToMenuClicked)
 		SLATE_EVENT(FSimpleDelegate, OnQuitClicked)
 	SLATE_END_ARGS()
@@ -24,10 +25,12 @@ private:
 		const FSlateFontInfo& Font);
 
 	FReply HandleResume();
+	FReply HandleSettings();
 	FReply HandleQuitToMenu();
 	FReply HandleQuit();
 
 	FSimpleDelegate OnResume;
+	FSimpleDelegate OnSettings;
 	FSimpleDelegate OnQuitToMenu;
 	FSimpleDelegate OnQuit;
 };


### PR DESCRIPTION
## What

Makes the new KBVEUI widgets live in the chuck game. They were built game-agnostic in KBVEUI; chuck now mounts + wires them.

### Top bar — `SKBVETopBar`
Mounted persistent in `AchuckCorePlayerController::OnPossess` (z-order 6). Left = player name, Right = online status, both bound to controller state set by the existing auth (`HandleSupabaseSignedIn`/`SignedOut`) and chat (`HandleChatConnected`/`Disconnected`) handlers.

### Toasts — `SchuckToastHost` (new) + `SKBVEToastLayer`
New thin chuck host anchors an `SKBVEToastLayer` top-right (z32) and subscribes the chuck event bus (`UchuckUIEvents`), pushing toasts on:
- `ItemConsumed` → success ("+N HP")
- `AuthStatus` signed-in → info ("Signed in as …")
- `AuthError` → error (message)

Keeps KBVEUI agnostic — the host owns the chuck-specific subscriptions, unsubscribes in its destructor (mirrors `SchuckHUD`).

### Settings — `SKBVESettingsFrame` from the pause menu
- `SchuckPauseMenu` gains a **Settings** button (+ `OnSettingsClicked` delegate).
- Controller `OpenSettings`/`CloseSettings` mount the settings frame (z22, above the pause overlay) with a **V-Sync toggle** + **resolution-scale slider** wired to `UGameUserSettings`; **Apply** calls `ApplySettings`+`SaveSettings`. Manages the `Settings` UI flag + input focus, restores pause focus on close.

All mounts unmount in `OnUnPossess`. No `Build.cs` change (chuck already deps KBVEUI + Engine + Slate).

## Not verified
No local UE toolchain — **not compiled**. Needs a UE editor/UAT build pass. Several KBVEUI widgets it uses (toast, top bar, settings rows) are also themselves uncompiled (built earlier this session).

## Follow-ups
- Settings frame currently has 2 rows (V-Sync, res scale) — extend with audio/keybinds.
- Toast triggers are a starter set; add damage/level-up/pickup as desired.