### PR TITLE
fix(KBVELibGit): libgit2 macOS TLS via SecureTransport

### DIFF
--- a/packages/unreal/KBVELibGit/Source/KBVELibGit/KBVELibGit.Build.cs
+++ b/packages/unreal/KBVELibGit/Source/KBVELibGit/KBVELibGit.Build.cs
@@ -41,11 +41,15 @@ public class KBVELibGit : ModuleRules
 			PublicAdditionalLibraries.Add(Path.Combine(LibDir, "libgit2.a"));
 			// libgit2 uses iconv for Unicode path normalization on macOS
 			PublicAdditionalLibraries.Add("iconv");
+			// HTTPS via SecureTransport (SSL* APIs) — native macOS TLS, no OpenSSL
+			PublicFrameworks.AddRange(new string[] { "Security", "CoreFoundation" });
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Linux)
 		{
 			LibDir = Path.Combine(ThirdPartyDir, "lib", "Linux");
 			PublicAdditionalLibraries.Add(Path.Combine(LibDir, "libgit2.a"));
+			// HTTPS via OpenSSL — link system ssl/crypto
+			PublicSystemLibraries.AddRange(new string[] { "ssl", "crypto" });
 		}
 
 		// Suppress warnings in third-party code

--- a/packages/unreal/KBVELibGit/ThirdParty/build-libgit2.sh
+++ b/packages/unreal/KBVELibGit/ThirdParty/build-libgit2.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds libgit2 static libs with native TLS per platform:
+#   Mac    -> SecureTransport (Security.framework, no OpenSSL)
+#   Linux  -> OpenSSL (system)
+#   Win64  -> WinHTTP / SChannel (build on Windows, see notes)
+# Output: lib/<Platform>/(libgit2.a|git2.lib)
+# Usage:  ./build-libgit2.sh [mac|linux]
+
+LIBGIT2_TAG="v1.9.0"
+THIRDPARTY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/libgit2" && pwd)"
+WORK="${TMPDIR:-/tmp}/libgit2-build"
+PLATFORM="${1:-}"
+
+if [ -z "$PLATFORM" ]; then
+    case "$(uname -s)" in
+        Darwin) PLATFORM="mac" ;;
+        Linux)  PLATFORM="linux" ;;
+        *) echo "Pass platform: mac|linux (Win64 builds on Windows)"; exit 1 ;;
+    esac
+fi
+
+rm -rf "$WORK" && mkdir -p "$WORK"
+git clone --depth 1 --branch "$LIBGIT2_TAG" https://github.com/libgit2/libgit2.git "$WORK/src"
+
+COMMON_ARGS=(
+    -DBUILD_SHARED_LIBS=OFF
+    -DBUILD_TESTS=OFF
+    -DBUILD_CLI=OFF
+    -DUSE_SSH=OFF
+    -DREGEX_BACKEND=builtin
+    -DCMAKE_BUILD_TYPE=Release
+)
+
+case "$PLATFORM" in
+    mac)
+        cmake -S "$WORK/src" -B "$WORK/build" \
+            "${COMMON_ARGS[@]}" \
+            -DUSE_HTTPS=SecureTransport \
+            -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"
+        cmake --build "$WORK/build" --config Release -j
+        mkdir -p "$THIRDPARTY_DIR/lib/Mac"
+        cp "$WORK/build/libgit2.a" "$THIRDPARTY_DIR/lib/Mac/libgit2.a"
+        echo "Built Mac libgit2.a (SecureTransport)"
+        ;;
+    linux)
+        cmake -S "$WORK/src" -B "$WORK/build" \
+            "${COMMON_ARGS[@]}" \
+            -DUSE_HTTPS=OpenSSL
+        cmake --build "$WORK/build" --config Release -j
+        mkdir -p "$THIRDPARTY_DIR/lib/Linux"
+        cp "$WORK/build/libgit2.a" "$THIRDPARTY_DIR/lib/Linux/libgit2.a"
+        echo "Built Linux libgit2.a (OpenSSL)"
+        ;;
+    *)
+        echo "Unknown platform: $PLATFORM"; exit 1 ;;
+esac
+
+# Refresh public headers from the built source
+rm -rf "$THIRDPARTY_DIR/include"
+cp -R "$WORK/src/include" "$THIRDPARTY_DIR/include"
+echo "Headers synced from $LIBGIT2_TAG"


### PR DESCRIPTION
## Summary

Fixes libgit2 HTTPS on macOS. The prebuilt `Mac/libgit2.a` was compiled with `openssl-dynamic` (dlopens `libssl` at runtime) and **no SecureTransport backend** — stock macOS has no OpenSSL, so the dlopen failed and every clone/fetch died with `there is no TLS stream available`.

## Changes

- **Rebuilt `Mac/libgit2.a`** (universal x86_64 + arm64) with `-DUSE_HTTPS=SecureTransport` — native macOS TLS, zero OpenSSL runtime dependency.
- **`KBVELibGit.Build.cs`** — link `Security` + `CoreFoundation` (the SSL* APIs SecureTransport calls) on Mac; `ssl` + `crypto` on Linux.
- **`ThirdParty/build-libgit2.sh`** (new) — reproducible per-platform build at libgit2 `v1.9.0` with the correct TLS backend (Mac = SecureTransport, Linux = OpenSSL). No build script existed before; binaries were committed blind.

## Verified

Against **kbve/chuck**: editor compiles + links (`UnrealEditor-KBVELibGit.dylib`), boots, and **Check for Updates** clones the registry over HTTPS cleanly — no more "no TLS stream".

## Follow-ups (not in this PR)

- **Win64 / Linux** prebuilt libs not rebuilt here — Win64 git2.lib likely uses WinHTTP/SChannel (fine); Linux relies on system OpenSSL. Rebuild via the new script when those platforms are exercised.
- Registry fetch is still a **full clone (~2GB)**; libgit2 can't do partial/sparse. Lightweight fetch (GitHub HTTP API or release zips) is a separate follow-up.

Refs #11942

Docs: [Git](https://kbve.com/application/git/) · [Unreal](https://kbve.com/application/unreal/)
