### PR TITLE
feat(unreal): dropped-item actor/pool → KBVEItemDB with icon-provider seam

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/kbveitemdb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbveitemdb.mdx
@@ -45,6 +45,25 @@ to [KBVEGameplay](/project/kbvegameplay)'s effect half:
 Item DATA stays in the shared itemdb MDX. KBVEItemDB carries it + the inventory
 model; KBVEGameplay applies the consumable effects (atlas/icon rendering deferred).
 
+## Dropped items (`AKBVEDroppedItemActor` / `UKBVEDroppedItemPool`)
+
+Pooled, billboarded world-drop system — extracted from chuck's
+`chuckDroppedItemActor` / `chuckDroppedItemPool` and made game-agnostic.
+
+- **`AKBVEDroppedItemActor`** — sphere overlap root + icon/halo `UMaterialBillboardComponent`
+  + rarity `UPointLightComponent`. Idle bob, then pawn-overlap triggers a homing
+  ease toward the picker; on complete it calls back into the pool. No game types.
+- **`UKBVEDroppedItemPool`** (world subsystem) — preallocates `InitialPoolSize` (64)
+  actors, free-list `SpawnDrop` / `ReleaseDrop`, fires `OnItemPickedUp(Picker, ItemKey, Count)`
+  on homing-complete so the game owns auth + inventory add.
+- **`IKBVEDroppedItemVisualProvider`** (icon-provider seam) — game implements
+  `GetDroppedItemVisual(ItemKey, FKBVEDroppedItemVisual&)` to supply per-item
+  `IconMID` / `HaloMID` / `RarityColor`; registered via `SetVisualProvider`. Keeps
+  atlas/MID generation game-side while the pool stays generic.
+
+The chuck-specific `Cast<AchuckCoreCharacter>` + `ServerAddItemByKey` pickup path
+becomes: provider feeds visuals, `OnItemPickedUp` delegate feeds the inventory.
+
 ## Persistence (`FKBVEInventoryStore` / `UKBVEInventoryStoreSubsystem`)
 
 Durable local inventory via the **KBVESQLite** plugin — row-per-slot

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEDroppedItemActor.cpp
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEDroppedItemActor.cpp
@@ -1,0 +1,202 @@
+#include "KBVEDroppedItemActor.h"
+
+#include "KBVEDroppedItemPool.h"
+#include "Components/MaterialBillboardComponent.h"
+#include "Components/PointLightComponent.h"
+#include "Components/SphereComponent.h"
+#include "Engine/World.h"
+#include "GameFramework/Pawn.h"
+#include "Materials/MaterialInstanceDynamic.h"
+
+AKBVEDroppedItemActor::AKBVEDroppedItemActor()
+{
+	PrimaryActorTick.bCanEverTick = true;
+	PrimaryActorTick.TickGroup    = TG_PrePhysics;
+	PrimaryActorTick.TickInterval = 0.05f;
+
+	SphereRoot = CreateDefaultSubobject<USphereComponent>(TEXT("SphereRoot"));
+	SphereRoot->InitSphereRadius(70.f);
+	SphereRoot->SetCollisionEnabled(ECollisionEnabled::QueryOnly);
+	SphereRoot->SetCollisionProfileName(TEXT("OverlapAllDynamic"));
+	SphereRoot->SetGenerateOverlapEvents(true);
+	SphereRoot->OnComponentBeginOverlap.AddDynamic(this, &AKBVEDroppedItemActor::OnSphereBeginOverlap);
+	RootComponent = SphereRoot;
+
+	HaloBillboard = CreateDefaultSubobject<UMaterialBillboardComponent>(TEXT("HaloBillboard"));
+	HaloBillboard->SetupAttachment(RootComponent);
+	HaloBillboard->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	HaloBillboard->SetTranslucentSortPriority(0);
+
+	IconBillboard = CreateDefaultSubobject<UMaterialBillboardComponent>(TEXT("IconBillboard"));
+	IconBillboard->SetupAttachment(RootComponent);
+	IconBillboard->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	IconBillboard->SetTranslucentSortPriority(10);
+
+	RarityLight = CreateDefaultSubobject<UPointLightComponent>(TEXT("RarityLight"));
+	RarityLight->SetupAttachment(RootComponent);
+	RarityLight->SetIntensity(2400.f);
+	RarityLight->SetAttenuationRadius(280.f);
+	RarityLight->SetSourceRadius(8.f);
+	RarityLight->SetCastShadows(false);
+
+	SetReplicates(false);
+}
+
+void AKBVEDroppedItemActor::BeginPlay()
+{
+	Super::BeginPlay();
+	SetActorHiddenInGame(true);
+	SetActorTickEnabled(false);
+}
+
+void AKBVEDroppedItemActor::Acquire(int32 InItemKey, int32 InCount, const FVector& Loc, const FKBVEDroppedItemVisual& Visual)
+{
+	ItemKey = InItemKey;
+	Count   = InCount;
+	BaseLocation = Loc;
+	bActive = true;
+	bHoming = false;
+	HomingTarget = nullptr;
+	HomingTimer = 0.f;
+	BobPhase = 0.f;
+	GraceTimer = 2.0f;
+
+	SetActorScale3D(FVector::OneVector);
+	SetActorLocation(Loc);
+	SetActorHiddenInGame(false);
+	SetActorTickEnabled(true);
+	if (SphereRoot)
+	{
+		SphereRoot->SetGenerateOverlapEvents(true);
+	}
+
+	if (RarityLight)
+	{
+		RarityLight->SetLightColor(Visual.RarityColor);
+		RarityLight->SetIntensity(2400.f);
+	}
+
+	if (HaloBillboard && Visual.HaloMID)
+	{
+		HaloBillboard->Elements.Reset();
+		FMaterialSpriteElement Halo;
+		Halo.Material             = Visual.HaloMID;
+		Halo.bSizeIsInScreenSpace = false;
+		Halo.BaseSizeX            = 55.f;
+		Halo.BaseSizeY            = 55.f;
+		HaloBillboard->Elements.Add(Halo);
+		HaloBillboard->SetBoundsScale(4.f);
+		HaloBillboard->MarkRenderStateDirty();
+		HaloBillboard->UpdateBounds();
+	}
+
+	if (IconBillboard && Visual.IconMID)
+	{
+		IconBillboard->Elements.Reset();
+		FMaterialSpriteElement Icon;
+		Icon.Material             = Visual.IconMID;
+		Icon.bSizeIsInScreenSpace = false;
+		Icon.BaseSizeX            = 28.f;
+		Icon.BaseSizeY            = 28.f;
+		IconBillboard->Elements.Add(Icon);
+		IconBillboard->SetBoundsScale(4.f);
+		IconBillboard->MarkRenderStateDirty();
+		IconBillboard->UpdateBounds();
+	}
+}
+
+void AKBVEDroppedItemActor::Release()
+{
+	bActive = false;
+	bHoming = false;
+	HomingTarget = nullptr;
+	HomingTimer = 0.f;
+	ItemKey = 0;
+	Count   = 0;
+	SetActorScale3D(FVector::OneVector);
+	SetActorHiddenInGame(true);
+	SetActorTickEnabled(false);
+	SetActorTickInterval(0.05f);
+	if (HaloBillboard) HaloBillboard->Elements.Reset();
+	if (IconBillboard) IconBillboard->Elements.Reset();
+	if (RarityLight)
+	{
+		RarityLight->SetIntensity(0.f);
+		RarityLight->SetLightColor(FLinearColor::White);
+	}
+	if (SphereRoot) SphereRoot->SetGenerateOverlapEvents(false);
+}
+
+void AKBVEDroppedItemActor::Tick(float DeltaSeconds)
+{
+	Super::Tick(DeltaSeconds);
+	if (!bActive) return;
+
+	if (GraceTimer > 0.f)
+	{
+		GraceTimer -= DeltaSeconds;
+	}
+
+	if (bHoming)
+	{
+		HomingTimer += DeltaSeconds;
+		const float T = FMath::Clamp(HomingTimer / FMath::Max(HomingDuration, KINDA_SMALL_NUMBER), 0.f, 1.f);
+
+		AActor* Target = HomingTarget.Get();
+		FVector AimLoc = BaseLocation;
+		if (Target)
+		{
+			AimLoc = Target->GetActorLocation() + FVector(0.f, 0.f, 60.f);
+		}
+		const float EaseIn = T * T;
+		SetActorLocation(FMath::Lerp(BaseLocation, AimLoc, EaseIn));
+		SetActorScale3D(FVector(FMath::Lerp(1.f, 0.05f, EaseIn)));
+
+		if (RarityLight)
+		{
+			RarityLight->SetIntensity((1.f - T) * 2400.f);
+		}
+
+		if (T >= 1.f)
+		{
+			if (UWorld* W = GetWorld())
+			{
+				if (UKBVEDroppedItemPool* Pool = W->GetSubsystem<UKBVEDroppedItemPool>())
+				{
+					Pool->HandlePickupComplete(this, Target);
+					return;
+				}
+			}
+			Release();
+		}
+		return;
+	}
+
+	BobPhase = FMath::Fmod(BobPhase + DeltaSeconds, 1000.f);
+	FVector L = BaseLocation;
+	L.Z += FMath::Sin(BobPhase * 3.0f) * 6.f;
+	SetActorLocation(L);
+
+	if (RarityLight)
+	{
+		const float Pulse = 0.5f + 0.5f * FMath::Sin(BobPhase * 4.0f);
+		RarityLight->SetIntensity(1900.f + Pulse * 900.f);
+	}
+}
+
+void AKBVEDroppedItemActor::OnSphereBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult)
+{
+	if (!bActive || bHoming || GraceTimer > 0.f) return;
+	if (!OtherActor || OtherActor == this) return;
+	if (!Cast<APawn>(OtherActor)) return;
+
+	bHoming      = true;
+	HomingTarget = OtherActor;
+	HomingTimer  = 0.f;
+	BaseLocation = GetActorLocation();
+	SetActorTickInterval(0.f);
+	if (SphereRoot)
+	{
+		SphereRoot->SetGenerateOverlapEvents(false);
+	}
+}

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEDroppedItemPool.cpp
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Private/KBVEDroppedItemPool.cpp
@@ -1,0 +1,105 @@
+#include "KBVEDroppedItemPool.h"
+
+#include "KBVEDroppedItemActor.h"
+#include "Engine/World.h"
+
+bool UKBVEDroppedItemPool::ShouldCreateSubsystem(UObject* Outer) const
+{
+	const UWorld* W = Cast<UWorld>(Outer);
+	return W && W->IsGameWorld();
+}
+
+AKBVEDroppedItemActor* UKBVEDroppedItemPool::SpawnPooledActor(UWorld& World, const FVector& Loc)
+{
+	FActorSpawnParameters Params;
+	Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+	Params.ObjectFlags |= RF_Transient;
+	return World.SpawnActor<AKBVEDroppedItemActor>(AKBVEDroppedItemActor::StaticClass(), Loc, FRotator::ZeroRotator, Params);
+}
+
+void UKBVEDroppedItemPool::OnWorldBeginPlay(UWorld& InWorld)
+{
+	Super::OnWorldBeginPlay(InWorld);
+
+	AllActors.Reserve(InitialPoolSize);
+	FreeActors.Reserve(InitialPoolSize);
+
+	for (int32 i = 0; i < InitialPoolSize; ++i)
+	{
+		AKBVEDroppedItemActor* A = SpawnPooledActor(InWorld, FVector(0.f, 0.f, -100000.f));
+		if (!A) continue;
+		A->Release();
+		AllActors.Add(A);
+		FreeActors.Add(A);
+	}
+}
+
+void UKBVEDroppedItemPool::Deinitialize()
+{
+	for (AKBVEDroppedItemActor* A : AllActors)
+	{
+		if (IsValid(A))
+		{
+			A->Destroy();
+		}
+	}
+	AllActors.Reset();
+	FreeActors.Reset();
+	ActiveDrops.Reset();
+	Super::Deinitialize();
+}
+
+void UKBVEDroppedItemPool::SetVisualProvider(const TScriptInterface<IKBVEDroppedItemVisualProvider>& InProvider)
+{
+	VisualProvider = InProvider;
+}
+
+AKBVEDroppedItemActor* UKBVEDroppedItemPool::SpawnDrop(int32 ItemKey, int32 Count, const FVector& Loc)
+{
+	if (ItemKey <= 0 || Count <= 0) return nullptr;
+
+	AKBVEDroppedItemActor* A = nullptr;
+	while (FreeActors.Num() > 0 && !A)
+	{
+		A = FreeActors.Pop(EAllowShrinking::No);
+		if (!IsValid(A)) { A = nullptr; }
+	}
+	if (!A)
+	{
+		UWorld* W = GetWorld();
+		if (!W) return nullptr;
+		A = SpawnPooledActor(*W, Loc);
+		if (!A) return nullptr;
+		AllActors.Add(A);
+	}
+
+	FKBVEDroppedItemVisual Visual;
+	if (IKBVEDroppedItemVisualProvider* Provider = Cast<IKBVEDroppedItemVisualProvider>(VisualProvider.GetObject()))
+	{
+		Provider->GetDroppedItemVisual(ItemKey, Visual);
+	}
+
+	A->Acquire(ItemKey, Count, Loc, Visual);
+	ActiveDrops.Add(A);
+	return A;
+}
+
+void UKBVEDroppedItemPool::ReleaseDrop(AKBVEDroppedItemActor* Actor)
+{
+	if (!IsValid(Actor) || !Actor->IsActive()) return;
+	Actor->Release();
+	ActiveDrops.RemoveSingleSwap(Actor, EAllowShrinking::No);
+	FreeActors.Add(Actor);
+}
+
+void UKBVEDroppedItemPool::HandlePickupComplete(AKBVEDroppedItemActor* Actor, AActor* Picker)
+{
+	if (!IsValid(Actor)) return;
+	const int32 Key = Actor->GetItemKey();
+	const int32 Count = Actor->GetCount();
+	ReleaseDrop(Actor);
+	if (Key > 0 && Count > 0)
+	{
+		OnItemPickedUp.Broadcast(Picker, Key, Count);
+	}
+}

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEDroppedItemActor.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEDroppedItemActor.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "KBVEDroppedItemVisual.h"
+#include "KBVEDroppedItemActor.generated.h"
+
+class UMaterialBillboardComponent;
+class UPointLightComponent;
+class USphereComponent;
+
+UCLASS()
+class KBVEITEMDB_API AKBVEDroppedItemActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	AKBVEDroppedItemActor();
+
+	virtual void Tick(float DeltaSeconds) override;
+
+	void Acquire(int32 InItemKey, int32 InCount, const FVector& Loc, const FKBVEDroppedItemVisual& Visual);
+	void Release();
+
+	int32 GetItemKey() const { return ItemKey; }
+	int32 GetCount()   const { return Count; }
+	bool  IsActive()   const { return bActive; }
+
+protected:
+	virtual void BeginPlay() override;
+
+	UFUNCTION()
+	void OnSphereBeginOverlap(UPrimitiveComponent* OverlappedComp, AActor* OtherActor, UPrimitiveComponent* OtherComp, int32 OtherBodyIndex, bool bFromSweep, const FHitResult& SweepResult);
+
+	UPROPERTY(VisibleAnywhere, Category = "KBVE|Item")
+	TObjectPtr<USphereComponent> SphereRoot;
+
+	UPROPERTY(VisibleAnywhere, Category = "KBVE|Item")
+	TObjectPtr<UMaterialBillboardComponent> IconBillboard;
+
+	UPROPERTY(VisibleAnywhere, Category = "KBVE|Item")
+	TObjectPtr<UMaterialBillboardComponent> HaloBillboard;
+
+	UPROPERTY(VisibleAnywhere, Category = "KBVE|Item")
+	TObjectPtr<UPointLightComponent> RarityLight;
+
+	int32   ItemKey = 0;
+	int32   Count   = 0;
+	bool    bActive = false;
+	bool    bHoming = false;
+	float   BobPhase = 0.f;
+	float   GraceTimer = 0.f;
+	float   HomingTimer = 0.f;
+	float   HomingDuration = 0.35f;
+	FVector BaseLocation = FVector::ZeroVector;
+	TWeakObjectPtr<AActor> HomingTarget;
+};

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEDroppedItemPool.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEDroppedItemPool.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "KBVEDroppedItemVisual.h"
+#include "KBVEDroppedItemPool.generated.h"
+
+class AKBVEDroppedItemActor;
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_ThreeParams(FKBVEOnItemPickedUp, AActor*, Picker, int32, ItemKey, int32, Count);
+
+UCLASS()
+class KBVEITEMDB_API UKBVEDroppedItemPool : public UWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+	virtual void OnWorldBeginPlay(UWorld& InWorld) override;
+	virtual void Deinitialize() override;
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Item")
+	void SetVisualProvider(const TScriptInterface<IKBVEDroppedItemVisualProvider>& InProvider);
+
+	AKBVEDroppedItemActor* SpawnDrop(int32 ItemKey, int32 Count, const FVector& Loc);
+	void ReleaseDrop(AKBVEDroppedItemActor* Actor);
+	void HandlePickupComplete(AKBVEDroppedItemActor* Actor, AActor* Picker);
+
+	UPROPERTY(BlueprintAssignable, Category = "KBVE|Item")
+	FKBVEOnItemPickedUp OnItemPickedUp;
+
+	UPROPERTY(EditAnywhere, Category = "KBVE|Item")
+	int32 InitialPoolSize = 64;
+
+private:
+	AKBVEDroppedItemActor* SpawnPooledActor(UWorld& World, const FVector& Loc);
+
+	UPROPERTY()
+	TArray<TObjectPtr<AKBVEDroppedItemActor>> AllActors;
+
+	UPROPERTY()
+	TArray<TObjectPtr<AKBVEDroppedItemActor>> FreeActors;
+
+	UPROPERTY()
+	TArray<TObjectPtr<AKBVEDroppedItemActor>> ActiveDrops;
+
+	UPROPERTY()
+	TScriptInterface<IKBVEDroppedItemVisualProvider> VisualProvider;
+};

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEDroppedItemVisual.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/KBVEDroppedItemVisual.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Interface.h"
+#include "KBVEDroppedItemVisual.generated.h"
+
+class UMaterialInstanceDynamic;
+
+USTRUCT(BlueprintType)
+struct FKBVEDroppedItemVisual
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadWrite, Category = "KBVE|Item")
+	TObjectPtr<UMaterialInstanceDynamic> IconMID = nullptr;
+
+	UPROPERTY(BlueprintReadWrite, Category = "KBVE|Item")
+	TObjectPtr<UMaterialInstanceDynamic> HaloMID = nullptr;
+
+	UPROPERTY(BlueprintReadWrite, Category = "KBVE|Item")
+	FLinearColor RarityColor = FLinearColor::White;
+};
+
+UINTERFACE(MinimalAPI)
+class UKBVEDroppedItemVisualProvider : public UInterface
+{
+	GENERATED_BODY()
+};
+
+class KBVEITEMDB_API IKBVEDroppedItemVisualProvider
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool GetDroppedItemVisual(int32 ItemKey, FKBVEDroppedItemVisual& OutVisual) const { return false; }
+};


