### PR TITLE
perf(rareicon): jobify 4 more per-frame systems (Regen / MoraleExpiry / RestBonus / Hunt-prep)

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/HuntBehaviorSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/HuntBehaviorSystem.cs
@@ -1,21 +1,25 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Points Hostile units' MovementGoal at the player's Capital. If a damaged Player building is within <see cref="HuntJob.TargetingRadius"/> hexes of the hostile's current hex, the nearest damaged building wins. If a BanditScout has reported additional Player buildings into <see cref="KnownPlayerHexesSingleton"/>, those land in the same scan with a wider <see cref="HuntJob.KnownTargetRadius"/> — lets raid bandits divert to outposts the scout uncovered, even when the player's structures are intact. GarrisonPost defenders + BanditHome laborers are excluded.</summary>
+    /// <summary>Points Hostile units' MovementGoal at the player's Capital. If a damaged Player building is within <see cref="HuntJob.TargetingRadius"/> hexes of the hostile's current hex, the nearest damaged building wins. If a BanditScout has reported additional Player buildings into <see cref="KnownPlayerHexesSingleton"/>, those land in the same scan with a wider <see cref="HuntJob.KnownTargetRadius"/> — lets raid bandits divert to outposts the scout uncovered, even when the player's structures are intact. GarrisonPost defenders + BanditHome laborers are excluded. Damaged-building prep scan jobified as a parallel IJobEntity into NativeList.ParallelWriter so the per-frame scan stays off the main thread at scale.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     public partial struct HuntBehaviorSystem : ISystem
     {
         const int TargetingRadius = 12;
 
+        EntityQuery _buildingQuery;
+
         [BurstCompile]
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<MovementGoal>();
+            _buildingQuery = SystemAPI.QueryBuilder().WithAll<Building, BuildingHealth>().Build();
         }
 
         public void OnDestroy(ref SystemState state) { }
@@ -25,13 +29,12 @@ namespace RareIcon
             if (!SystemAPI.TryGetSingletonEntity<CapitalTag>(out var capital)) return;
             int2 capitalHex = SystemAPI.GetComponent<Building>(capital).RootHex;
 
-            var damagedHexes = new NativeList<int2>(32, Allocator.TempJob);
-            foreach (var (b, hp) in SystemAPI.Query<RefRO<Building>, RefRO<BuildingHealth>>())
+            int buildingCap = _buildingQuery.CalculateEntityCount();
+            var damagedHexes = new NativeList<int2>(math.max(1, buildingCap), Allocator.TempJob);
+            var damagedHandle = new CollectDamagedHexesJob
             {
-                if (b.ValueRO.OwnerFaction != FactionType.Player) continue;
-                if (hp.ValueRO.Value >= hp.ValueRO.Max) continue;
-                damagedHexes.Add(b.ValueRO.RootHex);
-            }
+                Writer = damagedHexes.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
 
             var knownHexes = new NativeList<int2>(8, Allocator.TempJob);
             if (SystemAPI.TryGetSingletonEntity<KnownPlayerHexesSingleton>(out var knownEntity)
@@ -48,13 +51,26 @@ namespace RareIcon
                 KnownHexes        = knownHexes.AsDeferredJobArray(),
                 TargetingRadius   = TargetingRadius,
                 KnownTargetRadius = KnownTargetRadius,
-            }.ScheduleParallel(state.Dependency);
+            }.ScheduleParallel(JobHandle.CombineDependencies(damagedHandle, state.Dependency));
 
             state.Dependency = damagedHexes.Dispose(handle);
             state.Dependency = knownHexes  .Dispose(state.Dependency);
         }
 
         public const int KnownTargetRadius = 24;
