### PR TITLE
perf(rareicon): jobify SelectionVisualSystem + LandmarkAuraEffectSystem

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/SelectionVisualSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/SelectionVisualSystem.cs
@@ -4,7 +4,7 @@ using Unity.Entities;
 
 namespace RareIcon
 {
-    /// <summary>Mirrors <see cref="SelectedTag"/> into the per-instance <see cref="UnitSelectedVisual"/> so HexUnit.shader can draw the selection ring. Also back-fills the visual component onto any Unit entity that spawned without it, keeping this system the single source of truth for selection rendering.</summary>
+    /// <summary>Mirrors <see cref="SelectedTag"/> into the per-instance <see cref="UnitSelectedVisual"/> so HexUnit.shader can draw the selection ring. Also back-fills the visual component onto any Unit entity that spawned without it, keeping this system the single source of truth for selection rendering. Two parallel IJobEntity passes (selected → 1f, unselected → 0f) replace the prior main-thread foreach scans so the per-frame UnitSelectedVisual sweep stays off the main thread at scale.</summary>
     [BurstCompile]
     public partial struct SelectionVisualSystem : ISystem
     {
@@ -18,6 +18,8 @@ namespace RareIcon
                 .Build(ref state);
         }
 
+        [BurstCompile] public void OnDestroy(ref SystemState state) { }
+
         public void OnUpdate(ref SystemState state)
         {
             if (!_missingVisual.IsEmpty)
@@ -30,17 +32,34 @@ namespace RareIcon
                     ecb.AddComponent(arr[i], new UnitSelectedVisual { Value = 0f });
             }
 
-            foreach (var vis in SystemAPI.Query<RefRW<UnitSelectedVisual>>()
-                                          .WithAll<SelectedTag>())
-            {
-                if (vis.ValueRO.Value != 1f) vis.ValueRW.Value = 1f;
-            }
+            var selectedHandle   = new MarkSelectedVisualJob   { Target = 1f }.ScheduleParallel(state.Dependency);
+            var unselectedHandle = new MarkUnselectedVisualJob { Target = 0f }.ScheduleParallel(state.Dependency);
 
-            foreach (var vis in SystemAPI.Query<RefRW<UnitSelectedVisual>>()
-                                          .WithNone<SelectedTag>())
-            {
-                if (vis.ValueRO.Value != 0f) vis.ValueRW.Value = 0f;
-            }
+            state.Dependency = Unity.Jobs.JobHandle.CombineDependencies(selectedHandle, unselectedHandle);
+        }
+    }
+
+    [BurstCompile]
+    [WithAll(typeof(SelectedTag))]
+    public partial struct MarkSelectedVisualJob : IJobEntity
+    {
+        public float Target;
+
+        void Execute(ref UnitSelectedVisual vis)
+        {
+            if (vis.Value != Target) vis.Value = Target;
+        }
+    }
+
+    [BurstCompile]
+    [WithNone(typeof(SelectedTag))]
+    public partial struct MarkUnselectedVisualJob : IJobEntity
+    {
+        public float Target;
+
+        void Execute(ref UnitSelectedVisual vis)
+        {
+            if (vis.Value != Target) vis.Value = Target;
         }
     }
 }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LandmarkAuraEffectSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LandmarkAuraEffectSystem.cs
@@ -1,11 +1,12 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Refreshes a small <see cref="MoraleBuff"/> on every Player-faction unit standing within <see cref="LandmarkAura"/>.Radius hexes of any aura-emitting landmark (hearths, alcoves, halls). Turn-gated cadence so the buff trickles in but never stacks. Companion to <see cref="ShrineProductionSystem"/> — shrines pay the player ledger, auras pay the units in earshot.</summary>
+    /// <summary>Refreshes a small <see cref="MoraleBuff"/> on every Player-faction unit standing within <see cref="LandmarkAura"/>.Radius hexes of any aura-emitting landmark (hearths, alcoves, halls). Turn-gated cadence so the buff trickles in but never stacks. Companion to <see cref="ShrineProductionSystem"/> — shrines pay the player ledger, auras pay the units in earshot. Player-unit scan runs as a parallel [BurstCompile] IJobEntity into EntityCommandBuffer.ParallelWriter; the small aura-array build stays main-thread since it iterates a handful of buildings at most.</summary>
     [BurstCompile]
     [WorldSystemFilter(WorldSystemFilterFlags.LocalSimulation | WorldSystemFilterFlags.ClientSimulation | WorldSystemFilterFlags.ThinClientSimulation)]
     [UpdateInGroup(typeof(EconomySystemGroup))]
