### PR TITLE
chore(agones): project ROWS service key into the dedicated-server fleet

### DIFF
--- a/apps/kube/agones/rows/manifests/fleet.yaml
+++ b/apps/kube/agones/rows/manifests/fleet.yaml
@@ -109,6 +109,15 @@ spec:
                                     secretKeyRef:
                                         name: ows-gameserver-secrets
                                         key: encryption-key
+                              # Server-to-server key for the gated ROWS write endpoints
+                              # (x-service-key). optional so pods still start before the
+                              # secret is populated; ROWS rejects writes until then.
+                              - name: OWS_SERVICE_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: ows-service-key
+                                        key: service-key
+                                        optional: true
                           resources:
                               requests:
                                   memory: 2Gi

--- a/apps/kube/agones/rows/manifests/service-key-external-secret.yaml
+++ b/apps/kube/agones/rows/manifests/service-key-external-secret.yaml
@@ -1,0 +1,69 @@
+# Projects the plaintext ROWS service key from kilobase/supabase-service-key (property
+# `key`) directly into arc-runners for the GameServer pods — the same kilobase secret
+# whose `hash` the ROWS deployment reads as SUPABASE_SERVICE_KEY_HASH. Plaintext never
+# lands in the rows namespace. Reuses the agones-ows-external-secrets ServiceAccount.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: supabase-service-key-reader-for-agones
+    namespace: kilobase
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-service-key']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: agones-read-supabase-service-key
+    namespace: kilobase
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: supabase-service-key-reader-for-agones
+subjects:
+    - kind: ServiceAccount
+      name: agones-ows-external-secrets
+      namespace: arc-runners
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-service-key-store
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: agones-ows-external-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-service-key
+    namespace: arc-runners
+spec:
+    refreshInterval: 15m
+    secretStoreRef:
+        name: kilobase-service-key-store
+        kind: SecretStore
+    target:
+        name: ows-service-key
+        creationPolicy: Owner
+    data:
+        - secretKey: service-key
+          remoteRef:
+              key: supabase-service-key
+              property: key


### PR DESCRIPTION
## What

Deliver the plaintext ROWS service key to the UE dedicated-server (`ows-hubworld`) GameServer pods so they can authenticate to the gated ROWS write endpoints via `x-service-key`. Final deploy step for the server-to-server path (#11973 / #11981).

## Changes

- **`service-key-external-secret.yaml`** (new): kilobase RBAC (`Role` + `RoleBinding` for the existing `agones-ows-external-secrets` SA, scoped to the single `supabase-service-key` secret) + an arc-runners `SecretStore` pointing at kilobase + an `ExternalSecret` projecting `kilobase/supabase-service-key.key` (plaintext) into the arc-runners secret `ows-service-key`. Mirrors the existing mc supabase pipeline.
- **`fleet.yaml`**: inject `OWS_SERVICE_KEY` from `ows-service-key` (`optional: true`).

## Security

- Same kilobase secret holds both forms: `hash` (argon2, read by the ROWS deployment as `SUPABASE_SERVICE_KEY_HASH`) and `key` (plaintext, read here). Single source of truth.
- Plaintext is projected **directly kilobase → arc-runners**, never into the rows namespace; RBAC is scoped to the one secret (narrowest grant).
- The UE side only loads `OWS_SERVICE_KEY` when `IsRunningDedicatedServer()` (#11981), so it never reaches a client build.
- `optional: true` means pods still start before the secret exists; ROWS just rejects their writes (401) until it's populated — no crash-loop.

## Ops step (one-time)

Populate kilobase secret `supabase-service-key` with two properties:
- `key`: the plaintext service key
- `hash`: `argon2(key)` (PHC string)

Then restart the fleet pods to pick up the env (k8s doesn't hot-reload `secretKeyRef`).

## Reaches the cluster

ArgoCD tracks `main`; lands after the periodic dev→main release. Directory-synced manifest dir, so the new file is auto-included.