### PR TITLE
feat(kubevirt): ArgoCD-managed runner lifecycle + activity-aware VM shutdown

### DIFF
--- a/apps/kube/kubevirt/keda/scaled-jobs.yaml
+++ b/apps/kube/kubevirt/keda/scaled-jobs.yaml
@@ -1,15 +1,16 @@
 # KEDA ScaledJobs for KubeVirt VM lifecycle.
 #
 # Scale UP: removed — VMs are now started via workflow_dispatch from CI.
-# Scale DOWN: cron trigger (every hour) → stop VM if idle + no sessions.
-#
-# The github-runner trigger was removed to eliminate GitHub API rate limit
-# pressure. CI workflows dispatch VM starts directly instead.
+# Scale DOWN: cron trigger fires the idle check; the check only stops the VM
+# when the runner is actually idle. The cron is just the check cadence, NOT a
+# hard timer — an active runner is never stopped.
 ---
 # ──────────────────────────────────────────────────────────────
-# SCALE DOWN — KEDA cron-triggered idle shutdown
-# Runs every hour, checks: age > 30min + no active sessions
-# GitHub API check removed — VMs are stopped based on age + connections only.
+# SCALE DOWN — KEDA cron-triggered idle check (activity-aware)
+# The idle-shutdown script stops the VM only when ALL hold:
+#   age > 30min, no queued/in-progress GitHub jobs for the runner label
+#   (GITHUB_TOKEN below re-enables this check), no VNC/RDP sessions.
+# A few GitHub API calls per check window — negligible rate-limit cost.
 # ──────────────────────────────────────────────────────────────
 
 # Windows VM shutdown
@@ -41,6 +42,13 @@ spec:
                             value: angelscript
                           - name: IDLE_THRESHOLD_MINUTES
                             value: '30'
+                          - name: GITHUB_ORG
+                            value: KBVE
+                          - name: GITHUB_TOKEN
+                            valueFrom:
+                                secretKeyRef:
+                                    name: github-arc-token
+                                    key: github_token
                       volumeMounts:
                           - name: script
                             mountPath: /scripts
@@ -91,6 +99,13 @@ spec:
                             value: angelscript
                           - name: IDLE_THRESHOLD_MINUTES
                             value: '30'
+                          - name: GITHUB_ORG
+                            value: KBVE
+                          - name: GITHUB_TOKEN
+                            valueFrom:
+                                secretKeyRef:
+                                    name: github-arc-token
+                                    key: github_token
                       volumeMounts:
                           - name: script
                             mountPath: /scripts

--- a/apps/kube/kubevirt/runner-application.yaml
+++ b/apps/kube/kubevirt/runner-application.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: kubevirt-runner
+    namespace: argocd
+    annotations:
+        argocd.argoproj.io/sync-wave: '4'
+    finalizers:
+        - resources-finalizer.argocd.argoproj.io
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: main
+        path: apps/kube/kubevirt/runner
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: angelscript
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: false
+        syncOptions:
+            - CreateNamespace=true
+            - ServerSideApply=true
+        retry:
+            limit: 3
+            backoff:
+                duration: 30s
+                factor: 2
+                maxDuration: 10m
+    revisionHistoryLimit: 3

--- a/apps/kube/kubevirt/runner/configmap.yaml
+++ b/apps/kube/kubevirt/runner/configmap.yaml
@@ -1,15 +1,21 @@
-# ConfigMap with the GitHub Actions runner install/update script.
+# ConfigMap with the GitHub Actions runner install/heal script.
 #
-# Orchestrates the full runner lifecycle via the QEMU Guest Agent:
-#   1. Scales up the file-server pod
-#   2. Downloads the runner package to the file-server
-#   3. Obtains a registration token from the GitHub API
-#   4. Executes PowerShell inside the Windows VM (via virsh guest-exec)
-#      to install/replace the runner as a Windows service
-#   5. Scales the file-server back down
+# Runs via the QEMU Guest Agent against the persistent-disk Windows VM:
+#   1. Mint a short-lived registration token from the admin:org PAT
+#      (github-arc-token) — only used if (re)registration is actually needed.
+#   2. Wait for the VM guest agent.
+#   3. Idempotent install/heal inside Windows:
+#        - If the runner service already runs as the desired account
+#          (.\Administrator): just Start-Service if stopped, then exit.
+#        - Otherwise (not installed, or running as NETWORK SERVICE): download
+#          the runner from GitHub (the VM has internet egress; it cannot reach
+#          the in-cluster file-server), then config.cmd --replace as a service
+#          under .\Administrator so build jobs run elevated.
 #
