### PR TITLE
feat(unreal): bridge KBVESupabase sign-in to a ROWS session

### DIFF
--- a/packages/unreal/KBVESupabaseROWSBridge/KBVESupabaseROWSBridge.uplugin
+++ b/packages/unreal/KBVESupabaseROWSBridge/KBVESupabaseROWSBridge.uplugin
@@ -1,0 +1,31 @@
+{
+	"FileVersion": 3,
+	"Version": 1,
+	"VersionName": "1.0",
+	"FriendlyName": "KBVE Supabase ROWS Bridge",
+	"Description": "Glue layer that links a KBVESupabase sign-in to a ROWS session — on Supabase OnSignedIn it adopts the JWT and calls ExternalLoginAndCreateSession, surfacing the resulting ROWS UserSessionGUID.",
+	"Category": "Game",
+	"CreatedBy": "KBVE",
+	"CreatedByURL": "https://kbve.com",
+	"DocsURL": "https://kbve.com/project/rows/",
+	"EnabledByDefault": true,
+	"CanContainContent": false,
+	"IsBetaVersion": true,
+	"Modules": [
+		{
+			"Name": "KBVESupabaseROWSBridge",
+			"Type": "Runtime",
+			"LoadingPhase": "Default"
+		}
+	],
+	"Plugins": [
+		{
+			"Name": "KBVESupabase",
+			"Enabled": true
+		},
+		{
+			"Name": "KBVEROWS",
+			"Enabled": true
+		}
+	]
+}

--- a/packages/unreal/KBVESupabaseROWSBridge/README.md
+++ b/packages/unreal/KBVESupabaseROWSBridge/README.md
@@ -1,0 +1,51 @@
+# KBVESupabaseROWSBridge
+
+Glue plugin that links a **KBVESupabase** sign-in to a **ROWS** session. The two
+plugins are intentionally decoupled; this bridge is the one-way orchestration layer
+that depends on both.
+
+## What it does
+
+On `UKBVESupabaseSubsystem::OnSignedIn` it:
+
+1. `UROWSAuthSubsystem::AdoptSupabaseSession(AccessToken, User.Id, User.KbveUsername)` —
+   stores the JWT in the ROWS core so every subsequent ROWS request carries
+   `Authorization: Bearer <token>`.
+2. `UROWSAuthSubsystem::ExternalLoginAndCreateSession(AccessToken)` — mints a ROWS
+   `UserSessionGUID` against `POST /api/Users/ExternalLoginAndCreateSession`.
+
+The resulting GUID is surfaced via `OnSupabaseRowsLinked`; failures via
+`OnSupabaseRowsLinkFailed`. Sign-out clears the ROWS Supabase session.
+
+## Usage
+
+Enable the plugin (it pulls in `KBVESupabase` + `KBVEROWS`). The bridge is a
+`UGameInstanceSubsystem` and auto-links on sign-in — no code required for the happy
+path. To react to the result:
+
+```cpp
+auto* Bridge = GetGameInstance()->GetSubsystem<USupabaseRowsBridgeSubsystem>();
+Bridge->OnSupabaseRowsLinked.AddDynamic(this, &UMyHud::HandleRowsReady);    // FString UserSessionGUID
+Bridge->OnSupabaseRowsLinkFailed.AddDynamic(this, &UMyHud::HandleRowsError); // FString ErrorMessage
+
+auto* Sb = GetGameInstance()->GetSubsystem<UKBVESupabaseSubsystem>();
+Sb->SignInWithPassword(Email, Password); // or StartOAuthSignIn(...)
+```
+
+For a session restored from a persisted refresh token, drive it manually after the
+restore completes:
+
+```cpp
+Bridge->LinkCurrentSupabaseSession();
+```
+
+`SetAutoLinkEnabled(false)` disables the automatic `OnSignedIn` hook if you want to
+control linking yourself.
+
+## Notes
+
+- `AdoptSupabaseSession` broadcasts ROWS `OnLoginSuccess` synchronously with the
+  Supabase user id; the bridge ignores that and only reports the real ROWS
+  `UserSessionGUID` returned by `ExternalLoginAndCreateSession`.
+- The tenant `X-CustomerGUID` header is still supplied by the ROWS core config; this
+  bridge only handles the player identity (Supabase UUID).

