### PR TITLE
fix(ci): install Playwright via cdn→azureedge→mcr-image fallback ladder

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -236,18 +236,49 @@ jobs:
               env:
                   UV_THREADPOOL_SIZE: '16'
                   MISSING: ${{ steps.baked-playwright.outputs.missing || steps.detect-playwright.outputs.browsers }}
+                  PW_VERSION: ${{ steps.playwright-version.outputs.version }}
               run: |
-                  set -euo pipefail
-                  for try in 1 2 3; do
-                    if pnpm exec playwright install --with-deps ${MISSING}; then
-                      echo "playwright install succeeded on attempt ${try}"
-                      exit 0
-                    fi
-                    echo "::warning::playwright install attempt ${try} failed; retrying in 15s"
-                    sleep 15
-                  done
-                  echo "::error::playwright install failed after 3 attempts"
-                  exit 1
+                  set -uo pipefail
+                  attempt_install() {
+                    local label="$1"
+                    echo "::group::playwright install via ${label}"
+                    timeout 600 pnpm exec playwright install --with-deps ${MISSING}
+                    local rc=$?
+                    echo "::endgroup::"
+                    return $rc
+                  }
+
+                  attempt_install "default cdn (try 1)" && exit 0
+                  echo "::warning::default cdn try 1 failed; retrying"
+                  sleep 10
+                  attempt_install "default cdn (try 2)" && exit 0
+                  echo "::warning::default cdn exhausted; trying azure edge mirror"
+
+                  export PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000
+                  export PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net
+                  attempt_install "azureedge (try 1)" && exit 0
+                  echo "::warning::azureedge try 1 failed; retrying"
+                  sleep 10
+                  attempt_install "azureedge (try 2)" && exit 0
+                  echo "::warning::azureedge exhausted; falling back to mcr playwright image"
+
+                  unset PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT
+                  unset PLAYWRIGHT_DOWNLOAD_HOST
+                  IMG="mcr.microsoft.com/playwright:v${PW_VERSION}-jammy"
+                  DEST="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+                  mkdir -p "$DEST"
+                  echo "::group::pull ${IMG}"
+                  if ! docker pull "$IMG"; then
+                    echo "::error::docker pull ${IMG} failed"
+                    echo "::endgroup::"
+                    exit 1
+                  fi
+                  echo "::endgroup::"
+                  CID=$(docker create "$IMG")
+                  docker cp "$CID:/ms-playwright/." "$DEST/"
+                  docker rm "$CID" >/dev/null
+                  pnpm exec playwright install-deps ${MISSING}
+                  echo "playwright browsers restored from ${IMG} into ${DEST}"
 
             - name: Install Playwright OS deps (cache hit)
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.baked-playwright.outputs.all_present != 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}


### PR DESCRIPTION
## Summary
Cache step (route A) already runs first. This patches the install step itself to degrade across three download paths instead of dying when \`cdn.playwright.dev\` stalls. Aimed at the github-hosted \`ubuntu-latest\` e2es that don't get the arc-runner-set browser bake.

## The ladder

| Route | Step | Source |
|---|---|---|
| A | \`Cache Playwright browsers\` | actions/cache@v5 |
| B1 / B2 | \`Install Playwright Browsers\` first two tries | \`pnpm exec playwright install --with-deps ...\` against default \`cdn.playwright.dev\` |
| C1 / C2 | Same step, next two tries | \`PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net\` + \`PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000\` |
| D | Last attempt | \`docker pull mcr.microsoft.com/playwright:v\${VER}-jammy\` + \`docker cp /ms-playwright/. \${PLAYWRIGHT_BROWSERS_PATH:-~/.cache/ms-playwright}/\` + \`playwright install-deps\` |

D is the always-reliable backstop — Microsoft's image is pre-built and Docker Hub's CDN doesn't share fate with \`cdn.playwright.dev\`. On \`ubuntu-latest\` the pull is ~30s and lands the browsers fully extracted at the cache path that the next run's \`actions/cache@v5\` then captures, so the next run hits route A.

Every B / C attempt is wrapped in \`timeout 600\` so a stalled TCP session can't burn the whole 40-minute step on one wedge — once 600s elapses the function returns non-zero and the ladder moves on.

## Why not route D first
B / C are cheaper when they work (no docker pull). D is the safety net.

## Test plan
- [ ] CI - Docker / irc-gateway green on this PR
- [ ] When CDN is healthy, install completes on B1 (logs show "default cdn (try 1)")
- [ ] Force a degraded run (cancel B1 partway, retry) → ladder progresses to C / D