### PR TITLE
feat(unreal): extract loading panel into KBVEUI (SKBVELoadingPanel)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.cpp
@@ -3,7 +3,7 @@
 #include "SchuckMainMenu.h"
 #include "SKBVELoginWidget.h"
 #include "SKBVEAccountPanel.h"
-#include "SchuckLoadingPanel.h"
+#include "SKBVELoadingPanel.h"
 #include "Engine/GameInstance.h"
 #include "Engine/GameViewportClient.h"
 #include "Engine/LocalPlayer.h"
@@ -42,7 +42,7 @@ void AchuckMenuPlayerController::BeginPlay()
 
 	LoginWidget   = SNew(SKBVELoginWidget).Subsystem(SupabaseSubsystem).Title(NSLOCTEXT("chuck", "LoginTitle", "Sign in to ChuckRPG"));
 	AccountWidget = SNew(SKBVEAccountPanel).Subsystem(SupabaseSubsystem);
-	LoadingWidget = SNew(SchuckLoadingPanel);
+	LoadingWidget = SNew(SKBVELoadingPanel).UnitLabel(TEXT("chunks"));
 	LoadingWidget->SetVisibility(EVisibility::Collapsed);
 
 	if (UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr)

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.h
@@ -7,7 +7,7 @@
 class SchuckMainMenu;
 class SKBVELoginWidget;
 class SKBVEAccountPanel;
-class SchuckLoadingPanel;
+class SKBVELoadingPanel;
 class UKBVESupabaseSubsystem;
 struct FKBVESupabaseSession;
 
@@ -46,7 +46,7 @@ private:
 	TSharedPtr<SchuckMainMenu>     MenuWidget;
 	TSharedPtr<SKBVELoginWidget>  LoginWidget;
 	TSharedPtr<SKBVEAccountPanel> AccountWidget;
-	TSharedPtr<SchuckLoadingPanel> LoadingWidget;
+	TSharedPtr<SKBVELoadingPanel> LoadingWidget;
 
 	UPROPERTY(Transient)
 	TWeakObjectPtr<UKBVESupabaseSubsystem> SupabaseSubsystem;

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbveui.mdx
@@ -32,9 +32,10 @@ Shared Slate UI component library for KBVE Unreal games — game-agnostic visual
 primitives (Core + Slate only): movable frames, the settings frame + reusable
 settings rows (toggle / slider / combo), hotbar, slots, tooltips, info panels,
 the `SKBVEEquipmentPanel` paper-doll (11 generic equip slots via `EKBVEEquipSlot`),
-and the **`SKBVEDevOverlay`** debug HUD (self-computed FPS/ms; entity-count and
-ping fed via `FKBVEDevOverlayIntProvider` delegates so the widget needs no Engine
-or Mass dep — the game supplies the numbers).
+the `SKBVELoadingPanel` full-screen loader (`InitialMessage` + `UnitLabel` args,
+`SetProgress`/`SetMessage`), and the **`SKBVEDevOverlay`** debug HUD (self-computed
+FPS/ms; entity-count and ping fed via `FKBVEDevOverlayIntProvider` delegates so the
+widget needs no Engine or Mass dep — the game supplies the numbers).
 
 Also holds **UI state** — `FKBVEUIState` (panel-flag set + cursor/movement/camera
 policy masks + `Has`/`Set`/`Diff`/`NeedsCursor`/`BlocksMovement` helpers) and

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVELoadingPanel.cpp
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Private/SKBVELoadingPanel.cpp
@@ -1,4 +1,4 @@
-#include "SchuckLoadingPanel.h"
+#include "SKBVELoadingPanel.h"
 
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/Layout/SBox.h"
@@ -7,10 +7,15 @@
 #include "Widgets/Text/STextBlock.h"
 #include "Styling/CoreStyle.h"
 