--- a/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/KBVESupabaseROWSBridge.Build.cs
+++ b/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/KBVESupabaseROWSBridge.Build.cs
@@ -1,0 +1,18 @@
+using UnrealBuildTool;
+
+public class KBVESupabaseROWSBridge : ModuleRules
+{
+	public KBVESupabaseROWSBridge(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"KBVESupabase",
+			"ROWS"
+		});
+	}
+}

--- a/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Private/KBVESupabaseROWSBridgeModule.cpp
+++ b/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Private/KBVESupabaseROWSBridgeModule.cpp
@@ -1,0 +1,15 @@
+#include "KBVESupabaseROWSBridgeModule.h"
+
+#define LOCTEXT_NAMESPACE "FKBVESupabaseROWSBridgeModule"
+
+void FKBVESupabaseROWSBridgeModule::StartupModule()
+{
+}
+
+void FKBVESupabaseROWSBridgeModule::ShutdownModule()
+{
+}
+
+#undef LOCTEXT_NAMESPACE
+
+IMPLEMENT_MODULE(FKBVESupabaseROWSBridgeModule, KBVESupabaseROWSBridge)

--- a/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Private/SupabaseRowsBridgeSubsystem.cpp
+++ b/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Private/SupabaseRowsBridgeSubsystem.cpp
@@ -1,0 +1,130 @@
+#include "SupabaseRowsBridgeSubsystem.h"
+#include "KBVESupabaseSubsystem.h"
+#include "ROWSAuthSubsystem.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogSupabaseRowsBridge, Log, All);
+
+void USupabaseRowsBridgeSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	Collection.InitializeDependency<UKBVESupabaseSubsystem>();
+	Collection.InitializeDependency<UROWSAuthSubsystem>();
+
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		Supabase = GI->GetSubsystem<UKBVESupabaseSubsystem>();
+		RowsAuth = GI->GetSubsystem<UROWSAuthSubsystem>();
+	}
+
+	if (Supabase)
+	{
+		Supabase->OnSignedIn.AddDynamic(this, &USupabaseRowsBridgeSubsystem::HandleSupabaseSignedIn);
+		Supabase->OnSignedOut.AddDynamic(this, &USupabaseRowsBridgeSubsystem::HandleSupabaseSignedOut);
+		Supabase->OnAuthError.AddDynamic(this, &USupabaseRowsBridgeSubsystem::HandleSupabaseAuthError);
+	}
+
+	if (RowsAuth)
+	{
+		RowsAuth->OnLoginSuccess.AddDynamic(this, &USupabaseRowsBridgeSubsystem::HandleRowsLoginSuccess);
+		RowsAuth->OnLoginError.AddDynamic(this, &USupabaseRowsBridgeSubsystem::HandleRowsLoginError);
+	}
+}
+
+void USupabaseRowsBridgeSubsystem::Deinitialize()
+{
+	if (Supabase)
+	{
+		Supabase->OnSignedIn.RemoveDynamic(this, &USupabaseRowsBridgeSubsystem::HandleSupabaseSignedIn);
+		Supabase->OnSignedOut.RemoveDynamic(this, &USupabaseRowsBridgeSubsystem::HandleSupabaseSignedOut);
+		Supabase->OnAuthError.RemoveDynamic(this, &USupabaseRowsBridgeSubsystem::HandleSupabaseAuthError);
+	}
+
+	if (RowsAuth)
+	{
+		RowsAuth->OnLoginSuccess.RemoveDynamic(this, &USupabaseRowsBridgeSubsystem::HandleRowsLoginSuccess);
+		RowsAuth->OnLoginError.RemoveDynamic(this, &USupabaseRowsBridgeSubsystem::HandleRowsLoginError);
+	}
+
+	Super::Deinitialize();
+}
+
+void USupabaseRowsBridgeSubsystem::SetAutoLinkEnabled(bool bEnabled)
+{
+	bAutoLinkOnSignIn = bEnabled;
+}
+
+bool USupabaseRowsBridgeSubsystem::LinkCurrentSupabaseSession()
+{
+	if (!Supabase || !Supabase->IsSignedIn())
+	{
+		return false;
+	}
+	LinkSession(Supabase->GetSession());
+	return true;
+}
+
+void USupabaseRowsBridgeSubsystem::HandleSupabaseSignedIn(const FKBVESupabaseSession& Session)
+{
+	if (bAutoLinkOnSignIn)
+	{
+		LinkSession(Session);
+	}
+}
+
+void USupabaseRowsBridgeSubsystem::HandleSupabaseSignedOut()
+{
+	bAwaitingExternalLogin = false;
+	if (RowsAuth)
+	{
+		RowsAuth->ClearSupabaseSession();
+	}
+}
+
+void USupabaseRowsBridgeSubsystem::HandleSupabaseAuthError(const FKBVESupabaseError& Error)
+{
+	bAwaitingExternalLogin = false;
+	OnSupabaseRowsLinkFailed.Broadcast(FString::Printf(TEXT("Supabase auth error (%d): %s"), Error.HttpStatus, *Error.Message));
+}
+
+void USupabaseRowsBridgeSubsystem::LinkSession(const FKBVESupabaseSession& Session)
+{
+	if (!RowsAuth)
+	{
+		OnSupabaseRowsLinkFailed.Broadcast(TEXT("ROWS auth subsystem unavailable"));
+		return;
+	}
+
+	if (Session.AccessToken.IsEmpty())
+	{
+		OnSupabaseRowsLinkFailed.Broadcast(TEXT("Supabase session has no access token"));
+		return;
+	}
+
+	RowsAuth->AdoptSupabaseSession(Session.AccessToken, Session.User.Id, Session.User.KbveUsername);
+
+	bAwaitingExternalLogin = true;
+	RowsAuth->ExternalLoginAndCreateSession(Session.AccessToken);
+
+	UE_LOG(LogSupabaseRowsBridge, Log, TEXT("Linking Supabase session to ROWS — userId=%s"), *Session.User.Id);
+}
+
+void USupabaseRowsBridgeSubsystem::HandleRowsLoginSuccess(const FString& UserSessionGUID)
+{
+	if (!bAwaitingExternalLogin)
+	{
+		return;
+	}
+	bAwaitingExternalLogin = false;
+	UE_LOG(LogSupabaseRowsBridge, Log, TEXT("ROWS session linked — userSessionGUID=%s"), *UserSessionGUID);
+	OnSupabaseRowsLinked.Broadcast(UserSessionGUID);
+}
+
+void USupabaseRowsBridgeSubsystem::HandleRowsLoginError(const FString& ErrorMessage)
+{
+	if (!bAwaitingExternalLogin)
+	{
+		return;
+	}
+	bAwaitingExternalLogin = false;
+	OnSupabaseRowsLinkFailed.Broadcast(ErrorMessage);
+}

