### PR TITLE
feat(rows): gate world IP behind Supabase JWT, key OWS user on Supabase UUID

### DIFF
--- a/apps/rows/src/error.rs
+++ b/apps/rows/src/error.rs
@@ -8,8 +8,8 @@ use utoipa::ToSchema;
 pub enum RowsError {
     #[error("not found: {0}")]
     NotFound(String),
-    #[error("unauthorized")]
-    Unauthorized,
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
     #[error("bad request: {0}")]
     BadRequest(String),
     #[error("conflict: {0}")]
@@ -24,7 +24,7 @@ impl RowsError {
     pub fn status(&self) -> StatusCode {
         match self {
             Self::NotFound(_) => StatusCode::NOT_FOUND,
-            Self::Unauthorized => StatusCode::UNAUTHORIZED,
+            Self::Unauthorized(_) => StatusCode::UNAUTHORIZED,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::Conflict(_) => StatusCode::CONFLICT,
             Self::Database(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -34,7 +34,7 @@ impl RowsError {
     pub fn code(&self) -> &'static str {
         match self {
             Self::NotFound(_) => "NOT_FOUND",
-            Self::Unauthorized => "UNAUTHORIZED",
+            Self::Unauthorized(_) => "UNAUTHORIZED",
             Self::BadRequest(_) => "BAD_REQUEST",
             Self::Conflict(_) => "CONFLICT",
             Self::Database(_) => "DATABASE_ERROR",
@@ -45,7 +45,7 @@ impl RowsError {
     pub fn into_tonic(self) -> tonic::Status {
         match &self {
             Self::NotFound(m) => tonic::Status::not_found(m),
-            Self::Unauthorized => tonic::Status::unauthenticated("unauthorized"),
+            Self::Unauthorized(m) => tonic::Status::unauthenticated(m),
             Self::BadRequest(m) => tonic::Status::invalid_argument(m),
             Self::Conflict(m) => tonic::Status::already_exists(m),
             Self::Database(e) => tonic::Status::internal(e.to_string()),

--- a/apps/rows/src/middleware.rs
+++ b/apps/rows/src/middleware.rs
@@ -33,6 +33,23 @@ pub async fn require_customer_guid(req: Request, next: Next) -> Response {
     }
 }
 
+/// Pulls the raw token out of an `Authorization: Bearer <jwt>` header. Case-insensitive scheme.
+pub fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
+    let raw = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())?
+        .trim();
+    let token = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?;
+    let token = token.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
 /// Returns `Uuid::nil()` when the header is missing or malformed so unprotected callers don't panic.
 pub fn extract_customer_guid(headers: &axum::http::HeaderMap) -> Uuid {
     headers

--- a/apps/rows/src/repo/users.rs
+++ b/apps/rows/src/repo/users.rs
@@ -8,8 +8,6 @@ pub struct UsersRepo<'a>(pub &'a DbPool);
 
 impl<'a> UsersRepo<'a> {
     pub async fn login(&self, email: &str, password: &str) -> Result<LoginResult, RowsError> {
-        // pgcrypto's `crypt()` accepts the legacy OWS C# bcrypt hashes; argon2 fallback below
-        // covers anything already migrated by the auto-rehash path.
         let row: Option<(Uuid, Uuid)> = sqlx::query_as(
             "SELECT c.customerguid, u.userguid
              FROM users u
@@ -24,7 +22,6 @@ impl<'a> UsersRepo<'a> {
 
         let (customer_guid, user_guid) = match row {
             Some(r) => {
-                // Fire-and-forget rehash so the next login uses argon2 (Option B migration).
                 let pool = self.0.clone();
                 let pw = password.to_string();
                 let email_owned = email.to_string();
@@ -293,24 +290,56 @@ impl<'a> UsersRepo<'a> {
         Ok(groups)
     }
 
-    /// OAuth-bridge upsert: the user authenticates via Supabase, so the OWS row gets a random
-    /// argon2 hash purely to satisfy the NOT NULL constraint on `passwordhash`.
-    pub async fn find_or_create_by_email(
+    /// Find-or-create the OWS user keyed on the Supabase UUID (`sub`), which becomes the canonical
+    /// `userguid`. Legacy rows matched by email (random `userguid` from the pre-Supabase era) are
+    /// re-keyed onto the Supabase UUID. A random argon2 hash satisfies the `passwordhash` NOT NULL
+    /// constraint since auth happens against Supabase, not this row.
+    pub async fn find_or_create_supabase_user(
         &self,
         customer_guid: Uuid,
+        supabase_uuid: Uuid,
         email: &str,
         first_name: &str,
         last_name: &str,
     ) -> Result<Uuid, RowsError> {
-        let existing: Option<(Uuid,)> =
+        let by_uuid: Option<(Uuid,)> =
+            sqlx::query_as("SELECT userguid FROM users WHERE customerguid = $1 AND userguid = $2")
+                .bind(customer_guid)
+                .bind(supabase_uuid)
+                .fetch_optional(self.0)
+                .await?;
+
+        if by_uuid.is_some() {
+            return Ok(supabase_uuid);
+        }
+
+        let by_email: Option<(Uuid,)> =
             sqlx::query_as("SELECT userguid FROM users WHERE customerguid = $1 AND email = $2")
                 .bind(customer_guid)
                 .bind(email)
                 .fetch_optional(self.0)
                 .await?;
 
-        if let Some((user_guid,)) = existing {
-            return Ok(user_guid);
+        if let Some((old_guid,)) = by_email {
+            if old_guid == supabase_uuid {
+                return Ok(supabase_uuid);
+            }
+            sqlx::query(
+                "WITH moved_chars AS (
+                     UPDATE characters SET userguid = $1 WHERE customerguid = $2 AND userguid = $3 RETURNING 1
+                 ), moved_sessions AS (
+                     UPDATE usersessions SET userguid = $1 WHERE customerguid = $2 AND userguid = $3 RETURNING 1
+                 )
+                 UPDATE users SET userguid = $1 WHERE customerguid = $2 AND userguid = $3",
+            )
+            .bind(supabase_uuid)
+            .bind(customer_guid)
+            .bind(old_guid)
+            .execute(self.0)
+            .await?;
+
+            tracing::info!(email = %email, old = %old_guid, new = %supabase_uuid, "Re-keyed legacy OWS user onto Supabase UUID");
+            return Ok(supabase_uuid);
         }
 
         use argon2::{
@@ -324,13 +353,12 @@ impl<'a> UsersRepo<'a> {
             .map_err(|e| RowsError::Internal(format!("Hash error: {e}")))?
             .to_string();
 
-        let user_guid = Uuid::new_v4();
         sqlx::query(
             "INSERT INTO users (customerguid, userguid, email, passwordhash, firstname, lastname, role, createdate)
              VALUES ($1, $2, $3, $4, $5, $6, 'Player', NOW())",
         )
         .bind(customer_guid)
-        .bind(user_guid)
+        .bind(supabase_uuid)
         .bind(email)
         .bind(&password_hash)
         .bind(first_name)
@@ -338,8 +366,8 @@ impl<'a> UsersRepo<'a> {
         .execute(self.0)
         .await?;
 
-        tracing::info!(email = %email, user_guid = %user_guid, "Created OWS user from external auth");
-        Ok(user_guid)
+        tracing::info!(email = %email, user_guid = %supabase_uuid, "Created OWS user from Supabase auth");
+        Ok(supabase_uuid)
     }
 
     pub async fn create_session(

--- a/apps/rows/src/rest/auth.rs
+++ b/apps/rows/src/rest/auth.rs
@@ -155,7 +155,7 @@ async fn get_all_characters(
 #[serde(rename_all = "camelCase")]
 struct GetServerDto {
     #[serde(default, rename = "userSessionGUID", alias = "userSessionGUId")]
-    _user_session_guid: Option<Uuid>,
+    user_session_guid: Option<Uuid>,
     character_name: String,
     zone_name: String,
     #[serde(default)]
@@ -167,6 +167,9 @@ async fn get_server_to_connect_to(
     headers: HeaderMap,
     Json(body): Json<GetServerDto>,
 ) -> ApiResult<crate::models::JoinMapResult> {
+    hs.svc
+        .confirm_login(&headers, body.user_session_guid)
+        .await?;
     let customer_guid = extract_customer_guid(&headers);
     let result = hs
         .svc

--- a/apps/rows/src/rest/instances.rs
+++ b/apps/rows/src/rest/instances.rs
@@ -283,7 +283,7 @@ async fn shut_down_server_instance(
 #[serde(rename_all = "camelCase")]
 struct GetServerDto {
     #[serde(default, rename = "userSessionGUID", alias = "userSessionGUId")]
-    _user_session_guid: Option<Uuid>,
+    user_session_guid: Option<Uuid>,
     character_name: String,
     zone_name: String,
     #[serde(default)]
@@ -295,6 +295,9 @@ async fn instance_get_server_to_connect_to(
     headers: HeaderMap,
     Json(body): Json<GetServerDto>,
 ) -> ApiResult<crate::models::JoinMapResult> {
+    hs.svc
+        .confirm_login(&headers, body.user_session_guid)
+        .await?;
     let customer_guid = extract_customer_guid(&headers);
     let result = hs
         .svc

--- a/apps/rows/src/service/auth.rs
+++ b/apps/rows/src/service/auth.rs
@@ -2,6 +2,7 @@ use super::{CachedSession, OWSService};
 use crate::error::RowsError;
 use crate::models::*;
 use crate::repo::UsersRepo;
+use axum::http::HeaderMap;
 use uuid::Uuid;
 
 impl OWSService {
@@ -102,7 +103,7 @@ impl OWSService {
         let name_part = email.split('@').next().unwrap_or("Player");
 
         let user_guid = repo
-            .find_or_create_by_email(customer_guid, &email, name_part, "")
+            .find_or_create_supabase_user(customer_guid, validated.user_id, &email, name_part, "")
             .await?;
 
         let session_guid = repo.create_session(customer_guid, user_guid).await?;
@@ -128,6 +129,34 @@ impl OWSService {
             user_session_guid: Some(session_guid),
             error_message: String::new(),
         })
+    }
+
+    /// Confirms the caller is logged in before a protected action (e.g. handing out a world IP).
+    /// Accepts a Supabase `Authorization: Bearer <jwt>` (validated locally) or, failing that, a
+    /// live `userSessionGUID` that resolves to a real session.
+    pub async fn confirm_login(
+        &self,
+        headers: &HeaderMap,
+        session_guid: Option<Uuid>,
+    ) -> Result<(), RowsError> {
+        if let Some(token) = crate::middleware::extract_bearer(headers) {
+            if self.state.supabase.jwt_enabled() {
+                crate::supabase::validate_jwt(&token, &self.state.supabase)
+                    .map_err(|e| RowsError::Unauthorized(format!("Invalid access token: {e}")))?;
+                return Ok(());
+            }
+        }
+
+        if let Some(sg) = session_guid {
+            self.resolve_session(sg)
+                .await
+                .map_err(|_| RowsError::Unauthorized("Invalid or expired session".into()))?;
+            return Ok(());
+        }
+
+        Err(RowsError::Unauthorized(
+            "Login required: send Authorization: Bearer <jwt> or a valid userSessionGUID".into(),
+        ))
     }
 
     pub async fn set_selected_character_and_get_session(

--- a/apps/rows/src/service/instances.rs
+++ b/apps/rows/src/service/instances.rs
@@ -66,7 +66,6 @@ impl OWSService {
         let pipeline = match pipeline.acquire_lock(&self.state.zone_spinup_locks) {
             Ok(p) => p,
             Err(_) => {
-                // Another allocation is already in-flight; tail the poll loop without re-allocating.
                 return AllocationPipeline::new(customer_guid, zone, &self.state.db)
                     .poll_until_ready(char_name)
                     .await;
@@ -82,7 +81,6 @@ impl OWSService {
                 let p = p.create_instance().await?;
                 let p = p.tag_gameserver(agones).await?;
 
-                // Hand the Iris-side server its map assignment via MQ.
                 if let Some(mq) = mq_ref {
                     let msg = crate::mq::SpinUpMessage {
                         customer_guid: customer_guid.to_string(),


### PR DESCRIPTION
## What

Migrate ROWS auth identity from the **OWS Customer GUID** to the **Supabase UUID**, and require a confirmed login before `GetServerToConnectTo` returns a world/server IP.

## Why

- The world-IP endpoints previously returned the IP with only an `X-CustomerGUID` header present — no login confirmation at all (the `userSessionGUID` in the body was ignored).
- `external_login` validated the Supabase JWT but **discarded the `sub`** — the OWS `userguid` was a random UUID linked only by email, so the Supabase identity never flowed through.

## Changes

- **`repo/users.rs`** — `find_or_create_by_email` → `find_or_create_supabase_user`. The OWS `userguid` is now the Supabase `sub`. New users insert with it; legacy email-matched rows (random `userguid` from the pre-Supabase era) are re-keyed onto the Supabase UUID via a single data-modifying CTE updating `characters` + `usersessions` + `users` together, so the two `NO ACTION` FKs (`FK_Characters_UserGUID`, `FK_UserSessions_UserGUID`) stay consistent at statement end.
- **`service/auth.rs`** — `external_login` threads `validated.user_id` into the upsert. New `confirm_login(headers, session_guid)` accepts `Authorization: Bearer <Supabase JWT>` (validated locally via existing `validate_jwt`) **or** a live `userSessionGUID`, else `401`.
- **`rest/auth.rs` + `rest/instances.rs`** — both `GetServerToConnectTo` handlers call `confirm_login` before returning the IP.
- **`error.rs`** — `Unauthorized` now carries a message.
- **`middleware.rs`** — add `extract_bearer`.

Tenant `customer_guid` stays server-config (single-tenant); the Supabase UUID identifies the player.

## Verification

`cargo check` + `cargo clippy -p rows` clean (run directly, not nx, per the worktree resolution caveat).

## Follow-ups (not in this PR)

1. gRPC `rows.PublicApi/GetServerToConnectTo` is still ungated — tonic uses request metadata, not `HeaderMap`, so it needs a separate auth path.
2. `confirm_login` proves a valid Supabase login but does not verify the caller owns `character_name`.