### PR TITLE
fix(kubevirt): disable github-runner VM start scaler (API burn)

### DIFF
--- a/apps/kube/kubevirt/keda/scaled-jobs.yaml
+++ b/apps/kube/kubevirt/keda/scaled-jobs.yaml
@@ -1,63 +1,63 @@
 # KEDA ScaledJobs for KubeVirt VM lifecycle.
 #
-# Scale UP: github-runner trigger — boots the VM when a job is queued for the
-# runner label. Windows only (macOS VM not provisioned). Long pollingInterval to
-# keep GitHub API usage low (the original short interval + 2 scalers caused the
-# rate-limit burn that got these removed; one scaler at 600s is well under limit).
+# Scale UP: DISABLED — the github-runner scaler polls the GitHub API and burns
+# rate-limit credits even at long intervals; the start ScaledJob below is
+# commented out. Start the VM manually (virtctl start) until a no-poll auto-start
+# (dispatch-time boot preamble) replaces it.
 # Scale DOWN: cron trigger fires the idle check; the check only stops the VM when
 # the runner is actually idle (activity-aware), never an active runner.
 ---
-# ──────────────────────────────────────────────────────────────
-# SCALE UP — boot the VM when a UE5-Win job is queued
-# ──────────────────────────────────────────────────────────────
-apiVersion: keda.sh/v1alpha1
-kind: ScaledJob
-metadata:
-    name: vm-start-windows-builder
-    namespace: angelscript
-spec:
-    pollingInterval: 600
-    minReplicaCount: 0
-    maxReplicaCount: 1
-    successfulJobsHistoryLimit: 3
-    failedJobsHistoryLimit: 3
-    jobTargetRef:
-        parallelism: 1
-        completions: 1
-        backoffLimit: 3
-        ttlSecondsAfterFinished: 300
-        template:
-            spec:
-                serviceAccountName: vm-scaler
-                restartPolicy: OnFailure
-                containers:
-                    - name: scaler
-                      image: ghcr.io/kbve/kubectl:0.1.4
-                      command: ['/bin/sh', '/scripts/scale.sh']
-                      env:
-                          - name: VM_NAME
-                            value: windows-builder
-                          - name: ACTION
-                            value: start
-                          - name: NAMESPACE
-                            value: angelscript
-                      volumeMounts:
-                          - name: script
-                            mountPath: /scripts
-                volumes:
-                    - name: script
-                      configMap:
-                          name: vm-scaler-script
-                          defaultMode: 0755
-    triggers:
-        - type: github-runner
-          metadata:
-              owner: KBVE
-              runnerScope: org
-              labels: UE5-Win
-              targetWorkflowQueueLength: '1'
-          authenticationRef:
-              name: github-runner-auth
+# # ──────────────────────────────────────────────────────────────
+# # SCALE UP — boot the VM when a UE5-Win job is queued
+# # ──────────────────────────────────────────────────────────────
+# apiVersion: keda.sh/v1alpha1
+# kind: ScaledJob
+# metadata:
+#     name: vm-start-windows-builder
+#     namespace: angelscript
+# spec:
+#     pollingInterval: 600
+#     minReplicaCount: 0
+#     maxReplicaCount: 1
+#     successfulJobsHistoryLimit: 3
+#     failedJobsHistoryLimit: 3
+#     jobTargetRef:
+#         parallelism: 1
+#         completions: 1
+#         backoffLimit: 3
+#         ttlSecondsAfterFinished: 300
+#         template:
+#             spec:
+#                 serviceAccountName: vm-scaler
+#                 restartPolicy: OnFailure
+#                 containers:
+#                     - name: scaler
+#                       image: ghcr.io/kbve/kubectl:0.1.4
+#                       command: ['/bin/sh', '/scripts/scale.sh']
+#                       env:
+#                           - name: VM_NAME
+#                             value: windows-builder
+#                           - name: ACTION
+#                             value: start
+#                           - name: NAMESPACE
+#                             value: angelscript
+#                       volumeMounts:
+#                           - name: script
+#                             mountPath: /scripts
+#                 volumes:
+#                     - name: script
+#                       configMap:
+#                           name: vm-scaler-script
+#                           defaultMode: 0755
+#     triggers:
+#         - type: github-runner
+#           metadata:
+#               owner: KBVE
+#               runnerScope: org
+#               labels: UE5-Win
+#               targetWorkflowQueueLength: '1'
+#           authenticationRef:
+#               name: github-runner-auth
 ---
 # ──────────────────────────────────────────────────────────────
 # SCALE DOWN — KEDA cron-triggered idle check (activity-aware)

--- a/apps/kube/kubevirt/keda/trigger-auth.yaml
+++ b/apps/kube/kubevirt/keda/trigger-auth.yaml
@@ -1,12 +1,14 @@
+# DISABLED with the github-runner start scaler (GitHub API rate-limit burn).
+# Re-enable together with vm-start-windows-builder in scaled-jobs.yaml.
 # KEDA TriggerAuthentication — GitHub PAT for the github-runner scaler.
 # Same ExternalSecret-synced secret the runner install uses.
-apiVersion: keda.sh/v1alpha1
-kind: TriggerAuthentication
-metadata:
-    name: github-runner-auth
-    namespace: angelscript
-spec:
-    secretTargetRef:
-        - parameter: personalAccessToken
-          name: github-arc-token
-          key: github_token
+# apiVersion: keda.sh/v1alpha1
+# kind: TriggerAuthentication
+# metadata:
+#     name: github-runner-auth
+#     namespace: angelscript
+# spec:
+#     secretTargetRef:
+#         - parameter: personalAccessToken
+#           name: github-arc-token
+#           key: github_token


### PR DESCRIPTION
Reverts the auto-start from #12000 — the github-runner KEDA scaler polls the GitHub API and burns rate-limit credits (same reason it was removed originally). Comment out `vm-start-windows-builder` + its TriggerAuthentication; the activity-aware stop scalers stay. For now the VM is started manually (virtctl start) and a queued UE5-Win job is captured when the runner comes online. A no-poll dispatch-time boot preamble can replace it later (tracked in #11987).