### PR TITLE
feat(KBVEItemDB): SQLite inventory persistence + shared connection seam + catalog store

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -703,6 +703,7 @@
 			"key": "ue_kbveitemdb",
 			"plugin_name": "KBVEItemDB",
 			"plugin_path": "packages/unreal/KBVEItemDB",
+			"dependency_plugins": "packages/unreal/KBVESQLite",
 			"supported_platforms": [
 				"Win64",
 				"Linux",

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbveitemdb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbveitemdb.mdx
@@ -12,6 +12,7 @@ key: ue_kbveitemdb
 pipeline: unreal
 plugin_name: KBVEItemDB
 plugin_path: packages/unreal/KBVEItemDB
+dependency_plugins: packages/unreal/KBVESQLite
 version: "0.1.0"
 source_path: packages/unreal/KBVEItemDB
 version_toml: packages/unreal/KBVEItemDB/version.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbveitemdb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbveitemdb.mdx
@@ -44,3 +44,20 @@ to [KBVEGameplay](/project/kbvegameplay)'s effect half:
 
 Item DATA stays in the shared itemdb MDX. KBVEItemDB carries it + the inventory
 model; KBVEGameplay applies the consumable effects (atlas/icon rendering deferred).
+
+## Persistence (`FKBVEInventoryStore` / `UKBVEInventoryStoreSubsystem`)
+
+Durable local inventory via the **KBVESQLite** plugin — row-per-slot
+(`player_inventory(player_id, bag_ref, slot_idx, item_key, count, durability, flags)`,
+WAL), save/load/count/clear by player id, opened at `Saved/KBVE/inventory.db`.
+
+**Two boundaries to respect:**
+
+1. **SQLite ⟂ Mass.** SQLite is a persistence boundary, not a per-tick datasource:
+   load → seed Mass fragments at spawn/login, mutate fragments on worker threads,
+   flush fragments → SQLite at intervals/logout (game thread / async). A single
+   `sqlite3*` is not thread-safe; never query it inside the Mass processor loop.
+2. **KBVESQLite ⟂ UE SQLiteCore.** KBVESQLite is the single sqlite provider for
+   KBVE code (its own vendored `sqlite3`). Do not also link the engine's
+   `SQLiteCore` in the same module — duplicate `sqlite3_*` symbols crash the build/run.
+   Plugins depending on KBVESQLite declare `dependency_plugins: packages/unreal/KBVESQLite`.

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvesqlite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvesqlite.mdx
@@ -27,4 +27,28 @@ supported_platforms:
 
 ## Overview
 
-KBVESQLite wraps SQLite as an embedded database plugin for Unreal Engine.
+KBVESQLite wraps SQLite as an embedded database plugin for Unreal Engine — a
+vendored `sqlite3` amalgamation plus a thin RAII wrapper so consumers never
+touch raw `sqlite3_*` calls.
+
+## Access seam
+
+- **`FKBVESQLiteConnection`** — RAII connection: `Open(path, bUseWAL)` / `Close` /
+  `Exec` / `Prepare` / `Begin` / `Commit` / `Rollback`.
+- **`FKBVESQLiteStatement`** — RAII prepared statement: `Bind*`, `Step` / `Execute`
+  / `Reset`, `Column*` accessors.
+
+Add `KBVESQLite` to your module's `PrivateDependencyModuleNames` and
+`dependency_plugins: packages/unreal/KBVESQLite` to your ci-registry entry so the
+CI plugin build stages it.
+
+## Rules
+
+- **Single sqlite provider** — never link the engine's `SQLiteCore` in the same
+  module; duplicate `sqlite3_*` symbols crash the build/run.
+- **Persistence boundary, not a Mass hot-loop datasource** — one connection is not
+  thread-safe; WAL gives many readers + one writer across separate connections.
+  Load at boundaries, keep the working set in memory/Mass fragments, flush async.
+
+Consumers: `FKBVEWorldChunkCache` (KBVEWorld), `FKBVEInventoryStore` +
+`FKBVEItemCatalogStore` (KBVEItemDB).

--- a/packages/unreal/KBVEItemDB/README.md
+++ b/packages/unreal/KBVEItemDB/README.md
@@ -1,0 +1,52 @@
+# KBVEItemDB
+
+Game-agnostic item database, inventory model, and item Mass fragments for KBVE Unreal games. The data + inventory half to [KBVEGameplay](../KBVEGameplay)'s effect half.
+
+## What it provides
+
+### Item catalog (read-only reference data)
+
+- **`FKBVEItemDef` / `FKBVEItemFood`** — runtime item def: identity, type flags, rarity, stacking, prices, tags, and consumable/food effect fields (`Heals` / `RestoreMana` / `RestoreEnergy` / `RegenPerSecond` / `RegenDuration` / `Cooldown` / `AnimationRef`) — shaped to map straight into KBVEGameplay's `FKBVEEffectSpec`.
+- **`UKBVEItemDatabase`** (GameInstance subsystem) — loads `Content/Data/itemdb-data.json` (the shared itemdb codegen artifact) into in-memory defs; `LookupByKey` / `LookupByRef`. Fast O(1) hot-path lookups.
+
+### Inventory model
+
+- **`FKBVEInventory` / `FKBVEInventoryBag` / `FKBVEInventoryStack`** — generic bags + slots.
+- **`UKBVEInventoryLibrary`** — `TryAdd` / `CountItem` / `FindFirstSlot`.
+
+### Mass
+
+- **`FKBVEDroppedItemFragment` / `FKBVEDroppedItemTag`** — world-dropped item entities (key, count, rarity, lifetime, magnet/pickup radius).
+
+### Persistence (SQLite, via KBVESQLite)
+
+- **`FKBVEInventoryStore` / `UKBVEInventoryStoreSubsystem`** — durable inventory save/load, row-per-slot (`player_inventory`), keyed by player id. Opens `Saved/KBVE/inventory.db`.
+- **`FKBVEItemCatalogStore`** + `UKBVEItemDatabase::PersistCatalogToDb(path)` — emit the catalog to a queryable read-only `item_def` table.
+
+## Where the data lives (the boundaries)
+
+```
+itemdb MDX  ──codegen──▶  itemdb-data.json  (canonical source)
+                               │ load
+                               ▼
+        UKBVEItemDatabase (in-memory defs, hot lookups)
+                               │ optional PersistCatalogToDb
+                               ▼
+        SQLite item_def  (read-only "safe data", queryable)
+
+LIVE inventory  =  Mass fragment (FchuckInventoryFragment)  ← authoritative gameplay, worker-thread accessible
+                               │ flush at boundaries (game thread / async)
+                               ▼
+        SQLite player_inventory  (durable persistence snapshot)
+```
+
+- **Live, mutable inventory = Mass.** That is the single authoritative copy and the worker-thread path. SQLite is **not** the live store.
+- **SQLite = persistence boundary + queryable static catalog.** Load→seed at spawn/login, flush at intervals/logout. Never queried in the Mass hot loop.
+- **No dupes.** One canonical source (MDX→JSON); the in-memory map and the SQLite catalog are read-only projections of it — not divergent writable copies.
+- **KBVESQLite is the single sqlite provider** (never link UE `SQLiteCore` alongside). KBVEItemDB declares `dependency_plugins: packages/unreal/KBVESQLite`.
+
+## Composition
+
+Consuming an item = lookup (`UKBVEItemDatabase`) → build an `FKBVEEffectSpec` from the def's food fields → apply via KBVEGameplay's `UKBVEEffectComponent`. KBVEItemDB never applies effects; it carries data + inventory.
+
+Icon/atlas rendering is deferred (UI-coupled).

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/KBVEItemDB.Build.cs
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/KBVEItemDB.Build.cs
@@ -17,7 +17,8 @@ public class KBVEItemDB : ModuleRules
 		PrivateDependencyModuleNames.AddRange(new string[]
 		{
 			"Json",
-			"JsonUtilities"
+			"JsonUtilities",
+			"KBVESQLite"
 		});
 	}
 }

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEInventoryStore.cpp
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEInventoryStore.cpp
@@ -1,12 +1,5 @@
 #include "KBVEInventoryStore.h"
 
