### PR TITLE
feat(rows): service-key auth for trusted server-to-server callers

### DIFF
--- a/apps/rows/src/grpc.rs
+++ b/apps/rows/src/grpc.rs
@@ -49,6 +49,17 @@ fn session_from_meta<T>(req: &Request<T>) -> Option<Uuid> {
         .ok()
 }
 
+/// Optional `x-service-key: <key>` metadata entry for trusted server-to-server callers (e.g. the UE
+/// dedicated server), validated against `SUPABASE_SERVICE_KEY_HASH`.
+fn service_key_from_meta<T>(req: &Request<T>) -> Option<String> {
+    let key = req.metadata().get("x-service-key")?.to_str().ok()?.trim();
+    if key.is_empty() {
+        None
+    } else {
+        Some(key.to_string())
+    }
+}
+
 pub struct PublicApiService {
     svc: Arc<OWSService>,
 }
@@ -159,16 +170,20 @@ impl PublicApi for PublicApiService {
         &self,
         req: Request<GetServerToConnectToRequest>,
     ) -> Result<Response<GetServerToConnectToResponse>, Status> {
-        let caller_guid = self
+        let caller = self
             .svc
-            .confirm_login_parts(bearer_from_meta(&req), session_from_meta(&req))
+            .confirm_login_parts(
+                bearer_from_meta(&req),
+                session_from_meta(&req),
+                service_key_from_meta(&req),
+            )
             .await
             .map_err(to_status)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         let result = self
             .svc
-            .get_server_to_connect_to(guid, caller_guid, &r.character_name, &r.character_name)
+            .get_server_to_connect_to(guid, caller, &r.character_name, &r.character_name)
             .await
             .map_err(to_status)?;
         if !result.success {
@@ -357,16 +372,20 @@ impl CharacterPersistence for CharacterPersistenceService {
         &self,
         req: Request<JoinMapRequest>,
     ) -> Result<Response<JoinMapResponse>, Status> {
-        let caller_guid = self
+        let caller = self
             .svc
-            .confirm_login_parts(bearer_from_meta(&req), session_from_meta(&req))
+            .confirm_login_parts(
+                bearer_from_meta(&req),
+                session_from_meta(&req),
+                service_key_from_meta(&req),
+            )
             .await
             .map_err(to_status)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         let result = self
             .svc
-            .get_server_to_connect_to(guid, caller_guid, &r.character_name, &r.zone_name)
+            .get_server_to_connect_to(guid, caller, &r.character_name, &r.zone_name)
             .await
             .map_err(to_status)?;
         Ok(Response::new(JoinMapResponse {

--- a/apps/rows/src/middleware.rs
+++ b/apps/rows/src/middleware.rs
@@ -50,6 +50,19 @@ pub fn extract_bearer(headers: &axum::http::HeaderMap) -> Option<String> {
     }
 }
 
+/// Pulls a trusted server-to-server service key out of the `x-service-key` header.
+pub fn extract_service_key(headers: &axum::http::HeaderMap) -> Option<String> {
+    let key = headers
+        .get("x-service-key")
+        .and_then(|v| v.to_str().ok())?
+        .trim();
+    if key.is_empty() {
+        None
+    } else {
+        Some(key.to_string())
+    }
+}
+
 /// Returns `Uuid::nil()` when the header is missing or malformed so unprotected callers don't panic.
 pub fn extract_customer_guid(headers: &axum::http::HeaderMap) -> Uuid {
     headers

--- a/apps/rows/src/rest/auth.rs
+++ b/apps/rows/src/rest/auth.rs
@@ -170,19 +170,14 @@ async fn get_server_to_connect_to(
     headers: HeaderMap,
     Json(body): Json<GetServerDto>,
 ) -> ApiResult<crate::models::JoinMapResult> {
-    let caller_guid = hs
+    let caller = hs
         .svc
         .confirm_login(&headers, body.user_session_guid)
         .await?;
     let customer_guid = extract_customer_guid(&headers);
     let result = hs
         .svc
-        .get_server_to_connect_to(
-            customer_guid,
-            caller_guid,
-            &body.character_name,
-            &body.zone_name,
-        )
+        .get_server_to_connect_to(customer_guid, caller, &body.character_name, &body.zone_name)
         .await?;
     Ok(Json(result))
 }

--- a/apps/rows/src/rest/instances.rs
+++ b/apps/rows/src/rest/instances.rs
@@ -295,19 +295,14 @@ async fn instance_get_server_to_connect_to(
     headers: HeaderMap,
     Json(body): Json<GetServerDto>,
 ) -> ApiResult<crate::models::JoinMapResult> {
-    let caller_guid = hs
+    let caller = hs
         .svc
         .confirm_login(&headers, body.user_session_guid)
         .await?;
     let customer_guid = extract_customer_guid(&headers);
     let result = hs
         .svc
-        .get_server_to_connect_to(
-            customer_guid,
-            caller_guid,
-            &body.character_name,
-            &body.zone_name,
-        )
+        .get_server_to_connect_to(customer_guid, caller, &body.character_name, &body.zone_name)
         .await?;
     Ok(Json(result))
 }

--- a/apps/rows/src/service/auth.rs
+++ b/apps/rows/src/service/auth.rs
@@ -1,4 +1,4 @@
-use super::{CachedSession, OWSService};
+use super::{AuthIdentity, CachedSession, OWSService};
 use crate::error::RowsError;
 use crate::models::*;
 use crate::repo::UsersRepo;
@@ -137,34 +137,45 @@ impl OWSService {
         })
     }
 
-    /// Confirms the caller is logged in before a protected action (e.g. handing out a world IP),
-    /// reading the bearer token from an HTTP `Authorization` header. Returns the authenticated
-    /// caller's `user_guid` (Supabase UUID). Transport-agnostic logic lives in
-    /// [`OWSService::confirm_login_parts`], shared with the gRPC surface.
+    /// Confirms the caller before a protected action (e.g. handing out a world IP), reading the
+    /// bearer token and optional service key from HTTP headers. Returns the [`AuthIdentity`].
+    /// Transport-agnostic logic lives in [`OWSService::confirm_login_parts`], shared with gRPC.
     pub async fn confirm_login(
         &self,
         headers: &HeaderMap,
         session_guid: Option<Uuid>,
-    ) -> Result<Uuid, RowsError> {
-        self.confirm_login_parts(crate::middleware::extract_bearer(headers), session_guid)
-            .await
+    ) -> Result<AuthIdentity, RowsError> {
+        self.confirm_login_parts(
+            crate::middleware::extract_bearer(headers),
+            session_guid,
+            crate::middleware::extract_service_key(headers),
+        )
+        .await
     }
 
-    /// Transport-agnostic login gate: accepts a Supabase bearer token (validated locally) or, failing
-    /// that, a live session GUID that resolves to a real session. Returns the authenticated caller's
-    /// `user_guid` (the JWT `sub` on the bearer path, the session's user on the session path) so
-    /// downstream checks like character ownership can use it. Reused by both the REST and gRPC entry
-    /// points so any future gRPC connection handler gates with a single call.
+    /// Transport-agnostic auth gate, in precedence order: a valid service key authenticates a trusted
+    /// server-to-server caller ([`AuthIdentity::Service`]); otherwise a Supabase bearer token or a
+    /// live session GUID authenticates a player ([`AuthIdentity::Player`] carrying the `user_guid` —
+    /// the JWT `sub` or the session's user). Reused by both the REST and gRPC entry points.
     pub async fn confirm_login_parts(
         &self,
         bearer: Option<String>,
         session_guid: Option<Uuid>,
-    ) -> Result<Uuid, RowsError> {
+        service_key: Option<String>,
+    ) -> Result<AuthIdentity, RowsError> {
+        if let Some(key) = service_key {
+            if self.state.supabase.service_key_enabled() {
+                crate::supabase::validate_service_key(&key, &self.state.supabase)
+                    .map_err(|e| RowsError::Unauthorized(format!("Invalid service key: {e}")))?;
+                return Ok(AuthIdentity::Service);
+            }
+        }
+
         if let Some(token) = bearer {
             if self.state.supabase.jwt_enabled() {
                 let validated = crate::supabase::validate_jwt(&token, &self.state.supabase)
                     .map_err(|e| RowsError::Unauthorized(format!("Invalid access token: {e}")))?;
-                return Ok(validated.user_id);
+                return Ok(AuthIdentity::Player(validated.user_id));
             }
         }
 
@@ -173,11 +184,12 @@ impl OWSService {
                 .resolve_session(sg)
                 .await
                 .map_err(|_| RowsError::Unauthorized("Invalid or expired session".into()))?;
-            return Ok(cached.user_guid);
+            return Ok(AuthIdentity::Player(cached.user_guid));
         }
 
         Err(RowsError::Unauthorized(
-            "Login required: send Authorization: Bearer <jwt> or a valid session GUID".into(),
+            "Login required: send Authorization: Bearer <jwt>, a valid session GUID, or a service key"
+                .into(),
         ))
     }
 

--- a/apps/rows/src/service/instances.rs
+++ b/apps/rows/src/service/instances.rs
@@ -1,4 +1,4 @@
-use super::OWSService;
+use super::{AuthIdentity, OWSService};
 use crate::agones::AllocationPipeline;
 use crate::error::RowsError;
 use crate::models::*;
@@ -6,16 +6,18 @@ use crate::repo::{CharsRepo, InstanceRepo};
 use uuid::Uuid;
 
 impl OWSService {
-    #[tracing::instrument(skip(self), fields(%customer_guid, %caller_guid, char_name, zone_name))]
+    #[tracing::instrument(skip(self, caller), fields(%customer_guid, char_name, zone_name))]
     pub async fn get_server_to_connect_to(
         &self,
         customer_guid: Uuid,
-        caller_guid: Uuid,
+        caller: AuthIdentity,
         char_name: &str,
         zone_name: &str,
     ) -> Result<JoinMapResult, RowsError> {
-        self.verify_character_owner(customer_guid, caller_guid, char_name)
-            .await?;
+        if let AuthIdentity::Player(caller_guid) = caller {
+            self.verify_character_owner(customer_guid, caller_guid, char_name)
+                .await?;
+        }
 
         let resolved_zone = self
             .resolve_zone(customer_guid, char_name, zone_name)

--- a/apps/rows/src/service/mod.rs
+++ b/apps/rows/src/service/mod.rs
@@ -20,6 +20,15 @@ pub struct CachedSession {
     pub created_at: std::time::Instant,
 }
 
+/// Who a confirmed request is acting as. `Player` carries the Supabase `user_guid` and is subject to
+/// per-character ownership checks; `Service` is a trusted server-to-server caller (validated service
+/// key) that bypasses player-scoped checks.
+#[derive(Clone, Copy, Debug)]
+pub enum AuthIdentity {
+    Player(uuid::Uuid),
+    Service,
+}
+
 impl OWSService {
     pub fn new(state: Arc<AppState>) -> Self {
         Self { state }

--- a/apps/rows/src/supabase.rs
+++ b/apps/rows/src/supabase.rs
@@ -104,16 +104,22 @@ pub fn validate_jwt(token: &str, config: &SupabaseConfig) -> Result<ValidatedUse
     })
 }
 
-/// Compares against the stored argon2 hash (constant-time, defeats timing attacks).
+/// Verifies a presented service key against the stored argon2 hash (`SUPABASE_SERVICE_KEY_HASH`).
+/// Used for trusted server-to-server callers (e.g. the UE dedicated server) that have no player
+/// JWT. argon2 verification is constant-time, defeating timing attacks.
 pub fn validate_service_key(key: &str, config: &SupabaseConfig) -> Result<(), JwtError> {
+    use argon2::{Argon2, PasswordHash, PasswordVerifier};
+
     let hash = config
         .service_key_hash
         .as_ref()
         .ok_or(JwtError::NotConfigured)?;
 
-    let _ = (key, hash);
-
-    Err(JwtError::NotConfigured)
+    let parsed = PasswordHash::new(hash).map_err(|_| JwtError::InvalidServiceKey)?;
+    Argon2::default()
+        .verify_password(key.as_bytes(), &parsed)
+        .map_err(|_| JwtError::InvalidServiceKey)?;
+    Ok(())
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## What

Implement the stubbed `validate_service_key` and add a **Service** auth identity so the UE dedicated server (and other trusted in-cluster callers) can hit ROWS — including the now-gated gRPC `join_map` / `get_server_to_connect_to` — without a player JWT.

## Why

The world-IP RPCs are gated behind a confirmed player login (#11946 / #11949). A dedicated server has no player JWT, so it had no way to call them. `validate_service_key` in `supabase.rs` was a stub and `SUPABASE_SERVICE_KEY_HASH` was unused.

## How

- **`supabase.rs`** — `validate_service_key` argon2-verifies the presented key against `SUPABASE_SERVICE_KEY_HASH` (constant-time).
- **`service/mod.rs`** — new `AuthIdentity { Player(user_guid), Service }`.
- **`service/auth.rs`** — `confirm_login_parts` gains an optional `service_key` (precedence: **service key → bearer → session**) and returns `AuthIdentity`. `confirm_login` reads the `x-service-key` header alongside the bearer.
- **`service/instances.rs`** — `get_server_to_connect_to` takes `AuthIdentity`; the character-ownership check runs only for `Player`, `Service` bypasses it.
- **`middleware.rs` / `grpc.rs`** — extract the service key from the `x-service-key` HTTP header and gRPC metadata; thread `AuthIdentity` through all four world-IP entry points.

Precedence-safe: if `SUPABASE_SERVICE_KEY_HASH` is unset, the service path is inert and player auth is unchanged.

## Deploy / follow-ups (not in this PR)

- **Wire `SUPABASE_SERVICE_KEY_HASH`** into the rows deployment (external secret, mirroring `rows-supabase-jwt`) and give the dedicated server the plaintext key. Without it the service path stays inert.
- **gRPC external exposure** — still REST-only on `api.chuckrpg.com`; in-cluster callers reach ROWS via the ClusterIP service (`rows.rows.svc.cluster.local:4322`), so server-to-server works in-cluster without external gRPC.
- **UE dedicated-server gRPC client** — still needs generating; this PR is the ROWS-side auth it will use (`x-service-key` metadata).

## Verification

`cargo check` + `cargo clippy -p rows` clean (direct cargo, not nx). rustfmt applied by pre-commit.