### PR TITLE
feat(KBVEGameplay): stats layer + combat interfaces

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvegameplay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvegameplay.mdx
@@ -40,3 +40,20 @@ the effect lifecycle from a data-driven `FKBVEEffectSpec`:
 
 Tick auto-disables when no effects or cooldowns are active. Effect DATA lives in
 the shared itemdb; the game builds an `FKBVEEffectSpec` from its item definition.
+
+## Stats + combat
+
+Also holds the agnostic gameplay-stat layer (the effect target it feeds):
+
+- **`FKBVEStatBlock`** — health / mana / stamina with regen rates + stamina
+  thresholds; `HealthFraction` / `ManaFraction` / `StaminaFraction`.
+- **`EKBVEMovementState`** — movement flag set (`OnGround`/`Moving`/`Sprinting`/…) +
+  `KBVEMove` helpers; gates stamina drain/regen.
+- **`FKBVEStatFragment`** + **`UKBVEStatRegenProcessor`** — Mass fragment + parallel
+  regen processor (health/mana regen, stamina drain on sprint, low-stamina + empty
+  penalty). Worker-thread, cache-coherent.
+- **`IKBVECombatDamageable` / `IKBVECombatAttacker`** — combat interfaces
+  (apply damage/heal/death/danger; attack-trace / combo / charged hooks).
+
+`UKBVEEffectComponent` applies effects through `IKBVEStatTarget`; a game's stat
+owner maps those onto its `FKBVEStatBlock` / `FKBVEStatFragment`.

--- a/packages/unreal/KBVEGameplay/KBVEGameplay.uplugin
+++ b/packages/unreal/KBVEGameplay/KBVEGameplay.uplugin
@@ -13,6 +13,9 @@
 	"IsExperimentalVersion": false,
 	"Installed": false,
 	"EnabledByDefault": false,
