### PR TITLE
feat(KBVEUI): UI state model (FKBVEUIState + KBVEUIFlag)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
@@ -31,5 +31,11 @@ Shared Slate UI component library for KBVE Unreal games — game-agnostic visual
 primitives (Core + Slate only): movable frames, the settings frame + reusable
 settings rows (toggle / slider / combo), hotbar, slots, tooltips, info panels.
 
+Also holds **UI state** — `FKBVEUIState` (panel-flag set + cursor/movement/camera
+policy masks + `Has`/`Set`/`Diff`/`NeedsCursor`/`BlocksMovement` helpers) and
+`KBVEUIFlag` common flag bits — so a controller tracks which panels are open and
+derives input/cursor mode without re-rolling the bitfield. Stays Core+Slate;
+domain-aware UI (item-aware inventory, Supabase auth/chat) composes on top.
+
 Plugin source ships via its own PR; this entry wires it into the build/release
 pipeline alongside the other UE plugins.

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/KBVEUIFlags.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/KBVEUIFlags.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+namespace KBVEUIFlag
+{
+	constexpr int32 None        = 0;
+	constexpr int32 Inventory   = 1 << 0;
+	constexpr int32 Pause       = 1 << 1;
+	constexpr int32 Settings    = 1 << 2;
+	constexpr int32 Map         = 1 << 3;
+	constexpr int32 Quest       = 1 << 4;
+	constexpr int32 Vendor      = 1 << 5;
+	constexpr int32 Chat        = 1 << 6;
+	constexpr int32 ChatFocused = 1 << 7;
+	constexpr int32 Dialog      = 1 << 8;
+	constexpr int32 Loading     = 1 << 9;
+	constexpr int32 DevOverlay  = 1 << 10;
+	constexpr int32 Tooltip     = 1 << 11;
+	constexpr int32 Targeting   = 1 << 12;
+	constexpr int32 Cutscene    = 1 << 13;
+
+	// Game-defined flags should start at bit 20 to avoid clashing with these.
+	constexpr int32 UserBitStart = 20;
+}

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/KBVEUIState.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/KBVEUIState.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "KBVEUIState.generated.h"
+
+USTRUCT(BlueprintType)
+struct KBVEUI_API FKBVEUIState
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "KBVE|UIState")
+	int32 Flags = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|UIState")
+	int32 NeedsCursorMask = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|UIState")
+	int32 BlockMovementMask = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|UIState")
+	int32 BlockCameraMask = 0;
+
+	bool Has(int32 Flag) const     { return (Flags & Flag) != 0; }
+	bool HasAny(int32 Mask) const  { return (Flags & Mask) != 0; }
+	bool HasAll(int32 Mask) const  { return Mask != 0 && (Flags & Mask) == Mask; }
+	bool AnyOpen() const           { return Flags != 0; }
+
+	/** Applies a flag; returns the previous flag set (for diff / change broadcast). */
+	int32 Set(int32 Flag, bool bOn)
+	{
+		const int32 Prev = Flags;
+		if (bOn) { Flags |= Flag; } else { Flags &= ~Flag; }
+		return Prev;
+	}
+
+	int32 Toggle(int32 Flag)
+	{
+		const int32 Prev = Flags;
+		Flags ^= Flag;
+		return Prev;
+	}
+
+	void Clear() { Flags = 0; }
+
+	/** Bits that changed relative to a previous snapshot. */
+	int32 Diff(int32 Prev) const { return Flags ^ Prev; }
+
+	bool NeedsCursor() const    { return (Flags & NeedsCursorMask) != 0; }
+	bool BlocksMovement() const { return (Flags & BlockMovementMask) != 0; }
+	bool BlocksCamera() const   { return (Flags & BlockCameraMask) != 0; }
+};


### PR DESCRIPTION
## What

First "easy win" of the chuck → plugin extraction: the generic **UI state** pattern moves into **KBVEUI** (no new plugin — consolidating, not multiplying).

- **`FKBVEUIState`** — `int32` panel-flag set + policy masks (`NeedsCursorMask` / `BlockMovementMask` / `BlockCameraMask`) + helpers: `Has` / `HasAny` / `HasAll` / `Set` (returns prev for diff) / `Toggle` / `Diff` / `AnyOpen` / `NeedsCursor` / `BlocksMovement` / `BlocksCamera`.
- **`KBVEUIFlag`** — common flag bits (Inventory, Pause, Settings, Map, Quest, Vendor, Chat, Dialog, Loading, DevOverlay, Tooltip, Targeting, Cutscene) + `UserBitStart` for game-defined flags.

This is the generalization of chuck's inline `EUiFlag` / `UiFlags` / `RefreshUiMouseMode` in `chuckCorePlayerController`.

## Design
- **KBVEUI stays foundational** — Core + Slate + CoreUObject only, **no Engine dep** (header-only USTRUCT). Keeps the UI plugin low in the dependency graph.
- **Domain-aware UI composes on top**, it doesn't go into KBVEUI core:
  - item-aware inventory binding → stays delegate-fed (or KBVEItemDB), so KBVEUI doesn't depend on KBVEItemDB.
  - Supabase auth/chat UI → a separate **KBVESupabaseUI** plugin (KBVEUI + KBVESupabase), not baked into KBVEUI — that's the "KBVEUI shouldn't hard-require Supabase" check.

## Not in this PR (next easy wins, same consolidation principle)
- Richer agnostic inventory/info widgets in KBVEUI (the generic slot/hotbar/info already exist).
- `KBVESupabaseUI` composition plugin.
- chuck adoption: replace the inline `EUiFlag` + `RefreshUiMouseMode` with `FKBVEUIState` (set masks once, drive cursor/movement from the queries).

## CI
Source-only addition to an already-wired plugin → no manifest change; compiles in the KBVEUI CI plugin build.