-# Self-contained: no VNC, no RDP, no manual steps.
-# Idempotent: uses --replace to update an existing runner.
+# The VM rootdisk is a PVC, so C:\actions-runner (.runner + .credentials)
+# persists across stop/start — normal boots auto-start the service with no
+# token and no re-register. This script only acts when something is missing or
+# the service account is wrong.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,70 +38,37 @@ data:
         RUNNER_INSTALL_DIR="${RUNNER_INSTALL_DIR:-C:\\actions-runner}"
         RUNNER_LOGON_ACCOUNT="${RUNNER_LOGON_ACCOUNT:-.\\Administrator}"
         ADMIN_PASSWORD="${ADMIN_PASSWORD:?ADMIN_PASSWORD required to run the runner service elevated}"
-        FILE_SERVER_URL="http://file-server.angelscript.svc:8080"
         RUNNER_ZIP="actions-runner-win-x64-${RUNNER_VERSION}.zip"
         RUNNER_DOWNLOAD_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_ZIP}"
 
-        echo "=== GitHub Actions Runner Install: ${VM_NAME} ==="
-        echo "  Org: ${GITHUB_ORG}"
-        echo "  Runner: ${RUNNER_NAME} (labels: ${RUNNER_LABELS})"
-        echo "  Version: ${RUNNER_VERSION}"
+        echo "=== GitHub Actions Runner Install/Heal: ${VM_NAME} ==="
+        echo "  Org: ${GITHUB_ORG} | Runner: ${RUNNER_NAME} (${RUNNER_LABELS}) | v${RUNNER_VERSION}"
 
-        # ── Phase 1: Scale up file-server ──
-        echo ""
-        echo "--- Phase 1: File server ---"
-        CURRENT_REPLICAS=$(kubectl get deploy file-server -n "${NAMESPACE}" \
-            -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "0")
-
-        if [ "${CURRENT_REPLICAS}" = "0" ]; then
-            echo "Scaling up file-server..."
-            kubectl scale deploy file-server -n "${NAMESPACE}" --replicas=1
-            echo "Waiting for file-server pod..."
-            kubectl wait --for=condition=ready pod \
-                -l app=file-server -n "${NAMESPACE}" --timeout=120s
-        else
-            echo "File-server already running (replicas: ${CURRENT_REPLICAS})"
+        # ── Phase 0: Skip if VM is not running (boot ScaledJob handles next boot) ──
+        STATUS=$(kubectl get vm "${VM_NAME}" -n "${NAMESPACE}" -o jsonpath='{.status.printableStatus}' 2>/dev/null || echo "Unknown")
+        if [ "${STATUS}" != "Running" ]; then
+            echo "SKIP: VM not running (${STATUS}); runner (re)registers on next boot."
+            exit 0
         fi
 
-        FS_POD=$(kubectl get pods -n "${NAMESPACE}" -l app=file-server \
-            -o jsonpath='{.items[0].metadata.name}')
-        echo "File-server pod: ${FS_POD}"
-
-        # ── Phase 2: Stage runner package ──
+        # ── Phase 1: Registration token (minted fresh; used only if registering) ──
         echo ""
