### PR TITLE
docs(rows): document the auth & identity model

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
@@ -66,6 +66,28 @@ The container exposes:
 
 ---
 
+### Authentication & Identity
+
+ROWS has three distinct identities. They are different axes — do not conflate them.
+
+| Identity | What it is | Source | How ROWS reads it |
+|----------|-----------|--------|-------------------|
+| **Tenant** (`customer_guid`) | The *game* — Chuck. One fixed value for the whole deployment. | `OWS_API_KEY` env (secret `ows-customer-guid`) | `X-CustomerGUID` header on every request |
+| **Player** (`userguid`) | A *person*. | Supabase UUID (`sub`) | Supabase JWT, or a session GUID minted from it |
+| **Trusted server** | The UE dedicated server / Iris instances. | Service key | `x-service-key` header, argon2-verified against `SUPABASE_SERVICE_KEY_HASH` |
+
+**The tenant is not the player.** `customer_guid` partitions every table (users, characters, zones, world servers, maps). All players and all UE instances share the **one** Chuck `customer_guid` so they inhabit the same world — multiple Iris instances are just rows in `worldservers` / `mapinstances` under that single tenant, not separate tenants. The player is identified by their Supabase UUID, which becomes the OWS `userguid`.
+
+**Player login.** The client signs in via Supabase (GoTrue) and posts the JWT to `ExternalLoginAndCreateSession`. ROWS validates it (HS256, `SUPABASE_JWT_SECRET`), keys the OWS user on the Supabase `sub`, and returns a `UserSessionGUID`. The UE client glue lives in the `KBVESupabaseROWSBridge` plugin.
+
+**Gates.**
+- **World IP** (`GetServerToConnectTo` / `JoinMap`) requires a confirmed login — a Supabase bearer JWT *or* a live session GUID — and verifies the caller owns the requested character before returning a server address.
+- **Server-write endpoints** (position/stats/logout, zone status, launcher register, spin-up/down) require a valid **service key**; player credentials do not pass. The dedicated server loads the key from `OWS_SERVICE_KEY` only on `IsRunningDedicatedServer()`, so it never enters a client build, and talks to ROWS in-cluster over the ClusterIP — the key never crosses the public internet.
+
+`SUPABASE_SERVICE_KEY_HASH` (rows) and the plaintext `OWS_SERVICE_KEY` (fleet) both derive from the one kilobase secret `supabase-service-key` (`hash` + `key`). Single-tenant by design; the multi-game GoTrue `customer_guid` claim path is intentionally unused.
+
+---
+
 ### Procedural World — Seed-Based Multi-Zone Architecture
 
 <Aside type="caution" title="Roadmap">


### PR DESCRIPTION
## What

Adds an **Authentication & Identity** section to `rows.mdx` documenting the model built across #11944 / #11946 / #11949 / #11951 / #11973 / #11981 / #11985.

## Why

The customer-vs-player distinction is easy to misread (OWS naming). This captures it once, clearly.

## Contents

- The three identities and how they differ: **tenant** (`customer_guid` = one fixed `OWS_API_KEY` for all of Chuck), **player** (Supabase UUID → `userguid`), **trusted server** (service key).
- Why the tenant is shared: it partitions every table, so all players and all Iris/UE instances live under one `customer_guid` (multiple instances = rows in `worldservers`/`mapinstances`, not separate tenants).
- Player login flow (Supabase JWT → `ExternalLoginAndCreateSession` → session GUID; `KBVESupabaseROWSBridge`).
- The gates: world-IP requires confirmed login + character ownership; server-write endpoints require the service key (dedicated-server-only, in-cluster).
- Single-tenant by design — the multi-game GoTrue `customer_guid` claim path is intentionally unused.

## Verification

`astro-kbve:build` passes (table + section render; frontmatter unchanged).