### PR TITLE
ci: wrap Setup Docker Buildx in wretry to absorb Docker Hub flakes (closes #11959)

### DIFF
--- a/.github/workflows/ci-mc-gradle-cache.yml
+++ b/.github/workflows/ci-mc-gradle-cache.yml
@@ -62,7 +62,11 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Setup Docker Buildx
-              uses: docker/setup-buildx-action@v4
+              uses: Wandalen/wretry.action@v3.7.0
+              with:
+                  action: docker/setup-buildx-action@v4
+                  attempt_limit: 3
+                  attempt_delay: 15000
 
             - name: Login to GHCR
               uses: docker/login-action@v4

--- a/.github/workflows/ci-mc-mods-cache.yml
+++ b/.github/workflows/ci-mc-mods-cache.yml
@@ -55,7 +55,11 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Setup Docker Buildx
-              uses: docker/setup-buildx-action@v4
+              uses: Wandalen/wretry.action@v3.7.0
+              with:
+                  action: docker/setup-buildx-action@v4
+                  attempt_limit: 3
+                  attempt_delay: 15000
 
             - name: Login to GHCR
               uses: docker/login-action@v4

--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -84,12 +84,16 @@ jobs:
                   fi
 
             - name: Setup Docker Buildx
-              uses: docker/setup-buildx-action@v4
+              uses: Wandalen/wretry.action@v3.7.0
               with:
-                  driver: docker-container
-                  driver-opts: |
-                      image=moby/buildkit:v0.24.0
-                      network=host
+                  action: docker/setup-buildx-action@v4
+                  attempt_limit: 3
+                  attempt_delay: 15000
+                  with: |
+                      driver: docker-container
+                      driver-opts: |
+                          image=moby/buildkit:v0.24.0
+                          network=host
 
             - name: Login to GHCR
               uses: docker/login-action@v4

--- a/.github/workflows/utils-publish-docker-image.yml
+++ b/.github/workflows/utils-publish-docker-image.yml
@@ -172,7 +172,11 @@ jobs:
 
             - name: Set up Docker Buildx
               if: ${{ steps.version_check.outputs.should_publish != 'false' && steps.promote.outputs.found != 'true' }}
-              uses: docker/setup-buildx-action@v4
+              uses: Wandalen/wretry.action@v3.7.0
+              with:
+                  action: docker/setup-buildx-action@v4
+                  attempt_limit: 3
+                  attempt_delay: 15000
 
             - name: Login to Docker Hub
               if: ${{ steps.version_check.outputs.should_publish != 'false' }}

--- a/.github/workflows/utils-self-hosted-job.yml
+++ b/.github/workflows/utils-self-hosted-job.yml
@@ -224,7 +224,11 @@ jobs:
 
             - name: Set up Docker Buildx
               if: inputs.setup_docker
-              uses: docker/setup-buildx-action@v4
+              uses: Wandalen/wretry.action@v3.7.0
+              with:
+                  action: docker/setup-buildx-action@v4
+                  attempt_limit: 3
+                  attempt_delay: 15000
 
             - name: Restore Docker Buildx Cache
               if: inputs.setup_docker


### PR DESCRIPTION
8 CI failures in past 48h all match same shape: buildkit pull from \`registry-1.docker.io\` hits \`context deadline exceeded\` while booting the buildx builder.

Examples: #11959, #11894, #11874, #11869, #11884, #11853, #11849, #11808.

## Fix

\`docker/setup-buildx-action\` has no native retry. Wrap every call site with \`Wandalen/wretry.action@v3.7.0\`:

\`\`\`yaml
- name: Setup Docker Buildx
  uses: Wandalen/wretry.action@v3.7.0
  with:
    action: docker/setup-buildx-action@v4
    attempt_limit: 3
    attempt_delay: 15000
    with: |
      # original action inputs go here
\`\`\`

3 attempts × 15s gap → covers the typical 5–30s Docker Hub blip without blowing up the workflow.

## Files

- \`.github/workflows/docker-test-app.yml\` (driver-opts preserved verbatim under wretry \`with:\` block)
- \`.github/workflows/utils-publish-docker-image.yml\`
- \`.github/workflows/utils-self-hosted-job.yml\`
- \`.github/workflows/ci-mc-gradle-cache.yml\`
- \`.github/workflows/ci-mc-mods-cache.yml\`

Closes #11959.