### PR TITLE
feat(rows+unreal): gate server-write endpoints + service-key from the dedicated server

### DIFF
--- a/apps/rows/src/rest/characters.rs
+++ b/apps/rows/src/rest/characters.rs
@@ -6,13 +6,7 @@ use axum::{Json, Router, extract::State, http::HeaderMap, middleware, routing::p
 use serde::Deserialize;
 
 pub(super) fn character_persistence_routes(hs: HandlerState) -> Router {
-    Router::new()
-        .route("/api/Characters/GetByName", post(get_char_by_name))
-        .route("/api/Characters/GetCustomData", post(get_custom_data))
-        .route(
-            "/api/Characters/AddOrUpdateCustomData",
-            post(add_or_update_custom_data),
-        )
+    let server = Router::new()
         .route(
             "/api/Characters/UpdateCharacterStats",
             post(update_character_stats),
@@ -22,6 +16,18 @@ pub(super) fn character_persistence_routes(hs: HandlerState) -> Router {
             post(update_all_positions),
         )
         .route("/api/Characters/PlayerLogout", post(player_logout))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            super::require_service_key,
+        ));
+
+    server
+        .route("/api/Characters/GetByName", post(get_char_by_name))
+        .route("/api/Characters/GetCustomData", post(get_custom_data))
+        .route(
+            "/api/Characters/AddOrUpdateCustomData",
+            post(add_or_update_custom_data),
+        )
         .route(
             "/api/Status/GetCharacterStatuses",
             post(get_character_statuses),

--- a/apps/rows/src/rest/instances.rs
+++ b/apps/rows/src/rest/instances.rs
@@ -12,20 +12,11 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 pub(super) fn instance_mgmt_routes(hs: HandlerState) -> Router {
-    Router::new()
+    let server = Router::new()
         .route("/api/Instance/SetZoneInstanceStatus", post(set_zone_status))
-        .route(
-            "/api/Instance/GetZoneInstancesForWorldServer",
-            post(get_zone_instances),
-        )
         .route(
             "/api/Instance/UpdateNumberOfPlayers",
             post(update_number_of_players),
-        )
-        .route("/api/Instance/GetZoneInstance", post(get_zone_instance))
-        .route(
-            "/api/Instance/GetServerInstanceFromPort",
-            post(get_server_instance_from_port),
         )
         .route("/api/Instance/RegisterLauncher", post(register_launcher))
         .route(
@@ -43,6 +34,21 @@ pub(super) fn instance_mgmt_routes(hs: HandlerState) -> Router {
         .route(
             "/api/Instance/ShutDownServerInstance",
             post(shut_down_server_instance),
+        )
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            super::require_service_key,
+        ));
+
+    server
+        .route(
+            "/api/Instance/GetZoneInstancesForWorldServer",
+            post(get_zone_instances),
+        )
+        .route("/api/Instance/GetZoneInstance", post(get_zone_instance))
+        .route(
+            "/api/Instance/GetServerInstanceFromPort",
+            post(get_server_instance_from_port),
         )
         .route(
             "/api/Instance/GetServerToConnectTo",

--- a/apps/rows/src/rest/mod.rs
+++ b/apps/rows/src/rest/mod.rs
@@ -10,7 +10,14 @@ mod zones;
 use crate::models::HealthResponse;
 use crate::service::OWSService;
 use crate::state::AppState;
-use axum::{Json, Router, extract::State, response::IntoResponse, routing::get};
+use axum::{
+    Json, Router,
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+    routing::get,
+};
 use std::sync::Arc;
 
 /// Bundles `AppState` (for middleware) and `OWSService` (for handlers) into one extractor.
@@ -18,6 +25,33 @@ use std::sync::Arc;
 pub struct HandlerState {
     pub app: Arc<AppState>,
     pub svc: Arc<OWSService>,
+}
+
+/// Gates server-to-server write routes: requires a valid `x-service-key` (validated against
+/// `SUPABASE_SERVICE_KEY_HASH`). Player JWTs and session GUIDs do NOT pass here — these endpoints
+/// mutate world/character state and are only for trusted callers like the UE dedicated server.
+pub async fn require_service_key(
+    State(hs): State<HandlerState>,
+    req: Request,
+    next: Next,
+) -> Response {
+    let authorized = crate::middleware::extract_service_key(req.headers())
+        .filter(|_| hs.app.supabase.service_key_enabled())
+        .map(|key| crate::supabase::validate_service_key(&key, &hs.app.supabase).is_ok())
+        .unwrap_or(false);
+
+    if authorized {
+        next.run(req).await
+    } else {
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "success": false,
+                "errorMessage": "Valid service key required for this endpoint"
+            })),
+        )
+            .into_response()
+    }
 }
 
 pub fn router(app: Arc<AppState>, svc: Arc<OWSService>) -> Router {

--- a/packages/unreal/KBVEROWS/Source/ROWS/Private/ROWSSubsystem.cpp
+++ b/packages/unreal/KBVEROWS/Source/ROWS/Private/ROWSSubsystem.cpp
@@ -46,8 +46,14 @@ void UROWSSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	EnsureTrailingSlash(CharacterPersistencePath);
 	EnsureTrailingSlash(GlobalDataPath);
 
-	UE_LOG(LogROWS, Log, TEXT("ROWS initialized — API: %s | Instance: %s | Character: %s | GlobalData: %s"),
-		*APIPath, *InstanceManagementPath, *CharacterPersistencePath, *GlobalDataPath);
+	if (IsRunningDedicatedServer())
+	{
+		ServiceKey = FPlatformMisc::GetEnvironmentVariable(TEXT("OWS_SERVICE_KEY"));
+	}
+
+	UE_LOG(LogROWS, Log, TEXT("ROWS initialized — API: %s | Instance: %s | Character: %s | GlobalData: %s | ServiceKey: %s"),
+		*APIPath, *InstanceManagementPath, *CharacterPersistencePath, *GlobalDataPath,
+		HasServiceKey() ? TEXT("loaded") : TEXT("none"));
 }
 
 void UROWSSubsystem::Deinitialize()