+    }
+
+    [BurstCompile]
+    public partial struct CollectDamagedHexesJob : IJobEntity
+    {
+        public NativeList<int2>.ParallelWriter Writer;
+
+        void Execute(in Building b, in BuildingHealth hp)
+        {
+            if (b.OwnerFaction != FactionType.Player) return;
+            if (hp.Value >= hp.Max) return;
+            Writer.AddNoResize(b.RootHex);
+        }
     }
 
     [BurstCompile]

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/MoraleBuffExpirySystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/MoraleBuffExpirySystem.cs
@@ -3,7 +3,7 @@ using Unity.Entities;
 
 namespace RareIcon
 {
-    /// <summary>Strips <see cref="MoraleBuff"/> components once <see cref="WorldClock"/>.TurnIndex reaches the buff's <see cref="MoraleBuff.ExpiresAtTurn"/>. Cheap iteration — only buffed units are touched, and the work scales with active buff count, not with the unit pool size.</summary>
+    /// <summary>Strips <see cref="MoraleBuff"/> components once <see cref="WorldClock"/>.TurnIndex reaches the buff's <see cref="MoraleBuff.ExpiresAtTurn"/>. Parallel IJobEntity scans only buffed units; structural removals go through end-sim ECB ParallelWriter with [ChunkIndexInQuery] for deterministic playback order.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(SimulationSystemGroup))]
     public partial struct MoraleBuffExpirySystem : ISystem
@@ -16,18 +16,31 @@ namespace RareIcon
 
         [BurstCompile] public void OnDestroy(ref SystemState state) { }
 
+        [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
             uint turn = SystemAPI.GetSingleton<WorldClock>().TurnIndex;
             var ecb = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>()
                                .CreateCommandBuffer(state.WorldUnmanaged);
 
-            foreach (var (buff, entity) in
-                     SystemAPI.Query<RefRO<MoraleBuff>>().WithEntityAccess())
+            state.Dependency = new ExpireMoraleBuffJob
             {
-                if (turn >= buff.ValueRO.ExpiresAtTurn)
-                    ecb.RemoveComponent<MoraleBuff>(entity);
-            }
+                Turn = turn,
+                Ecb  = ecb.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
+        }
+    }
+
+    [BurstCompile]
+    public partial struct ExpireMoraleBuffJob : IJobEntity
+    {
+        public uint                                Turn;
+        public EntityCommandBuffer.ParallelWriter  Ecb;
+
+        void Execute([ChunkIndexInQuery] int chunkIndex, Entity entity, in MoraleBuff buff)
+        {
+            if (Turn >= buff.ExpiresAtTurn)
+                Ecb.RemoveComponent<MoraleBuff>(chunkIndex, entity);
         }
     }
 }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BarracksRestBonusSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BarracksRestBonusSystem.cs
@@ -1,10 +1,11 @@
 using Unity.Burst;
+using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Passive ambient heal applied to Player units in Eat or Sleep relief standing on a ProvidesHealing-tagged building's footprint. Ticks BonusHealPerSecond × dt into Health.Value up to Max — independent of Medkit consumption so a unit eating or sleeping at a Barracks still benefits after its RegenBuff expires. Runs after BarracksHealExecutor so Medkit-driven instant/regen happens first; this is the supplementary trickle.</summary>
+    /// <summary>Passive ambient heal applied to Player units in Eat or Sleep relief standing on a ProvidesHealing-tagged building's footprint. Ticks BonusHealPerSecond × dt into Health.Value up to Max — independent of Medkit consumption so a unit eating or sleeping at a Barracks still benefits after its RegenBuff expires. Runs after BarracksHealExecutor so Medkit-driven instant/regen happens first; this is the supplementary trickle. Parallel IJobEntity walks Player units in Eat/Sleep relief; HexLookup / HexOccupant / ProvidesHealing read-only across worker threads.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateAfter(typeof(BarracksHealExecutor))]
@@ -26,28 +27,41 @@ namespace RareIcon
             float dt = SystemAPI.Time.DeltaTime;
             if (dt <= 0f) return;
 
-            var hexLookup = SystemAPI.GetSingleton<HexDBSingleton>();
+            var hexDB = SystemAPI.GetSingleton<HexDBSingleton>();
 
