### PR TITLE
feat(chuck): build unreal_game client from external KBVE/chuck repo

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.185",
+			"version": "1.0.186",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -961,11 +961,12 @@
 			"app_name": "chuck",
 			"engine": {
 				"version": "5.7.4",
-				"project_path": "apps/chuckrpg/unreal-chuck",
+				"project_path": "chuck",
 				"build_targets": [
 					"Win64",
 					"Linux"
-				]
+				],
+				"external_repo_url": "https://github.com/kbve/chuck"
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"version": "0.3.19",

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -593,11 +593,13 @@ jobs:
               run: docker pull "${{ env.UE_IMAGE }}"
 
             - name: Checkout monorepo
+              if: inputs.external_repo_url == ''
               uses: actions/checkout@v6
               with:
                   lfs: false
 
             - name: Pull game LFS (Forgejo) + materialize project
+              if: inputs.external_repo_url == ''
               env:
                   FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
                   FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
@@ -620,6 +622,74 @@ jobs:
                   rm -rf /tmp/game-project
                   mkdir -p /tmp/game-project
                   cp -r "${PROJ}/." /tmp/game-project/
+
+            - name: Clone external game repo + materialize project
+              if: inputs.external_repo_url != ''
+              env:
+                  GH_TOKEN: ${{ steps.pat.outputs.token }}
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+              run: |
+                  SLUG="${{ inputs.external_repo_url }}"
+                  SLUG="${SLUG#https://github.com/}"
+                  SLUG="${SLUG#git@github.com:}"
+                  SLUG="${SLUG%.git}"
+                  SUBDIR="${{ inputs.project_path }}"
+                  echo "::notice::Cloning external game repo ${SLUG} (default branch), subdir '${SUBDIR}'"
+                  rm -rf /tmp/game-clone /tmp/game-project
+
+                  GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 \
+                    "https://x-access-token:${GH_TOKEN}@github.com/${SLUG}.git" /tmp/game-clone
+
+                  cd /tmp/game-clone
+
+                  if [ -n "${SUBDIR}" ] && [ "${SUBDIR}" != "." ]; then
+                    INCLUDE="${SUBDIR}/**"
+                    SRC="/tmp/game-clone/${SUBDIR}"
+                  else
+                    INCLUDE="**"
+                    SRC="/tmp/game-clone"
+                  fi
+
+                  RAW_LFS=""
+                  [ -f .lfsconfig ] && RAW_LFS=$(git config -f .lfsconfig lfs.url 2>/dev/null || true)
+                  case "${RAW_LFS}" in
+                    *forgejo.kbve.com/*|*git.kbve.com/*)
+                      if [ -z "${FORGEJO_USER}" ] || [ -z "${FORGEJO_TOKEN}" ]; then
+                        echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing — cannot pull LFS from git.kbve.com"
+                        exit 1
+                      fi
+                      echo "::add-mask::${FORGEJO_TOKEN}"
+                      # Derive repo path from the repo's own .lfsconfig (preserves owner/repo case —
+                      # Forgejo LFS routing is case-sensitive: KBVE/chuck = 401, kbve/chuck = 302) and
+                      # force the HTTPS ingress host git.kbve.com (.74) over the ssh/Cilium .71 route.
+                      REPO_PATH="${RAW_LFS#ssh://}"; REPO_PATH="${REPO_PATH#https://}"; REPO_PATH="${REPO_PATH#http://}"
+                      REPO_PATH="${REPO_PATH#*@}"
+                      REPO_PATH="${REPO_PATH#*/}"
+                      REPO_PATH="${REPO_PATH%/}"
+                      case "${REPO_PATH}" in
+                        */info/lfs) ;;
+                        *.git) REPO_PATH="${REPO_PATH}/info/lfs" ;;
+                        *) REPO_PATH="${REPO_PATH%.git}.git/info/lfs" ;;
+                      esac
+                      AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
+                      echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
+                      git -c lfs.url="${AUTH_LFS}" lfs install --local
+                      git -c lfs.url="${AUTH_LFS}" lfs pull --include="${INCLUDE}"
+                      ;;
+                    *)
+                      echo "::notice::Pulling LFS (${INCLUDE}) from origin (GitHub-native)"
+                      git lfs install --local
+                      git lfs pull --include="${INCLUDE}"
+                      ;;
+                  esac
+
+                  if [ ! -d "${SRC}" ]; then
+                    echo "::error::project_path '${SUBDIR}' not found in ${SLUG}"
+                    exit 1
+                  fi
+                  mkdir -p /tmp/game-project
+                  cp -r "${SRC}/." /tmp/game-project/
 
             - name: Build Linux client
               run: |