-void SchuckLoadingPanel::Construct(const FArguments& InArgs)
+void SKBVELoadingPanel::Construct(const FArguments& InArgs)
 {
 	SetCanTick(false);
 	SetVisibility(EVisibility::HitTestInvisible);
+	UnitLabel = InArgs._UnitLabel;
+
+	const FString InitialCount = UnitLabel.IsEmpty()
+		? FString(TEXT("0 / 0"))
+		: FString::Printf(TEXT("0 / 0 %s"), *UnitLabel);
 
 	ChildSlot
 	[
@@ -35,7 +40,7 @@ void SchuckLoadingPanel::Construct(const FArguments& InArgs)
 					.Padding(0, 0, 0, 16)
 					[
 						SAssignNew(StatusText, STextBlock)
-						.Text(FText::FromString(TEXT("Generating world...")))
+						.Text(InArgs._InitialMessage)
 						.ColorAndOpacity(FLinearColor::White)
 						.Font(FCoreStyle::GetDefaultFontStyle("Bold", 22))
 					]
@@ -51,7 +56,7 @@ void SchuckLoadingPanel::Construct(const FArguments& InArgs)
 					.HAlign(HAlign_Center)
 					[
 						SAssignNew(CountText, STextBlock)
-						.Text(FText::FromString(TEXT("0 / 0 chunks")))
+						.Text(FText::FromString(InitialCount))
 						.ColorAndOpacity(FLinearColor(0.8f, 0.8f, 0.8f, 1.f))
 						.Font(FCoreStyle::GetDefaultFontStyle("Regular", 12))
 					]
@@ -61,17 +66,20 @@ void SchuckLoadingPanel::Construct(const FArguments& InArgs)
 	];
 }
 
-void SchuckLoadingPanel::SetProgress(int32 Completed, int32 Total)
+void SKBVELoadingPanel::SetProgress(int32 Completed, int32 Total)
 {
 	const float Pct = Total > 0 ? FMath::Clamp(static_cast<float>(Completed) / static_cast<float>(Total), 0.f, 1.f) : 0.f;
 	if (Bar.IsValid()) Bar->SetPercent(Pct);
 	if (CountText.IsValid())
 	{
-		CountText->SetText(FText::FromString(FString::Printf(TEXT("%d / %d chunks"), Completed, Total)));
+		const FString Text = UnitLabel.IsEmpty()
+			? FString::Printf(TEXT("%d / %d"), Completed, Total)
+			: FString::Printf(TEXT("%d / %d %s"), Completed, Total, *UnitLabel);
+		CountText->SetText(FText::FromString(Text));
 	}
 }
 
-void SchuckLoadingPanel::SetMessage(const FString& Msg)
+void SKBVELoadingPanel::SetMessage(const FString& Msg)
 {
 	if (StatusText.IsValid()) StatusText->SetText(FText::FromString(Msg));
 }

--- a/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVELoadingPanel.h
+++ b/packages/unreal/KBVEUI/Source/KBVEUI/Public/SKBVELoadingPanel.h
@@ -2,14 +2,20 @@
 
 #include "CoreMinimal.h"
 #include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
 
 class STextBlock;
 class SProgressBar;
 
-class SchuckLoadingPanel : public SCompoundWidget
+class KBVEUI_API SKBVELoadingPanel : public SCompoundWidget
 {
 public:
-	SLATE_BEGIN_ARGS(SchuckLoadingPanel) {}
+	SLATE_BEGIN_ARGS(SKBVELoadingPanel)
+		: _InitialMessage(NSLOCTEXT("SKBVELoadingPanel", "DefaultMessage", "Loading..."))
+		, _UnitLabel(TEXT(""))
+	{}
+		SLATE_ARGUMENT(FText, InitialMessage)
+		SLATE_ARGUMENT(FString, UnitLabel)
 	SLATE_END_ARGS()
 
 	void Construct(const FArguments& InArgs);
@@ -18,6 +24,7 @@ public:
 	void SetMessage(const FString& Msg);
 
 private:
+	FString UnitLabel;
 	TSharedPtr<STextBlock>   StatusText;
 	TSharedPtr<STextBlock>   CountText;
 	TSharedPtr<SProgressBar> Bar;


### PR DESCRIPTION
## Summary

Full-screen loader → **`SKBVELoadingPanel`** in the KBVEUI base module. Pure Slate, zero chuck coupling.

- Title + `SProgressBar` + count line; `SetProgress(done,total)` / `SetMessage`.
- Hardcoded strings parameterized: `InitialMessage` (default "Loading...") + `UnitLabel` args. chuck passes `UnitLabel("chunks")` and sets "Generating world..." at runtime as before.
- chuck menu controller constructs `SKBVELoadingPanel`; `SchuckLoadingPanel` deleted (git rename).

Stays Core+Slate.

## Test
UE C++ compile-checked via KBVEUI plugin CI build + chuck game build — no local UE toolchain.