### PR TITLE
feat(rows): enforce character ownership before handing out a world IP

### DIFF
--- a/apps/rows/src/error.rs
+++ b/apps/rows/src/error.rs
@@ -10,6 +10,8 @@ pub enum RowsError {
     NotFound(String),
     #[error("unauthorized: {0}")]
     Unauthorized(String),
+    #[error("forbidden: {0}")]
+    Forbidden(String),
     #[error("bad request: {0}")]
     BadRequest(String),
     #[error("conflict: {0}")]
@@ -25,6 +27,7 @@ impl RowsError {
         match self {
             Self::NotFound(_) => StatusCode::NOT_FOUND,
             Self::Unauthorized(_) => StatusCode::UNAUTHORIZED,
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::Conflict(_) => StatusCode::CONFLICT,
             Self::Database(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -35,6 +38,7 @@ impl RowsError {
         match self {
             Self::NotFound(_) => "NOT_FOUND",
             Self::Unauthorized(_) => "UNAUTHORIZED",
+            Self::Forbidden(_) => "FORBIDDEN",
             Self::BadRequest(_) => "BAD_REQUEST",
             Self::Conflict(_) => "CONFLICT",
             Self::Database(_) => "DATABASE_ERROR",
@@ -46,6 +50,7 @@ impl RowsError {
         match &self {
             Self::NotFound(m) => tonic::Status::not_found(m),
             Self::Unauthorized(m) => tonic::Status::unauthenticated(m),
+            Self::Forbidden(m) => tonic::Status::permission_denied(m),
             Self::BadRequest(m) => tonic::Status::invalid_argument(m),
             Self::Conflict(m) => tonic::Status::already_exists(m),
             Self::Database(e) => tonic::Status::internal(e.to_string()),

--- a/apps/rows/src/grpc.rs
+++ b/apps/rows/src/grpc.rs
@@ -155,7 +155,8 @@ impl PublicApi for PublicApiService {
         &self,
         req: Request<GetServerToConnectToRequest>,
     ) -> Result<Response<GetServerToConnectToResponse>, Status> {
-        self.svc
+        let caller_guid = self
+            .svc
             .confirm_login_parts(bearer_from_meta(&req), session_from_meta(&req))
             .await
             .map_err(to_status)?;
@@ -163,7 +164,7 @@ impl PublicApi for PublicApiService {
         let guid = self.svc.state().config.customer_guid;
         let result = self
             .svc
-            .get_server_to_connect_to(guid, &r.character_name, &r.character_name)
+            .get_server_to_connect_to(guid, caller_guid, &r.character_name, &r.character_name)
             .await
             .map_err(to_status)?;
         if !result.success {
@@ -352,7 +353,8 @@ impl CharacterPersistence for CharacterPersistenceService {
         &self,
         req: Request<JoinMapRequest>,
     ) -> Result<Response<JoinMapResponse>, Status> {
-        self.svc
+        let caller_guid = self
+            .svc
             .confirm_login_parts(bearer_from_meta(&req), session_from_meta(&req))
             .await
             .map_err(to_status)?;
@@ -360,7 +362,7 @@ impl CharacterPersistence for CharacterPersistenceService {
         let guid = self.svc.state().config.customer_guid;
         let result = self
             .svc
-            .get_server_to_connect_to(guid, &r.character_name, &r.zone_name)
+            .get_server_to_connect_to(guid, caller_guid, &r.character_name, &r.zone_name)
             .await
             .map_err(to_status)?;
         Ok(Response::new(JoinMapResponse {

--- a/apps/rows/src/rest/auth.rs
+++ b/apps/rows/src/rest/auth.rs
@@ -167,13 +167,19 @@ async fn get_server_to_connect_to(
     headers: HeaderMap,
     Json(body): Json<GetServerDto>,
 ) -> ApiResult<crate::models::JoinMapResult> {
-    hs.svc
+    let caller_guid = hs
+        .svc
         .confirm_login(&headers, body.user_session_guid)
         .await?;
     let customer_guid = extract_customer_guid(&headers);
     let result = hs
         .svc
-        .get_server_to_connect_to(customer_guid, &body.character_name, &body.zone_name)
+        .get_server_to_connect_to(
+            customer_guid,
+            caller_guid,
+            &body.character_name,
+            &body.zone_name,
+        )
         .await?;
     Ok(Json(result))
 }

--- a/apps/rows/src/rest/instances.rs
+++ b/apps/rows/src/rest/instances.rs
@@ -295,13 +295,19 @@ async fn instance_get_server_to_connect_to(
     headers: HeaderMap,
     Json(body): Json<GetServerDto>,
 ) -> ApiResult<crate::models::JoinMapResult> {
-    hs.svc
+    let caller_guid = hs
+        .svc
         .confirm_login(&headers, body.user_session_guid)
         .await?;
     let customer_guid = extract_customer_guid(&headers);
     let result = hs
         .svc
-        .get_server_to_connect_to(customer_guid, &body.character_name, &body.zone_name)
+        .get_server_to_connect_to(
+            customer_guid,
+            caller_guid,
+            &body.character_name,
+            &body.zone_name,
+        )
         .await?;
     Ok(Json(result))
 }

--- a/apps/rows/src/service/auth.rs
+++ b/apps/rows/src/service/auth.rs
@@ -132,38 +132,42 @@ impl OWSService {
     }
 
     /// Confirms the caller is logged in before a protected action (e.g. handing out a world IP),
-    /// reading the bearer token from an HTTP `Authorization` header. Transport-agnostic logic lives
-    /// in [`OWSService::confirm_login_parts`], shared with the gRPC surface.
+    /// reading the bearer token from an HTTP `Authorization` header. Returns the authenticated
+    /// caller's `user_guid` (Supabase UUID). Transport-agnostic logic lives in
+    /// [`OWSService::confirm_login_parts`], shared with the gRPC surface.
     pub async fn confirm_login(
         &self,
         headers: &HeaderMap,
         session_guid: Option<Uuid>,
-    ) -> Result<(), RowsError> {
+    ) -> Result<Uuid, RowsError> {
         self.confirm_login_parts(crate::middleware::extract_bearer(headers), session_guid)
             .await
     }
 
     /// Transport-agnostic login gate: accepts a Supabase bearer token (validated locally) or, failing
-    /// that, a live session GUID that resolves to a real session. Reused by both the REST and gRPC
-    /// entry points so any future gRPC connection handler gates with a single call.
+    /// that, a live session GUID that resolves to a real session. Returns the authenticated caller's
+    /// `user_guid` (the JWT `sub` on the bearer path, the session's user on the session path) so
+    /// downstream checks like character ownership can use it. Reused by both the REST and gRPC entry
+    /// points so any future gRPC connection handler gates with a single call.
     pub async fn confirm_login_parts(
         &self,
         bearer: Option<String>,
         session_guid: Option<Uuid>,
-    ) -> Result<(), RowsError> {
+    ) -> Result<Uuid, RowsError> {
         if let Some(token) = bearer {
             if self.state.supabase.jwt_enabled() {
-                crate::supabase::validate_jwt(&token, &self.state.supabase)
+                let validated = crate::supabase::validate_jwt(&token, &self.state.supabase)
                     .map_err(|e| RowsError::Unauthorized(format!("Invalid access token: {e}")))?;
-                return Ok(());
+                return Ok(validated.user_id);
             }
         }
 
         if let Some(sg) = session_guid {
-            self.resolve_session(sg)
+            let cached = self
+                .resolve_session(sg)
                 .await
                 .map_err(|_| RowsError::Unauthorized("Invalid or expired session".into()))?;
-            return Ok(());
+            return Ok(cached.user_guid);
         }
 
         Err(RowsError::Unauthorized(

--- a/apps/rows/src/service/instances.rs
+++ b/apps/rows/src/service/instances.rs
@@ -6,13 +6,17 @@ use crate::repo::{CharsRepo, InstanceRepo};
 use uuid::Uuid;
 
 impl OWSService {
-    #[tracing::instrument(skip(self), fields(%customer_guid, char_name, zone_name))]
+    #[tracing::instrument(skip(self), fields(%customer_guid, %caller_guid, char_name, zone_name))]
     pub async fn get_server_to_connect_to(
         &self,
         customer_guid: Uuid,
+        caller_guid: Uuid,
         char_name: &str,
         zone_name: &str,
     ) -> Result<JoinMapResult, RowsError> {
+        self.verify_character_owner(customer_guid, caller_guid, char_name)
+            .await?;
+
         let resolved_zone = self
             .resolve_zone(customer_guid, char_name, zone_name)
             .await?;
@@ -29,6 +33,45 @@ impl OWSService {
     }
 
     /// Handles the `GETLASTZONENAME` magic string by reading the character's last `map_name`.
+    /// Enforces that the authenticated caller owns the character before a world IP is handed out.
+    /// Backwards compatibility: a character with no owner (legacy `NULL` `userguid`) is allowed
+    /// through with a warning; a missing character is left for the downstream zone lookup to report.
+    /// Only a character owned by a different user is rejected.
+    async fn verify_character_owner(
+        &self,
+        customer_guid: Uuid,
+        caller_guid: Uuid,
+        char_name: &str,
+    ) -> Result<(), RowsError> {
+        let chars_repo = CharsRepo(&self.state.db);
+        let Some(character) = chars_repo.get_by_name(customer_guid, char_name).await? else {
+            return Ok(());
+        };
+
+        match character.user_guid {
+            Some(owner) if owner == caller_guid => Ok(()),
+            None => {
+                tracing::warn!(
+                    char_name,
+                    caller = %caller_guid,
+                    "Character has no owner — allowing for backwards compatibility"
+                );
+                Ok(())
+            }
+            Some(owner) => {
+                tracing::warn!(
+                    char_name,
+                    caller = %caller_guid,
+                    owner = %owner,
+                    "Rejected world-IP request: character owned by another user"
+                );
+                Err(RowsError::Forbidden(format!(
+                    "Character '{char_name}' does not belong to the authenticated user"
+                )))
+            }
+        }
+    }
+
     async fn resolve_zone(
         &self,
         customer_guid: Uuid,


### PR DESCRIPTION
## What

Verify the authenticated caller **owns** the requested character before `GetServerToConnectTo` / `JoinMap` returns a server IP. Final follow-up from #11944 / #11946.

## Why

The login gate proves a valid Supabase login but not that the caller owns the character they're requesting a connection for — any logged-in user could fetch any character's world IP.

## Changes

- **`service/auth.rs`** — `confirm_login` / `confirm_login_parts` now return the authenticated caller's `user_guid` (JWT `sub` on the bearer path, the session's user on the session path) instead of `()`.
- **`service/instances.rs`** — `get_server_to_connect_to` takes `caller_guid` and calls a new `verify_character_owner`.
- **`error.rs`** — add `Forbidden` → `403` / gRPC `permission_denied` for the ownership rejection.
- **`rest/auth.rs`, `rest/instances.rs`, `grpc.rs`** — thread `caller_guid` from the gate into `get_server_to_connect_to` across all four entry points (REST Users + Instance, gRPC PublicApi + CharacterPersistence).

## Backwards compatibility

- Character owned by the caller → allowed.
- Character with a **NULL owner** (legacy pre-Supabase rows) → allowed, with a warning. Keeps existing data working.
- Missing character → left for the downstream zone lookup to report (unchanged).
- Character owned by a **different** user → `403 Forbidden`.

## Verification

`cargo check` + `cargo clippy -p rows` clean (direct cargo, not nx). rustfmt applied by pre-commit.