### PR TITLE
fix(rareicon): inline FogCull ClassifyHex to dodge Burst BC1064

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/FogCullSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/FogCullSystem.cs
@@ -65,27 +65,6 @@ namespace RareIcon
             state.Dependency = JobHandle.CombineDependencies(unitHandle, buildingHandle);
         }
 
-        [BurstCompile]
-        public static void ClassifyHex(
-            int2 hex,
-            int  sortKey,
-            Entity entity,
-            in NativeHashMap<int2, Entity>      hexLookup,
-            in ComponentLookup<FogVisibility>   fogLookup,
-            in ComponentLookup<DisableRendering> disabledLookup,
-            ref EntityCommandBuffer.ParallelWriter ecb)
-        {
-            bool fogged = false;
-            if (hexLookup.TryGetValue(hex, out var hexEntity)
-                && fogLookup.HasComponent(hexEntity))
-            {
-                fogged = fogLookup[hexEntity].Value > 0.5f;
-            }
-
-            bool currentlyDisabled = disabledLookup.HasComponent(entity);
-            if (fogged && !currentlyDisabled)       ecb.AddComponent<DisableRendering>(sortKey, entity);
-            else if (!fogged && currentlyDisabled)  ecb.RemoveComponent<DisableRendering>(sortKey, entity);
-        }
     }
 
     [BurstCompile]
@@ -101,7 +80,17 @@ namespace RareIcon
         {
             if (f.Value == FactionType.Player) return;
             int2 hex = HexMeshUtil.WorldToHex(t.Position.x, t.Position.y, 0.25f);
-            FogCullSystem.ClassifyHex(hex, chunkIndex, entity, HexLookup, FogLookup, DisabledLookup, ref Ecb);
+
+            bool fogged = false;
+            if (HexLookup.TryGetValue(hex, out var hexEntity)
+                && FogLookup.HasComponent(hexEntity))
+            {
+                fogged = FogLookup[hexEntity].Value > 0.5f;
+            }
+
+            bool currentlyDisabled = DisabledLookup.HasComponent(entity);
+            if (fogged && !currentlyDisabled)      Ecb.AddComponent<DisableRendering>(chunkIndex, entity);
+            else if (!fogged && currentlyDisabled) Ecb.RemoveComponent<DisableRendering>(chunkIndex, entity);
         }
     }
 
@@ -116,7 +105,18 @@ namespace RareIcon
         void Execute([ChunkIndexInQuery] int chunkIndex, Entity entity, in Building b)
         {
             if (b.OwnerFaction == FactionType.Player) return;
-            FogCullSystem.ClassifyHex(b.RootHex, chunkIndex, entity, HexLookup, FogLookup, DisabledLookup, ref Ecb);
+            int2 hex = b.RootHex;
+
+            bool fogged = false;
+            if (HexLookup.TryGetValue(hex, out var hexEntity)
+                && FogLookup.HasComponent(hexEntity))
+            {
+                fogged = FogLookup[hexEntity].Value > 0.5f;
+            }
+
+            bool currentlyDisabled = DisabledLookup.HasComponent(entity);
+            if (fogged && !currentlyDisabled)      Ecb.AddComponent<DisableRendering>(chunkIndex, entity);
+            else if (!fogged && currentlyDisabled) Ecb.RemoveComponent<DisableRendering>(chunkIndex, entity);
         }
     }
 }


### PR DESCRIPTION
Burst rejected the shared `FogCullSystem.ClassifyHex` static helper introduced in #11861:

```
Burst error BC1064: Unsupported parameter `Unity.Mathematics.int2` `hex`
in function `RareIcon.FogCullSystem.ClassifyHex(Unity.Mathematics.int2 hex,
int sortKey, Unity.Entities.Entity entity, …)`: structs cannot be passed
to or returned from external functions in burst. To fix this issue,
use a reference or pointer.
```

Cross-function struct-by-value calls inside a `[BurstCompile] IJobEntity` hit this even when the callee is also `[BurstCompile] static` — Burst treats the boundary as external. The helper took `int2 hex` + `Entity entity` by value, which is what tripped the error.

## Fix

Inline the ~10-line classification body into each of `ClassifyFogUnitsJob.Execute` and `ClassifyFogBuildingsJob.Execute` so the work stays inside one Burst compilation unit. Drops the static helper entirely; behaviour is byte-identical to the helper version.

```csharp
// inside ClassifyFogUnitsJob.Execute
int2 hex = HexMeshUtil.WorldToHex(t.Position.x, t.Position.y, 0.25f);
bool fogged = false;
if (HexLookup.TryGetValue(hex, out var hexEntity) && FogLookup.HasComponent(hexEntity))
    fogged = FogLookup[hexEntity].Value > 0.5f;
bool currentlyDisabled = DisabledLookup.HasComponent(entity);
if (fogged && !currentlyDisabled)      Ecb.AddComponent<DisableRendering>(chunkIndex, entity);
else if (!fogged && currentlyDisabled) Ecb.RemoveComponent<DisableRendering>(chunkIndex, entity);
```

Same body inside `ClassifyFogBuildingsJob.Execute` — only difference is `hex = b.RootHex` instead of the world→hex conversion.

## Test plan

- [ ] Burst compiles `ClassifyFogUnitsJob` + `ClassifyFogBuildingsJob` without BC1064.
- [ ] Fog reveal / hide still flips `DisableRendering` correctly on Player advance / retreat.
- [ ] No regression vs the pre-#11861 main-thread `SystemBase` behaviour.

## Alternative considered

Switching the helper signature to `in int2 hex` + `in Entity entity` would also work in current Burst, but the `in` ref-readonly contract for blittable structs has historically been brittle across Unity / Burst versions. Inlining is the safer fix.