### PR TITLE
feat(KBVELibGit): package lock system

### DIFF
--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/KBVEPluginLock.cpp
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/KBVEPluginLock.cpp
@@ -1,0 +1,129 @@
+#include "KBVEPluginLock.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+#include "Serialization/JsonReader.h"
+#include "Serialization/JsonWriter.h"
+#include "Serialization/JsonSerializer.h"
+#include "Dom/JsonObject.h"
+
+FString FKBVEPluginLock::GetLockFilePath()
+{
+	return FPaths::Combine(FPaths::ProjectDir(), LockFileName);
+}
+
+bool FKBVEPluginLock::Exists()
+{
+	return FPaths::FileExists(GetLockFilePath());
+}
+
+bool FKBVEPluginLock::Load(FKBVEPluginLockFile& OutLock)
+{
+	OutLock = FKBVEPluginLockFile();
+
+	FString Content;
+	if (!FFileHelper::LoadFileToString(Content, *GetLockFilePath()))
+	{
+		return false;
+	}
+
+	TSharedPtr<FJsonObject> Root;
+	TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(Content);
+	if (!FJsonSerializer::Deserialize(Reader, Root) || !Root.IsValid())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[KBVELibGit] Lockfile is not valid JSON: %s"), *GetLockFilePath());
+		return false;
+	}
+
+	Root->TryGetStringField(TEXT("engine"), OutLock.Engine);
+	Root->TryGetStringField(TEXT("registry"), OutLock.Registry);
+
+	const TArray<TSharedPtr<FJsonValue>>* Plugins = nullptr;
+	if (Root->TryGetArrayField(TEXT("plugins"), Plugins))
+	{
+		for (const TSharedPtr<FJsonValue>& Value : *Plugins)
+		{
+			const TSharedPtr<FJsonObject>* Obj = nullptr;
+			if (!Value->TryGetObject(Obj) || !Obj->IsValid())
+			{
+				continue;
+			}
+
+			FKBVEPluginLockEntry Entry;
+			(*Obj)->TryGetStringField(TEXT("name"), Entry.Name);
+			(*Obj)->TryGetStringField(TEXT("version"), Entry.Version);
+			(*Obj)->TryGetStringField(TEXT("resolution"), Entry.Resolution);
+			(*Obj)->TryGetStringField(TEXT("ref"), Entry.Ref);
+			(*Obj)->TryGetStringField(TEXT("integrity"), Entry.Integrity);
+
+			if (!Entry.Name.IsEmpty())
+			{
+				OutLock.Plugins.Add(MoveTemp(Entry));
+			}
+		}
+	}
+
+	return true;
+}
+
+bool FKBVEPluginLock::Save(const FKBVEPluginLockFile& Lock)
+{
+	TSharedRef<FJsonObject> Root = MakeShared<FJsonObject>();
+	Root->SetStringField(TEXT("engine"), Lock.Engine);
+	Root->SetStringField(TEXT("registry"), Lock.Registry);
+
+	TArray<TSharedPtr<FJsonValue>> Plugins;
+	for (const FKBVEPluginLockEntry& Entry : Lock.Plugins)
+	{
+		TSharedRef<FJsonObject> Obj = MakeShared<FJsonObject>();
+		Obj->SetStringField(TEXT("name"), Entry.Name);
+		Obj->SetStringField(TEXT("version"), Entry.Version);
+		Obj->SetStringField(TEXT("resolution"), Entry.Resolution);
+		Obj->SetStringField(TEXT("ref"), Entry.Ref);
+		Obj->SetStringField(TEXT("integrity"), Entry.Integrity);
+		Plugins.Add(MakeShared<FJsonValueObject>(Obj));
+	}
+	Root->SetArrayField(TEXT("plugins"), Plugins);
+
+	FString Output;
+	TSharedRef<TJsonWriter<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>> Writer =
+		TJsonWriterFactory<TCHAR, TPrettyJsonPrintPolicy<TCHAR>>::Create(&Output);
+
+	if (!FJsonSerializer::Serialize(Root, Writer))
+	{
+		return false;
+	}
+
+	if (!FFileHelper::SaveStringToFile(Output, *GetLockFilePath()))
+	{
+		UE_LOG(LogTemp, Error, TEXT("[KBVELibGit] Failed to write lockfile: %s"), *GetLockFilePath());
+		return false;
+	}
+
+	UE_LOG(LogTemp, Log, TEXT("[KBVELibGit] Wrote lockfile: %s (%d plugin(s))"), *GetLockFilePath(), Lock.Plugins.Num());
+	return true;
+}
+
+const FKBVEPluginLockEntry* FKBVEPluginLock::FindEntry(const FKBVEPluginLockFile& Lock, const FString& Name)
+{
+	for (const FKBVEPluginLockEntry& Entry : Lock.Plugins)
+	{
+		if (Entry.Name.Equals(Name, ESearchCase::IgnoreCase))
+		{
+			return &Entry;
+		}
+	}
+	return nullptr;
+}
+
+FKBVEPluginLockEntry& FKBVEPluginLock::UpsertEntry(FKBVEPluginLockFile& Lock, const FKBVEPluginLockEntry& Entry)
+{
+	for (FKBVEPluginLockEntry& Existing : Lock.Plugins)
+	{
+		if (Existing.Name.Equals(Entry.Name, ESearchCase::IgnoreCase))
+		{
+			Existing = Entry;
+			return Existing;
+		}
+	}
+	return Lock.Plugins.Add_GetRef(Entry);
+}

