### PR TITLE
feat(cryptothrone): /health reports version + bump to 0.1.7

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/api.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/api.spec.ts
@@ -12,10 +12,12 @@ test.describe('axum game API', () => {
 		);
 	});
 
-	test('health check returns OK', async ({ request }) => {
+	test('health check reports status and version', async ({ request }) => {
 		const res = await request.get('/health');
 		expect(res.status()).toBe(200);
-		expect(await res.text()).toBe('OK');
+		const body = await res.json();
+		expect(body.status).toBe('ok');
+		expect(body.version).toMatch(/^\d+\.\d+\.\d+$/);
 	});
 
 	test('lists all items as JSON', async ({ request }) => {

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -94,7 +94,11 @@ fn router() -> Router {
 }
 
 async fn health() -> impl IntoResponse {
-    "OK"
+    axum::Json(serde_json::json!({
+        "status": "ok",
+        "name": env!("CARGO_PKG_NAME"),
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
 }
 
 async fn cache_headers(request: Request, next: Next) -> Response {
@@ -206,7 +210,9 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::OK);
         let body = response.into_body().collect().await.unwrap().to_bytes();
-        assert_eq!(&body[..], b"OK");
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["version"], env!("CARGO_PKG_VERSION"));
     }
 
     #[tokio::test]

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.6"
+version: "0.1.7"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## /health → deployed version
`cryptothrone.com/health` now returns the actual build's version instead of a bare `OK`:
```json
{ "status": "ok", "name": "axum-cryptothrone", "version": "0.1.7" }
```
Sourced from `CARGO_PKG_NAME`/`CARGO_PKG_VERSION` at compile time, so it always reflects whatever the CI publish baked in.

- updated the rust unit test + the docker e2e `api.spec` health assertion (version matches `x.y.z`)

## Publish
Bumped the CI registry MDX `version: 0.1.6 -> 0.1.7`. `version.toml` + `Cargo.toml` are auto-synced by the post-publish atom PR, so the shipped binary reports 0.1.7 at /health once published.

Verified: `cargo test test_health_endpoint` passes.