### PR TITLE
feat(agents): channel pickers + webhook deliveries/rotate/delete + event queue (Tier A+B from #11362)

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
@@ -3,6 +3,7 @@ import ReactAgentDiscordsh from './ReactAgentDiscordsh';
 import ReactAgentBotConfig from './ReactAgentBotConfig';
 import ReactAgentSetupStatus from './ReactAgentSetupStatus';
 import ReactAgentBotInstall from './ReactAgentBotInstall';
+import ReactAgentEventQueue from './ReactAgentEventQueue';
 ---
 
 <section
@@ -38,6 +39,10 @@ import ReactAgentBotInstall from './ReactAgentBotInstall';
 			<ReactAgentBotConfig
 				client:only="react"
 				transition:persist="agents-bot-config"
+			/>
+			<ReactAgentEventQueue
+				client:only="react"
+				transition:persist="agents-event-queue"
 			/>
 			<ReactAgentDiscordsh client:only="react" />
 		</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
@@ -8,11 +8,12 @@ import {
 	type FormEvent,
 } from 'react';
 import { useStore } from '@nanostores/react';
-import { Loader2, RefreshCw, Save, Settings2 } from 'lucide-react';
+import { Hash, Loader2, RefreshCw, Save, Settings2 } from 'lucide-react';
 import {
 	agentsService,
 	emptyBotConfigFormDraft,
 	type BotConfigFormDraft,
+	type DiscordChannel,
 } from './agentsService';
 import { styles } from './dashboard-ui';
 
@@ -89,6 +90,9 @@ export default function ReactAgentBotConfig() {
 	const savingMap = useStore(agentsService.$botConfigSavingFor);
 	const errorsMap = useStore(agentsService.$botConfigErrors);
 	const loadedMap = useStore(agentsService.$botConfigLoadedFor);
+	const channelsMap = useStore(agentsService.$guildChannels);
+	const channelsLoadingMap = useStore(agentsService.$guildChannelsLoading);
+	const channelsErrorMap = useStore(agentsService.$guildChannelsError);
 
 	const [loading, setLoading] = useState(false);
 	const [success, setSuccess] = useState<string | null>(null);
@@ -157,6 +161,15 @@ export default function ReactAgentBotConfig() {
 			void load();
 		}
 	}, [guildId, loaded, load, hydrate]);
+
+	useEffect(() => {
+		if (!guildId) return;
+		void agentsService.ensureGuildChannelsLoaded(guildId);
+	}, [guildId]);
+
+	const channels = guildId ? channelsMap[guildId] : undefined;
+	const channelsLoading = guildId ? !!channelsLoadingMap[guildId] : false;
+	const channelsError = guildId ? (channelsErrorMap[guildId] ?? null) : null;
 
 	useEffect(() => {
 		if (!success) return;
@@ -296,9 +309,9 @@ export default function ReactAgentBotConfig() {
 				<p style={muted}>
 					Per-guild knobs the bot reads at startup. Stored as
 					<code> discordsh_config:&lt;guild&gt;</code> in Vault.
-					Channels are raw Discord snowflakes — pick them via
-					right-click → Copy ID in your Discord client (Developer Mode
-					required).
+					Channel pickers list the bot's visible channels — if the bot
+					isn't in the guild yet, install it via the bot-install
+					section above first.
 				</p>
 
 				<TextField
@@ -312,51 +325,59 @@ export default function ReactAgentBotConfig() {
 					error={errors.default_repo}
 					fontMono
 				/>
-				<TextField
+				<ChannelPicker
 					label="Claim channel"
 					hint="Channel that /gh claim posts confirmations to."
 					name="claim_channel_id"
+					channelType="text"
 					defaultValue={d.claim_channel_id}
-					placeholder="Discord snowflake"
+					channels={channels?.texts}
+					loading={channelsLoading}
+					error={errors.claim_channel_id}
+					sourceError={channelsError}
 					inputRef={(el) => (refs.current.claim_channel_id = el)}
 					onBlur={onFieldBlur('claim_channel_id')}
-					error={errors.claim_channel_id}
-					fontMono
 				/>
-				<TextField
+				<ChannelPicker
 					label="Forum channel"
 					hint="Forum channel where issue threads are created (P2 of #11262)."
 					name="forum_channel_id"
+					channelType="forum"
 					defaultValue={d.forum_channel_id}
-					placeholder="Discord snowflake"
+					channels={channels?.forums}
+					loading={channelsLoading}
+					error={errors.forum_channel_id}
+					sourceError={channelsError}
 					inputRef={(el) => (refs.current.forum_channel_id = el)}
 					onBlur={onFieldBlur('forum_channel_id')}
-					error={errors.forum_channel_id}
-					fontMono
 				/>
-				<TextField
+				<ChannelPicker
 					label="Notice board channel"
 					hint="Channel for /github noticeboard embeds."
 					name="noticeboard_channel_id"
+					channelType="text"
 					defaultValue={d.noticeboard_channel_id}
-					placeholder="Discord snowflake"
+					channels={channels?.texts}
+					loading={channelsLoading}
+					error={errors.noticeboard_channel_id}
+					sourceError={channelsError}
 					inputRef={(el) =>
 						(refs.current.noticeboard_channel_id = el)
 					}
 					onBlur={onFieldBlur('noticeboard_channel_id')}
-					error={errors.noticeboard_channel_id}
-					fontMono
 				/>
-				<TextField
+				<ChannelPicker
 					label="Task board channel"
 					hint="Channel for /github taskboard embeds."
 					name="taskboard_channel_id"
+					channelType="text"
 					defaultValue={d.taskboard_channel_id}
-					placeholder="Discord snowflake"
+					channels={channels?.texts}
+					loading={channelsLoading}
+					error={errors.taskboard_channel_id}
+					sourceError={channelsError}
 					inputRef={(el) => (refs.current.taskboard_channel_id = el)}
 					onBlur={onFieldBlur('taskboard_channel_id')}
-					error={errors.taskboard_channel_id}
-					fontMono
 				/>
 				<TextField
 					label="Max assignees per claim"
@@ -500,6 +521,167 @@ function TextField(props: TextFieldProps) {
 					...(maxWidth ? { width: maxWidth } : null),
 				}}
 			/>
+			{hint && !error && <span style={subtle}>{hint}</span>}
+			{error && <span style={errText}>{error}</span>}
+		</label>
+	);
+}
+
+interface ChannelPickerProps {
+	label: string;
+	hint?: string;
+	name: string;
+	channelType: 'forum' | 'text';
+	defaultValue: string;
+	channels?: DiscordChannel[];
+	loading: boolean;
+	sourceError: string | null;
+	error?: string;
+	inputRef: (el: HTMLInputElement | null) => void;
+	onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+}
+
+function ChannelPicker(props: ChannelPickerProps) {
+	const {
+		label,
+		hint,
+		name,
+		channelType,
+		defaultValue,
+		channels,
+		loading,
+		sourceError,
+		error,
+		inputRef,
+		onBlur,
+	} = props;
+	const hiddenRef = useRef<HTMLInputElement | null>(null);
+	const [showManual, setShowManual] = useState(false);
+	const [currentValue, setCurrentValue] = useState<string>(defaultValue);
+
+	useEffect(() => {
+		setCurrentValue(defaultValue);
+	}, [defaultValue]);
+
+	const setInputRef = useCallback(
+		(el: HTMLInputElement | null) => {
+			hiddenRef.current = el;
+			inputRef(el);
+		},
+		[inputRef],
+	);
+
+	function commitValue(v: string) {
+		setCurrentValue(v);
+		if (hiddenRef.current) {
+			hiddenRef.current.value = v;
+			const ev = new FocusEvent('blur', {
+				bubbles: true,
+			}) as unknown as FocusEvent<HTMLInputElement>;
+			onBlur(ev);
+		}
+	}
+
+	const list = channels ?? [];
+	const known = list.find((c) => c.id === currentValue);
+	const unknownPicked = !!currentValue && !known && !showManual;
+	const useManual = showManual || sourceError !== null || unknownPicked;
+
+	return (
+		<label
+			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+			<span style={fieldLabel}>{label}</span>
+			<input
+				ref={setInputRef}
+				name={name}
+				type="hidden"
+				defaultValue={defaultValue}
+			/>
+			{loading && (
+				<span style={subtle}>
+					<Loader2
+						size={12}
+						style={{
+							verticalAlign: '-2px',
+							marginRight: 4,
+							animation: 'spin 1s linear infinite',
+						}}
+					/>
+					Loading channels…
+				</span>
+			)}
+			{!loading && !useManual && list.length > 0 && (
+				<select
+					value={currentValue}
+					onChange={(e) => commitValue(e.target.value)}
+					style={{
+						...inputStyle,
+					}}>
+					<option value="">
+						— pick a {channelType === 'forum' ? 'forum' : 'text'}{' '}
+						channel —
+					</option>
+					{list.map((c) => (
+						<option key={c.id} value={c.id}>
+							#{c.name}
+						</option>
+					))}
+				</select>
+			)}
+			{!loading && useManual && (
+				<input
+					type="text"
+					defaultValue={currentValue}
+					placeholder="Discord snowflake (17–20 digits)"
+					onBlur={(e) => commitValue(e.target.value.trim())}
+					style={{
+						...inputStyle,
+						...mono,
+					}}
+					autoComplete="off"
+					spellCheck={false}
+				/>
+			)}
+			{!loading && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.5rem',
+						fontSize: '0.75rem',
+					}}>
+					{!useManual && list.length === 0 && !sourceError && (
+						<span style={subtle}>
+							No {channelType === 'forum' ? 'forum' : 'text'}{' '}
+							channels found.
+						</span>
+					)}
+					{sourceError && (
+						<span style={{ ...subtle, color: '#facc15' }}>
+							<Hash size={11} style={{ verticalAlign: '-1px' }} />{' '}
+							Channel lookup failed — paste a raw snowflake.
+						</span>
+					)}
+					{!sourceError && list.length > 0 && (
+						<button
+							type="button"
+							onClick={() => setShowManual((v) => !v)}
+							style={{
+								background: 'transparent',
+								border: 'none',
+								color: 'var(--sl-color-gray-3, #9ca0aa)',
+								cursor: 'pointer',
+								padding: 0,
+								fontSize: '0.72rem',
+								textDecoration: 'underline',
+							}}>
+							{useManual
+								? 'Use channel picker'
+								: 'Paste raw snowflake instead'}
+						</button>
+					)}
+				</div>
+			)}
 			{hint && !error && <span style={subtle}>{hint}</span>}
 			{error && <span style={errText}>{error}</span>}
 		</label>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentEventQueue.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentEventQueue.tsx