@@ -683,7 +753,7 @@ jobs:
               run: |
                   docker logout ghcr.io 2>/dev/null || true
                   docker system prune -f 2>/dev/null || true
-                  rm -rf /tmp/game-project /tmp/ue5-game-output 2>/dev/null || true
+                  rm -rf /tmp/game-project /tmp/game-clone /tmp/ue5-game-output 2>/dev/null || true
 
     game_build_windows:
         name: Game Build (Win64 client)
@@ -698,6 +768,7 @@ jobs:
             contents: read
         steps:
             - name: Checkout monorepo
+              if: inputs.external_repo_url == ''
               uses: actions/checkout@v6
               with:
                   lfs: false
@@ -715,6 +786,8 @@ jobs:
                   "runuat=$(Join-Path $engineRoot 'Engine\Build\BatchFiles\RunUAT.bat')" >> $env:GITHUB_OUTPUT
 
             - name: Pull game LFS (Forgejo)
+              id: monorepo_proj
+              if: inputs.external_repo_url == ''
               env:
                   FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
                   FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
@@ -729,11 +802,66 @@ jobs:
                   Write-Host "::notice::Pulling LFS for $proj from $lfsUrl"
                   git -c lfs.url="$authUrl" lfs install --local
                   git -c lfs.url="$authUrl" lfs pull --include="$proj/**"
+                  "proj_root=$(Join-Path $env:GITHUB_WORKSPACE $proj)" >> $env:GITHUB_OUTPUT
+
+            - name: Clone external game repo (Win64)
+              id: ext_proj
+              if: inputs.external_repo_url != ''
+              env:
+                  EPIC_PAT: ${{ secrets.epic_pat }}
+                  UNITY_PAT: ${{ secrets.UNITY_PAT }}
+                  FORGEJO_USER: ${{ secrets.FORGEJO_USER }}
+                  FORGEJO_TOKEN: ${{ secrets.FORGEJO_TOKEN }}
+              run: |
+                  $token = if ($env:EPIC_PAT) { $env:EPIC_PAT } else { $env:UNITY_PAT }
+                  if (-not $token) { Write-Host "::error::No PAT available — set epic_pat or UNITY_PAT"; exit 1 }
+                  Write-Host "::add-mask::$token"
+
+                  $slug = '${{ inputs.external_repo_url }}'
+                  $slug = $slug -replace '^https://github.com/', '' -replace '^git@github.com:', '' -replace '\.git$', ''
+                  $subdir = '${{ inputs.project_path }}'
+                  $clone = 'C:\game-clone'
+                  if (Test-Path $clone) { Remove-Item -Recurse -Force $clone -ErrorAction SilentlyContinue }
+                  Write-Host "::notice::Cloning external game repo $slug (default branch), subdir '$subdir'"
+
+                  $env:GIT_LFS_SKIP_SMUDGE = '1'
+                  git clone --depth 1 "https://x-access-token:$token@github.com/$slug.git" $clone
+                  if ($LASTEXITCODE -ne 0) { Write-Host "::error::clone failed"; exit $LASTEXITCODE }
+                  Remove-Item Env:\GIT_LFS_SKIP_SMUDGE
+
+                  Push-Location $clone
+                  if ($subdir -and $subdir -ne '.') { $include = "$subdir/**"; $src = Join-Path $clone $subdir }
+                  else { $include = '**'; $src = $clone }
+
+                  $rawLfs = if (Test-Path .lfsconfig) { (git config -f .lfsconfig lfs.url) } else { '' }
+                  if ($rawLfs -match 'kbve\.com') {
+                      if (-not $env:FORGEJO_USER -or -not $env:FORGEJO_TOKEN) { Write-Host "::error::FORGEJO_USER / FORGEJO_TOKEN missing"; exit 1 }
+                      Write-Host "::add-mask::$($env:FORGEJO_TOKEN)"
+                      $repoPath = $rawLfs -replace '^ssh://','' -replace '^https?://',''
+                      $repoPath = $repoPath -replace '^[^/]*@',''
+                      $repoPath = $repoPath -replace '^[^/]+/','' -replace '/$',''
+                      if ($repoPath -notmatch '/info/lfs$') {
+                          $repoPath = ($repoPath -replace '\.git$','') + '.git/info/lfs'
+                      }
+                      $authLfs = "https://$($env:FORGEJO_USER):$($env:FORGEJO_TOKEN)@git.kbve.com/$repoPath"
+                      Write-Host "::notice::Pulling LFS ($include) from git.kbve.com/$repoPath (normalized from $rawLfs)"
+                      git -c lfs.url="$authLfs" lfs install --local
+                      git -c lfs.url="$authLfs" lfs pull --include="$include"
+                  } else {
+                      Write-Host "::notice::Pulling LFS ($include) from origin (GitHub-native)"
+                      git lfs install --local
+                      git lfs pull --include="$include"
+                  }
+                  Pop-Location
+
+                  if (-not (Test-Path $src)) { Write-Host "::error::project_path '$subdir' not found in $slug"; exit 1 }
+                  "proj_root=$src" >> $env:GITHUB_OUTPUT
 
             - name: Build Win64 client
               run: |