-        echo "--- Phase 2: Stage runner package ---"
-        # Check if already staged
-        EXISTS=$(kubectl exec "${FS_POD}" -n "${NAMESPACE}" -- \
-            sh -c "[ -f /shared/${RUNNER_ZIP} ] && echo yes || echo no")
-        if [ "${EXISTS}" = "yes" ]; then
-            echo "Runner package already staged: ${RUNNER_ZIP}"
-        else
-            echo "Downloading ${RUNNER_ZIP} to file-server..."
-            kubectl exec "${FS_POD}" -n "${NAMESPACE}" -- \
-                wget -q -O "/shared/${RUNNER_ZIP}" "${RUNNER_DOWNLOAD_URL}"
-            echo "Downloaded."
-        fi
-
-        # ── Phase 3: Get registration token ──
-        echo ""
-        echo "--- Phase 3: Registration token ---"
+        echo "--- Phase 1: Registration token ---"
         REG_TOKEN=$(wget -q -O - \
             --header="Authorization: token ${GITHUB_TOKEN}" \
             --header="Accept: application/vnd.github.v3+json" \
             --post-data="" \
             "https://api.github.com/orgs/${GITHUB_ORG}/actions/runners/registration-token" \
             2>/dev/null | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
-
         if [ -z "${REG_TOKEN}" ]; then
-            echo "ERROR: Failed to obtain registration token"
-            echo "Ensure GITHUB_TOKEN has admin:org scope"
+            echo "ERROR: Failed to obtain registration token (GITHUB_TOKEN needs admin:org)"
             exit 1
         fi
         echo "Registration token obtained."
 
-        # ── Phase 4: Wait for VM guest agent ──
+        # ── Phase 2: Wait for VM guest agent ──
         echo ""
-        echo "--- Phase 4: VM guest agent ---"
+        echo "--- Phase 2: VM guest agent ---"
         for i in $(seq 1 60); do
             AGENT=$(kubectl get vmi "${VM_NAME}" -n "${NAMESPACE}" \
                 -o jsonpath='{.status.conditions[?(@.type=="AgentConnected")].status}' \
@@ -112,7 +85,6 @@ data:
             sleep 10
         done
 
-        # Find virt-launcher pod and domain
         POD=$(kubectl get pods -n "${NAMESPACE}" \
             -l "vm.kubevirt.io/name=${VM_NAME}" \
             -o jsonpath='{.items[0].metadata.name}')
@@ -120,66 +92,50 @@ data:
             sh -c "virsh list --name 2>/dev/null | grep -v '^\s*$' | head -1")
         echo "Virt-launcher: ${POD}, Domain: ${DOMAIN}"
 
-        # ── Phase 5: Install runner via guest agent ──
+        # ── Phase 3: Idempotent install/heal via guest agent ──
         echo ""
-        echo "--- Phase 5: Install runner ---"
-
-        # Build the PowerShell install script
-        # Uses single quotes in PS to avoid escaping issues.
-        # Escape single quotes in the password for the PS single-quoted literal.
+        echo "--- Phase 3: Install/heal runner ---"
+        # PS uses single quotes to avoid escaping; password single-quotes doubled.
         ADMIN_PASSWORD_PS=$(printf '%s' "${ADMIN_PASSWORD}" | sed "s/'/''/g")
-        PS_SCRIPT="\$ErrorActionPreference = 'Stop'; \$installDir = '${RUNNER_INSTALL_DIR}'; \$fsUrl = '${FILE_SERVER_URL}'; \$zip = '${RUNNER_ZIP}'; \$org = '${GITHUB_ORG}'; \$token = '${REG_TOKEN}'; \$name = '${RUNNER_NAME}'; \$labels = '${RUNNER_LABELS}'; \$logonAccount = '${RUNNER_LOGON_ACCOUNT}'; \$logonPwd = '${ADMIN_PASSWORD_PS}'; Write-Output 'Stopping existing runner service...'; try { Stop-Service actions.runner.* -Force -ErrorAction SilentlyContinue } catch {}; Write-Output 'Downloading runner from file-server...'; New-Item -ItemType Directory -Force -Path \$installDir | Out-Null; \$zipPath = Join-Path \$installDir \$zip; Invoke-WebRequest -Uri \"\$fsUrl/\$zip\" -OutFile \$zipPath -UseBasicParsing; Write-Output 'Extracting...'; Expand-Archive -Path \$zipPath -DestinationPath \$installDir -Force; Remove-Item \$zipPath -Force; Write-Output 'Configuring runner...'; Set-Location \$installDir; & .\\config.cmd --url \"https://github.com/\$org\" --token \$token --name \$name --labels \$labels --runasservice --windowslogonaccount \$logonAccount --windowslogonpassword \$logonPwd --replace --unattended; Write-Output 'Runner installed as service under' \$logonAccount"
+        PS_SCRIPT="\$ErrorActionPreference = 'Stop'; \$installDir = '${RUNNER_INSTALL_DIR}'; \$dlUrl = '${RUNNER_DOWNLOAD_URL}'; \$zip = '${RUNNER_ZIP}'; \$org = '${GITHUB_ORG}'; \$token = '${REG_TOKEN}'; \$name = '${RUNNER_NAME}'; \$labels = '${RUNNER_LABELS}'; \$logonAccount = '${RUNNER_LOGON_ACCOUNT}'; \$logonPwd = '${ADMIN_PASSWORD_PS}'; \$svc = Get-CimInstance Win32_Service -Filter \"Name like 'actions.runner.%'\" -ErrorAction SilentlyContinue | Select-Object -First 1; if (\$svc -and \$svc.StartName -match 'Administrator') { if (\$svc.State -ne 'Running') { Start-Service \$svc.Name }; Write-Output \"ALREADY_OK: \$(\$svc.Name) runs as \$(\$svc.StartName)\"; exit 0 }; if (\$svc) { Write-Output \"Re-registering: service runs as \$(\$svc.StartName), switching to \$logonAccount\" } else { Write-Output 'Fresh install' }; try { Stop-Service actions.runner.* -Force -ErrorAction SilentlyContinue } catch {}; New-Item -ItemType Directory -Force -Path \$installDir | Out-Null; if (-not (Test-Path (Join-Path \$installDir 'config.cmd'))) { Write-Output 'Downloading runner from GitHub...'; \$zipPath = Join-Path \$installDir \$zip; curl.exe -L -s --retry 5 --retry-all-errors -C - -o \$zipPath \$dlUrl; Expand-Archive -Path \$zipPath -DestinationPath \$installDir -Force; Remove-Item \$zipPath -Force } else { Write-Output 'Runner binaries present, reusing' }; Set-Location \$installDir; & .\\config.cmd --url \"https://github.com/\$org\" --token \$token --name \$name --labels \$labels --runasservice --windowslogonaccount \$logonAccount --windowslogonpassword \$logonPwd --replace --unattended; Write-Output \"REGISTERED runner as \$logonAccount\""
 
-        # Escape for JSON
         ESCAPED_PS=$(printf '%s' "${PS_SCRIPT}" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
-        echo "Executing runner install inside Windows..."
+        echo "Executing runner install/heal inside Windows..."
         RESULT=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
             virsh qemu-agent-command "${DOMAIN}" \
             "{\"execute\":\"guest-exec\",\"arguments\":{\"path\":\"powershell.exe\",\"arg\":[\"-NoProfile\",\"-ExecutionPolicy\",\"Bypass\",\"-Command\",\"${ESCAPED_PS}\"],\"capture-output\":true}}" \
             --timeout 300 2>&1)
         echo "Guest agent response: ${RESULT}"
 
-        # Check result
         PID=$(echo "${RESULT}" | sed -n 's/.*"pid":\([0-9]*\).*/\1/p')
-        if [ -n "${PID}" ]; then
-            echo "Waiting for install to complete (PID: ${PID})..."
-            sleep 60
-            STATUS_RESULT=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
-                virsh qemu-agent-command "${DOMAIN}" \
-                "{\"execute\":\"guest-exec-status\",\"arguments\":{\"pid\":${PID}}}" \
-                --timeout 30 2>&1)
-            echo "Exec status: ${STATUS_RESULT}"
+        if [ -z "${PID}" ]; then
+            echo "ERROR: Could not parse guest-exec PID"
+            exit 1
+        fi
 
