### PR TITLE
fix(astro-kbve): forgejo dashboard survives client router transitions

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoAuth.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoAuth.tsx
@@ -1,4 +1,5 @@
-import { useCallback, type ReactNode } from 'react';
+import { useCallback, useEffect, type ReactNode } from 'react';
+import { useStore } from '@nanostores/react';
 import { forgejoService } from './forgejoService';
 import { AuthGate } from './dashboard-ui';
 
@@ -8,6 +9,16 @@ export default function ReactForgejoAuth({
 	children: ReactNode;
 }) {
 	const initAuth = useCallback(() => forgejoService.initAuth(), []);
+	const authState = useStore(forgejoService.$authState);
+
+	useEffect(() => {
+		if (authState !== 'authenticated') return;
+		forgejoService.loadCacheAndFetch();
+		return () => {
+			forgejoService.dispose();
+		};
+	}, [authState]);
+
 	return (
 		<AuthGate
 			$authState={forgejoService.$authState}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
 import { forgejoService, formatSize, langColor } from './forgejoService';
 import {
@@ -250,10 +249,6 @@ export default function ReactForgejoSummary() {
 	const totalUsers = useStore(forgejoService.$totalUsers);
 	const totalSize = useStore(forgejoService.$totalSize);
 	const totalReleases = useStore(forgejoService.$totalReleases);
-
-	useEffect(() => {
-		forgejoService.loadCacheAndFetch();
-	}, []);
 
 	if (loading && totalRepos === 0) {
 		return (

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -1,4 +1,5 @@
 import { atom, computed } from 'nanostores';
+import { persistentAtom } from '@nanostores/persistent';
 import { initSupa, getSupa } from '@/lib/supa';
 
 // ---------------------------------------------------------------------------
@@ -147,6 +148,7 @@ interface CachedData {
 // ---------------------------------------------------------------------------
 
 const CACHE_KEY = 'cache:forgejo:data';
+const EXPANDED_KEY = 'forgejo:expandedRepo';
 const CACHE_TTL_MS = 60 * 1000;
 const PROXY_BASE = '/dashboard/forgejo/proxy';
 const REFRESH_INTERVAL_MS = 30 * 1000;
@@ -404,8 +406,14 @@ class ForgejoService {
 	public readonly $errorReason = atom<string | null>(null);
 	public readonly $lastUpdated = atom<Date | null>(null);
 
-	// Expanded repo detail
-	public readonly $expandedRepo = atom<string | null>(null);
+	public readonly $expandedRepo = persistentAtom<string | null>(
+		EXPANDED_KEY,
+		null,
+		{
+			encode: (v) => (v === null ? '' : v),
+			decode: (raw) => (raw === '' ? null : raw),
+		},
+	);
 	public readonly $repoDetails = atom<Record<string, RepoDetail>>({});
 
 	// Computed
@@ -552,8 +560,20 @@ class ForgejoService {
 			this.$loading.set(false);
 		}
 
-		this.fetchData();
+		this.fetchData().then(() => {
+			const restored = this.$expandedRepo.get();
+			if (restored && !this.$repoDetails.get()[restored]) {
+				this._fetchRepoDetail(restored);
+			}
+		});
 		this._startAutoRefresh();
+	}
+
+	public dispose(): void {
+		if (this._refreshInterval) {
+			clearInterval(this._refreshInterval);
+			this._refreshInterval = undefined;
+		}
 	}
 
 	public refresh(): void {


### PR DESCRIPTION
## Symptom
Forgejo dashboard buttons "broke" when navigating around via Astro's client router. Refresh stopped firing or fired twice in quick succession, and a row the user had just expanded would snap back to collapsed the moment they touched any link.

## Why
Three reinforcing problems in [forgejoService.ts](apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts) + the islands that consume it:

1. **\`\$expandedRepo\` was an in-memory atom.** Every client-router swap unmounted the island tree; the next mount re-initialised the atom to \`null\` and the row collapsed even though the persisted scroll position made it look like nothing else had changed.
2. **\`loadCacheAndFetch\` was triggered by [ReactForgejoSummary](apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx)'s mount \`useEffect\`.** Anything that suppressed Summary (auth race, early return on empty repos, future restructure) would leave the table empty with no fetch ever firing.
3. **\`_refreshInterval\` was started inside \`loadCacheAndFetch\` but never cleared on island unmount.** Astro view transitions tear React islands down; the singleton service kept polling, and each subsequent navigation back stacked the next interval on top of whatever was still ticking. Eventually multiple in-flight refreshes raced each other into the same atoms.

## Fix
Move the data lifecycle up into [ReactForgejoAuth](apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoAuth.tsx), where it can ride the same \`\$authState\` subscription the gate already uses:

\`\`\`tsx
const authState = useStore(forgejoService.\$authState);
useEffect(() => {
  if (authState !== 'authenticated') return;
  forgejoService.loadCacheAndFetch();
  return () => forgejoService.dispose();
}, [authState]);
\`\`\`

In [forgejoService.ts](apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts):

- \`\$expandedRepo\` is now a \`persistentAtom('forgejo:expandedRepo', null)\` with a tiny string-or-null encode pair (empty-string sentinel for \`null\`). Restores across client-router swaps and across hard reloads.
- \`loadCacheAndFetch\` chains a \`.then(...)\` that re-fetches the restored repo's branches/commits/releases/languages when \`\$repoDetails\` is empty — otherwise the persisted ID would point at an empty detail map and the expanded panel would render the loader forever.
- New \`dispose()\` clears \`_refreshInterval\` and zeroes the handle so a subsequent mount can restart cleanly. AuthGate's useEffect cleanup calls it on every island unmount, including the one Astro fires during a view transition.

[ReactForgejoSummary](apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx) loses its mount \`useEffect\` (and its now-unused \`useEffect\` import). That responsibility belonged upstream all along.

## Test plan
- [ ] Hard load \`/dashboard/forgejo\` — repo table populates, refresh button cycles loading state, repo row expand fetches detail
- [ ] Expand a repo, click any sidebar link that triggers a view transition, then navigate back — row stays expanded and detail panel survives the trip (detail re-fetches if cache TTL'd out)
- [ ] Refresh after several navigations — \`docker stats\` style timing: no compounding background fetches; only one interval is running at a time
- [ ] Sign-out scenarios still hit the AuthGate path cleanly