--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/KBVEPluginRegistry.cpp
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/KBVEPluginRegistry.cpp
@@ -1,4 +1,5 @@
 #include "KBVEPluginRegistry.h"
+#include "KBVEPluginLock.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 #include "HAL/FileManager.h"
@@ -100,6 +101,26 @@ void FKBVEPluginRegistry::ReadRemoteVersions(TArray<FKBVEPluginEntry>& Entries, 
 		else
 		{
 			Entry.bUpdateAvailable = false;
+		}
+	}
+}
+
+void FKBVEPluginRegistry::ApplyLockStatus(TArray<FKBVEPluginEntry>& Entries, const FKBVEPluginLockFile& Lock)
+{
+	for (FKBVEPluginEntry& Entry : Entries)
+	{
+		const FKBVEPluginLockEntry* Pin = FKBVEPluginLock::FindEntry(Lock, Entry.Name);
+		if (Pin)
+		{
+			Entry.bInLock = true;
+			Entry.LockedVersion = Pin->Version;
+			Entry.bMatchesLock = Entry.bInstalled && Entry.LocalVersion == Pin->Version;
+		}
+		else
+		{
+			Entry.bInLock = false;
+			Entry.LockedVersion.Empty();
+			Entry.bMatchesLock = false;
 		}
 	}
 }

--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/SGitInstallerPanel.cpp
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/Private/SGitInstallerPanel.cpp
@@ -1,4 +1,5 @@
 #include "SGitInstallerPanel.h"
+#include "KBVEPluginLock.h"
 #include "Widgets/Layout/SBox.h"
 #include "Widgets/Layout/SScrollBox.h"
 #include "Widgets/Layout/SSeparator.h"
@@ -53,9 +54,25 @@ void SGitInstallerPanel::Construct(const FArguments& InArgs)
 			.AutoHeight()
 			.Padding(0, 0, 0, 8)
 			[
-				SNew(SButton)
-				.Text(LOCTEXT("CheckUpdatesBtn", "Check for Updates"))
-				.OnClicked(this, &SGitInstallerPanel::OnCheckForUpdatesClicked)
+				SNew(SHorizontalBox)
+
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				.Padding(0, 0, 5, 0)
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("CheckUpdatesBtn", "Check for Updates"))
+					.OnClicked(this, &SGitInstallerPanel::OnCheckForUpdatesClicked)
+				]
+
+				+ SHorizontalBox::Slot()
+				.AutoWidth()
+				[
+					SNew(SButton)
+					.Text(LOCTEXT("WriteLockBtn", "Write Lock"))
+					.ToolTipText(LOCTEXT("WriteLockTip", "Pin installed plugin versions to unreal-plugins.lock.json"))
+					.OnClicked(this, &SGitInstallerPanel::OnWriteLockClicked)
+				]
 			]
 
 			// Registry list
