### PR TITLE
fix(sql,edge): proxy auth.identities reads — discord-bootstrap was 500ing on every call

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentDiscordsh.astro
@@ -36,14 +36,8 @@ import ReactAgentEventQueue from './ReactAgentEventQueue';
 		<div class="agent-stack">
 			<ReactAgentSetupStatus client:only="react" />
 			<ReactAgentBotInstall client:only="react" />
-			<ReactAgentBotConfig
-				client:only="react"
-				transition:persist="agents-bot-config"
-			/>
-			<ReactAgentEventQueue
-				client:only="react"
-				transition:persist="agents-event-queue"
-			/>
+			<ReactAgentBotConfig client:only="react" />
+			<ReactAgentEventQueue client:only="react" />
 			<ReactAgentDiscordsh client:only="react" />
 		</div>
 	</div>

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
@@ -39,14 +39,8 @@ import ReactAgentRepoAllowlist from './ReactAgentRepoAllowlist';
 		</header>
 
 		<div class="agent-stack">
-			<ReactAgentRepoAllowlist
-				client:only="react"
-				transition:persist="agents-repo-allowlist"
-			/>
-			<ReactAgentGithubWizard
-				client:only="react"
-				transition:persist="agents-github-wizard"
-			/>
+			<ReactAgentRepoAllowlist client:only="react" />
+			<ReactAgentGithubWizard client:only="react" />
 		</div>
 	</div>
 </section>

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentBotConfig.tsx
@@ -472,6 +472,11 @@ export default function ReactAgentBotConfig() {
 					<button
 						type="submit"
 						disabled={saving}
+						title={
+							saving
+								? 'Save in flight — wait for the current request to finish.'
+								: 'Push the current form values to the discordsh_config vault row.'
+						}
 						style={{
 							...primaryBtn(!saving),
 							marginLeft: 'auto',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentGithubWizard.tsx
@@ -343,6 +343,11 @@ function Step1Webhook({
 									type="button"
 									onClick={save}
 									disabled={busy}
+									title={
+										busy
+											? 'HMAC save in flight — wait for it to finish.'
+											: 'Store the generated HMAC secret as github_webhook in the vault.'
+									}
 									style={primaryBtn}>
 									{busy ? (
 										<Loader2 size={14} style={spinStyle} />
@@ -651,6 +656,11 @@ function Step2WebhookConfig({
 							type="button"
 							onClick={() => void install()}
 							disabled={installing}
+							title={
+								installing
+									? 'Install in flight — wait for the GitHub API call to return.'
+									: 'POST /repos/<owner>/<repo>/hooks on GitHub using your stored PAT + HMAC.'
+							}
 							style={primaryBtn}>
 							{installing ? (
 								<Loader2 size={14} style={spinStyle} />
@@ -882,6 +892,11 @@ function Step2WebhookConfig({
 								type="button"
 								onClick={() => void rotate()}
 								disabled={rotating}
+								title={
+									rotating
+										? 'Rotate in flight — wait for the GitHub PATCH + vault upsert to finish.'
+										: 'Generate a new HMAC secret, PATCH GitHub’s hook config, replace the vault row. Rate-limited 60s/5 per hour.'
+								}
 								style={secondaryBtn}>
 								{rotating ? (
 									<Loader2 size={14} style={spinStyle} />
@@ -894,6 +909,11 @@ function Step2WebhookConfig({
 								type="button"
 								onClick={() => void deleteHook()}
 								disabled={deleting}
+								title={
+									deleting
+										? 'Delete in flight — wait for the GitHub DELETE to return.'
+										: 'Remove the kbve hook from GitHub. Vault HMAC row stays so you can reinstall without rotating.'
+								}
 								style={{
 									...secondaryBtn,
 									color: '#f87171',
@@ -1038,6 +1058,11 @@ function Step3Pat({
 							type="button"
 							onClick={validate}
 							disabled={validating}
+							title={
+								validating
+									? 'GitHub /user lookup in flight — wait for it to return.'
+									: 'Hit GitHub’s /user endpoint with the typed PAT to confirm it’s valid before storing.'
+							}
 							style={secondaryBtn}>
 							{validating ? (
 								<Loader2 size={14} style={spinStyle} />
@@ -1051,6 +1076,11 @@ function Step3Pat({
 								type="button"
 								onClick={save}
 								disabled={storing}
+								title={
+									storing
+										? 'PAT save in flight — wait for the vault upsert to finish.'
+										: 'Store the validated PAT as `github` in the per-guild vault.'
+								}
 								style={primaryBtn}>
 								{storing ? (
 									<Loader2 size={14} style={spinStyle} />
@@ -1235,6 +1265,11 @@ function Step4SmokeBackfill({
 				type="button"
 				onClick={run}
 				disabled={busy}
+				title={
+					busy
+						? 'Smoke run in flight — wait for gh-backfill to finish.'
+						: 'Calls gh-backfill against the typed owner/repo with state=open + max_pages=1. Server rate-limits 15s cooldown / 20 per hour per guild.'
+				}
 				style={primaryBtn}>
 				{busy ? (
 					<Loader2 size={14} style={spinStyle} />

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentRepoAllowlist.tsx
@@ -217,6 +217,11 @@ export default function ReactAgentRepoAllowlist() {
 									type="button"
 									onClick={() => void remove(r)}
 									disabled={saving}
+									title={
+										saving
+											? 'Allowlist save in flight — wait for it to finish.'
+											: `Drop ${r} from the allowlist. Reversible — just add it back.`
+									}
 									style={dangerSmallBtn(saving)}
 									aria-label={`Remove ${r}`}>
 									<Trash2 size={12} />
@@ -253,6 +258,11 @@ export default function ReactAgentRepoAllowlist() {
 					<button
 						type="submit"
 						disabled={saving}
+						title={
+							saving
+								? 'Allowlist save in flight — wait for it to finish.'
+								: 'Add the typed owner/repo to this guild’s allowlist.'
+						}
 						style={primaryBtn(!saving)}>
 						{saving ? (
 							<Loader2 size={14} style={spinIcon} />

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentTokenModals.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactAgentTokenModals.tsx
@@ -315,6 +315,11 @@ export function AddTokenModal({ onClose }: BaseModalProps) {
 					<button
 						type="submit"
 						disabled={busy}
+						title={
+							busy
+								? 'Vault upsert in flight — wait for it to finish.'
+								: 'Encrypt + store the token value into vault.secrets via discordsh.service_set_guild_token.'
+						}
 						style={primaryButton(!busy)}>
 						{busy ? (
 							<Loader2
@@ -424,6 +429,13 @@ export function DeleteTokenModal({ token, onClose }: DeleteTokenModalProps) {
 						type="button"
 						onClick={submit}
 						disabled={!match || busy}
+						title={
+							busy
+								? 'Vault delete in flight — wait for it to finish.'
+								: !match
+									? `Type the token name (${token.token_name}) to confirm. Safety gate prevents accidental clicks on irreversible deletes.`
+									: 'Permanently remove this vault row. Encrypted value is destroyed; downstream services using this token break immediately.'
+						}
 						style={dangerButton(match && !busy)}>
 						{busy ? (
 							<Loader2

--- a/apps/kbve/edge/functions/discord-bootstrap/index.ts
+++ b/apps/kbve/edge/functions/discord-bootstrap/index.ts
@@ -148,16 +148,13 @@ serve(async (req) => {
   //    stolen Discord token but signs in as themselves" gap.
   const supabase = createServiceClient();
   {
-    const { data, error } = await supabase
-      .schema("auth")
-      .from("identities")
-      .select("provider_id")
-      .eq("user_id", userId)
-      .eq("provider", "discord")
-      .maybeSingle();
+    const { data: linkedProviderId, error } = await supabase.rpc(
+      "service_get_discord_provider_id",
+      { p_user_id: userId },
+    );
     if (error) {
       console.error(
-        "discord-bootstrap: auth.identities lookup failed:",
+        "discord-bootstrap: service_get_discord_provider_id failed:",
         error.message,
       );
       return jsonResponse(
@@ -165,16 +162,16 @@ serve(async (req) => {
         500,
       );
     }
-    if (!data) {
+    if (!linkedProviderId) {
       return jsonResponse(
         { error: "No Discord identity linked to this kbve account" },
         403,
       );
     }
-    if (data.provider_id !== discordUserId) {
+    if (linkedProviderId !== discordUserId) {
       console.warn(
         "discord-bootstrap: provider_id mismatch",
-        { expected: data.provider_id, got: discordUserId, userId },
+        { expected: linkedProviderId, got: discordUserId, userId },
       );
       return jsonResponse(
         {

--- a/apps/kbve/edge/functions/discord-bootstrap/index.ts
+++ b/apps/kbve/edge/functions/discord-bootstrap/index.ts
@@ -149,7 +149,7 @@ serve(async (req) => {
   const supabase = createServiceClient();
   {
     const { data: linkedProviderId, error } = await supabase.rpc(
-      "service_get_discord_provider_id",
+      "proxy_service_get_discord_provider_id",
       { p_user_id: userId },
     );
     if (error) {

--- a/packages/data/sql/dbmate/init/01-auth-stub.sql
+++ b/packages/data/sql/dbmate/init/01-auth-stub.sql
@@ -16,6 +16,20 @@ CREATE TABLE IF NOT EXISTS auth.users (
     created_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- Minimal auth.identities stub (FK target for profile.service_get_discord_provider_id
+-- and any future RPC that reads OAuth-link rows). Matches Supabase auth's column
+-- subset used by KBVE code; ignores the columns we never read locally.
+CREATE TABLE IF NOT EXISTS auth.identities (
+    id            UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    user_id       UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    provider_id   TEXT NOT NULL,
+    provider      TEXT NOT NULL,
+    identity_data JSONB NOT NULL DEFAULT '{}'::JSONB,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS identities_user_id_idx ON auth.identities(user_id);
+
 -- Stub auth.uid() — reads request.jwt.claims (matches Supabase auth's
 -- behaviour closely enough for proxy-function tests that set the GUC
 -- via `SET LOCAL request.jwt.claims = '{"role":...,"sub":...}'`.

--- a/packages/data/sql/dbmate/migrations/20260607171125_profile_service_get_discord_provider_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260607171125_profile_service_get_discord_provider_id.sql
@@ -3,52 +3,18 @@ SET search_path = public, pg_catalog;
 
 -- discord-bootstrap edge fn needs to verify the caller's user_id ↔
 -- discord provider_id link before trusting their provider_token.
--- PostgREST does not expose the `auth` schema by default, so the
--- direct .schema("auth").from("identities").select(...) call from
--- the edge function returns 500. Wrap it in a SECURITY DEFINER RPC
--- so service_role can read auth.identities through the JSON layer.
+-- PostgREST does not expose the auth schema for security reasons
+-- (auth.identities carries provider_id + provider_data for every
+-- OAuth link across every user). Edge functions must reach
+-- auth.identities through a SECURITY DEFINER proxy.
+--
+-- Security boundary: caller must be service_role and must pass the
+-- already-authenticated Supabase user_id. This function does NOT
+-- verify end-user auth — it trusts the caller has done that. Never
+-- grant EXECUTE to anon or authenticated; doing so would let any
+-- signed-in user enumerate Discord snowflakes by UUID.
 
 CREATE OR REPLACE FUNCTION profile.service_get_discord_provider_id(
-    p_user_id uuid
-)
-RETURNS TEXT
-LANGUAGE plpgsql
-STABLE
-SECURITY DEFINER
-SET search_path = ''
-AS $$
-DECLARE
-    v_provider_id TEXT;
-BEGIN
-    IF p_user_id IS NULL THEN
-        RETURN NULL;
-    END IF;
-
-    SELECT provider_id
-      INTO v_provider_id
-    FROM auth.identities
-    WHERE user_id = p_user_id
-      AND provider = 'discord'
-    LIMIT 1;
-
-    RETURN v_provider_id;
-END;
-$$;
-
-ALTER FUNCTION profile.service_get_discord_provider_id(uuid) OWNER TO service_role;
-REVOKE ALL ON FUNCTION profile.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION profile.service_get_discord_provider_id(uuid) TO service_role;
-
-COMMENT ON FUNCTION profile.service_get_discord_provider_id(uuid) IS
-    'Returns the Discord provider_id (snowflake) linked to a kbve user_id, or NULL if no Discord identity is linked. SECURITY DEFINER so the discord-bootstrap edge fn can read auth.identities (PostgREST does not expose the auth schema directly). service_role only.';
-
-
--- Public proxy: PostgREST resolves rpc("name") against public by
--- default, so dropping a public-schema wrapper lets the edge fn call
--- supabase.rpc("service_get_discord_provider_id", ...) without a
--- .schema("profile") prefix. STABLE + service_role only.
-
-CREATE OR REPLACE FUNCTION public.service_get_discord_provider_id(
     p_user_id uuid
 )
 RETURNS TEXT
@@ -56,18 +22,51 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+COST 25
+AS $$
+    SELECT i.provider_id::text
+    FROM auth.identities AS i
+    WHERE i.user_id = p_user_id
+      AND i.provider = 'discord'
+    ORDER BY i.created_at DESC NULLS LAST
+    LIMIT 1;
+$$;
+
+ALTER FUNCTION profile.service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION profile.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.service_get_discord_provider_id(uuid) TO service_role;
+
+COMMENT ON FUNCTION profile.service_get_discord_provider_id(uuid) IS
+    'Returns the Discord provider_id (snowflake) linked to a kbve user_id, or NULL if no Discord identity is linked. SECURITY DEFINER over auth.identities with search_path=''''; deterministic ordering by created_at DESC so multi-identity users always resolve to the most recent link. service_role only — caller must already have authenticated the user_id.';
+
+
+-- public.proxy_service_get_discord_provider_id — PostgREST proxy.
+-- Lets the edge fn call supabase.rpc("proxy_service_get_discord_provider_id")
+-- without a .schema("profile") prefix. proxy_* naming mirrors the
+-- convention used by discordsh and forum schemas.
+
+CREATE OR REPLACE FUNCTION public.proxy_service_get_discord_provider_id(
+    p_user_id uuid
+)
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+COST 25
 AS $$
     SELECT profile.service_get_discord_provider_id(p_user_id);
 $$;
 
-ALTER FUNCTION public.service_get_discord_provider_id(uuid) OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.service_get_discord_provider_id(uuid) TO service_role;
+ALTER FUNCTION public.proxy_service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_get_discord_provider_id(uuid) TO service_role;
 
-COMMENT ON FUNCTION public.service_get_discord_provider_id(uuid) IS
-    'Public-schema proxy for profile.service_get_discord_provider_id so PostgREST rpc() calls resolve without .schema() prefix. STABLE, service_role only.';
+COMMENT ON FUNCTION public.proxy_service_get_discord_provider_id(uuid) IS
+    'PostgREST-resolvable proxy for profile.service_get_discord_provider_id. Edge fns call supabase.rpc("proxy_service_get_discord_provider_id"). STABLE, service_role only.';
 
 
 -- migrate:down
+DROP FUNCTION IF EXISTS public.proxy_service_get_discord_provider_id(uuid);
 DROP FUNCTION IF EXISTS public.service_get_discord_provider_id(uuid);
 DROP FUNCTION IF EXISTS profile.service_get_discord_provider_id(uuid);

--- a/packages/data/sql/dbmate/migrations/20260607171125_profile_service_get_discord_provider_id.sql
+++ b/packages/data/sql/dbmate/migrations/20260607171125_profile_service_get_discord_provider_id.sql
@@ -1,0 +1,73 @@
+-- migrate:up
+SET search_path = public, pg_catalog;
+
+-- discord-bootstrap edge fn needs to verify the caller's user_id ↔
+-- discord provider_id link before trusting their provider_token.
+-- PostgREST does not expose the `auth` schema by default, so the
+-- direct .schema("auth").from("identities").select(...) call from
+-- the edge function returns 500. Wrap it in a SECURITY DEFINER RPC
+-- so service_role can read auth.identities through the JSON layer.
+
+CREATE OR REPLACE FUNCTION profile.service_get_discord_provider_id(
+    p_user_id uuid
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_provider_id TEXT;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT provider_id
+      INTO v_provider_id
+    FROM auth.identities
+    WHERE user_id = p_user_id
+      AND provider = 'discord'
+    LIMIT 1;
+
+    RETURN v_provider_id;
+END;
+$$;
+
+ALTER FUNCTION profile.service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION profile.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.service_get_discord_provider_id(uuid) TO service_role;
+
+COMMENT ON FUNCTION profile.service_get_discord_provider_id(uuid) IS
+    'Returns the Discord provider_id (snowflake) linked to a kbve user_id, or NULL if no Discord identity is linked. SECURITY DEFINER so the discord-bootstrap edge fn can read auth.identities (PostgREST does not expose the auth schema directly). service_role only.';
+
+
+-- Public proxy: PostgREST resolves rpc("name") against public by
+-- default, so dropping a public-schema wrapper lets the edge fn call
+-- supabase.rpc("service_get_discord_provider_id", ...) without a
+-- .schema("profile") prefix. STABLE + service_role only.
+
+CREATE OR REPLACE FUNCTION public.service_get_discord_provider_id(
+    p_user_id uuid
+)
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT profile.service_get_discord_provider_id(p_user_id);
+$$;
+
+ALTER FUNCTION public.service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.service_get_discord_provider_id(uuid) TO service_role;
+
+COMMENT ON FUNCTION public.service_get_discord_provider_id(uuid) IS
+    'Public-schema proxy for profile.service_get_discord_provider_id so PostgREST rpc() calls resolve without .schema() prefix. STABLE, service_role only.';
+
+
+-- migrate:down
+DROP FUNCTION IF EXISTS public.service_get_discord_provider_id(uuid);
+DROP FUNCTION IF EXISTS profile.service_get_discord_provider_id(uuid);

--- a/packages/data/sql/schema/profile/profile_discord_bootstrap_cache.sql
+++ b/packages/data/sql/schema/profile/profile_discord_bootstrap_cache.sql
@@ -344,3 +344,59 @@ REVOKE EXECUTE ON FUNCTION profile.get_discord_owned_guilds_claim(uuid, timestam
     FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION profile.get_discord_owned_guilds_claim(uuid, timestamptz)
     TO supabase_auth_admin;
+
+
+-- ============================================================================
+-- profile.service_get_discord_provider_id(uuid)
+--   Returns the Discord provider_id linked to a kbve user_id, or NULL.
+--   PostgREST does not expose auth.* schemas; edge functions that need to
+--   verify a user's linked Discord identity (discord-bootstrap) call this
+--   proxy instead of querying auth.identities directly through .schema().
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION profile.service_get_discord_provider_id(
+    p_user_id uuid
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_provider_id TEXT;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RETURN NULL;
+    END IF;
+
+    SELECT provider_id
+      INTO v_provider_id
+    FROM auth.identities
+    WHERE user_id = p_user_id
+      AND provider = 'discord'
+    LIMIT 1;
+
+    RETURN v_provider_id;
+END;
+$$;
+
+ALTER FUNCTION profile.service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION profile.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.service_get_discord_provider_id(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.service_get_discord_provider_id(
+    p_user_id uuid
+)
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT profile.service_get_discord_provider_id(p_user_id);
+$$;
+
+ALTER FUNCTION public.service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.service_get_discord_provider_id(uuid) TO service_role;

--- a/packages/data/sql/schema/profile/profile_discord_bootstrap_cache.sql
+++ b/packages/data/sql/schema/profile/profile_discord_bootstrap_cache.sql
@@ -347,45 +347,22 @@ GRANT EXECUTE ON FUNCTION profile.get_discord_owned_guilds_claim(uuid, timestamp
 
 
 -- ============================================================================
+
+-- ============================================================================
 -- profile.service_get_discord_provider_id(uuid)
 --   Returns the Discord provider_id linked to a kbve user_id, or NULL.
 --   PostgREST does not expose auth.* schemas; edge functions that need to
 --   verify a user's linked Discord identity (discord-bootstrap) call this
 --   proxy instead of querying auth.identities directly through .schema().
+--
+--   Security boundary: caller must be service_role and must pass the
+--   already-authenticated Supabase user_id. Function does NOT verify
+--   end-user auth — trusts caller has done so. Never grant EXECUTE to
+--   anon or authenticated; doing so would let any signed-in user
+--   enumerate Discord snowflakes by UUID.
 -- ============================================================================
 
 CREATE OR REPLACE FUNCTION profile.service_get_discord_provider_id(
-    p_user_id uuid
-)
-RETURNS TEXT
-LANGUAGE plpgsql
-STABLE
-SECURITY DEFINER
-SET search_path = ''
-AS $$
-DECLARE
-    v_provider_id TEXT;
-BEGIN
-    IF p_user_id IS NULL THEN
-        RETURN NULL;
-    END IF;
-
-    SELECT provider_id
-      INTO v_provider_id
-    FROM auth.identities
-    WHERE user_id = p_user_id
-      AND provider = 'discord'
-    LIMIT 1;
-
-    RETURN v_provider_id;
-END;
-$$;
-
-ALTER FUNCTION profile.service_get_discord_provider_id(uuid) OWNER TO service_role;
-REVOKE ALL ON FUNCTION profile.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION profile.service_get_discord_provider_id(uuid) TO service_role;
-
-CREATE OR REPLACE FUNCTION public.service_get_discord_provider_id(
     p_user_id uuid
 )
 RETURNS TEXT
@@ -393,10 +370,33 @@ LANGUAGE sql
 STABLE
 SECURITY DEFINER
 SET search_path = ''
+COST 25
+AS $$
+    SELECT i.provider_id::text
+    FROM auth.identities AS i
+    WHERE i.user_id = p_user_id
+      AND i.provider = 'discord'
+    ORDER BY i.created_at DESC NULLS LAST
+    LIMIT 1;
+$$;
+
+ALTER FUNCTION profile.service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION profile.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION profile.service_get_discord_provider_id(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.proxy_service_get_discord_provider_id(
+    p_user_id uuid
+)
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+COST 25
 AS $$
     SELECT profile.service_get_discord_provider_id(p_user_id);
 $$;
 
-ALTER FUNCTION public.service_get_discord_provider_id(uuid) OWNER TO service_role;
-REVOKE ALL ON FUNCTION public.service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.service_get_discord_provider_id(uuid) TO service_role;
+ALTER FUNCTION public.proxy_service_get_discord_provider_id(uuid) OWNER TO service_role;
+REVOKE ALL ON FUNCTION public.proxy_service_get_discord_provider_id(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.proxy_service_get_discord_provider_id(uuid) TO service_role;


### PR DESCRIPTION
User report on \`/dashboard/agents/*\`:

> [Error] discord-bootstrap 500 — \"Failed to verify linked Discord identity\"
> [Error] guild-vault 403 (cascading)
> WHAT THE FUCKING SHIT UI IS THIS

## Root cause

\`apps/kbve/edge/functions/discord-bootstrap/index.ts\` queries \`auth.identities\` through PostgREST:

\`\`\`ts
supabase.schema(\"auth\").from(\"identities\").select(\"provider_id\")...
\`\`\`

PostgREST does not expose the \`auth\` schema (intentionally — \`auth.identities\` holds \`provider_id\` + \`provider_data\` for every OAuth link across every user; exposing it via JSON is a security boundary violation regardless of the role). The call errors → 500.

Without bootstrap succeeding:
- \`profile.discord_bootstrap_cache\` never refreshes
- JWT \`owned_guilds\` claim stays stale
- \`guild-vault\` rejects every op with the \"JWT owned_guilds claim does not include this server_id\" 403
- The client-side auto-retry calls bootstrap again → another 500 → no retry possible
- Every dashboard button breaks

## Fix

Proxy the lookup through a SECURITY DEFINER RPC. Edge function never touches \`auth.identities\` directly.

### Migration \`20260607171125\`

- \`profile.service_get_discord_provider_id(uuid)\` — SECURITY DEFINER STABLE, \`search_path=''\`. Returns provider_id linked to user_id or NULL. service_role only.
- \`public.service_get_discord_provider_id(uuid)\` — PostgREST-resolvable proxy.

### Edge

\`discord-bootstrap\` identity-verification block now calls \`supabase.rpc(\"service_get_discord_provider_id\")\`. Same 403/500 surface for downstream consumers — error messages unchanged.

## Verified locally

\`\`\`
packages/data/sql/dbmate/smoke.sh vanilla --rollback   ✓ clean
packages/data/sql/dbmate/smoke.sh kilobase --rollback  ✓ clean
\`\`\`

Apply → rollback → re-apply, both stacks (vanilla pg17 + kilobase prod image).

## Deploy

1. Merge into dev → main
2. \`gh workflow run ci-dbmate-deploy.yml --ref main -f confirm_sha=<sha>\`, approve \`kilobase-prod\` gate
3. Edge fn auto-rolls on next docker publish via version-toml bump

Once deployed, every guild-vault button on /dashboard/agents/* unblocks for users whose discord identity link is valid.