### PR TITLE
fix(ci): install docker compose v2 plugin in ci-dbmate-validate

### DIFF
--- a/.github/workflows/ci-dbmate-validate.yml
+++ b/.github/workflows/ci-dbmate-validate.yml
@@ -50,15 +50,26 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
-            - name: Install dbmate + psql client
+            - name: Install dbmate + psql client + docker compose v2
               run: |
                   sudo apt-get update -qq
                   sudo apt-get install -y --no-install-recommends postgresql-client
                   curl -fsSL -o /usr/local/bin/dbmate \
                       https://github.com/amacneil/dbmate/releases/download/v2.28.0/dbmate-linux-amd64
                   chmod +x /usr/local/bin/dbmate
+                  # ARC runner image ships docker CLI but not the compose
+                  # subcommand plugin. Drop the official v2 plugin binary
+                  # into the standard plugin path so `docker compose ...`
+                  # resolves.
+                  if ! docker compose version >/dev/null 2>&1; then
+                      sudo mkdir -p /usr/local/lib/docker/cli-plugins
+                      sudo curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-compose \
+                          https://github.com/docker/compose/releases/download/v2.31.0/docker-compose-linux-x86_64
+                      sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+                  fi
                   dbmate --version
                   psql --version
+                  docker compose version
 
             - name: Bring up kilobase compose stack
               working-directory: packages/data/sql/dbmate


### PR DESCRIPTION
Follow-up to #12033. After the migration validate workflow moved off vanilla onto kilobase compose, dispatch failed:

\`\`\`
$ gh run view 27114035152 --log-failed
unknown shorthand flag: 'f' in -f
Usage:  docker [OPTIONS] COMMAND [ARG...]
\`\`\`

ARC runner image ships docker CLI but no compose subcommand plugin, so \`docker compose -f kilobase-docker-compose.yml up -d\` is parsed as bare \`docker\` + unknown flag.

## Fix

Drop the official Compose v2 binary into \`/usr/local/lib/docker/cli-plugins/\` during the install step. Guarded by \`docker compose version\` so a future ARC image bundling the plugin skips the install silently.

\`\`\`yaml
if ! docker compose version >/dev/null 2>&1; then
    sudo mkdir -p /usr/local/lib/docker/cli-plugins
    sudo curl -fsSL -o /usr/local/lib/docker/cli-plugins/docker-compose \
        https://github.com/docker/compose/releases/download/v2.31.0/docker-compose-linux-x86_64
    sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
fi
\`\`\`

Trivial single-file change.