@@ -177,6 +194,12 @@ void SGitInstallerPanel::InitializeRegistry()
 	TArray<FKBVEPluginEntry> Defaults = FKBVEPluginRegistry::GetDefaultEntries();
 	FKBVEPluginRegistry::CheckLocalInstallStatus(Defaults);
 
+	FKBVEPluginLockFile Lock;
+	if (FKBVEPluginLock::Load(Lock))
+	{
+		FKBVEPluginRegistry::ApplyLockStatus(Defaults, Lock);
+	}
+
 	RegistryEntries.Empty();
 	for (FKBVEPluginEntry& E : Defaults)
 	{
@@ -221,6 +244,20 @@ TSharedRef<ITableRow> SGitInstallerPanel::OnGenerateRegistryRow(
 			VersionLabel = TEXT("not installed");
 		}
 		StatusColor = FLinearColor::Gray;
+	}
+
+	// Lockfile annotation
+	if (Entry->bInLock)
+	{
+		if (Entry->bInstalled && !Entry->bMatchesLock)
+		{
+			VersionLabel += FString::Printf(TEXT("  [locked v%s — drift]"), *Entry->LockedVersion);
+			StatusColor = FLinearColor::Red;
+		}
+		else
+		{
+			VersionLabel += FString::Printf(TEXT("  [locked v%s]"), *Entry->LockedVersion);
+		}
 	}
 
 	// Action button
@@ -381,6 +418,12 @@ FReply SGitInstallerPanel::OnCheckForUpdatesClicked()
 			FKBVEPluginRegistry::CheckLocalInstallStatus(Updated);
 			FKBVEPluginRegistry::ReadRemoteVersions(Updated, CapturedStagingPath);
 
