### PR TITLE
refactor(unreal): move generic stat/combat event payloads to KBVEGameplay

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckEventPayloads.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckEventPayloads.h
@@ -2,36 +2,15 @@
 
 #include "CoreMinimal.h"
 #include "MassEntityHandle.h"
+#include "KBVEGameplayEvents.h"
 
-// UI-domain payloads: emitted on the game thread, consumed by Slate / UMG.
-struct FchuckHealthChangedPayload
-{
-	float Current = 0.f;
-	float Max     = 0.f;
-};
-
-struct FchuckManaChangedPayload
-{
-	float Current = 0.f;
-	float Max     = 0.f;
-};
-
-struct FchuckStaminaChangedPayload
-{
-	float Current     = 0.f;
-	float Max         = 0.f;
-	float RegenDelay  = 0.f;
-};
+// Generic stat/combat payloads (Health / Mana / Stamina / DamageReceived /
+// CombatHit / EntityKilled) live in KBVEGameplay's KBVEGameplayEvents.h. Only
+// chuck-specific payloads remain below.
 
 struct FchuckInventoryDirtyPayload
 {
 	int32 BagIndex = 0;
-};
-
-struct FchuckDamageReceivedPayload
-{
-	float Amount    = 0.f;
-	uint8 DamageBit = 0;
 };
 
 struct FchuckTooltipPayload
@@ -54,20 +33,6 @@ struct FchuckItemConsumedPayload
 };
 
 // Sim-domain payloads: enqueued from Mass workers, drained on the game thread.
-struct FchuckCombatHitPayload
-{
-	FMassEntityHandle Source;
-	FMassEntityHandle Target;
-	float             Amount = 0.f;
-	uint8             DamageBit = 0;
-};
-
-struct FchuckEntityKilledPayload
-{
-	FMassEntityHandle Entity;
-	FMassEntityHandle KilledBy;
-};
-
 struct FchuckPickupRequestPayload
 {
 	FMassEntityHandle Source;

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSimEvents.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSimEvents.cpp
@@ -11,7 +11,7 @@ UchuckSimEvents* UchuckSimEvents::Get(const UObject* WorldContext)
 
 void UchuckSimEvents::Tick(float DeltaTime)
 {
-	CombatHits.Drain([this](const FchuckCombatHitPayload& P) { OnCombatHit.Publish(P); });
-	Killed.Drain    ([this](const FchuckEntityKilledPayload& P) { OnKilled.Publish(P);    });
+	CombatHits.Drain([this](const FKBVECombatHitPayload& P) { OnCombatHit.Publish(P); });
+	Killed.Drain    ([this](const FKBVEEntityKilledPayload& P) { OnKilled.Publish(P);    });
 	Pickups.Drain   ([this](const FchuckPickupRequestPayload& P) { OnPickup.Publish(P);  });
 }

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSimEvents.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckSimEvents.h
@@ -30,11 +30,11 @@ public:
 	virtual bool IsTickable() const override { return true; }
 	virtual bool IsTickableInEditor() const override { return false; }
 
-	TKBVEMpscQueue<FchuckCombatHitPayload>    CombatHits;
-	TKBVEMpscQueue<FchuckEntityKilledPayload> Killed;
+	TKBVEMpscQueue<FKBVECombatHitPayload>    CombatHits;
+	TKBVEMpscQueue<FKBVEEntityKilledPayload> Killed;
 	TKBVEMpscQueue<FchuckPickupRequestPayload> Pickups;
 
-	TKBVEChannel<FchuckCombatHitPayload>      OnCombatHit;
-	TKBVEChannel<FchuckEntityKilledPayload>   OnKilled;
+	TKBVEChannel<FKBVECombatHitPayload>      OnCombatHit;
+	TKBVEChannel<FKBVEEntityKilledPayload>   OnKilled;
 	TKBVEChannel<FchuckPickupRequestPayload>  OnPickup;
 };

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckUIEvents.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckUIEvents.h
@@ -23,11 +23,11 @@ class UchuckUIEvents : public UGameInstanceSubsystem
 public:
 	static UchuckUIEvents* Get(const UObject* WorldContext);
 
-	TKBVEChannel<FchuckHealthChangedPayload>   Health;
-	TKBVEChannel<FchuckManaChangedPayload>     Mana;
-	TKBVEChannel<FchuckStaminaChangedPayload>  Stamina;
+	TKBVEChannel<FKBVEHealthChangedPayload>   Health;
+	TKBVEChannel<FKBVEManaChangedPayload>     Mana;
+	TKBVEChannel<FKBVEStaminaChangedPayload>  Stamina;
 	TKBVEChannel<FchuckInventoryDirtyPayload>  InventoryDirty;
-	TKBVEChannel<FchuckDamageReceivedPayload>  DamageReceived;
+	TKBVEChannel<FKBVEDamageReceivedPayload>  DamageReceived;
 	TKBVEChannel<FchuckTooltipPayload>         Tooltip;
 	TKBVEChannel<FchuckItemConsumedPayload>    ItemConsumed;
 

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/HUD/SchuckHUD.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/HUD/SchuckHUD.cpp
@@ -129,21 +129,21 @@ void SchuckHUD::BindToEventBus()
 	UchuckUIEvents* Bus = C ? UchuckUIEvents::Get(C) : nullptr;
 	if (!Bus) return;
 
