### PR TITLE
fix(astro): modal focus trap + sitegraph a11y + deferred search

### DIFF
--- a/packages/npm/astro/src/react/ModalOverlay.tsx
+++ b/packages/npm/astro/src/react/ModalOverlay.tsx
@@ -21,6 +21,8 @@ export function ModalOverlay({
 }: ModalOverlayProps) {
 	const { isOpen, close } = useModal();
 	const vnodeRef = useRef<HTMLDivElement>(null);
+	const panelRef = useRef<HTMLDivElement>(null);
+	const restoreFocusRef = useRef<HTMLElement | null>(null);
 	const [hoverClose, setHoverClose] = useState(false);
 	const open = isOpen(id);
 
@@ -42,15 +44,54 @@ export function ModalOverlay({
 		};
 	}, [open, vnode, children]);
 
-	// Escape key handler
+	// Escape to close + Tab focus trap so keyboard users can't tab out of the
+	// open dialog into the inert page behind it.
 	useEffect(() => {
 		if (!open) return;
 		const handler = (e: KeyboardEvent) => {
-			if (e.key === 'Escape') close(id);
+			if (e.key === 'Escape') {
+				close(id);
+				return;
+			}
+			if (e.key !== 'Tab') return;
+			const panel = panelRef.current;
+			if (!panel) return;
+			const focusables = panel.querySelectorAll<HTMLElement>(
+				'a[href], button:not([disabled]), textarea, input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+			);
+			if (focusables.length === 0) {
+				e.preventDefault();
+				panel.focus();
+				return;
+			}
+			const first = focusables[0];
+			const last = focusables[focusables.length - 1];
+			const activeEl = document.activeElement;
+			if (e.shiftKey && (activeEl === first || activeEl === panel)) {
+				e.preventDefault();
+				last.focus();
+			} else if (!e.shiftKey && activeEl === last) {
+				e.preventDefault();
+				first.focus();
+			}
 		};
 		document.addEventListener('keydown', handler);
 		return () => document.removeEventListener('keydown', handler);
 	}, [open, id, close]);
+
+	// Save the element that had focus before opening, move focus into the
+	// dialog, and restore it on close — WCAG 2.4.3 focus order.
+	useEffect(() => {
+		if (!open) return;
+		restoreFocusRef.current =
+			document.activeElement instanceof HTMLElement
+				? document.activeElement
+				: null;
+		panelRef.current?.focus();
+		return () => {
+			restoreFocusRef.current?.focus();
+		};
+	}, [open]);
 
 	// Lock body scroll
 	useEffect(() => {
@@ -125,7 +166,10 @@ export function ModalOverlay({
 				if (open && closeOnBackdrop && e.target === e.currentTarget)
 					close(id);
 			}}>
-			<div style={panelStyle}>
+			<div
+				ref={panelRef}
+				tabIndex={-1}
+				style={{ ...panelStyle, outline: 'none' }}>
 				{title && (
 					<div
 						style={{

--- a/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
+++ b/packages/npm/astro/src/sitegraph/react/SiteGraph.tsx
@@ -4,6 +4,7 @@ import {
 	useState,
 	useCallback,
 	useMemo,
+	useDeferredValue,
 	type CSSProperties,
 } from 'react';
 import {
@@ -300,6 +301,10 @@ export function SiteGraph({
 		return loadStoredDepth(depthProp, minDepth, maxDepth);
 	});
 	const [search, setSearch] = useState(() => readUrlState().q ?? '');
+	// Keep the input responsive while the expensive per-node filter/label
+	// recompute (and on big graphs, the reconcile of every node) lags a frame
+	// behind keystrokes instead of blocking them.
+	const deferredSearch = useDeferredValue(search);
 	const reducedMotion = useMemo(prefersReducedMotion, []);
 
 	// Responsive sizing — ResizeObserver on the container.
@@ -966,8 +971,8 @@ export function SiteGraph({
 	};
 
 	const matchesSearch = (node: GraphNode): boolean => {
-		if (!search) return true;
-		const q = search.toLowerCase();
+		if (!deferredSearch) return true;
+		const q = deferredSearch.toLowerCase();
 		return (
 			node.title.toLowerCase().includes(q) ||
 			node.id.toLowerCase().includes(q)
@@ -1156,7 +1161,7 @@ export function SiteGraph({
 						const labelVisible =
 							node.isCurrent ||
 							hoveredId === node.id ||
-							(search && filterPass) ||
+							(deferredSearch && filterPass) ||
 							node.degree >= 5 ||
 							zoom >= 1.2;
 
@@ -1379,6 +1384,8 @@ export function SiteGraph({
 					value={zoom}
 					onChange={handleSliderChange}
 					title={`Zoom: ${Math.round(zoom * 100)}%`}
+					aria-label="Zoom level"
+					aria-valuetext={`${Math.round(zoom * 100)}%`}
 					style={{
 						flex: 1,
 						height: '3px',
@@ -1387,7 +1394,6 @@ export function SiteGraph({
 						background: `linear-gradient(to right, var(--sl-color-accent, #06b6d4) 0%, var(--sl-color-accent, #06b6d4) ${((zoom - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM)) * 100}%, var(--sl-color-gray-5, #262626) ${((zoom - MIN_ZOOM) / (MAX_ZOOM - MIN_ZOOM)) * 100}%, var(--sl-color-gray-5, #262626) 100%)`,
 						borderRadius: '2px',
 						cursor: 'pointer',
-						outline: 'none',
 					}}
 				/>
 			</div>


### PR DESCRIPTION
## What

Second `@kbve/astro` improvement pass — a correctness / performance / a11y sweep (3 recon agents across the package). Most flagged items turned out to be **already handled** or **non-bugs** on inspection; shipping only the verified-real wins.

### Fixes
- **ModalOverlay focus management** (WCAG 2.4.3 / 2.1.2): trap Tab inside the open dialog (was leaking focus into the inert page behind it), save the previously-focused element on open and restore it on close. Panel is now focusable (`tabIndex=-1`) and receives focus on open. ESC/role=dialog/aria-modal were already present.
- **SiteGraph zoom slider a11y**: add `aria-label` + `aria-valuetext`, and drop `outline: none` so keyboard focus is visible.
- **SiteGraph search perf**: `useDeferredValue` so the filter input stays responsive while the per-node filter/label recompute (and node reconcile on large graphs) lags a frame behind keystrokes instead of blocking them.

### Investigated & dismissed (verified non-issues)
- `cross-domain.ts` cookie parse — safe: `encodeURIComponent` escapes `=`, and `.find` guarantees a `=`, so no `undefined` reaches `decodeURIComponent`.
- `renderVNode` dynamic imports (ModalOverlay + ToastContainer) — both already guard with `typeof === 'function'`.
- SiteGraph per-tick element caching — already done in a prior PR (not re-querying).
- Nested `<label>` on the depth select — valid implicit association.

## Verified
- isolated `tsc` on both files: clean
- react + sitegraph specs: 14/14
- `astro-kbve:build`: clean (exit 0, 7721 pages)

## Deferred (bigger / lower-ROI, noted not done)
- Full keyboard reachability for the hundreds of SVG graph nodes (role/tabindex/onKeyDown) — real but large UX design question; left for a focused follow-up.