+			FKBVEPluginLockFile Lock;
+			if (FKBVEPluginLock::Load(Lock))
+			{
+				FKBVEPluginRegistry::ApplyLockStatus(Updated, Lock);
+			}
+
 			Panel->RegistryEntries.Empty();
 			for (FKBVEPluginEntry& E : Updated)
 			{
@@ -457,16 +500,127 @@ void SGitInstallerPanel::InstallPluginFromMonorepo(TSharedPtr<FKBVEPluginEntry> 
 		Entry->bInstalled = true;
 		Entry->LocalVersion = Entry->RemoteVersion;
 		Entry->bUpdateAvailable = false;
+
+		FString HeadRef, HeadSha;
+		FGitRepoService::GetRepoStatus(RegistryStagingPath, HeadRef, HeadSha);
+		PinToLock(Entry->Name, Entry->RemoteVersion, HeadSha);
+
 		RegistryListView->RequestListRefresh();
 
 		SetStatus(FString::Printf(
-			TEXT("Installed %s v%s. Restart the editor to load it."),
+			TEXT("Installed %s v%s and pinned to lockfile. Restart the editor to load it."),
 			*Entry->Name, *Entry->RemoteVersion), FColor::Green);
 	}
 	else
 	{
 		SetStatus(FString::Printf(TEXT("Failed to install %s — check output log."), *Entry->Name), FColor::Red);
 	}
+}
+
+// ─────────────────────────────────────────────────────────
+// Lockfile
+// ─────────────────────────────────────────────────────────
+
+void SGitInstallerPanel::PinToLock(const FString& Name, const FString& Version, const FString& Ref)
+{
+	FKBVEPluginLockFile Lock;
+	FKBVEPluginLock::Load(Lock);
+
+	if (Lock.Registry.IsEmpty())
+	{
+		Lock.Registry = FKBVEPluginRegistry::RegistryRepoUrl;
+	}
+
+	FKBVEPluginLockEntry Entry;
+	Entry.Name = Name;
+	Entry.Version = Version;
+	Entry.Resolution = FKBVEPluginLock::ResolutionSource;
+	Entry.Ref = Ref;
+	Entry.Integrity = Ref;
+	FKBVEPluginLock::UpsertEntry(Lock, Entry);
+
+	FKBVEPluginLock::Save(Lock);
+
+	for (const TSharedPtr<FKBVEPluginEntry>& E : RegistryEntries)
+	{
+		if (E->Name == Name)
+		{
+			E->bInLock = true;
+			E->LockedVersion = Version;
+			E->bMatchesLock = E->bInstalled && E->LocalVersion == Version;
+		}
+	}
+}
+
+FReply SGitInstallerPanel::OnWriteLockClicked()
+{
+	FKBVEPluginLockFile Lock;
+	FKBVEPluginLock::Load(Lock);
+
+	if (Lock.Registry.IsEmpty())
+	{
+		Lock.Registry = FKBVEPluginRegistry::RegistryRepoUrl;
+	}
+
+	FString HeadRef, HeadSha;
+	const bool bHaveStaging = !RegistryStagingPath.IsEmpty() && IFileManager::Get().DirectoryExists(*RegistryStagingPath);
+	if (bHaveStaging)
+	{
+		FGitRepoService::GetRepoStatus(RegistryStagingPath, HeadRef, HeadSha);
+	}
+
+	int32 PinCount = 0;
+	for (const TSharedPtr<FKBVEPluginEntry>& E : RegistryEntries)
+	{
+		if (!E->bInstalled || E->LocalVersion.IsEmpty())
+		{
+			continue;
+		}
+
+		FKBVEPluginLockEntry Entry;
+		Entry.Name = E->Name;
+		Entry.Version = E->LocalVersion;
+		Entry.Resolution = FKBVEPluginLock::ResolutionSource;
+
+		// Keep an existing ref/integrity unless we have a fresh registry SHA
+		if (const FKBVEPluginLockEntry* Existing = FKBVEPluginLock::FindEntry(Lock, E->Name))
+		{
+			Entry.Ref = Existing->Ref;
+			Entry.Integrity = Existing->Integrity;
+		}
+		if (!HeadSha.IsEmpty())
+		{
+			Entry.Ref = HeadSha;
+			Entry.Integrity = HeadSha;
+		}
+
+		FKBVEPluginLock::UpsertEntry(Lock, Entry);
+		E->bInLock = true;
+		E->LockedVersion = E->LocalVersion;
+		E->bMatchesLock = true;
+		PinCount++;
+	}
+
+	if (PinCount == 0)
+	{
+		SetStatus(TEXT("No installed plugins to lock."), FColor::Yellow);
+		return FReply::Handled();
+	}
+
+	if (FKBVEPluginLock::Save(Lock))
+	{
+		if (RegistryListView.IsValid())
+		{
+			RegistryListView->RequestListRefresh();
+		}
+		SetStatus(FString::Printf(TEXT("Wrote lockfile with %d pinned plugin(s)."), PinCount), FColor::Green);
+	}
+	else
+	{
+		SetStatus(TEXT("Failed to write lockfile — check the output log."), FColor::Red);
+	}
+
+	return FReply::Handled();
 }
 
 // ─────────────────────────────────────────────────────────

