### PR TITLE
chore(unreal): scrub chuck-specific names from shared plugin source

### DIFF
--- a/packages/unreal/KBVEROWS/Source/ROWS/Public/ROWSLoginController.h
+++ b/packages/unreal/KBVEROWS/Source/ROWS/Public/ROWSLoginController.h
@@ -15,7 +15,7 @@ class UROWSLoadingWidget;
  * AROWSLoginController
  *
  * Orchestrates: Login Screen -> Character Select -> Loading -> Travel to Game Map
- * Mirrors ChuckLoginController — create-once widgets, HideAllWidgets, delegates to ROWS subsystems.
+ * Create-once widgets, HideAllWidgets, delegates to ROWS subsystems.
  */
 UCLASS()
 class ROWS_API AROWSLoginController : public APlayerController

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
@@ -19,7 +19,7 @@ public class KBVESQLite : ModuleRules
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 
 		// Force default symbol visibility on sqlite3 entry points so consumer
-		// modules (chuck, etc) can link directly against sqlite3_open/...etc
+		// consumer modules can link directly against sqlite3_open/...etc
 		// from this plugin's .dylib/.so without re-bundling the amalgamation.
 		PublicDefinitions.Add("SQLITE_API=__attribute__((visibility(\"default\")))");
 		PublicDefinitions.Add("SQLITE_EXTERN=extern __attribute__((visibility(\"default\")))");

--- a/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Actors/KBVEWebTerminalActor.h
+++ b/packages/unreal/KBVEWebSurface/Source/KBVEWebSurface/Public/Actors/KBVEWebTerminalActor.h
@@ -11,7 +11,7 @@ class UObject;
 /**
  * Drop-in interactive terminal. Bundles a backing static mesh frame, a flat
  * web surface, and the configuration any consumer needs. Designed to be the
- * one-actor entry point for chuckrpg and other downstream Unreal projects.
+ * one-actor entry point for any downstream KBVE Unreal project.
  */
 UCLASS(BlueprintType, Blueprintable, DisplayName = "KBVE Web Terminal")
 class KBVEWEBSURFACE_API AKBVEWebTerminalActor : public AActor

--- a/packages/unreal/UEDevOps/Source/UEDevOpsEditor/Private/UEDevOpsEditorModule.cpp
+++ b/packages/unreal/UEDevOps/Source/UEDevOpsEditor/Private/UEDevOpsEditorModule.cpp
@@ -62,7 +62,7 @@ static FAutoConsoleCommand GUEDevOpsPanelCmd(
 
 static FAutoConsoleCommand GUEDevOpsImportArcadeCmd(
 	TEXT("UEDevOps.ImportArcade"),
-	TEXT("One-shot: import the chuck arcade cabinet from Raw/Props/Arcade with all canonical paths."),
+	TEXT("One-shot: import an arcade cabinet prop from Raw/Props/Arcade with all canonical paths."),
 	FConsoleCommandDelegate::CreateLambda([]()
 	{
 		const FString Source = FPaths::ConvertRelativePathToFull(


### PR DESCRIPTION
## Summary

Plugins must read as game-agnostic **KBVE**, not reference `chuck`. Scrubbed the remaining chuck/chuckrpg mentions from shared plugin **source** (comments only — no behavior change):

- **KBVEWebSurface** `KBVEWebTerminalActor.h` — "entry point for chuckrpg…" → "any downstream KBVE Unreal project".
- **KBVEROWS** `ROWSLoginController.h` — dropped "Mirrors ChuckLoginController".
- **KBVESQLite** `KBVESQLite.Build.cs` — "modules (chuck, etc)" → "consumer modules".
- **UEDevOps** `UEDevOpsEditorModule.cpp` — `UEDevOps.ImportArcade` description generalized ("an arcade cabinet prop").

Verified: `grep chuck packages/unreal/**/*.{h,cpp,cs,uplugin}` is now **clean** — zero chuck references in any plugin source. (The KBVEItemDB doc/comment scrub rides in #12024.)

## Note
`UEDevOps.ImportArcade` still hardcodes `Raw/Props/Arcade` paths — game-specific *content* tooling living in the shared editor module. Comment generalized; if you want it fully agnostic, the source/dest paths should become command args (follow-up).

## Test
Comment-only; no compile impact.