-            EXITCODE=$(echo "${STATUS_RESULT}" | sed -n 's/.*"exitcode":\([0-9]*\).*/\1/p')
-            if [ "${EXITCODE}" = "0" ]; then
-                echo ""
-                echo "=== SUCCESS: Runner installed on ${VM_NAME} ==="
-                echo "  Name:   ${RUNNER_NAME}"
-                echo "  Labels: ${RUNNER_LABELS}"
-                echo "  Dir:    ${RUNNER_INSTALL_DIR}"
-            else
-                echo "WARNING: Install exited with code ${EXITCODE}"
-                # Decode base64 output if present
-                OUT_DATA=$(echo "${STATUS_RESULT}" | sed -n 's/.*"out-data":"\([^"]*\)".*/\1/p')
-                if [ -n "${OUT_DATA}" ]; then
-                    echo "Output: $(echo "${OUT_DATA}" | base64 -d 2>/dev/null || echo "${OUT_DATA}")"
-                fi
-                ERR_DATA=$(echo "${STATUS_RESULT}" | sed -n 's/.*"err-data":"\([^"]*\)".*/\1/p')
-                if [ -n "${ERR_DATA}" ]; then
-                    echo "Stderr: $(echo "${ERR_DATA}" | base64 -d 2>/dev/null || echo "${ERR_DATA}")"
-                fi
-                exit 1
-            fi
+        echo "Waiting for install/heal to complete (PID: ${PID})..."
+        sleep 60
+        STATUS_RESULT=$(kubectl exec "${POD}" -n "${NAMESPACE}" -c compute -- \
+            virsh qemu-agent-command "${DOMAIN}" \
+            "{\"execute\":\"guest-exec-status\",\"arguments\":{\"pid\":${PID}}}" \
+            --timeout 30 2>&1)
+        echo "Exec status: ${STATUS_RESULT}"
+
+        OUT_DATA=$(echo "${STATUS_RESULT}" | sed -n 's/.*"out-data":"\([^"]*\)".*/\1/p')
+        if [ -n "${OUT_DATA}" ]; then
+            echo "Output: $(echo "${OUT_DATA}" | base64 -d 2>/dev/null || echo "${OUT_DATA}")"
+        fi
+        ERR_DATA=$(echo "${STATUS_RESULT}" | sed -n 's/.*"err-data":"\([^"]*\)".*/\1/p')
+        if [ -n "${ERR_DATA}" ]; then
+            echo "Stderr: $(echo "${ERR_DATA}" | base64 -d 2>/dev/null || echo "${ERR_DATA}")"
+        fi
+
+        EXITCODE=$(echo "${STATUS_RESULT}" | sed -n 's/.*"exitcode":\([0-9]*\).*/\1/p')
+        if [ "${EXITCODE}" = "0" ]; then
+            echo ""
+            echo "=== SUCCESS: runner healthy on ${VM_NAME} (${RUNNER_NAME}, ${RUNNER_LABELS}) ==="
         else
