### PR TITLE
feat(unreal): extract dev overlay into KBVEUI (SKBVEDevOverlay)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -13,7 +13,10 @@
 #include "Kismet/KismetSystemLibrary.h"
 #include "chuckEventPayloads.h"
 #include "chuckUIEvents.h"
-#include "SchuckDevOverlay.h"
+#include "SKBVEDevOverlay.h"
+#include "GameFramework/PlayerState.h"
+#include "MassEntitySubsystem.h"
+#include "MassEntityManager.h"
 #include "SchuckHotbar.h"
 #include "SchuckHUD.h"
 #include "SchuckInventoryWindow.h"
@@ -492,7 +495,22 @@ void AchuckCorePlayerController::OnToggleDevOverlayPressed(const FInputActionVal
 
 	if (HasUiFlag(EUiFlag::DevOverlay))
 	{
-		DevOverlayWidget = SNew(SchuckDevOverlay).OwningController(this);
+		DevOverlayWidget = SNew(SKBVEDevOverlay)
+			.EntityCountProvider(FKBVEDevOverlayIntProvider::CreateLambda([this]() -> int32
+			{
+				if (UWorld* W = GetWorld())
+				{
+					if (UMassEntitySubsystem* Mass = W->GetSubsystem<UMassEntitySubsystem>())
+					{
+						return (int32)Mass->GetEntityManager().DebugGetEntityCount();
+					}
+				}
+				return 0;
+			}))
+			.PingProvider(FKBVEDevOverlayIntProvider::CreateLambda([this]() -> int32
+			{
+				return PlayerState ? (int32)PlayerState->GetPingInMilliseconds() : 0;
+			}));
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), DevOverlayWidget.ToSharedRef(), 15);
 	}
 	else if (DevOverlayWidget.IsValid())

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.h
@@ -6,7 +6,7 @@
 
 class SchuckHUD;
 class SchuckPauseMenu;
-class SchuckDevOverlay;
+class SKBVEDevOverlay;
 class SchuckHotbar;
 class SchuckInventoryWindow;
 class SKBVELoginWidget;
@@ -84,7 +84,7 @@ protected:
 private:
 	TSharedPtr<SchuckHUD>             HUDWidget;
 	TSharedPtr<SchuckPauseMenu>       PauseWidget;
-	TSharedPtr<SchuckDevOverlay>      DevOverlayWidget;
+	TSharedPtr<SKBVEDevOverlay>       DevOverlayWidget;
 	TSharedPtr<SchuckHotbar>          HotbarWidget;
 	TSharedPtr<SchuckInventoryWindow> InventoryWidget;
 	TSharedPtr<SKBVELoginWidget>      LoginWidget;

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
@@ -30,7 +30,10 @@ supported_platforms:
 
 Shared Slate UI component library for KBVE Unreal games — game-agnostic visual
 primitives (Core + Slate only): movable frames, the settings frame + reusable
-settings rows (toggle / slider / combo), hotbar, slots, tooltips, info panels.
+settings rows (toggle / slider / combo), hotbar, slots, tooltips, info panels,
+and the **`SKBVEDevOverlay`** debug HUD (self-computed FPS/ms; entity-count and
+ping fed via `FKBVEDevOverlayIntProvider` delegates so the widget needs no Engine
+or Mass dep — the game supplies the numbers).
 
 Also holds **UI state** — `FKBVEUIState` (panel-flag set + cursor/movement/camera
 policy masks + `Has`/`Set`/`Diff`/`NeedsCursor`/`BlocksMovement` helpers) and

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEDevOverlay.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVEDevOverlay.cpp
@@ -1,21 +1,16 @@
-#include "SchuckDevOverlay.h"
+#include "SKBVEDevOverlay.h"
 
-#include "ChuckUIStyle.h"
 #include "KBVEUIRenderer.h"
-#include "Engine/World.h"
-#include "GameFramework/PlayerController.h"
-#include "GameFramework/PlayerState.h"
-#include "MassEntityManager.h"
-#include "MassEntitySubsystem.h"
 #include "Styling/CoreStyle.h"
 
-void SchuckDevOverlay::Construct(const FArguments& InArgs)
+void SKBVEDevOverlay::Construct(const FArguments& InArgs)
 {
-	Owner = InArgs._OwningController;
+	EntityCountProvider = InArgs._EntityCountProvider;
+	PingProvider = InArgs._PingProvider;
 	SetCanTick(true);
 }
 
