### PR TITLE
fix(kubevirt): whitespace-tolerant runner token JSON parse

### DIFF
--- a/apps/kube/kubevirt/runner/configmap.yaml
+++ b/apps/kube/kubevirt/runner/configmap.yaml
@@ -114,7 +114,7 @@ data:
             -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             "https://api.github.com/orgs/${GITHUB_ORG}/actions/runners/registration-token" \
-            | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+            | sed -n 's/.*"token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
         if [ -z "${REG_TOKEN}" ]; then
             echo "ERROR: Failed to obtain registration token (GITHUB_TOKEN needs admin:org)"
             exit 1


### PR DESCRIPTION
The real reason the runner never re-registered: the mint returns HTTP 201 with the token, but GitHub pretty-prints the JSON (`"token": "..."` — space after colon, multi-line) and the sed pattern was `"token":"` (no space), extracting nothing -> empty token -> 'Failed to obtain registration token'. Verified the whitespace-tolerant sed extracts the token. The original wget version had the same sed, so the script never registered the runner (it was set up manually as NETWORK SERVICE).