-#include "HAL/PlatformFileManager.h"
-#include "Misc/Paths.h"
-
-THIRD_PARTY_INCLUDES_START
-#include "sqlite3.h"
-THIRD_PARTY_INCLUDES_END
-
 namespace
 {
 	static const char* kCreateSql =
@@ -29,110 +22,57 @@ namespace
 		"SELECT slot_idx, item_key, count, durability, flags FROM player_inventory WHERE player_id = ?1 AND bag_ref = ?2;";
 	static const char* kCountSql =
 		"SELECT COALESCE(SUM(count), 0) FROM player_inventory WHERE player_id = ?1 AND item_key = ?2;";
-
-	sqlite3* AsHandle(void* P) { return reinterpret_cast<sqlite3*>(P); }
-}
-
-FKBVEInventoryStore::~FKBVEInventoryStore()
-{
-	Close();
 }
 
 bool FKBVEInventoryStore::Open(const FString& DbPath)
 {
-	if (Db) return true;
-
-	IPlatformFile& FS = FPlatformFileManager::Get().GetPlatformFile();
-	const FString DbDir = FPaths::GetPath(DbPath);
-	if (!DbDir.IsEmpty()) FS.CreateDirectoryTree(*DbDir);
-
-	const FTCHARToUTF8 Conv(*DbPath);
-	sqlite3* Handle = nullptr;
-	if (sqlite3_open_v2(Conv.Get(), &Handle, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr) != SQLITE_OK)
-	{
-		UE_LOG(LogTemp, Warning, TEXT("[KBVEInventoryStore] open failed: %s"), UTF8_TO_TCHAR(Handle ? sqlite3_errmsg(Handle) : "null"));
-		if (Handle) sqlite3_close(Handle);
-		return false;
-	}
-
-	sqlite3_exec(Handle, "PRAGMA journal_mode=WAL;",   nullptr, nullptr, nullptr);
-	sqlite3_exec(Handle, "PRAGMA synchronous=NORMAL;", nullptr, nullptr, nullptr);
-	sqlite3_exec(Handle, "PRAGMA temp_store=MEMORY;",  nullptr, nullptr, nullptr);
-
-	char* Err = nullptr;
-	if (sqlite3_exec(Handle, kCreateSql, nullptr, nullptr, &Err) != SQLITE_OK)
-	{
-		UE_LOG(LogTemp, Warning, TEXT("[KBVEInventoryStore] create failed: %s"), UTF8_TO_TCHAR(Err ? Err : ""));
-		sqlite3_free(Err);
-		sqlite3_close(Handle);
-		return false;
-	}
-
-	Db = Handle;
-	UE_LOG(LogTemp, Display, TEXT("[KBVEInventoryStore] opened %s"), *DbPath);
-	return true;
+	if (!Conn.Open(DbPath)) return false;
+	return Conn.Exec(kCreateSql);
 }
 
 void FKBVEInventoryStore::Close()
 {
-	if (Db)
-	{
-		sqlite3_close(AsHandle(Db));
-		Db = nullptr;
-	}
+	Conn.Close();
 }
 
 bool FKBVEInventoryStore::InsertBag(const FString& PlayerId, const FKBVEInventoryBag& Bag)
 {
-	const FTCHARToUTF8 PlayerConv(*PlayerId);
-	const FTCHARToUTF8 BagConv(*Bag.BagRef.ToString());
+	const FString BagRef = Bag.BagRef.ToString();
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn.Prepare(kInsertSql);
+	if (!Stmt.IsValid()) return false;
 
-	sqlite3_stmt* Stmt = nullptr;
-	if (sqlite3_prepare_v2(AsHandle(Db), kInsertSql, -1, &Stmt, nullptr) != SQLITE_OK) return false;
-
-	bool bOk = true;
 	for (int32 i = 0; i < Bag.Slots.Num(); ++i)
 	{
 		const FKBVEInventoryStack& Slot = Bag.Slots[i];
 		if (Slot.IsEmpty()) continue;
 
-		sqlite3_reset(Stmt);
-		sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
-		sqlite3_bind_text(Stmt, 2, BagConv.Get(), -1, SQLITE_TRANSIENT);
-		sqlite3_bind_int(Stmt, 3, i);
-		sqlite3_bind_int(Stmt, 4, Slot.ItemKey);
-		sqlite3_bind_int(Stmt, 5, Slot.Count);
-		sqlite3_bind_int(Stmt, 6, Slot.Durability);
-		sqlite3_bind_int(Stmt, 7, static_cast<int32>(Slot.Flags));
-
-		if (sqlite3_step(Stmt) != SQLITE_DONE)
-		{
-			bOk = false;
-			break;
-		}
+		Stmt->Reset();
+		Stmt->BindText(1, PlayerId);
+		Stmt->BindText(2, BagRef);
+		Stmt->BindInt(3, i);
+		Stmt->BindInt(4, Slot.ItemKey);
+		Stmt->BindInt(5, Slot.Count);
+		Stmt->BindInt(6, Slot.Durability);
+		Stmt->BindInt(7, static_cast<int32>(Slot.Flags));
+		if (!Stmt->Execute()) return false;
 	}
-	sqlite3_finalize(Stmt);
-	return bOk;
+	return true;
 }
 
 bool FKBVEInventoryStore::SaveInventory(const FString& PlayerId, const FKBVEInventory& Inventory)
 {
-	if (!Db) return false;
+	if (!Conn.IsOpen()) return false;
 
-	sqlite3_exec(AsHandle(Db), "BEGIN;", nullptr, nullptr, nullptr);
-
-	const FTCHARToUTF8 PlayerConv(*PlayerId);
-	sqlite3_stmt* DelStmt = nullptr;
-	if (sqlite3_prepare_v2(AsHandle(Db), kDeleteSql, -1, &DelStmt, nullptr) == SQLITE_OK)
+	Conn.Begin();
+	if (TSharedPtr<FKBVESQLiteStatement> Del = Conn.Prepare(kDeleteSql))
 	{
-		sqlite3_bind_text(DelStmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
-		sqlite3_step(DelStmt);
-		sqlite3_finalize(DelStmt);
+		Del->BindText(1, PlayerId);
+		Del->Execute();
 	}
 
 	const bool bOk = InsertBag(PlayerId, Inventory.DefaultBag) && InsertBag(PlayerId, Inventory.Hotbar);
 
-	sqlite3_exec(AsHandle(Db), bOk ? "COMMIT;" : "ROLLBACK;", nullptr, nullptr, nullptr);
+	if (bOk) Conn.Commit(); else Conn.Rollback();
 	return bOk;
 }
 
@@ -143,32 +83,28 @@ void FKBVEInventoryStore::LoadBag(const FString& PlayerId, FKBVEInventoryBag& Ba
 		Slot = FKBVEInventoryStack();
 	}
 
-	const FTCHARToUTF8 PlayerConv(*PlayerId);
-	const FTCHARToUTF8 BagConv(*Bag.BagRef.ToString());
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn.Prepare(kLoadSql);
+	if (!Stmt.IsValid()) return;
 
-	sqlite3_stmt* Stmt = nullptr;
-	if (sqlite3_prepare_v2(AsHandle(Db), kLoadSql, -1, &Stmt, nullptr) != SQLITE_OK) return;
+	Stmt->BindText(1, PlayerId);
+	Stmt->BindText(2, Bag.BagRef.ToString());
 
-	sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
-	sqlite3_bind_text(Stmt, 2, BagConv.Get(), -1, SQLITE_TRANSIENT);
-
-	while (sqlite3_step(Stmt) == SQLITE_ROW)
+	while (Stmt->Step())
 	{
-		const int32 SlotIdx = sqlite3_column_int(Stmt, 0);
+		const int32 SlotIdx = Stmt->ColumnInt(0);
 		if (!Bag.Slots.IsValidIndex(SlotIdx)) continue;
 
 		FKBVEInventoryStack& Slot = Bag.Slots[SlotIdx];
-		Slot.ItemKey    = sqlite3_column_int(Stmt, 1);
-		Slot.Count      = sqlite3_column_int(Stmt, 2);
-		Slot.Durability = sqlite3_column_int(Stmt, 3);
-		Slot.Flags      = static_cast<uint8>(sqlite3_column_int(Stmt, 4));
+		Slot.ItemKey    = Stmt->ColumnInt(1);
+		Slot.Count      = Stmt->ColumnInt(2);
+		Slot.Durability = Stmt->ColumnInt(3);
+		Slot.Flags      = static_cast<uint8>(Stmt->ColumnInt(4));
 	}
-	sqlite3_finalize(Stmt);
 }
 
 bool FKBVEInventoryStore::LoadInventory(const FString& PlayerId, FKBVEInventory& Inventory) const
 {
-	if (!Db) return false;
+	if (!Conn.IsOpen()) return false;
 	Inventory.DefaultBag.EnsureSize();
 	Inventory.Hotbar.EnsureSize();
 	LoadBag(PlayerId, Inventory.DefaultBag);
@@ -178,29 +114,19 @@ bool FKBVEInventoryStore::LoadInventory(const FString& PlayerId, FKBVEInventory&
 
 bool FKBVEInventoryStore::ClearPlayer(const FString& PlayerId)
 {
-	if (!Db) return false;
-	const FTCHARToUTF8 PlayerConv(*PlayerId);
-	sqlite3_stmt* Stmt = nullptr;
-	if (sqlite3_prepare_v2(AsHandle(Db), kDeleteSql, -1, &Stmt, nullptr) != SQLITE_OK) return false;
-	sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
-	const int32 Rc = sqlite3_step(Stmt);
-	sqlite3_finalize(Stmt);
-	return Rc == SQLITE_DONE;
+	if (!Conn.IsOpen()) return false;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn.Prepare(kDeleteSql);
+	if (!Stmt.IsValid()) return false;
+	Stmt->BindText(1, PlayerId);
+	return Stmt->Execute();
 }
 
 int32 FKBVEInventoryStore::CountItem(const FString& PlayerId, int32 ItemKey) const
 {
-	if (!Db) return 0;
-	const FTCHARToUTF8 PlayerConv(*PlayerId);
-	sqlite3_stmt* Stmt = nullptr;
-	if (sqlite3_prepare_v2(AsHandle(Db), kCountSql, -1, &Stmt, nullptr) != SQLITE_OK) return 0;
-	sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
-	sqlite3_bind_int(Stmt, 2, ItemKey);
-	int32 Total = 0;
-	if (sqlite3_step(Stmt) == SQLITE_ROW)
-	{
-		Total = sqlite3_column_int(Stmt, 0);
-	}
-	sqlite3_finalize(Stmt);
-	return Total;
+	if (!Conn.IsOpen()) return 0;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn.Prepare(kCountSql);
+	if (!Stmt.IsValid()) return 0;
+	Stmt->BindText(1, PlayerId);
+	Stmt->BindInt(2, ItemKey);
+	return Stmt->Step() ? Stmt->ColumnInt(0) : 0;
 }

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEInventoryStore.cpp
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEInventoryStore.cpp
@@ -1,0 +1,206 @@
+#include "KBVEInventoryStore.h"
+
+#include "HAL/PlatformFileManager.h"
+#include "Misc/Paths.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "sqlite3.h"
+THIRD_PARTY_INCLUDES_END
+
+namespace
+{
+	static const char* kCreateSql =
+		"CREATE TABLE IF NOT EXISTS player_inventory ("
+		" player_id TEXT NOT NULL,"
+		" bag_ref TEXT NOT NULL,"
+		" slot_idx INTEGER NOT NULL,"
+		" item_key INTEGER NOT NULL,"
+		" count INTEGER NOT NULL,"
+		" durability INTEGER NOT NULL DEFAULT 0,"
+		" flags INTEGER NOT NULL DEFAULT 0,"
+		" PRIMARY KEY (player_id, bag_ref, slot_idx)"
+		") WITHOUT ROWID;";
+
+	static const char* kDeleteSql = "DELETE FROM player_inventory WHERE player_id = ?1;";
+	static const char* kInsertSql =
+		"INSERT INTO player_inventory(player_id, bag_ref, slot_idx, item_key, count, durability, flags)"
+		" VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7);";
+	static const char* kLoadSql =
+		"SELECT slot_idx, item_key, count, durability, flags FROM player_inventory WHERE player_id = ?1 AND bag_ref = ?2;";
+	static const char* kCountSql =
+		"SELECT COALESCE(SUM(count), 0) FROM player_inventory WHERE player_id = ?1 AND item_key = ?2;";
+
+	sqlite3* AsHandle(void* P) { return reinterpret_cast<sqlite3*>(P); }
+}
+
+FKBVEInventoryStore::~FKBVEInventoryStore()
+{
+	Close();
+}
+
+bool FKBVEInventoryStore::Open(const FString& DbPath)
+{
+	if (Db) return true;
+
+	IPlatformFile& FS = FPlatformFileManager::Get().GetPlatformFile();
+	const FString DbDir = FPaths::GetPath(DbPath);
+	if (!DbDir.IsEmpty()) FS.CreateDirectoryTree(*DbDir);
+
+	const FTCHARToUTF8 Conv(*DbPath);
+	sqlite3* Handle = nullptr;
+	if (sqlite3_open_v2(Conv.Get(), &Handle, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr) != SQLITE_OK)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[KBVEInventoryStore] open failed: %s"), UTF8_TO_TCHAR(Handle ? sqlite3_errmsg(Handle) : "null"));
+		if (Handle) sqlite3_close(Handle);
+		return false;
+	}
+
+	sqlite3_exec(Handle, "PRAGMA journal_mode=WAL;",   nullptr, nullptr, nullptr);
+	sqlite3_exec(Handle, "PRAGMA synchronous=NORMAL;", nullptr, nullptr, nullptr);
+	sqlite3_exec(Handle, "PRAGMA temp_store=MEMORY;",  nullptr, nullptr, nullptr);
+
+	char* Err = nullptr;
+	if (sqlite3_exec(Handle, kCreateSql, nullptr, nullptr, &Err) != SQLITE_OK)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[KBVEInventoryStore] create failed: %s"), UTF8_TO_TCHAR(Err ? Err : ""));
+		sqlite3_free(Err);
+		sqlite3_close(Handle);
+		return false;
+	}
+
+	Db = Handle;
+	UE_LOG(LogTemp, Display, TEXT("[KBVEInventoryStore] opened %s"), *DbPath);
+	return true;
+}
+
+void FKBVEInventoryStore::Close()
+{
+	if (Db)
+	{
+		sqlite3_close(AsHandle(Db));
+		Db = nullptr;
+	}
+}
+
+bool FKBVEInventoryStore::InsertBag(const FString& PlayerId, const FKBVEInventoryBag& Bag)
+{
+	const FTCHARToUTF8 PlayerConv(*PlayerId);
+	const FTCHARToUTF8 BagConv(*Bag.BagRef.ToString());
+
+	sqlite3_stmt* Stmt = nullptr;
+	if (sqlite3_prepare_v2(AsHandle(Db), kInsertSql, -1, &Stmt, nullptr) != SQLITE_OK) return false;
+
+	bool bOk = true;
+	for (int32 i = 0; i < Bag.Slots.Num(); ++i)
+	{
+		const FKBVEInventoryStack& Slot = Bag.Slots[i];
+		if (Slot.IsEmpty()) continue;
+
+		sqlite3_reset(Stmt);
+		sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
+		sqlite3_bind_text(Stmt, 2, BagConv.Get(), -1, SQLITE_TRANSIENT);
+		sqlite3_bind_int(Stmt, 3, i);
+		sqlite3_bind_int(Stmt, 4, Slot.ItemKey);
+		sqlite3_bind_int(Stmt, 5, Slot.Count);
+		sqlite3_bind_int(Stmt, 6, Slot.Durability);
+		sqlite3_bind_int(Stmt, 7, static_cast<int32>(Slot.Flags));
+
+		if (sqlite3_step(Stmt) != SQLITE_DONE)
+		{
+			bOk = false;
+			break;
+		}
+	}
+	sqlite3_finalize(Stmt);
+	return bOk;
+}
+
+bool FKBVEInventoryStore::SaveInventory(const FString& PlayerId, const FKBVEInventory& Inventory)
+{
+	if (!Db) return false;
+
+	sqlite3_exec(AsHandle(Db), "BEGIN;", nullptr, nullptr, nullptr);
+
+	const FTCHARToUTF8 PlayerConv(*PlayerId);
+	sqlite3_stmt* DelStmt = nullptr;
+	if (sqlite3_prepare_v2(AsHandle(Db), kDeleteSql, -1, &DelStmt, nullptr) == SQLITE_OK)
+	{
+		sqlite3_bind_text(DelStmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
+		sqlite3_step(DelStmt);
+		sqlite3_finalize(DelStmt);
+	}
+
+	const bool bOk = InsertBag(PlayerId, Inventory.DefaultBag) && InsertBag(PlayerId, Inventory.Hotbar);
+
+	sqlite3_exec(AsHandle(Db), bOk ? "COMMIT;" : "ROLLBACK;", nullptr, nullptr, nullptr);
+	return bOk;
+}
+
+void FKBVEInventoryStore::LoadBag(const FString& PlayerId, FKBVEInventoryBag& Bag) const
+{
+	for (FKBVEInventoryStack& Slot : Bag.Slots)
+	{
+		Slot = FKBVEInventoryStack();
+	}
+
+	const FTCHARToUTF8 PlayerConv(*PlayerId);
+	const FTCHARToUTF8 BagConv(*Bag.BagRef.ToString());
+
+	sqlite3_stmt* Stmt = nullptr;
+	if (sqlite3_prepare_v2(AsHandle(Db), kLoadSql, -1, &Stmt, nullptr) != SQLITE_OK) return;
+
+	sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_text(Stmt, 2, BagConv.Get(), -1, SQLITE_TRANSIENT);
+
+	while (sqlite3_step(Stmt) == SQLITE_ROW)
+	{
+		const int32 SlotIdx = sqlite3_column_int(Stmt, 0);
+		if (!Bag.Slots.IsValidIndex(SlotIdx)) continue;
+
+		FKBVEInventoryStack& Slot = Bag.Slots[SlotIdx];
+		Slot.ItemKey    = sqlite3_column_int(Stmt, 1);
+		Slot.Count      = sqlite3_column_int(Stmt, 2);
+		Slot.Durability = sqlite3_column_int(Stmt, 3);
+		Slot.Flags      = static_cast<uint8>(sqlite3_column_int(Stmt, 4));
+	}
+	sqlite3_finalize(Stmt);
+}
+
+bool FKBVEInventoryStore::LoadInventory(const FString& PlayerId, FKBVEInventory& Inventory) const
+{
+	if (!Db) return false;
+	Inventory.DefaultBag.EnsureSize();
+	Inventory.Hotbar.EnsureSize();
+	LoadBag(PlayerId, Inventory.DefaultBag);
+	LoadBag(PlayerId, Inventory.Hotbar);
+	return true;
+}
+
+bool FKBVEInventoryStore::ClearPlayer(const FString& PlayerId)
+{
+	if (!Db) return false;
+	const FTCHARToUTF8 PlayerConv(*PlayerId);
+	sqlite3_stmt* Stmt = nullptr;
+	if (sqlite3_prepare_v2(AsHandle(Db), kDeleteSql, -1, &Stmt, nullptr) != SQLITE_OK) return false;
+	sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
+	const int32 Rc = sqlite3_step(Stmt);
+	sqlite3_finalize(Stmt);
+	return Rc == SQLITE_DONE;
+}
+
+int32 FKBVEInventoryStore::CountItem(const FString& PlayerId, int32 ItemKey) const
+{
+	if (!Db) return 0;
+	const FTCHARToUTF8 PlayerConv(*PlayerId);
+	sqlite3_stmt* Stmt = nullptr;
+	if (sqlite3_prepare_v2(AsHandle(Db), kCountSql, -1, &Stmt, nullptr) != SQLITE_OK) return 0;
+	sqlite3_bind_text(Stmt, 1, PlayerConv.Get(), -1, SQLITE_TRANSIENT);
+	sqlite3_bind_int(Stmt, 2, ItemKey);
+	int32 Total = 0;
+	if (sqlite3_step(Stmt) == SQLITE_ROW)
+	{
+		Total = sqlite3_column_int(Stmt, 0);
+	}
+	sqlite3_finalize(Stmt);
+	return Total;
+}

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEInventoryStoreSubsystem.cpp
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEInventoryStoreSubsystem.cpp
@@ -1,0 +1,42 @@
+#include "KBVEInventoryStoreSubsystem.h"
+
+#include "Misc/Paths.h"
+
+void UKBVEInventoryStoreSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	const FString DbPath = FPaths::ProjectSavedDir() / TEXT("KBVE/inventory.db");
+	Store.Open(DbPath);
+}
+
+void UKBVEInventoryStoreSubsystem::Deinitialize()
+{
+	Store.Close();
+	Super::Deinitialize();
+}
+
+bool UKBVEInventoryStoreSubsystem::OpenAt(const FString& DbPath)
+{
+	Store.Close();
+	return Store.Open(DbPath);
+}
+
+bool UKBVEInventoryStoreSubsystem::SaveInventory(const FString& PlayerId, const FKBVEInventory& Inventory)
+{
+	return Store.SaveInventory(PlayerId, Inventory);
+}
+
+bool UKBVEInventoryStoreSubsystem::LoadInventory(const FString& PlayerId, FKBVEInventory& Inventory)
+{
+	return Store.LoadInventory(PlayerId, Inventory);
+}
+
+int32 UKBVEInventoryStoreSubsystem::CountItem(const FString& PlayerId, int32 ItemKey)
+{
+	return Store.CountItem(PlayerId, ItemKey);
+}
+
+bool UKBVEInventoryStoreSubsystem::ClearPlayer(const FString& PlayerId)
+{
+	return Store.ClearPlayer(PlayerId);
+}

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEItemCatalogStore.cpp
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEItemCatalogStore.cpp
@@ -1,0 +1,99 @@
+#include "KBVEItemCatalogStore.h"
+
+namespace
+{
+	static const char* kCreateSql =
+		"CREATE TABLE IF NOT EXISTS item_def ("
+		" key INTEGER PRIMARY KEY,"
+		" ref TEXT NOT NULL,"
+		" name TEXT,"
+		" type_flags INTEGER NOT NULL DEFAULT 0,"
+		" rarity INTEGER NOT NULL DEFAULT 0,"
+		" max_stack INTEGER NOT NULL DEFAULT 1,"
+		" stackable INTEGER NOT NULL DEFAULT 0,"
+		" consumable INTEGER NOT NULL DEFAULT 0,"
+		" buy_price INTEGER NOT NULL DEFAULT 0,"
+		" sell_price INTEGER NOT NULL DEFAULT 0"
+		");";
+
+	static const char* kUpsertSql =
+		"INSERT INTO item_def(key, ref, name, type_flags, rarity, max_stack, stackable, consumable, buy_price, sell_price)"
+		" VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)"
+		" ON CONFLICT(key) DO UPDATE SET"
+		" ref=excluded.ref, name=excluded.name, type_flags=excluded.type_flags, rarity=excluded.rarity,"
+		" max_stack=excluded.max_stack, stackable=excluded.stackable, consumable=excluded.consumable,"
+		" buy_price=excluded.buy_price, sell_price=excluded.sell_price;";
+
+	static const char* kByTypeSql = "SELECT key FROM item_def WHERE (type_flags & ?1) != 0;";
+	static const char* kCountSql  = "SELECT COUNT(*) FROM item_def;";
+}
+
+bool FKBVEItemCatalogStore::Open(const FString& DbPath)
+{
+	if (!Conn.Open(DbPath)) return false;
+	return Conn.Exec(kCreateSql);
+}
+
+void FKBVEItemCatalogStore::Close()
+{
+	Conn.Close();
+}
+
+bool FKBVEItemCatalogStore::SaveCatalog(const TArray<FKBVEItemDef>& Items)
+{
+	if (!Conn.IsOpen()) return false;
+
+	Conn.Begin();
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn.Prepare(kUpsertSql);
+	if (!Stmt.IsValid())
+	{
+		Conn.Rollback();
+		return false;
+	}
+
+	bool bOk = true;
+	for (const FKBVEItemDef& Def : Items)
+	{
+		Stmt->Reset();
+		Stmt->BindInt(1, Def.Key);
+		Stmt->BindText(2, Def.Ref.ToString());
+		Stmt->BindText(3, Def.Name);
+		Stmt->BindInt(4, Def.TypeFlags);
+		Stmt->BindInt(5, static_cast<int32>(Def.Rarity));
+		Stmt->BindInt(6, Def.MaxStack);
+		Stmt->BindInt(7, Def.bStackable ? 1 : 0);
+		Stmt->BindInt(8, Def.bConsumable ? 1 : 0);
+		Stmt->BindInt(9, Def.BuyPrice);
+		Stmt->BindInt(10, Def.SellPrice);
+		if (!Stmt->Execute())
+		{
+			bOk = false;
+			break;
+		}
+	}
+
+	if (bOk) Conn.Commit(); else Conn.Rollback();
+	return bOk;
+}
+
+int32 FKBVEItemCatalogStore::GetKeysByTypeFlag(int32 Mask, TArray<int32>& OutKeys) const
+{
+	OutKeys.Reset();
+	if (!Conn.IsOpen()) return 0;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn.Prepare(kByTypeSql);
+	if (!Stmt.IsValid()) return 0;
+	Stmt->BindInt(1, Mask);
+	while (Stmt->Step())
+	{
+		OutKeys.Add(Stmt->ColumnInt(0));
+	}
+	return OutKeys.Num();
+}
+
+int32 FKBVEItemCatalogStore::NumRows() const
+{
+	if (!Conn.IsOpen()) return 0;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn.Prepare(kCountSql);
+	if (!Stmt.IsValid()) return 0;
+	return Stmt->Step() ? Stmt->ColumnInt(0) : 0;
+}

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEItemDatabase.cpp
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEItemDatabase.cpp
@@ -1,5 +1,6 @@
 #include "KBVEItemDatabase.h"
 