--- a/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Public/KBVESupabaseROWSBridgeModule.h
+++ b/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Public/KBVESupabaseROWSBridgeModule.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Modules/ModuleManager.h"
+
+class FKBVESupabaseROWSBridgeModule : public IModuleInterface
+{
+public:
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+};

--- a/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Public/SupabaseRowsBridgeSubsystem.h
+++ b/packages/unreal/KBVESupabaseROWSBridge/Source/KBVESupabaseROWSBridge/Public/SupabaseRowsBridgeSubsystem.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "KBVESupabaseTypes.h"
+#include "SupabaseRowsBridgeSubsystem.generated.h"
+
+class UKBVESupabaseSubsystem;
+class UROWSAuthSubsystem;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSupabaseRowsLinked, const FString&, UserSessionGUID);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnSupabaseRowsLinkFailed, const FString&, ErrorMessage);
+
+/**
+ * USupabaseRowsBridgeSubsystem
+ *
+ * Connects the two decoupled plugins: when KBVESupabase signs a player in, this bridge
+ * adopts the Supabase JWT into ROWS (so every ROWS request carries Authorization: Bearer)
+ * and calls ExternalLoginAndCreateSession to mint a ROWS UserSessionGUID. The resulting
+ * GUID (or error) is surfaced via OnSupabaseRowsLinked / OnSupabaseRowsLinkFailed.
+ *
+ * Auto-links on Supabase sign-in by default; call LinkCurrentSupabaseSession to drive it
+ * manually (e.g. for a session restored from a persisted refresh token).
+ */
+UCLASS()
+class KBVESUPABASEROWSBRIDGE_API USupabaseRowsBridgeSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	UPROPERTY(BlueprintAssignable, Category = "KBVE|SupabaseROWSBridge")
+	FOnSupabaseRowsLinked OnSupabaseRowsLinked;
+
+	UPROPERTY(BlueprintAssignable, Category = "KBVE|SupabaseROWSBridge")
+	FOnSupabaseRowsLinkFailed OnSupabaseRowsLinkFailed;
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|SupabaseROWSBridge")
+	void SetAutoLinkEnabled(bool bEnabled);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|SupabaseROWSBridge")
+	bool LinkCurrentSupabaseSession();
+
+private:
+	UFUNCTION()
+	void HandleSupabaseSignedIn(const FKBVESupabaseSession& Session);
+
+	UFUNCTION()
+	void HandleSupabaseSignedOut();
+
+	UFUNCTION()
+	void HandleSupabaseAuthError(const FKBVESupabaseError& Error);
+
+	UFUNCTION()
+	void HandleRowsLoginSuccess(const FString& UserSessionGUID);
+
+	UFUNCTION()
+	void HandleRowsLoginError(const FString& ErrorMessage);
+
+	void LinkSession(const FKBVESupabaseSession& Session);
+
+	UPROPERTY()
+	TObjectPtr<UKBVESupabaseSubsystem> Supabase;
+
+	UPROPERTY()
+	TObjectPtr<UROWSAuthSubsystem> RowsAuth;
+
+	UPROPERTY()
+	bool bAutoLinkOnSignIn = true;
+
+	bool bAwaitingExternalLogin = false;
+};


