### PR TITLE
build(unreal): track plugin native libs in normal git (no LFS), un-ignore Binaries shared libs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -27,15 +27,11 @@ apps/godot/**/addons/**/bin/**/*.dll   filter=lfs diff=lfs merge=lfs -text
 apps/godot/**/addons/**/bin/**/*.so    filter=lfs diff=lfs merge=lfs -text
 apps/godot/**/addons/**/bin/**/*.wasm  filter=lfs diff=lfs merge=lfs -text
 
-# KBVE UE plugin runtime shared libs (Binaries/<Platform>/ + ThirdParty bin) via
-# LFS — pointer files here, blobs on the configured LFS endpoint.
-# NOTE: static link libs (.a / .lib) are intentionally NOT LFS — they stay as
-# normal git blobs so a plain clone (and the CI plugin build) gets them at
-# link time without an LFS pull.
-packages/unreal/**/*.dylib filter=lfs diff=lfs merge=lfs -text
-packages/unreal/**/*.dll   filter=lfs diff=lfs merge=lfs -text
-packages/unreal/**/*.so    filter=lfs diff=lfs merge=lfs -text
-packages/unreal/**/*.bundle filter=lfs diff=lfs merge=lfs -text
+# KBVE UE plugin native libs (packages/unreal/**) are intentionally NORMAL git
+# blobs, NOT LFS — static (.a/.lib) and shared (.dylib/.dll/.so/.bundle) alike.
+# A plain clone (and the CI plugin build) gets every prebuilt lib at link/load
+# time with no LFS pull. Plugin libs are pinned third-party versions that change
+# rarely, so the history cost is acceptable for the zero-friction download.
 
 # Unreal Engine — apps/chuckrpg/unreal-chuck binary assets
 # Pointer files live in this repo; blobs live on git.kbve.com/KBVE/chuck.git

--- a/.gitattributes
+++ b/.gitattributes
@@ -27,14 +27,14 @@ apps/godot/**/addons/**/bin/**/*.dll   filter=lfs diff=lfs merge=lfs -text
 apps/godot/**/addons/**/bin/**/*.so    filter=lfs diff=lfs merge=lfs -text
 apps/godot/**/addons/**/bin/**/*.wasm  filter=lfs diff=lfs merge=lfs -text
 
-# KBVE UE plugin native libs — prebuilt third-party (ThirdParty/.../lib) +
-# shipped runtime libs (Binaries/<Platform>/). Pointer files here, blobs via
-# the configured LFS endpoint, so consumers pull prebuilt libs without a build.
+# KBVE UE plugin runtime shared libs (Binaries/<Platform>/ + ThirdParty bin) via
+# LFS — pointer files here, blobs on the configured LFS endpoint.
+# NOTE: static link libs (.a / .lib) are intentionally NOT LFS — they stay as
+# normal git blobs so a plain clone (and the CI plugin build) gets them at
+# link time without an LFS pull.
 packages/unreal/**/*.dylib filter=lfs diff=lfs merge=lfs -text
 packages/unreal/**/*.dll   filter=lfs diff=lfs merge=lfs -text
 packages/unreal/**/*.so    filter=lfs diff=lfs merge=lfs -text
-packages/unreal/**/*.a     filter=lfs diff=lfs merge=lfs -text
-packages/unreal/**/*.lib   filter=lfs diff=lfs merge=lfs -text
 packages/unreal/**/*.bundle filter=lfs diff=lfs merge=lfs -text
 
 # Unreal Engine — apps/chuckrpg/unreal-chuck binary assets

--- a/.gitattributes
+++ b/.gitattributes
@@ -27,6 +27,16 @@ apps/godot/**/addons/**/bin/**/*.dll   filter=lfs diff=lfs merge=lfs -text
 apps/godot/**/addons/**/bin/**/*.so    filter=lfs diff=lfs merge=lfs -text
 apps/godot/**/addons/**/bin/**/*.wasm  filter=lfs diff=lfs merge=lfs -text
 
+# KBVE UE plugin native libs — prebuilt third-party (ThirdParty/.../lib) +
+# shipped runtime libs (Binaries/<Platform>/). Pointer files here, blobs via
+# the configured LFS endpoint, so consumers pull prebuilt libs without a build.
+packages/unreal/**/*.dylib filter=lfs diff=lfs merge=lfs -text
+packages/unreal/**/*.dll   filter=lfs diff=lfs merge=lfs -text
+packages/unreal/**/*.so    filter=lfs diff=lfs merge=lfs -text
+packages/unreal/**/*.a     filter=lfs diff=lfs merge=lfs -text
+packages/unreal/**/*.lib   filter=lfs diff=lfs merge=lfs -text
+packages/unreal/**/*.bundle filter=lfs diff=lfs merge=lfs -text
+
 # Unreal Engine — apps/chuckrpg/unreal-chuck binary assets
 # Pointer files live in this repo; blobs live on git.kbve.com/KBVE/chuck.git
 # (see apps/chuckrpg/unreal-chuck/.lfsconfig). Covers UE cooked asset blobs,

--- a/.gitignore
+++ b/.gitignore
@@ -163,7 +163,14 @@ apps/agones/factorio/mods-local/dist/
 
 # Unreal Engine plugin + project build artifacts (per-machine, never commit).
 # Covers packages/unreal/<Plugin>/ and apps/**/unreal-*/.
-packages/unreal/*/Binaries/
+# Exception: shipped native libs under a plugin's Binaries/<Platform>/ ARE
+# tracked (via LFS, see .gitattributes) so consumers pull prebuilt
+# .dylib/.dll/.so without a local build. ThirdParty/ libs are never ignored.
+packages/unreal/*/Binaries/**
+!packages/unreal/*/Binaries/**/
+!packages/unreal/*/Binaries/**/*.dylib
+!packages/unreal/*/Binaries/**/*.dll
+!packages/unreal/*/Binaries/**/*.so
 packages/unreal/*/Build/
 packages/unreal/*/Intermediate/
 packages/unreal/*/Saved/


### PR DESCRIPTION
## What

`packages/unreal` plugins ship prebuilt native libs that consumers and the CI plugin builds must pull on a plain clone — **no LFS process**.

### `.gitignore`
`packages/unreal/*/Binaries/` ignored the whole dir, swallowing shipped runtime libs. Narrowed: `.dylib`/`.dll`/`.so` under `Binaries/<Platform>/` are tracked; build junk (`.pdb`/`.modules`/etc.) stays ignored. `ThirdParty/` libs were never ignored.

### `.gitattributes`
**All `packages/unreal` native libs are normal git blobs — no LFS.** Static (`.a`/`.lib`) and shared (`.dylib`/`.dll`/`.so`/`.bundle`) alike. A plain clone and the CI `BuildPlugin` get every prebuilt lib at link/load time with zero LFS pull. (Plugin libs are pinned third-party versions that change rarely, so the git-history cost is acceptable for the frictionless download.)

Verified: every lib → `filter: unspecified` (raw git); Binaries shared libs un-ignored; `.pdb`/`.modules` still ignored. KBVELibGit's existing `libgit2.a`/`git2.lib` are untouched.

## Scope
Config only — no binaries added/migrated.