+#include "KBVEItemCatalogStore.h"
 #include "Dom/JsonObject.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
@@ -199,4 +200,16 @@ bool UKBVEItemDatabase::GetItemByRef(FName Ref, FKBVEItemDef& OutDef) const
 		return true;
 	}
 	return false;
+}
+
+bool UKBVEItemDatabase::PersistCatalogToDb(const FString& DbPath) const
+{
+	FKBVEItemCatalogStore Store;
+	if (!Store.Open(DbPath))
+	{
+		return false;
+	}
+	const bool bOk = Store.SaveCatalog(Items);
+	Store.Close();
+	return bOk;
 }

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEInventoryStore.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEInventoryStore.h
@@ -2,15 +2,14 @@
 
 #include "CoreMinimal.h"
 #include "KBVEInventoryTypes.h"
+#include "KBVESQLiteConnection.h"
 
 class KBVEITEMDB_API FKBVEInventoryStore
 {
 public:
-	~FKBVEInventoryStore();
-
 	bool Open(const FString& DbPath);
 	void Close();
-	bool IsOpen() const { return Db != nullptr; }
+	bool IsOpen() const { return Conn.IsOpen(); }
 
 	bool SaveInventory(const FString& PlayerId, const FKBVEInventory& Inventory);
 	bool LoadInventory(const FString& PlayerId, FKBVEInventory& Inventory) const;
@@ -21,5 +20,5 @@ private:
 	bool InsertBag(const FString& PlayerId, const FKBVEInventoryBag& Bag);
 	void LoadBag(const FString& PlayerId, FKBVEInventoryBag& Bag) const;
 
-	void* Db = nullptr;
+	FKBVESQLiteConnection Conn;
 };

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEInventoryStore.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEInventoryStore.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "KBVEInventoryTypes.h"
+
+class KBVEITEMDB_API FKBVEInventoryStore
+{
+public:
+	~FKBVEInventoryStore();
+
+	bool Open(const FString& DbPath);
+	void Close();
+	bool IsOpen() const { return Db != nullptr; }
+
+	bool SaveInventory(const FString& PlayerId, const FKBVEInventory& Inventory);
+	bool LoadInventory(const FString& PlayerId, FKBVEInventory& Inventory) const;
+	bool ClearPlayer(const FString& PlayerId);
+	int32 CountItem(const FString& PlayerId, int32 ItemKey) const;
+
+private:
+	bool InsertBag(const FString& PlayerId, const FKBVEInventoryBag& Bag);
+	void LoadBag(const FString& PlayerId, FKBVEInventoryBag& Bag) const;
+
+	void* Db = nullptr;
+};

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEInventoryStoreSubsystem.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEInventoryStoreSubsystem.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "KBVEInventoryStore.h"
+#include "KBVEInventoryTypes.h"
+#include "KBVEInventoryStoreSubsystem.generated.h"
+
+UCLASS()
+class KBVEITEMDB_API UKBVEInventoryStoreSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Inventory")
+	bool OpenAt(const FString& DbPath);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Inventory")
+	bool SaveInventory(const FString& PlayerId, const FKBVEInventory& Inventory);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Inventory")
+	bool LoadInventory(const FString& PlayerId, UPARAM(ref) FKBVEInventory& Inventory);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Inventory")
+	int32 CountItem(const FString& PlayerId, int32 ItemKey);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Inventory")
+	bool ClearPlayer(const FString& PlayerId);
+
+private:
+	FKBVEInventoryStore Store;
+};

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEItemCatalogStore.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEItemCatalogStore.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "KBVEItemTypes.h"
+#include "KBVESQLiteConnection.h"
+
+class KBVEITEMDB_API FKBVEItemCatalogStore
+{
+public:
+	bool Open(const FString& DbPath);
+	void Close();
+	bool IsOpen() const { return Conn.IsOpen(); }
+
+	bool SaveCatalog(const TArray<FKBVEItemDef>& Items);
+
+	int32 GetKeysByTypeFlag(int32 Mask, TArray<int32>& OutKeys) const;
+	int32 NumRows() const;
+
+private:
+	FKBVESQLiteConnection Conn;
+};

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEItemDatabase.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEItemDatabase.h
@@ -33,6 +33,9 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "KBVE|Item")
 	int32 Num() const { return Items.Num(); }
 
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Item")
+	bool PersistCatalogToDb(const FString& DbPath) const;
+
 private:
 	UPROPERTY()
 	TArray<FKBVEItemDef> Items;