### PR DESCRIPTION
## What

New decoupled UE plugin **`KBVESupabaseROWSBridge`** that connects the existing — but previously unwired — `KBVESupabase` and `KBVEROWS` plugins, completing the player login path: **Supabase sign-in → ROWS session → world IP**.

## Why

ROWS already validates Supabase JWTs in prod (`SUPABASE_JWT_SECRET` is deployed), `UROWSAuthSubsystem` already has `ExternalLoginAndCreateSession` + `AdoptSupabaseSession`, and `KBVESupabase` already exposes the session/JWT. But **no code connected them** — a player signing in via Supabase never got a ROWS session. This is that missing link.

## How

`USupabaseRowsBridgeSubsystem` (GameInstanceSubsystem) binds `UKBVESupabaseSubsystem::OnSignedIn` and:

1. `UROWSAuthSubsystem::AdoptSupabaseSession(AccessToken, User.Id, User.KbveUsername)` → ROWS core injects `Authorization: Bearer <jwt>` on every request.
2. `ExternalLoginAndCreateSession(AccessToken)` → mints the ROWS `UserSessionGUID`.

Result surfaced via `OnSupabaseRowsLinked(UserSessionGUID)` / `OnSupabaseRowsLinkFailed(Error)`; ROWS Supabase session cleared on Supabase sign-out.

- Auto-links on sign-in (`SetAutoLinkEnabled(false)` to opt out); `LinkCurrentSupabaseSession()` for sessions restored from a persisted refresh token.
- Guards against `AdoptSupabaseSession`'s synchronous `OnLoginSuccess` (fires with the Supabase user id) so only the real ROWS `UserSessionGUID` is reported.
- One-way dependency on both plugins; **no changes to `KBVESupabase` or `KBVEROWS`**.

## Verification

No UE toolchain in this environment, so **not compiled here** — verified by matching every symbol/signature against the two plugins' headers (delegates `OnSignedIn`/`OnSignedOut`/`OnAuthError`/`OnLoginSuccess`/`OnLoginError`, `GetSession`/`IsSignedIn`, `AdoptSupabaseSession`/`ExternalLoginAndCreateSession`/`ClearSupabaseSession`, and `FKBVESupabaseSession.User.{Id,KbveUsername,AccessToken}`). It compiles as part of any game build that enables the plugin.

## Follow-ups (not in this PR)

- Register the plugin in the CI plugin-build registry (ci-registry MDX + version.toml) if a standalone plugin release is wanted — not required for it to compile inside the chuck game build.
- Game-side UI hookup (login widget → `SignInWithPassword`/`StartOAuthSignIn`) lives in the chuck game project.