-            echo "WARNING: Could not parse PID — check VM manually"
+            echo "ERROR: install/heal exited with code ${EXITCODE:-unknown}"
+            exit 1
         fi
-
-        # ── Phase 6: Scale down file-server ──
-        echo ""
-        echo "--- Phase 6: Cleanup ---"
-        if [ "${CURRENT_REPLICAS}" = "0" ]; then
-            echo "Scaling file-server back to 0..."
-            kubectl scale deploy file-server -n "${NAMESPACE}" --replicas=0
-        fi
-        echo "Done."

--- a/apps/kube/kubevirt/runner/job.yaml
+++ b/apps/kube/kubevirt/runner/job.yaml
@@ -31,6 +31,12 @@ metadata:
     labels:
         app: angelscript
         component: vm-runner
+    annotations:
+        # ArgoCD Sync hook: recreate + run the idempotent install on each sync
+        # (avoids the immutable-Job error on resync). Heals the runner when the
+        # VM is up; Phase 0 in the script exits cleanly when the VM is down.
+        argocd.argoproj.io/hook: Sync
+        argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
     backoffLimit: 2
     ttlSecondsAfterFinished: 86400

--- a/apps/kube/kubevirt/runner/scaled-job.yaml
+++ b/apps/kube/kubevirt/runner/scaled-job.yaml
@@ -1,0 +1,89 @@
+# KEDA ScaledJob: (re)register/heal the GitHub Actions runner whenever the
+# windows-builder VM boots. Triggered by the VM pod existing (same pattern as
+# autologon). The install script is idempotent — on a normal boot the runner
+# service is already installed on the persistent disk and running as
+# .\Administrator, so it exits fast (ALREADY_OK) without minting a token or
+# downloading anything. It only re-registers on first install, runner-version
+# change, or to switch the service off NETWORK SERVICE onto .\Administrator.
+apiVersion: keda.sh/v1alpha1
+kind: ScaledJob
+metadata:
+    name: vm-runner-install-windows-on-boot
+    namespace: angelscript
+    labels:
+        app: angelscript
+        component: vm-runner
+spec:
+    pollingInterval: 30
+    successfulJobsHistoryLimit: 1
+    failedJobsHistoryLimit: 2
+    maxReplicaCount: 1
+    triggers:
+        - type: kubernetes-workload
+          metadata:
+              podSelector: 'vm.kubevirt.io/name=windows-builder'
+              value: '1'
+    jobTargetRef:
+        parallelism: 1
+        completions: 1
+        backoffLimit: 3
+        ttlSecondsAfterFinished: 600
+        template:
+            metadata:
+                labels:
+                    component: vm-runner
+            spec:
+                serviceAccountName: vm-scaler
+                restartPolicy: OnFailure
+                securityContext:
+                    runAsNonRoot: true
+                    runAsUser: 10001
+                    runAsGroup: 10001
+                    seccompProfile:
+                        type: RuntimeDefault
+                containers:
+                    - name: runner-install
+                      image: ghcr.io/kbve/kubectl:0.1.4
+                      command: ['/bin/sh', '/scripts/install-runner.sh']
+                      securityContext:
+                          allowPrivilegeEscalation: false
+                          readOnlyRootFilesystem: true
+                          capabilities:
+                              drop: ['ALL']
+                      env:
+                          - name: VM_NAME
+                            value: windows-builder
+                          - name: NAMESPACE
+                            value: angelscript
+                          - name: GITHUB_ORG
+                            value: KBVE
+                          - name: RUNNER_NAME
+                            value: windows-builder
+                          - name: RUNNER_LABELS
+                            value: UE5-Win
+                          - name: RUNNER_VERSION
+                            value: '2.333.0'
+                          - name: RUNNER_LOGON_ACCOUNT
+                            value: '.\Administrator'
+                          - name: GITHUB_TOKEN
+                            valueFrom:
+                                secretKeyRef:
+                                    name: github-arc-token
+                                    key: github_token
+                          - name: ADMIN_PASSWORD
+                            valueFrom:
+                                secretKeyRef:
+                                    name: windows-builder-admin
+                                    key: password
+                      volumeMounts:
+                          - name: script
+                            mountPath: /scripts
+                          - name: tmp
+                            mountPath: /tmp
+                volumes:
+                    - name: script
+                      configMap:
+                          name: vm-runner-install-script
+                          defaultMode: 0755
+                    - name: tmp
+                      emptyDir: {}

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -110,3 +110,5 @@ resources:
     # Guacamole — browser-based RDP gateway for Windows VMs
     - kubevirt/guacamole-application.yaml
     - kubevirt/autologon-application.yaml