--- a/packages/unreal/KBVESQLite/README.md
+++ b/packages/unreal/KBVESQLite/README.md
@@ -1,0 +1,53 @@
+# KBVESQLite
+
+Embedded SQLite for KBVE Unreal Engine plugins — a vendored `sqlite3` amalgamation plus a thin RAII wrapper so consumers never touch raw `sqlite3_*` calls.
+
+## What it provides
+
+- **Vendored `sqlite3`** (3.51.x) exposed via `PublicIncludePaths` (`#include "sqlite3.h"`), with default symbol visibility so consumer modules link directly against this plugin's binary.
+- **`FKBVESQLiteConnection`** — RAII connection wrapper:
+    - `Open(path, bUseWAL=true)` / `Close()` / `IsOpen()`
+    - `Exec(sql)` — fire-and-forget statements
+    - `Prepare(sql)` → `TSharedPtr<FKBVESQLiteStatement>`
+    - `Begin()` / `Commit()` / `Rollback()`
+- **`FKBVESQLiteStatement`** — RAII prepared statement:
+    - `BindInt` / `BindInt64` / `BindText` / `BindBlob`
+    - `Step()` (row), `Execute()` (done), `Reset()`
+    - `ColumnInt` / `ColumnInt64` / `ColumnText` / `ColumnBlob`
+
+## Usage
+
+```cpp
+#include "KBVESQLiteConnection.h"
+
+FKBVESQLiteConnection Conn;
+Conn.Open(FPaths::ProjectSavedDir() / TEXT("KBVE/data.db")); // WAL on
+Conn.Exec("CREATE TABLE IF NOT EXISTS kv (k TEXT PRIMARY KEY, v INTEGER);");
+
+Conn.Begin();
+if (TSharedPtr<FKBVESQLiteStatement> S = Conn.Prepare("INSERT INTO kv(k,v) VALUES(?1,?2);"))
+{
+    S->BindText(1, TEXT("gold"));
+    S->BindInt(2, 500);
+    S->Execute();
+}
+Conn.Commit();
+
+if (TSharedPtr<FKBVESQLiteStatement> Q = Conn.Prepare("SELECT v FROM kv WHERE k=?1;"))
+{
+    Q->BindText(1, TEXT("gold"));
+    if (Q->Step()) { int32 Gold = Q->ColumnInt(0); }
+}
+```
+
+Add `"KBVESQLite"` to your module's `PrivateDependencyModuleNames`, and (for the CI plugin build) add `dependency_plugins: packages/unreal/KBVESQLite` to your ci-registry MDX so it's staged.
+
+## Rules
+
+- **Single sqlite provider.** Do **not** also link the engine's `SQLiteCore` in the same module — two vendored `sqlite3` copies produce duplicate `sqlite3_*` symbols and crash the build/run. KBVE code uses KBVESQLite only.
+- **Persistence boundary, not a hot-loop datasource.** A single connection is not thread-safe; WAL allows many readers + one writer only across _separate_ connections. Don't query SQLite inside a Mass `ParallelForEachEntityChunk` loop — load at boundaries (spawn/login), keep the working set in memory / Mass fragments, flush at intervals/logout (game thread or async task).
+
+## Consumers
+
+- `FKBVEWorldChunkCache` (KBVEWorld) — terrain chunk BLOB cache.
+- `FKBVEInventoryStore` / `FKBVEItemCatalogStore` (KBVEItemDB) — inventory persistence + queryable item catalog.

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteConnection.cpp
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESQLiteConnection.cpp
@@ -1,0 +1,170 @@
+#include "KBVESQLiteConnection.h"
+
+#include "HAL/PlatformFileManager.h"
+#include "Misc/Paths.h"
+
+THIRD_PARTY_INCLUDES_START
+#include "sqlite3.h"
+THIRD_PARTY_INCLUDES_END
+
+namespace
+{
+	sqlite3* AsDb(void* P) { return reinterpret_cast<sqlite3*>(P); }
+	sqlite3_stmt* AsStmt(void* P) { return reinterpret_cast<sqlite3_stmt*>(P); }
+}
+
+FKBVESQLiteStatement::FKBVESQLiteStatement(void* InDb, const char* Sql)
+{
+	if (InDb)
+	{
+		sqlite3_stmt* Prepared = nullptr;
+		if (sqlite3_prepare_v2(AsDb(InDb), Sql, -1, &Prepared, nullptr) == SQLITE_OK)
+		{
+			Stmt = Prepared;
+		}
+	}
+}
+
+FKBVESQLiteStatement::~FKBVESQLiteStatement()
+{
+	if (Stmt)
+	{
+		sqlite3_finalize(AsStmt(Stmt));
+		Stmt = nullptr;
+	}
+}
+
+void FKBVESQLiteStatement::BindInt(int32 Index, int32 Value)
+{
+	if (Stmt) sqlite3_bind_int(AsStmt(Stmt), Index, Value);
+}
+
+void FKBVESQLiteStatement::BindInt64(int32 Index, int64 Value)
+{
+	if (Stmt) sqlite3_bind_int64(AsStmt(Stmt), Index, Value);
+}
+
+void FKBVESQLiteStatement::BindText(int32 Index, const FString& Value)
+{
+	if (!Stmt) return;
+	const FTCHARToUTF8 Conv(*Value);
+	sqlite3_bind_text(AsStmt(Stmt), Index, Conv.Get(), -1, SQLITE_TRANSIENT);
+}
+
+void FKBVESQLiteStatement::BindBlob(int32 Index, const TArray<uint8>& Value)
+{
+	if (Stmt) sqlite3_bind_blob(AsStmt(Stmt), Index, Value.GetData(), Value.Num(), SQLITE_TRANSIENT);
+}
+
+bool FKBVESQLiteStatement::Step() const
+{
+	return Stmt && sqlite3_step(AsStmt(Stmt)) == SQLITE_ROW;
+}
+
+bool FKBVESQLiteStatement::Execute() const
+{
+	return Stmt && sqlite3_step(AsStmt(Stmt)) == SQLITE_DONE;
+}
+
+void FKBVESQLiteStatement::Reset()
+{
+	if (Stmt) sqlite3_reset(AsStmt(Stmt));
+}
+
+int32 FKBVESQLiteStatement::ColumnInt(int32 Col) const
+{
+	return Stmt ? sqlite3_column_int(AsStmt(Stmt), Col) : 0;
+}
+
+int64 FKBVESQLiteStatement::ColumnInt64(int32 Col) const
+{
+	return Stmt ? sqlite3_column_int64(AsStmt(Stmt), Col) : 0;
+}
+
+FString FKBVESQLiteStatement::ColumnText(int32 Col) const
+{
+	if (!Stmt) return FString();
+	const unsigned char* Text = sqlite3_column_text(AsStmt(Stmt), Col);
+	return Text ? FString(UTF8_TO_TCHAR(reinterpret_cast<const char*>(Text))) : FString();
+}
+
+bool FKBVESQLiteStatement::ColumnBlob(int32 Col, TArray<uint8>& OutBlob) const
+{
+	if (!Stmt) return false;
+	const void* Bytes = sqlite3_column_blob(AsStmt(Stmt), Col);
+	const int32 N = sqlite3_column_bytes(AsStmt(Stmt), Col);
+	if (Bytes && N > 0)
+	{
+		OutBlob.SetNumUninitialized(N);
+		FMemory::Memcpy(OutBlob.GetData(), Bytes, N);
+		return true;
+	}
+	return false;
+}
+
+FKBVESQLiteConnection::~FKBVESQLiteConnection()
+{
+	Close();
+}
+
+bool FKBVESQLiteConnection::Open(const FString& DbPath, bool bUseWAL)
+{
+	if (Db) return true;
+
+	IPlatformFile& FS = FPlatformFileManager::Get().GetPlatformFile();
+	const FString DbDir = FPaths::GetPath(DbPath);
+	if (!DbDir.IsEmpty()) FS.CreateDirectoryTree(*DbDir);
+
+	const FTCHARToUTF8 Conv(*DbPath);
+	sqlite3* Handle = nullptr;
+	if (sqlite3_open_v2(Conv.Get(), &Handle, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, nullptr) != SQLITE_OK)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[KBVESQLite] open failed: %s"), UTF8_TO_TCHAR(Handle ? sqlite3_errmsg(Handle) : "null"));
+		if (Handle) sqlite3_close(Handle);
+		return false;
+	}
+
+	if (bUseWAL)
+	{
+		sqlite3_exec(Handle, "PRAGMA journal_mode=WAL;",   nullptr, nullptr, nullptr);
+		sqlite3_exec(Handle, "PRAGMA synchronous=NORMAL;", nullptr, nullptr, nullptr);
+		sqlite3_exec(Handle, "PRAGMA temp_store=MEMORY;",  nullptr, nullptr, nullptr);
+	}
+
+	Db = Handle;
+	return true;
+}
+
+void FKBVESQLiteConnection::Close()
+{
+	if (Db)
+	{
+		sqlite3_close(AsDb(Db));
+		Db = nullptr;
+	}
+}
+
+bool FKBVESQLiteConnection::Exec(const char* Sql)
+{
+	if (!Db) return false;
+	char* Err = nullptr;
+	const int32 Rc = sqlite3_exec(AsDb(Db), Sql, nullptr, nullptr, &Err);
+	if (Rc != SQLITE_OK)
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[KBVESQLite] exec failed: %s"), UTF8_TO_TCHAR(Err ? Err : ""));
+		sqlite3_free(Err);
+		return false;
+	}
+	return true;
+}
+
+TSharedPtr<FKBVESQLiteStatement> FKBVESQLiteConnection::Prepare(const char* Sql) const
+{
+	if (!Db) return nullptr;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = MakeShared<FKBVESQLiteStatement>(Db, Sql);
+	return Stmt->IsValid() ? Stmt : nullptr;
+}
+
+void FKBVESQLiteConnection::Begin()    { Exec("BEGIN;"); }
+void FKBVESQLiteConnection::Commit()   { Exec("COMMIT;"); }
+void FKBVESQLiteConnection::Rollback() { Exec("ROLLBACK;"); }

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/Public/KBVESQLiteConnection.h
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/Public/KBVESQLiteConnection.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class KBVESQLITE_API FKBVESQLiteStatement
+{
+public:
+	FKBVESQLiteStatement(void* InDb, const char* Sql);
+	~FKBVESQLiteStatement();
+
+	bool IsValid() const { return Stmt != nullptr; }
+
+	void BindInt(int32 Index, int32 Value);
+	void BindInt64(int32 Index, int64 Value);
+	void BindText(int32 Index, const FString& Value);
+	void BindBlob(int32 Index, const TArray<uint8>& Value);
+
+	bool Step() const;       // true on a row (SQLITE_ROW)
+	bool Execute() const;    // true on completion (SQLITE_DONE)
+	void Reset();
+
+	int32   ColumnInt(int32 Col) const;
+	int64   ColumnInt64(int32 Col) const;
+	FString ColumnText(int32 Col) const;
+	bool    ColumnBlob(int32 Col, TArray<uint8>& OutBlob) const;
+
+private:
+	void* Stmt = nullptr;
+};
+
+class KBVESQLITE_API FKBVESQLiteConnection
+{
+public:
+	FKBVESQLiteConnection() = default;
+	~FKBVESQLiteConnection();
+
+	FKBVESQLiteConnection(const FKBVESQLiteConnection&) = delete;
+	FKBVESQLiteConnection& operator=(const FKBVESQLiteConnection&) = delete;
+
+	bool Open(const FString& DbPath, bool bUseWAL = true);
+	void Close();
+	bool IsOpen() const { return Db != nullptr; }
+
+	bool Exec(const char* Sql);
+
+	TSharedPtr<FKBVESQLiteStatement> Prepare(const char* Sql) const;
+
+	void Begin();
+	void Commit();
+	void Rollback();
+
+	void* GetRawHandle() const { return Db; }
+
+private:
+	void* Db = nullptr;
+};