@@ -43,19 +44,17 @@ namespace RareIcon
             int auraCount = _auraQuery.CalculateEntityCount();
             if (auraCount == 0) return;
 
-            var centers = new NativeArray<int2>(auraCount, Allocator.Temp);
-            var radii   = new NativeArray<byte>(auraCount, Allocator.Temp);
-            int idx = 0;
+            var centers = new NativeList<int2>(auraCount, Allocator.TempJob);
+            var radii   = new NativeList<byte>(auraCount, Allocator.TempJob);
             foreach (var (aura, building) in
                      SystemAPI.Query<RefRO<LandmarkAura>, RefRO<Building>>())
             {
                 if (aura.ValueRO.Radius == 0) continue;
-                centers[idx] = building.ValueRO.RootHex;
-                radii[idx]   = aura.ValueRO.Radius;
-                idx++;
+                centers.Add(building.ValueRO.RootHex);
+                radii.Add(aura.ValueRO.Radius);
             }
 
-            if (idx == 0)
+            if (centers.Length == 0)
             {
                 centers.Dispose();
                 radii.Dispose();
@@ -66,41 +65,63 @@ namespace RareIcon
                                .CreateCommandBuffer(state.WorldUnmanaged);
             var buffLookup = SystemAPI.GetComponentLookup<MoraleBuff>(true);
 
-            foreach (var (faction, movement, entity) in
-                     SystemAPI.Query<RefRO<Faction>, RefRO<UnitMovement>>().WithEntityAccess())
+            state.Dependency = new ApplyAuraBuffJob
             {
-                if (faction.ValueRO.Value != FactionType.Player) continue;
-                int2 here = movement.ValueRO.CurrentHex;
+                Centers       = centers.AsArray(),
+                Radii         = radii.AsArray(),
+                Turn          = turn,
+                BuffLookup    = buffLookup,
+                Ecb           = ecb.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
-                bool inAura = false;
-                for (int i = 0; i < idx; i++)
-                {
-                    if (HexDistance(here, centers[i]) <= radii[i]) { inAura = true; break; }
-                }
-                if (!inAura) continue;
-
-                var refreshed = new MoraleBuff
-                {
-                    ExpiresAtTurn  = turn + BuffDurationTurns,
-                    WorkBonusPct   = WorkBonusPct,
-                    CombatBonusPct = CombatBonusPct,
-                };
-                if (buffLookup.HasComponent(entity))
-                    ecb.SetComponent(entity, refreshed);
-                else
-                    ecb.AddComponent(entity, refreshed);
-            }
-
-            centers.Dispose();
-            radii.Dispose();
+            state.Dependency = centers.Dispose(state.Dependency);
+            state.Dependency = radii.Dispose(state.Dependency);
         }
 