### PR DESCRIPTION
## Summary

Extracts chuck's `chuckDroppedItemActor` / `chuckDroppedItemPool` into **KBVEItemDB** as a game-agnostic, pooled, billboarded world-drop system.

- `AKBVEDroppedItemActor` — sphere overlap root + icon/halo `UMaterialBillboardComponent` + rarity `UPointLightComponent`; idle bob → pawn-overlap homing ease → pool callback. No game types.
- `UKBVEDroppedItemPool` (world subsystem) — preallocates `InitialPoolSize` (64), free-list `SpawnDrop` / `ReleaseDrop`, fires `OnItemPickedUp(Picker, ItemKey, Count)` on homing-complete so the game owns auth + inventory add.
- `IKBVEDroppedItemVisualProvider` (icon-provider seam) — game implements `GetDroppedItemVisual(ItemKey, FKBVEDroppedItemVisual&)` to supply per-item `IconMID` / `HaloMID` / `RarityColor`; registered via `SetVisualProvider`.

The chuck-specific `Cast<AchuckCoreCharacter>` + `ServerAddItemByKey` pickup path becomes: provider feeds visuals, `OnItemPickedUp` delegate feeds the inventory.

No Build.cs / manifest change — KBVEItemDB already deps Engine + MassEntity; uses only Engine billboard/light/sphere/MID types.

## Test

UE C++ compile-checked via the plugin CI build (no local UE toolchain).