### PR DESCRIPTION
## What

SQLite for KBVEItemDB, with a **reusable access seam** so future plugins don't re-roll raw sqlite3. Architecture locked: **live inventory = Mass** (authoritative gameplay), **SQLite = persistence boundary + queryable static catalog**.

### Shared seam (KBVESQLite)
- **`FKBVESQLiteConnection`** — RAII `Open(WAL)`/`Close`/`Exec`/`Prepare`/`Begin/Commit/Rollback`.
- **`FKBVESQLiteStatement`** — RAII prepared statement (bind int/int64/text/blob, step/execute, column accessors).
- **Only KBVESQLite touches `sqlite3.h` now** — consumers use the wrapper. Future NPC/Quest/Map persistence reuses this instead of duplicating boilerplate (`FKBVEWorldChunkCache` can migrate too).

### KBVEItemDB (no raw sqlite3 in the plugin)
- **`FKBVEInventoryStore`** — refactored onto the connection. Persistence boundary, row-per-slot, save/load/count/clear. (`UKBVEInventoryStoreSubsystem` opens `Saved/KBVE/inventory.db`.)
- **`FKBVEItemCatalogStore`** — itemdb catalog → read-only `item_def` SQLite table ("safe data", queryable). `UKBVEItemDatabase::PersistCatalogToDb(path)` emits it; `GetKeysByTypeFlag` is an example SQL query.

### The two boundaries (documented in the MDX + memory)
1. **SQLite ⟂ Mass** — SQLite at load/flush boundaries, never the processor hot loop. Live inventory stays in `FchuckInventoryFragment`.
2. **KBVESQLite ⟂ UE SQLiteCore** — KBVESQLite is the single sqlite provider; linking SQLiteCore alongside = duplicate `sqlite3_*` symbols → crash. `dependency_plugins: packages/unreal/KBVESQLite` stages it in CI.

### No dupes
One canonical source (itemdb MDX → JSON). The SQLite catalog + the in-memory lookup map are read-only **projections** of it, not divergent writable copies. Live mutable state lives in exactly one place: Mass.

## Not verified locally
No UE toolchain — relies on the CI plugin build (staging KBVESQLite) to compile-check the sqlite wrapper + stores.

## Follow-up
chuck adoption: save inventory on change/EndPlay + load on BeginPlay (player id = profile ULID), converting `FchuckInventory` ⇄ `FKBVEInventory`. Optionally migrate `FKBVEWorldChunkCache` onto `FKBVESQLiteConnection`.