### PR TITLE
feat(kubevirt): enable ExpandDisks feature gate

### DIFF
--- a/apps/kube/kubevirt/cr/kubevirt.yaml
+++ b/apps/kube/kubevirt/cr/kubevirt.yaml
@@ -12,6 +12,7 @@ spec:
                 - LiveMigration
                 - HotplugVolumes
                 - NetworkBindingPlugins
+                - ExpandDisks
         smbios:
             sku: TalosCloud
             version: v0.1.0


### PR DESCRIPTION
The Windows builder engine build ran out of disk during GitDependencies (`Free space left: 25 MB` -> `Aborting dependency updating`). The rootdisk PVC was expanded 120Gi->300Gi, but the guest still reported Disk0 = 118GB: KubeVirt does not resize a PVC-backed disk image to the PVC capacity unless the `ExpandDisks` feature gate is enabled.

Add `ExpandDisks` so virt-launcher expands the disk image to the PVC size on VM startup. After this syncs, a VM restart grows Disk0 to ~300GB; the guest C: partition is then extended (the trailing recovery partition is removed first, since it sits after C:).

Part of #11987.