+	"Plugins": [
+		{ "Name": "MassEntity", "Enabled": true }
+	],
 	"Modules": [
 		{
 			"Name": "KBVEGameplay",

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/KBVEGameplay.Build.cs
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/KBVEGameplay.Build.cs
@@ -10,7 +10,8 @@ public class KBVEGameplay : ModuleRules
 		{
 			"Core",
 			"CoreUObject",
-			"Engine"
+			"Engine",
+			"MassEntity"
 		});
 
 		PrivateDependencyModuleNames.AddRange(new string[] { });

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEStatRegenProcessor.cpp
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEStatRegenProcessor.cpp
@@ -1,0 +1,62 @@
+#include "KBVEStatRegenProcessor.h"
+
+#include "MassExecutionContext.h"
+#include "KBVEStatFragment.h"
+
+UKBVEStatRegenProcessor::UKBVEStatRegenProcessor()
+	: EntityQuery(*this)
+{
+	ExecutionFlags = (int32)EProcessorExecutionFlags::All;
+	ProcessingPhase = EMassProcessingPhase::PrePhysics;
+	bAutoRegisterWithProcessingPhases = true;
+}
+
+void UKBVEStatRegenProcessor::ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager)
+{
+	EntityQuery.AddRequirement<FKBVEStatFragment>(EMassFragmentAccess::ReadWrite);
+}
+
+void UKBVEStatRegenProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(KBVE_StatRegen_Execute);
+
+	const float DeltaSeconds = Context.GetDeltaTimeSeconds();
+
+	EntityQuery.ParallelForEachEntityChunk(EntityManager, Context,
+		[DeltaSeconds](FMassExecutionContext& Chunk)
+		{
+			const TArrayView<FKBVEStatFragment> Stats = Chunk.GetMutableFragmentView<FKBVEStatFragment>();
+			for (FKBVEStatFragment& S : Stats)
+			{
+				S.Health = FMath::Min(S.Health + S.HealthRegenPerSec * DeltaSeconds, S.MaxHealth);
+				S.Mana   = FMath::Min(S.Mana   + S.ManaRegenPerSec   * DeltaSeconds, S.MaxMana);
+
+				const bool bDraining =
+					KBVEMove::Has(S.MoveState, EKBVEMovementState::Sprinting) &&
+					KBVEMove::Has(S.MoveState, EKBVEMovementState::Moving)    &&
+					KBVEMove::Has(S.MoveState, EKBVEMovementState::OnGround)  &&
+					!KBVEMove::HasAny(S.MoveState, EKBVEMovementState::Crouching);
+
+				if (S.StaminaRegenDelay > 0.f)
+				{
+					S.StaminaRegenDelay = FMath::Max(0.f, S.StaminaRegenDelay - DeltaSeconds);
+				}
+				else if (bDraining)
+				{
+					S.Stamina = FMath::Max(0.f, S.Stamina - S.StaminaSprintDrainPerSec * DeltaSeconds);
+					if (S.Stamina <= 0.f)
+					{
+						S.StaminaRegenDelay = S.StaminaEmptyPenaltySec;
+					}
+				}
+				else
+				{
+					const float Rate =
+						(S.Stamina <= S.StaminaLowThreshold)
+							? S.StaminaRegenPerSec * S.StaminaLowRegenMultiplier
+							: S.StaminaRegenPerSec;
+					S.Stamina = FMath::Min(S.Stamina + Rate * DeltaSeconds, S.MaxStamina);
+				}
+			}
+		});
+}

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVECombatInterfaces.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVECombatInterfaces.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+#include "KBVECombatInterfaces.generated.h"
+
+class AActor;
+
+UINTERFACE(MinimalAPI)
+class UKBVECombatDamageable : public UInterface
+{
+	GENERATED_BODY()
+};
+
+class KBVEGAMEPLAY_API IKBVECombatDamageable
+{
+	GENERATED_BODY()
+
+public:
+	virtual void ApplyDamage(float Damage, AActor* Causer, const FVector& HitLocation, const FVector& Impulse) {}
+	virtual void ApplyHealing(float Healing, AActor* Healer) {}
+	virtual void HandleDeath(AActor* Killer) {}
+	virtual void NotifyDanger(const FVector& DangerLocation, AActor* Source) {}
+};
+
+UINTERFACE(MinimalAPI)
+class UKBVECombatAttacker : public UInterface
+{
+	GENERATED_BODY()
+};
+
+class KBVEGAMEPLAY_API IKBVECombatAttacker
+{
+	GENERATED_BODY()
+
+public:
+	virtual void DoAttackTrace(FName DamageSourceBone) {}
+	virtual void CheckCombo() {}
+	virtual void CheckChargedAttack() {}
+};

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEMovementState.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEMovementState.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Misc/EnumClassFlags.h"
+
+enum class EKBVEMovementState : uint8
+{
+	None      = 0,
+	OnGround  = 1 << 0,
+	InAir     = 1 << 1,
+	Moving    = 1 << 2,
+	Sprinting = 1 << 3,
+	Crouching = 1 << 4,
+	Falling   = 1 << 5,
+	Swimming  = 1 << 6,
+	Climbing  = 1 << 7,
+};
+ENUM_CLASS_FLAGS(EKBVEMovementState);
+
+namespace KBVEMove
+{
+	FORCEINLINE bool Has(EKBVEMovementState S, EKBVEMovementState Flag)    { return EnumHasAllFlags(S, Flag); }
+	FORCEINLINE bool HasAny(EKBVEMovementState S, EKBVEMovementState Flags) { return EnumHasAnyFlags(S, Flags); }
+	FORCEINLINE void Set(EKBVEMovementState& S, EKBVEMovementState Flag)    { EnumAddFlags(S, Flag); }
+	FORCEINLINE void Clear(EKBVEMovementState& S, EKBVEMovementState Flag)  { EnumRemoveFlags(S, Flag); }
+	FORCEINLINE void Assign(EKBVEMovementState& S, EKBVEMovementState Flag, bool bOn)
+	{
+		if (bOn) EnumAddFlags(S, Flag); else EnumRemoveFlags(S, Flag);
+	}
+}

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatBlock.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatBlock.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "KBVEStatBlock.generated.h"
+
+USTRUCT(BlueprintType)
+struct FKBVEStatBlock
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float MaxHealth = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float Health = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float HealthRegenPerSec = 5.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float MaxMana = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float Mana = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float ManaRegenPerSec = 3.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float MaxStamina = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float Stamina = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float StaminaRegenPerSec = 10.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float StaminaSprintDrainPerSec = 20.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float StaminaLowThreshold = 10.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float StaminaLowRegenMultiplier = 0.5f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float StaminaEmptyPenaltySec = 2.5f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float StaminaWarnThreshold = 20.f;
+
+	float StaminaRegenDelay = 0.f;
+
+	float HealthFraction()  const { return MaxHealth  > 0.f ? FMath::Clamp(Health  / MaxHealth,  0.f, 1.f) : 0.f; }
+	float ManaFraction()    const { return MaxMana    > 0.f ? FMath::Clamp(Mana    / MaxMana,    0.f, 1.f) : 0.f; }
+	float StaminaFraction() const { return MaxStamina > 0.f ? FMath::Clamp(Stamina / MaxStamina, 0.f, 1.f) : 0.f; }
+};

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatFragment.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatFragment.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MassEntityTypes.h"
+#include "KBVEMovementState.h"
+#include "KBVEStatFragment.generated.h"
+
+USTRUCT()
+struct KBVEGAMEPLAY_API FKBVEStatFragment : public FMassFragment
+{
+	GENERATED_BODY()
+
+	float Health = 100.f;
+	float MaxHealth = 100.f;
+	float HealthRegenPerSec = 5.f;
+
+	float Mana = 100.f;
+	float MaxMana = 100.f;
+	float ManaRegenPerSec = 3.f;
+
+	float Stamina = 100.f;
+	float MaxStamina = 100.f;
+	float StaminaRegenPerSec = 10.f;
+	float StaminaSprintDrainPerSec = 20.f;
+	float StaminaLowThreshold = 10.f;
+	float StaminaLowRegenMultiplier = 0.5f;
+	float StaminaEmptyPenaltySec = 2.5f;
+	float StaminaRegenDelay = 0.f;
+
+	EKBVEMovementState MoveState = EKBVEMovementState::None;
+};

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatRegenProcessor.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatRegenProcessor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MassProcessor.h"
+#include "KBVEStatRegenProcessor.generated.h"
+
+UCLASS()
+class KBVEGAMEPLAY_API UKBVEStatRegenProcessor : public UMassProcessor
+{
+	GENERATED_BODY()
+
+public:
+	UKBVEStatRegenProcessor();
+
+protected:
+	virtual void ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager) override;
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+};


