### PR TITLE
fix(ci-unreal): skip Setup.bat prereq hang on Win engine (sync deps directly)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1021,9 +1021,14 @@ jobs:
 
             - name: Run Setup
               if: steps.check.outputs.skip != 'true'
+              timeout-minutes: 90
               shell: powershell
               run: |
-                  Push-Location $env:ENGINE_ROOT; .\Setup.bat --force; Pop-Location
+                  Push-Location $env:ENGINE_ROOT
+                  & .\Engine\Binaries\DotNET\GitDependencies\win-x64\GitDependencies.exe --force
+                  $rc = $LASTEXITCODE
+                  Pop-Location
+                  if ($rc -ne 0) { Write-Host "::error::GitDependencies failed ($rc)"; exit $rc }
 
             - name: Generate project files
               if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1041,10 +1041,27 @@ jobs:
               shell: powershell
               run: |
                   Push-Location $env:ENGINE_ROOT
+                  $log = Join-Path $env:RUNNER_TEMP 'engine-build-editor.log'
                   .\Engine\Build\BatchFiles\RunUAT.bat BuildTarget `
                     -target=UnrealEditor -platform=Win64 -configuration=Development `
-                    -notools -unattended -utf8output
+                    -notools -unattended -utf8output 2>&1 | Tee-Object -FilePath $log
+                  $rc = $LASTEXITCODE
                   Pop-Location
+                  $free = [math]::Round((Get-Volume -DriveLetter C).SizeRemaining / 1GB)
+                  Write-Host "::notice::Build Editor exit=$rc freeC=${free}GB"
+                  if ($rc -ne 0) { Write-Host "::error::Build Editor failed ($rc)"; exit $rc }
+
+            - name: Upload engine build logs
+              if: always() && steps.check.outputs.skip != 'true'
+              uses: actions/upload-artifact@v4
+              with:
+                  name: engine-win-logs-${{ github.run_id }}
+                  if-no-files-found: ignore
+                  retention-days: 7
+                  path: |
+                      ${{ runner.temp }}/engine-build-editor.log
+                      C:/UnrealEngine/Engine/Programs/AutomationTool/Saved/Logs/**
+                      C:/UnrealEngine/Engine/Programs/UnrealBuildTool/Log*.txt
 
             - name: Mark engine ref
               if: steps.check.outputs.skip != 'true'


### PR DESCRIPTION
## Problem
With the disk now large enough, the engine `Run Setup` got GitDependencies to 100% (6.3 GB) then hung **10 hours** until the job timeout:
```
15:36:10 Installing prerequisites...
01:11:50 ##[error]The operation was canceled.
```
Setup.bat's next line is:
```bat
start /wait Engine\Extras\Redist\en-us\vc_redist.x64.exe /quiet /norestart
```
The runner runs as **LocalSystem (session 0)**, where the redist installer cannot render a window and blocks forever. Setup.bat also has an `:error -> pause` keypress trap.

## Fix
Call `GitDependencies.exe --force` directly to sync the binary dependencies (what the build needs) and skip Setup.bat's prereq installer, version-selector, and pause traps. `vc_redist` is a runtime redistributable, not required to compile the engine (the VS toolchain installed by win-setup provides the build runtime). Added a 90-min step timeout so a future stall fails fast instead of 10h.

Part of #11987.