### PR TITLE
fix(ci-unreal): robust egress check + resumable downloads (-C -)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1531,12 +1531,14 @@ jobs:
 
             - name: Check internet egress
               run: |
-                  $code = curl.exe -sS -o NUL -L -m 60 --connect-timeout 30 -w "%{http_code}" "https://dot.net/v1/dotnet-install.ps1" 2>&1
-                  Write-Host "egress probe (dot.net script) -> HTTP $code"
-                  $dl = curl.exe -sS -L -m 120 --connect-timeout 30 -o C:\egress-test.bin "https://aka.ms/vs/17/release/vs_BuildTools.exe" 2>&1
-                  if ($dl) { Write-Host "download stderr: $dl" }
+                  $ErrorActionPreference = 'SilentlyContinue'
+                  $code = curl.exe -s -o NUL -L -m 60 --connect-timeout 30 -w "%{http_code}" "https://dot.net/v1/dotnet-install.ps1"
+                  Write-Host "egress probe (dot.net) -> HTTP $code"
+                  Remove-Item C:\egress-test.bin -ErrorAction SilentlyContinue
+                  curl.exe -s -L --retry 5 --retry-all-errors -C - -m 300 --connect-timeout 30 -o C:\egress-test.bin "https://aka.ms/vs/17/release/vs_BuildTools.exe"
+                  $rc = $LASTEXITCODE
                   $sz = (Get-Item C:\egress-test.bin -ErrorAction SilentlyContinue).Length
-                  Write-Host "test download size: $sz bytes (curl exit $LASTEXITCODE)"
+                  Write-Host "VS bootstrapper test download: curl exit=$rc size=$sz bytes"
                   exit 0
 
             - name: Install Visual Studio 2022 Build Tools
