### PR TITLE
fix(ci-unreal): Setup.bat --force on Win engine (GitDependencies prompt blocks CI)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1023,7 +1023,7 @@ jobs:
               if: steps.check.outputs.skip != 'true'
               shell: powershell
               run: |
-                  Push-Location $env:ENGINE_ROOT; .\Setup.bat; Pop-Location
+                  Push-Location $env:ENGINE_ROOT; .\Setup.bat --force; Pop-Location
 
             - name: Generate project files
               if: steps.check.outputs.skip != 'true'


### PR DESCRIPTION
## Problem
Engine build run 27093224809 got past the cron-kill (busy-runner guard worked, Setup ran through the :00 window) but failed at `Generate project files`:
```
Error: [C:\UnrealEngine\Engine\Binaries\ThirdParty\DotNet\8.0.412\win-x64\host\fxr] does not exist
RunUBT ERROR: UnrealBuildTool failed to check dependencies.
```
Root cause is upstream in `Run Setup`:
```
Unhandled exception. System.InvalidOperationException: Cannot read keys when ... console input has been redirected.
   at GitDependencies.Program.UpdateWorkingTree(...)
Would you like to overwrite your changes (y/n)? Press any key to continue . . .
```
The Windows engine lives on a persistent PVC. The 23-min cron-kill left GitDependencies' binary blobs half-downloaded; on the next run GitDependencies sees them as locally modified and prompts to overwrite. CI stdin is redirected -> `ReadKey` throws -> the bundled DotNet runtime (`host/fxr`) is never fetched -> GenerateProjectFiles fails.

## Fix
`Setup.bat --force` -> GitDependencies overwrites modified files without prompting. Linux engine path uses an ephemeral runner (fresh checkout) and is unaffected.

Part of #11987.