### PR TITLE
docs(rows): mark legacy OWS local login/register as deprecated

### DIFF
--- a/apps/rows/src/grpc.rs
+++ b/apps/rows/src/grpc.rs
@@ -55,6 +55,8 @@ pub struct PublicApiService {
 
 #[tonic::async_trait]
 impl PublicApi for PublicApiService {
+    /// DEPRECATED: legacy OWS local email/password login. Prefer Supabase auth (bearer metadata on
+    /// the protected RPCs); retained for backwards compatibility and slated for removal.
     async fn login(&self, req: Request<LoginRequest>) -> Result<Response<LoginResponse>, Status> {
         let r = req.get_ref();
         let result = self
@@ -76,6 +78,8 @@ impl PublicApi for PublicApiService {
         }))
     }
 
+    /// DEPRECATED: legacy OWS local account creation. Accounts now originate in Supabase and are
+    /// provisioned on first external login; retained for backwards compatibility, slated for removal.
     async fn register(
         &self,
         req: Request<RegisterRequest>,

--- a/apps/rows/src/repo/users.rs
+++ b/apps/rows/src/repo/users.rs
@@ -7,6 +7,9 @@ use uuid::Uuid;
 pub struct UsersRepo<'a>(pub &'a DbPool);
 
 impl<'a> UsersRepo<'a> {
+    /// DEPRECATED: verifies a legacy OWS local password (bcrypt via pgcrypto, argon2 fallback, with
+    /// transparent rehash). Supabase is now the auth source; this and the `passwordhash` column are
+    /// kept for backwards compatibility and will be removed once legacy clients are migrated.
     pub async fn login(&self, email: &str, password: &str) -> Result<LoginResult, RowsError> {
         let row: Option<(Uuid, Uuid)> = sqlx::query_as(
             "SELECT c.customerguid, u.userguid
@@ -180,6 +183,9 @@ impl<'a> UsersRepo<'a> {
         self.get_session(session_guid).await
     }
 
+    /// DEPRECATED: inserts a legacy OWS local account with a password hash. Supabase-backed accounts
+    /// are provisioned via [`UsersRepo::find_or_create_supabase_user`]; kept for backwards
+    /// compatibility, slated for removal.
     pub async fn register(
         &self,
         customer_guid: Uuid,
@@ -293,7 +299,8 @@ impl<'a> UsersRepo<'a> {
     /// Find-or-create the OWS user keyed on the Supabase UUID (`sub`), which becomes the canonical
     /// `userguid`. Legacy rows matched by email (random `userguid` from the pre-Supabase era) are
     /// re-keyed onto the Supabase UUID. A random argon2 hash satisfies the `passwordhash` NOT NULL
-    /// constraint since auth happens against Supabase, not this row.
+    /// constraint since auth happens against Supabase, not this row — the column is now vestigial and
+    /// is kept (unused) for backwards compatibility; it is slated for removal alongside local login.
     pub async fn find_or_create_supabase_user(
         &self,
         customer_guid: Uuid,

--- a/apps/rows/src/rest/auth.rs
+++ b/apps/rows/src/rest/auth.rs
@@ -62,6 +62,9 @@ struct LoginDto {
     password: String,
 }
 
+/// DEPRECATED: `LoginAndCreateSession` is the legacy OWS local email/password login. Clients should
+/// authenticate against Supabase and call `ExternalLoginAndCreateSession`; this endpoint stays only
+/// for backwards compatibility and will be removed.
 async fn login(
     State(hs): State<HandlerState>,
     Json(body): Json<LoginDto>,
@@ -212,6 +215,9 @@ struct RegisterUserDto {
     last_name: String,
 }
 
+/// DEPRECATED: `RegisterUser` creates a legacy OWS local account with a password hash. Accounts now
+/// originate in Supabase and are provisioned on first `ExternalLoginAndCreateSession`; kept for
+/// backwards compatibility only, slated for removal.
 async fn register_user(
     State(hs): State<HandlerState>,
     headers: HeaderMap,

--- a/apps/rows/src/service/auth.rs
+++ b/apps/rows/src/service/auth.rs
@@ -6,6 +6,9 @@ use axum::http::HeaderMap;
 use uuid::Uuid;
 
 impl OWSService {
+    /// DEPRECATED: legacy OWS local email/password login. Authentication now flows through Supabase
+    /// via [`OWSService::external_login`]; this path is retained only for backwards compatibility
+    /// with old OWS clients and local dev, and will be removed once those are migrated.
     pub async fn login(&self, email: &str, password: &str) -> Result<LoginResult, RowsError> {
         let repo = UsersRepo(&self.state.db);
         let result = repo.login(email, password).await?;
@@ -30,6 +33,9 @@ impl OWSService {
         Ok(result)
     }
 
+    /// DEPRECATED: legacy OWS local account creation. New accounts originate in Supabase and are
+    /// provisioned on first [`OWSService::external_login`]; kept for backwards compatibility only,
+    /// slated for removal.
     pub async fn register(
         &self,
         email: &str,


### PR DESCRIPTION
## What

Document the OWS-local email/password auth as **deprecated** now that authentication flows through Supabase (`ExternalLoginAndCreateSession` + the JWT `confirm_login` gate from #11944 / #11946). No behavior change — the legacy endpoints stay functional.

## Why

With the Supabase integration, local creds are no longer required: `find_or_create_supabase_user` already writes a throwaway random `passwordhash` that nobody verifies. The local login/register paths are pure legacy. Per decision, we keep them (and the `passwordhash` column) working for backwards compatibility with old OWS clients / local dev, and just flag the deprecation for now.

## Changes (doc-only)

Deprecation notes added to:
- REST `LoginAndCreateSession` + `RegisterUser` handlers
- gRPC `PublicApi::login` + `register`
- `OWSService::login` / `register`, `UsersRepo::login` / `register`
- `find_or_create_supabase_user` — note the `passwordhash` column is now vestigial, kept unused for backwards compatibility, slated for removal with local login.

## Not done (intentionally)

- No removal of endpoints / password path.
- No schema migration — `passwordhash` column left as-is.

## Verification

`cargo check -p rows` clean. rustfmt applied by pre-commit.