-	HealthHandle = Bus->Health.Subscribe(C, [this](const FchuckHealthChangedPayload& P)
+	HealthHandle = Bus->Health.Subscribe(C, [this](const FKBVEHealthChangedPayload& P)
 	{
 		FchuckHUDState S = Target;
 		S.HealthCurrent = P.Current;
 		S.HealthMax     = P.Max;
 		SetState(S);
 	});
-	ManaHandle = Bus->Mana.Subscribe(C, [this](const FchuckManaChangedPayload& P)
+	ManaHandle = Bus->Mana.Subscribe(C, [this](const FKBVEManaChangedPayload& P)
 	{
 		FchuckHUDState S = Target;
 		S.ManaCurrent = P.Current;
 		S.ManaMax     = P.Max;
 		SetState(S);
 	});
-	StaminaHandle = Bus->Stamina.Subscribe(C, [this](const FchuckStaminaChangedPayload& P)
+	StaminaHandle = Bus->Stamina.Subscribe(C, [this](const FKBVEStaminaChangedPayload& P)
 	{
 		FchuckHUDState S = Target;
 		S.StaminaCurrent    = P.Current;
@@ -151,7 +151,7 @@ void SchuckHUD::BindToEventBus()
 		S.StaminaRegenDelay = P.RegenDelay;
 		SetState(S);
 	});
-	DamageHandle = Bus->DamageReceived.Subscribe(C, [this](const FchuckDamageReceivedPayload& P)
+	DamageHandle = Bus->DamageReceived.Subscribe(C, [this](const FKBVEDamageReceivedPayload& P)
 	{
 		DamageFlashUntil = HUDTimeSeconds + 0.6f;
 		FchuckHUDState S = Target;

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvegameplay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvegameplay.mdx
@@ -60,3 +60,14 @@ Also holds the agnostic gameplay-stat layer (the effect target it feeds):
 
 `UKBVEEffectComponent` applies effects through `IKBVEStatTarget`; a game's stat
 owner maps those onto its `FKBVEStatBlock` / `FKBVEStatFragment`.
+
+## Event payloads (`KBVEGameplayEvents.h`)
+
+Shared cross-game vocabulary for stat/combat signals — plain POD structs a game
+and reusable UI agree on: `FKBVEHealthChangedPayload` / `FKBVEManaChangedPayload`
+/ `FKBVEStaminaChangedPayload` (current/max + stamina regen delay),
+`FKBVEDamageReceivedPayload` (amount + damage-bit), and the Mass-sim
+`FKBVECombatHitPayload` / `FKBVEEntityKilledPayload` (entity handles). Transport
+stays the game's — these are only the contract; chuck pipes them through its own
+`TKBVEChannel` hubs. Game-specific payloads (inventory-dirty, tooltip,
+item-consumed, pickup, auth, chat, ui-flags) stay in the game.

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEGameplayEvents.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEGameplayEvents.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MassEntityHandle.h"
+
+// Shared gameplay event payloads — the cross-game vocabulary for stat / combat
+// signals. Plain POD structs; transport (channels, MPSC queues) is the game's,
+// these are just the contract a KBVE game and reusable UI agree on.
+
+struct FKBVEHealthChangedPayload
+{
+	float Current = 0.f;
+	float Max     = 0.f;
+};
+
+struct FKBVEManaChangedPayload
+{
+	float Current = 0.f;
+	float Max     = 0.f;
+};
+
+struct FKBVEStaminaChangedPayload
+{
+	float Current    = 0.f;
+	float Max        = 0.f;
+	float RegenDelay = 0.f;
+};
+
+struct FKBVEDamageReceivedPayload
+{
+	float Amount    = 0.f;
+	uint8 DamageBit = 0;
+};
+
+struct FKBVECombatHitPayload
+{
+	FMassEntityHandle Source;
+	FMassEntityHandle Target;
+	float             Amount    = 0.f;
+	uint8             DamageBit = 0;
+};
+
+struct FKBVEEntityKilledPayload
+{
+	FMassEntityHandle Entity;
+	FMassEntityHandle KilledBy;
+};


### PR DESCRIPTION
## Summary

Gives KBVEGameplay a **shared event-payload vocabulary** (`KBVEGameplayEvents.h`) so any KBVE game + reusable UI agree on stat/combat signal shapes.

Moved (chuck → KBVEGameplay, `Fchuck*` → `FKBVE*`):
- `FKBVEHealthChangedPayload`, `FKBVEManaChangedPayload`, `FKBVEStaminaChangedPayload`
- `FKBVEDamageReceivedPayload`
- `FKBVECombatHitPayload`, `FKBVEEntityKilledPayload` (Mass entity handles)

chuck includes the header from `chuckEventPayloads.h` and renames its bus channels (`UchuckUIEvents`/`UchuckSimEvents`) + subscribers (`SchuckHUD`, sim drain) to the `FKBVE` types. **Transport stays chuck's** — the `TKBVEChannel`/`TKBVEMpscQueue` hubs are unchanged; only the payload structs are shared.

Stays game-specific (chuck): inventory-dirty, tooltip, item-consumed, pickup, auth, chat, ui-flags. Chat already has its own KBVE contract (`FKBVEChatLineView` / `FKBVEChatMessage`), so it's untouched here.

KBVEGameplay already a chuck dep (+ MassEntity) — no Build.cs change.

## Test
UE C++ compile-checked via KBVEGameplay plugin CI build + chuck game build — no local UE toolchain.