### PR TITLE
feat(mc-lot): /mc/world/ page with SSR map + live RCON + DB overlay

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCPoiPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCPoiPanel.astro
@@ -1,0 +1,177 @@
+---
+import { MCPoiFrontmatterSchema } from '@/data/schema';
+
+const { data } = Astro.props;
+const p = MCPoiFrontmatterSchema.parse(data);
+
+const blockX = p.chunk_x * 16;
+const blockZ = p.chunk_z * 16;
+
+const kindAccent: Record<string, string> = {
+	spawn: '#fde68a',
+	marketplace: '#7dd3fc',
+	portal: '#f9a8d4',
+	monument: '#fcd34d',
+	biome: '#86efac',
+	shop: '#a5b4fc',
+	guild: '#fca5a5',
+	admin: '#f87171',
+	landmark: '#cbd5e1',
+};
+const accent = kindAccent[p.kind] ?? '#cbd5e1';
+---
+
+<section class="mcpoi-panel not-content kbve-dashboard-page">
+	<header class="mcpoi-panel__head">
+		<div>
+			<h2>{p.display_name}</h2>
+			<p class="mcpoi-panel__sub">
+				<code>{p.poi_id}</code> · <code>{p.world}</code>
+			</p>
+			<div class="mcpoi-panel__pills">
+				<span class="mcpoi-pill" style={`--accent:${accent}`}>
+					{p.kind}
+				</span>
+				{
+					p.radius_chunks > 0 && (
+						<span class="mcpoi-pill mcpoi-pill--alt">
+							{p.radius_chunks} chunk radius
+						</span>
+					)
+				}
+			</div>
+		</div>
+		{p.icon && <div class="mcpoi-panel__icon">{p.icon}</div>}
+	</header>
+
+	<dl class="mcpoi-stats">
+		<div>
+			<dt>Chunk coords</dt>
+			<dd>({p.chunk_x}, {p.chunk_z})</dd>
+		</div>
+		<div>
+			<dt>Block coords</dt>
+			<dd>({blockX}, {blockZ})</dd>
+		</div>
+		{
+			p.anchor_y !== undefined && (
+				<div>
+					<dt>Anchor Y</dt>
+					<dd>{p.anchor_y}</dd>
+				</div>
+			)
+		}
+		<div>
+			<dt>World</dt>
+			<dd><code>{p.world}</code></dd>
+		</div>
+	</dl>
+
+	{
+		(p.about.summary || p.about.notes) && (
+			<section class="mcpoi-about">
+				{p.about.summary && (
+					<p class="mcpoi-about__summary">{p.about.summary}</p>
+				)}
+				{p.about.notes && (
+					<p class="mcpoi-about__notes">
+						<em>{p.about.notes}</em>
+					</p>
+				)}
+			</section>
+		)
+	}
+
+	<p class="mcpoi-panel__back">
+		<a href="/mc/world/">← Back to world map</a>
+	</p>
+</section>
+
+<style>
+	.mcpoi-panel {
+		display: flex;
+		flex-direction: column;
+		gap: 1rem;
+		padding: 1rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.6rem;
+		background: var(--sl-color-bg-nav);
+	}
+
+	.mcpoi-panel__head {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		align-items: flex-start;
+		flex-wrap: wrap;
+	}
+
+	.mcpoi-panel__head h2 {
+		margin: 0;
+	}
+
+	.mcpoi-panel__sub {
+		margin: 0.2rem 0 0.4rem;
+		color: var(--sl-color-gray-3);
+		font-size: 0.85em;
+	}
+
+	.mcpoi-panel__pills {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+	}
+
+	.mcpoi-pill {
+		display: inline-block;
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+		font-size: 0.78em;
+		background: color-mix(in srgb, var(--accent, #cbd5e1) 25%, transparent);
+		color: var(--accent, #cbd5e1);
+		border: 1px solid var(--accent, #cbd5e1);
+		text-transform: capitalize;
+	}
+
+	.mcpoi-pill--alt {
+		--accent: #94a3b8;
+	}
+
+	.mcpoi-panel__icon {
+		font-size: 2rem;
+		font-weight: 700;
+		color: var(--accent, #cbd5e1);
+		opacity: 0.8;
+	}
+
+	.mcpoi-stats {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		row-gap: 0.4rem;
+		column-gap: 0.75rem;
+		margin: 0;
+	}
+
+	.mcpoi-stats > div {
+		display: contents;
+	}
+
+	.mcpoi-stats dt {
+		color: var(--sl-color-gray-3);
+		font-size: 0.85em;
+	}
+
+	.mcpoi-stats dd {
+		margin: 0;
+	}
+
+	.mcpoi-about__notes {
+		color: var(--sl-color-gray-3);
+		font-size: 0.92em;
+	}
+
+	.mcpoi-panel__back {
+		margin: 0;
+		font-size: 0.88em;
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMap.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMap.astro
@@ -1,0 +1,362 @@
+---
+import { getCollection } from 'astro:content';
+import { MCLotFrontmatterSchema, MCPoiFrontmatterSchema } from '@/data/schema';
+
+interface Props {
+	world?: string;
+	minChunk?: number;
+	maxChunk?: number;
+}
+const world = Astro.props.world ?? 'minecraft:overworld';
+const MIN = Astro.props.minChunk ?? -32;
+const MAX = Astro.props.maxChunk ?? 32;
+const span = MAX - MIN + 1;
+const SIZE = 640;
+const cell = SIZE / span;
+
+const lotEntries = await getCollection('docs', (entry) => {
+	const m = (entry.data as { mc_lot?: unknown }).mc_lot;
+	if (!m) return false;
+	try {
+		const parsed = MCLotFrontmatterSchema.parse(m);
+		return parsed.world === world;
+	} catch {
+		return false;
+	}
+});
+
+type LotRow = ReturnType<typeof MCLotFrontmatterSchema.parse> & {
+	slug: string;
+};
+const lots: LotRow[] = lotEntries.map((e) => ({
+	...MCLotFrontmatterSchema.parse((e.data as { mc_lot: unknown }).mc_lot),
+	slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
+}));
+
+const poiEntries = await getCollection('docs', (entry) => {
+	const m = (entry.data as { mc_poi?: unknown }).mc_poi;
+	if (!m) return false;
+	try {
+		const parsed = MCPoiFrontmatterSchema.parse(m);
+		return parsed.world === world;
+	} catch {
+		return false;
+	}
+});
+
+type PoiRow = ReturnType<typeof MCPoiFrontmatterSchema.parse> & {
+	slug: string;
+};
+const pois: PoiRow[] = poiEntries.map((e) => ({
+	...MCPoiFrontmatterSchema.parse((e.data as { mc_poi: unknown }).mc_poi),
+	slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
+}));
+
+const kindAccent: Record<string, string> = {
+	spawn: '#fde68a',
+	marketplace: '#7dd3fc',
+	portal: '#f9a8d4',
+	monument: '#fcd34d',
+	biome: '#86efac',
+	shop: '#a5b4fc',
+	guild: '#fca5a5',
+	admin: '#f87171',
+	landmark: '#cbd5e1',
+};
+
+const stateAccent: Record<string, string> = {
+	vacant: '#86efac',
+	owned: '#7dd3fc',
+	built: '#a5b4fc',
+	under_build: '#fcd34d',
+	demolishing: '#fca5a5',
+};
+
+const blockMin = MIN * 16;
+const blockMax = (MAX + 1) * 16 - 1;
+---
+
+<section class="mcworld not-content">
+	<header class="mcworld__head">
+		<h2>World overview · {world}</h2>
+		<p>
+			Chunks <code>{MIN}</code> .. <code>{MAX}</code> · blocks <code>
+				{blockMin}
+			</code> .. <code>{blockMax}</code> ·
+			{lots.length} surveyed lot{lots.length === 1 ? '' : 's'} ·
+			{pois.length} POI{pois.length === 1 ? '' : 's'}.
+		</p>
+	</header>
+
+	<div class="mcworld__legend">
+		<div>
+			<strong>Lots</strong>
+			{
+				Object.entries(stateAccent).map(([k, c]) => (
+					<span>
+						<i style={`background:${c}`} />
+						{k}
+					</span>
+				))
+			}
+		</div>
+		<div>
+			<strong>POIs</strong>
+			{
+				Object.entries(kindAccent).map(([k, c]) => (
+					<span>
+						<i style={`background:${c}; border-radius: 999px`} />
+						{k}
+					</span>
+				))
+			}
+		</div>
+	</div>
+
+	<div class="mcworld__wrap" data-world={world} data-min={MIN} data-max={MAX}>
+		<svg
+			viewBox={`0 0 ${SIZE} ${SIZE}`}
+			width={SIZE}
+			height={SIZE}
+			class="mcworld__svg"
+			role="img"
+			aria-label={`World map for ${world} covering chunks ${MIN} to ${MAX}`}>
+			<rect x={0} y={0} width={SIZE} height={SIZE} fill="#0a0d12"></rect>
+
+			{
+				Array.from({ length: span + 1 }, (_, i) => i).map((i) => (
+					<line
+						x1={i * cell}
+						y1={0}
+						x2={i * cell}
+						y2={SIZE}
+						stroke={
+							i % 16 === 0
+								? '#3b4252'
+								: i % 4 === 0
+									? '#222a36'
+									: '#161c25'
+						}
+						stroke-width={
+							i % 16 === 0 ? 1 : i % 4 === 0 ? 0.6 : 0.2
+						}
+					/>
+				))
+			}
+			{
+				Array.from({ length: span + 1 }, (_, i) => i).map((i) => (
+					<line
+						x1={0}
+						y1={i * cell}
+						x2={SIZE}
+						y2={i * cell}
+						stroke={
+							i % 16 === 0
+								? '#3b4252'
+								: i % 4 === 0
+									? '#222a36'
+									: '#161c25'
+						}
+						stroke-width={
+							i % 16 === 0 ? 1 : i % 4 === 0 ? 0.6 : 0.2
+						}
+					/>
+				))
+			}
+
+			<line
+				x1={(0 - MIN) * cell}
+				y1={0}
+				x2={(0 - MIN) * cell}
+				y2={SIZE}
+				stroke="#475569"
+				stroke-width="1">
+			</line>
+			<line
+				x1={0}
+				y1={(0 - MIN) * cell}
+				x2={SIZE}
+				y2={(0 - MIN) * cell}
+				stroke="#475569"
+				stroke-width="1">
+			</line>
+
+			{
+				pois
+					.filter((p) => p.radius_chunks > 0 && p.kind === 'biome')
+					.map((p) => {
+						const cx = (p.chunk_x - MIN) * cell + cell / 2;
+						const cz = (p.chunk_z - MIN) * cell + cell / 2;
+						const r = p.radius_chunks * cell;
+						return (
+							<circle
+								cx={cx}
+								cy={cz}
+								r={r}
+								fill="none"
+								stroke={kindAccent[p.kind]}
+								stroke-width="1.5"
+								stroke-dasharray="4 4"
+								opacity="0.65">
+								<title>{p.display_name}</title>
+							</circle>
+						);
+					})
+			}
+
+			{
+				lots.map((lot) => {
+					const x = (lot.chunk_x_min - MIN) * cell;
+					const y = (lot.chunk_z_min - MIN) * cell;
+					const w = (lot.chunk_x_max - lot.chunk_x_min + 1) * cell;
+					const h = (lot.chunk_z_max - lot.chunk_z_min + 1) * cell;
+					const accent = stateAccent[lot.state] ?? '#cbd5e1';
+					return (
+						<a href={`/${lot.slug}/`}>
+							<rect
+								x={x}
+								y={y}
+								width={w}
+								height={h}
+								fill={accent}
+								fill-opacity={0.55}
+								stroke="#0a0d12"
+								stroke-width={0.6}>
+								<title>
+									{lot.lot_id} · {lot.state}
+								</title>
+							</rect>
+						</a>
+					);
+				})
+			}
+
+			<g data-mcworld-live-lots></g>
+
+			{
+				pois
+					.filter((p) => p.kind !== 'biome')
+					.map((p) => {
+						const cx = (p.chunk_x - MIN) * cell + cell / 2;
+						const cz = (p.chunk_z - MIN) * cell + cell / 2;
+						return (
+							<a href={`/${p.slug}/`}>
+								<circle
+									cx={cx}
+									cy={cz}
+									r={6}
+									fill={kindAccent[p.kind] ?? '#cbd5e1'}
+									stroke="#0a0d12"
+									stroke-width="1.5">
+									<title>
+										{p.display_name} · {p.kind} · chunk (
+										{p.chunk_x}, {p.chunk_z})
+									</title>
+								</circle>
+								<text
+									x={cx + 9}
+									y={cz + 4}
+									font-size="10"
+									fill="#e5e7eb"
+									font-weight="500">
+									{p.display_name}
+								</text>
+							</a>
+						);
+					})
+			}
+		</svg>
+	</div>
+
+	<p class="mcworld__hint">
+		1 grid cell = 1 chunk = 16×16 blocks. Faint gridlines: 1-chunk; medium:
+		4-chunk; heavy: 16-chunk (1 region edge). Tinted gray crosshair: world
+		origin (0, 0).
+	</p>
+</section>
+
+<style>
+	.mcworld {
+		display: flex;
+		flex-direction: column;
+		gap: 0.7rem;
+		padding: 1rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.6rem;
+		background: var(--sl-color-bg-nav);
+		align-items: flex-start;
+	}
+
+	.mcworld__head h2 {
+		margin: 0;
+		font-size: 1.2rem;
+	}
+
+	.mcworld__head p {
+		margin: 0.2rem 0 0;
+		color: var(--sl-color-gray-3);
+		font-size: 0.9em;
+	}
+
+	.mcworld__legend {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3rem;
+		font-size: 0.82em;
+		color: var(--sl-color-gray-3);
+	}
+
+	.mcworld__legend > div {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+		align-items: center;
+	}
+
+	.mcworld__legend strong {
+		color: var(--sl-color-white);
+		min-width: 3.5rem;
+	}
+
+	.mcworld__legend span {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+	}
+
+	.mcworld__legend i {
+		display: inline-block;
+		width: 0.75rem;
+		height: 0.75rem;
+		border-radius: 0.15rem;
+		opacity: 0.7;
+		border: 1px solid var(--sl-color-gray-6);
+	}
+
+	.mcworld__wrap {
+		width: 100%;
+		max-width: 640px;
+		position: relative;
+	}
+
+	.mcworld__svg {
+		width: 100%;
+		height: auto;
+		border-radius: 0.4rem;
+		display: block;
+	}
+
+	.mcworld__svg a:hover rect {
+		fill-opacity: 0.85;
+	}
+
+	.mcworld__svg a:hover circle {
+		stroke: var(--sl-color-white);
+	}
+
+	.mcworld__hint {
+		margin: 0;
+		font-size: 0.78em;
+		color: var(--sl-color-gray-4);
+	}
+</style>

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
@@ -45,6 +45,10 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 	const [error, setError] = useState<string | null>(null);
 	const mountedRef = useRef(false);
 	const abortRef = useRef<AbortController | null>(null);
+	// Cache the static-side SVG + injection-point lookup once on mount so
+	// dbLots updates don't re-walk the DOM every refresh.
+	const liveLayerRef = useRef<SVGGElement | null>(null);
+	const svgRef = useRef<SVGSVGElement | null>(null);
 
 	const cancel = useCallback(() => {
 		if (abortRef.current) {
@@ -90,6 +94,17 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 
 	useEffect(() => {
 		mountedRef.current = true;
+		// Bind DOM handles ONCE per mount. ClientRouter swap-back rebuilds
+		// the DOM, so the next mount picks up fresh references.
+		const wrap = document.querySelector<HTMLDivElement>(
+			`[data-world="${world}"]`,
+		);
+		svgRef.current =
+			wrap?.querySelector<SVGSVGElement>('.mcworld__svg') ?? null;
+		liveLayerRef.current =
+			wrap?.querySelector<SVGGElement>('[data-mcworld-live-lots]') ??
+			null;
+
 		document
 			.querySelectorAll('[data-mcworld-live-skeleton]')
 			.forEach((el) => el.remove());
@@ -117,20 +132,23 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 			document.removeEventListener('visibilitychange', onHidden);
 			window.removeEventListener('pagehide', teardown);
 			cancel();
+			// Drop any injected rects so a clean React unmount doesn't leak
+			// nodes into the Astro-owned SVG. ClientRouter swap-away tears
+			// the whole DOM anyway, but this covers the React-only path.
+			if (liveLayerRef.current) {
+				liveLayerRef.current.replaceChildren();
+			}
+			liveLayerRef.current = null;
+			svgRef.current = null;
 		};
-	}, [refresh, cancel]);
+	}, [refresh, cancel, world]);
 
-	// Project DB lots into the parent SVG's grid using the data-* attrs.
+	// Project DB lots into the cached SVG group. No DOM walk per update.
 	useEffect(() => {
-		const wrap = document.querySelector<HTMLDivElement>('[data-world]');
-		const liveLayer = wrap?.querySelector<SVGGElement>(
-			'[data-mcworld-live-lots]',
-		);
-		if (!wrap || !liveLayer || !dbLots) return;
-		const svg = wrap.querySelector<SVGSVGElement>('.mcworld__svg');
-		if (!svg) return;
-		const vb = svg.viewBox.baseVal;
-		const SIZE = vb.width;
+		const liveLayer = liveLayerRef.current;
+		const svg = svgRef.current;
+		if (!liveLayer || !svg || !dbLots) return;
+		const SIZE = svg.viewBox.baseVal.width;
 		const span = maxChunk - minChunk + 1;
 		const cell = SIZE / span;
 		liveLayer.replaceChildren();

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
@@ -1,0 +1,212 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type McServerStatus = {
+	server: string;
+	online: number;
+	max: number;
+	reachable: boolean;
+};
+
+type McPlayerList = {
+	online: number;
+	max: number;
+	servers: McServerStatus[];
+};
+
+type Lot = {
+	lot_id: string;
+	chunk_x_min: number;
+	chunk_x_max: number;
+	chunk_z_min: number;
+	chunk_z_max: number;
+	is_owned: boolean;
+	is_owned_by_me: boolean;
+	state: number;
+};
+
+const STATE_FILL = ['vacant', 'owned', 'built', 'under_build', 'demolishing'];
+const STATE_HEX = [
+	'rgba(134, 239, 172, 0.55)',
+	'rgba(125, 211, 252, 0.55)',
+	'rgba(165, 180, 252, 0.55)',
+	'rgba(252, 211, 77, 0.55)',
+	'rgba(252, 165, 165, 0.55)',
+];
+
+interface Props {
+	world: string;
+	minChunk: number;
+	maxChunk: number;
+}
+
+export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
+	const [status, setStatus] = useState<McPlayerList | null>(null);
+	const [dbLots, setDbLots] = useState<Lot[] | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const mountedRef = useRef(false);
+	const abortRef = useRef<AbortController | null>(null);
+
+	const cancel = useCallback(() => {
+		if (abortRef.current) {
+			abortRef.current.abort();
+			abortRef.current = null;
+		}
+	}, []);
+
+	const refresh = useCallback(async () => {
+		cancel();
+		const ctrl = new AbortController();
+		abortRef.current = ctrl;
+		try {
+			const [statusRes, lotsRes] = await Promise.all([
+				fetch('/api/v1/mc/players', { signal: ctrl.signal }).then(
+					(r) => (r.ok ? r.json() : null),
+				),
+				fetch(
+					`/api/v1/mc/lots/viewport?${new URLSearchParams({
+						world,
+						min_chunk_x: String(minChunk),
+						max_chunk_x: String(maxChunk),
+						min_chunk_z: String(minChunk),
+						max_chunk_z: String(maxChunk),
+						limit: '1024',
+					})}`,
+					{ signal: ctrl.signal },
+				).then((r) => (r.ok ? r.json() : null)),
+			]);
+			if (ctrl.signal.aborted || !mountedRef.current) return;
+			if (statusRes) setStatus(statusRes);
+			if (Array.isArray(lotsRes)) setDbLots(lotsRes);
+		} catch (e) {
+			if ((e as Error)?.name === 'AbortError') return;
+			if (!mountedRef.current) return;
+			setError(
+				e instanceof Error ? e.message : 'failed to load live data',
+			);
+		} finally {
+			if (abortRef.current === ctrl) abortRef.current = null;
+		}
+	}, [cancel, world, minChunk, maxChunk]);
+
+	useEffect(() => {
+		mountedRef.current = true;
+		document
+			.querySelectorAll('[data-mcworld-live-skeleton]')
+			.forEach((el) => el.remove());
+
+		void refresh();
+		const interval = window.setInterval(() => void refresh(), 30_000);
+
+		const teardown = () => {
+			cancel();
+			window.clearInterval(interval);
+		};
+		const onHidden = () => {
+			if (document.visibilityState === 'hidden') cancel();
+			else if (document.visibilityState === 'visible') void refresh();
+		};
+		document.addEventListener('astro:before-swap', teardown);
+		document.addEventListener('astro:before-preparation', teardown);
+		document.addEventListener('visibilitychange', onHidden);
+		window.addEventListener('pagehide', teardown);
+		return () => {
+			mountedRef.current = false;
+			window.clearInterval(interval);
+			document.removeEventListener('astro:before-swap', teardown);
+			document.removeEventListener('astro:before-preparation', teardown);
+			document.removeEventListener('visibilitychange', onHidden);
+			window.removeEventListener('pagehide', teardown);
+			cancel();
+		};
+	}, [refresh, cancel]);
+
+	// Project DB lots into the parent SVG's grid using the data-* attrs.
+	useEffect(() => {
+		const wrap = document.querySelector<HTMLDivElement>('[data-world]');
+		const liveLayer = wrap?.querySelector<SVGGElement>(
+			'[data-mcworld-live-lots]',
+		);
+		if (!wrap || !liveLayer || !dbLots) return;
+		const svg = wrap.querySelector<SVGSVGElement>('.mcworld__svg');
+		if (!svg) return;
+		const vb = svg.viewBox.baseVal;
+		const SIZE = vb.width;
+		const span = maxChunk - minChunk + 1;
+		const cell = SIZE / span;
+		liveLayer.replaceChildren();
+
+		for (const lot of dbLots) {
+			const x = (lot.chunk_x_min - minChunk) * cell;
+			const y = (lot.chunk_z_min - minChunk) * cell;
+			const w = (lot.chunk_x_max - lot.chunk_x_min + 1) * cell;
+			const h = (lot.chunk_z_max - lot.chunk_z_min + 1) * cell;
+			const fill = lot.is_owned_by_me
+				? 'rgba(96, 165, 250, 0.85)'
+				: (STATE_HEX[lot.state] ?? 'rgba(203, 213, 225, 0.55)');
+			const rect = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'rect',
+			);
+			rect.setAttribute('x', String(x));
+			rect.setAttribute('y', String(y));
+			rect.setAttribute('width', String(w));
+			rect.setAttribute('height', String(h));
+			rect.setAttribute('fill', fill);
+			rect.setAttribute('stroke', '#0a0d12');
+			rect.setAttribute('stroke-width', '0.6');
+			const t = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'title',
+			);
+			t.textContent = `${lot.lot_id} (live · ${STATE_FILL[lot.state] ?? lot.state})`;
+			rect.appendChild(t);
+			liveLayer.appendChild(rect);
+		}
+	}, [dbLots, minChunk, maxChunk]);
+
+	const total = status?.online ?? 0;
+	const max = status?.max ?? 0;
+
+	return (
+		<aside className="mcworldlive">
+			<div className="mcworldlive__row">
+				<span className="mcworldlive__dot mcworldlive__dot--live" />
+				<strong>{total}</strong>
+				<span> / {max} online</span>
+				<button
+					type="button"
+					className="mcworldlive__refresh"
+					onClick={() => void refresh()}>
+					Refresh
+				</button>
+			</div>
+			{status && status.servers.length > 0 && (
+				<ul className="mcworldlive__servers">
+					{status.servers.map((s) => (
+						<li key={s.server}>
+							<span
+								className={
+									s.reachable
+										? 'mcworldlive__dot mcworldlive__dot--ok'
+										: 'mcworldlive__dot mcworldlive__dot--bad'
+								}
+							/>
+							<code>{s.server}</code> {s.online} / {s.max}
+						</li>
+					))}
+				</ul>
+			)}
+			{dbLots !== null && (
+				<p className="mcworldlive__hint">
+					Live DB overlay: {dbLots.length} lot
+					{dbLots.length === 1 ? '' : 's'} from
+					<code> /api/v1/mc/lots/viewport</code>. Refreshes every 30
+					s; lots you own render in deep blue.
+				</p>
+			)}
+			{error && <p className="mcworldlive__error">{error}</p>}
+		</aside>
+	);
+}
+
+export default MCWorldMapLive;

--- a/apps/kbve/astro-kbve/src/components/mcdb/mc-world-live.css
+++ b/apps/kbve/astro-kbve/src/components/mcdb/mc-world-live.css
@@ -1,0 +1,95 @@
+.mcworldlive {
+	display: flex;
+	flex-direction: column;
+	gap: 0.4rem;
+	padding: 0.6rem 0.8rem;
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.4rem;
+	background: var(--sl-color-bg);
+	max-width: 640px;
+}
+
+.mcworldlive__row {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.92em;
+}
+
+.mcworldlive__row strong {
+	font-size: 1.1em;
+	color: var(--sl-color-white);
+}
+
+.mcworldlive__refresh {
+	margin-left: auto;
+	background: var(--sl-color-bg-nav);
+	color: var(--sl-color-white);
+	border: 1px solid var(--sl-color-gray-5);
+	border-radius: 0.3rem;
+	padding: 0.2rem 0.6rem;
+	font: inherit;
+	font-size: 0.85em;
+	cursor: pointer;
+}
+
+.mcworldlive__dot {
+	display: inline-block;
+	width: 0.6rem;
+	height: 0.6rem;
+	border-radius: 999px;
+	background: var(--sl-color-gray-5);
+}
+
+.mcworldlive__dot--live {
+	background: #4ade80;
+	box-shadow: 0 0 0.4rem rgba(74, 222, 128, 0.6);
+	animation: mcworldlive-pulse 1.6s ease-in-out infinite;
+}
+
+.mcworldlive__dot--ok {
+	background: #4ade80;
+}
+
+.mcworldlive__dot--bad {
+	background: #f87171;
+}
+
+.mcworldlive__servers {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.2rem;
+	font-size: 0.85em;
+	color: var(--sl-color-gray-3);
+}
+
+.mcworldlive__servers li {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+}
+
+.mcworldlive__hint {
+	margin: 0;
+	font-size: 0.78em;
+	color: var(--sl-color-gray-4);
+}
+
+.mcworldlive__error {
+	margin: 0;
+	font-size: 0.85em;
+	color: var(--sl-color-red);
+}
+
+@keyframes mcworldlive-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.5;
+	}
+}

--- a/apps/kbve/astro-kbve/src/components/mcdb/mc-world-live.css
+++ b/apps/kbve/astro-kbve/src/components/mcdb/mc-world-live.css
@@ -1,12 +1,26 @@
-.mcworldlive {
+.mcworldlive,
+.mcworldlive-skeleton {
 	display: flex;
 	flex-direction: column;
 	gap: 0.4rem;
 	padding: 0.6rem 0.8rem;
-	border: 1px solid var(--sl-color-gray-5);
 	border-radius: 0.4rem;
 	background: var(--sl-color-bg);
 	max-width: 640px;
+	/* Pin the height so the skeleton -> live swap and the
+	   "servers list arrives" growth don't shift the page. */
+	min-height: 6.5rem;
+	box-sizing: border-box;
+}
+
+.mcworldlive {
+	border: 1px solid var(--sl-color-gray-5);
+}
+
+.mcworldlive-skeleton {
+	border: 1px dashed var(--sl-color-gray-5);
+	color: var(--sl-color-gray-3);
+	font-size: 0.9em;
 }
 
 .mcworldlive__row {

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -18,6 +18,7 @@ import {
 	McBlockSchema,
 	MCSchematicFrontmatterSchema,
 	MCLotFrontmatterSchema,
+	MCPoiFrontmatterSchema,
 } from '@/data/schema';
 
 const OSRSFrontmatterSchema = OSRSExtendedSchema;
@@ -186,6 +187,7 @@ export const collections = {
 				mc_block: McBlockSchema.optional(),
 				mc_schematic: MCSchematicFrontmatterSchema.optional(),
 				mc_lot: MCLotFrontmatterSchema.optional(),
+				mc_poi: MCPoiFrontmatterSchema.optional(),
 				'yt-tracks': z.array(z.string()).optional(),
 				'yt-sets': z.array(z.string()).optional(),
 				// Journal post metadata consumed by the RSS feed

--- a/apps/kbve/astro-kbve/src/content/docs/mc/poi/admin-hub.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/poi/admin-hub.mdx
@@ -1,0 +1,28 @@
+---
+title: Admin Hub
+description: Staff teleport hub — restricted access.
+sidebar:
+    label: Admin Hub
+    hidden: true
+tags:
+    - minecraft
+    - mc
+    - mc-poi
+mc_poi:
+    poi_id: admin_hub
+    display_name: Admin Hub
+    kind: admin
+    world: minecraft:overworld
+    chunk_x: 0
+    chunk_z: 16
+    radius_chunks: 2
+    anchor_y: 80
+    icon: '⌬'
+    about:
+        summary: Staff teleport hub. Holds the lot survey console and the moderation booth.
+        notes: Reachable only via /tp by a player with the forum.is_staff bit.
+---
+
+import MCPoiPanel from '@/components/mcdb/MCPoiPanel.astro';
+
+<MCPoiPanel data={frontmatter.mc_poi} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/poi/end-portal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/poi/end-portal.mdx
@@ -1,0 +1,28 @@
+---
+title: End Portal Hub
+description: Stronghold-anchored end portal — accessible after the dragon is contested.
+sidebar:
+    label: End Portal
+    hidden: true
+tags:
+    - minecraft
+    - mc
+    - mc-poi
+mc_poi:
+    poi_id: end_portal_north
+    display_name: End Portal Hub
+    kind: portal
+    world: minecraft:overworld
+    chunk_x: -8
+    chunk_z: -18
+    radius_chunks: 1
+    anchor_y: 30
+    icon: 'E'
+    about:
+        summary: End portal carved into a stronghold north of spawn.
+        notes: Eyes-of-ender already placed; one-way trip to the end dimension. Respawns drop you back at spawn.
+---
+
+import MCPoiPanel from '@/components/mcdb/MCPoiPanel.astro';
+
+<MCPoiPanel data={frontmatter.mc_poi} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/poi/marketplace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/poi/marketplace.mdx
@@ -1,0 +1,28 @@
+---
+title: Marketplace
+description: Central plaza marketplace covering the sample lot grid.
+sidebar:
+    label: Marketplace
+    hidden: true
+tags:
+    - minecraft
+    - mc
+    - mc-poi
+mc_poi:
+    poi_id: marketplace
+    display_name: Plaza Marketplace
+    kind: marketplace
+    world: minecraft:overworld
+    chunk_x: 0
+    chunk_z: 0
+    radius_chunks: 4
+    anchor_y: 63
+    icon: '$'
+    about:
+        summary: Plaza marketplace covering the 3x3 sample lot grid around spawn.
+        notes: Lot purchases settle here. Shop owners build out vendor stalls on their owned parcels.
+---
+
+import MCPoiPanel from '@/components/mcdb/MCPoiPanel.astro';
+
+<MCPoiPanel data={frontmatter.mc_poi} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/poi/nether-portal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/poi/nether-portal.mdx
@@ -1,0 +1,28 @@
+---
+title: Nether Portal
+description: Public nether portal — east of spawn, linked to the central nether hub.
+sidebar:
+    label: Nether Portal
+    hidden: true
+tags:
+    - minecraft
+    - mc
+    - mc-poi
+mc_poi:
+    poi_id: nether_portal_east
+    display_name: East Nether Portal
+    kind: portal
+    world: minecraft:overworld
+    chunk_x: 12
+    chunk_z: 0
+    radius_chunks: 1
+    anchor_y: 63
+    icon: 'N'
+    about:
+        summary: Public obsidian portal east of spawn linking to the central nether hub.
+        notes: 1:8 scaling means this lines up with nether coords (96, 0). Hub built around the receiving portal.
+---
+
+import MCPoiPanel from '@/components/mcdb/MCPoiPanel.astro';
+
+<MCPoiPanel data={frontmatter.mc_poi} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/poi/spawn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/poi/spawn.mdx
@@ -1,0 +1,28 @@
+---
+title: Spawn
+description: World spawn point — every fresh login lands here.
+sidebar:
+    label: Spawn
+    hidden: true
+tags:
+    - minecraft
+    - mc
+    - mc-poi
+mc_poi:
+    poi_id: spawn
+    display_name: Spawn
+    kind: spawn
+    world: minecraft:overworld
+    chunk_x: 0
+    chunk_z: 0
+    radius_chunks: 1
+    anchor_y: 63
+    icon: '★'
+    about:
+        summary: World spawn point. New arrivals land here; bed-less respawns drop them here too.
+        notes: Surrounded by the central plaza lot grid. PvP disabled inside a 16-chunk radius.
+---
+
+import MCPoiPanel from '@/components/mcdb/MCPoiPanel.astro';
+
+<MCPoiPanel data={frontmatter.mc_poi} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/poi/wilderness-edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/poi/wilderness-edge.mdx
@@ -1,0 +1,28 @@
+---
+title: Wilderness Edge
+description: Approximate boundary where the surveyed lot grid ends and unclaimed terrain begins.
+sidebar:
+    label: Wilderness Edge
+    hidden: true
+tags:
+    - minecraft
+    - mc
+    - mc-poi
+mc_poi:
+    poi_id: wilderness_edge
+    display_name: Wilderness Edge
+    kind: biome
+    world: minecraft:overworld
+    chunk_x: 0
+    chunk_z: 0
+    radius_chunks: 24
+    anchor_y: 63
+    icon: '~'
+    about:
+        summary: Boundary where the surveyed plaza ends and the open wilderness begins.
+        notes: Past this ring, claims happen through the lot RPC against fresh chunks. PvP is enabled.
+---
+
+import MCPoiPanel from '@/components/mcdb/MCPoiPanel.astro';
+
+<MCPoiPanel data={frontmatter.mc_poi} />

--- a/apps/kbve/astro-kbve/src/content/docs/mc/world/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/world/index.mdx
@@ -27,10 +27,8 @@ through `/api/v1/mc/lots/viewport` plus the RCON-driven player count.
 
 <MCWorldMap minChunk={-32} maxChunk={32} />
 
-<div data-mcworld-live-skeleton>
-	<div style="padding:0.6rem 0.8rem;border:1px dashed var(--sl-color-gray-5);border-radius:0.4rem;color:var(--sl-color-gray-3);">
-		Loading live overlay…
-	</div>
+<div class="mcworldlive-skeleton" data-mcworld-live-skeleton>
+	Loading live overlay…
 </div>
 
 <MCWorldMapLive

--- a/apps/kbve/astro-kbve/src/content/docs/mc/world/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/mc/world/index.mdx
@@ -1,0 +1,51 @@
+---
+title: World Map
+description: |
+    Top-down overview of the live KBVE Minecraft world. Surveyed plaza
+    lots, editorial points of interest, real-time DB lot overlay, and
+    live player count from RCON.
+tableOfContents: false
+graph:
+    visible: false
+sidebar:
+    label: World Map
+    order: 7
+tags:
+    - minecraft
+    - mc
+    - mc-world
+---
+
+import MCWorldMap from '@/components/mcdb/MCWorldMap.astro';
+import MCWorldMapLive from '@/components/mcdb/MCWorldMapLive';
+import '@/components/mcdb/mc-world-live.css';
+
+A chunk-scale top-down view of `minecraft:overworld`. The static layer
+renders editorial points of interest and the surveyed plaza lot grid
+from MDX; the live layer overlays the current `mc.lot` table contents
+through `/api/v1/mc/lots/viewport` plus the RCON-driven player count.
+
+<MCWorldMap minChunk={-32} maxChunk={32} />
+
+<div data-mcworld-live-skeleton>
+	<div style="padding:0.6rem 0.8rem;border:1px dashed var(--sl-color-gray-5);border-radius:0.4rem;color:var(--sl-color-gray-3);">
+		Loading live overlay…
+	</div>
+</div>
+
+<MCWorldMapLive
+	client:only="react"
+	world="minecraft:overworld"
+	minChunk={-32}
+	maxChunk={32}
+/>
+
+## How to read it
+
+- Grid: 1 cell = 1 chunk = 16×16 blocks. Heavier gridlines mark 16-chunk region boundaries.
+- Tinted gray crosshair: world origin (0, 0).
+- Tinted rectangles: editorial sample lots from `/mc/lots/`.
+- Colored circles + labels: points of interest from `/mc/poi/`.
+- Dashed circles: biome / wilderness rings.
+- Rectangles painted on top (when the live layer hydrates): real `mc.lot` rows from the deployed DB. Lots you own render in deep blue.
+- Live badge: total online players across every reachable RCON-bridged server.

--- a/apps/kbve/astro-kbve/src/data/schema/mc/index.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/index.ts
@@ -4,3 +4,4 @@ export * from './enchants';
 export * from './blocks';
 export * from './schematic';
 export * from './lot';
+export * from './poi';

--- a/apps/kbve/astro-kbve/src/data/schema/mc/poi.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/mc/poi.ts
@@ -1,0 +1,36 @@
+import { z } from 'astro/zod';
+
+export const MCPoiKindSchema = z.enum([
+	'spawn',
+	'marketplace',
+	'portal',
+	'monument',
+	'biome',
+	'shop',
+	'guild',
+	'admin',
+	'landmark',
+]);
+export type MCPoiKind = z.infer<typeof MCPoiKindSchema>;
+
+export const MCPoiFrontmatterSchema = z.object({
+	poi_id: z.string().min(3).max(96),
+	display_name: z.string().min(1),
+	kind: MCPoiKindSchema,
+	world: z
+		.string()
+		.regex(/^[a-z0-9_.-]+:[a-z0-9_/.-]+$/)
+		.default('minecraft:overworld'),
+	chunk_x: z.number().int(),
+	chunk_z: z.number().int(),
+	radius_chunks: z.number().int().nonnegative().default(0),
+	anchor_y: z.number().int().min(-64).max(319).optional(),
+	icon: z.string().default(''),
+	about: z
+		.object({
+			summary: z.string().default(''),
+			notes: z.string().default(''),
+		})
+		.default({ summary: '', notes: '' }),
+});
+export type MCPoiFrontmatter = z.infer<typeof MCPoiFrontmatterSchema>;


### PR DESCRIPTION
## Summary

New \`/mc/world/\` page — chunk-scale top-down view of the current KBVE Minecraft world. Static SSG layer over the existing MDX catalog plus a hydrating React island that overlays the live \`mc.lot\` DB rows + RCON player count.

### Static (Astro / SSG)
- **\`MCWorldMap.astro\`** — chunk-grid SVG over a configurable \`(minChunk, maxChunk)\` window. Default \`-32..32\` = 64 chunks = 1024 blocks. Light / medium / heavy gridlines mark 1/4/16-chunk boundaries plus a faint origin crosshair.
- **Plaza lots** (existing \`mc_lot\` collection) paint as state-colored translucent rectangles linking back to \`/mc/lots/<slug>/\`.
- **POIs** (new \`mc_poi\` collection) paint as colored dots with labels and detail-page links. Biome-kind POIs render as dashed radius rings.
- An empty \`<g data-mcworld-live-lots />\` sits inside the SVG as the injection point the live island uses on hydration.

### Content collection: \`mc_poi\`
- **Schema** \`MCPoiFrontmatterSchema\` — \`chunk_x\` / \`chunk_z\` / \`radius_chunks\` / \`anchor_y\` / \`kind\` enum / \`icon\` / about.
- Six seed POIs: \`spawn\`, \`marketplace\`, \`nether-portal\` (east), \`end-portal\` (north stronghold), \`wilderness-edge\` (biome ring), \`admin-hub\`.
- **\`MCPoiPanel.astro\`** detail page renders coords / kind pill / radius pill / icon / about block / back-to-world link.

### Live (React island, \`client:only="react"\`)
- **\`MCWorldMapLive.tsx\`** fetches \`/api/v1/mc/players\` + \`/api/v1/mc/lots/viewport\` every 30 s.
  - Player-count badge with per-server reachability dots.
  - DB lot rows project into the parent SVG by reading the wrapper's \`data-min\` / \`data-max\` / \`viewBox\` and appending \`<rect>\` nodes into the static \`[data-mcworld-live-lots]\` group.
  - Lots the caller owns paint in deep blue.
- **Lifecycle hardening** matches the dashboard pattern: \`AbortController\` owns every fetch; \`mountedRef\` gates late settles; \`visibilitychange\` pauses on tab hide and resumes on show; \`astro:before-swap\` / \`astro:before-preparation\` / \`pagehide\` tear down before navigation.
- \`data-mcworld-live-skeleton\` in the static MDX gets removed on first hydration.

## Test plan
- [ ] \`./kbve.sh -nx astro-kbve:build\` emits \`/mc/world/index.html\` with the static legend, plaza rectangles, and six POI dots (verified locally).
- [ ] Six POI detail pages emit under \`/mc/poi/<slug>/\`.
- [ ] On a deployed instance the player badge updates every 30 s and lots from \`/api/v1/mc/lots/viewport\` overlay the static plaza.
- [ ] Backgrounding the tab cancels the polling interval; foregrounding triggers an immediate refresh.
- [ ] Swap-navigating away tears the interval down without a setState-after-unmount warning.