### PR TITLE
feat(unreal): FKBVESettingsStore in KBVESQLite + wire chuck settings persistence

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSettings.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSettings.cpp
@@ -1,9 +1,29 @@
 #include "chuckSettings.h"
 
+#include "KBVESettingsStore.h"
 #include "Engine/GameInstance.h"
 #include "Engine/World.h"
-#include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
+
+namespace
+{
+	const FString GWindowScope = TEXT("window");
+
+	FString GeometryToValue(const FchuckWindowGeometry& G)
+	{
+		return FString::Printf(TEXT("%f,%f,%f,%f"), G.Position.X, G.Position.Y, G.Size.X, G.Size.Y);
+	}
+
+	bool ValueToGeometry(const FString& Value, FchuckWindowGeometry& Out)
+	{
+		TArray<FString> Parts;
+		Value.ParseIntoArray(Parts, TEXT(","));
+		if (Parts.Num() != 4) return false;
+		Out.Position = FVector2D(FCString::Atod(*Parts[0]), FCString::Atod(*Parts[1]));
+		Out.Size     = FVector2D(FCString::Atod(*Parts[2]), FCString::Atod(*Parts[3]));
+		return true;
+	}
+}
 
 UchuckSettings* UchuckSettings::Get(const UObject* WorldContext)
 {
@@ -17,12 +37,19 @@ UchuckSettings* UchuckSettings::Get(const UObject* WorldContext)
 void UchuckSettings::Initialize(FSubsystemCollectionBase& Collection)
 {
 	Super::Initialize(Collection);
+	Store = MakeUnique<FKBVESettingsStore>();
+	const FString DbPath = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("KBVE"), TEXT("settings.db"));
+	Store->Open(DbPath);
 	LoadAll();
 }
 
 void UchuckSettings::Deinitialize()
 {
-	SaveAll();
+	if (Store.IsValid())
+	{
+		Store->Close();
+		Store.Reset();
+	}
 	WindowStates.Empty();
 	Super::Deinitialize();
 }