### PR DESCRIPTION
## What

Second batch of chuck→plugin easy wins, **into the existing KBVEGameplay** (no new plugin). Stats are its natural home — it already owns `IKBVEStatTarget` + `UKBVEEffectComponent`, so effects → stat deltas → regen now live together.

- **`FKBVEStatBlock`** — health/mana/stamina + regen rates + stamina thresholds + `*Fraction()` helpers (from `FchuckStatBlock`).
- **`EKBVEMovementState`** + `KBVEMove` helpers — movement flag set that gates stamina drain/regen (from `EchuckMoveState`).
- **`FKBVEStatFragment`** + **`UKBVEStatRegenProcessor`** — Mass fragment + parallel regen processor: health/mana regen, sprint stamina drain, low-stamina multiplier, empty-penalty delay (from `chuckStatRegenProcessor`).
- **`IKBVECombatDamageable` / `IKBVECombatAttacker`** — clean KBVE-authored combat interfaces (apply damage/heal/death/danger; attack-trace / combo / charged hooks). *Re-authored, not copied from Epic's template.*

## Build/CI
- `Build.cs` gains `MassEntity`; `.uplugin` declares the `MassEntity` engine plugin → compiles standalone in CI.
- No manifest change (already-wired plugin, engine dep).

## Easy-wins status (into existing plugins, no new plugins)
- ✅ UI State → KBVEUI (#11947)
- ✅ Stats + combat interfaces → KBVEGameplay (this)
- Inventory UI generic widgets already in KBVEUI.
- **Deferred (need new plugins):** KBVESettings, KBVESupabaseUI, KBVECombat melee component.

## Not verified locally
No UE toolchain — relies on the CI plugin build to compile-check (Mass processor API + interfaces).

## Follow-up (chuck adoption)
Migrate `chuckStats`/`chuckStatsFragment`/`chuckStatRegenProcessor` → the KBVE equivalents, and `ICombatDamageable`/`ICombatAttacker` → the KBVE interfaces.