### PR TITLE
fix(rareicon): inline LandmarkAuraEffectSystem.HexDistance — same BC1064 trap as FogCull

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LandmarkAuraEffectSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/LandmarkAuraEffectSystem.cs
@@ -108,7 +108,9 @@ namespace RareIcon
             bool inAura = false;
             for (int i = 0; i < Centers.Length; i++)
             {
-                if (LandmarkAuraEffectSystem.HexDistance(here, Centers[i]) <= Radii[i]) { inAura = true; break; }
+                int2 d = Centers[i] - here;
+                int dist = (math.abs(d.x) + math.abs(d.y) + math.abs(-d.x - d.y)) / 2;
+                if (dist <= Radii[i]) { inAura = true; break; }
             }
             if (!inAura) return;
 


### PR DESCRIPTION
Follow-up to #11919. Same Burst BC1064 trap that hit `FogCullSystem.ClassifyHex` survives in `LandmarkAuraEffectSystem.HexDistance`, called cross-type from `ApplyAuraBuffJob.Execute`:

```csharp
// ApplyAuraBuffJob.Execute (BurstCompile)
if (LandmarkAuraEffectSystem.HexDistance(here, Centers[i]) <= Radii[i]) { … }
```

`int2` params travel by value → external function boundary under WinPlayer AOT Burst → BC1064 even though both sides are `[BurstCompile]`.

## Fix

Inline the four-line axial distance computation directly into the aura check loop:

```csharp
int2 d = Centers[i] - here;
int dist = (math.abs(d.x) + math.abs(d.y) + math.abs(-d.x - d.y)) / 2;
if (dist <= Radii[i]) { inAura = true; break; }
```

Drops the cross-type static reference. Math identical (axial hex distance).

## Other recent jobified systems verified clean

Swept `RegenBuffSystem` / `MoraleBuffExpirySystem` / `BarracksRestBonusSystem` / `HuntBehaviorSystem` / `SelectionVisualSystem` / `ResourceRegrowSystem` for the same pattern — no remaining cross-type Burst static calls with struct-by-value params.

## Note on the prior build error

The error log the user pasted referenced `FogCullSystem.ClassifyHex` which is already gone in main (removed by the merged #11919). If the WinPlayer build is still hitting that line, pull latest and clear `Library/Bee/artifacts` so Burst recompiles fresh.

This PR addresses the next instance of the same pattern surfaced by the same WinPlayer AOT pass.

## Test plan

- [ ] Burst compiles `ApplyAuraBuffJob` without BC1064 on WinPlayer.
- [ ] Aura behavior unchanged: Player units inside any landmark aura still get MoraleBuff refreshed.
- [ ] No regression in Standalone Windows / Linux / OSX builds.