### PR TITLE
feat(astro-kbve): smooth crossfade between Yuki VRMA animations

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
@@ -149,8 +149,9 @@ interface YukiVRMRuntime {
 	setState(state: string): void;
 	pointAt(x: number, y: number): void;
 	setActive(active: boolean): void;
-	playAnimation(url: string, loop?: boolean): Promise<void>;
-	stopAnimation(): void;
+	playAnimation(url: string, loop?: boolean, fade?: number): Promise<void>;
+	stopAnimation(fade?: number): void;
+	setIdleAnimation(url: string | null): void;
 	destroy(): void;
 }
 
@@ -404,6 +405,7 @@ export async function mountYukiPanel(host: HTMLElement): Promise<void> {
 			(
 				window as unknown as { yukiMotions?: typeof MOTIONS }
 			).yukiMotions = MOTIONS;
+			vrmRuntime.setIdleAnimation(MOTIONS.fullbody);
 			void vrmRuntime.playAnimation(MOTIONS.fullbody, true);
 			setTimeout(fireFirstGreet, 600);
 		} catch (err) {

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -335,15 +335,21 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	>();
 	let currentAction: ReturnType<typeof mixer.clipAction> | null = null;
 	let idleAnimationUrl: string | null = null;
-	const DEFAULT_FADE = 0.35;
+	const DEFAULT_FADE = 0.8;
+	const IDLE_RESUME_FADE = 1.0;
 
 	mixer.addEventListener('finished', (e) => {
 		const ev = e as unknown as {
 			action: ReturnType<typeof mixer.clipAction>;
 		};
+		console.warn('[yuki-vrm] action finished', {
+			finished: ev.action,
+			isCurrent: ev.action === currentAction,
+			idleUrl: idleAnimationUrl,
+		});
 		if (ev.action !== currentAction) return;
 		if (idleAnimationUrl) {
-			void playAnimation(idleAnimationUrl, true, 0.6);
+			void playAnimation(idleAnimationUrl, true, IDLE_RESUME_FADE);
 		} else {
 			stopAnimation();
 		}

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -403,14 +403,13 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		next.setLoop(loop ? LoopRepeat : LoopOnce, Infinity);
 		next.clampWhenFinished = true;
 		next.reset();
-		next.setEffectiveTimeScale(1);
-		next.setEffectiveWeight(1);
-		next.play();
 		if (currentAction) {
-			currentAction.crossFadeTo(next, fade, false);
-		} else {
+			currentAction.fadeOut(fade);
 			next.fadeIn(fade);
+		} else {
+			next.setEffectiveWeight(1);
 		}
+		next.play();
 		currentAction = next;
 	};
 

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -395,15 +395,19 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		const clip = await loadClip(url);
 		if (!clip) return;
 		const next = mixer.clipAction(clip);
-		next.reset();
+		if (currentAction === next) {
+			next.paused = false;
+			return;
+		}
+		next.enabled = true;
 		next.setLoop(loop ? LoopRepeat : LoopOnce, Infinity);
 		next.clampWhenFinished = true;
-		next.setEffectiveWeight(1);
+		next.reset();
 		next.setEffectiveTimeScale(1);
-		next.enabled = true;
+		next.setEffectiveWeight(1);
 		next.play();
-		if (currentAction && currentAction !== next) {
-			currentAction.crossFadeTo(next, fade, true);
+		if (currentAction) {
+			currentAction.crossFadeTo(next, fade, false);
 		} else {
 			next.fadeIn(fade);
 		}

--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts
@@ -46,8 +46,9 @@ export interface YukiVRMHandle {
 	setState(state: YukiState): void;
 	pointAt(x: number, y: number): void;
 	setActive(active: boolean): void;
-	playAnimation(url: string, loop?: boolean): Promise<void>;
-	stopAnimation(): void;
+	playAnimation(url: string, loop?: boolean, fade?: number): Promise<void>;
+	stopAnimation(fade?: number): void;
+	setIdleAnimation(url: string | null): void;
 	destroy(): void;
 }
 
@@ -328,36 +329,85 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 	let firstRenderLogged = false;
 
 	const mixer = new AnimationMixer(vrm.scene);
+	const clipCache = new Map<
+		string,
+		ReturnType<typeof createVRMAnimationClip>
+	>();
 	let currentAction: ReturnType<typeof mixer.clipAction> | null = null;
+	let idleAnimationUrl: string | null = null;
+	const DEFAULT_FADE = 0.35;
 
-	const stopAnimation = (): void => {
-		if (currentAction) {
-			currentAction.stop();
-			currentAction = null;
+	mixer.addEventListener('finished', (e) => {
+		const ev = e as unknown as {
+			action: ReturnType<typeof mixer.clipAction>;
+		};
+		if (ev.action !== currentAction) return;
+		if (idleAnimationUrl) {
+			void playAnimation(idleAnimationUrl, true, 0.6);
+		} else {
+			stopAnimation();
 		}
-		mixer.stopAllAction();
-		applyRestPose(vrm);
+	});
+
+	const stopAnimation = (fade = DEFAULT_FADE): void => {
+		if (!currentAction) {
+			applyRestPose(vrm);
+			return;
+		}
+		const action = currentAction;
+		currentAction = null;
+		action.fadeOut(fade);
+		setTimeout(
+			() => {
+				action.stop();
+				if (!currentAction) applyRestPose(vrm);
+			},
+			Math.ceil(fade * 1000) + 16,
+		);
 	};
 
-	const playAnimation = async (url: string, loop = true): Promise<void> => {
+	const loadClip = async (
+		url: string,
+	): Promise<ReturnType<typeof createVRMAnimationClip> | null> => {
+		const cached = clipCache.get(url);
+		if (cached) return cached;
 		const gltf = await loader.loadAsync(url);
 		const animations: unknown[] =
 			(gltf.userData as { vrmAnimations?: unknown[] })?.vrmAnimations ??
 			[];
 		if (!animations.length) {
 			console.warn('[yuki-vrm] no vrmAnimations in', url);
-			return;
+			return null;
 		}
 		const clip = createVRMAnimationClip(
 			animations[0] as Parameters<typeof createVRMAnimationClip>[0],
 			vrm,
 		);
-		stopAnimation();
-		currentAction = mixer.clipAction(clip);
-		currentAction.setLoop(loop ? LoopRepeat : LoopOnce, Infinity);
-		currentAction.clampWhenFinished = true;
-		currentAction.play();
-		console.warn('[yuki-vrm] animation playing', url);
+		clipCache.set(url, clip);
+		return clip;
+	};
+
+	const playAnimation = async (
+		url: string,
+		loop = true,
+		fade = DEFAULT_FADE,
+	): Promise<void> => {
+		const clip = await loadClip(url);
+		if (!clip) return;
+		const next = mixer.clipAction(clip);
+		next.reset();
+		next.setLoop(loop ? LoopRepeat : LoopOnce, Infinity);
+		next.clampWhenFinished = true;
+		next.setEffectiveWeight(1);
+		next.setEffectiveTimeScale(1);
+		next.enabled = true;
+		next.play();
+		if (currentAction && currentAction !== next) {
+			currentAction.crossFadeTo(next, fade, true);
+		} else {
+			next.fadeIn(fade);
+		}
+		currentAction = next;
 	};
 
 	const tick = (now: number) => {
@@ -527,6 +577,9 @@ export async function mountYukiVRM(opts: MountOpts): Promise<YukiVRMHandle> {
 		setActive,
 		playAnimation,
 		stopAnimation,
+		setIdleAnimation: (url: string | null) => {
+			idleAnimationUrl = url;
+		},
 		destroy,
 	};
 }


### PR DESCRIPTION
## Summary
Follow-up to #11996. Hard cuts between Yuki's animations replaced with three.js \`AnimationMixer.crossFadeTo\` so motions blend in/out over 0.35s by default.

## What changes

### Crossfade instead of stop+play
[\`playAnimation\`](apps/kbve/astro-kbve/src/components/jay/dock/YukiVRM.ts) now resets the next action and \`crossFadeTo\`s from the current one. \`stopAnimation(fade?)\` fades out instead of slamming back to the rest pose. Both gain a \`fade\` argument (seconds).

### Auto-resume to idle
\`mixer.addEventListener('finished', ...)\` watches one-shot clips (greeting, peace, etc.). When they finish it crossfades back to the registered \`idleAnimationUrl\`. [YukiPanel](apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts) registers \`MOTIONS.fullbody\` as that idle on mount so the greeting flows naturally back to the standing idle without a hard cut.

### Clip cache
First load of a \`.vrma\` hits the GLTFLoader; subsequent triggers reuse the cached \`AnimationClip\`. Crossfade kicks in instantly without the network round trip.

## Console
\`\`\`
yuki.playAnimation(yukiMotions.greeting, false)   // crossfades back to fullbody on finish
yuki.playAnimation(yukiMotions.dance, true, 0.8)  // 0.8s blend in
yuki.stopAnimation(1.0)                            // 1s fade out
yuki.setIdleAnimation(yukiMotions.pose)            // change the auto-resume target
yuki.setIdleAnimation(null)                        // disable auto-resume
\`\`\`

## Test plan
- [ ] Open Yuki dock + Float, hit \`yuki.playAnimation(yukiMotions.spin)\` then \`yuki.playAnimation(yukiMotions.peace)\` — transition blends, no T-pose flash.
- [ ] \`yuki.playAnimation(yukiMotions.greeting, false)\` — after greeting ends, fullbody idle fades in automatically.
- [ ] \`yuki.stopAnimation(2.0)\` — slow fade out, procedural breath/sway anim picks back up.