@@ -40,22 +67,24 @@ bool UchuckSettings::GetWindowGeometry(FName WindowKey, FchuckWindowGeometry& Ou
 void UchuckSettings::SetWindowGeometry(const FchuckWindowGeometry& InGeometry)
 {
 	WindowStates.FindOrAdd(InGeometry.WindowKey) = InGeometry;
-	// TODO(KBVESQLite): replace this lazy save with a transactional UPSERT
-	// on a chuck_window_state(key, pos_x, pos_y, size_x, size_y) table once
-	// the sqlite binding is wired. For now we coast on in-memory only --
-	// state persists across map travel within a session but not across
-	// process restarts.
+	if (Store.IsValid())
+	{
+		Store->SetString(GWindowScope, InGeometry.WindowKey.ToString(), GeometryToValue(InGeometry));
+	}
 }
 
 void UchuckSettings::LoadAll()
 {
-	// TODO(KBVESQLite): open ~/Documents/chuckrpg/settings.db, SELECT *
-	// FROM chuck_window_state and populate WindowStates.
-}
-
-void UchuckSettings::SaveAll()
-{
-	// TODO(KBVESQLite): begin transaction, UPSERT each WindowStates entry,
-	// commit. Run on Deinitialize + on a periodic timer so we don't lose
-	// state on a hard crash.
+	if (!Store.IsValid()) return;
+	TMap<FString, FString> Pairs;
+	if (!Store->LoadScope(GWindowScope, Pairs)) return;
+	for (const TPair<FString, FString>& Pair : Pairs)
+	{
+		FchuckWindowGeometry G;
+		G.WindowKey = FName(*Pair.Key);
+		if (ValueToGeometry(Pair.Value, G))
+		{
+			WindowStates.Add(G.WindowKey, G);
+		}
+	}
 }

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSettings.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSettings.h
@@ -4,9 +4,8 @@
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "chuckSettings.generated.h"
 
-// Per-window geometry persisted across sessions. Storage layer is KBVESQLite
-// (TODO: wire the actual sqlite3 binding). Subsystem exposes the API now so
-// call sites can land + the persistence flip is a one-file change later.
+class FKBVESettingsStore;
+
 USTRUCT()
 struct FchuckWindowGeometry
 {
@@ -33,7 +32,8 @@ public:
 
 private:
 	void LoadAll();
-	void SaveAll();
 
 	UPROPERTY() TMap<FName, FchuckWindowGeometry> WindowStates;
+
+	TUniquePtr<FKBVESettingsStore> Store;
 };

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvesqlite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvesqlite.mdx
@@ -37,6 +37,9 @@ touch raw `sqlite3_*` calls.
   `Exec` / `Prepare` / `Begin` / `Commit` / `Rollback`.
 - **`FKBVESQLiteStatement`** — RAII prepared statement: `Bind*`, `Step` / `Execute`
   / `Reset`, `Column*` accessors.
+- **`FKBVESettingsStore`** — scoped key/value prefs on a connection
+  (`kv_settings(scope, key, value)`, UPSERT): typed `Set/Get String|Int|Float|Bool`,
+  `RemoveKey`, `LoadScope`. Agnostic settings persistence — UI is KBVEUI's job.
 
 Add `KBVESQLite` to your module's `PrivateDependencyModuleNames` and
 `dependency_plugins: packages/unreal/KBVESQLite` to your ci-registry entry so the
@@ -51,4 +54,5 @@ CI plugin build stages it.
   Load at boundaries, keep the working set in memory/Mass fragments, flush async.
 
 Consumers: `FKBVEWorldChunkCache` (KBVEWorld), `FKBVEInventoryStore` +
-`FKBVEItemCatalogStore` (KBVEItemDB).
+`FKBVEItemCatalogStore` (KBVEItemDB), `FKBVESettingsStore` (chuck `UchuckSettings`
+window geometry, `Saved/KBVE/settings.db`).

--- a/packages/unreal/KBVESQLite/README.md
+++ b/packages/unreal/KBVESQLite/README.md
@@ -14,6 +14,11 @@ Embedded SQLite for KBVE Unreal Engine plugins — a vendored `sqlite3` amalgama
     - `BindInt` / `BindInt64` / `BindText` / `BindBlob`
     - `Step()` (row), `Execute()` (done), `Reset()`
     - `ColumnInt` / `ColumnInt64` / `ColumnText` / `ColumnBlob`
+- **`FKBVESettingsStore`** (`KBVESettingsStore.h`) — scoped key/value prefs store
+  on top of a connection (`kv_settings(scope, key, value)`, UPSERT). Typed
+  `SetString/Int/Float/Bool` + `GetString/Int/Float/Bool`, `RemoveKey`,
+  `LoadScope(scope, TMap&)`. The agnostic primitive for game/editor settings —
+  the UI lives in KBVEUI, the persistence lives here.
 
 ## Usage
 
@@ -51,3 +56,4 @@ Add `"KBVESQLite"` to your module's `PrivateDependencyModuleNames`, and (for the
 
 - `FKBVEWorldChunkCache` (KBVEWorld) — terrain chunk BLOB cache.
 - `FKBVEInventoryStore` / `FKBVEItemCatalogStore` (KBVEItemDB) — inventory persistence + queryable item catalog.
+- `FKBVESettingsStore` — used by chuck's `UchuckSettings` (window geometry) under the `Saved/KBVE/settings.db` `window` scope.

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESettingsStore.cpp
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/Private/KBVESettingsStore.cpp
@@ -1,0 +1,139 @@
+#include "KBVESettingsStore.h"
+
+#include "KBVESQLiteConnection.h"
+
+FKBVESettingsStore::~FKBVESettingsStore()
+{
+	Close();
+}
+
+bool FKBVESettingsStore::IsOpen() const
+{
+	return Conn.IsValid() && Conn->IsOpen();
+}
+
+bool FKBVESettingsStore::Open(const FString& DbPath)
+{
+	Close();
+	Conn = MakeUnique<FKBVESQLiteConnection>();
+	if (!Conn->Open(DbPath))
+	{
+		Conn.Reset();
+		return false;
+	}
+	if (!EnsureSchema())
+	{
+		Close();
+		return false;
+	}
+	return true;
+}
+
+void FKBVESettingsStore::Close()
+{
+	if (Conn.IsValid())
+	{
+		Conn->Close();
+		Conn.Reset();
+	}
+}
+
+bool FKBVESettingsStore::EnsureSchema()
+{
+	return Conn->Exec(
+		"CREATE TABLE IF NOT EXISTS kv_settings ("
+		"scope TEXT NOT NULL,"
+		"key TEXT NOT NULL,"
+		"value TEXT NOT NULL,"
+		"PRIMARY KEY (scope, key));");
+}
+
+bool FKBVESettingsStore::SetString(const FString& Scope, const FString& Key, const FString& Value)
+{
+	if (!IsOpen()) return false;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn->Prepare(
+		"INSERT INTO kv_settings (scope, key, value) VALUES (?1, ?2, ?3) "
+		"ON CONFLICT(scope, key) DO UPDATE SET value = excluded.value;");
+	if (!Stmt.IsValid()) return false;
+	Stmt->BindText(1, Scope);
+	Stmt->BindText(2, Key);
+	Stmt->BindText(3, Value);
+	return Stmt->Execute();
+}
+
+bool FKBVESettingsStore::SetInt(const FString& Scope, const FString& Key, int64 Value)
+{
+	return SetString(Scope, Key, LexToString(Value));
+}
+
+bool FKBVESettingsStore::SetFloat(const FString& Scope, const FString& Key, double Value)
+{
+	return SetString(Scope, Key, LexToString(Value));
+}
+
+bool FKBVESettingsStore::SetBool(const FString& Scope, const FString& Key, bool Value)
+{
+	return SetString(Scope, Key, Value ? TEXT("1") : TEXT("0"));
+}
+
+bool FKBVESettingsStore::GetString(const FString& Scope, const FString& Key, FString& OutValue) const
+{
+	if (!IsOpen()) return false;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn->Prepare(
+		"SELECT value FROM kv_settings WHERE scope = ?1 AND key = ?2;");
+	if (!Stmt.IsValid()) return false;
+	Stmt->BindText(1, Scope);
+	Stmt->BindText(2, Key);
+	if (!Stmt->Step()) return false;
+	OutValue = Stmt->ColumnText(0);
+	return true;
+}
+
+bool FKBVESettingsStore::GetInt(const FString& Scope, const FString& Key, int64& OutValue) const
+{
+	FString Raw;
+	if (!GetString(Scope, Key, Raw)) return false;
+	OutValue = FCString::Atoi64(*Raw);
+	return true;
+}
+
+bool FKBVESettingsStore::GetFloat(const FString& Scope, const FString& Key, double& OutValue) const
+{
+	FString Raw;
+	if (!GetString(Scope, Key, Raw)) return false;
+	OutValue = FCString::Atod(*Raw);
+	return true;
+}
+
+bool FKBVESettingsStore::GetBool(const FString& Scope, const FString& Key, bool& OutValue) const
+{
+	FString Raw;
+	if (!GetString(Scope, Key, Raw)) return false;
+	OutValue = Raw == TEXT("1") || Raw.ToBool();
+	return true;
+}
+
+bool FKBVESettingsStore::RemoveKey(const FString& Scope, const FString& Key)
+{
+	if (!IsOpen()) return false;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn->Prepare(
+		"DELETE FROM kv_settings WHERE scope = ?1 AND key = ?2;");
+	if (!Stmt.IsValid()) return false;
+	Stmt->BindText(1, Scope);
+	Stmt->BindText(2, Key);
+	return Stmt->Execute();
+}
+
+bool FKBVESettingsStore::LoadScope(const FString& Scope, TMap<FString, FString>& OutPairs) const
+{
+	if (!IsOpen()) return false;
+	TSharedPtr<FKBVESQLiteStatement> Stmt = Conn->Prepare(
+		"SELECT key, value FROM kv_settings WHERE scope = ?1;");
+	if (!Stmt.IsValid()) return false;
+	Stmt->BindText(1, Scope);
+	while (Stmt->Step())
+	{
+		OutPairs.Add(Stmt->ColumnText(0), Stmt->ColumnText(1));
+	}
+	return true;
+}

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/Public/KBVESettingsStore.h
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/Public/KBVESettingsStore.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FKBVESQLiteConnection;
+
+class KBVESQLITE_API FKBVESettingsStore
+{
+public:
+	FKBVESettingsStore() = default;
+	~FKBVESettingsStore();
+
+	bool Open(const FString& DbPath);
+	void Close();
+	bool IsOpen() const;
+
+	bool SetString(const FString& Scope, const FString& Key, const FString& Value);
+	bool SetInt(const FString& Scope, const FString& Key, int64 Value);
+	bool SetFloat(const FString& Scope, const FString& Key, double Value);
+	bool SetBool(const FString& Scope, const FString& Key, bool Value);
+
+	bool GetString(const FString& Scope, const FString& Key, FString& OutValue) const;
+	bool GetInt(const FString& Scope, const FString& Key, int64& OutValue) const;
+	bool GetFloat(const FString& Scope, const FString& Key, double& OutValue) const;
+	bool GetBool(const FString& Scope, const FString& Key, bool& OutValue) const;
+
+	bool RemoveKey(const FString& Scope, const FString& Key);
+	bool LoadScope(const FString& Scope, TMap<FString, FString>& OutPairs) const;
+
+private:
+	bool EnsureSchema();
+
+	TUniquePtr<FKBVESQLiteConnection> Conn;
+};


### PR DESCRIPTION
## Summary

Settings persistence lands in **KBVESQLite** (no new plugin) — the agnostic primitive; the settings UI stays in KBVEUI.

- **`FKBVESettingsStore`** (`KBVESettingsStore.h`) — scoped key/value prefs on top of `FKBVESQLiteConnection`: `kv_settings(scope, key, value)` with UPSERT, typed `Set/Get String|Int|Float|Bool`, `RemoveKey`, `LoadScope(scope, TMap&)`. Plain C++ (KBVESQLite stays Core-only).
- **chuck `UchuckSettings`** — flips the `TODO(KBVESQLite)` stubs to real persistence: window geometry now survives process restarts via `Saved/KBVE/settings.db` under the `window` scope (serialize-on-set, load-on-init).

## Decision

Per discussion: **not** folded into ROWS (server domain ≠ local-client config). Rather than a standalone KBVESettings/KBVEPersistence plugin, the persistence primitive lives in KBVESQLite and the UI in KBVEUI — keeps the plugin count flat.

## Test

UE C++ compile-checked via the KBVESQLite plugin CI build + chuck game build (no local UE toolchain).