-            var hexOccupantLookup   = SystemAPI.GetComponentLookup<HexOccupant>(true);
-            var providesHealLookup  = SystemAPI.GetComponentLookup<ProvidesHealing>(true);
-
-            foreach (var (intentRO, movementRO, healthRW, factionRO) in
-                     SystemAPI.Query<RefRO<ReliefIntent>, RefRO<UnitMovement>, RefRW<Health>, RefRO<Faction>>())
+            state.Dependency = new BarracksRestBonusJob
             {
-                if (factionRO.ValueRO.Value != FactionType.Player) continue;
-                byte kind = intentRO.ValueRO.Kind;
-                if (kind != ReliefKind.Eat && kind != ReliefKind.Sleep) continue;
+                Dt                  = dt,
+                BonusHealPerSecond  = BonusHealPerSecond,
+                HexLookup           = hexDB.Lookup,
+                HexOccupantLookup   = SystemAPI.GetComponentLookup<HexOccupant>(true),
+                ProvidesHealLookup  = SystemAPI.GetComponentLookup<ProvidesHealing>(true),
+            }.ScheduleParallel(state.Dependency);
+        }
+    }
 
-                ref var health = ref healthRW.ValueRW;
-                if (health.Value >= health.Max) continue;
+    [BurstCompile]
+    public partial struct BarracksRestBonusJob : IJobEntity
+    {
+        public float Dt;
+        public float BonusHealPerSecond;
+        [ReadOnly] public NativeHashMap<int2, Entity>     HexLookup;
+        [ReadOnly] public ComponentLookup<HexOccupant>    HexOccupantLookup;
+        [ReadOnly] public ComponentLookup<ProvidesHealing> ProvidesHealLookup;
 
-                if (!hexLookup.Lookup.TryGetValue(movementRO.ValueRO.CurrentHex, out var tile)) continue;
-                if (!hexOccupantLookup.HasComponent(tile)) continue;
-                var building = hexOccupantLookup[tile].Building;
-                if (!providesHealLookup.HasComponent(building)) continue;
+        void Execute(in ReliefIntent intent, in UnitMovement movement, ref Health health, in Faction faction)
+        {
+            if (faction.Value != FactionType.Player) return;
+            byte kind = intent.Kind;
+            if (kind != ReliefKind.Eat && kind != ReliefKind.Sleep) return;
+            if (health.Value >= health.Max) return;
 
-                health.Value = math.min(health.Max, health.Value + BonusHealPerSecond * dt);
-            }
+            if (!HexLookup.TryGetValue(movement.CurrentHex, out var tile)) return;
+            if (!HexOccupantLookup.HasComponent(tile)) return;
+            var building = HexOccupantLookup[tile].Building;
+            if (!ProvidesHealLookup.HasComponent(building)) return;
+
+            health.Value = math.min(health.Max, health.Value + BonusHealPerSecond * Dt);
         }
     }
 }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/RegenBuffSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/RegenBuffSystem.cs
@@ -4,7 +4,7 @@ using Unity.Mathematics;
 
 namespace RareIcon
 {
-    /// <summary>Ticks active RegenBuff components: restores Health.Value by AmountPerSecond * dt each frame, clamps at Health.Max, removes the component via the end-sim ECB when TimeRemaining ≤ 0. Runs in BehaviorSystemGroup after ReliefSystem so consumption-side systems (Medkit, food-at-Barracks) have already added/refreshed the buff this frame.</summary>
+    /// <summary>Ticks active RegenBuff components: restores Health.Value by AmountPerSecond * dt each frame, clamps at Health.Max, removes the component via the end-sim ECB ParallelWriter when TimeRemaining ≤ 0. Runs in BehaviorSystemGroup after ReliefSystem so consumption-side systems (Medkit, food-at-Barracks) have already added/refreshed the buff this frame. Parallel IJobEntity replaces the prior main-thread foreach.</summary>
     [BurstCompile]
     [UpdateInGroup(typeof(BehaviorSystemGroup))]
     [UpdateAfter(typeof(ReliefSystem))]
@@ -26,18 +26,27 @@ namespace RareIcon
             var ecb = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>()
                 .CreateCommandBuffer(state.WorldUnmanaged);
 
-            foreach (var (buffRW, healthRW, entity) in
-                     SystemAPI.Query<RefRW<RegenBuff>, RefRW<Health>>().WithEntityAccess())
+            state.Dependency = new RegenBuffTickJob
             {
-                ref var buff   = ref buffRW.ValueRW;
-                ref var health = ref healthRW.ValueRW;
+                Dt  = dt,
+                Ecb = ecb.AsParallelWriter(),
+            }.ScheduleParallel(state.Dependency);
+        }
+    }
 
