### PR TITLE
fix(ci-unreal): win-setup downloads to RUNNER_TEMP (C:\ root write denied)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1532,12 +1532,15 @@ jobs:
             - name: Check internet egress
               run: |
                   $ErrorActionPreference = 'SilentlyContinue'
+                  $admin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+                  Write-Host "runner elevated (admin): $admin ; user: $([Security.Principal.WindowsIdentity]::GetCurrent().Name)"
+                  Write-Host "RUNNER_TEMP: $env:RUNNER_TEMP"
                   $code = curl.exe -s -o NUL -L -m 60 --connect-timeout 30 -w "%{http_code}" "https://dot.net/v1/dotnet-install.ps1"
                   Write-Host "egress probe (dot.net) -> HTTP $code"
-                  Remove-Item C:\egress-test.bin -ErrorAction SilentlyContinue
-                  curl.exe -s -L --retry 5 --retry-all-errors -C - -m 300 --connect-timeout 30 -o C:\egress-test.bin "https://aka.ms/vs/17/release/vs_BuildTools.exe"
+                  Remove-Item $env:RUNNER_TEMP\egress-test.bin -ErrorAction SilentlyContinue
+                  curl.exe -s -L --retry 5 --retry-all-errors -C - -m 300 --connect-timeout 30 -o $env:RUNNER_TEMP\egress-test.bin "https://aka.ms/vs/17/release/vs_BuildTools.exe"
                   $rc = $LASTEXITCODE
-                  $sz = (Get-Item C:\egress-test.bin -ErrorAction SilentlyContinue).Length
+                  $sz = (Get-Item $env:RUNNER_TEMP\egress-test.bin -ErrorAction SilentlyContinue).Length
                   Write-Host "VS bootstrapper test download: curl exit=$rc size=$sz bytes"
                   exit 0
 
@@ -1546,9 +1549,9 @@ jobs:
               run: |
                   if (Test-Path "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC") { Write-Host "VS Build Tools already installed."; exit 0 }
                   Write-Host "Downloading VS Build Tools bootstrapper from aka.ms ..."