-                  $uproject = Get-ChildItem -Path (Join-Path $env:GITHUB_WORKSPACE '${{ inputs.project_path }}') -Filter *.uproject | Select-Object -First 1
-                  if (-not $uproject) { Write-Host "::error::No .uproject found"; exit 1 }
+                  $projRoot = '${{ steps.monorepo_proj.outputs.proj_root }}${{ steps.ext_proj.outputs.proj_root }}'
+                  $uproject = Get-ChildItem -Path $projRoot -Filter *.uproject | Select-Object -First 1
+                  if (-not $uproject) { Write-Host "::error::No .uproject found in $projRoot"; exit 1 }
                   $out = "C:\ue5-game-output"
                   New-Item -ItemType Directory -Force -Path $out | Out-Null
                   Write-Host "::notice::Building $($uproject.FullName) (Win64 client)"
@@ -763,6 +891,7 @@ jobs:
               if: always()
               run: |
                   if (Test-Path C:\ue5-game-output) { Remove-Item -Recurse -Force C:\ue5-game-output -ErrorAction SilentlyContinue }
+                  if (Test-Path C:\game-clone) { Remove-Item -Recurse -Force C:\game-clone -ErrorAction SilentlyContinue }
 
     game_build_mac:
         name: Game Build (Mac client — STUB)

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-game.mdx
@@ -22,7 +22,8 @@ status: beta
 homepage_url: https://kbve.itch.io/chuckrpg
 engine:
     version: "5.7.4"
-    project_path: apps/chuckrpg/unreal-chuck
+    project_path: chuck
+    external_repo_url: https://github.com/kbve/chuck
     build_targets:
         - Win64
         - Linux
@@ -35,14 +36,17 @@ external_publish:
 
 Chuck RPG UE5 standalone game client. The playable build (distinct from the
 [Unreal Chuck](/project/unreal-chuck) dedicated server) is compiled from the
-monorepo source at `apps/chuckrpg/unreal-chuck` (Content pulled from the chuck
-Forgejo LFS endpoint) and shipped to itch.io under `kbve/chuckrpg`.
+external game repo [`KBVE/chuck`](https://github.com/kbve/chuck) (default branch,
+`.uproject` under `engine.project_path`, Content pulled from the chuck Forgejo LFS
+endpoint) and shipped to itch.io under `kbve/chuckrpg`.
 
 ## Pipeline
 
 `pipeline: unreal_game` → `ci-main.yml` dispatches `ci-unreal.yml` (`task: game`)
 → `ci-unreal-build.yml` (`mode: game`) whenever the MDX `version:` here outpaces