-void SchuckDevOverlay::Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime)
+void SKBVEDevOverlay::Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime)
 {
 	SCompoundWidget::Tick(AllottedGeometry, InCurrentTime, InDeltaTime);
 
@@ -27,29 +22,18 @@ void SchuckDevOverlay::Tick(const FGeometry& AllottedGeometry, const double InCu
 		SmoothedMS  = SmoothedMS  * (1.f - Alpha) + (InDeltaTime * 1000.f) * Alpha;
 	}
 
-	APlayerController* PC = Owner.Get();
-	if (!PC)
+	if (EntityCountProvider.IsBound())
 	{
-		return;
-	}
-	UWorld* World = PC->GetWorld();
-	if (!World)
-	{
-		return;
+		EntityCount = EntityCountProvider.Execute();
 	}
 
-	if (APlayerState* PS = PC->PlayerState)
+	if (PingProvider.IsBound())
 	{
-		PingMs = (int32)PS->GetPingInMilliseconds();
-	}
-
-	if (UMassEntitySubsystem* Mass = World->GetSubsystem<UMassEntitySubsystem>())
-	{
-		EntityCount = (int32)Mass->GetEntityManager().DebugGetEntityCount();
+		PingMs = PingProvider.Execute();
 	}
 }
 
-int32 SchuckDevOverlay::OnPaint(
+int32 SKBVEDevOverlay::OnPaint(
 	const FPaintArgs& Args,
 	const FGeometry& AllottedGeometry,
 	const FSlateRect& MyCullingRect,
@@ -58,8 +42,7 @@ int32 SchuckDevOverlay::OnPaint(
 	const FWidgetStyle& InWidgetStyle,
 	bool bParentEnabled) const
 {
-	const ISlateStyle& Style = FChuckUIStyle::Get();
-	const FSlateFontInfo Font = Style.GetFontStyle(FChuckUIStyle::FKeys::HUD_Label_Font);
+	const FSlateFontInfo Font = FCoreStyle::GetDefaultFontStyle("Mono", 10);
 	const FVector2D Size = AllottedGeometry.GetLocalSize();
 
 	const FVector2D PanelSize(220.f, 88.f);

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVEDevOverlay.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVEDevOverlay.h
@@ -4,13 +4,14 @@
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
 
-class APlayerController;
+DECLARE_DELEGATE_RetVal(int32, FKBVEDevOverlayIntProvider);
 
-class SchuckDevOverlay : public SCompoundWidget
+class KBVEUI_API SKBVEDevOverlay : public SCompoundWidget
 {
 public:
-	SLATE_BEGIN_ARGS(SchuckDevOverlay) {}
-		SLATE_ARGUMENT(TWeakObjectPtr<APlayerController>, OwningController)
+	SLATE_BEGIN_ARGS(SKBVEDevOverlay) {}
+		SLATE_EVENT(FKBVEDevOverlayIntProvider, EntityCountProvider)
+		SLATE_EVENT(FKBVEDevOverlayIntProvider, PingProvider)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
@@ -31,7 +32,8 @@ protected:
 		bool bParentEnabled) const override;
 
 private:
-	TWeakObjectPtr<APlayerController> Owner;
+	FKBVEDevOverlayIntProvider EntityCountProvider;
+	FKBVEDevOverlayIntProvider PingProvider;
 
 	float SmoothedFPS = 60.f;
 	float SmoothedMS  = 16.7f;


### PR DESCRIPTION
## Summary

Moves chuck's debug HUD into the **KBVEUI** base module as **`SKBVEDevOverlay`** — and does it without breaking KBVEUI's Core+Slate-only contract.

- Self-computes FPS / frame-ms from Slate tick delta (pure).
- **Entity count** and **ping** are fed via `FKBVEDevOverlayIntProvider` delegates, so the widget needs **no Engine and no Mass dependency**. The original read `UMassEntitySubsystem` + `APlayerState` directly; that game knowledge now lives in the caller.
- chuck wires the two lambdas (Mass `DebugGetEntityCount`, `PlayerState->GetPingInMilliseconds`); `SchuckDevOverlay` deleted (git rename).

Demonstrates the agnostic pattern: when a generic widget needs game/engine data, push it through a delegate rather than dragging the dep into the shared module.

## Test

UE C++ compile-checked via the KBVEUI plugin CI build + chuck game build — no local UE toolchain.