### PR TITLE
fix(irc-e2e): smoke CORS test must send Origin to trigger header

### DIFF
--- a/apps/irc/irc-e2e/e2e/smoke.spec.ts
+++ b/apps/irc/irc-e2e/e2e/smoke.spec.ts
@@ -27,11 +27,14 @@ test.describe('Smoke: Security Headers', () => {
 });
 
 test.describe('Smoke: CORS', () => {
-	test('CORS headers are present', async ({ request }) => {
-		const response = await request.get('/health');
+	test('CORS headers echo allowed Origin', async ({ request }) => {
+		const origin = 'http://localhost:4321';
+		const response = await request.get('/health', {
+			headers: { Origin: origin },
+		});
 		const headers = response.headers();
 
-		expect(headers['access-control-allow-origin']).toBeTruthy();
+		expect(headers['access-control-allow-origin']).toBe(origin);
 	});
 });
 


### PR DESCRIPTION
## Summary
Closes #11874. The irc-gateway CI - Docker job has been failing on \`Smoke: CORS › CORS headers are present\` since the Playwright install ladder unblocked the install step. The download path is now fine; the e2e was always broken — the test fired \`GET /health\` with **no Origin header**, so \`tower_http::CorsLayer\` correctly emitted no \`access-control-allow-origin\`, and \`expect(...).toBeTruthy()\` failed on every retry.

\`\`\`
1) [docker] › apps/irc/irc-e2e/e2e/smoke.spec.ts:30:6 › Smoke: CORS › CORS headers are present
   Error: expect(received).toBeTruthy()
     34 |   expect(headers['access-control-allow-origin']).toBeTruthy();
\`\`\`

## Fix
Send \`Origin: http://localhost:4321\` (allowed by [build_cors_layer](apps/irc/irc-gateway/src/transport/https.rs) via the dev-localhost branch of \`is_origin_allowed\`) and assert the response echoes that exact origin instead of just being truthy. Tightens the contract too — a misconfigured CorsLayer that returned \`*\` to a non-allowlisted origin wouldn't have caught the regression with the old assertion.

## Test plan
- [ ] \`pnpm nx e2e irc --configuration=ci\` green
- [ ] CI - Docker / irc-gateway green