### PR TITLE
fix(arc-runner): expose npm globals on PATH so pnpm self-check passes

### DIFF
--- a/packages/docker/arc-runner/Dockerfile
+++ b/packages/docker/arc-runner/Dockerfile
@@ -64,18 +64,19 @@ RUN set -eux; \
 ARG NODE_VERSION
 ARG PNPM_VERSION
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright
+ENV PATH=/opt/node-current/bin:$PATH
 RUN set -eux; \
     cd /tmp; \
     curl -fsSL -O "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"; \
     curl -fsSL -O "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt"; \
     grep "node-v${NODE_VERSION}-linux-x64.tar.xz" SHASUMS256.txt | sha256sum -c -; \
     tar -xJf "node-v${NODE_VERSION}-linux-x64.tar.xz" -C /opt; \
-    ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/node" /usr/local/bin/node; \
-    ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/npm" /usr/local/bin/npm; \
-    ln -s "/opt/node-v${NODE_VERSION}-linux-x64/bin/npx" /usr/local/bin/npx; \
+    ln -s "/opt/node-v${NODE_VERSION}-linux-x64" /opt/node-current; \
     rm "node-v${NODE_VERSION}-linux-x64.tar.xz" SHASUMS256.txt; \
     npm install -g "pnpm@${PNPM_VERSION}"; \
     node --version >/dev/null; \
+    npm --version >/dev/null; \
+    npx --version >/dev/null; \
     pnpm --version >/dev/null
 
 ARG PLAYWRIGHT_VERSION


### PR DESCRIPTION
## Summary
Follow-up to #11865 / #11881. Build run [#27062702333](https://github.com/KBVE/kbve/actions/runs/27062702333) died with:

\`\`\`
#11 4.260 + node --version
#11 4.266 + pnpm --version
#11 4.266 /bin/sh: 1: pnpm: not found
#11 ERROR: ... did not complete successfully: exit code: 127
\`\`\`

\`npm install -g pnpm\` succeeded (\`added 1 package in 1s\`) but the next \`pnpm --version >/dev/null\` couldn't resolve it. The Dockerfile created \`/usr/local/bin/{node,npm,npx}\` symlinks individually, missing pnpm. The 0.1.3 image shipped with the same latent bug because Buildx layer cache fed it a pre-existing layer; the multi-stage rebuild for 0.1.4 had no cached layer to land on and tripped the fault.

## Fix
Replace the per-binary symlinks with \`/opt/node-current\` → versioned dir + \`ENV PATH=/opt/node-current/bin:$PATH\`. Every npm-installed global (pnpm, plus future tooling) is on PATH automatically. Future \`NODE_VERSION\` bumps just retarget one symlink instead of editing four \`ln -s\` lines.

Also extends the self-check to \`npm --version\` + \`npx --version\` so the same regression can't slip through again.

## Test plan
- [ ] CI - Docker / arc-runner build completes; the offending RUN passes the pnpm self-check
- [ ] Resulting \`ghcr.io/kbve/arc-runner:0.1.4\` boots and \`pnpm --version\` resolves on the runner