+    # Runner — (re)register the GitHub Actions runner as Administrator on VM boot
+    - kubevirt/runner-application.yaml


### PR DESCRIPTION
## Why
Follow-up to #11920. The runner was registered manually (kubectl apply) and ran as NETWORK SERVICE. Make it ArgoCD-managed, self-healing as Administrator on boot, and stop the VM only when the runner is genuinely idle (the timer was killing active builds).

## Won't-break design
The VM `rootdisk` is a **PVC** (persistent) — the runner + `.credentials` survive stop/start. So:
- Normal boot → the Windows service auto-starts with saved creds. The boot job's script sees the service already running as `.\Administrator` and exits fast (`ALREADY_OK`) — **no token minted, no download, nothing to break**.
- It only mints a registration token (from the `github-arc-token` PAT — the long-lived sealed secret) + re-registers on: fresh install, runner-version change, or the one-time switch off NETWORK SERVICE → `.\Administrator`.
- The short-lived registration token is never stored (expires ~1h); only the PAT is a secret, and it already exists.

## Runner (`apps/kube/kubevirt/runner`)
- `runner-application.yaml` (ArgoCD app) + kustomization entry — declarative, no manual apply.
- `scaled-job.yaml` — KEDA ScaledJob triggered on VM-boot (podSelector, same pattern as autologon) → runs the idempotent install/heal.
- `configmap.yaml` install script: idempotent (skip if already admin), downloads the runner from GitHub directly (VM can't reach the in-cluster file-server), Phase 0 exits cleanly if VM is down.
- `job.yaml` → ArgoCD Sync hook (recreate-on-sync; avoids immutable-Job errors) for on-change heal.

## Shutdown (`keda/scaled-jobs.yaml`)
- Pass `GITHUB_TOKEN` to the stop ScaledJobs so the idle-shutdown script's busy/queued/in-progress check actually runs. The cron is now just the **check cadence**, not a hard timer — an active runner is never stopped. Negligible API cost (a few calls per check window).