### PR TITLE
fix(ci-unreal): install .NET Framework 4.8 Dev Pack for NetFxSDK (VS modify unreliable)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1731,6 +1731,21 @@ jobs:
                   Write-Host "VS Build Tools installer exited: $($p.ExitCode)"
                   exit 0
 
+            - name: Install .NET Framework 4.8 Dev Pack (NetFxSDK)
+              timeout-minutes: 20
+              run: |
+                  $ErrorActionPreference = 'SilentlyContinue'
+                  $keys = (Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK' -ErrorAction SilentlyContinue).PSChildName
+                  if ($keys) { Write-Host "NETFXSDK already present: $($keys -join ', ')"; exit 0 }
+                  Write-Host "Downloading .NET Framework 4.8 Developer Pack ..."
+                  curl.exe -L -s --retry 5 --retry-all-errors -C - --connect-timeout 30 -o $env:RUNNER_TEMP\ndp48-devpack.exe "https://go.microsoft.com/fwlink/?linkid=2088517"
+                  if (!(Test-Path $env:RUNNER_TEMP\ndp48-devpack.exe)) { Write-Host "::warning::NetFx DevPack download failed."; exit 0 }
+                  $p = Start-Process $env:RUNNER_TEMP\ndp48-devpack.exe -ArgumentList '/q','/norestart' -Wait -PassThru
+                  Write-Host "NetFx 4.8 DevPack exited: $($p.ExitCode)"
+                  $keys = (Get-ChildItem 'HKLM:\SOFTWARE\Microsoft\Microsoft SDKs\NETFXSDK' -ErrorAction SilentlyContinue).PSChildName
+                  Write-Host "NETFXSDK now: $($keys -join ', ')"
+                  exit 0
+
             - name: Install Python 3
               run: |
                   if (Get-Command python -ErrorAction SilentlyContinue) { Write-Host "Python already installed: $(python --version)"; exit 0 }


### PR DESCRIPTION
## Problem
After #12040, win-setup ran the VS bootstrapper in `modify` mode but it **exited 1 in ~12s** and added nothing - NETFXSDK registry is still empty on the VM, so the engine build keeps failing at `SwarmInterface: Could not find NetFxSDK install dir`. The VS-installer modify path is unreliable here (LocalSystem runner, bootstrapper self-update in --quiet, no logs in the runner's TEMP).

## Fix
Add a dedicated win-setup step that installs the **.NET Framework 4.8 Developer Pack** standalone (`/q /norestart`). It reliably creates `HKLM\...\NETFXSDK\4.8` (reference assemblies + SDK) that UBT requires, independent of the VS installer. Idempotent (skips if a NETFXSDK key exists) and echoes the resulting keys for verification.

After merge: re-run `win-setup`, confirm NETFXSDK populated, then re-dispatch `engine`.

Part of #11987.