### PR TITLE
refactor(astro): ClientRouter audit — worker timeout + comment cleanup

### DIFF
--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -1,4 +1,3 @@
-// Hooks
 export { useDroid } from './hooks/useDroid';
 export type { DroidState } from './hooks/useDroid';
 export { useDroidEvents } from './hooks/useDroidEvents';
@@ -6,7 +5,6 @@ export { useToast } from './hooks/useToast';
 export { useTooltip } from './hooks/useTooltip';
 export { useModal } from './hooks/useModal';
 
-// React components
 export { DroidProvider, useDroidContext } from './react/DroidProvider';
 export { DroidStatus } from './react/DroidStatus';
 export { ToastContainer } from './react/ToastContainer';
@@ -16,7 +14,6 @@ export type { ModalOverlayProps } from './react/ModalOverlay';
 export { TooltipOverlay } from './react/TooltipOverlay';
 export type { TooltipOverlayProps } from './react/TooltipOverlay';
 
-// Ruffle
 export { ReactRuffle } from './components/ruffle/ReactRuffle';
 export type { ReactRuffleProps } from './components/ruffle/ReactRuffle';
 export {
@@ -38,7 +35,6 @@ export type {
 	RuffleSourceOptions,
 } from './components/ruffle/ruffle';
 
-// Auth
 export {
 	AuthBridge,
 	useAuthBridge,
@@ -55,7 +51,6 @@ export {
 } from './auth';
 export type { OAuthProvider, SessionView } from './auth';
 
-// Icons
 export { DiscordIcon, GitHubIcon, TwitchIcon } from './icons';
 
 // State stores (pass-through from @kbve/droid)
@@ -97,7 +92,6 @@ export {
 	ModalPayloadSchema,
 } from '@kbve/droid';
 
-// Canvas overlay
 export { CanvasOverlay } from './react/CanvasOverlay';
 export type { CanvasOverlayProps } from './react/CanvasOverlay';
 
@@ -108,10 +102,8 @@ export type { RenderPath } from '@kbve/droid';
 // Gateway (pass-through from @kbve/droid)
 export { SupabaseGateway } from '@kbve/droid';
 
-// Utilities
 export { cn } from './utils/cn';
 
-// Sitegraph
 export type {
 	SiteGraphData,
 	SiteGraphNode,

--- a/packages/npm/astro/src/react/CanvasOverlay.tsx
+++ b/packages/npm/astro/src/react/CanvasOverlay.tsx
@@ -18,7 +18,6 @@ export function CanvasOverlay({
 		const canvas = canvasRef.current;
 		if (!canvas) return;
 
-		// Size to viewport
 		const resize = () => {
 			canvas.width = window.innerWidth;
 			canvas.height = window.innerHeight;
@@ -26,7 +25,6 @@ export function CanvasOverlay({
 		resize();
 		window.addEventListener('resize', resize);
 
-		// Transfer to worker
 		void overlayManager.bindCanvas(canvas, dbGet);
 
 		return () => {

--- a/packages/npm/astro/src/sitegraph/react/worker-client.ts
+++ b/packages/npm/astro/src/sitegraph/react/worker-client.ts
@@ -109,15 +109,36 @@ function resolveEndpoint(endpoint: string): string {
  * Returns `null` when no worker is wired so callers can fall back to a
  * direct fetch.
  */
+const WORKER_TIMEOUT_MS = 10_000;
+
 export function fetchViaWorker(
 	endpoint: string,
+	timeoutMs = WORKER_TIMEOUT_MS,
 ): Promise<SiteGraphData> | null {
 	const port = activePort;
 	if (!port) return null;
 	const requestId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
 	const absoluteEndpoint = resolveEndpoint(endpoint);
 	return new Promise<SiteGraphData>((resolve, reject) => {
-		pending.set(requestId, { resolve, reject });
+		// A worker that never replies (killed, blob URL revoked, clone failure)
+		// would otherwise leave this entry in `pending` forever and hang the
+		// cache promise in "loading". On timeout the caller falls back to a
+		// direct fetch.
+		const timer = setTimeout(() => {
+			if (pending.delete(requestId)) {
+				reject(new Error('SiteGraph worker timed out'));
+			}
+		}, timeoutMs);
+		pending.set(requestId, {
+			resolve: (data) => {
+				clearTimeout(timer);
+				resolve(data);
+			},
+			reject: (err) => {
+				clearTimeout(timer);
+				reject(err);
+			},
+		});
 		try {
 			port.postMessage({
 				type: 'get',
@@ -125,6 +146,7 @@ export function fetchViaWorker(
 				requestId,
 			});
 		} catch (err) {
+			clearTimeout(timer);
 			pending.delete(requestId);
 			reject(err instanceof Error ? err : new Error(String(err)));
 		}


### PR DESCRIPTION
## What

Full ClientRouter (View Transitions / SPA swap) safety audit of `@kbve/astro`.

### Verdict: already swap-safe
The package holds up under repeated mount/unmount across navigations:
- **`.astro` scripts** (ScrollRing, RingHero, ObserverCollections, SocialTooltip, ScrollZoomHero) register their globals/observers/timers through the `onMount`/`onSwap` helper in `utils/clientRouter.ts`, which tears them down on `astro:before-swap`/`pagehide`. Verified each.
- **React islands** rely on the confirmed unmount chain: `astro-island` `disconnectedCallback` → `astro:after-swap` → `astro:unmount` → `@astrojs/react` `root.unmount()` → `useEffect` cleanups run.

Investigated and **dismissed as false positives** (read the code):
- `Redirect.astro` — standalone full HTML redirect page (own `<head>` + meta-refresh), not an island; its `setTimeout` can't leak across swaps.
- `_ringNav.ts` `navLock` — `ringNavigate` does `window.location.href` (full-page nav), so the module re-evaluates and the lock resets.
- `AstroRuffle.astro` — load/error listeners already self-remove (`{ once: true }` + explicit `cleanup()`).

### One real fix
`worker-client.ts` `fetchViaWorker` had **no timeout**. A SharedWorker that never replied (killed / blob URL revoked / structured-clone failure) left the request in the module-scope `pending` map forever and hung the cache promise in "loading". Added a 10s timeout that clears the entry and rejects — and `cache.ts` already falls back to a direct `fetch` on rejection, so the graph still renders.

### Cleanup
Stripped useless comments: section-banner comments in `index.ts` (`// Hooks`, `// Auth`, …) and two code-narrating comments in `CanvasOverlay.tsx`. Kept the load-bearing WHY comments (re-export origins, Safari/blob-URL quirks, race-condition fixes).

## Verified
- sitegraph react specs: 14/14
- `astro-kbve:build`: clean (exit 0, 7702 pages)