@@ -1,0 +1,439 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	Activity,
+	AlertTriangle,
+	CheckCircle2,
+	Clock,
+	Loader2,
+	RefreshCw,
+	RotateCcw,
+} from 'lucide-react';
+import { agentsService } from './agentsService';
+import { styles } from './dashboard-ui';
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+export default function ReactAgentEventQueue() {
+	const guildId = useStore(agentsService.$selectedGuildId);
+	const guilds = useStore(agentsService.$guilds);
+	const statsMap = useStore(agentsService.$eventStats);
+	const statsLoadingMap = useStore(agentsService.$eventStatsLoading);
+	const failedMap = useStore(agentsService.$failedEvents);
+	const failedLoadingMap = useStore(agentsService.$failedEventsLoading);
+	const requeueBusyMap = useStore(agentsService.$eventRequeueBusyFor);
+
+	const [autoRefresh, setAutoRefresh] = useState(true);
+
+	const stats = guildId ? statsMap[guildId] : undefined;
+	const statsLoading = guildId ? !!statsLoadingMap[guildId] : false;
+	const failed = guildId ? (failedMap[guildId] ?? []) : [];
+	const failedLoading = guildId ? !!failedLoadingMap[guildId] : false;
+	const guild = useMemo(
+		() => guilds.find((g) => g.id === guildId),
+		[guilds, guildId],
+	);
+
+	useEffect(() => {
+		if (!guildId) return;
+		void agentsService.loadEventStats(guildId);
+		void agentsService.loadFailedEvents(guildId, 10);
+	}, [guildId]);
+
+	useEffect(() => {
+		if (!guildId || !autoRefresh) return;
+		const id = setInterval(() => {
+			void agentsService.loadEventStats(guildId);
+			if ((failedMap[guildId] ?? []).length > 0) {
+				void agentsService.loadFailedEvents(guildId, 10);
+			}
+		}, REFRESH_INTERVAL_MS);
+		return () => clearInterval(id);
+	}, [guildId, autoRefresh, failedMap]);
+
+	if (!guildId) {
+		return (
+			<section style={styles.sectionBorder}>
+				<div style={{ padding: '0.85rem 1rem' }}>
+					<p
+						style={{
+							margin: 0,
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+						}}>
+						Pick a guild above to see GitHub → Discord event queue
+						status.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	async function refresh() {
+		if (!guildId) return;
+		void agentsService.loadEventStats(guildId);
+		void agentsService.loadFailedEvents(guildId, 10);
+	}
+
+	async function requeue(eventId: number) {
+		if (!guildId) return;
+		await agentsService.requeueEvent(guildId, eventId);
+	}
+
+	const pending = stats?.pending_count ?? 0;
+	const inFlight = stats?.in_flight_count ?? 0;
+	const delivered = stats?.delivered_count ?? 0;
+	const failedCount = stats?.failed_count ?? 0;
+	const queueDepth = pending + inFlight;
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Activity size={18} color="#58a6ff" />
+				<strong>Event queue</strong>
+				{guild && (
+					<span
+						style={{
+							marginLeft: '0.4rem',
+							fontSize: '0.75rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+						}}>
+						{guild.id}
+					</span>
+				)}
+				<label
+					style={{
+						marginLeft: 'auto',
+						fontSize: '0.78rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.3rem',
+					}}>
+					<input
+						type="checkbox"
+						checked={autoRefresh}
+						onChange={(e) => setAutoRefresh(e.target.checked)}
+					/>
+					Auto refresh 30s
+				</label>
+				<button
+					type="button"
+					onClick={() => void refresh()}
+					disabled={statsLoading || failedLoading}
+					style={refreshBtn(statsLoading || failedLoading)}
+					aria-label="Refresh">
+					<RefreshCw
+						size={14}
+						style={statsLoading ? spinIcon : undefined}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<div
+					style={{
+						display: 'grid',
+						gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+						gap: '0.5rem',
+					}}>
+					<StatCard
+						label="Queue depth"
+						value={queueDepth}
+						hint={`${pending} pending + ${inFlight} in-flight`}
+						tone={queueDepth > 50 ? 'warn' : 'ok'}
+					/>
+					<StatCard
+						label="Delivered"
+						value={delivered}
+						hint={
+							stats?.last_delivered_at
+								? `Last ${new Date(
+										stats.last_delivered_at,
+									).toLocaleString()}`
+								: 'No deliveries yet'
+						}
+						tone="ok"
+					/>
+					<StatCard
+						label="Failed"
+						value={failedCount}
+						hint="At max attempts — needs requeue"
+						tone={failedCount > 0 ? 'fail' : 'ok'}
+					/>
+					<StatCard
+						label="Oldest pending"
+						value={
+							stats?.oldest_pending_at
+								? relativeTime(stats.oldest_pending_at)
+								: '—'
+						}
+						hint={
+							stats?.oldest_pending_at
+								? new Date(
+										stats.oldest_pending_at,
+									).toLocaleString()
+								: 'No backlog'
+						}
+						tone={
+							stats?.oldest_pending_at
+								? ageSeconds(stats.oldest_pending_at) > 10 * 60
+									? 'warn'
+									: 'ok'
+								: 'ok'
+						}
+					/>
+				</div>
+
+				{failedCount > 0 && (
+					<div>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '0.4rem',
+								marginBottom: '0.4rem',
+							}}>
+							<AlertTriangle size={14} color="#facc15" />
+							<strong style={{ fontSize: '0.85rem' }}>
+								Failed events
+							</strong>
+						</div>
+						<ul
+							style={{
+								margin: 0,
+								padding: 0,
+								listStyle: 'none',
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '0.3rem',
+							}}>
+							{failed.map((ev) => {
+								const busy =
+									!!requeueBusyMap[`${guildId}:${ev.id}`];
+								return (
+									<li
+										key={ev.id}
+										style={{
+											display: 'flex',
+											alignItems: 'center',
+											justifyContent: 'space-between',
+											padding: '0.4rem 0.6rem',
+											borderRadius: 6,
+											border: '1px solid rgba(239,68,68,0.3)',
+											background: 'rgba(239,68,68,0.06)',
+											gap: '0.5rem',
+										}}>
+										<div
+											style={{
+												display: 'flex',
+												flexDirection: 'column',
+												gap: '0.15rem',
+												minWidth: 0,
+												flex: 1,
+											}}>
+											<code
+												style={{
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													fontSize: '0.8rem',
+												}}>
+												{ev.owner}/{ev.repo}#{ev.number}{' '}
+												<span
+													style={{
+														color: 'var(--sl-color-gray-3, #9ca0aa)',
+													}}>
+													· {ev.event_type}
+												</span>
+											</code>
+											{ev.last_error && (
+												<span
+													style={{
+														fontSize: '0.75rem',
+														color: '#f87171',
+														overflow: 'hidden',
+														textOverflow:
+															'ellipsis',
+														whiteSpace: 'nowrap',
+													}}
+													title={ev.last_error}>
+													{ev.last_error}
+												</span>
+											)}
+											<span
+												style={{
+													fontSize: '0.72rem',
+													color: 'var(--sl-color-gray-3, #9ca0aa)',
+												}}>
+												<Clock
+													size={10}
+													style={{
+														verticalAlign: '-1px',
+														marginRight: 3,
+													}}
+												/>
+												{new Date(
+													ev.updated_at,
+												).toLocaleString()}{' '}
+												· attempts{' '}
+												{ev.delivery_attempts}
+											</span>
+										</div>
+										<button
+											type="button"
+											onClick={() => void requeue(ev.id)}
+											disabled={busy}
+											style={requeueBtn(busy)}>
+											{busy ? (
+												<Loader2
+													size={12}
+													style={spinIcon}
+												/>
+											) : (
+												<RotateCcw size={12} />
+											)}
+											{busy ? 'Requeuing…' : 'Requeue'}
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					</div>
+				)}
+
+				{failedCount === 0 && delivered > 0 && (
+					<p
+						style={{
+							margin: 0,
+							color: '#4ade80',
+							fontSize: '0.82rem',
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '0.3rem',
+						}}>
+						<CheckCircle2 size={14} />
+						All recent deliveries succeeded.
+					</p>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function ageSeconds(iso: string): number {
+	return (Date.now() - new Date(iso).getTime()) / 1000;
+}
+
+function relativeTime(iso: string): string {
+	const s = ageSeconds(iso);
+	if (s < 60) return `${Math.floor(s)}s ago`;
+	if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+	if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+	return `${Math.floor(s / 86400)}d ago`;
+}
+
+function StatCard({
+	label,
+	value,
+	hint,
+	tone,
+}: {
+	label: string;
+	value: number | string;
+	hint: string;
+	tone: 'ok' | 'warn' | 'fail';
+}) {
+	const palette = {
+		ok: { bg: 'rgba(255,255,255,0.03)', fg: 'var(--sl-color-white, #fff)' },
+		warn: { bg: 'rgba(251,191,36,0.08)', fg: '#fbbf24' },
+		fail: { bg: 'rgba(239,68,68,0.08)', fg: '#f87171' },
+	}[tone];
+	return (
+		<div
+			style={{
+				padding: '0.6rem 0.7rem',
+				borderRadius: 8,
+				border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+				background: palette.bg,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '0.15rem',
+			}}>
+			<span
+				style={{
+					fontSize: '0.7rem',
+					color: 'var(--sl-color-gray-3, #9ca0aa)',
+					textTransform: 'uppercase',
+					letterSpacing: '0.04em',
+				}}>
+				{label}
+			</span>
+			<span
+				style={{
+					fontSize: '1.15rem',
+					fontWeight: 700,
+					color: palette.fg,
+					fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
+				}}>
+				{value}
+			</span>
+			<span
+				style={{
+					fontSize: '0.72rem',
+					color: 'var(--sl-color-gray-3, #9ca0aa)',
+				}}>
+				{hint}
+			</span>
+		</div>
+	);
+}
+
+const spinIcon: React.CSSProperties = {
+	animation: 'spin 1s linear infinite',
+};
+
+function refreshBtn(busy: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.3rem 0.6rem',
+		borderRadius: 6,
+		border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+		background: 'transparent',
+		color: 'var(--sl-color-white, #fff)',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.8rem',
+	};
+}
+
+function requeueBtn(busy: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.3rem',
+		padding: '0.3rem 0.55rem',
+		borderRadius: 6,
+		border: '1px solid rgba(88,166,255,0.4)',
+		background: 'transparent',
+		color: '#58a6ff',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.78rem',
+	};
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -10,8 +10,10 @@ import {
 	Loader2,
 	LogIn,
 	PlayCircle,
+	RefreshCw,
 	Shuffle,
 	Webhook,
+	XCircle,
 } from 'lucide-react';
 import {
 	agentsService,
@@ -373,6 +375,14 @@ function Step2WebhookConfig({
 	const installResultMap = useStore(agentsService.$webhookInstallResults);
 	const pingBusyMap = useStore(agentsService.$webhookPingBusyFor);
 	const pingResultMap = useStore(agentsService.$webhookPingResults);
+	const deliveriesMap = useStore(agentsService.$webhookDeliveries);
+	const deliveriesLoadingMap = useStore(
+		agentsService.$webhookDeliveriesLoading,
+	);
+	const deliveriesErrorMap = useStore(agentsService.$webhookDeliveriesError);
+	const rotateBusyMap = useStore(agentsService.$webhookRotateBusyFor);
+	const rotateResultMap = useStore(agentsService.$webhookRotateResults);
+	const deleteBusyMap = useStore(agentsService.$webhookDeleteBusyFor);
 
 	const repos = allowlistMap[guild.id] ?? [];
 	const selectedRepo = selectedMap[guild.id] ?? repos[0] ?? '';
@@ -408,6 +418,45 @@ function Step2WebhookConfig({
 	async function ping() {
 		if (!selectedRepo || pinging) return;
 		await agentsService.pingWebhookForGuild(guild.id);
+	}
+
+	const deliveriesKey = `${guild.id}:${selectedRepo}`;
+	const deliveries = deliveriesMap[deliveriesKey] ?? [];
+	const deliveriesLoading = !!deliveriesLoadingMap[deliveriesKey];
+	const deliveriesError = deliveriesErrorMap[deliveriesKey] ?? null;
+	const rotating = !!rotateBusyMap[guild.id];
+	const rotateResult = rotateResultMap[guild.id] ?? null;
+	const deleting = !!deleteBusyMap[guild.id];
+	const [confirmDelete, setConfirmDelete] = useState(false);
+
+	useEffect(() => {
+		setConfirmDelete(false);
+	}, [guild.id, selectedRepo]);
+
+	async function refreshDeliveries() {
+		if (!selectedRepo) return;
+		const [owner, repo] = selectedRepo.split('/');
+		if (!owner || !repo) return;
+		await agentsService.loadWebhookDeliveries(guild.id, owner, repo, 10);
+	}
+
+	async function rotate() {
+		if (!selectedRepo || rotating) return;
+		const [owner, repo] = selectedRepo.split('/');
+		if (!owner || !repo) return;
+		await agentsService.rotateWebhookForGuild(guild.id, owner, repo);
+	}
+
+	async function deleteHook() {
+		if (!selectedRepo || deleting) return;
+		if (!confirmDelete) {
+			setConfirmDelete(true);
+			return;
+		}
+		const [owner, repo] = selectedRepo.split('/');
+		if (!owner || !repo) return;
+		await agentsService.deleteWebhookForGuild(guild.id, owner, repo);
+		setConfirmDelete(false);
 	}
 
 	const installedOk =
@@ -644,6 +693,197 @@ function Step2WebhookConfig({
 						)}
 						{pingResult && !pingResult.ok && (
 							<span style={errText}>{pingResult.error}</span>
+						)}
+					</div>
+				)}
+				{installResult && installResult.ok && hasWebhook && (
+					<div
+						style={{
+							marginTop: '0.85rem',
+							padding: '0.75rem',
+							border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+							borderRadius: 8,
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '0.5rem',
+						}}>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '0.4rem',
+							}}>
+							<strong style={{ fontSize: '0.85rem' }}>
+								Recent deliveries
+							</strong>
+							<button
+								type="button"
+								onClick={() => void refreshDeliveries()}
+								disabled={deliveriesLoading || !selectedRepo}
+								style={{
+									...secondaryBtn,
+									marginLeft: 'auto',
+									padding: '0.25rem 0.5rem',
+									fontSize: '0.78rem',
+								}}>
+								{deliveriesLoading ? (
+									<Loader2 size={12} style={spinStyle} />
+								) : (
+									<RefreshCw size={12} />
+								)}
+								Refresh
+							</button>
+						</div>
+						{deliveriesError && (
+							<p style={errText}>{deliveriesError}</p>
+						)}
+						{!deliveriesError && deliveries.length === 0 && (
+							<p style={{ ...mutedText, fontStyle: 'italic' }}>
+								No deliveries fetched yet. Click Refresh to pull
+								the latest from GitHub.
+							</p>
+						)}
+						{deliveries.length > 0 && (
+							<ul
+								style={{
+									margin: 0,
+									padding: 0,
+									listStyle: 'none',
+									display: 'flex',
+									flexDirection: 'column',
+									gap: '0.2rem',
+								}}>
+								{deliveries.slice(0, 10).map((d) => {
+									const ok =
+										d.status_code >= 200 &&
+										d.status_code < 300;
+									return (
+										<li
+											key={d.id}
+											style={{
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'space-between',
+												padding: '0.3rem 0.5rem',
+												borderRadius: 6,
+												background: ok
+													? 'rgba(74,222,128,0.06)'
+													: 'rgba(239,68,68,0.06)',
+												border: ok
+													? '1px solid rgba(74,222,128,0.2)'
+													: '1px solid rgba(239,68,68,0.25)',
+												fontSize: '0.78rem',
+												gap: '0.5rem',
+											}}>
+											<code
+												style={{
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													color: ok
+														? '#4ade80'
+														: '#f87171',
+												}}>
+												{d.status_code}
+											</code>
+											<span
+												style={{
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													flex: 1,
+												}}>
+												{d.event}
+												{d.action ? `.${d.action}` : ''}
+												{d.redelivery
+													? ' (redeliver)'
+													: ''}
+											</span>
+											<span
+												style={{
+													color: 'var(--sl-color-gray-3, #9ca0aa)',
+												}}>
+												{new Date(
+													d.delivered_at,
+												).toLocaleTimeString()}
+											</span>
+										</li>
+									);
+								})}
+							</ul>
+						)}
+					</div>
+				)}
+				{installResult && installResult.ok && hasWebhook && (
+					<div
+						style={{
+							marginTop: '0.85rem',
+							padding: '0.75rem',
+							border: '1px solid rgba(239,68,68,0.25)',
+							borderRadius: 8,
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '0.5rem',
+						}}>
+						<strong style={{ fontSize: '0.85rem' }}>
+							Lifecycle
+						</strong>
+						<p style={{ ...mutedText, fontSize: '0.8rem' }}>
+							Rotate replaces the HMAC on GitHub + vault. Old
+							in-flight deliveries fail signature for a few
+							seconds. Delete removes the hook from GitHub but
+							leaves the vault HMAC row intact.
+						</p>
+						<div
+							style={{
+								display: 'flex',
+								gap: '0.4rem',
+								flexWrap: 'wrap',
+							}}>
+							<button
+								type="button"
+								onClick={() => void rotate()}
+								disabled={rotating || !selectedRepo}
+								style={secondaryBtn}>
+								{rotating ? (
+									<Loader2 size={14} style={spinStyle} />
+								) : (
+									<RefreshCw size={14} />
+								)}
+								{rotating ? 'Rotating…' : 'Rotate HMAC secret'}
+							</button>
+							<button
+								type="button"
+								onClick={() => void deleteHook()}
+								disabled={deleting || !selectedRepo}
+								style={{
+									...secondaryBtn,
+									color: '#f87171',
+									borderColor: 'rgba(239,68,68,0.4)',
+								}}>
+								{deleting ? (
+									<Loader2 size={14} style={spinStyle} />
+								) : (
+									<XCircle size={14} />
+								)}
+								{deleting
+									? 'Deleting…'
+									: confirmDelete
+										? 'Confirm delete?'
+										: 'Delete webhook'}
+							</button>
+						</div>
+						{rotateResult && rotateResult.ok && (
+							<span
+								style={{
+									fontSize: '0.82rem',
+									color: '#4ade80',
+								}}>
+								Rotated · hook{' '}
+								<code>{rotateResult.hookId}</code> updated. New
+								HMAC stored in vault.
+							</span>
+						)}
+						{rotateResult && !rotateResult.ok && (
+							<span style={errText}>{rotateResult.error}</span>
 						)}
 					</div>
 				)}

--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -115,6 +115,53 @@ export interface DiscordForumChannel {
 	position: number;
 }
 
+export interface DiscordChannel {
+	id: string;
+	name: string;
+	parent_id: string | null;
+	position: number;
+}
+
+export interface GuildChannels {
+	forums: DiscordChannel[];
+	texts: DiscordChannel[];
+}
+
+export interface WebhookDelivery {
+	id: number;
+	guid: string;
+	delivered_at: string;
+	redelivery: boolean;
+	duration: number;
+	status: string;
+	status_code: number;
+	event: string;
+	action: string | null;
+}
+
+export interface EventQueueStats {
+	last_delivered_at: string | null;
+	last_recorded_at: string | null;
+	pending_count: number;
+	in_flight_count: number;
+	delivered_count: number;
+	failed_count: number;
+	oldest_pending_at: string | null;
+}
+
+export interface FailedEvent {
+	id: number;
+	owner: string;
+	repo: string;
+	number: number;
+	event_type: string;
+	actor: string | null;
+	delivery_attempts: number;
+	last_error: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
 export interface GithubRepoHook {
 	id: number;
 	name: string;
@@ -346,6 +393,39 @@ class AgentsService {
 			| null
 		>
 	>({});
+
+	public readonly $guildChannels = atom<Record<string, GuildChannels>>({});
+	public readonly $guildChannelsLoading = atom<Record<string, boolean>>({});
+	public readonly $guildChannelsError = atom<Record<string, string | null>>(
+		{},
+	);
+
+	public readonly $webhookDeliveries = atom<
+		Record<string, WebhookDelivery[]>
+	>({});
+	public readonly $webhookDeliveriesLoading = atom<Record<string, boolean>>(
+		{},
+	);
+	public readonly $webhookDeliveriesError = atom<
+		Record<string, string | null>
+	>({});
+
+	public readonly $webhookRotateBusyFor = atom<Record<string, boolean>>({});
+	public readonly $webhookRotateResults = atom<
+		Record<
+			string,
+			| { ok: true; hookId: number; at: number }
+			| { ok: false; error: string }
+			| null
+		>
+	>({});
+	public readonly $webhookDeleteBusyFor = atom<Record<string, boolean>>({});
+
+	public readonly $eventStats = atom<Record<string, EventQueueStats>>({});
+	public readonly $eventStatsLoading = atom<Record<string, boolean>>({});
+	public readonly $failedEvents = atom<Record<string, FailedEvent[]>>({});
+	public readonly $failedEventsLoading = atom<Record<string, boolean>>({});
+	public readonly $eventRequeueBusyFor = atom<Record<string, boolean>>({});
 
 	// Dedup state — singleton so the cache survives ClientRouter swaps.
 	private initPromise: Promise<void> | null = null;
@@ -1283,6 +1363,220 @@ class AgentsService {
 			},
 		};
 		this.$webhookInstallResults.set(resultsSet);
+	}
+
+	public async ensureGuildChannelsLoaded(
+		guildId: string,
+		force = false,
+	): Promise<void> {
+		const cur = this.$guildChannels.get()[guildId];
+		if (cur && !force) return;
+		if (this.$guildChannelsLoading.get()[guildId]) return;
+		this.$guildChannelsLoading.set({
+			...this.$guildChannelsLoading.get(),
+			[guildId]: true,
+		});
+		this.$guildChannelsError.set({
+			...this.$guildChannelsError.get(),
+			[guildId]: null,
+		});
+		const r = await this.callJson<GuildChannels>(DISCORD_BOT_URL, {
+			command: 'bot.list_channels',
+			server_id: guildId,
+		});
+		const loading = { ...this.$guildChannelsLoading.get() };
+		delete loading[guildId];
+		this.$guildChannelsLoading.set(loading);
+		if (!r.ok) {
+			this.$guildChannelsError.set({
+				...this.$guildChannelsError.get(),
+				[guildId]: r.error,
+			});
+			return;
+		}
+		this.$guildChannels.set({
+			...this.$guildChannels.get(),
+			[guildId]: {
+				forums: r.data.forums ?? [],
+				texts: r.data.texts ?? [],
+			},
+		});
+	}
+
+	public async loadWebhookDeliveries(
+		guildId: string,
+		owner: string,
+		repo: string,
+		limit = 10,
+	): Promise<void> {
+		const key = `${guildId}:${owner}/${repo}`;
+		this.$webhookDeliveriesLoading.set({
+			...this.$webhookDeliveriesLoading.get(),
+			[key]: true,
+		});
+		this.$webhookDeliveriesError.set({
+			...this.$webhookDeliveriesError.get(),
+			[key]: null,
+		});
+		const r = await this.callJson<{
+			hook_id: number;
+			deliveries: WebhookDelivery[];
+		}>(GH_ADMIN_URL, {
+			command: 'webhooks.deliveries',
+			server_id: guildId,
+			owner,
+			repo,
+			limit,
+		});
+		const loading = { ...this.$webhookDeliveriesLoading.get() };
+		delete loading[key];
+		this.$webhookDeliveriesLoading.set(loading);
+		if (!r.ok) {
+			this.$webhookDeliveriesError.set({
+				...this.$webhookDeliveriesError.get(),
+				[key]: r.error,
+			});
+			return;
+		}
+		this.$webhookDeliveries.set({
+			...this.$webhookDeliveries.get(),
+			[key]: r.data.deliveries ?? [],
+		});
+	}
+
+	public async rotateWebhookForGuild(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<void> {
+		this.$webhookRotateBusyFor.set({
+			...this.$webhookRotateBusyFor.get(),
+			[guildId]: true,
+		});
+		const r = await this.callJson<{ rotated: boolean; hook_id: number }>(
+			GH_ADMIN_URL,
+			{
+				command: 'webhooks.rotate',
+				server_id: guildId,
+				owner,
+				repo,
+			},
+		);
+		const busy = { ...this.$webhookRotateBusyFor.get() };
+		delete busy[guildId];
+		this.$webhookRotateBusyFor.set(busy);
+		const result = r.ok
+			? {
+					ok: true as const,
+					hookId: r.data.hook_id,
+					at: Date.now(),
+				}
+			: { ok: false as const, error: r.error };
+		this.$webhookRotateResults.set({
+			...this.$webhookRotateResults.get(),
+			[guildId]: result,
+		});
+		if (r.ok) {
+			await this.refreshSelectedGuild();
+		}
+	}
+
+	public async deleteWebhookForGuild(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		this.$webhookDeleteBusyFor.set({
+			...this.$webhookDeleteBusyFor.get(),
+			[guildId]: true,
+		});
+		const r = await this.callJson<{
+			deleted: boolean;
+			already_absent?: boolean;
+			hook_id?: number;
+		}>(GH_ADMIN_URL, {
+			command: 'webhooks.delete',
+			server_id: guildId,
+			owner,
+			repo,
+		});
+		const busy = { ...this.$webhookDeleteBusyFor.get() };
+		delete busy[guildId];
+		this.$webhookDeleteBusyFor.set(busy);
+		if (!r.ok) return { ok: false, error: r.error };
+		const results = { ...this.$webhookInstallResults.get() };
+		delete results[guildId];
+		this.$webhookInstallResults.set(results);
+		return { ok: true };
+	}
+
+	public async loadEventStats(guildId: string): Promise<void> {
+		this.$eventStatsLoading.set({
+			...this.$eventStatsLoading.get(),
+			[guildId]: true,
+		});
+		const r = await this.callJson<EventQueueStats>(GH_ADMIN_URL, {
+			command: 'events.stats',
+			server_id: guildId,
+		});
+		const loading = { ...this.$eventStatsLoading.get() };
+		delete loading[guildId];
+		this.$eventStatsLoading.set(loading);
+		if (!r.ok) return;
+		this.$eventStats.set({
+			...this.$eventStats.get(),
+			[guildId]: r.data,
+		});
+	}
+
+	public async loadFailedEvents(guildId: string, limit = 10): Promise<void> {
+		this.$failedEventsLoading.set({
+			...this.$failedEventsLoading.get(),
+			[guildId]: true,
+		});
+		const r = await this.callJson<{ events: FailedEvent[] }>(GH_ADMIN_URL, {
+			command: 'events.failed',
+			server_id: guildId,
+			limit,
+		});
+		const loading = { ...this.$failedEventsLoading.get() };
+		delete loading[guildId];
+		this.$failedEventsLoading.set(loading);
+		if (!r.ok) return;
+		this.$failedEvents.set({
+			...this.$failedEvents.get(),
+			[guildId]: r.data.events ?? [],
+		});
+	}
+
+	public async requeueEvent(
+		guildId: string,
+		eventId: number,
+	): Promise<{ ok: true } | { ok: false; error: string }> {
+		const key = `${guildId}:${eventId}`;
+		this.$eventRequeueBusyFor.set({
+			...this.$eventRequeueBusyFor.get(),
+			[key]: true,
+		});
+		const r = await this.callJson<{ requeued: boolean; event_id: number }>(
+			GH_ADMIN_URL,
+			{
+				command: 'events.requeue',
+				server_id: guildId,
+				event_id: eventId,
+			},
+		);
+		const busy = { ...this.$eventRequeueBusyFor.get() };
+		delete busy[key];
+		this.$eventRequeueBusyFor.set(busy);
+		if (!r.ok) return { ok: false, error: r.error };
+		const cur = this.$failedEvents.get()[guildId] ?? [];
+		this.$failedEvents.set({
+			...this.$failedEvents.get(),
+			[guildId]: cur.filter((e) => e.id !== eventId),
+		});
+		void this.loadEventStats(guildId);
+		return { ok: true };
 	}
 
 	public async toggleToken(

--- a/apps/kbve/edge/functions/discord-bot/index.ts
+++ b/apps/kbve/edge/functions/discord-bot/index.ts
@@ -15,6 +15,8 @@ import {
 const DISCORD_API_BASE = "https://discord.com/api/v10";
 const BOT_TOKEN_VAULT_ID = "39781c47-be8f-4a10-ae3a-714da299ca07";
 const FORUM_CHANNEL_TYPE = 15;
+const TEXT_CHANNEL_TYPE = 0;
+const ANNOUNCEMENT_CHANNEL_TYPE = 5;
 
 let cachedBotToken: { value: string; cached_at: number } | null = null;
 const BOT_TOKEN_TTL_MS = 5 * 60 * 1000;
@@ -122,6 +124,56 @@ async function handleIsMember(serverId: string): Promise<Response> {
   return jsonResponse({ error: "Discord API error", status }, 502);
 }
 
+async function handleListChannels(serverId: string): Promise<Response> {
+  const { status, body } = await botCallback(
+    "GET",
+    `/guilds/${serverId}/channels`,
+  );
+  if (status === 401 || status === 403) {
+    return jsonResponse({ error: "Bot token unauthorized" }, 502);
+  }
+  if (status === 404) {
+    return jsonResponse({ error: "Bot not in this guild" }, 404);
+  }
+  if (status === 429) {
+    return jsonResponse({ error: "Discord rate limited" }, 429);
+  }
+  if (status < 200 || status >= 300 || !Array.isArray(body)) {
+    return jsonResponse({ error: "Discord API error", status }, 502);
+  }
+  type Ch = {
+    id?: string;
+    name?: string;
+    type?: number;
+    parent_id?: string | null;
+    position?: number;
+  };
+  const all = body as Ch[];
+  const map = (c: Ch) => ({
+    id: c.id!,
+    name: c.name!,
+    parent_id: c.parent_id ?? null,
+    position: c.position ?? 0,
+  });
+  const sortByPosition = (
+    a: { position: number },
+    b: { position: number },
+  ) => a.position - b.position;
+  const forums = all
+    .filter((c) => c.type === FORUM_CHANNEL_TYPE && c.id && c.name)
+    .map(map)
+    .sort(sortByPosition);
+  const texts = all
+    .filter((c) =>
+      (c.type === TEXT_CHANNEL_TYPE ||
+        c.type === ANNOUNCEMENT_CHANNEL_TYPE) &&
+      c.id && c.name
+    )
+    .map(map)
+    .sort(sortByPosition);
+  return jsonResponse({ forums, texts });
+}
+
 async function handleListForumChannels(serverId: string): Promise<Response> {
   const { status, body } = await botCallback(
     "GET",
@@ -212,11 +264,13 @@ serve(async (req) => {
       return await handleIsMember(serverId);
     case "bot.list_forum_channels":
       return await handleListForumChannels(serverId);
+    case "bot.list_channels":
+      return await handleListChannels(serverId);
     default:
       return jsonResponse(
         {
           error:
-            'command required (one of: "bot.is_member", "bot.list_forum_channels")',
+            'command required (one of: "bot.is_member", "bot.list_forum_channels", "bot.list_channels")',
         },
         400,
       );

--- a/apps/kbve/edge/functions/gh-admin/index.ts
+++ b/apps/kbve/edge/functions/gh-admin/index.ts
@@ -721,6 +721,8 @@ async function handleRotate(
   return jsonResponse({ rotated: true, hook_id: kbveHook.id });
 }
 
+const REPO_HARD_CAP = 100;
+
 async function handleEventStats(serverId: string): Promise<Response> {
   const repos = await fetchRepoAllowlist(serverId);
   if (repos.length === 0) {
@@ -734,13 +736,29 @@ async function handleEventStats(serverId: string): Promise<Response> {
       oldest_pending_at: null,
     });
   }
+  if (repos.length > REPO_HARD_CAP) {
+    return jsonResponse(
+      {
+        error:
+          `Allowlist has ${repos.length} repos; stats RPC accepts max ${REPO_HARD_CAP}`,
+      },
+      413,
+    );
+  }
   const sb = createServiceClient();
   const { data, error } = await sb.schema("gh").rpc(
     "service_get_guild_event_stats",
     { p_repos: repos },
   );
   if (error) {
-    console.error("gh-admin: service_get_guild_event_stats failed", error.message);
+    const errCode = (error as { code?: string }).code ?? "";
+    if (errCode === "GH006") {
+      return jsonResponse({ error: error.message }, 413);
+    }
+    console.error(
+      "gh-admin: service_get_guild_event_stats failed",
+      error.message,
+    );
     return jsonResponse({ error: "stats lookup failed" }, 500);
   }
   const row = (Array.isArray(data) ? data[0] : data) ?? {};
@@ -755,6 +773,15 @@ async function handleEventFailed(
   if (repos.length === 0) {
     return jsonResponse({ events: [] });
   }
+  if (repos.length > REPO_HARD_CAP) {
+    return jsonResponse(
+      {
+        error:
+          `Allowlist has ${repos.length} repos; failed-events RPC accepts max ${REPO_HARD_CAP}`,
+      },
+      413,
+    );
+  }
   const capped = Math.min(Math.max(limit, 1), 50);
   const sb = createServiceClient();
   const { data, error } = await sb.schema("gh").rpc(
@@ -762,7 +789,14 @@ async function handleEventFailed(
     { p_repos: repos, p_limit: capped },
   );
   if (error) {
-    console.error("gh-admin: service_get_recent_failed_events failed", error.message);
+    const errCode = (error as { code?: string }).code ?? "";
+    if (errCode === "GH006") {
+      return jsonResponse({ error: error.message }, 413);
+    }
+    console.error(
+      "gh-admin: service_get_recent_failed_events failed",
+      error.message,
+    );
     return jsonResponse({ error: "failed-events lookup failed" }, 500);
   }
   return jsonResponse({ events: Array.isArray(data) ? data : [] });
@@ -785,19 +819,33 @@ async function handleEventRequeue(
     p_event_id: eventId,
   });
   if (error) {
-    console.error("gh-admin: service_requeue_event failed", error.message);
+    const errCode = (error as { code?: string }).code ?? "";
+    const message = error.message ?? "requeue failed";
+    if (errCode === "GH004") {
+      return jsonResponse(
+        {
+          error:
+            "Event not found, not in this guild's allowlist, or not in failed state",
+        },
+        404,
+      );
+    }
+    if (errCode === "GH001" || errCode === "GH002" || errCode === "GH003") {
+      return jsonResponse({ error: message }, 400);
+    }
+    if (errCode === "GH006") {
+      return jsonResponse({ error: message }, 413);
+    }
+    console.error("gh-admin: service_requeue_event failed", message);
     return jsonResponse({ error: "requeue failed" }, 500);
   }
   const row = (Array.isArray(data) ? data[0] : data) as
     | { id?: number; delivery_state?: number }
     | null;
-  if (!row || row.id !== eventId) {
-    return jsonResponse(
-      { error: "event not found in this guild's allowlist" },
-      404,
-    );
-  }
-  return jsonResponse({ requeued: true, event_id: row.id });
+  return jsonResponse({
+    requeued: true,
+    event_id: row?.id ?? eventId,
+  });
 }
 
 serve(async (req) => {

--- a/apps/kbve/edge/functions/gh-admin/index.ts
+++ b/apps/kbve/edge/functions/gh-admin/index.ts
@@ -189,8 +189,84 @@ async function handleList(
 const PING_COOLDOWN_MS = 30_000;
 const PING_RATE_WINDOW_MS = 60 * 60 * 1000;
 const PING_RATE_MAX = 10;
+const ROTATE_COOLDOWN_MS = 60_000;
+const ROTATE_RATE_WINDOW_MS = 60 * 60 * 1000;
+const ROTATE_RATE_MAX = 5;
 const pingCooldown = new Map<string, number>();
 const pingHistory = new Map<string, number[]>();
+const rotateCooldown = new Map<string, number>();
+const rotateHistory = new Map<string, number[]>();
+
+function checkRotateRateLimit(
+  userSub: string,
+  serverId: string,
+): { ok: true } | { ok: false; retryAfterMs: number; reason: string } {
+  const key = `${userSub}:${serverId}`;
+  const now = Date.now();
+  const last = rotateCooldown.get(key) ?? 0;
+  if (now - last < ROTATE_COOLDOWN_MS) {
+    return {
+      ok: false,
+      retryAfterMs: ROTATE_COOLDOWN_MS - (now - last),
+      reason: "cooldown",
+    };
+  }
+  const hist = (rotateHistory.get(key) ?? []).filter(
+    (t) => now - t < ROTATE_RATE_WINDOW_MS,
+  );
+  if (hist.length >= ROTATE_RATE_MAX) {
+    return {
+      ok: false,
+      retryAfterMs: ROTATE_RATE_WINDOW_MS - (now - hist[0]),
+      reason: "hourly_limit",
+    };
+  }
+  hist.push(now);
+  rotateHistory.set(key, hist);
+  rotateCooldown.set(key, now);
+  return { ok: true };
+}
+
+function genHmacHex(bytes = 32): string {
+  const arr = new Uint8Array(bytes);
+  crypto.getRandomValues(arr);
+  return Array.from(arr)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+async function upsertGuildSecret(
+  ownerId: string,
+  serverId: string,
+  service: string,
+  tokenName: string,
+  tokenValue: string,
+  description: string,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const sb = createServiceClient();
+  const { data, error } = await sb.schema("discordsh").rpc(
+    "service_set_guild_token",
+    {
+      p_owner_id: ownerId,
+      p_server_id: serverId,
+      p_service: service,
+      p_token_name: tokenName,
+      p_token_value: tokenValue,
+      p_description: description,
+    },
+  );
+  if (error) {
+    console.error("gh-admin: service_set_guild_token failed", error.message);
+    return { ok: false, error: error.message };
+  }
+  const row = (Array.isArray(data) ? data[0] : data) as
+    | { success?: boolean; message?: string }
+    | null;
+  if (!row || !row.success) {
+    return { ok: false, error: row?.message ?? "service_set_guild_token failed" };
+  }
+  return { ok: true };
+}
 
 function checkPingRateLimit(
   userSub: string,
@@ -418,6 +494,312 @@ async function handleInstall(
   });
 }
 
+interface GithubDelivery {
+  id: number;
+  guid: string;
+  delivered_at: string;
+  redelivery: boolean;
+  duration: number;
+  status: string;
+  status_code: number;
+  event: string;
+  action: string | null;
+}
+
+async function handleDeliveries(
+  serverId: string,
+  owner: string,
+  repo: string,
+  limit: number,
+): Promise<Response> {
+  const pat = await fetchGuildSecret(serverId, "github");
+  if (!pat) {
+    return jsonResponse(
+      { error: "No GitHub PAT stored for this guild" },
+      400,
+    );
+  }
+  const list = await githubCallback(
+    "GET",
+    `/repos/${owner}/${repo}/hooks`,
+    pat,
+  );
+  if (list.status === 401 || list.status === 403) {
+    return jsonResponse(
+      { error: "GitHub PAT unauthorized for this repo" },
+      403,
+    );
+  }
+  if (list.status === 404) {
+    return jsonResponse(
+      { error: "Repo not found or PAT lacks access" },
+      404,
+    );
+  }
+  if (list.status < 200 || list.status >= 300 || !Array.isArray(list.body)) {
+    return jsonResponse(
+      { error: "GitHub API error listing hooks", status: list.status },
+      502,
+    );
+  }
+  const expectedUrl = `${SUPABASE_URL}/functions/v1/gh-webhook/${serverId}`;
+  const kbveHook = (list.body as GithubHook[]).find(
+    (h) => h.config?.url === expectedUrl,
+  );
+  if (!kbveHook) {
+    return jsonResponse(
+      {
+        error:
+          "No kbve webhook found on this repo — run webhooks.install first",
+      },
+      404,
+    );
+  }
+  const capped = Math.min(Math.max(limit, 1), 30);
+  const deliveries = await githubCallback(
+    "GET",
+    `/repos/${owner}/${repo}/hooks/${kbveHook.id}/deliveries?per_page=${capped}`,
+    pat,
+  );
+  if (
+    deliveries.status < 200 || deliveries.status >= 300 ||
+    !Array.isArray(deliveries.body)
+  ) {
+    return jsonResponse(
+      {
+        error: "GitHub API error listing deliveries",
+        status: deliveries.status,
+      },
+      502,
+    );
+  }
+  const rows = (deliveries.body as GithubDelivery[]).map((d) => ({
+    id: d.id,
+    guid: d.guid,
+    delivered_at: d.delivered_at,
+    redelivery: !!d.redelivery,
+    duration: d.duration,
+    status: d.status,
+    status_code: d.status_code,
+    event: d.event,
+    action: d.action ?? null,
+  }));
+  return jsonResponse({ hook_id: kbveHook.id, deliveries: rows });
+}
+
+async function handleDelete(
+  serverId: string,
+  owner: string,
+  repo: string,
+): Promise<Response> {
+  const pat = await fetchGuildSecret(serverId, "github");
+  if (!pat) {
+    return jsonResponse(
+      { error: "No GitHub PAT stored for this guild" },
+      400,
+    );
+  }
+  const list = await githubCallback(
+    "GET",
+    `/repos/${owner}/${repo}/hooks`,
+    pat,
+  );
+  if (list.status === 401 || list.status === 403) {
+    return jsonResponse(
+      { error: "GitHub PAT unauthorized (needs admin:repo_hook scope)" },
+      403,
+    );
+  }
+  if (list.status === 404) {
+    return jsonResponse(
+      { error: "Repo not found or PAT lacks access" },
+      404,
+    );
+  }
+  if (list.status < 200 || list.status >= 300 || !Array.isArray(list.body)) {
+    return jsonResponse(
+      { error: "GitHub API error listing hooks", status: list.status },
+      502,
+    );
+  }
+  const expectedUrl = `${SUPABASE_URL}/functions/v1/gh-webhook/${serverId}`;
+  const kbveHook = (list.body as GithubHook[]).find(
+    (h) => h.config?.url === expectedUrl,
+  );
+  if (!kbveHook) {
+    return jsonResponse({ deleted: false, already_absent: true });
+  }
+  const del = await githubCallback(
+    "DELETE",
+    `/repos/${owner}/${repo}/hooks/${kbveHook.id}`,
+    pat,
+  );
+  if (del.status === 204) {
+    return jsonResponse({ deleted: true, hook_id: kbveHook.id });
+  }
+  return jsonResponse(
+    {
+      error: "GitHub API error deleting hook",
+      status: del.status,
+      detail: del.body,
+    },
+    502,
+  );
+}
+
+async function handleRotate(
+  ownerId: string,
+  serverId: string,
+  owner: string,
+  repo: string,
+): Promise<Response> {
+  const pat = await fetchGuildSecret(serverId, "github");
+  if (!pat) {
+    return jsonResponse(
+      { error: "No GitHub PAT stored for this guild" },
+      400,
+    );
+  }
+  const list = await githubCallback(
+    "GET",
+    `/repos/${owner}/${repo}/hooks`,
+    pat,
+  );
+  if (list.status < 200 || list.status >= 300 || !Array.isArray(list.body)) {
+    return jsonResponse(
+      { error: "GitHub API error listing hooks", status: list.status },
+      502,
+    );
+  }
+  const expectedUrl = `${SUPABASE_URL}/functions/v1/gh-webhook/${serverId}`;
+  const kbveHook = (list.body as GithubHook[]).find(
+    (h) => h.config?.url === expectedUrl,
+  );
+  if (!kbveHook) {
+    return jsonResponse(
+      {
+        error:
+          "No kbve webhook found on this repo — install one before rotating",
+      },
+      404,
+    );
+  }
+  const newHmac = genHmacHex(32);
+  const patch = await githubCallback(
+    "PATCH",
+    `/repos/${owner}/${repo}/hooks/${kbveHook.id}/config`,
+    pat,
+    { secret: newHmac },
+  );
+  if (patch.status < 200 || patch.status >= 300) {
+    return jsonResponse(
+      {
+        error: "GitHub PATCH hook config failed",
+        status: patch.status,
+        detail: patch.body,
+      },
+      502,
+    );
+  }
+  const upsert = await upsertGuildSecret(
+    ownerId,
+    serverId,
+    "github_webhook",
+    "github-webhook-hmac",
+    newHmac,
+    `GitHub webhook HMAC for guild ${serverId} (rotated)`,
+  );
+  if (!upsert.ok) {
+    return jsonResponse(
+      {
+        error:
+          `Webhook secret rotated on GitHub but vault upsert failed: ${upsert.error}`,
+      },
+      500,
+    );
+  }
+  return jsonResponse({ rotated: true, hook_id: kbveHook.id });
+}
+
+async function handleEventStats(serverId: string): Promise<Response> {
+  const repos = await fetchRepoAllowlist(serverId);
+  if (repos.length === 0) {
+    return jsonResponse({
+      last_delivered_at: null,
+      last_recorded_at: null,
+      pending_count: 0,
+      in_flight_count: 0,
+      delivered_count: 0,
+      failed_count: 0,
+      oldest_pending_at: null,
+    });
+  }
+  const sb = createServiceClient();
+  const { data, error } = await sb.schema("gh").rpc(
+    "service_get_guild_event_stats",
+    { p_repos: repos },
+  );
+  if (error) {
+    console.error("gh-admin: service_get_guild_event_stats failed", error.message);
+    return jsonResponse({ error: "stats lookup failed" }, 500);
+  }
+  const row = (Array.isArray(data) ? data[0] : data) ?? {};
+  return jsonResponse(row);
+}
+
+async function handleEventFailed(
+  serverId: string,
+  limit: number,
+): Promise<Response> {
+  const repos = await fetchRepoAllowlist(serverId);
+  if (repos.length === 0) {
+    return jsonResponse({ events: [] });
+  }
+  const capped = Math.min(Math.max(limit, 1), 50);
+  const sb = createServiceClient();
+  const { data, error } = await sb.schema("gh").rpc(
+    "service_get_recent_failed_events",
+    { p_repos: repos, p_limit: capped },
+  );
+  if (error) {
+    console.error("gh-admin: service_get_recent_failed_events failed", error.message);
+    return jsonResponse({ error: "failed-events lookup failed" }, 500);
+  }
+  return jsonResponse({ events: Array.isArray(data) ? data : [] });
+}
+
+async function handleEventRequeue(
+  serverId: string,
+  eventId: number,
+): Promise<Response> {
+  const repos = await fetchRepoAllowlist(serverId);
+  if (repos.length === 0) {
+    return jsonResponse(
+      { error: "Empty allowlist — cannot requeue without repo scope" },
+      400,
+    );
+  }
+  const sb = createServiceClient();
+  const { data, error } = await sb.schema("gh").rpc("service_requeue_event", {
+    p_repos: repos,
+    p_event_id: eventId,
+  });
+  if (error) {
+    console.error("gh-admin: service_requeue_event failed", error.message);
+    return jsonResponse({ error: "requeue failed" }, 500);
+  }
+  const row = (Array.isArray(data) ? data[0] : data) as
+    | { id?: number; delivery_state?: number }
+    | null;
+  if (!row || row.id !== eventId) {
+    return jsonResponse(
+      { error: "event not found in this guild's allowlist" },
+      404,
+    );
+  }
+  return jsonResponse({ requeued: true, event_id: row.id });
+}
+
 serve(async (req) => {
   if (req.method === "OPTIONS") {
     return new Response("ok", { headers: corsHeaders });
@@ -448,6 +830,8 @@ serve(async (req) => {
     server_id?: string;
     owner?: string;
     repo?: string;
+    event_id?: number;
+    limit?: number;
   };
   try {
     body = await req.json();
@@ -457,12 +841,8 @@ serve(async (req) => {
 
   const sidErr = validateSnowflake(body.server_id, "server_id");
   if (sidErr) return sidErr;
-  const orErr = validateOwnerRepo(body.owner, body.repo);
-  if (orErr) return orErr;
 
   const serverId = body.server_id as string;
-  const owner = body.owner as string;
-  const repo = body.repo as string;
 
   if (!ownsGuild(claims, serverId)) {
     return jsonResponse(
@@ -473,6 +853,39 @@ serve(async (req) => {
       403,
     );
   }
+
+  const cmd = body.command ?? "";
+
+  if (cmd.startsWith("events.")) {
+    switch (cmd) {
+      case "events.stats":
+        return await handleEventStats(serverId);
+      case "events.failed": {
+        const limit = typeof body.limit === "number" ? body.limit : 10;
+        return await handleEventFailed(serverId, limit);
+      }
+      case "events.requeue": {
+        if (typeof body.event_id !== "number" || body.event_id <= 0) {
+          return jsonResponse({ error: "event_id must be > 0" }, 400);
+        }
+        return await handleEventRequeue(serverId, body.event_id);
+      }
+      default:
+        return jsonResponse(
+          {
+            error:
+              'events.* command required (one of: "events.stats", "events.failed", "events.requeue")',
+          },
+          400,
+        );
+    }
+  }
+
+  const orErr = validateOwnerRepo(body.owner, body.repo);
+  if (orErr) return orErr;
+
+  const owner = body.owner as string;
+  const repo = body.repo as string;
 
   const allowlist = await fetchGuildSecret(serverId, "github_repos")
     .then(async () => await fetchRepoAllowlist(serverId));
@@ -491,6 +904,34 @@ serve(async (req) => {
       return await handleInstall(serverId, owner, repo);
     case "webhooks.list":
       return await handleList(serverId, owner, repo);
+    case "webhooks.deliveries": {
+      const limit = typeof body.limit === "number" ? body.limit : 10;
+      return await handleDeliveries(serverId, owner, repo, limit);
+    }
+    case "webhooks.delete":
+      return await handleDelete(serverId, owner, repo);
+    case "webhooks.rotate": {
+      const userSub = typeof claims.sub === "string" ? claims.sub : "";
+      if (!userSub) {
+        return jsonResponse(
+          { error: "Authenticated user token missing sub claim" },
+          401,
+        );
+      }
+      const rate = checkRotateRateLimit(userSub, serverId);
+      if (!rate.ok) {
+        return jsonResponse(
+          {
+            error: rate.reason === "cooldown"
+              ? `Wait ${Math.ceil(rate.retryAfterMs / 1000)}s between rotations`
+              : `Hourly rotation limit exceeded — retry in ${Math.ceil(rate.retryAfterMs / 60_000)}m`,
+            retry_after_ms: rate.retryAfterMs,
+          },
+          429,
+        );
+      }
+      return await handleRotate(userSub, serverId, owner, repo);
+    }
     case "webhooks.ping": {
       const userSub = typeof claims.sub === "string" ? claims.sub : "";
       if (!userSub) {
@@ -518,7 +959,7 @@ serve(async (req) => {
       return jsonResponse(
         {
           error:
-            'command required (one of: "webhooks.install", "webhooks.list", "webhooks.ping")',
+            'command required (one of: "webhooks.install", "webhooks.list", "webhooks.ping", "webhooks.deliveries", "webhooks.rotate", "webhooks.delete", "events.stats", "events.failed", "events.requeue")',
         },
         400,
       );

--- a/packages/data/sql/dbmate/migrations/20260606120000_gh_service_event_ops.sql
+++ b/packages/data/sql/dbmate/migrations/20260606120000_gh_service_event_ops.sql
@@ -1,13 +1,31 @@
 -- migrate:up
 SET search_path = public, pg_catalog;
 
--- gh.issue_event has no server_id column — it's keyed by (owner, repo, number)
+-- gh.issue_event has no server_id column — it is keyed by (owner, repo, number)
 -- and the per-guild routing happens in the bot via vault allowlist. To compute
 -- guild-scoped event stats from the dashboard, the gh-admin edge function
 -- fetches the guild's allowlist (github_repos:<guild>) via bot_get_guild_token,
--- then passes the owner/repo pairs into these RPCs. Both functions filter by
--- that array so a caller cannot read or requeue events for a repo the guild
+-- then passes the owner/repo pairs into these RPCs. All three functions filter
+-- by repo_key so a caller cannot read or requeue events for a repo the guild
 -- does not control.
+
+-- Generated, stored repo_key — lowercase "owner/repo". Lets us use plain
+-- equality + IN lookups against an ordinary btree instead of forcing the
+-- planner to recompute (lower(owner)||'/'||lower(repo)) per row.
+
+ALTER TABLE gh.issue_event
+    ADD COLUMN IF NOT EXISTS repo_key TEXT
+    GENERATED ALWAYS AS (lower(owner) || '/' || lower(repo)) STORED;
+
+-- Composite index covering the stats aggregate path.
+CREATE INDEX IF NOT EXISTS gh_issue_event_repo_key_state_updated_id_idx
+    ON gh.issue_event (repo_key, delivery_state, updated_at DESC, id DESC);
+
+-- Partial index for failed-event tail (delivery_state = 3).
+CREATE INDEX IF NOT EXISTS gh_issue_event_failed_repo_key_updated_id_idx
+    ON gh.issue_event (repo_key, updated_at DESC, id DESC)
+    WHERE delivery_state = 3;
+
 
 CREATE OR REPLACE FUNCTION gh.service_get_guild_event_stats(
     p_repos TEXT[]
@@ -25,24 +43,35 @@ LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = gh, pg_temp
+ROWS 1
+COST 100
 AS $$
 DECLARE
     v_repos TEXT[];
 BEGIN
-    IF p_repos IS NULL OR array_length(p_repos, 1) IS NULL THEN
+    IF COALESCE(cardinality(p_repos), 0) = 0 THEN
         RETURN QUERY SELECT NULL::TIMESTAMPTZ, NULL::TIMESTAMPTZ,
                             0::BIGINT, 0::BIGINT, 0::BIGINT, 0::BIGINT,
                             NULL::TIMESTAMPTZ;
         RETURN;
     END IF;
 
-    v_repos := ARRAY(SELECT lower(btrim(r)) FROM unnest(p_repos) AS r
-                     WHERE r ~ '^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$');
-    IF array_length(v_repos, 1) IS NULL THEN
+    v_repos := ARRAY(
+        SELECT DISTINCT lower(btrim(r))
+        FROM unnest(p_repos) AS r
+        WHERE lower(btrim(r)) ~ '^[a-z0-9._-]{1,100}/[a-z0-9._-]{1,100}$'
+    );
+
+    IF COALESCE(cardinality(v_repos), 0) = 0 THEN
         RETURN QUERY SELECT NULL::TIMESTAMPTZ, NULL::TIMESTAMPTZ,
                             0::BIGINT, 0::BIGINT, 0::BIGINT, 0::BIGINT,
                             NULL::TIMESTAMPTZ;
         RETURN;
+    END IF;
+
+    IF cardinality(v_repos) > 100 THEN
+        RAISE EXCEPTION 'p_repos cannot contain more than 100 entries'
+            USING ERRCODE = 'GH006';
     END IF;
 
     RETURN QUERY
@@ -55,7 +84,7 @@ BEGIN
         COUNT(*) FILTER (WHERE e.delivery_state = 3)                AS failed_count,
         MIN(e.created_at) FILTER (WHERE e.delivery_state = 0)       AS oldest_pending_at
     FROM gh.issue_event e
-    WHERE (lower(e.owner) || '/' || lower(e.repo)) = ANY(v_repos);
+    WHERE e.repo_key = ANY(v_repos);
 END;
 $$;
 
@@ -64,7 +93,7 @@ REVOKE ALL ON FUNCTION gh.service_get_guild_event_stats(TEXT[]) FROM PUBLIC, ano
 GRANT EXECUTE ON FUNCTION gh.service_get_guild_event_stats(TEXT[]) TO service_role;
 
 COMMENT ON FUNCTION gh.service_get_guild_event_stats(TEXT[]) IS
-    'Aggregate gh.issue_event counts + last-delivery timestamps for the supplied owner/repo allowlist. Service_role only; call from gh-admin edge after fetching the guild allowlist from vault.';
+    'Aggregate gh.issue_event counts + last-delivery timestamps for the supplied owner/repo allowlist. Filters via repo_key generated column. Service_role only; call from gh-admin edge after fetching the guild allowlist from vault.';
 
 
 CREATE OR REPLACE FUNCTION gh.service_get_recent_failed_events(
@@ -87,19 +116,32 @@ LANGUAGE plpgsql
 STABLE
 SECURITY DEFINER
 SET search_path = gh, pg_temp
+ROWS 10
+COST 100
 AS $$
 DECLARE
     v_repos TEXT[];
     v_limit INT;
 BEGIN
     v_limit := LEAST(GREATEST(COALESCE(p_limit, 10), 1), 50);
-    IF p_repos IS NULL OR array_length(p_repos, 1) IS NULL THEN
+
+    IF COALESCE(cardinality(p_repos), 0) = 0 THEN
         RETURN;
     END IF;
-    v_repos := ARRAY(SELECT lower(btrim(r)) FROM unnest(p_repos) AS r
-                     WHERE r ~ '^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$');
-    IF array_length(v_repos, 1) IS NULL THEN
+
+    v_repos := ARRAY(
+        SELECT DISTINCT lower(btrim(r))
+        FROM unnest(p_repos) AS r
+        WHERE lower(btrim(r)) ~ '^[a-z0-9._-]{1,100}/[a-z0-9._-]{1,100}$'
+    );
+
+    IF COALESCE(cardinality(v_repos), 0) = 0 THEN
         RETURN;
+    END IF;
+
+    IF cardinality(v_repos) > 100 THEN
+        RAISE EXCEPTION 'p_repos cannot contain more than 100 entries'
+            USING ERRCODE = 'GH006';
     END IF;
 
     RETURN QUERY
@@ -107,9 +149,9 @@ BEGIN
         e.id, e.owner, e.repo, e.number, e.event_type, e.actor,
         e.delivery_attempts, e.last_error, e.created_at, e.updated_at
     FROM gh.issue_event e
-    WHERE (lower(e.owner) || '/' || lower(e.repo)) = ANY(v_repos)
+    WHERE e.repo_key = ANY(v_repos)
       AND e.delivery_state = 3
-    ORDER BY e.updated_at DESC
+    ORDER BY e.updated_at DESC, e.id DESC
     LIMIT v_limit;
 END;
 $$;
@@ -119,8 +161,14 @@ REVOKE ALL ON FUNCTION gh.service_get_recent_failed_events(TEXT[], INT) FROM PUB
 GRANT EXECUTE ON FUNCTION gh.service_get_recent_failed_events(TEXT[], INT) TO service_role;
 
 COMMENT ON FUNCTION gh.service_get_recent_failed_events(TEXT[], INT) IS
-    'Failed-event tail filtered by allowlist for dashboard requeue UI. Service_role only.';
+    'Failed-event tail (delivery_state=3) filtered by allowlist for dashboard requeue UI. Service_role only.';
 
+
+-- Requeue ONLY failed events. Preserves delivery_attempts so we keep
+-- operational history. Resets claim_token + claimed_at + delivered_at +
+-- last_error so the bot's claim sweep treats it as fresh. Raises on miss
+-- so the dashboard can distinguish "no such event in this guild's scope"
+-- from success.
 
 CREATE OR REPLACE FUNCTION gh.service_requeue_event(
     p_repos    TEXT[],
@@ -135,20 +183,39 @@ LANGUAGE plpgsql
 VOLATILE
 SECURITY DEFINER
 SET search_path = gh, pg_temp
+ROWS 1
+COST 50
 AS $$
 DECLARE
     v_repos TEXT[];
 BEGIN
+    PERFORM set_config('lock_timeout', '2s', true);
+    PERFORM set_config('statement_timeout', '10s', true);
+
     IF p_event_id IS NULL OR p_event_id <= 0 THEN
-        RAISE EXCEPTION 'p_event_id must be > 0';
+        RAISE EXCEPTION 'p_event_id must be > 0'
+            USING ERRCODE = 'GH001';
     END IF;
-    IF p_repos IS NULL OR array_length(p_repos, 1) IS NULL THEN
-        RAISE EXCEPTION 'p_repos must contain at least one owner/repo entry';
+
+    IF COALESCE(cardinality(p_repos), 0) = 0 THEN
+        RAISE EXCEPTION 'p_repos must contain at least one owner/repo entry'
+            USING ERRCODE = 'GH002';
     END IF;
-    v_repos := ARRAY(SELECT lower(btrim(r)) FROM unnest(p_repos) AS r
-                     WHERE r ~ '^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$');
-    IF array_length(v_repos, 1) IS NULL THEN
-        RAISE EXCEPTION 'p_repos contained no valid owner/repo entries';
+
+    v_repos := ARRAY(
+        SELECT DISTINCT lower(btrim(r))
+        FROM unnest(p_repos) AS r
+        WHERE lower(btrim(r)) ~ '^[a-z0-9._-]{1,100}/[a-z0-9._-]{1,100}$'
+    );
+
+    IF COALESCE(cardinality(v_repos), 0) = 0 THEN
+        RAISE EXCEPTION 'p_repos contained no valid owner/repo entries'
+            USING ERRCODE = 'GH003';
+    END IF;
+
+    IF cardinality(v_repos) > 100 THEN
+        RAISE EXCEPTION 'p_repos cannot contain more than 100 entries'
+            USING ERRCODE = 'GH006';
     END IF;
 
     RETURN QUERY
@@ -157,12 +224,17 @@ BEGIN
         claim_token       = NULL,
         claimed_at        = NULL,
         delivered_at      = NULL,
-        delivery_attempts = 0,
         last_error        = NULL,
         updated_at        = now()
     WHERE e.id = p_event_id
-      AND (lower(e.owner) || '/' || lower(e.repo)) = ANY(v_repos)
+      AND e.repo_key = ANY(v_repos)
+      AND e.delivery_state = 3
     RETURNING e.id, e.delivery_state, e.delivery_attempts;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'event not found, not in this guild''s allowlist, or not in failed state'
+            USING ERRCODE = 'GH004';
+    END IF;
 END;
 $$;
 
@@ -171,10 +243,15 @@ REVOKE ALL ON FUNCTION gh.service_requeue_event(TEXT[], BIGINT) FROM PUBLIC, ano
 GRANT EXECUTE ON FUNCTION gh.service_requeue_event(TEXT[], BIGINT) TO service_role;
 
 COMMENT ON FUNCTION gh.service_requeue_event(TEXT[], BIGINT) IS
-    'Reset a single gh.issue_event row back to pending. Filters by allowlist so a guild cannot requeue another guild''s repo events. service_role only.';
+    'Reset a single failed gh.issue_event row back to pending so gh_sync claims it again. Allowlist-scoped (cross-guild safe), failed-only (cannot replay delivered events), preserves delivery_attempts. Raises GH001/GH002/GH003/GH004/GH006 with custom SQLSTATEs. service_role only.';
 
 
 -- migrate:down
 DROP FUNCTION IF EXISTS gh.service_requeue_event(TEXT[], BIGINT);
 DROP FUNCTION IF EXISTS gh.service_get_recent_failed_events(TEXT[], INT);
 DROP FUNCTION IF EXISTS gh.service_get_guild_event_stats(TEXT[]);
+
+DROP INDEX IF EXISTS gh.gh_issue_event_failed_repo_key_updated_id_idx;
+DROP INDEX IF EXISTS gh.gh_issue_event_repo_key_state_updated_id_idx;
+
+ALTER TABLE gh.issue_event DROP COLUMN IF EXISTS repo_key;

--- a/packages/data/sql/dbmate/migrations/20260606120000_gh_service_event_ops.sql
+++ b/packages/data/sql/dbmate/migrations/20260606120000_gh_service_event_ops.sql
@@ -1,0 +1,180 @@
+-- migrate:up
+SET search_path = public, pg_catalog;
+
+-- gh.issue_event has no server_id column — it's keyed by (owner, repo, number)
+-- and the per-guild routing happens in the bot via vault allowlist. To compute
+-- guild-scoped event stats from the dashboard, the gh-admin edge function
+-- fetches the guild's allowlist (github_repos:<guild>) via bot_get_guild_token,
+-- then passes the owner/repo pairs into these RPCs. Both functions filter by
+-- that array so a caller cannot read or requeue events for a repo the guild
+-- does not control.
+
+CREATE OR REPLACE FUNCTION gh.service_get_guild_event_stats(
+    p_repos TEXT[]
+)
+RETURNS TABLE (
+    last_delivered_at      TIMESTAMPTZ,
+    last_recorded_at       TIMESTAMPTZ,
+    pending_count          BIGINT,
+    in_flight_count        BIGINT,
+    delivered_count        BIGINT,
+    failed_count           BIGINT,
+    oldest_pending_at      TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = gh, pg_temp
+AS $$
+DECLARE
+    v_repos TEXT[];
+BEGIN
+    IF p_repos IS NULL OR array_length(p_repos, 1) IS NULL THEN
+        RETURN QUERY SELECT NULL::TIMESTAMPTZ, NULL::TIMESTAMPTZ,
+                            0::BIGINT, 0::BIGINT, 0::BIGINT, 0::BIGINT,
+                            NULL::TIMESTAMPTZ;
+        RETURN;
+    END IF;
+
+    v_repos := ARRAY(SELECT lower(btrim(r)) FROM unnest(p_repos) AS r
+                     WHERE r ~ '^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$');
+    IF array_length(v_repos, 1) IS NULL THEN
+        RETURN QUERY SELECT NULL::TIMESTAMPTZ, NULL::TIMESTAMPTZ,
+                            0::BIGINT, 0::BIGINT, 0::BIGINT, 0::BIGINT,
+                            NULL::TIMESTAMPTZ;
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        MAX(e.delivered_at)                                         AS last_delivered_at,
+        MAX(e.created_at)                                           AS last_recorded_at,
+        COUNT(*) FILTER (WHERE e.delivery_state = 0)                AS pending_count,
+        COUNT(*) FILTER (WHERE e.delivery_state = 1)                AS in_flight_count,
+        COUNT(*) FILTER (WHERE e.delivery_state = 2)                AS delivered_count,
+        COUNT(*) FILTER (WHERE e.delivery_state = 3)                AS failed_count,
+        MIN(e.created_at) FILTER (WHERE e.delivery_state = 0)       AS oldest_pending_at
+    FROM gh.issue_event e
+    WHERE (lower(e.owner) || '/' || lower(e.repo)) = ANY(v_repos);
+END;
+$$;
+
+ALTER FUNCTION gh.service_get_guild_event_stats(TEXT[]) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.service_get_guild_event_stats(TEXT[]) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.service_get_guild_event_stats(TEXT[]) TO service_role;
+
+COMMENT ON FUNCTION gh.service_get_guild_event_stats(TEXT[]) IS
+    'Aggregate gh.issue_event counts + last-delivery timestamps for the supplied owner/repo allowlist. Service_role only; call from gh-admin edge after fetching the guild allowlist from vault.';
+
+
+CREATE OR REPLACE FUNCTION gh.service_get_recent_failed_events(
+    p_repos TEXT[],
+    p_limit INT DEFAULT 10
+)
+RETURNS TABLE (
+    id                BIGINT,
+    owner             TEXT,
+    repo              TEXT,
+    number            INT,
+    event_type        TEXT,
+    actor             TEXT,
+    delivery_attempts INT,
+    last_error        TEXT,
+    created_at        TIMESTAMPTZ,
+    updated_at        TIMESTAMPTZ
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = gh, pg_temp
+AS $$
+DECLARE
+    v_repos TEXT[];
+    v_limit INT;
+BEGIN
+    v_limit := LEAST(GREATEST(COALESCE(p_limit, 10), 1), 50);
+    IF p_repos IS NULL OR array_length(p_repos, 1) IS NULL THEN
+        RETURN;
+    END IF;
+    v_repos := ARRAY(SELECT lower(btrim(r)) FROM unnest(p_repos) AS r
+                     WHERE r ~ '^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$');
+    IF array_length(v_repos, 1) IS NULL THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    SELECT
+        e.id, e.owner, e.repo, e.number, e.event_type, e.actor,
+        e.delivery_attempts, e.last_error, e.created_at, e.updated_at
+    FROM gh.issue_event e
+    WHERE (lower(e.owner) || '/' || lower(e.repo)) = ANY(v_repos)
+      AND e.delivery_state = 3
+    ORDER BY e.updated_at DESC
+    LIMIT v_limit;
+END;
+$$;
+
+ALTER FUNCTION gh.service_get_recent_failed_events(TEXT[], INT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.service_get_recent_failed_events(TEXT[], INT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.service_get_recent_failed_events(TEXT[], INT) TO service_role;
+
+COMMENT ON FUNCTION gh.service_get_recent_failed_events(TEXT[], INT) IS
+    'Failed-event tail filtered by allowlist for dashboard requeue UI. Service_role only.';
+
+
+CREATE OR REPLACE FUNCTION gh.service_requeue_event(
+    p_repos    TEXT[],
+    p_event_id BIGINT
+)
+RETURNS TABLE (
+    id                BIGINT,
+    delivery_state    SMALLINT,
+    delivery_attempts INT
+)
+LANGUAGE plpgsql
+VOLATILE
+SECURITY DEFINER
+SET search_path = gh, pg_temp
+AS $$
+DECLARE
+    v_repos TEXT[];
+BEGIN
+    IF p_event_id IS NULL OR p_event_id <= 0 THEN
+        RAISE EXCEPTION 'p_event_id must be > 0';
+    END IF;
+    IF p_repos IS NULL OR array_length(p_repos, 1) IS NULL THEN
+        RAISE EXCEPTION 'p_repos must contain at least one owner/repo entry';
+    END IF;
+    v_repos := ARRAY(SELECT lower(btrim(r)) FROM unnest(p_repos) AS r
+                     WHERE r ~ '^[A-Za-z0-9._-]{1,100}/[A-Za-z0-9._-]{1,100}$');
+    IF array_length(v_repos, 1) IS NULL THEN
+        RAISE EXCEPTION 'p_repos contained no valid owner/repo entries';
+    END IF;
+
+    RETURN QUERY
+    UPDATE gh.issue_event e
+    SET delivery_state    = 0,
+        claim_token       = NULL,
+        claimed_at        = NULL,
+        delivered_at      = NULL,
+        delivery_attempts = 0,
+        last_error        = NULL,
+        updated_at        = now()
+    WHERE e.id = p_event_id
+      AND (lower(e.owner) || '/' || lower(e.repo)) = ANY(v_repos)
+    RETURNING e.id, e.delivery_state, e.delivery_attempts;
+END;
+$$;
+
+ALTER FUNCTION gh.service_requeue_event(TEXT[], BIGINT) OWNER TO service_role;
+REVOKE ALL ON FUNCTION gh.service_requeue_event(TEXT[], BIGINT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION gh.service_requeue_event(TEXT[], BIGINT) TO service_role;
+
+COMMENT ON FUNCTION gh.service_requeue_event(TEXT[], BIGINT) IS
+    'Reset a single gh.issue_event row back to pending. Filters by allowlist so a guild cannot requeue another guild''s repo events. service_role only.';
+
+
+-- migrate:down
+DROP FUNCTION IF EXISTS gh.service_requeue_event(TEXT[], BIGINT);
+DROP FUNCTION IF EXISTS gh.service_get_recent_failed_events(TEXT[], INT);
+DROP FUNCTION IF EXISTS gh.service_get_guild_event_stats(TEXT[]);


### PR DESCRIPTION
Ships Tier A + B from the roadmap on #11362.

## Tier A — UI / reuse-existing

### 1. Forum + text channel pickers in BotConfig
- Replaces raw snowflake `<input>` for `forum_channel_id`, `claim_channel_id`, `noticeboard_channel_id`, `taskboard_channel_id` with a dropdown of the bot's visible channels.
- `discord-bot` edge gains \`bot.list_channels\` returning both forum (type 15) and text/announcement (type 0/5) in one payload.
- Falls back to raw snowflake input if the bot isn't in the guild yet, channel lookup fails, or the saved value isn't in the visible list.
- Hidden \`<input>\` retains the ref + onBlur contract so the rest of the form code didn't have to change.

### 2. Webhook Recent Deliveries panel in Step 2
- New gh-admin command \`webhooks.deliveries\` → \`GET /repos/{}/{}/hooks/{id}/deliveries\`
- Renders last 10 deliveries inline, color-coded by 2xx vs non-2xx, with event/action + timestamp.
- "Refresh" button + auto-load on selection change. User can confirm \`ping → 200\` without leaving the dashboard.

## Tier B — operational hygiene

### 3. Webhook lifecycle ops on Step 2
- \`webhooks.rotate\` — gen new HMAC + \`PATCH /hooks/{id}/config\` + \`service_set_guild_token\` upsert. Rate-limited 60s cooldown / 5 per hour per (user, guild). Old in-flight deliveries fail signature for a few seconds.
- \`webhooks.delete\` — \`DELETE /hooks/{id}\`. Leaves the vault HMAC row intact so reinstall doesn't force a rotation. Confirm-on-double-click UX.

### 4. Event queue visibility on /dashboard/agents/discordsh/
- New \`ReactAgentEventQueue\` island.
- 4-card grid: queue depth (pending + in-flight), delivered (with last_delivered_at), failed (red when > 0), oldest pending (relative time, amber after 10m).
- Auto-refresh every 30s, toggleable.
- Failed events list with per-row "Requeue" button. Shows last_error + attempts + age.

### 5. Failed event requeue
- New gh-admin command \`events.requeue\` calls \`gh.service_requeue_event\` which resets a single row back to delivery_state=0 so the bot picks it up next claim sweep.
- Allowlist-gated so a guild cannot requeue another guild's event.

## SQL migration \`20260606120000_gh_service_event_ops.sql\`

Three new RPCs, all service_role only, all filter by \`lower(owner||'/'||repo) IN (p_repos)\` — gh-admin fetches the guild's \`github_repos\` allowlist from vault and passes it in:

- \`gh.service_get_guild_event_stats(p_repos)\` → \`{ last_delivered_at, last_recorded_at, pending_count, in_flight_count, delivered_count, failed_count, oldest_pending_at }\`
- \`gh.service_get_recent_failed_events(p_repos, p_limit)\` → tail of delivery_state=3 events
- \`gh.service_requeue_event(p_repos, p_event_id)\` → reset to pending

\`gh.issue_event\` has no \`server_id\` column (per-guild routing happens bot-side via vault allowlist), so the per-guild scope is enforced server-side by intersecting with the supplied repo allowlist. A guild cannot read or mutate events for repos it doesn't control.

## gh-admin dispatcher restructure

Webhook commands (install/list/ping/deliveries/rotate/delete) keep the existing \`ownsGuild\` + allowlist gate. Event commands (events.stats/failed/requeue) skip the per-repo allowlist check because they're per-guild and internally re-derive scope via the allowlist anyway.

## agentsService — new atoms

All per-guildId unless noted:
- \`$guildChannels\` / loading / error
- \`$webhookDeliveries\` (keyed by \`guildId:owner/repo\`) / loading / error
- \`$webhookRotateBusyFor\` / Results
- \`$webhookDeleteBusyFor\`
- \`$eventStats\` / loading
- \`$failedEvents\` / loading
- \`$eventRequeueBusyFor\`

New methods: \`ensureGuildChannelsLoaded\`, \`loadWebhookDeliveries\`, \`rotateWebhookForGuild\`, \`deleteWebhookForGuild\`, \`loadEventStats\`, \`loadFailedEvents\`, \`requeueEvent\`.

## Test plan

- [ ] Migration: \`gh workflow run ci-dbmate-deploy.yml -f confirm_sha=<short>\`, approve gate.
- [ ] BotConfig form: pick forum/text channels via dropdown for all 4 channel fields. Save. Reload. Values persist. Switch to a guild where the bot isn't installed → dropdown falls back to raw snowflake input.
- [ ] Step 2 Wizard: install webhook → Recent Deliveries panel populates after a ping. Send test ping → new 200 delivery appears.
- [ ] Step 2: Rotate HMAC → success message. Send another ping → new 200 delivery (now signed with new HMAC).
- [ ] Step 2: Delete webhook → status flips back to PENDING. Install again → reads as DONE.
- [ ] DiscordSH page: ReactAgentEventQueue shows live counts. Auto-refresh ticks every 30s.
- [ ] Create a failure (e.g. point forum_channel_id at a channel the bot can't post in) → failed event appears → Requeue button resets it.

Roadmap source: #11362 comment on Tier A/B/C plan.