-`version.toml`, or `source_path` files change.
+`version.toml`, or `source_path` files change. `engine.external_repo_url` makes the
+builder clone `KBVE/chuck` (default branch) instead of using the monorepo shell; the
+version gate / `version_toml` tracker still lives in this monorepo.
 
 ## Build Matrix
 
@@ -64,10 +68,16 @@ Bump `version:` above `version.toml` (`apps/chuckrpg/unreal-chuck/version.toml`)
 run `npx nx run astro-kbve:sync:ci-manifest`, commit. The next `ci-main` run fans
 out the game build + itch upload for this entry.
 
-## Source: monorepo now, KBVE/chuck later
+## Source: external KBVE/chuck
 
-Builds source from the lightweight monorepo shell `apps/chuckrpg/unreal-chuck`
-— small and fast, so it doubles as the build/test loop for the UE plugins in
-`packages/unreal/`. Later we expand to the full external game repo `KBVE/chuck`
-by re-adding the `engine.external_repo_url` branch (clone external when set,
-else monorepo). Tracked in [#11828](https://github.com/KBVE/kbve/issues/11828).
+Builds source from the external game repo
+[`KBVE/chuck`](https://github.com/kbve/chuck) (default branch). The builder clones
+it with the GitHub PAT, then materializes `engine.project_path` (`chuck/` — the dir
+holding `Chuck.uproject`). Content blobs come from the chuck Forgejo LFS endpoint
+(`git.kbve.com/KBVE/chuck.git`); the repo's own `.lfsconfig` points at the `ssh://`
+Forgejo remote, which the builder normalizes to the authenticated HTTPS ingress
+route at build time.
+
+When `engine.external_repo_url` is empty the builder falls back to the monorepo
+shell `apps/chuckrpg/unreal-chuck` (the lightweight plugin build/test loop in
+`packages/unreal/`). Closes [#11828](https://github.com/KBVE/kbve/issues/11828).


### PR DESCRIPTION
## What

Switch the `unreal_chuck_game` pipeline to build from the external game repo [`KBVE/chuck`](https://github.com/kbve/chuck) (default branch) instead of the monorepo shell `apps/chuckrpg/unreal-chuck`. The dedicated-server entry (`unreal_chuck` / `ue5_server`) is left as-is.

## Changes

- **`unreal-chuck-game.mdx`** — add `engine.external_repo_url: https://github.com/kbve/chuck`, set `engine.project_path: chuck` (the in-repo dir holding `Chuck.uproject`). `version_toml` stays in the monorepo, so the version gate / published tracker is unchanged.
- **`ci-unreal-build.yml`** — `game_build_linux` + `game_build_windows` clone the external repo with the GitHub PAT when `external_repo_url` is set; the monorepo checkout + Forgejo-from-`.lfsconfig` path remains the fallback when it is empty.
  - Content/LFS blobs pull from the chuck **Forgejo** endpoint. The repo's `.lfsconfig` points at the `ssh://forgejo.kbve.com/...` remote, which the builder normalizes to the authenticated HTTPS ingress route `git.kbve.com` (`.74`, not the Cilium `.71`).
  - The Forgejo repo path is parsed from `.lfsconfig` (not the GitHub URL) to **preserve owner/repo case** — Forgejo LFS routing is case-sensitive (`KBVE/chuck` → 401 auth gate, `kbve/chuck` → 302 wrong redirect).
- **`ci-dispatch-manifest.json`** — regenerated. (Also picks up a pre-existing `astro_kbve` 1.0.185→1.0.186 manifest drift.)

The router (`ci-unreal.yml`) and `ci-main.yml` already forward `external_repo_url` — no change needed there.

## Verification

- `astro-kbve:build` passes (validates MDX schema), manifest regenerated via `sync:ci-manifest`.
- `actionlint` clean on the new clone steps; YAML parses.
- LFS route probed: `POST git.kbve.com/KBVE/chuck.git/info/lfs/objects/batch` → 401 (route alive + repo exists + auth gate). Path normalizer verified against ssh / https / no-`.git` forms.

### Untested until first real run
- `FORGEJO_USER` / `FORGEJO_TOKEN` secrets authorize the chuck repo (same secrets the existing monorepo path uses).
- `git.kbve.com` reachable from inside `arc-runner-ue`.

Closes #11828