@@ -73,6 +79,10 @@ void UROWSSubsystem::PostRequest(
 	Request->SetVerb(TEXT("POST"));
 	Request->SetHeader(TEXT("Content-Type"), TEXT("application/json"));
 	Request->SetHeader(TEXT("X-CustomerGUID"), CustomerKey);
+	if (!ServiceKey.IsEmpty())
+	{
+		Request->SetHeader(TEXT("x-service-key"), ServiceKey);
+	}
 	if (!SupabaseAccessToken.IsEmpty())
 	{
 		Request->SetHeader(TEXT("Authorization"), FString::Printf(TEXT("Bearer %s"), *SupabaseAccessToken));

--- a/packages/unreal/KBVEROWS/Source/ROWS/Public/ROWSSubsystem.h
+++ b/packages/unreal/KBVEROWS/Source/ROWS/Public/ROWSSubsystem.h
@@ -74,6 +74,13 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "ROWS|Config")
 	FString GetCustomerKey() const { return CustomerKey; }
 
+	// --- Service Key (dedicated server only) ---
+
+	/// True when a server-to-server service key is loaded. Only populated on a dedicated server
+	/// build from the OWS_SERVICE_KEY env var; never read into a client build. The plaintext key is
+	/// intentionally not exposed via Blueprint to keep it off the client/log surface.
+	bool HasServiceKey() const { return !ServiceKey.IsEmpty(); }
+
 	// --- HTTP Helpers (used by domain subsystems) ---
 
 	void PostRequest(
@@ -106,6 +113,7 @@ protected:
 	FString CharacterPersistencePath;
 	FString GlobalDataPath;
 	FString EncryptionKey;
+	FString ServiceKey;
 
 	// Session
 	FString UserSessionGUID;


### PR DESCRIPTION
## What

Two halves of the same feature — secure server-to-server between the **UE dedicated server** (Agones GameServer pod) and ROWS, over **REST** (no gRPC; KBVEROWS is HTTP-only).

### ROWS — gate the server-write endpoints
A new `require_service_key` middleware gates the dedicated-server write surface behind a valid `x-service-key` (argon2-verified against `SUPABASE_SERVICE_KEY_HASH`). Player JWTs / session GUIDs do **not** pass. Split into service-gated sub-routers:
- characters: `UpdateCharacterStats`, `UpdateAllPlayerPositions`, `PlayerLogout`
- instances: `SetZoneInstanceStatus`, `UpdateNumberOfPlayers`, `RegisterLauncher`, `StartInstanceLauncher`, `ShutDownInstanceLauncher`, `SpinUpServerInstance`, `ShutDownServerInstance`

Reads + `GetServerToConnectTo` stay on the player path. Inert (rejects all) until `SUPABASE_SERVICE_KEY_HASH` is set.

### UE — inject the service key from the dedicated server
`UROWSSubsystem` loads `OWS_SERVICE_KEY` **only when `IsRunningDedicatedServer()`** and attaches it as `x-service-key` on every ROWS request. Existing `RegisterLauncher` / `UpdateNumberOfPlayers` / `GetServerToConnectTo` now authenticate from the server automatically.

## Security

- Plaintext key is **server-only**: loaded solely on a dedicated-server build, never enters a client package, not Blueprint-exposed, never logged (init logs `loaded`/`none`).
- Delivered in-cluster via the Agones GameServer pod env (k8s secret); travels only over the ClusterIP (`rows.rows.svc.cluster.local:4322`), never the public internet — which is why no external gRPC/REST exposure is needed.
- No secret leaks on the ROWS side: status endpoint exposes only a `service_key_configured` boolean; errors echo only the verdict (`Invalid service key`), never the key or hash.

## Transport decision

REST, not gRPC: KBVEROWS is 100% HTTP, ROWS REST covers every server op, and the service-key auth works over REST. A UE gRPC client would mean dragging the whole gRPC+protobuf toolchain into UE for no functional gain (only the optional health stream).

## Verification

ROWS: `cargo check` + `cargo clippy -p rows` clean (direct cargo). UE: not compiled here (no UE toolchain) — changes mirror existing KBVEROWS patterns and are minimal.

## Follow-ups

- Per-frame reporting wrappers (position/stats/logout/zone-status/spin-down) + GameMode hooks — add with the game build so they compile/test.
- Wire `OWS_SERVICE_KEY` into the Agones Fleet/GameServer pod spec from a k8s secret (matching `SUPABASE_SERVICE_KEY_HASH` on the ROWS side).