### PR TITLE
feat(mc-lot): visual preview panels + indices for catalog and plaza

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCLotPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCLotPanel.astro
@@ -1,0 +1,356 @@
+---
+import { getCollection } from 'astro:content';
+import { MCLotFrontmatterSchema } from '@/data/schema';
+
+const { data } = Astro.props;
+const lot = MCLotFrontmatterSchema.parse(data);
+
+const chunkW = lot.chunk_x_max - lot.chunk_x_min + 1;
+const chunkD = lot.chunk_z_max - lot.chunk_z_min + 1;
+const blockXMin = lot.chunk_x_min * 16;
+const blockZMin = lot.chunk_z_min * 16;
+const blockXMax = (lot.chunk_x_max + 1) * 16 - 1;
+const blockZMax = (lot.chunk_z_max + 1) * 16 - 1;
+const blockW = blockXMax - blockXMin + 1;
+const blockD = blockZMax - blockZMin + 1;
+const area = chunkW * chunkD;
+
+const stateAccent: Record<string, string> = {
+	vacant: '#86efac',
+	owned: '#7dd3fc',
+	built: '#a5b4fc',
+	under_build: '#fcd34d',
+	demolishing: '#fca5a5',
+};
+const accent = stateAccent[lot.state] ?? '#cbd5e1';
+
+// Pull every lot in the same world so the panel can render an overview
+// SVG marking THIS lot inside the broader plaza.
+const allLots = await getCollection('docs', (entry) => {
+	const m = (entry.data as { mc_lot?: unknown }).mc_lot;
+	if (!m) return false;
+	try {
+		const parsed = MCLotFrontmatterSchema.parse(m);
+		return parsed.world === lot.world;
+	} catch {
+		return false;
+	}
+});
+
+const peers = allLots.map((e) => MCLotFrontmatterSchema.parse(e.data.mc_lot));
+const minX = Math.min(...peers.map((p) => p.chunk_x_min), lot.chunk_x_min) - 1;
+const maxX = Math.max(...peers.map((p) => p.chunk_x_max), lot.chunk_x_max) + 1;
+const minZ = Math.min(...peers.map((p) => p.chunk_z_min), lot.chunk_z_min) - 1;
+const maxZ = Math.max(...peers.map((p) => p.chunk_z_max), lot.chunk_z_max) + 1;
+
+const spanX = maxX - minX + 1;
+const spanZ = maxZ - minZ + 1;
+const MAP_PX = 360;
+const cellSize = Math.min(MAP_PX / spanX, MAP_PX / spanZ);
+const mapW = spanX * cellSize;
+const mapD = spanZ * cellSize;
+---
+
+<section class="mclot-panel not-content kbve-dashboard-page">
+	<header class="mclot-panel__head">
+		<div>
+			<h2>{Astro.props.title ?? lot.lot_id}</h2>
+			<p class="mclot-panel__sub">
+				<code>{lot.lot_id}</code> · <code>{lot.world}</code>
+			</p>
+			<div class="mclot-panel__pills">
+				<span class="mclot-pill" style={`--accent:${accent}`}>
+					{lot.state}
+				</span>
+				{
+					lot.current_schematic_id && (
+						<span class="mclot-pill mclot-pill--schem">
+							<code>{lot.current_schematic_id}</code>
+						</span>
+					)
+				}
+			</div>
+		</div>
+		<div class="mclot-panel__price">
+			{
+				lot.price_credits > 0 && (
+					<span>
+						<strong>{lot.price_credits.toLocaleString()}</strong>{' '}
+						credits
+					</span>
+				)
+			}
+			{
+				lot.price_khash > 0 && (
+					<span>
+						<strong>{lot.price_khash.toLocaleString()}</strong>{' '}
+						khash
+					</span>
+				)
+			}
+			{
+				lot.price_credits === 0 && lot.price_khash === 0 && (
+					<span>free</span>
+				)
+			}
+		</div>
+	</header>
+
+	<div class="mclot-panel__grid">
+		<dl class="mclot-stats">
+			<div>
+				<dt>Chunks</dt>
+				<dd>
+					({lot.chunk_x_min}..{lot.chunk_x_max}, {lot.chunk_z_min}..
+					{lot.chunk_z_max})
+				</dd>
+			</div>
+			<div>
+				<dt>Blocks</dt>
+				<dd>
+					({blockXMin}..{blockXMax}, {blockZMin}..{blockZMax})
+				</dd>
+			</div>
+			<div>
+				<dt>Footprint</dt>
+				<dd>
+					{chunkW}×{chunkD} chunks · {blockW}×{blockD} blocks · area {
+						area
+					}
+				</dd>
+			</div>
+			<div>
+				<dt>Anchor Y</dt>
+				<dd>{lot.anchor_y}</dd>
+			</div>
+		</dl>
+
+		<figure class="mclot-figure">
+			<figcaption>Position in {lot.world}</figcaption>
+			<svg
+				viewBox={`0 0 ${mapW} ${mapD}`}
+				width={mapW}
+				height={mapD}
+				role="img"
+				aria-label={`Plaza overview, highlighting ${lot.lot_id}`}>
+				<rect x={0} y={0} width={mapW} height={mapD} fill="#0c0f14">
+				</rect>
+				{
+					Array.from({ length: spanX + 1 }, (_, i) => i).map((i) => (
+						<line
+							x1={i * cellSize}
+							y1={0}
+							x2={i * cellSize}
+							y2={mapD}
+							stroke="#1c2230"
+							stroke-width="0.5"
+						/>
+					))
+				}
+				{
+					Array.from({ length: spanZ + 1 }, (_, i) => i).map((i) => (
+						<line
+							x1={0}
+							y1={i * cellSize}
+							x2={mapW}
+							y2={i * cellSize}
+							stroke="#1c2230"
+							stroke-width="0.5"
+						/>
+					))
+				}
+				{
+					peers.map((p) => {
+						const isMe = p.lot_id === lot.lot_id;
+						const x = (p.chunk_x_min - minX) * cellSize;
+						const y = (p.chunk_z_min - minZ) * cellSize;
+						const w =
+							(p.chunk_x_max - p.chunk_x_min + 1) * cellSize;
+						const h =
+							(p.chunk_z_max - p.chunk_z_min + 1) * cellSize;
+						return (
+							<g>
+								<rect
+									x={x}
+									y={y}
+									width={w}
+									height={h}
+									fill={
+										isMe
+											? accent
+											: 'rgba(120, 200, 120, 0.4)'
+									}
+									stroke={isMe ? '#ffffff' : '#101218'}
+									stroke-width={isMe ? 2 : 1}
+									opacity={isMe ? 0.95 : 0.55}>
+									<title>{p.lot_id}</title>
+								</rect>
+								{isMe && (
+									<text
+										x={x + w / 2}
+										y={y + h / 2 + 4}
+										text-anchor="middle"
+										font-size="11"
+										fill="#0c0f14"
+										font-weight="bold">
+										HERE
+									</text>
+								)}
+							</g>
+						);
+					})
+				}
+			</svg>
+			<p class="mclot-figure__hint">
+				Coordinates in chunks. 1 chunk = 16 blocks. This lot is marked
+				in {lot.state} colors.
+			</p>
+		</figure>
+	</div>
+
+	{
+		(lot.about.summary || lot.about.notes) && (
+			<section class="mclot-about">
+				{lot.about.summary && (
+					<p class="mclot-about__summary">{lot.about.summary}</p>
+				)}
+				{lot.about.notes && (
+					<p class="mclot-about__notes">
+						<em>{lot.about.notes}</em>
+					</p>
+				)}
+			</section>
+		)
+	}
+</section>
+
+<style>
+	.mclot-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: 1rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.6rem;
+		background: var(--sl-color-bg-nav);
+	}
+
+	.mclot-panel__head {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		align-items: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.mclot-panel__head h2 {
+		margin: 0;
+	}
+
+	.mclot-panel__sub {
+		margin: 0.2rem 0 0.4rem;
+		color: var(--sl-color-gray-3);
+		font-size: 0.85em;
+	}
+
+	.mclot-panel__pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+	}
+
+	.mclot-pill {
+		display: inline-block;
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.78em;
+		background: color-mix(in srgb, var(--accent, #cbd5e1) 25%, transparent);
+		color: var(--accent, #cbd5e1);
+		border: 1px solid var(--accent, #cbd5e1);
+		text-transform: capitalize;
+	}
+
+	.mclot-pill--schem {
+		--accent: #94a3b8;
+	}
+
+	.mclot-panel__price {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 0.15rem;
+	}
+
+	.mclot-panel__price strong {
+		color: var(--sl-color-white);
+	}
+
+	.mclot-panel__grid {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: start;
+	}
+
+	@media (max-width: 720px) {
+		.mclot-panel__grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.mclot-stats {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		row-gap: 0.4rem;
+		column-gap: 0.75rem;
+		margin: 0;
+	}
+
+	.mclot-stats > div {
+		display: contents;
+	}
+
+	.mclot-stats dt {
+		color: var(--sl-color-gray-3);
+		font-size: 0.85em;
+	}
+
+	.mclot-stats dd {
+		margin: 0;
+	}
+
+	.mclot-figure {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		align-items: flex-start;
+	}
+
+	.mclot-figure figcaption {
+		font-size: 0.85em;
+		color: var(--sl-color-gray-3);
+	}
+
+	.mclot-figure svg {
+		max-width: 100%;
+		height: auto;
+		border-radius: 0.3rem;
+	}
+
+	.mclot-figure__hint {
+		margin: 0;
+		font-size: 0.75em;
+		color: var(--sl-color-gray-4);
+	}
+
+	.mclot-about {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+	}
+
+	.mclot-about__notes {
+		color: var(--sl-color-gray-3);
+		font-size: 0.92em;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCPlazaOverview.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCPlazaOverview.astro
@@ -1,0 +1,221 @@
+---
+import { getCollection } from 'astro:content';
+import { MCLotFrontmatterSchema } from '@/data/schema';
+
+interface Props {
+	world?: string;
+}
+const world = Astro.props.world ?? 'minecraft:overworld';
+
+const entries = await getCollection('docs', (entry) => {
+	const m = (entry.data as { mc_lot?: unknown }).mc_lot;
+	if (!m) return false;
+	try {
+		const parsed = MCLotFrontmatterSchema.parse(m);
+		return parsed.world === world;
+	} catch {
+		return false;
+	}
+});
+
+type LotRow = ReturnType<typeof MCLotFrontmatterSchema.parse> & {
+	slug: string;
+	title: string;
+};
+
+const lots: LotRow[] = entries.map((e) => {
+	const m = MCLotFrontmatterSchema.parse(
+		(e.data as { mc_lot: unknown }).mc_lot,
+	);
+	return {
+		...m,
+		slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
+		title: (e.data as { title?: string }).title ?? m.lot_id,
+	};
+});
+
+const minX = Math.min(...lots.map((l) => l.chunk_x_min)) - 1;
+const maxX = Math.max(...lots.map((l) => l.chunk_x_max)) + 1;
+const minZ = Math.min(...lots.map((l) => l.chunk_z_min)) - 1;
+const maxZ = Math.max(...lots.map((l) => l.chunk_z_max)) + 1;
+const spanX = maxX - minX + 1;
+const spanZ = maxZ - minZ + 1;
+const SIZE = 520;
+const cell = Math.min(SIZE / spanX, SIZE / spanZ);
+const mapW = spanX * cell;
+const mapD = spanZ * cell;
+
+const stateAccent: Record<string, string> = {
+	vacant: '#86efac',
+	owned: '#7dd3fc',
+	built: '#a5b4fc',
+	under_build: '#fcd34d',
+	demolishing: '#fca5a5',
+};
+---
+
+<section class="mcplaza not-content">
+	<header class="mcplaza__head">
+		<h2>Plaza overview · {world}</h2>
+		<p>
+			Every editorial lot in <code>{world}</code> rendered to scale. Click any
+			cell to open its detail page.
+		</p>
+	</header>
+
+	<div class="mcplaza__legend">
+		{
+			Object.entries(stateAccent).map(([state, color]) => (
+				<span class="mcplaza__legend-pill">
+					<i style={`background:${color}`} />
+					{state}
+				</span>
+			))
+		}
+	</div>
+
+	<svg
+		viewBox={`0 0 ${mapW} ${mapD}`}
+		width={mapW}
+		height={mapD}
+		class="mcplaza__svg"
+		role="img"
+		aria-label={`Plaza overview of ${lots.length} lots in ${world}`}>
+		<rect x={0} y={0} width={mapW} height={mapD} fill="#0c0f14"></rect>
+		{
+			Array.from({ length: spanX + 1 }, (_, i) => i).map((i) => (
+				<line
+					x1={i * cell}
+					y1={0}
+					x2={i * cell}
+					y2={mapD}
+					stroke={i % 4 === 0 ? '#3b4252' : '#1c2230'}
+					stroke-width={i % 4 === 0 ? 1 : 0.4}
+				/>
+			))
+		}
+		{
+			Array.from({ length: spanZ + 1 }, (_, i) => i).map((i) => (
+				<line
+					x1={0}
+					y1={i * cell}
+					x2={mapW}
+					y2={i * cell}
+					stroke={i % 4 === 0 ? '#3b4252' : '#1c2230'}
+					stroke-width={i % 4 === 0 ? 1 : 0.4}
+				/>
+			))
+		}
+		{
+			lots.map((lot) => {
+				const x = (lot.chunk_x_min - minX) * cell;
+				const y = (lot.chunk_z_min - minZ) * cell;
+				const w = (lot.chunk_x_max - lot.chunk_x_min + 1) * cell;
+				const h = (lot.chunk_z_max - lot.chunk_z_min + 1) * cell;
+				const accent = stateAccent[lot.state] ?? '#cbd5e1';
+				return (
+					<a href={`/${lot.slug}/`}>
+						<rect
+							x={x}
+							y={y}
+							width={w}
+							height={h}
+							fill={accent}
+							fill-opacity={0.55}
+							stroke="#101218"
+							stroke-width={1}>
+							<title>
+								{lot.title} · {lot.state} · chunks (
+								{lot.chunk_x_min}, {lot.chunk_z_min})..(
+								{lot.chunk_x_max}, {lot.chunk_z_max})
+							</title>
+						</rect>
+						<text
+							x={x + w / 2}
+							y={y + h / 2 + 4}
+							text-anchor="middle"
+							font-size={Math.min(cell * 0.6, 12)}
+							fill="#0c0f14"
+							font-weight="bold">
+							{lot.lot_id.split(':').pop()}
+						</text>
+					</a>
+				);
+			})
+		}
+	</svg>
+
+	<p class="mcplaza__hint">
+		1 grid cell = 1 chunk = 16×16 blocks. Heavier gridlines mark 4-chunk
+		boundaries.
+	</p>
+</section>
+
+<style>
+	.mcplaza {
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		padding: 1rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.6rem;
+		background: var(--sl-color-bg-nav);
+		align-items: flex-start;
+	}
+
+	.mcplaza__head {
+		display: flex;
+		flex-direction: column;
+		gap: 0.2rem;
+	}
+
+	.mcplaza__head h2 {
+		margin: 0;
+		font-size: 1.15rem;
+	}
+
+	.mcplaza__head p {
+		margin: 0;
+		color: var(--sl-color-gray-3);
+		font-size: 0.9em;
+	}
+
+	.mcplaza__legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.mcplaza__legend-pill {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.82em;
+		color: var(--sl-color-gray-3);
+	}
+
+	.mcplaza__legend-pill i {
+		display: inline-block;
+		width: 0.85rem;
+		height: 0.85rem;
+		border-radius: 0.2rem;
+		opacity: 0.65;
+		border: 1px solid var(--sl-color-gray-6);
+	}
+
+	.mcplaza__svg {
+		max-width: 100%;
+		height: auto;
+		border-radius: 0.4rem;
+	}
+
+	.mcplaza__svg a:hover rect {
+		fill-opacity: 0.9;
+	}
+
+	.mcplaza__hint {
+		margin: 0;
+		font-size: 0.78em;
+		color: var(--sl-color-gray-4);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCSchematicCatalog.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCSchematicCatalog.astro
@@ -1,0 +1,222 @@
+---
+import { getCollection } from 'astro:content';
+import { MCSchematicFrontmatterSchema } from '@/data/schema';
+
+const entries = await getCollection('docs', (entry) => {
+	const m = (entry.data as { mc_schematic?: unknown }).mc_schematic;
+	if (!m) return false;
+	try {
+		MCSchematicFrontmatterSchema.parse(m);
+		return true;
+	} catch {
+		return false;
+	}
+});
+
+type Row = ReturnType<typeof MCSchematicFrontmatterSchema.parse> & {
+	slug: string;
+	title: string;
+};
+
+const rows: Row[] = entries
+	.map((e) => {
+		const m = MCSchematicFrontmatterSchema.parse(
+			(e.data as { mc_schematic: unknown }).mc_schematic,
+		);
+		return {
+			...m,
+			slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
+			title: (e.data as { title?: string }).title ?? m.display_name,
+		};
+	})
+	.sort(
+		(a, b) =>
+			a.tier - b.tier || a.display_name.localeCompare(b.display_name),
+	);
+
+const categoryAccent: Record<string, string> = {
+	house: '#86efac',
+	castle: '#fcd34d',
+	tower: '#a5b4fc',
+	farm: '#fde68a',
+	shop: '#7dd3fc',
+	utility: '#cbd5e1',
+	monument: '#f9a8d4',
+};
+
+const THUMB = 90;
+---
+
+<section class="mcschem-catalog not-content">
+	<header class="mcschem-catalog__head">
+		<h2>Schematic catalog</h2>
+		<p>
+			Every editorial build template with its footprint, tier, and price.
+			Click any card to open its detail panel.
+		</p>
+	</header>
+
+	<div class="mcschem-catalog__grid">
+		{
+			rows.map((s) => {
+				const accent = categoryAccent[s.category] ?? '#cbd5e1';
+				const longest = Math.max(s.dims_x, s.dims_z);
+				const px = Math.min(6, THUMB / longest);
+				const w = s.dims_x * px;
+				const h = s.dims_z * px;
+				return (
+					<a class="mcschem-card" href={`/${s.slug}/`}>
+						<div class="mcschem-card__head">
+							<span
+								class="mcschem-card__tier"
+								style={`--accent:${accent}`}>
+								T{s.tier}
+							</span>
+							<span class="mcschem-card__cat">{s.category}</span>
+						</div>
+						<h3>{s.display_name}</h3>
+						<svg
+							viewBox={`0 0 ${Math.max(w, 40)} ${Math.max(h, 40)}`}
+							width={Math.max(w, 40)}
+							height={Math.max(h, 40)}
+							class="mcschem-card__svg"
+							role="img"
+							aria-label={`${s.display_name} footprint`}>
+							<rect
+								x={0}
+								y={0}
+								width={w}
+								height={h}
+								fill="#0c0f14"
+								stroke={accent}
+								stroke-width="1"
+							/>
+						</svg>
+						<dl class="mcschem-card__stats">
+							<div>
+								<dt>Dims</dt>
+								<dd>
+									{s.dims_x}×{s.dims_y}×{s.dims_z}
+								</dd>
+							</div>
+							<div>
+								<dt>Price</dt>
+								<dd>
+									{s.price_credits > 0 && (
+										<>{s.price_credits.toLocaleString()}c</>
+									)}
+									{s.price_credits > 0 &&
+										s.price_khash > 0 &&
+										' · '}
+									{s.price_khash > 0 && (
+										<>{s.price_khash.toLocaleString()}k</>
+									)}
+									{s.price_credits === 0 &&
+										s.price_khash === 0 &&
+										'free'}
+								</dd>
+							</div>
+						</dl>
+					</a>
+				);
+			})
+		}
+	</div>
+</section>
+
+<style>
+	.mcschem-catalog {
+		display: flex;
+		flex-direction: column;
+		gap: 0.7rem;
+	}
+
+	.mcschem-catalog__head h2 {
+		margin: 0;
+		font-size: 1.15rem;
+	}
+
+	.mcschem-catalog__head p {
+		margin: 0.2rem 0 0;
+		color: var(--sl-color-gray-3);
+		font-size: 0.9em;
+	}
+
+	.mcschem-catalog__grid {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+		gap: 0.7rem;
+	}
+
+	.mcschem-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+		padding: 0.7rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.5rem;
+		background: var(--sl-color-bg-nav);
+		color: var(--sl-color-white);
+		text-decoration: none;
+	}
+
+	.mcschem-card:hover {
+		border-color: var(--sl-color-accent);
+	}
+
+	.mcschem-card h3 {
+		margin: 0;
+		font-size: 0.95rem;
+	}
+
+	.mcschem-card__head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.3rem;
+	}
+
+	.mcschem-card__tier {
+		display: inline-block;
+		padding: 0.1rem 0.4rem;
+		border-radius: 0.3rem;
+		font-size: 0.7em;
+		font-weight: 600;
+		background: color-mix(in srgb, var(--accent) 25%, transparent);
+		color: var(--accent);
+		border: 1px solid var(--accent);
+	}
+
+	.mcschem-card__cat {
+		font-size: 0.78em;
+		color: var(--sl-color-gray-3);
+		text-transform: capitalize;
+	}
+
+	.mcschem-card__svg {
+		align-self: center;
+		max-width: 100%;
+		height: auto;
+	}
+
+	.mcschem-card__stats {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.4rem;
+		margin: 0;
+		font-size: 0.78em;
+	}
+
+	.mcschem-card__stats div {
+		display: flex;
+		flex-direction: column;
+	}
+
+	.mcschem-card__stats dt {
+		color: var(--sl-color-gray-3);
+	}
+
+	.mcschem-card__stats dd {
+		margin: 0;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCSchematicPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCSchematicPanel.astro
@@ -1,0 +1,363 @@
+---
+import { MCSchematicFrontmatterSchema } from '@/data/schema';
+
+const { data } = Astro.props;
+const s = MCSchematicFrontmatterSchema.parse(data);
+
+const CHUNK = 16;
+const footprintChunksX = Math.ceil(s.dims_x / CHUNK);
+const footprintChunksZ = Math.ceil(s.dims_z / CHUNK);
+
+// Render at ~6 px per block; cap to keep oversized castles from
+// overflowing the panel.
+const RAW_PX_PER_BLOCK = 6;
+const MAX_SIZE = 280;
+const longest = Math.max(s.dims_x, s.dims_z);
+const pxPerBlock = Math.min(RAW_PX_PER_BLOCK, MAX_SIZE / longest);
+const svgW = s.dims_x * pxPerBlock;
+const svgD = s.dims_z * pxPerBlock;
+const svgH = s.dims_y * pxPerBlock;
+
+const totalCredits = s.price_credits;
+const totalKhash = s.price_khash;
+
+const categoryAccent: Record<string, string> = {
+	house: '#86efac',
+	castle: '#fcd34d',
+	tower: '#a5b4fc',
+	farm: '#fde68a',
+	shop: '#7dd3fc',
+	utility: '#cbd5e1',
+	monument: '#f9a8d4',
+};
+const accent = categoryAccent[s.category] ?? '#cbd5e1';
+---
+
+<section class="mcschem-panel not-content kbve-dashboard-page">
+	<header class="mcschem-panel__head">
+		<div>
+			<h2>{s.display_name}</h2>
+			<p class="mcschem-panel__sub">
+				<code>{s.schematic_id}</code>
+			</p>
+			<div class="mcschem-panel__pills">
+				<span class="mcschem-pill" style={`--accent:${accent}`}>
+					{s.category}
+				</span>
+				<span class="mcschem-pill mcschem-pill--tier">
+					tier {s.tier}
+				</span>
+				{
+					!s.enabled && (
+						<span class="mcschem-pill mcschem-pill--off">
+							disabled
+						</span>
+					)
+				}
+			</div>
+		</div>
+		<div class="mcschem-panel__price">
+			{
+				totalCredits > 0 && (
+					<span>
+						<strong>{totalCredits.toLocaleString()}</strong> credits
+					</span>
+				)
+			}
+			{
+				totalKhash > 0 && (
+					<span>
+						<strong>{totalKhash.toLocaleString()}</strong> khash
+					</span>
+				)
+			}
+			{totalCredits === 0 && totalKhash === 0 && <span>free</span>}
+		</div>
+	</header>
+
+	<div class="mcschem-panel__grid">
+		<dl class="mcschem-stats">
+			<div>
+				<dt>Dimensions</dt>
+				<dd>{s.dims_x}×{s.dims_y}×{s.dims_z} blocks</dd>
+			</div>
+			<div>
+				<dt>Footprint</dt>
+				<dd>
+					{footprintChunksX}×{footprintChunksZ} chunk{
+						footprintChunksX * footprintChunksZ === 1 ? '' : 's'
+					}
+				</dd>
+			</div>
+			<div>
+				<dt>Height</dt>
+				<dd>{s.dims_y} blocks</dd>
+			</div>
+			<div>
+				<dt>Resource</dt>
+				<dd><code>{s.resource_path}</code></dd>
+			</div>
+		</dl>
+
+		<figure class="mcschem-figure">
+			<figcaption>Top-down footprint</figcaption>
+			<svg
+				viewBox={`0 0 ${Math.max(svgW, 80)} ${Math.max(svgD, 80)}`}
+				width={Math.max(svgW, 80)}
+				height={Math.max(svgD, 80)}
+				role="img"
+				aria-label={`${s.display_name} footprint, ${s.dims_x} by ${s.dims_z} blocks`}>
+				<rect
+					x={0}
+					y={0}
+					width={svgW}
+					height={svgD}
+					fill="#0c0f14"
+					stroke={accent}
+					stroke-width="1">
+				</rect>
+				{
+					Array.from({ length: s.dims_x + 1 }, (_, i) => i).map(
+						(i) => (
+							<line
+								x1={i * pxPerBlock}
+								y1={0}
+								x2={i * pxPerBlock}
+								y2={svgD}
+								stroke={i % CHUNK === 0 ? '#3b4252' : '#1c2230'}
+								stroke-width={i % CHUNK === 0 ? 1 : 0.3}
+							/>
+						),
+					)
+				}
+				{
+					Array.from({ length: s.dims_z + 1 }, (_, i) => i).map(
+						(i) => (
+							<line
+								x1={0}
+								y1={i * pxPerBlock}
+								x2={svgW}
+								y2={i * pxPerBlock}
+								stroke={i % CHUNK === 0 ? '#3b4252' : '#1c2230'}
+								stroke-width={i % CHUNK === 0 ? 1 : 0.3}
+							/>
+						),
+					)
+				}
+			</svg>
+			<p class="mcschem-figure__hint">
+				1 px ≈ {(1 / pxPerBlock).toFixed(2)} blocks. Heavier gridlines mark
+				16-block chunk boundaries.
+			</p>
+		</figure>
+
+		<figure class="mcschem-figure mcschem-figure--side">
+			<figcaption>Side profile</figcaption>
+			<svg
+				viewBox={`0 0 ${Math.max(svgW, 80)} ${Math.max(svgH, 60)}`}
+				width={Math.max(svgW, 80)}
+				height={Math.max(svgH, 60)}
+				role="img"
+				aria-label={`${s.display_name} side, ${s.dims_x} wide by ${s.dims_y} tall blocks`}>
+				<rect
+					x={0}
+					y={Math.max(svgH, 60) - svgH}
+					width={svgW}
+					height={svgH}
+					fill="#0c0f14"
+					stroke={accent}
+					stroke-width="1">
+				</rect>
+				<line
+					x1={0}
+					y1={Math.max(svgH, 60)}
+					x2={Math.max(svgW, 80)}
+					y2={Math.max(svgH, 60)}
+					stroke="#3b4252"
+					stroke-width="1">
+				</line>
+			</svg>
+			<p class="mcschem-figure__hint">
+				{s.dims_y} blocks tall over a {s.dims_x}-block-wide baseline.
+			</p>
+		</figure>
+	</div>
+
+	{
+		(s.about.summary || s.about.lore) && (
+			<section class="mcschem-about">
+				{s.about.summary && (
+					<p class="mcschem-about__summary">{s.about.summary}</p>
+				)}
+				{s.about.lore && (
+					<p class="mcschem-about__lore">
+						<em>{s.about.lore}</em>
+					</p>
+				)}
+			</section>
+		)
+	}
+
+	{
+		s.tags.length > 0 && (
+			<footer class="mcschem-panel__tags">
+				{s.tags.map((t) => (
+					<span class="mcschem-tag">#{t}</span>
+				))}
+			</footer>
+		)
+	}
+</section>
+
+<style>
+	.mcschem-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: 1rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.6rem;
+		background: var(--sl-color-bg-nav);
+	}
+
+	.mcschem-panel__head {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		align-items: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.mcschem-panel__head h2 {
+		margin: 0;
+	}
+
+	.mcschem-panel__sub {
+		margin: 0.2rem 0 0.4rem;
+		color: var(--sl-color-gray-3);
+		font-size: 0.85em;
+	}
+
+	.mcschem-panel__pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+	}
+
+	.mcschem-pill {
+		display: inline-block;
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.78em;
+		background: color-mix(in srgb, var(--accent, #cbd5e1) 25%, transparent);
+		color: var(--accent, #cbd5e1);
+		border: 1px solid var(--accent, #cbd5e1);
+		text-transform: capitalize;
+	}
+
+	.mcschem-pill--tier {
+		--accent: #94a3b8;
+	}
+
+	.mcschem-pill--off {
+		--accent: #f87171;
+	}
+
+	.mcschem-panel__price {
+		display: flex;
+		flex-direction: column;
+		align-items: flex-end;
+		gap: 0.15rem;
+		font-size: 0.95em;
+	}
+
+	.mcschem-panel__price strong {
+		color: var(--sl-color-white);
+	}
+
+	.mcschem-panel__grid {
+		display: grid;
+		gap: 1rem;
+		grid-template-columns: minmax(0, 1fr) auto;
+		align-items: start;
+	}
+
+	@media (max-width: 720px) {
+		.mcschem-panel__grid {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	.mcschem-stats {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		row-gap: 0.4rem;
+		column-gap: 0.75rem;
+		margin: 0;
+	}
+
+	.mcschem-stats > div {
+		display: contents;
+	}
+
+	.mcschem-stats dt {
+		color: var(--sl-color-gray-3);
+		font-size: 0.85em;
+	}
+
+	.mcschem-stats dd {
+		margin: 0;
+	}
+
+	.mcschem-figure {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		align-items: flex-start;
+	}
+
+	.mcschem-figure figcaption {
+		font-size: 0.85em;
+		color: var(--sl-color-gray-3);
+	}
+
+	.mcschem-figure svg {
+		max-width: 100%;
+		height: auto;
+		border-radius: 0.3rem;
+	}
+
+	.mcschem-figure__hint {
+		margin: 0;
+		font-size: 0.75em;
+		color: var(--sl-color-gray-4);
+	}
+
+	.mcschem-about {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+	}
+
+	.mcschem-about__lore {
+		color: var(--sl-color-gray-3);
+		font-size: 0.92em;
+	}
+
+	.mcschem-panel__tags {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.3rem;
+		border-top: 1px solid var(--sl-color-gray-6);
+		padding-top: 0.5rem;
+	}
+
+	.mcschem-tag {
+		font-size: 0.75em;
+		color: var(--sl-color-gray-3);
+		padding: 0.05rem 0.4rem;
+		border-radius: 0.3rem;
+		background: var(--sl-color-bg);
+		border: 1px solid var(--sl-color-gray-6);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/index.mdx
@@ -5,6 +5,8 @@ description: |
     the lot marketplace. Mirror of the on-disk catalog the survival
     backend ships with.
 tableOfContents: false
+graph:
+    visible: false
 sidebar:
     label: Sample Lots
     order: 6
@@ -14,60 +16,16 @@ tags:
     - mc-lot
 ---
 
-import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+import MCPlazaOverview from '@/components/mcdb/MCPlazaOverview.astro';
 
 A 3×3 plaza of 2×2-chunk parcels centered on the spawn area at sea
-level. These exist as MDX records, not as rows in the `mc.lot` table —
-the marketplace dashboard renders them so prospective buyers can see
-the shape of a parcel before any real lots are surveyed.
+level. Each cell below links to a detailed lot panel with chunk + block
+coordinates and price.
 
-Real parcels are created by admin tooling against the deployed schema
-once a region is opened for sale.
+These exist as MDX records, not as rows in the `mc.lot` table — the
+marketplace dashboard renders them so prospective buyers can see the
+shape of a parcel before any real lots are surveyed. Real parcels are
+created by admin tooling against the deployed schema once a region is
+opened for sale.
 
-<CardGrid>
-  <LinkCard
-    title="Plaza Northwest"
-    description="Outer ring — credit-priced corner parcel at chunks (-4,-4)."
-    href="/mc/lots/plaza-northwest/"
-  />
-  <LinkCard
-    title="Plaza North"
-    description="North-edge parcel at chunks (-1,-4)."
-    href="/mc/lots/plaza-north/"
-  />
-  <LinkCard
-    title="Plaza Northeast"
-    description="Outer ring — credit-priced corner parcel at chunks (2,-4)."
-    href="/mc/lots/plaza-northeast/"
-  />
-  <LinkCard
-    title="Plaza West"
-    description="West-edge parcel at chunks (-4,-1)."
-    href="/mc/lots/plaza-west/"
-  />
-  <LinkCard
-    title="Plaza Center"
-    description="Center premium parcel at chunks (-1,-1) — highest credit price."
-    href="/mc/lots/plaza-center/"
-  />
-  <LinkCard
-    title="Plaza East"
-    description="East-edge parcel at chunks (2,-1)."
-    href="/mc/lots/plaza-east/"
-  />
-  <LinkCard
-    title="Plaza Southwest"
-    description="Outer ring — credit-priced corner parcel at chunks (-4,2)."
-    href="/mc/lots/plaza-southwest/"
-  />
-  <LinkCard
-    title="Plaza South"
-    description="South-edge parcel at chunks (-1,2)."
-    href="/mc/lots/plaza-south/"
-  />
-  <LinkCard
-    title="Plaza Southeast"
-    description="Outer ring — credit-priced corner parcel at chunks (2,2)."
-    href="/mc/lots/plaza-southeast/"
-  />
-</CardGrid>
+<MCPlazaOverview />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-center.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-center.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Central plaza site. Frontage on all four cardinal lots.
 ---
 
-Premium central parcel — frontage on all four cardinal lots.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-east.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-east.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Mid-priced. Mirrors the West edge across the plaza.
 ---
 
-East-edge parcel adjacent to the central premium lot.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-north.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-north.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Mid-priced. Good frontage for a shop facing the central plaza.
 ---
 
-North-edge parcel adjacent to the central premium lot.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-northeast.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-northeast.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Mirrors NW corner price.
 ---
 
-Outer-ring NE corner parcel.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-northwest.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-northwest.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: First-time buyers; pairs well with Starter Cottage + Wheat Farm.
 ---
 
-Outer-ring NW corner parcel.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-south.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-south.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Mid-priced. Mirrors the North edge across the plaza.
 ---
 
-South-edge parcel adjacent to the central premium lot.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-southeast.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-southeast.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Mirrors NW/NE/SW corner price.
 ---
 
-Outer-ring SE corner parcel.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-southwest.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-southwest.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Mirrors NW corner price.
 ---
 
-Outer-ring SW corner parcel.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-west.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/lots/plaza-west.mdx
@@ -24,4 +24,6 @@ mc_lot:
         notes: Mid-priced. Mirrors the East edge across the plaza.
 ---
 
-West-edge parcel adjacent to the central premium lot.
+import MCLotPanel from '@/components/mcdb/MCLotPanel.astro';
+
+<MCLotPanel data={frontmatter.mc_lot} title={frontmatter.title} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/index.mdx
@@ -4,6 +4,8 @@ description: |
     Build templates that the survival worker can apply to a purchased lot.
     Source of truth for the lot dashboard schematic picker.
 tableOfContents: false
+graph:
+    visible: false
 sidebar:
     label: Schematics
     order: 5
@@ -13,7 +15,7 @@ tags:
     - mc-lot
 ---
 
-import { CardGrid, LinkCard } from '@astrojs/starlight/components';
+import MCSchematicCatalog from '@/components/mcdb/MCSchematicCatalog.astro';
 
 The catalog below is the editorial source of truth for every build
 template the worker can apply to a lot. Each entry is a Markdown record
@@ -26,52 +28,4 @@ JSON snapshot at build time; the database catalog (`mc.schematic`) is
 loaded from the same snapshot by ops tooling rather than hand-rolled
 SQL.
 
-## Starter — credit-priced
-
-<CardGrid>
-  <LinkCard
-    title="Starter Cottage"
-    description="7×6×7 timber cottage. Tier 1 — first home for new arrivals."
-    href="/mc/schematics/starter-cottage/"
-  />
-  <LinkCard
-    title="Wooden Cabin"
-    description="9×7×11 mid-size cabin with a loft. Tier 2."
-    href="/mc/schematics/starter-cabin/"
-  />
-  <LinkCard
-    title="Watch Tower"
-    description="5×12×5 wood-and-stone watch tower. Tier 2."
-    href="/mc/schematics/starter-watch-tower/"
-  />
-  <LinkCard
-    title="Wheat Farm"
-    description="11×4×11 enclosed wheat field with a water channel."
-    href="/mc/schematics/starter-wheat-farm/"
-  />
-  <LinkCard
-    title="Corner Shop"
-    description="9×6×9 trading post with stalls. Tier 2."
-    href="/mc/schematics/starter-corner-shop/"
-  />
-  <LinkCard
-    title="Storage Silo"
-    description="7×14×7 vertical storage column. Tier 3."
-    href="/mc/schematics/util-storage-silo/"
-  />
-</CardGrid>
-
-## Mid-tier — khash-priced
-
-<CardGrid>
-  <LinkCard
-    title="Castle Keep"
-    description="25×24×25 stone keep with battlements. Tier 5."
-    href="/mc/schematics/mid-castle-keep/"
-  />
-  <LinkCard
-    title="Obelisk Monument"
-    description="5×16×5 obsidian obelisk. Tier 4 decorative monument."
-    href="/mc/schematics/mid-obelisk/"
-  />
-</CardGrid>
+<MCSchematicCatalog />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/mid-castle-keep.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/mid-castle-keep.mdx
@@ -29,6 +29,6 @@ mc_schematic:
         lore: First mid-game build. Khash-priced — a status symbol for established players.
 ---
 
-A 25×24×25 stone keep with four corner towers, a central courtyard, a
-crenellated battlement, and arrow slits along every wall. Footprint
-demands a 4×4 chunk lot; lower-tier lots reject the queue request.
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
+
+<MCSchematicPanel data={frontmatter.mc_schematic} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/mid-obelisk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/mid-obelisk.mdx
@@ -29,5 +29,6 @@ mc_schematic:
         lore: Decorative landmark. Marks plaza centers, guild headquarters, or memorial sites.
 ---
 
-A 5×16×5 obsidian obelisk on a sandstone plinth with subtle end-rod
-illumination. No mechanical effect — it's a landmark.
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
+
+<MCSchematicPanel data={frontmatter.mc_schematic} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-cabin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-cabin.mdx
@@ -28,6 +28,6 @@ mc_schematic:
         lore: The next step up from the Starter Cottage. Room for a chest line and a furnace stack.
 ---
 
-A 9×7×11 spruce cabin with a sleeping loft, covered porch, and an
-internal storage nook. Designed to fit a 2×2 chunk lot with room around
-the exterior for paths and fencing.
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
+
+<MCSchematicPanel data={frontmatter.mc_schematic} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-corner-shop.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-corner-shop.mdx
@@ -28,6 +28,6 @@ mc_schematic:
         lore: First commerce hub. Drop it on a central lot to seed a trading district.
 ---
 
-A 9×6×9 trading post with two stalls, a back-room storage with four
-barrels, and a front-facing sign rack. The roofline drops slightly on
-the corner side for street visibility.
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
+
+<MCSchematicPanel data={frontmatter.mc_schematic} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-cottage.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-cottage.mdx
@@ -28,12 +28,6 @@ mc_schematic:
         lore: First-home grant. Cheap to build, easy to extend, and forgiving on smaller lots.
 ---
 
-import { Aside } from '@astrojs/starlight/components';
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
 
-A 7×6×7 timber cottage. Built from oak planks and cobblestone; ships
-with a hearth, a single bed, and a window facing the entrance.
-
-<Aside type="tip" title="Pairing">
-  Fits any 2×2 chunk lot. Pair with **Wheat Farm** on the adjacent
-  parcel for a self-sufficient starter homestead.
-</Aside>
+<MCSchematicPanel data={frontmatter.mc_schematic} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-watch-tower.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-watch-tower.mdx
@@ -28,6 +28,6 @@ mc_schematic:
         lore: Slot it into a corner of a settlement for a lookout that doesn't eat much real estate.
 ---
 
-A 5×12×5 stone-and-spruce watch tower with internal ladders, an
-open-air battlement, and slit windows along the climb. Footprint stays
-under a quarter of a 2×2 chunk lot — useful for perimeter coverage.
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
+
+<MCSchematicPanel data={frontmatter.mc_schematic} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-wheat-farm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/starter-wheat-farm.mdx
@@ -28,5 +28,6 @@ mc_schematic:
         lore: First passive food source. Pairs with any starter house.
 ---
 
-An 11×4×11 wheat field laid out around a central irrigation channel,
-fenced for mob protection, with a torch grid for night-time growth.
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
+
+<MCSchematicPanel data={frontmatter.mc_schematic} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/schematics/util-storage-silo.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/schematics/util-storage-silo.mdx
@@ -28,6 +28,6 @@ mc_schematic:
         lore: Mid-game storage upgrade. Built tall to keep the lot footprint small.
 ---
 
-A 7×14×7 utility build — a vertical column of double-chests with the
-plumbing pre-laid for a hopper-based item sorter. Footprint stays small
-on the ground floor to fit alongside an existing house.
+import MCSchematicPanel from '@/components/mcdb/MCSchematicPanel.astro';
+
+<MCSchematicPanel data={frontmatter.mc_schematic} />


### PR DESCRIPTION
## Summary

Visual layer over the merged MDX catalog so editorial can see the lots and schematics before any \`.nbt\` files or data points get attached.

### Detail panels
- **\`MCSchematicPanel.astro\`** — renders schematic frontmatter as a card: category + tier + enabled pills, formatted price, dimensions / footprint / height / resource path stats, top-down SVG footprint with chunk gridlines, and a side-profile SVG so users can compare base width vs height. The eight schematic MDX files now embed it.
- **\`MCLotPanel.astro\`** — renders lot frontmatter with state + schematic pills, formatted price, chunk + block coordinate stats, footprint, and a per-lot overview SVG that pulls every same-world lot from the docs collection so the visitor can see THIS parcel highlighted with a \`HERE\` badge inside the broader plaza. The nine plaza MDX files now embed it.

### Index overviews
- **\`MCSchematicCatalog.astro\`** — reads the docs collection, sorts by tier, renders a responsive grid of mini-cards (tier badge, category, footprint thumbnail, dims, price). Mounted on \`/mc/schematics/\` index.
- **\`MCPlazaOverview.astro\`** — renders every same-world lot as a clickable SVG cell with state-colored fill, lot label, chunk gridlines, and a legend. Mounted on \`/mc/lots/\` index.

### Build-time only
Pure SSG. Zero client JS. Everything reads from MDX frontmatter validated against \`MCSchematicFrontmatterSchema\` / \`MCLotFrontmatterSchema\` (added earlier).

## Test plan
- [ ] \`./kbve.sh -nx astro-kbve:build\` emits \`/mc/schematics/<slug>/index.html\` for all eight schematics with the panel markup (verified locally).
- [ ] Plaza index shows nine clickable SVG cells; clicking each opens the matching lot page with the \`HERE\` badge on the right cell.
- [ ] Schematic index sorts tier 1 → tier 5 with footprint thumbnails matching the dimensions in frontmatter.
- [ ] Each schematic detail page shows both top-down + side-profile SVGs scaled to actual block dimensions.