--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/Public/KBVEPluginLock.h
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/Public/KBVEPluginLock.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+struct FKBVEPluginLockEntry
+{
+	FString Name;
+	FString Version;
+	FString Resolution = TEXT("source"); // "source" | "asset"
+	FString Ref;
+	FString Integrity;
+};
+
+struct FKBVEPluginLockFile
+{
+	FString Engine;
+	FString Registry;
+	TArray<FKBVEPluginLockEntry> Plugins;
+};
+
+class KBVELIBGIT_API FKBVEPluginLock
+{
+public:
+	static constexpr const TCHAR* LockFileName = TEXT("unreal-plugins.lock.json");
+	static constexpr const TCHAR* ResolutionSource = TEXT("source");
+	static constexpr const TCHAR* ResolutionAsset  = TEXT("asset");
+
+	static FString GetLockFilePath();
+	static bool Exists();
+	static bool Load(FKBVEPluginLockFile& OutLock);
+	static bool Save(const FKBVEPluginLockFile& Lock);
+
+	static const FKBVEPluginLockEntry* FindEntry(const FKBVEPluginLockFile& Lock, const FString& Name);
+	static FKBVEPluginLockEntry& UpsertEntry(FKBVEPluginLockFile& Lock, const FKBVEPluginLockEntry& Entry);
+};

--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/Public/KBVEPluginRegistry.h
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/Public/KBVEPluginRegistry.h
@@ -24,7 +24,18 @@ struct FKBVEPluginEntry
 
 	/** Whether an update is available (remote > local) */
 	bool bUpdateAvailable = false;
+
+	/** Version pinned in the project lockfile (empty if not pinned) */
+	FString LockedVersion;
+
+	/** Whether this plugin appears in the lockfile */
+	bool bInLock = false;
+
+	/** Whether the installed version matches the lockfile pin */
+	bool bMatchesLock = false;
 };
+
+struct FKBVEPluginLockFile;
 
 /**
  * Manages the list of known KBVE plugins from the kbve/kbve monorepo.
@@ -62,4 +73,7 @@ public:
 	 * Populates RemoteVersion and bUpdateAvailable on each entry.
 	 */
 	static void ReadRemoteVersions(TArray<FKBVEPluginEntry>& Entries, const FString& ClonedRepoPath);
+
+	/** Populate LockedVersion/bInLock/bMatchesLock from the project lockfile. */
+	static void ApplyLockStatus(TArray<FKBVEPluginEntry>& Entries, const FKBVEPluginLockFile& Lock);
 };

--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/Public/SGitInstallerPanel.h
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/Public/SGitInstallerPanel.h
@@ -47,6 +47,12 @@ private:
 	/** Refresh button — clones/fetches the monorepo and reads remote versions */
 	FReply OnCheckForUpdatesClicked();
 
+	/** Write the lockfile from currently installed plugin versions */
+	FReply OnWriteLockClicked();
+
+	/** Pin a single plugin into the lockfile at the given version + ref, then save */
+	void PinToLock(const FString& Name, const FString& Version, const FString& Ref);
+
 	/** Install a specific plugin from the registry */
 	void OnInstallRegistryPlugin(TSharedPtr<FKBVEPluginEntry> Entry);
 


### PR DESCRIPTION
## Summary

Adds a **package lock system** to KBVELibGit. The plugin now reads/writes a per-project `unreal-plugins.lock.json` (beside the consuming game's `.uproject`) so installs are pinned + reproducible instead of tracking registry branch HEAD.

npm model: lock **logic** lives in the plugin, lock **file** lives in the consumer (e.g. kbve/chuck).

## Changes

- **`FKBVEPluginLock`** (new) — read/write/find/upsert `unreal-plugins.lock.json`. Pins `name`, `version`, `resolution` (`source`|`asset`), `ref`, `integrity`.
- **`FKBVEPluginRegistry::ApplyLockStatus`** — populates `LockedVersion`/`bInLock`/`bMatchesLock` on entries.
- **`SGitInstallerPanel`** — loads lock on init/refresh, **"Write Lock"** button pins installed versions, install auto-pins + saves, rows show `[locked vX]` / red `[locked vX — drift]`.

Resolution defaults to `source`; `asset` mode reserved for published release zips.

## Notes / not done

- Not compiled in UE editor yet — code matches existing idioms but needs a build pass.
- `asset` resolution (release-zip download) + integrity checksums: struct-ready, not wired.
- Token path for private registry: not added (registry public today).

First slice of the lock system tracked in #11942.

Refs #11942

Docs: [Git](https://kbve.com/application/git/) · [Unreal](https://kbve.com/application/unreal/)