@@ -1544,7 +1546,7 @@ jobs:
               run: |
                   if (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC") { Write-Host "VS Build Tools already installed."; exit 0 }
                   Write-Host "Downloading VS Build Tools bootstrapper from aka.ms ..."
-                  curl.exe -L -sS --retry 5 --retry-connrefused --connect-timeout 30 -o C:\vs_buildtools.exe "https://aka.ms/vs/17/release/vs_BuildTools.exe"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\vs_buildtools.exe "https://aka.ms/vs/17/release/vs_BuildTools.exe"
                   if (!(Test-Path C:\vs_buildtools.exe)) { Write-Host "::warning::VS bootstrapper download failed."; exit 0 }
                   $p = Start-Process C:\vs_buildtools.exe -ArgumentList @(
                       '--add','Microsoft.VisualStudio.Workload.VCTools',
@@ -1559,7 +1561,7 @@ jobs:
             - name: Install Python 3
               run: |
                   if (Get-Command python -ErrorAction SilentlyContinue) { Write-Host "Python already installed: $(python --version)"; exit 0 }
-                  curl.exe -L -sS --retry 5 --retry-connrefused --connect-timeout 30 -o C:\python-install.exe "https://www.python.org/ftp/python/3.12.7/python-3.12.7-amd64.exe"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\python-install.exe "https://www.python.org/ftp/python/3.12.7/python-3.12.7-amd64.exe"
                   if (!(Test-Path C:\python-install.exe)) { Write-Host "::warning::Python download failed."; exit 0 }
                   Start-Process C:\python-install.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
                   exit 0
@@ -1567,7 +1569,7 @@ jobs:
             - name: Install .NET SDK 8.0
               run: |
                   if (Get-Command dotnet -ErrorAction SilentlyContinue) { Write-Host ".NET already installed: $(dotnet --version)"; exit 0 }
-                  curl.exe -L -sS --retry 5 --retry-connrefused --connect-timeout 30 -o C:\dotnet-install.ps1 "https://dot.net/v1/dotnet-install.ps1"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\dotnet-install.ps1 "https://dot.net/v1/dotnet-install.ps1"
                   if (!(Test-Path C:\dotnet-install.ps1)) { Write-Host "::warning::dotnet-install.ps1 download failed."; exit 0 }
                   & C:\dotnet-install.ps1 -Channel 8.0 -InstallDir "C:\Program Files\dotnet"
                   if (Test-Path "C:\Program Files\dotnet\dotnet.exe") {
@@ -1582,7 +1584,7 @@ jobs:
             - name: Install DirectX Runtime
               run: |
                   if (Test-Path "$env:SystemRoot\System32\d3dx9_43.dll") { Write-Host "DirectX runtime already present."; exit 0 }
-                  curl.exe -L -sS --retry 5 --retry-connrefused --connect-timeout 30 -o C:\dxredist.exe "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\dxredist.exe "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe"
                   if (!(Test-Path C:\dxredist.exe)) { Write-Host "::warning::DirectX redist download failed."; exit 0 }
                   Start-Process C:\dxredist.exe -ArgumentList '/Q','/T:C:\dxredist' -Wait
                   if (Test-Path C:\dxredist\DXSETUP.exe) { Start-Process C:\dxredist\DXSETUP.exe -ArgumentList '/silent' -Wait }
@@ -1591,7 +1593,7 @@ jobs:
             - name: Install CMake
               run: |
                   if (Get-Command cmake -ErrorAction SilentlyContinue) { Write-Host "CMake already installed: $(cmake --version | Select-Object -First 1)"; exit 0 }
-                  curl.exe -L -sS --retry 5 --retry-connrefused --connect-timeout 30 -o C:\cmake-install.msi "https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-windows-x86_64.msi"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\cmake-install.msi "https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-windows-x86_64.msi"
                   if (!(Test-Path C:\cmake-install.msi)) { Write-Host "::warning::CMake download failed."; exit 0 }
                   Start-Process msiexec.exe -ArgumentList '/i','C:\cmake-install.msi','/quiet','/norestart','ADD_CMAKE_TO_PATH=System' -Wait
                   exit 0
@@ -1600,7 +1602,7 @@ jobs:
               run: |
                   git lfs version 2>$null
                   if ($LASTEXITCODE -eq 0) { git lfs install; Write-Host "Git LFS already installed: $(git lfs version)"; exit 0 }
-                  curl.exe -L -sS --retry 5 --retry-connrefused --connect-timeout 30 -o C:\git-lfs.exe "https://github.com/git-lfs/git-lfs/releases/download/v3.7.1/git-lfs-windows-amd64-v3.7.1.exe"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\git-lfs.exe "https://github.com/git-lfs/git-lfs/releases/download/v3.7.1/git-lfs-windows-amd64-v3.7.1.exe"
                   if (!(Test-Path C:\git-lfs.exe)) { Write-Host "::warning::Git LFS download failed."; exit 0 }
                   Start-Process C:\git-lfs.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait
                   git lfs install
@@ -1609,7 +1611,7 @@ jobs:
             - name: Install PowerShell 7
               run: |
                   if (Get-Command pwsh -ErrorAction SilentlyContinue) { Write-Host "pwsh already installed: $(pwsh --version)"; exit 0 }
-                  curl.exe -L -sS --retry 5 --retry-connrefused --connect-timeout 30 -o C:\pwsh.msi "https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\pwsh.msi "https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi"
                   if (!(Test-Path C:\pwsh.msi)) { Write-Host "::warning::pwsh MSI download failed."; exit 0 }
                   Start-Process msiexec.exe -ArgumentList '/i','C:\pwsh.msi','/quiet','/norestart','ADD_PATH=1' -Wait
                   Write-Host "PowerShell 7 installed."


### PR DESCRIPTION
The egress diagnostic crashed on 2>&1 (curl stderr -> ErrorActionPreference=Stop -> step terminated -> installs skipped), masking whether MTU=1400 fixed downloads. Remove 2>&1, relax ErrorActionPreference, report test-download byte size. Install curls back to silent -s + resumable -C - --retry-all-errors to survive masquerade drops.