-                buff.TimeRemaining -= dt;
-                health.Value = math.min(health.Max, health.Value + buff.AmountPerSecond * dt);
+    [BurstCompile]
+    public partial struct RegenBuffTickJob : IJobEntity
+    {
+        public float                                  Dt;
+        public EntityCommandBuffer.ParallelWriter     Ecb;
 
-                if (buff.TimeRemaining <= 0f)
-                    ecb.RemoveComponent<RegenBuff>(entity);
-            }
+        void Execute([ChunkIndexInQuery] int chunkIndex, Entity entity, ref RegenBuff buff, ref Health health)
+        {
+            buff.TimeRemaining -= Dt;
+            health.Value = math.min(health.Max, health.Value + buff.AmountPerSecond * Dt);
+
+            if (buff.TimeRemaining <= 0f)
+                Ecb.RemoveComponent<RegenBuff>(chunkIndex, entity);
         }
     }
 }


### PR DESCRIPTION
Continues the per-system parallelization arc (#11743 / #11751 / #11758 / #11858 / #11861 / #11890 / #11905). Four small per-frame systems converted to parallel `IJobEntity` passes.

## RegenBuffSystem

Was: main-thread foreach over `RegenBuff + Health`, decrementing `TimeRemaining`, clamping `Health.Value`, `ecb.RemoveComponent` on expiry.

Now: `RegenBuffTickJob : IJobEntity ScheduleParallel`. `[ChunkIndexInQuery]` sortKey for deterministic ECB playback on the expiry path.

## MoraleBuffExpirySystem

Was: main-thread foreach over `MoraleBuff`, checking `turn >= ExpiresAtTurn`, `ecb.RemoveComponent` on expiry.

Now: `ExpireMoraleBuffJob : IJobEntity ScheduleParallel`. Same `[ChunkIndexInQuery]` pattern. Buff entity count is small at any given turn but the system runs every tick.

## BarracksRestBonusSystem

Was: main-thread foreach over `(ReliefIntent, UnitMovement, Health, Faction)` filtering Player + `Eat`/`Sleep` relief, checking the current hex's `HexOccupant` building for `ProvidesHealing`, ticking `Health.Value` by `BonusHealPerSecond * dt`.

Now: `BarracksRestBonusJob : IJobEntity ScheduleParallel`. `HexLookup` (NativeHashMap) + `HexOccupantLookup` + `ProvidesHealingLookup` all `[ReadOnly]` across worker threads. Same Player-only, Eat/Sleep-only, ProvidesHealing-gated heal trickle.

## HuntBehaviorSystem

`HuntJob` already `IJobEntity` parallel — the per-frame stutter source was the main-thread damaged-Player-buildings prep scan ahead of it.

Add `CollectDamagedHexesJob : IJobEntity ScheduleParallel` into `NativeList<int2>.ParallelWriter`. Capacity pre-grown to the building-count upper bound via cached `EntityQuery.CalculateEntityCount()`. `knownHexes` buffer copy stays main-thread (small, singleton). `HuntJob` now depends on the prep handle so the damaged scan and the per-hostile scoring overlap.

## Behaviour preserved

- Same heal formulas (`BonusHealPerSecond = 1.5`, `RegenBuff AmountPerSecond * dt`).
- Same `MoraleBuff` turn-threshold expiry semantics.
- Same Player + Eat/Sleep + ProvidesHealing gating in Barracks rest bonus.
- Same damaged-building filter (`OwnerFaction == Player && Value < Max`) in `HuntBehaviorSystem`.

## Test plan

- [ ] Burst compiles `RegenBuffTickJob` + `ExpireMoraleBuffJob` + `BarracksRestBonusJob` + `CollectDamagedHexesJob` clean.
- [ ] No safety errors with `ENABLE_UNITY_COLLECTIONS_CHECKS` on the `[ChunkIndexInQuery]` + parallel ECB writer flows.
- [ ] Regen buff still ticks Health up and expires on TimeRemaining ≤ 0.
- [ ] Morale buffs removed exactly once when turn ≥ ExpiresAtTurn.
- [ ] Player unit eating/sleeping on a Barracks footprint still gets the 1.5 hp/s trickle; non-Player or non-relief units do not.
- [ ] Hostile units still target the closest damaged Player building within radius, fall back to Capital otherwise.