-        static int HexDistance(int2 a, int2 b)
+        public static int HexDistance(int2 a, int2 b)
         {
             int dx = b.x - a.x;
             int dy = b.y - a.y;
             int dz = -dx - dy;
             return (math.abs(dx) + math.abs(dy) + math.abs(dz)) / 2;
+        }
+    }
+
+    [BurstCompile]
+    public partial struct ApplyAuraBuffJob : IJobEntity
+    {
+        const uint  BuffDurationTurns   = 6u;
+        const sbyte WorkBonusPct        = 3;
+        const sbyte CombatBonusPct      = 0;
+
+        [ReadOnly] public NativeArray<int2>            Centers;
+        [ReadOnly] public NativeArray<byte>            Radii;
+        [ReadOnly] public ComponentLookup<MoraleBuff>  BuffLookup;
+        public            EntityCommandBuffer.ParallelWriter Ecb;
+        public            uint                              Turn;
+
+        void Execute([ChunkIndexInQuery] int chunkIndex, Entity entity, in Faction faction, in UnitMovement movement)
+        {
+            if (faction.Value != FactionType.Player) return;
+            int2 here = movement.CurrentHex;
+
+            bool inAura = false;
+            for (int i = 0; i < Centers.Length; i++)
+            {
+                if (LandmarkAuraEffectSystem.HexDistance(here, Centers[i]) <= Radii[i]) { inAura = true; break; }
+            }
+            if (!inAura) return;
+
+            var refreshed = new MoraleBuff
+            {
+                ExpiresAtTurn  = Turn + BuffDurationTurns,
+                WorkBonusPct   = WorkBonusPct,
+                CombatBonusPct = CombatBonusPct,
+            };
+            if (BuffLookup.HasComponent(entity))
+                Ecb.SetComponent(chunkIndex, entity, refreshed);
+            else
+                Ecb.AddComponent(chunkIndex, entity, refreshed);
         }
     }
 }


### PR DESCRIPTION
Two small per-tick systems with main-thread foreach scans converted to parallel `IJobEntity` passes. Same pattern as #11743 / #11751 / #11758 / #11858 / #11861.

## SelectionVisualSystem

| | |
|---|---|
| Tick | Per frame |
| Before | 2 main-thread foreach (selected → 1f, unselected → 0f) |
| After | `MarkSelectedVisualJob` `‖` `MarkUnselectedVisualJob` (both `[BurstCompile] IJobEntity ScheduleParallel`) |

```csharp
[BurstCompile] [WithAll(typeof(SelectedTag))]
struct MarkSelectedVisualJob : IJobEntity {
    public float Target;
    void Execute(ref UnitSelectedVisual vis) {
        if (vis.Value != Target) vis.Value = Target;
    }
}
```

Backfill of missing `UnitSelectedVisual` stays main-thread — `_missingVisual` query is empty after the first frame.

## LandmarkAuraEffectSystem

| | |
|---|---|
| Tick | 3-turn cadence |
| Before | Small aura-array build + main-thread foreach over every Player unit checking distance to all auras + per-entity `ecb.SetComponent` / `ecb.AddComponent` |
| After | Aura-array build still main-thread (handful of buildings). `ApplyAuraBuffJob : IJobEntity` walks Player units in parallel, reads Centers / Radii / BuffLookup `[ReadOnly]`, emits Set/Add via `EntityCommandBuffer.ParallelWriter` with `[ChunkIndexInQuery]` sortKey for deterministic EndSimulation playback. |

At 100k Player units the per-unit aura scan dominated the 3-turn cadence cost. Now off the main thread.

Centers/Radii bumped to `NativeList<TempJob>` + `AsArray()` so the container lifetime survives the scheduled job without main-thread sync. `HexDistance` helper promoted to `public static` on the system so the job (separate type) can call it under Burst.

## Behaviour preserved

- Same `SelectedTag` → `1f`, `!SelectedTag` → `0f` mapping.
- Same aura radius check, same 3-turn cadence, same buff payload (`ExpiresAtTurn` + `WorkBonusPct` + `CombatBonusPct`).
- Same Set-vs-Add edge depending on whether `MoraleBuff` already exists on the entity.

## Test plan

- [ ] Burst compiles `MarkSelectedVisualJob` + `MarkUnselectedVisualJob` + `ApplyAuraBuffJob` clean.
- [ ] No safety errors with `ENABLE_UNITY_COLLECTIONS_CHECKS` on `[ChunkIndexInQuery]` + parallel ECB writer.
- [ ] Click-select a unit → ring renders (UnitSelectedVisual = 1).
- [ ] Click-deselect → ring disappears (= 0).
- [ ] Walk a Player unit into a Landmark aura → MoraleBuff applied with `WorkBonusPct = 3` and ExpiresAtTurn = turn + 6.
- [ ] Re-enter same aura → buff refreshed (SetComponent path), not duplicated.