### PR TITLE
feat(KBVEGameplay): generic melee component

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvegameplay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvegameplay.mdx
@@ -54,6 +54,9 @@ Also holds the agnostic gameplay-stat layer (the effect target it feeds):
   penalty). Worker-thread, cache-coherent.
 - **`IKBVECombatDamageable` / `IKBVECombatAttacker`** — combat interfaces
   (apply damage/heal/death/danger; attack-trace / combo / charged hooks).
+- **`UKBVEMeleeComponent`** — generic melee sweep: forward sphere trace from a
+  mesh socket, hits `IKBVECombatDamageable`, applies damage + knockback/launch
+  impulse, fires `OnMeleeHit`; per-swing dedupe (`BeginSwing`/`EndSwing`).
 
 `UKBVEEffectComponent` applies effects through `IKBVEStatTarget`; a game's stat
 owner maps those onto its `FKBVEStatBlock` / `FKBVEStatFragment`.

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEMeleeComponent.cpp
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEMeleeComponent.cpp
@@ -1,0 +1,90 @@
+#include "KBVEMeleeComponent.h"
+
+#include "KBVECombatInterfaces.h"
+#include "Components/MeshComponent.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+
+UKBVEMeleeComponent::UKBVEMeleeComponent()
+{
+	PrimaryComponentTick.bCanEverTick = false;
+}
+
+void UKBVEMeleeComponent::SetMeshComponent(UMeshComponent* InMesh)
+{
+	MeshComp = InMesh;
+}
+
+UMeshComponent* UKBVEMeleeComponent::ResolveMesh() const
+{
+	if (MeshComp.IsValid())
+	{
+		return MeshComp.Get();
+	}
+	const AActor* Owner = GetOwner();
+	return Owner ? Owner->FindComponentByClass<UMeshComponent>() : nullptr;
+}
+
+void UKBVEMeleeComponent::BeginSwing()
+{
+	HitThisSwing.Reset();
+}
+
+void UKBVEMeleeComponent::EndSwing()
+{
+	HitThisSwing.Reset();
+}
+
+void UKBVEMeleeComponent::DoAttackTrace(FName SourceBone)
+{
+	AActor* Owner = GetOwner();
+	UMeshComponent* Mesh = ResolveMesh();
+	UWorld* World = GetWorld();
+	if (!Owner || !Mesh || !World)
+	{
+		return;
+	}
+
+	if (!bHitPawns && !bHitWorldDynamic)
+	{
+		return;
+	}
+
+	const FVector TraceStart = Mesh->GetSocketLocation(SourceBone);
+	const FVector TraceEnd   = TraceStart + (Owner->GetActorForwardVector() * TraceDistance);
+
+	FCollisionObjectQueryParams ObjectParams;
+	if (bHitPawns)        ObjectParams.AddObjectTypesToQuery(ECC_Pawn);
+	if (bHitWorldDynamic) ObjectParams.AddObjectTypesToQuery(ECC_WorldDynamic);
+
+	FCollisionShape Shape;
+	Shape.SetSphere(TraceRadius);
+
+	FCollisionQueryParams QueryParams;
+	QueryParams.AddIgnoredActor(Owner);
+
+	TArray<FHitResult> OutHits;
+	if (!World->SweepMultiByObjectType(OutHits, TraceStart, TraceEnd, FQuat::Identity, ObjectParams, Shape, QueryParams))
+	{
+		return;
+	}
+
+	for (const FHitResult& Hit : OutHits)
+	{
+		AActor* HitActor = Hit.GetActor();
+		IKBVECombatDamageable* Damageable = Cast<IKBVECombatDamageable>(HitActor);
+		if (!Damageable)
+		{
+			continue;
+		}
+		if (bSingleHitPerSwing && HitThisSwing.Contains(HitActor))
+		{
+			continue;
+		}
+		HitThisSwing.Add(HitActor);
+
+		const FVector Impulse = (Hit.ImpactNormal * -KnockbackImpulse) + (FVector::UpVector * LaunchImpulse);
+		Damageable->ApplyDamage(Damage, Owner, Hit.ImpactPoint, Impulse);
+		OnMeleeHit.Broadcast(HitActor, Hit.ImpactPoint, Damage);
+	}
+}

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEMeleeComponent.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEMeleeComponent.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "KBVEMeleeComponent.generated.h"
+
+class UMeshComponent;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FKBVEOnMeleeHit, AActor*, HitActor, FVector, ImpactPoint, float, Damage);
+
+UCLASS(ClassGroup = (KBVE), meta = (BlueprintSpawnableComponent), DisplayName = "KBVE Melee Component")
+class KBVEGAMEPLAY_API UKBVEMeleeComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+	UKBVEMeleeComponent();
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Combat")
+	void SetMeshComponent(UMeshComponent* InMesh);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Combat")
+	void BeginSwing();
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Combat")
+	void EndSwing();
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Combat")
+	void DoAttackTrace(FName SourceBone);
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	float TraceDistance = 100.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	float TraceRadius = 50.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	float Damage = 10.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	float KnockbackImpulse = 0.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	float LaunchImpulse = 0.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	bool bHitPawns = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	bool bHitWorldDynamic = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	bool bSingleHitPerSwing = true;
+
+	UPROPERTY(BlueprintAssignable, Category = "KBVE|Combat")
+	FKBVEOnMeleeHit OnMeleeHit;
+
+private:
+	UMeshComponent* ResolveMesh() const;
+
+	UPROPERTY()
+	TWeakObjectPtr<UMeshComponent> MeshComp;
+
+	TSet<TWeakObjectPtr<AActor>> HitThisSwing;
+};


### PR DESCRIPTION
## What

Continues chuck → plugin extraction (into the **existing** KBVEGameplay, no new plugin). Pulls the melee-attack logic out of chuck's `ACombatCharacter::DoAttackTrace` into a reusable component — the combat interfaces it needs (`IKBVECombatDamageable`) already live in KBVEGameplay.

- **`UKBVEMeleeComponent`** — forward sphere sweep from a mesh socket → hits `IKBVECombatDamageable` → `ApplyDamage` + knockback/launch impulse. Fires `OnMeleeHit(HitActor, ImpactPoint, Damage)` (replaces the game's BP `DealtDamage` hook). Per-swing dedupe (`BeginSwing`/`EndSwing` + `bSingleHitPerSwing`). Configurable `TraceDistance`/`TraceRadius`/`Damage`/`KnockbackImpulse`/`LaunchImpulse` + Pawn/WorldDynamic object-type toggles. Resolves the owner's `UMeshComponent` (or `SetMeshComponent`).

## Design
- No new deps — KBVEGameplay already has `Engine` + the combat interfaces.
- Agnostic: operates on any actor with a mesh + a damageable target; game wires the AnimNotify → `DoAttackTrace(bone)` and listens to `OnMeleeHit` for FX.

## Not verified locally
No UE toolchain — CI plugin build compile-checks the sweep/interface usage.

## Follow-up (chuck adoption)
Route `ACombatCharacter::DoAttackTrace` (and combo/charged hooks) through `UKBVEMeleeComponent` + `IKBVECombatDamageable`, dropping the duplicated trace code.

## Extraction status (into existing plugins)
- ✅ UI State → KBVEUI (#11947)
- ✅ Stats + combat interfaces → KBVEGameplay (#11948)
- ✅ Melee component → KBVEGameplay (this)
- Deferred (need new plugins): KBVESettings, KBVESupabaseUI, dropped-item actor/pool (needs MID/icon abstraction).