### PR TITLE
feat(rows): gate gRPC world-IP RPCs behind Supabase JWT

### DIFF
--- a/apps/rows/src/grpc.rs
+++ b/apps/rows/src/grpc.rs
@@ -24,6 +24,31 @@ fn to_status(e: crate::error::RowsError) -> Status {
     e.into_tonic()
 }
 
+/// Pulls a Supabase token out of the gRPC `authorization: Bearer <jwt>` metadata entry.
+fn bearer_from_meta<T>(req: &Request<T>) -> Option<String> {
+    let raw = req.metadata().get("authorization")?.to_str().ok()?.trim();
+    let token = raw
+        .strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))?
+        .trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+/// Optional `x-user-session: <uuid>` metadata entry, the gRPC equivalent of the REST session GUID.
+fn session_from_meta<T>(req: &Request<T>) -> Option<Uuid> {
+    req.metadata()
+        .get("x-user-session")?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
 pub struct PublicApiService {
     svc: Arc<OWSService>,
 }
@@ -130,6 +155,10 @@ impl PublicApi for PublicApiService {
         &self,
         req: Request<GetServerToConnectToRequest>,
     ) -> Result<Response<GetServerToConnectToResponse>, Status> {
+        self.svc
+            .confirm_login_parts(bearer_from_meta(&req), session_from_meta(&req))
+            .await
+            .map_err(to_status)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         let result = self
@@ -323,6 +352,10 @@ impl CharacterPersistence for CharacterPersistenceService {
         &self,
         req: Request<JoinMapRequest>,
     ) -> Result<Response<JoinMapResponse>, Status> {
+        self.svc
+            .confirm_login_parts(bearer_from_meta(&req), session_from_meta(&req))
+            .await
+            .map_err(to_status)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         let result = self

--- a/apps/rows/src/service/auth.rs
+++ b/apps/rows/src/service/auth.rs
@@ -131,15 +131,27 @@ impl OWSService {
         })
     }
 
-    /// Confirms the caller is logged in before a protected action (e.g. handing out a world IP).
-    /// Accepts a Supabase `Authorization: Bearer <jwt>` (validated locally) or, failing that, a
-    /// live `userSessionGUID` that resolves to a real session.
+    /// Confirms the caller is logged in before a protected action (e.g. handing out a world IP),
+    /// reading the bearer token from an HTTP `Authorization` header. Transport-agnostic logic lives
+    /// in [`OWSService::confirm_login_parts`], shared with the gRPC surface.
     pub async fn confirm_login(
         &self,
         headers: &HeaderMap,
         session_guid: Option<Uuid>,
     ) -> Result<(), RowsError> {
-        if let Some(token) = crate::middleware::extract_bearer(headers) {
+        self.confirm_login_parts(crate::middleware::extract_bearer(headers), session_guid)
+            .await
+    }
+
+    /// Transport-agnostic login gate: accepts a Supabase bearer token (validated locally) or, failing
+    /// that, a live session GUID that resolves to a real session. Reused by both the REST and gRPC
+    /// entry points so any future gRPC connection handler gates with a single call.
+    pub async fn confirm_login_parts(
+        &self,
+        bearer: Option<String>,
+        session_guid: Option<Uuid>,
+    ) -> Result<(), RowsError> {
+        if let Some(token) = bearer {
             if self.state.supabase.jwt_enabled() {
                 crate::supabase::validate_jwt(&token, &self.state.supabase)
                     .map_err(|e| RowsError::Unauthorized(format!("Invalid access token: {e}")))?;
@@ -155,7 +167,7 @@ impl OWSService {
         }
 
         Err(RowsError::Unauthorized(
-            "Login required: send Authorization: Bearer <jwt> or a valid userSessionGUID".into(),
+            "Login required: send Authorization: Bearer <jwt> or a valid session GUID".into(),
         ))
     }
 


### PR DESCRIPTION
## What

Extend the Supabase login gate (added in #11944) to the **gRPC** surface, so world/server-IP handoffs are authenticated over gRPC the same way they are over REST.

## Why

`PublicApi::get_server_to_connect_to` and `CharacterPersistence::join_map` both return a server IP but did no auth — the REST PR could only gate the HTTP handlers. This closes that gap and sets up gRPC as the path for future connection handling.

## Changes

- **`service/auth.rs`** — split the transport-agnostic core out into `confirm_login_parts(bearer, session_guid)`. `confirm_login` (REST) now delegates to it, so REST and gRPC share one gate.
- **`grpc.rs`** — add metadata extractors:
  - `bearer_from_meta` → `authorization: Bearer <Supabase JWT>`
  - `session_from_meta` → `x-user-session: <uuid>` (gRPC equivalent of the REST session GUID)

  Both IP-returning RPCs call `confirm_login_parts` before returning; failures map to gRPC `unauthenticated` via the existing `RowsError::into_tonic`.

Metadata-based auth leaves the `.proto` message schemas untouched, so any future gRPC connection handler gates with a single call.

## Verification

`cargo check` + `cargo clippy -p rows` clean (run directly, not nx, per the worktree caveat). rustfmt applied by pre-commit.

## Note

`join_map` now requires auth metadata — if any server-internal caller invokes it without a token, it will need to pass one (or move to a server-to-server RPC). Flagging in case an Iris-side caller exists.