### PR TITLE
feat(astro-kbve): ClientRouter-safe AdsterraAds component

### DIFF
--- a/apps/kbve/astro-kbve/src/components/kbve/AdsterraAds.astro
+++ b/apps/kbve/astro-kbve/src/components/kbve/AdsterraAds.astro
@@ -1,0 +1,72 @@
+---
+interface Props {
+	adKey?: string;
+	src?: string;
+	label?: string;
+	class?: string;
+}
+
+const {
+	adKey = '0755355327191f72faebfb9b15d3d52e',
+	src = 'https://pl29665769.effectivecpmnetwork.com/0755355327191f72faebfb9b15d3d52e/invoke.js',
+	label = 'Advertisement',
+	class: className = '',
+} = Astro.props;
+
+const containerId = `container-${adKey}`;
+---
+
+<aside
+	class:list={[
+		'not-content mx-auto my-6 block w-full max-w-full overflow-hidden rounded-lg border border-[var(--sl-color-gray-5)] bg-[var(--sl-color-bg-sidebar)] p-3 box-border [contain:layout_paint] sm:my-4 sm:p-2',
+		className,
+	]}
+	role="complementary"
+	aria-label={label}>
+	<span
+		class="mb-2 block text-center text-[0.7rem] font-medium uppercase tracking-wider text-[var(--sl-color-gray-3)] opacity-80">
+		{label}
+	</span>
+	<div id={containerId} class="relative w-full max-w-full overflow-hidden">
+	</div>
+</aside>
+
+{
+	/* Astro dedupes a static <script src> by URL, so on a repeat ClientRouter
+	   visit the loader would never re-run and the slot would stay empty.
+	   Inject a fresh loader element on every page arrival (data-astro-rerun)
+	   and tear it down on swap so nothing leaks or double-loads. */
+}
+<script is:inline define:vars={{ containerId, src }} data-astro-rerun>
+	(function () {
+		const cleanup = () => {
+			document
+				.querySelectorAll(`script[data-adsterra-for="${containerId}"]`)
+				.forEach((el) => el.remove());
+			const container = document.getElementById(containerId);
+			if (container) {
+				container.innerHTML = '';
+				delete container.dataset.adsterraLoaded;
+			}
+		};
+
+		const mount = () => {
+			const container = document.getElementById(containerId);
+			if (!container || container.dataset.adsterraLoaded === 'true')
+				return;
+			container.dataset.adsterraLoaded = 'true';
+
+			const loader = document.createElement('script');
+			loader.async = true;
+			loader.src = src;
+			loader.setAttribute('data-cfasync', 'false');
+			loader.setAttribute('data-adsterra-for', containerId);
+			document.body.appendChild(loader);
+		};
+
+		document.addEventListener('astro:before-swap', cleanup, { once: true });
+		window.addEventListener('pagehide', cleanup, { once: true });
+
+		mount();
+	})();
+</script>

--- a/apps/kbve/astro-kbve/src/content/docs/service.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/service.mdx
@@ -10,6 +10,7 @@ sidebar:
 ---
 
 import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
+import AdsterraAds from '@/components/kbve/AdsterraAds.astro';
 import RingShipGrid from '@kbve/astro/components/hero/ring/RingShipGrid.astro';
 import RingShipCard from '@kbve/astro/components/hero/ring/RingShipCard.astro';
 import ScrollRing from '@kbve/astro/components/hero/observer/ScrollRing.astro';
@@ -60,6 +61,8 @@ Three-step engagement:
 3. **Handoff** — full source, IaC, runbooks. No lock-in.
 
 <DeferredAdsense label="Sponsored" />
+
+<AdsterraAds label="Sponsored" />
 
 ## Talk to us
 

--- a/packages/npm/astro/src/components/hero/ring/RingShipGrid.astro
+++ b/packages/npm/astro/src/components/hero/ring/RingShipGrid.astro
@@ -34,7 +34,7 @@ const { heading, tagline } = Astro.props;
 
 	.rsg__grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
 		gap: 1rem;
 	}
 </style>


### PR DESCRIPTION
## What

Adds an Adsterra ad unit as a reusable component and drops it on **service.mdx** as a single test placement.

- **`AdsterraAds.astro`** (`components/kbve/`) — renders the `#container-<key>` slot inside a labeled `<aside>` (matches `DeferredAdsense` styling) and loads the Adsterra `invoke.js` loader.
- **service.mdx** — one `<AdsterraAds />` placement under the existing AdSense unit, to validate before rolling wider.

## ClientRouter safety

Astro dedupes a static `<script src>` by URL, so on a **repeat** SPA navigation the loader would never re-execute and the slot would stay empty. Instead:
- An inline `data-astro-rerun` script injects a **fresh** loader element on every page arrival (initial load + each `astro:after-swap`).
- On `astro:before-swap` / `pagehide` it tears down — removes the injected loader (`data-adsterra-for`) and clears the container — so nothing leaks or double-loads across navigations.
- A `data-adsterraLoaded` guard prevents a double-inject within a single page life.

Same pattern the existing `DeferredAdsense` uses for its post-swap re-push.

## Props
`adKey`, `src`, `label`, `class` — all default to the supplied Adsterra unit, so `<AdsterraAds />` works bare; override to reuse for other slots.

## Verified
`astro-kbve:build` completes (7733 pages). Built `/service/index.html` contains the container div, the loader src, `data-astro-rerun`, and the `astro:before-swap` cleanup. (nx exits 1 after on the known worktree post-build bug — the build itself prints Complete!.)

## Note
Ad will only actually render on the deployed domain (Adsterra serves by referrer/domain); locally the slot stays empty, which is expected.