-                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\vs_buildtools.exe "https://aka.ms/vs/17/release/vs_BuildTools.exe"
-                  if (!(Test-Path C:\vs_buildtools.exe)) { Write-Host "::warning::VS bootstrapper download failed."; exit 0 }
-                  $p = Start-Process C:\vs_buildtools.exe -ArgumentList @(
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\vs_buildtools.exe "https://aka.ms/vs/17/release/vs_BuildTools.exe"
+                  if (!(Test-Path $env:RUNNER_TEMP\vs_buildtools.exe)) { Write-Host "::warning::VS bootstrapper download failed."; exit 0 }
+                  $p = Start-Process $env:RUNNER_TEMP\vs_buildtools.exe -ArgumentList @(
                       '--add','Microsoft.VisualStudio.Workload.VCTools',
                       '--add','Microsoft.VisualStudio.Component.VC.Tools.x86.x64',
                       '--add','Microsoft.VisualStudio.Component.Windows11SDK.26100',
@@ -1561,17 +1564,17 @@ jobs:
             - name: Install Python 3
               run: |
                   if (Get-Command python -ErrorAction SilentlyContinue) { Write-Host "Python already installed: $(python --version)"; exit 0 }
-                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\python-install.exe "https://www.python.org/ftp/python/3.12.7/python-3.12.7-amd64.exe"
-                  if (!(Test-Path C:\python-install.exe)) { Write-Host "::warning::Python download failed."; exit 0 }
-                  Start-Process C:\python-install.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\python-install.exe "https://www.python.org/ftp/python/3.12.7/python-3.12.7-amd64.exe"
+                  if (!(Test-Path $env:RUNNER_TEMP\python-install.exe)) { Write-Host "::warning::Python download failed."; exit 0 }
+                  Start-Process $env:RUNNER_TEMP\python-install.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
                   exit 0
 
             - name: Install .NET SDK 8.0
               run: |
                   if (Get-Command dotnet -ErrorAction SilentlyContinue) { Write-Host ".NET already installed: $(dotnet --version)"; exit 0 }
-                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\dotnet-install.ps1 "https://dot.net/v1/dotnet-install.ps1"
-                  if (!(Test-Path C:\dotnet-install.ps1)) { Write-Host "::warning::dotnet-install.ps1 download failed."; exit 0 }
-                  & C:\dotnet-install.ps1 -Channel 8.0 -InstallDir "C:\Program Files\dotnet"
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\dotnet-install.ps1 "https://dot.net/v1/dotnet-install.ps1"
+                  if (!(Test-Path $env:RUNNER_TEMP\dotnet-install.ps1)) { Write-Host "::warning::dotnet-install.ps1 download failed."; exit 0 }
+                  & $env:RUNNER_TEMP\dotnet-install.ps1 -Channel 8.0 -InstallDir "C:\Program Files\dotnet"
                   if (Test-Path "C:\Program Files\dotnet\dotnet.exe") {
                       $machinePath = [Environment]::GetEnvironmentVariable("Path","Machine")
                       if ($machinePath -notlike "*C:\Program Files\dotnet*") {
@@ -1584,36 +1587,36 @@ jobs:
             - name: Install DirectX Runtime
               run: |
                   if (Test-Path "$env:SystemRoot\System32\d3dx9_43.dll") { Write-Host "DirectX runtime already present."; exit 0 }
-                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\dxredist.exe "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe"
-                  if (!(Test-Path C:\dxredist.exe)) { Write-Host "::warning::DirectX redist download failed."; exit 0 }
-                  Start-Process C:\dxredist.exe -ArgumentList '/Q','/T:C:\dxredist' -Wait
-                  if (Test-Path C:\dxredist\DXSETUP.exe) { Start-Process C:\dxredist\DXSETUP.exe -ArgumentList '/silent' -Wait }
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\dxredist.exe "https://download.microsoft.com/download/8/4/A/84A35BF1-DAFE-4AE8-82AF-AD2AE20B6B14/directx_Jun2010_redist.exe"
+                  if (!(Test-Path $env:RUNNER_TEMP\dxredist.exe)) { Write-Host "::warning::DirectX redist download failed."; exit 0 }
+                  Start-Process $env:RUNNER_TEMP\dxredist.exe -ArgumentList '/Q','/T:$env:RUNNER_TEMP\dxredist' -Wait
+                  if (Test-Path $env:RUNNER_TEMP\dxredist\DXSETUP.exe) { Start-Process $env:RUNNER_TEMP\dxredist\DXSETUP.exe -ArgumentList '/silent' -Wait }
                   exit 0
 
             - name: Install CMake
               run: |
                   if (Get-Command cmake -ErrorAction SilentlyContinue) { Write-Host "CMake already installed: $(cmake --version | Select-Object -First 1)"; exit 0 }
-                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\cmake-install.msi "https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-windows-x86_64.msi"
-                  if (!(Test-Path C:\cmake-install.msi)) { Write-Host "::warning::CMake download failed."; exit 0 }
-                  Start-Process msiexec.exe -ArgumentList '/i','C:\cmake-install.msi','/quiet','/norestart','ADD_CMAKE_TO_PATH=System' -Wait
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\cmake-install.msi "https://github.com/Kitware/CMake/releases/download/v3.30.5/cmake-3.30.5-windows-x86_64.msi"
+                  if (!(Test-Path $env:RUNNER_TEMP\cmake-install.msi)) { Write-Host "::warning::CMake download failed."; exit 0 }
+                  Start-Process msiexec.exe -ArgumentList '/i','$env:RUNNER_TEMP\cmake-install.msi','/quiet','/norestart','ADD_CMAKE_TO_PATH=System' -Wait
                   exit 0
 
             - name: Install Git LFS
               run: |
                   git lfs version 2>$null
                   if ($LASTEXITCODE -eq 0) { git lfs install; Write-Host "Git LFS already installed: $(git lfs version)"; exit 0 }
-                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\git-lfs.exe "https://github.com/git-lfs/git-lfs/releases/download/v3.7.1/git-lfs-windows-amd64-v3.7.1.exe"
-                  if (!(Test-Path C:\git-lfs.exe)) { Write-Host "::warning::Git LFS download failed."; exit 0 }
-                  Start-Process C:\git-lfs.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\git-lfs.exe "https://github.com/git-lfs/git-lfs/releases/download/v3.7.1/git-lfs-windows-amd64-v3.7.1.exe"
+                  if (!(Test-Path $env:RUNNER_TEMP\git-lfs.exe)) { Write-Host "::warning::Git LFS download failed."; exit 0 }
+                  Start-Process $env:RUNNER_TEMP\git-lfs.exe -ArgumentList '/VERYSILENT','/NORESTART' -Wait
                   git lfs install
                   exit 0
 
             - name: Install PowerShell 7
               run: |
                   if (Get-Command pwsh -ErrorAction SilentlyContinue) { Write-Host "pwsh already installed: $(pwsh --version)"; exit 0 }
-                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o C:\pwsh.msi "https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi"
-                  if (!(Test-Path C:\pwsh.msi)) { Write-Host "::warning::pwsh MSI download failed."; exit 0 }
-                  Start-Process msiexec.exe -ArgumentList '/i','C:\pwsh.msi','/quiet','/norestart','ADD_PATH=1' -Wait
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\pwsh.msi "https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/PowerShell-7.4.6-win-x64.msi"
+                  if (!(Test-Path $env:RUNNER_TEMP\pwsh.msi)) { Write-Host "::warning::pwsh MSI download failed."; exit 0 }
+                  Start-Process msiexec.exe -ArgumentList '/i','$env:RUNNER_TEMP\pwsh.msi','/quiet','/norestart','ADD_PATH=1' -Wait
                   Write-Host "PowerShell 7 installed."
                   exit 0
 


### PR DESCRIPTION
Root cause of the download failures: curl exit 23 / 0 bytes = write-permission denial on C:\ root, not a network/MTU issue (disk 96GB free, egress HTTP 200). Download all installers into $env:RUNNER_TEMP. Also log runner elevation, since VS/.NET install to Program Files needs admin.