### PR TITLE
feat(npm): extract agents dashboard into @kbve/droid + @kbve/astro

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts
@@ -556,12 +556,13 @@ class AgentsService {
 			if (providerToken) {
 				this.$providerToken.set(providerToken);
 				this.$authState.set('authenticated');
-
-				// Fire the bootstrap edge fn so the JWT hook picks up
-				// fresh owned_guilds on the next mint. Best-effort; a
-				// failure here doesn't block the page.
-				void this.bootstrapDiscord(providerToken);
-				await this.loadOwnedGuilds();
+				const cachedOwned = userId ? loadCachedGuilds(userId) : null;
+				if (cachedOwned && cachedOwned.length > 0) {
+					this.$guilds.set(cachedOwned);
+					if (cachedOwned.length === 1) {
+						this.selectGuild(cachedOwned[0].id);
+					}
+				}
 				return;
 			}
 
@@ -624,32 +625,49 @@ class AgentsService {
 		}
 	}
 
+	private bootstrapInflight: Promise<boolean> | null = null;
+	private lastBootstrapAt = 0;
+	private lastBootstrapOk = false;
+	private readonly BOOTSTRAP_COOLDOWN_MS = 5 * 60 * 1000;
+
 	private async bootstrapDiscord(providerToken: string): Promise<boolean> {
 		const accessToken = this.$accessToken.get();
 		if (!accessToken) return false;
-		try {
-			const resp = await fetch(DISCORD_BOOTSTRAP_URL, {
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${accessToken}`,
-				},
-				body: JSON.stringify({ provider_token: providerToken }),
-			});
-			if (!resp.ok) {
-				const text = await resp.text();
-				console.warn(
-					'[agentsService] discord-bootstrap returned',
-					resp.status,
-					text.slice(0, 200),
-				);
-				return false;
-			}
+		const now = Date.now();
+		if (
+			this.lastBootstrapOk &&
+			now - this.lastBootstrapAt < this.BOOTSTRAP_COOLDOWN_MS
+		) {
 			return true;
-		} catch (e) {
-			console.warn('[agentsService] discord-bootstrap threw:', e);
-			return false;
 		}
+		if (this.bootstrapInflight) return this.bootstrapInflight;
+		this.bootstrapInflight = (async () => {
+			try {
+				const resp = await fetch(DISCORD_BOOTSTRAP_URL, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${accessToken}`,
+					},
+					body: JSON.stringify({ provider_token: providerToken }),
+				});
+				if (!resp.ok) {
+					if (resp.status === 429) {
+						this.lastBootstrapAt = Date.now();
+						this.lastBootstrapOk = true;
+					}
+					return false;
+				}
+				this.lastBootstrapAt = Date.now();
+				this.lastBootstrapOk = true;
+				return true;
+			} catch {
+				return false;
+			} finally {
+				this.bootstrapInflight = null;
+			}
+		})();
+		return this.bootstrapInflight;
 	}
 
 	private refreshInflight: Promise<boolean> | null = null;
@@ -837,7 +855,6 @@ class AgentsService {
 					body: JSON.stringify({
 						command: 'tokens.list_tokens',
 						server_id: guildId,
-						provider_token: providerToken,
 					}),
 					signal: abort.signal,
 				});
@@ -902,8 +919,7 @@ class AgentsService {
 	}): Promise<{ ok: true; tokenId: string } | { ok: false; error: string }> {
 		const guildId = this.$selectedGuildId.get();
 		const accessToken = this.$accessToken.get();
-		const providerToken = this.$providerToken.get();
-		if (!guildId || !accessToken || !providerToken) {
+		if (!guildId || !accessToken) {
 			return { ok: false, error: 'No guild selected or session missing' };
 		}
 
@@ -912,7 +928,6 @@ class AgentsService {
 			accessToken,
 			{
 				server_id: guildId,
-				provider_token: providerToken,
 				token_name: input.tokenName,
 				service: input.service,
 				token_value: input.tokenValue,
@@ -938,8 +953,7 @@ class AgentsService {
 	): Promise<{ ok: true } | { ok: false; error: string }> {
 		const guildId = this.$selectedGuildId.get();
 		const accessToken = this.$accessToken.get();
-		const providerToken = this.$providerToken.get();
-		if (!guildId || !accessToken || !providerToken) {
+		if (!guildId || !accessToken) {
 			return { ok: false, error: 'No guild selected or session missing' };
 		}
 
@@ -948,7 +962,6 @@ class AgentsService {
 			accessToken,
 			{
 				server_id: guildId,
-				provider_token: providerToken,
 				token_id: tokenId,
 			},
 		);
@@ -971,8 +984,7 @@ class AgentsService {
 	> {
 		const guildId = this.$selectedGuildId.get();
 		const accessToken = this.$accessToken.get();
-		const providerToken = this.$providerToken.get();
-		if (!guildId || !accessToken || !providerToken) {
+		if (!guildId || !accessToken) {
 			return { ok: false, error: 'No guild selected or session missing' };
 		}
 
@@ -981,7 +993,6 @@ class AgentsService {
 			accessToken,
 			{
 				server_id: guildId,
-				provider_token: providerToken,
 				service,
 			},
 		);
@@ -1770,8 +1781,7 @@ class AgentsService {
 	): Promise<{ ok: true } | { ok: false; error: string }> {
 		const guildId = this.$selectedGuildId.get();
 		const accessToken = this.$accessToken.get();
-		const providerToken = this.$providerToken.get();
-		if (!guildId || !accessToken || !providerToken) {
+		if (!guildId || !accessToken) {
 			return { ok: false, error: 'No guild selected or session missing' };
 		}
 
@@ -1780,7 +1790,6 @@ class AgentsService {
 			accessToken,
 			{
 				server_id: guildId,
-				provider_token: providerToken,
 				token_id: tokenId,
 				is_active: isActive,
 			},

--- a/packages/npm/astro/package.json
+++ b/packages/npm/astro/package.json
@@ -69,7 +69,8 @@
 		"@kbve/droid": ">=0.1.0",
 		"@nanostores/react": ">=0.7.0",
 		"nanostores": ">=0.9.0",
-		"d3-force": ">=3.0.0"
+		"d3-force": ">=3.0.0",
+		"lucide-react": ">=0.400.0"
 	},
 	"peerDependenciesMeta": {
 		"astro": {

--- a/packages/npm/astro/src/agents/ReactAgentBotConfig.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentBotConfig.tsx
@@ -1,0 +1,797 @@
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type FocusEvent,
+	type FormEvent,
+} from 'react';
+import { useStore } from '@nanostores/react';
+import { Hash, Loader2, RefreshCw, Save, Settings2 } from 'lucide-react';
+import { useAgents } from './context';
+import { emptyBotConfigFormDraft } from '@kbve/droid';
+import type { BotConfigFormDraft, DiscordChannel } from '@kbve/droid';
+import { styles } from '../dashboard/dashboard-ui';
+
+const SNOWFLAKE_RE = /^[0-9]{17,20}$/;
+const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
+
+type TextFieldKey =
+	| 'default_repo'
+	| 'claim_channel_id'
+	| 'forum_channel_id'
+	| 'noticeboard_channel_id'
+	| 'taskboard_channel_id'
+	| 'max_assignees';
+
+type BoolFieldKey = 'mirror_pr_events' | 'active';
+
+type Errors = Partial<Record<TextFieldKey, string>>;
+
+function validateField(k: TextFieldKey, raw: string): string | null {
+	const v = raw.trim();
+	if (k === 'max_assignees') {
+		if (!v) return 'Required';
+		const n = parseInt(v, 10);
+		if (Number.isNaN(n) || n < 1 || n > 10) return 'Must be 1–10';
+		return null;
+	}
+	if (!v) return null;
+	if (k === 'default_repo') {
+		return REPO_RE.test(v) ? null : 'Must be owner/repo';
+	}
+	return SNOWFLAKE_RE.test(v)
+		? null
+		: 'Must be a Discord snowflake (17–20 digits)';
+}
+
+function readForm(
+	refs: Record<TextFieldKey, HTMLInputElement | null>,
+	mirror: boolean,
+	active: boolean,
+): BotConfigFormDraft {
+	const get = (k: TextFieldKey) => refs[k]?.value ?? '';
+	return {
+		default_repo: get('default_repo'),
+		claim_channel_id: get('claim_channel_id'),
+		forum_channel_id: get('forum_channel_id'),
+		noticeboard_channel_id: get('noticeboard_channel_id'),
+		taskboard_channel_id: get('taskboard_channel_id'),
+		max_assignees: get('max_assignees'),
+		mirror_pr_events: mirror,
+		active,
+	};
+}
+
+function validateAll(draft: BotConfigFormDraft): Errors {
+	const errs: Errors = {};
+	const keys: TextFieldKey[] = [
+		'default_repo',
+		'claim_channel_id',
+		'forum_channel_id',
+		'noticeboard_channel_id',
+		'taskboard_channel_id',
+		'max_assignees',
+	];
+	for (const k of keys) {
+		const e = validateField(k, draft[k] as string);
+		if (e) errs[k] = e;
+	}
+	return errs;
+}
+
+export default function ReactAgentBotConfig() {
+	const agents = useAgents();
+	const guildId = useStore(agents.$selectedGuildId);
+	const guilds = useStore(agents.$guilds);
+	const savingMap = useStore(agents.$botConfigSavingFor);
+	const errorsMap = useStore(agents.$botConfigErrors);
+	const loadedMap = useStore(agents.$botConfigLoadedFor);
+	const channelsMap = useStore(agents.$guildChannels);
+	const channelsLoadingMap = useStore(agents.$guildChannelsLoading);
+	const channelsErrorMap = useStore(agents.$guildChannelsError);
+
+	const [loading, setLoading] = useState(false);
+	const [success, setSuccess] = useState<string | null>(null);
+	const [errors, setErrors] = useState<Errors>({});
+	const [, setRev] = useState(0);
+
+	const saving = guildId ? !!savingMap[guildId] : false;
+	const serverError = guildId ? (errorsMap[guildId] ?? null) : null;
+	const loaded = guildId ? !!loadedMap[guildId] : false;
+
+	const refs = useRef<Record<TextFieldKey, HTMLInputElement | null>>({
+		default_repo: null,
+		claim_channel_id: null,
+		forum_channel_id: null,
+		noticeboard_channel_id: null,
+		taskboard_channel_id: null,
+		max_assignees: null,
+	});
+	const mirrorRef = useRef<boolean>(true);
+	const activeRef = useRef<boolean>(true);
+	const initialDraftRef = useRef<BotConfigFormDraft>(
+		emptyBotConfigFormDraft(),
+	);
+
+	const hydrate = useCallback(
+		(force: boolean) => {
+			if (!guildId) return;
+			const snapshot =
+				agents.$botConfigDrafts.get()[guildId] ??
+				emptyBotConfigFormDraft();
+			initialDraftRef.current = snapshot;
+			mirrorRef.current = snapshot.mirror_pr_events;
+			activeRef.current = snapshot.active;
+			(Object.keys(refs.current) as TextFieldKey[]).forEach((k) => {
+				const el = refs.current[k];
+				if (
+					el &&
+					(force || el.value === '' || el.value !== snapshot[k])
+				) {
+					el.value = snapshot[k] as string;
+				}
+			});
+			setErrors(validateAll(snapshot));
+			setRev((r) => r + 1);
+		},
+		[guildId],
+	);
+
+	const load = useCallback(
+		async (force = false) => {
+			if (!guildId) return;
+			setLoading(true);
+			setSuccess(null);
+			await agents.ensureBotConfigLoaded(guildId, force);
+			setLoading(false);
+			hydrate(true);
+		},
+		[guildId, hydrate],
+	);
+
+	useEffect(() => {
+		if (!guildId) return;
+		if (loaded) {
+			hydrate(false);
+		} else {
+			void load();
+		}
+	}, [guildId, loaded, load, hydrate]);
+
+	useEffect(() => {
+		if (!guildId) return;
+		void agents.ensureGuildChannelsLoaded(guildId);
+	}, [guildId]);
+
+	const channels = guildId ? channelsMap[guildId] : undefined;
+	const channelsLoading = guildId ? !!channelsLoadingMap[guildId] : false;
+	const channelsError = guildId ? (channelsErrorMap[guildId] ?? null) : null;
+
+	useEffect(() => {
+		if (!success) return;
+		const t = setTimeout(() => setSuccess(null), 2500);
+		return () => clearTimeout(t);
+	}, [success]);
+
+	function commitToDraft() {
+		if (!guildId) return;
+		const cur = readForm(
+			refs.current,
+			mirrorRef.current,
+			activeRef.current,
+		);
+		agents.patchBotConfigDraft(guildId, cur);
+	}
+
+	function onFieldBlur(k: TextFieldKey) {
+		return (_: FocusEvent<HTMLInputElement>) => {
+			const v = refs.current[k]?.value ?? '';
+			const err = validateField(k, v);
+			setErrors((prev) => {
+				const next = { ...prev };
+				if (err) next[k] = err;
+				else delete next[k];
+				return next;
+			});
+			commitToDraft();
+		};
+	}
+
+	function onBoolChange(k: BoolFieldKey, v: boolean) {
+		if (k === 'mirror_pr_events') mirrorRef.current = v;
+		else activeRef.current = v;
+		commitToDraft();
+		setRev((r) => r + 1);
+	}
+
+	async function onSubmit(e: FormEvent<HTMLFormElement>) {
+		e.preventDefault();
+		if (!guildId || saving) return;
+		const draft = readForm(
+			refs.current,
+			mirrorRef.current,
+			activeRef.current,
+		);
+		const allErrors = validateAll(draft);
+		setErrors(allErrors);
+		const errorKeys = Object.keys(allErrors) as TextFieldKey[];
+		if (errorKeys.length > 0) {
+			const first = errorKeys[0];
+			const el = refs.current[first];
+			if (el) {
+				el.focus();
+				el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+			}
+			return;
+		}
+		agents.patchBotConfigDraft(guildId, draft);
+		setSuccess(null);
+		const r = await agents.saveBotConfigDraft(guildId);
+		if (r.ok) setSuccess('Saved.');
+	}
+
+	const anyError = useMemo(() => Object.keys(errors).length > 0, [errors]);
+	const guild = useMemo(
+		() => guilds.find((g) => g.id === guildId),
+		[guilds, guildId],
+	);
+
+	if (!guildId) {
+		return (
+			<section style={styles.sectionBorder}>
+				<div style={{ padding: '0.85rem 1rem' }}>
+					<p
+						style={{
+							margin: 0,
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+						}}>
+						Pick a guild above to manage its DiscordSH config.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	const d = initialDraftRef.current;
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Settings2 size={18} color="#58a6ff" />
+				<strong>Bot config</strong>
+				{guild && (
+					<span
+						style={{
+							marginLeft: '0.4rem',
+							fontSize: '0.75rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+						}}>
+						{guild.id}
+					</span>
+				)}
+				<button
+					type="button"
+					onClick={() =>
+						void agents.ensureGuildChannelsLoaded(guildId, true)
+					}
+					disabled={channelsLoading}
+					style={refreshBtn(channelsLoading)}
+					title="Re-fetch the bot's visible channels. Cached for 7 days otherwise to avoid Discord rate limits."
+					aria-label="Refresh channels">
+					<RefreshCw
+						size={14}
+						style={channelsLoading ? spinIcon : undefined}
+					/>
+					Channels
+				</button>
+				<button
+					type="button"
+					onClick={() => void load(true)}
+					disabled={loading || saving}
+					style={refreshBtn(loading || saving)}
+					aria-label="Refresh">
+					<RefreshCw
+						size={14}
+						style={loading ? spinIcon : undefined}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<form
+				onSubmit={onSubmit}
+				autoComplete="off"
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<p style={muted}>
+					Per-guild knobs the bot reads at startup. Stored as
+					<code> discordsh_config:&lt;guild&gt;</code> in Vault.
+					Channel pickers list the bot's visible channels — if the bot
+					isn't in the guild yet, install it via the bot-install
+					section above first.
+				</p>
+
+				<TextField
+					label="Default repository"
+					hint="Used by /gh shortcuts when no repo argument is supplied. Format: owner/repo."
+					name="default_repo"
+					defaultValue={d.default_repo}
+					placeholder="KBVE/kbve"
+					inputRef={(el) => (refs.current.default_repo = el)}
+					onBlur={onFieldBlur('default_repo')}
+					error={errors.default_repo}
+					fontMono
+				/>
+				<ChannelPicker
+					label="Claim channel"
+					hint="Channel that /gh claim posts confirmations to."
+					name="claim_channel_id"
+					channelType="text"
+					defaultValue={d.claim_channel_id}
+					channels={channels?.texts}
+					loading={channelsLoading}
+					error={errors.claim_channel_id}
+					sourceError={channelsError}
+					inputRef={(el) => (refs.current.claim_channel_id = el)}
+					onBlur={onFieldBlur('claim_channel_id')}
+				/>
+				<ChannelPicker
+					label="Forum channel"
+					hint="Forum channel where issue threads are created (P2 of #11262)."
+					name="forum_channel_id"
+					channelType="forum"
+					defaultValue={d.forum_channel_id}
+					channels={channels?.forums}
+					loading={channelsLoading}
+					error={errors.forum_channel_id}
+					sourceError={channelsError}
+					inputRef={(el) => (refs.current.forum_channel_id = el)}
+					onBlur={onFieldBlur('forum_channel_id')}
+				/>
+				<ChannelPicker
+					label="Notice board channel"
+					hint="Channel for /github noticeboard embeds."
+					name="noticeboard_channel_id"
+					channelType="text"
+					defaultValue={d.noticeboard_channel_id}
+					channels={channels?.texts}
+					loading={channelsLoading}
+					error={errors.noticeboard_channel_id}
+					sourceError={channelsError}
+					inputRef={(el) =>
+						(refs.current.noticeboard_channel_id = el)
+					}
+					onBlur={onFieldBlur('noticeboard_channel_id')}
+				/>
+				<ChannelPicker
+					label="Task board channel"
+					hint="Channel for /github taskboard embeds."
+					name="taskboard_channel_id"
+					channelType="text"
+					defaultValue={d.taskboard_channel_id}
+					channels={channels?.texts}
+					loading={channelsLoading}
+					error={errors.taskboard_channel_id}
+					sourceError={channelsError}
+					inputRef={(el) => (refs.current.taskboard_channel_id = el)}
+					onBlur={onFieldBlur('taskboard_channel_id')}
+				/>
+				<TextField
+					label="Max assignees per claim"
+					hint="Refuse /gh claim once an issue already has this many GitHub assignees."
+					name="max_assignees"
+					defaultValue={d.max_assignees}
+					placeholder="2"
+					inputRef={(el) => (refs.current.max_assignees = el)}
+					onBlur={onFieldBlur('max_assignees')}
+					error={errors.max_assignees}
+					inputMode="numeric"
+					pattern="[0-9]*"
+					maxWidth={100}
+				/>
+
+				<label style={toggleRow}>
+					<input
+						type="checkbox"
+						defaultChecked={d.mirror_pr_events}
+						onChange={(e) =>
+							onBoolChange('mirror_pr_events', e.target.checked)
+						}
+					/>
+					<span>
+						<strong>Mirror PR events</strong>
+						<span style={subtle}>
+							Include pull_request + PR review events when the bot
+							syncs GitHub activity to Discord.
+						</span>
+					</span>
+				</label>
+
+				<label style={toggleRow}>
+					<input
+						type="checkbox"
+						defaultChecked={d.active}
+						onChange={(e) =>
+							onBoolChange('active', e.target.checked)
+						}
+					/>
+					<span>
+						<strong>Active</strong>
+						<span style={subtle}>
+							Master switch. Disable to temporarily silence the
+							bot for this guild without deleting the config row.
+						</span>
+					</span>
+				</label>
+
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.6rem',
+						marginTop: '0.4rem',
+					}}>
+					{success && (
+						<span
+							style={{
+								color: '#4ade80',
+								fontSize: '0.82rem',
+							}}>
+							{success}
+						</span>
+					)}
+					{serverError && (
+						<span style={errTextLine}>{serverError}</span>
+					)}
+					{anyError && !saving && (
+						<span style={errTextLine}>
+							Fix field errors before saving.
+						</span>
+					)}
+					<button
+						type="submit"
+						disabled={saving}
+						title={
+							saving
+								? 'Save in flight — wait for the current request to finish.'
+								: 'Push the current form values to the discordsh_config vault row.'
+						}
+						style={{
+							...primaryBtn(!saving),
+							marginLeft: 'auto',
+						}}>
+						{saving ? (
+							<Loader2 size={14} style={spinIcon} />
+						) : (
+							<Save size={14} />
+						)}
+						{saving ? 'Saving…' : 'Save config'}
+					</button>
+				</div>
+			</form>
+		</section>
+	);
+}
+
+interface TextFieldProps {
+	label: string;
+	hint?: string;
+	name: string;
+	defaultValue: string;
+	placeholder?: string;
+	inputRef: (el: HTMLInputElement | null) => void;
+	onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+	error?: string;
+	fontMono?: boolean;
+	inputMode?: 'text' | 'numeric';
+	pattern?: string;
+	maxWidth?: number;
+}
+
+function TextField(props: TextFieldProps) {
+	const {
+		label,
+		hint,
+		name,
+		defaultValue,
+		placeholder,
+		inputRef,
+		onBlur,
+		error,
+		fontMono,
+		inputMode,
+		pattern,
+		maxWidth,
+	} = props;
+	return (
+		<label
+			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+			<span style={fieldLabel}>{label}</span>
+			<input
+				ref={inputRef}
+				name={name}
+				defaultValue={defaultValue}
+				placeholder={placeholder}
+				onBlur={onBlur}
+				autoComplete="off"
+				spellCheck={false}
+				inputMode={inputMode}
+				pattern={pattern}
+				style={{
+					...inputStyle,
+					...(fontMono ? mono : null),
+					...(maxWidth ? { width: maxWidth } : null),
+				}}
+			/>
+			{hint && !error && <span style={subtle}>{hint}</span>}
+			{error && <span style={errText}>{error}</span>}
+		</label>
+	);
+}
+
+interface ChannelPickerProps {
+	label: string;
+	hint?: string;
+	name: string;
+	channelType: 'forum' | 'text';
+	defaultValue: string;
+	channels?: DiscordChannel[];
+	loading: boolean;
+	sourceError: string | null;
+	error?: string;
+	inputRef: (el: HTMLInputElement | null) => void;
+	onBlur: (e: FocusEvent<HTMLInputElement>) => void;
+}
+
+function ChannelPicker(props: ChannelPickerProps) {
+	const {
+		label,
+		hint,
+		name,
+		channelType,
+		defaultValue,
+		channels,
+		loading,
+		sourceError,
+		error,
+		inputRef,
+		onBlur,
+	} = props;
+	const hiddenRef = useRef<HTMLInputElement | null>(null);
+	const [showManual, setShowManual] = useState(false);
+	const [currentValue, setCurrentValue] = useState<string>(defaultValue);
+
+	useEffect(() => {
+		setCurrentValue(defaultValue);
+	}, [defaultValue]);
+
+	const setInputRef = useCallback(
+		(el: HTMLInputElement | null) => {
+			hiddenRef.current = el;
+			inputRef(el);
+		},
+		[inputRef],
+	);
+
+	function commitValue(v: string) {
+		setCurrentValue(v);
+		if (hiddenRef.current) {
+			hiddenRef.current.value = v;
+			const ev = new FocusEvent('blur', {
+				bubbles: true,
+			}) as unknown as FocusEvent<HTMLInputElement>;
+			onBlur(ev);
+		}
+	}
+
+	const list = channels ?? [];
+	const known = list.find((c) => c.id === currentValue);
+	const unknownPicked = !!currentValue && !known && !showManual;
+	const useManual = showManual || sourceError !== null || unknownPicked;
+
+	return (
+		<label
+			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+			<span style={fieldLabel}>{label}</span>
+			<input
+				ref={setInputRef}
+				name={name}
+				type="hidden"
+				defaultValue={defaultValue}
+			/>
+			{loading && (
+				<span style={subtle}>
+					<Loader2
+						size={12}
+						style={{
+							verticalAlign: '-2px',
+							marginRight: 4,
+							animation: 'spin 1s linear infinite',
+						}}
+					/>
+					Loading channels…
+				</span>
+			)}
+			{!loading && !useManual && list.length > 0 && (
+				<select
+					value={currentValue}
+					onChange={(e) => commitValue(e.target.value)}
+					style={{
+						...inputStyle,
+					}}>
+					<option value="">
+						— pick a {channelType === 'forum' ? 'forum' : 'text'}{' '}
+						channel —
+					</option>
+					{list.map((c) => (
+						<option key={c.id} value={c.id}>
+							#{c.name}
+						</option>
+					))}
+				</select>
+			)}
+			{!loading && useManual && (
+				<input
+					type="text"
+					defaultValue={currentValue}
+					placeholder="Discord snowflake (17–20 digits)"
+					onBlur={(e) => commitValue(e.target.value.trim())}
+					style={{
+						...inputStyle,
+						...mono,
+					}}
+					autoComplete="off"
+					spellCheck={false}
+				/>
+			)}
+			{!loading && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.5rem',
+						fontSize: '0.75rem',
+					}}>
+					{!useManual && list.length === 0 && !sourceError && (
+						<span style={subtle}>
+							No {channelType === 'forum' ? 'forum' : 'text'}{' '}
+							channels found.
+						</span>
+					)}
+					{sourceError && (
+						<span style={{ ...subtle, color: '#facc15' }}>
+							<Hash size={11} style={{ verticalAlign: '-1px' }} />{' '}
+							Channel lookup failed — paste a raw snowflake.
+						</span>
+					)}
+					{!sourceError && list.length > 0 && (
+						<button
+							type="button"
+							onClick={() => setShowManual((v) => !v)}
+							style={{
+								background: 'transparent',
+								border: 'none',
+								color: 'var(--sl-color-gray-3, #9ca0aa)',
+								cursor: 'pointer',
+								padding: 0,
+								fontSize: '0.72rem',
+								textDecoration: 'underline',
+							}}>
+							{useManual
+								? 'Use channel picker'
+								: 'Paste raw snowflake instead'}
+						</button>
+					)}
+				</div>
+			)}
+			{hint && !error && <span style={subtle}>{hint}</span>}
+			{error && <span style={errText}>{error}</span>}
+		</label>
+	);
+}
+
+const inputStyle: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	boxSizing: 'border-box',
+	width: '100%',
+};
+
+const mono: React.CSSProperties = {
+	fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
+};
+
+const muted: React.CSSProperties = {
+	margin: 0,
+	fontSize: '0.85rem',
+	color: 'var(--sl-color-gray-2, #c2c5cc)',
+	lineHeight: 1.5,
+};
+
+const subtle: React.CSSProperties = {
+	display: 'block',
+	fontSize: '0.75rem',
+	color: 'var(--sl-color-gray-3, #9ca0aa)',
+	marginTop: '0.15rem',
+};
+
+const fieldLabel: React.CSSProperties = {
+	fontSize: '0.8rem',
+	fontWeight: 600,
+	color: 'var(--sl-color-white, #fff)',
+};
+
+const errText: React.CSSProperties = {
+	margin: 0,
+	color: '#f87171',
+	fontSize: '0.78rem',
+};
+
+const errTextLine: React.CSSProperties = {
+	color: '#f87171',
+	fontSize: '0.78rem',
+};
+
+const toggleRow: React.CSSProperties = {
+	display: 'flex',
+	alignItems: 'flex-start',
+	gap: '0.6rem',
+	fontSize: '0.85rem',
+	color: 'var(--sl-color-gray-2, #c2c5cc)',
+};
+
+function refreshBtn(busy: boolean): React.CSSProperties {
+	return {
+		marginLeft: 'auto',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.3rem 0.6rem',
+		borderRadius: 6,
+		border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+		background: 'transparent',
+		color: 'var(--sl-color-white, #fff)',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.8rem',
+	};
+}
+
+function primaryBtn(enabled: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+		padding: '0.5rem 0.95rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
+		color: '#0d1117',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		fontSize: '0.85rem',
+	};
+}
+
+const spinIcon: React.CSSProperties = {
+	animation: 'spin 1s linear infinite',
+};

--- a/packages/npm/astro/src/agents/ReactAgentBotInstall.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentBotInstall.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	AlertTriangle,
+	CheckCircle2,
+	ExternalLink,
+	Loader2,
+	RefreshCw,
+} from 'lucide-react';
+import { useAgents } from './context';
+import { styles } from '../dashboard/dashboard-ui';
+
+type Status =
+	| 'idle'
+	| 'checking'
+	| 'present'
+	| 'missing'
+	| 'error'
+	| 'unconfigured';
+
+export default function ReactAgentBotInstall() {
+	const agents = useAgents();
+	const guilds = useStore(agents.$guilds);
+	const selectedGuildId = useStore(agents.$selectedGuildId);
+	const membershipMap = useStore(agents.$botMembership);
+	const membershipLoadingMap = useStore(agents.$botMembershipLoading);
+	const membershipErrorMap = useStore(agents.$botMembershipError);
+
+	const cached = selectedGuildId ? membershipMap[selectedGuildId] : null;
+	const checking = selectedGuildId
+		? !!membershipLoadingMap[selectedGuildId]
+		: false;
+	const cachedError = selectedGuildId
+		? (membershipErrorMap[selectedGuildId] ?? null)
+		: null;
+
+	const errorMsg = cachedError;
+	const status: Status = checking
+		? 'checking'
+		: cachedError
+			? cachedError.includes('DISCORD_BOT_CLIENT_ID') ||
+				cachedError.includes('not configured')
+				? 'unconfigured'
+				: 'error'
+			: cached
+				? cached.isMember
+					? 'present'
+					: 'missing'
+				: 'idle';
+
+	const guild = useMemo(
+		() => guilds.find((g) => g.id === selectedGuildId) ?? null,
+		[guilds, selectedGuildId],
+	);
+
+	const installUrl = useMemo(
+		() => (selectedGuildId ? agents.botInstallUrl(selectedGuildId) : null),
+		[selectedGuildId],
+	);
+
+	async function probe() {
+		if (!selectedGuildId) return;
+		await agents.ensureBotMembershipLoaded(selectedGuildId, true);
+	}
+
+	useEffect(() => {
+		if (!selectedGuildId) return;
+		void agents.ensureBotMembershipLoaded(selectedGuildId);
+	}, [selectedGuildId]);
+
+	if (!guild) return null;
+
+	const dot = (() => {
+		if (status === 'present') {
+			return <CheckCircle2 size={18} color="#4ade80" />;
+		}
+		if (status === 'checking' || status === 'idle') {
+			return (
+				<Loader2
+					size={18}
+					color="#94a3b8"
+					style={{ animation: 'spin 1s linear infinite' }}
+				/>
+			);
+		}
+		return <AlertTriangle size={18} color="#facc15" />;
+	})();
+
+	const heading = (() => {
+		if (status === 'present') return `KBVE bot is in ${guild.name}`;
+		if (status === 'missing') return `KBVE bot not in ${guild.name}`;
+		if (status === 'unconfigured') return 'Bot presence check unavailable';
+		if (status === 'error') return 'Bot presence check failed';
+		return `Checking bot presence in ${guild.name}…`;
+	})();
+
+	const subline = (() => {
+		if (status === 'present') {
+			return 'Routing should work once the rest of the wizard is green.';
+		}
+		if (status === 'missing') {
+			return 'Click install to add the KBVE bot to this guild. Discord will open the standard authorize screen.';
+		}
+		if (status === 'unconfigured') {
+			return 'Edge fn needs DISCORD_BOT_CLIENT_ID env wired. Falls back to manual install link.';
+		}
+		if (status === 'error') {
+			return errorMsg ?? 'Try again in a moment.';
+		}
+		return null;
+	})();
+
+	const showInstall =
+		status === 'missing' || status === 'unconfigured' || status === 'error';
+
+	return (
+		<section style={styles.sectionBorder}>
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.7rem',
+				}}>
+				<div
+					style={{
+						width: 32,
+						height: 32,
+						borderRadius: 8,
+						background:
+							status === 'present'
+								? 'rgba(74,222,128,0.12)'
+								: 'rgba(250,204,21,0.12)',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+					}}>
+					{dot}
+				</div>
+				<div style={{ flex: 1, minWidth: 0 }}>
+					<strong>{heading}</strong>
+					{subline && (
+						<div
+							style={{
+								fontSize: '0.78rem',
+								color: 'var(--sl-color-gray-3, #9ca0aa)',
+								marginTop: 2,
+							}}>
+							{subline}
+						</div>
+					)}
+				</div>
+				<button
+					type="button"
+					onClick={() => void probe()}
+					disabled={status === 'checking'}
+					aria-label="Re-check bot presence"
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.3rem',
+						padding: '0.3rem 0.6rem',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+						background: 'transparent',
+						color: 'var(--sl-color-white, #fff)',
+						fontSize: '0.75rem',
+						cursor: status === 'checking' ? 'wait' : 'pointer',
+					}}>
+					<RefreshCw
+						size={12}
+						style={
+							status === 'checking'
+								? { animation: 'spin 1s linear infinite' }
+								: undefined
+						}
+					/>
+					Re-check
+				</button>
+				{showInstall &&
+					(installUrl ? (
+						<a
+							href={installUrl}
+							target="_blank"
+							rel="noopener noreferrer"
+							onClick={() => {
+								if (selectedGuildId) {
+									agents.invalidateBotMembership(
+										selectedGuildId,
+									);
+								}
+							}}
+							style={{
+								display: 'inline-flex',
+								alignItems: 'center',
+								gap: '0.35rem',
+								padding: '0.35rem 0.7rem',
+								borderRadius: 6,
+								background: '#5865F2',
+								color: '#fff',
+								fontWeight: 600,
+								fontSize: '0.78rem',
+								textDecoration: 'none',
+							}}>
+							<ExternalLink size={12} />
+							Install bot
+						</a>
+					) : (
+						<span
+							style={{
+								fontSize: '0.72rem',
+								color: '#f87171',
+								padding: '0.2rem 0.4rem',
+							}}
+							title="Set PUBLIC_DISCORD_BOT_CLIENT_ID at build time">
+							Install link unavailable (build env missing)
+						</span>
+					))}
+			</div>
+			{status === 'error' && errorMsg && (
+				<div
+					style={{
+						padding: '0.5rem 1rem 0.85rem 1rem',
+						color: '#f87171',
+						fontSize: '0.75rem',
+						borderTop: '1px solid var(--sl-color-gray-5, #1f2024)',
+					}}>
+					{errorMsg}
+				</div>
+			)}
+		</section>
+	);
+}

--- a/packages/npm/astro/src/agents/ReactAgentDiscordsh.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentDiscordsh.tsx
@@ -1,0 +1,548 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	Loader2,
+	LogIn,
+	RefreshCw,
+	AlertTriangle,
+	KeyRound,
+	Plus,
+	Trash2,
+	Power,
+} from 'lucide-react';
+import { useAgents } from './context';
+import type { AgentTokenRow, DiscordGuild } from '@kbve/droid';
+import { styles } from '../dashboard/dashboard-ui';
+import { AddTokenModal, DeleteTokenModal } from './ReactAgentTokenModals';
+import ReactAgentGuildPicker from './ReactAgentGuildPicker';
+
+function formatDate(iso: string): string {
+	try {
+		return new Date(iso).toLocaleString();
+	} catch {
+		return iso;
+	}
+}
+
+function maskService(svc: string): { label: string; color: string } {
+	if (svc === 'github') return { label: 'github · PAT', color: '#58a6ff' };
+	if (svc === 'github_webhook')
+		return { label: 'github · webhook', color: '#a78bfa' };
+	if (svc === 'github_repos')
+		return { label: 'github · repo list', color: '#34d399' };
+	if (svc === 'irc') return { label: 'irc', color: '#fb7185' };
+	return { label: svc, color: '#94a3b8' };
+}
+
+export default function ReactAgentDiscordsh() {
+	const agents = useAgents();
+	const authState = useStore(agents.$authState);
+	const guilds = useStore(agents.$guilds);
+	const selectedGuildId = useStore(agents.$selectedGuildId);
+	const tokens = useStore(agents.$tokens);
+	const tokensLoading = useStore(agents.$tokensLoading);
+	const tokensError = useStore(agents.$tokensError);
+
+	useEffect(() => {
+		void agents.initAuth();
+	}, []);
+
+	const selectedGuild = useMemo(
+		() => guilds.find((g) => g.id === selectedGuildId) ?? null,
+		[guilds, selectedGuildId],
+	);
+
+	if (authState === 'loading') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<Loader2
+					size={28}
+					style={{
+						animation: 'spin 1s linear infinite',
+						color: 'var(--sl-color-accent, #58a6ff)',
+					}}
+				/>
+				<p
+					style={{
+						marginTop: '0.75rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Loading session…
+				</p>
+			</div>
+		);
+	}
+
+	if (authState === 'unauthenticated') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<div style={styles.iconBadge('#58a6ff')}>
+					<LogIn size={28} color="#58a6ff" />
+				</div>
+				<h2 style={{ margin: '0.5rem 0' }}>Sign in required</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						maxWidth: 480,
+					}}>
+					Manage your discordsh integration by signing in with
+					Discord. We use your Discord identity to verify which guilds
+					you own before showing or editing their stored tokens.
+				</p>
+				<button
+					type="button"
+					onClick={() => void agents.signInWithDiscord()}
+					style={{
+						marginTop: '1rem',
+						padding: '0.55rem 1.1rem',
+						borderRadius: 8,
+						border: 'none',
+						background: '#5865F2',
+						color: '#fff',
+						fontWeight: 600,
+						cursor: 'pointer',
+					}}>
+					Sign in with Discord
+				</button>
+			</div>
+		);
+	}
+
+	if (authState === 'discord_reauth_required') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<div style={styles.iconBadge('#facc15')}>
+					<AlertTriangle size={28} color="#facc15" />
+				</div>
+				<h2 style={{ margin: '0.5rem 0' }}>Discord session expired</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						maxWidth: 480,
+					}}>
+					Your Discord access token has expired or was not captured by
+					the last sign-in. Re-sign-in to grant the agents dashboard a
+					fresh provider token (used only to verify guild ownership;
+					never stored).
+				</p>
+				<button
+					type="button"
+					onClick={() => void agents.signInWithDiscord()}
+					style={{
+						marginTop: '1rem',
+						padding: '0.55rem 1.1rem',
+						borderRadius: 8,
+						border: 'none',
+						background: '#5865F2',
+						color: '#fff',
+						fontWeight: 600,
+						cursor: 'pointer',
+					}}>
+					Re-sign-in with Discord
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="not-content"
+			style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+			<ReactAgentGuildPicker />
+
+			{guilds.length > 1 && selectedGuild && (
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.78rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					This guild is shared across the agents surface — visit{' '}
+					<a href="/dashboard/agents/github/">GitHub</a> to configure
+					the webhook + PAT for the same guild.
+				</p>
+			)}
+
+			{selectedGuild ? (
+				<TokenList
+					guild={selectedGuild}
+					tokens={tokens}
+					loading={tokensLoading}
+					error={tokensError}
+					onRefresh={() => void agents.refreshSelectedGuild()}
+				/>
+			) : (
+				<EmptyGuildPrompt guildCount={guilds.length} />
+			)}
+		</div>
+	);
+}
+
+interface TokenListProps {
+	guild: DiscordGuild;
+	tokens: AgentTokenRow[];
+	loading: boolean;
+	error: string | null;
+	onRefresh: () => void;
+}
+
+function TokenList({
+	guild,
+	tokens,
+	loading,
+	error,
+	onRefresh,
+}: TokenListProps) {
+	const agents = useAgents();
+	const [addOpen, setAddOpen] = useState(false);
+	const [pendingDelete, setPendingDelete] = useState<AgentTokenRow | null>(
+		null,
+	);
+	const [togglingId, setTogglingId] = useState<string | null>(null);
+
+	async function handleToggle(t: AgentTokenRow) {
+		setTogglingId(t.token_id);
+		await agents.toggleToken(t.token_id, !t.is_active);
+		setTogglingId(null);
+	}
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<KeyRound size={18} color="#a78bfa" />
+				<strong>Tokens for {guild.name}</strong>
+				<span
+					style={{
+						marginLeft: '0.4rem',
+						fontSize: '0.75rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						fontFamily:
+							'var(--sl-font-mono, ui-monospace, monospace)',
+					}}>
+					{guild.id}
+				</span>
+				<button
+					type="button"
+					onClick={() => setAddOpen(true)}
+					style={{
+						marginLeft: 'auto',
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+						padding: '0.3rem 0.7rem',
+						borderRadius: 6,
+						border: 'none',
+						background: '#58a6ff',
+						color: '#0d1117',
+						cursor: 'pointer',
+						fontSize: '0.8rem',
+						fontWeight: 600,
+					}}
+					aria-label="Add token">
+					<Plus size={14} />
+					Add token
+				</button>
+				<button
+					type="button"
+					onClick={onRefresh}
+					disabled={loading}
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+						padding: '0.3rem 0.6rem',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+						background: 'transparent',
+						color: 'var(--sl-color-white, #fff)',
+						cursor: loading ? 'wait' : 'pointer',
+						fontSize: '0.8rem',
+					}}
+					aria-label="Refresh tokens">
+					<RefreshCw
+						size={14}
+						style={
+							loading
+								? { animation: 'spin 1s linear infinite' }
+								: undefined
+						}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div style={{ padding: '0.85rem 1rem' }}>
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+				{!error && loading && tokens.length === 0 && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						Loading tokens…
+					</p>
+				)}
+				{!error && !loading && tokens.length === 0 && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+							margin: 0,
+						}}>
+						No tokens registered for this guild yet.
+					</p>
+				)}
+				{tokens.length > 0 && (
+					<div style={{ overflowX: 'auto' }}>
+						<table
+							style={{
+								width: '100%',
+								borderCollapse: 'collapse',
+								fontSize: '0.85rem',
+							}}>
+							<thead>
+								<tr
+									style={{
+										textAlign: 'left',
+										color: 'var(--sl-color-gray-3, #9ca0aa)',
+									}}>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Name
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Service
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Description
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Active
+									</th>
+									<th style={{ padding: '0.4rem 0.5rem' }}>
+										Created
+									</th>
+									<th
+										style={{
+											padding: '0.4rem 0.5rem',
+											textAlign: 'right',
+										}}>
+										Actions
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{tokens.map((t) => {
+									const svc = maskService(t.service);
+									return (
+										<tr
+											key={t.token_id}
+											style={{
+												borderTop:
+													'1px solid var(--sl-color-gray-5, #262626)',
+											}}>
+											<td style={{ padding: '0.5rem' }}>
+												<code
+													style={{
+														fontFamily:
+															'var(--sl-font-mono, ui-monospace, monospace)',
+													}}>
+													{t.token_name}
+												</code>
+											</td>
+											<td style={{ padding: '0.5rem' }}>
+												<span
+													style={{
+														fontSize: '0.75rem',
+														padding:
+															'0.15rem 0.5rem',
+														borderRadius: 6,
+														background: `${svc.color}22`,
+														color: svc.color,
+													}}>
+													{svc.label}
+												</span>
+											</td>
+											<td
+												style={{
+													padding: '0.5rem',
+													color: 'var(--sl-color-gray-2, #c2c5cc)',
+												}}>
+												{t.description || '—'}
+											</td>
+											<td style={{ padding: '0.5rem' }}>
+												{t.is_active ? (
+													<span
+														style={{
+															color: '#4ade80',
+														}}>
+														● active
+													</span>
+												) : (
+													<span
+														style={{
+															color: '#94a3b8',
+														}}>
+														○ disabled
+													</span>
+												)}
+											</td>
+											<td
+												style={{
+													padding: '0.5rem',
+													color: 'var(--sl-color-gray-3, #9ca0aa)',
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													fontSize: '0.78rem',
+												}}>
+												{formatDate(t.created_at)}
+											</td>
+											<td
+												style={{
+													padding: '0.5rem',
+													textAlign: 'right',
+													whiteSpace: 'nowrap',
+												}}>
+												<button
+													type="button"
+													onClick={() =>
+														handleToggle(t)
+													}
+													disabled={
+														togglingId ===
+														t.token_id
+													}
+													aria-label={
+														t.is_active
+															? 'Disable token'
+															: 'Enable token'
+													}
+													title={
+														t.is_active
+															? 'Disable token'
+															: 'Enable token'
+													}
+													style={{
+														display: 'inline-flex',
+														alignItems: 'center',
+														gap: '0.25rem',
+														padding:
+															'0.25rem 0.5rem',
+														borderRadius: 6,
+														border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+														background:
+															'transparent',
+														color: t.is_active
+															? '#fbbf24'
+															: '#4ade80',
+														cursor:
+															togglingId ===
+															t.token_id
+																? 'wait'
+																: 'pointer',
+														fontSize: '0.75rem',
+														marginRight: '0.35rem',
+													}}>
+													{togglingId ===
+													t.token_id ? (
+														<Loader2
+															size={12}
+															style={{
+																animation:
+																	'spin 1s linear infinite',
+															}}
+														/>
+													) : (
+														<Power size={12} />
+													)}
+													{t.is_active
+														? 'Disable'
+														: 'Enable'}
+												</button>
+												<button
+													type="button"
+													onClick={() =>
+														setPendingDelete(t)
+													}
+													aria-label="Delete token"
+													title="Delete token"
+													style={{
+														display: 'inline-flex',
+														alignItems: 'center',
+														gap: '0.25rem',
+														padding:
+															'0.25rem 0.5rem',
+														borderRadius: 6,
+														border: '1px solid rgba(239,68,68,0.4)',
+														background:
+															'transparent',
+														color: '#f87171',
+														cursor: 'pointer',
+														fontSize: '0.75rem',
+													}}>
+													<Trash2 size={12} />
+													Delete
+												</button>
+											</td>
+										</tr>
+									);
+								})}
+							</tbody>
+						</table>
+					</div>
+				)}
+				<p
+					style={{
+						marginTop: '0.85rem',
+						fontSize: '0.78rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Token values are written to Supabase Vault encrypted and
+					never returned by the dashboard. Use Disable to
+					soft-deactivate a token without removing it.
+				</p>
+			</div>
+
+			{addOpen && <AddTokenModal onClose={() => setAddOpen(false)} />}
+			{pendingDelete && (
+				<DeleteTokenModal
+					token={pendingDelete}
+					onClose={() => setPendingDelete(null)}
+				/>
+			)}
+		</section>
+	);
+}
+
+function EmptyGuildPrompt({ guildCount }: { guildCount: number }) {
+	if (guildCount === 0) return null;
+	return (
+		<section style={styles.sectionBorder}>
+			<div style={{ padding: '1rem' }}>
+				<p
+					style={{
+						margin: 0,
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Pick a guild above to view its registered bot tokens.
+				</p>
+			</div>
+		</section>
+	);
+}

--- a/packages/npm/astro/src/agents/ReactAgentEventQueue.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentEventQueue.tsx
@@ -1,0 +1,555 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	Activity,
+	AlertTriangle,
+	CheckCircle2,
+	Clock,
+	Loader2,
+	RefreshCw,
+	RotateCcw,
+} from 'lucide-react';
+import { useAgents } from './context';
+import { styles } from '../dashboard/dashboard-ui';
+
+const REFRESH_INTERVAL_MS = 30_000;
+
+export default function ReactAgentEventQueue() {
+	const agents = useAgents();
+	const guildId = useStore(agents.$selectedGuildId);
+	const guilds = useStore(agents.$guilds);
+	const statsMap = useStore(agents.$eventStats);
+	const statsLoadingMap = useStore(agents.$eventStatsLoading);
+	const failedMap = useStore(agents.$failedEvents);
+	const failedLoadingMap = useStore(agents.$failedEventsLoading);
+	const pendingMap = useStore(agents.$pendingEvents);
+	const pendingLoadingMap = useStore(agents.$pendingEventsLoading);
+	const requeueBusyMap = useStore(agents.$eventRequeueBusyFor);
+
+	const [autoRefresh, setAutoRefresh] = useState(true);
+
+	const stats = guildId ? statsMap[guildId] : undefined;
+	const statsLoading = guildId ? !!statsLoadingMap[guildId] : false;
+	const failed = guildId ? (failedMap[guildId] ?? []) : [];
+	const failedLoading = guildId ? !!failedLoadingMap[guildId] : false;
+	const pending = guildId ? (pendingMap[guildId] ?? []) : [];
+	const pendingLoading = guildId ? !!pendingLoadingMap[guildId] : false;
+	const guild = useMemo(
+		() => guilds.find((g) => g.id === guildId),
+		[guilds, guildId],
+	);
+
+	useEffect(() => {
+		if (!guildId) return;
+		void agents.loadEventStats(guildId);
+		void agents.loadFailedEvents(guildId, 10);
+		void agents.loadPendingEvents(guildId, 10);
+	}, [guildId]);
+
+	useEffect(() => {
+		if (!guildId || !autoRefresh) return;
+		const id = setInterval(() => {
+			void agents.loadEventStats(guildId);
+			if ((failedMap[guildId] ?? []).length > 0) {
+				void agents.loadFailedEvents(guildId, 10);
+			}
+			const cur = statsMap[guildId];
+			const queueDepth =
+				(cur?.pending_count ?? 0) + (cur?.in_flight_count ?? 0);
+			if (queueDepth > 0) {
+				void agents.loadPendingEvents(guildId, 10);
+			}
+		}, REFRESH_INTERVAL_MS);
+		return () => clearInterval(id);
+	}, [guildId, autoRefresh, failedMap, statsMap]);
+
+	if (!guildId) {
+		return (
+			<section style={styles.sectionBorder}>
+				<div style={{ padding: '0.85rem 1rem' }}>
+					<p
+						style={{
+							margin: 0,
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+						}}>
+						Pick a guild above to see GitHub → Discord event queue
+						status.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	async function refresh() {
+		if (!guildId) return;
+		void agents.loadEventStats(guildId);
+		void agents.loadFailedEvents(guildId, 10);
+		void agents.loadPendingEvents(guildId, 10);
+	}
+
+	async function requeue(eventId: number) {
+		if (!guildId) return;
+		await agents.requeueEvent(guildId, eventId);
+	}
+
+	const pendingCount = stats?.pending_count ?? 0;
+	const inFlight = stats?.in_flight_count ?? 0;
+	const delivered = stats?.delivered_count ?? 0;
+	const failedCount = stats?.failed_count ?? 0;
+	const queueDepth = pendingCount + inFlight;
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Activity size={18} color="#58a6ff" />
+				<strong>Event queue</strong>
+				{guild && (
+					<span
+						style={{
+							marginLeft: '0.4rem',
+							fontSize: '0.75rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+						}}>
+						{guild.id}
+					</span>
+				)}
+				<label
+					style={{
+						marginLeft: 'auto',
+						fontSize: '0.78rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.3rem',
+					}}>
+					<input
+						type="checkbox"
+						checked={autoRefresh}
+						onChange={(e) => setAutoRefresh(e.target.checked)}
+					/>
+					Auto refresh 30s
+				</label>
+				<button
+					type="button"
+					onClick={() => void refresh()}
+					disabled={statsLoading || failedLoading}
+					style={refreshBtn(statsLoading || failedLoading)}
+					aria-label="Refresh">
+					<RefreshCw
+						size={14}
+						style={statsLoading ? spinIcon : undefined}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<div
+					style={{
+						display: 'grid',
+						gridTemplateColumns: 'repeat(4, minmax(0, 1fr))',
+						gap: '0.5rem',
+					}}>
+					<StatCard
+						label="Queue depth"
+						value={queueDepth}
+						hint={`${pendingCount} pending + ${inFlight} in-flight`}
+						tone={queueDepth > 50 ? 'warn' : 'ok'}
+					/>
+					<StatCard
+						label="Delivered"
+						value={delivered}
+						hint={
+							stats?.last_delivered_at
+								? `Last ${new Date(
+										stats.last_delivered_at,
+									).toLocaleString()}`
+								: 'No deliveries yet'
+						}
+						tone="ok"
+					/>
+					<StatCard
+						label="Failed"
+						value={failedCount}
+						hint="At max attempts — needs requeue"
+						tone={failedCount > 0 ? 'fail' : 'ok'}
+					/>
+					<StatCard
+						label="Oldest pending"
+						value={
+							stats?.oldest_pending_at
+								? relativeTime(stats.oldest_pending_at)
+								: '—'
+						}
+						hint={
+							stats?.oldest_pending_at
+								? new Date(
+										stats.oldest_pending_at,
+									).toLocaleString()
+								: 'No backlog'
+						}
+						tone={
+							stats?.oldest_pending_at
+								? ageSeconds(stats.oldest_pending_at) > 10 * 60
+									? 'warn'
+									: 'ok'
+								: 'ok'
+						}
+					/>
+				</div>
+
+				{failedCount > 0 && (
+					<div>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '0.4rem',
+								marginBottom: '0.4rem',
+							}}>
+							<AlertTriangle size={14} color="#facc15" />
+							<strong style={{ fontSize: '0.85rem' }}>
+								Failed events
+							</strong>
+						</div>
+						<ul
+							style={{
+								margin: 0,
+								padding: 0,
+								listStyle: 'none',
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '0.3rem',
+							}}>
+							{failed.map((ev) => {
+								const busy =
+									!!requeueBusyMap[`${guildId}:${ev.id}`];
+								return (
+									<li
+										key={ev.id}
+										style={{
+											display: 'flex',
+											alignItems: 'center',
+											justifyContent: 'space-between',
+											padding: '0.4rem 0.6rem',
+											borderRadius: 6,
+											border: '1px solid rgba(239,68,68,0.3)',
+											background: 'rgba(239,68,68,0.06)',
+											gap: '0.5rem',
+										}}>
+										<div
+											style={{
+												display: 'flex',
+												flexDirection: 'column',
+												gap: '0.15rem',
+												minWidth: 0,
+												flex: 1,
+											}}>
+											<code
+												style={{
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													fontSize: '0.8rem',
+												}}>
+												{ev.owner}/{ev.repo}#{ev.number}{' '}
+												<span
+													style={{
+														color: 'var(--sl-color-gray-3, #9ca0aa)',
+													}}>
+													· {ev.event_type}
+												</span>
+											</code>
+											{ev.last_error && (
+												<span
+													style={{
+														fontSize: '0.75rem',
+														color: '#f87171',
+														overflow: 'hidden',
+														textOverflow:
+															'ellipsis',
+														whiteSpace: 'nowrap',
+													}}
+													title={ev.last_error}>
+													{ev.last_error}
+												</span>
+											)}
+											<span
+												style={{
+													fontSize: '0.72rem',
+													color: 'var(--sl-color-gray-3, #9ca0aa)',
+												}}>
+												<Clock
+													size={10}
+													style={{
+														verticalAlign: '-1px',
+														marginRight: 3,
+													}}
+												/>
+												{new Date(
+													ev.updated_at,
+												).toLocaleString()}{' '}
+												· attempts{' '}
+												{ev.delivery_attempts}
+											</span>
+										</div>
+										<button
+											type="button"
+											onClick={() => void requeue(ev.id)}
+											disabled={busy}
+											style={requeueBtn(busy)}>
+											{busy ? (
+												<Loader2
+													size={12}
+													style={spinIcon}
+												/>
+											) : (
+												<RotateCcw size={12} />
+											)}
+											{busy ? 'Requeuing…' : 'Requeue'}
+										</button>
+									</li>
+								);
+							})}
+						</ul>
+					</div>
+				)}
+
+				{queueDepth > 0 && (
+					<div>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '0.4rem',
+								marginBottom: '0.4rem',
+							}}>
+							<Clock size={14} color="#fbbf24" />
+							<strong style={{ fontSize: '0.85rem' }}>
+								Backed up in queue ({queueDepth})
+							</strong>
+						</div>
+						{pendingLoading && pending.length === 0 ? (
+							<p
+								style={{
+									margin: 0,
+									color: 'var(--sl-color-gray-3, #9ca0aa)',
+									fontSize: '0.78rem',
+								}}>
+								Loading pending events…
+							</p>
+						) : pending.length === 0 ? (
+							<p
+								style={{
+									margin: 0,
+									color: 'var(--sl-color-gray-3, #9ca0aa)',
+									fontSize: '0.78rem',
+								}}>
+								Queue depth reported but no visible owner/repo
+								rows — your allowlist may be empty.
+							</p>
+						) : (
+							<ul
+								style={{
+									margin: 0,
+									padding: 0,
+									listStyle: 'none',
+									display: 'flex',
+									flexDirection: 'column',
+									gap: '0.25rem',
+								}}>
+								{pending.map((ev) => {
+									const inFlight = ev.delivery_state === 1;
+									return (
+										<li
+											key={ev.id}
+											style={{
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'space-between',
+												padding: '0.3rem 0.55rem',
+												borderRadius: 6,
+												border: inFlight
+													? '1px solid rgba(88,166,255,0.3)'
+													: '1px solid rgba(251,191,36,0.3)',
+												background: inFlight
+													? 'rgba(88,166,255,0.05)'
+													: 'rgba(251,191,36,0.05)',
+												fontSize: '0.78rem',
+												gap: '0.4rem',
+											}}>
+											<code
+												style={{
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													flex: 1,
+												}}>
+												{ev.owner}/{ev.repo}#{ev.number}{' '}
+												<span
+													style={{
+														color: 'var(--sl-color-gray-3, #9ca0aa)',
+													}}>
+													· {ev.event_type}
+												</span>
+											</code>
+											<span
+												style={{
+													color: inFlight
+														? '#58a6ff'
+														: '#fbbf24',
+													fontSize: '0.72rem',
+												}}>
+												{inFlight
+													? 'in-flight'
+													: 'pending'}
+											</span>
+											<span
+												style={{
+													color: 'var(--sl-color-gray-3, #9ca0aa)',
+													fontSize: '0.72rem',
+												}}>
+												{relativeTime(ev.created_at)}
+											</span>
+										</li>
+									);
+								})}
+							</ul>
+						)}
+					</div>
+				)}
+
+				{failedCount === 0 && queueDepth === 0 && delivered > 0 && (
+					<p
+						style={{
+							margin: 0,
+							color: '#4ade80',
+							fontSize: '0.82rem',
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: '0.3rem',
+						}}>
+						<CheckCircle2 size={14} />
+						All recent deliveries succeeded.
+					</p>
+				)}
+			</div>
+		</section>
+	);
+}
+
+function ageSeconds(iso: string): number {
+	return (Date.now() - new Date(iso).getTime()) / 1000;
+}
+
+function relativeTime(iso: string): string {
+	const s = ageSeconds(iso);
+	if (s < 60) return `${Math.floor(s)}s ago`;
+	if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+	if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+	return `${Math.floor(s / 86400)}d ago`;
+}
+
+function StatCard({
+	label,
+	value,
+	hint,
+	tone,
+}: {
+	label: string;
+	value: number | string;
+	hint: string;
+	tone: 'ok' | 'warn' | 'fail';
+}) {
+	const palette = {
+		ok: { bg: 'rgba(255,255,255,0.03)', fg: 'var(--sl-color-white, #fff)' },
+		warn: { bg: 'rgba(251,191,36,0.08)', fg: '#fbbf24' },
+		fail: { bg: 'rgba(239,68,68,0.08)', fg: '#f87171' },
+	}[tone];
+	return (
+		<div
+			style={{
+				padding: '0.6rem 0.7rem',
+				borderRadius: 8,
+				border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+				background: palette.bg,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: '0.15rem',
+			}}>
+			<span
+				style={{
+					fontSize: '0.7rem',
+					color: 'var(--sl-color-gray-3, #9ca0aa)',
+					textTransform: 'uppercase',
+					letterSpacing: '0.04em',
+				}}>
+				{label}
+			</span>
+			<span
+				style={{
+					fontSize: '1.15rem',
+					fontWeight: 700,
+					color: palette.fg,
+					fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
+				}}>
+				{value}
+			</span>
+			<span
+				style={{
+					fontSize: '0.72rem',
+					color: 'var(--sl-color-gray-3, #9ca0aa)',
+				}}>
+				{hint}
+			</span>
+		</div>
+	);
+}
+
+const spinIcon: React.CSSProperties = {
+	animation: 'spin 1s linear infinite',
+};
+
+function refreshBtn(busy: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.3rem 0.6rem',
+		borderRadius: 6,
+		border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+		background: 'transparent',
+		color: 'var(--sl-color-white, #fff)',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.8rem',
+	};
+}
+
+function requeueBtn(busy: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.3rem',
+		padding: '0.3rem 0.55rem',
+		borderRadius: 6,
+		border: '1px solid rgba(88,166,255,0.4)',
+		background: 'transparent',
+		color: '#58a6ff',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.78rem',
+	};
+}

--- a/packages/npm/astro/src/agents/ReactAgentGithubWizard.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentGithubWizard.tsx
@@ -1,0 +1,1497 @@
+import { useEffect, useMemo, useRef, useState, type FocusEvent } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	AlertTriangle,
+	CheckCircle2,
+	Copy,
+	ExternalLink,
+	Eye,
+	EyeOff,
+	Loader2,
+	LogIn,
+	PlayCircle,
+	RefreshCw,
+	Shuffle,
+	Webhook,
+	XCircle,
+} from 'lucide-react';
+import { useAgents } from './context';
+import type { AgentTokenRow, DiscordGuild } from '@kbve/droid';
+import { styles } from '../dashboard/dashboard-ui';
+import ReactAgentGuildPicker from './ReactAgentGuildPicker';
+
+const GITHUB_OWNER_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}$/;
+const GITHUB_REPO_RE = /^[A-Za-z0-9._-]{1,100}$/;
+
+const WEBHOOK_TOKEN_NAME = 'github-webhook-hmac';
+const WEBHOOK_SERVICE = 'github_webhook';
+const PAT_TOKEN_NAME = 'github-pat';
+const PAT_SERVICE = 'github';
+
+function genHex(bytes = 32): string {
+	const arr = new Uint8Array(bytes);
+	crypto.getRandomValues(arr);
+	return Array.from(arr)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+	try {
+		await navigator.clipboard.writeText(text);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export default function ReactAgentGithubWizard() {
+	const agents = useAgents();
+	const authState = useStore(agents.$authState);
+	const guilds = useStore(agents.$guilds);
+	const selectedGuildId = useStore(agents.$selectedGuildId);
+	const tokens = useStore(agents.$tokens);
+
+	useEffect(() => {
+		void agents.initAuth();
+	}, []);
+
+	const selectedGuild = useMemo<DiscordGuild | null>(
+		() => guilds.find((g) => g.id === selectedGuildId) ?? null,
+		[guilds, selectedGuildId],
+	);
+
+	if (authState === 'loading') {
+		return (
+			<CenterMsg
+				icon={<Loader2 size={28} style={spinStyle} />}
+				msg="Loading session…"
+			/>
+		);
+	}
+	if (authState === 'unauthenticated') {
+		return (
+			<CenterMsg
+				icon={<LogIn size={28} color="#58a6ff" />}
+				msg="Sign in with Discord to access the wizard."
+				cta={
+					<button
+						type="button"
+						onClick={() => void agents.signInWithDiscord()}
+						style={primaryBtn}>
+						Sign in with Discord
+					</button>
+				}
+			/>
+		);
+	}
+	if (authState === 'discord_reauth_required') {
+		return (
+			<CenterMsg
+				icon={<AlertTriangle size={28} color="#facc15" />}
+				msg="Discord session expired. Re-sign-in to continue."
+				cta={
+					<button
+						type="button"
+						onClick={() => void agents.signInWithDiscord()}
+						style={primaryBtn}>
+						Re-sign-in
+					</button>
+				}
+			/>
+		);
+	}
+
+	if (!selectedGuild) {
+		return (
+			<div
+				className="not-content"
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '1rem',
+				}}>
+				<ReactAgentGuildPicker title="Pick a guild to configure GitHub for" />
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.85rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					The wizard provisions per-guild Vault rows (
+					<code>github_pat:&lt;guild&gt;</code> +{' '}
+					<code>github_webhook:&lt;guild&gt;</code>) that any KBVE
+					agent (discordsh today, future PR-review / CI / chatops bots
+					later) can consume. Guild selection is shared across the
+					whole agents surface.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div
+			className="not-content"
+			style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+			<ReactAgentGuildPicker title="Configuring GitHub for" />
+			<WizardBody guild={selectedGuild} tokens={tokens} />
+		</div>
+	);
+}
+
+interface WizardBodyProps {
+	guild: DiscordGuild;
+	tokens: AgentTokenRow[];
+}
+
+function WizardBody({ guild, tokens }: WizardBodyProps) {
+	const existingWebhook = useMemo(
+		() => tokens.find((t) => t.service === WEBHOOK_SERVICE) ?? null,
+		[tokens],
+	);
+	const existingPat = useMemo(
+		() => tokens.find((t) => t.service === PAT_SERVICE) ?? null,
+		[tokens],
+	);
+
+	return (
+		<div
+			className="not-content"
+			style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+			<header
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.6rem',
+					padding: '0.75rem 1rem',
+					border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+					borderRadius: 12,
+					background: 'rgba(88,166,255,0.06)',
+				}}>
+				<Webhook size={20} color="#58a6ff" />
+				<div>
+					<div style={{ fontWeight: 600 }}>GitHub provider setup</div>
+					<div
+						style={{
+							fontSize: '0.78rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+						}}>
+						Guild: {guild.name}
+						{' · '}
+						<code
+							style={{
+								fontFamily:
+									'var(--sl-font-mono, ui-monospace, monospace)',
+							}}>
+							{guild.id}
+						</code>
+					</div>
+				</div>
+			</header>
+
+			<Step1Webhook guild={guild} existing={existingWebhook} />
+			<Step2WebhookConfig guild={guild} hasWebhook={!!existingWebhook} />
+			<Step3Pat guildId={guild.id} existing={existingPat} />
+			<Step4SmokeBackfill
+				guildId={guild.id}
+				ready={!!existingWebhook && !!existingPat}
+			/>
+		</div>
+	);
+}
+
+function Step1Webhook({
+	guild,
+	existing,
+}: {
+	guild: DiscordGuild;
+	existing: AgentTokenRow | null;
+}) {
+	const agents = useAgents();
+	const draftsMap = useStore(agents.$webhookDrafts);
+	const savingMap = useStore(agents.$webhookSavingFor);
+	const errorsMap = useStore(agents.$webhookErrors);
+
+	const secret = draftsMap[guild.id] ?? null;
+	const busy = !!savingMap[guild.id];
+	const error = errorsMap[guild.id] ?? null;
+
+	const [reveal, setReveal] = useState(false);
+	const [copied, setCopied] = useState(false);
+
+	const stored = !!existing;
+
+	useEffect(() => {
+		setReveal(false);
+		setCopied(false);
+	}, [guild.id]);
+
+	async function generate() {
+		agents.setWebhookDraft(guild.id, genHex(32));
+		setReveal(true);
+		setCopied(false);
+		agents.clearWebhookError(guild.id);
+	}
+
+	async function save() {
+		if (!secret) return;
+		const r = await agents.saveWebhookDraft(
+			guild.id,
+			WEBHOOK_TOKEN_NAME,
+			`GitHub webhook HMAC for guild ${guild.id}`,
+		);
+		if (r.ok) setReveal(false);
+	}
+
+	async function copy() {
+		if (!secret) return;
+		const ok = await copyToClipboard(secret);
+		setCopied(ok);
+		if (ok) setTimeout(() => setCopied(false), 2500);
+	}
+
+	return (
+		<StepCard
+			n={1}
+			title="HMAC webhook secret"
+			status={stored ? 'done' : secret ? 'pending' : 'todo'}>
+			{stored ? (
+				<p style={mutedText}>
+					<CheckCircle2
+						size={14}
+						color="#4ade80"
+						style={{ verticalAlign: '-2px', marginRight: 6 }}
+					/>
+					Already stored as{' '}
+					<code>
+						{WEBHOOK_SERVICE}:{guild.id}
+					</code>{' '}
+					(token <code>{existing!.token_name}</code>). To rotate,
+					delete the existing row from the per-guild{' '}
+					<a href="/dashboard/agents/discordsh/">token list</a> and
+					run this wizard again.
+				</p>
+			) : (
+				<>
+					<p style={mutedText}>
+						Generate a random ≥32-char HMAC secret. The same value
+						goes into the GitHub webhook config in Step 2.
+					</p>
+					{!secret && (
+						<button
+							type="button"
+							onClick={generate}
+							style={primaryBtn}>
+							<Shuffle size={14} />
+							Generate 32-byte hex secret
+						</button>
+					)}
+					{secret && (
+						<>
+							<div
+								style={{
+									display: 'flex',
+									alignItems: 'stretch',
+									gap: '0.4rem',
+								}}>
+								<input
+									readOnly
+									type={reveal ? 'text' : 'password'}
+									value={secret}
+									style={{
+										...inputStyle,
+										fontFamily:
+											'var(--sl-font-mono, ui-monospace, monospace)',
+										flex: 1,
+									}}
+								/>
+								<button
+									type="button"
+									onClick={() => setReveal((r) => !r)}
+									style={iconBtn}
+									aria-label={reveal ? 'Hide' : 'Reveal'}>
+									{reveal ? (
+										<EyeOff size={14} />
+									) : (
+										<Eye size={14} />
+									)}
+								</button>
+								<button
+									type="button"
+									onClick={copy}
+									style={iconBtn}
+									aria-label="Copy">
+									<Copy size={14} />
+									{copied ? ' Copied' : ''}
+								</button>
+							</div>
+							<div
+								style={{
+									display: 'flex',
+									gap: '0.4rem',
+									flexWrap: 'wrap',
+								}}>
+								<button
+									type="button"
+									onClick={generate}
+									style={secondaryBtn}>
+									<Shuffle size={14} />
+									Regenerate
+								</button>
+								<button
+									type="button"
+									onClick={save}
+									disabled={busy}
+									title={
+										busy
+											? 'HMAC save in flight — wait for it to finish.'
+											: 'Store the generated HMAC secret as github_webhook in the vault.'
+									}
+									style={primaryBtn}>
+									{busy ? (
+										<Loader2 size={14} style={spinStyle} />
+									) : (
+										<CheckCircle2 size={14} />
+									)}
+									{busy ? 'Saving…' : 'Save to Vault'}
+								</button>
+							</div>
+						</>
+					)}
+					{error && <p style={errText}>{error}</p>}
+				</>
+			)}
+		</StepCard>
+	);
+}
+
+function Step2WebhookConfig({
+	guild,
+	hasWebhook,
+}: {
+	guild: DiscordGuild;
+	hasWebhook: boolean;
+}) {
+	const agents = useAgents();
+	const url = agents.webhookUrlFor(guild.id);
+	const allowlistMap = useStore(agents.$repoAllowlistDrafts);
+	const selectedMap = useStore(agents.$webhookInstallSelected);
+	const installBusyMap = useStore(agents.$webhookInstallBusyFor);
+	const installResultMap = useStore(agents.$webhookInstallResults);
+	const pingBusyMap = useStore(agents.$webhookPingBusyFor);
+	const pingResultMap = useStore(agents.$webhookPingResults);
+	const deliveriesMap = useStore(agents.$webhookDeliveries);
+	const deliveriesLoadingMap = useStore(agents.$webhookDeliveriesLoading);
+	const deliveriesErrorMap = useStore(agents.$webhookDeliveriesError);
+	const rotateBusyMap = useStore(agents.$webhookRotateBusyFor);
+	const rotateResultMap = useStore(agents.$webhookRotateResults);
+	const deleteBusyMap = useStore(agents.$webhookDeleteBusyFor);
+
+	const repos = allowlistMap[guild.id] ?? [];
+	const selectedRepo = selectedMap[guild.id] ?? repos[0] ?? '';
+	const installing = !!installBusyMap[guild.id];
+	const installResult = installResultMap[guild.id] ?? null;
+	const pinging = !!pingBusyMap[guild.id];
+	const pingResult = pingResultMap[guild.id] ?? null;
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!selectedMap[guild.id] && repos.length > 0) {
+			agents.setWebhookInstallSelected(guild.id, repos[0]);
+		}
+	}, [guild.id, repos, selectedMap]);
+
+	useEffect(() => {
+		if (!hasWebhook || !selectedRepo) return;
+		void agents.verifyWebhookInstall(guild.id, selectedRepo);
+	}, [guild.id, hasWebhook, selectedRepo]);
+
+	async function copy() {
+		const ok = await copyToClipboard(url);
+		setCopied(ok);
+		if (ok) setTimeout(() => setCopied(false), 2500);
+	}
+
+	const [actionBlockMsg, setActionBlockMsg] = useState<string | null>(null);
+
+	async function install() {
+		if (installing) return;
+		setActionBlockMsg(null);
+		if (!selectedRepo) {
+			setActionBlockMsg('Pick a repo from the dropdown first.');
+			return;
+		}
+		if (!hasWebhook) {
+			setActionBlockMsg(
+				'Finish Step 1 first — HMAC secret must be stored.',
+			);
+			return;
+		}
+		agents.setWebhookInstallSelected(guild.id, selectedRepo);
+		await agents.installWebhookForGuild(guild.id);
+	}
+
+	async function ping() {
+		if (pinging) return;
+		setActionBlockMsg(null);
+		if (!selectedRepo) {
+			setActionBlockMsg('Pick a repo from the dropdown first.');
+			return;
+		}
+		await agents.pingWebhookForGuild(guild.id);
+	}
+
+	const deliveriesKey = `${guild.id}:${selectedRepo}`;
+	const deliveries = deliveriesMap[deliveriesKey] ?? [];
+	const deliveriesLoading = !!deliveriesLoadingMap[deliveriesKey];
+	const deliveriesError = deliveriesErrorMap[deliveriesKey] ?? null;
+	const rotating = !!rotateBusyMap[guild.id];
+	const rotateResult = rotateResultMap[guild.id] ?? null;
+	const deleting = !!deleteBusyMap[guild.id];
+	const [confirmDelete, setConfirmDelete] = useState(false);
+
+	useEffect(() => {
+		setConfirmDelete(false);
+	}, [guild.id, selectedRepo]);
+
+	async function refreshDeliveries() {
+		setActionBlockMsg(null);
+		if (!selectedRepo) {
+			setActionBlockMsg('Pick a repo from the dropdown first.');
+			return;
+		}
+		const [owner, repo] = selectedRepo.split('/');
+		if (!owner || !repo) {
+			setActionBlockMsg('Selected repo is malformed.');
+			return;
+		}
+		await agents.loadWebhookDeliveries(guild.id, owner, repo, 10);
+	}
+
+	async function rotate() {
+		if (rotating) return;
+		setActionBlockMsg(null);
+		if (!selectedRepo) {
+			setActionBlockMsg('Pick a repo from the dropdown first.');
+			return;
+		}
+		const [owner, repo] = selectedRepo.split('/');
+		if (!owner || !repo) {
+			setActionBlockMsg('Selected repo is malformed.');
+			return;
+		}
+		await agents.rotateWebhookForGuild(guild.id, owner, repo);
+	}
+
+	async function deleteHook() {
+		if (deleting) return;
+		setActionBlockMsg(null);
+		if (!selectedRepo) {
+			setActionBlockMsg('Pick a repo from the dropdown first.');
+			return;
+		}
+		if (!confirmDelete) {
+			setConfirmDelete(true);
+			return;
+		}
+		const [owner, repo] = selectedRepo.split('/');
+		if (!owner || !repo) {
+			setActionBlockMsg('Selected repo is malformed.');
+			return;
+		}
+		await agents.deleteWebhookForGuild(guild.id, owner, repo);
+		setConfirmDelete(false);
+	}
+
+	const installedOk =
+		!!installResult &&
+		installResult.ok &&
+		(installResult.installed || installResult.alreadyPresent);
+	const step2Status: StepStatus = !hasWebhook
+		? 'todo'
+		: installedOk
+			? 'done'
+			: 'pending';
+
+	return (
+		<StepCard
+			n={2}
+			title="Configure the GitHub webhook"
+			status={step2Status}
+			disabled={!hasWebhook}>
+			<p style={mutedText}>
+				Copy the per-guild webhook URL, then create a new webhook on the
+				GitHub repository you want to mirror. Use the HMAC secret from
+				Step 1 as the webhook Secret field.
+			</p>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'stretch',
+					gap: '0.4rem',
+				}}>
+				<input
+					readOnly
+					value={url}
+					style={{
+						...inputStyle,
+						fontFamily:
+							'var(--sl-font-mono, ui-monospace, monospace)',
+						flex: 1,
+					}}
+				/>
+				<button
+					type="button"
+					onClick={copy}
+					style={iconBtn}
+					aria-label="Copy URL">
+					<Copy size={14} />
+					{copied ? ' Copied' : ''}
+				</button>
+			</div>
+			<ol
+				style={{
+					margin: '0.6rem 0 0 1.1rem',
+					padding: 0,
+					color: 'var(--sl-color-gray-2, #c2c5cc)',
+					fontSize: '0.88rem',
+					lineHeight: 1.6,
+				}}>
+				<li>
+					Open your repo on GitHub → Settings → Webhooks →{' '}
+					<em>Add webhook</em>.
+				</li>
+				<li>
+					<strong>Payload URL</strong>: paste the URL above.
+				</li>
+				<li>
+					<strong>Content type</strong>: <code>application/json</code>
+				</li>
+				<li>
+					<strong>Secret</strong>: paste the value you generated in
+					Step 1.
+				</li>
+				<li>
+					<strong>SSL verification</strong>: enable.
+				</li>
+				<li>
+					<strong>Which events</strong>: select{' '}
+					<em>Let me select individual events</em> and tick Issues,
+					Issue comments, Pull requests, Pull request reviews, Pull
+					request review comments. Leave everything else unticked.
+				</li>
+				<li>
+					Click <em>Add webhook</em>. GitHub will fire a{' '}
+					<code>ping</code> immediately; the function should respond
+					200 in under a second.
+				</li>
+			</ol>
+
+			<div
+				style={{
+					marginTop: '0.85rem',
+					padding: '0.75rem',
+					border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+					borderRadius: 8,
+					background: 'rgba(88,166,255,0.04)',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.5rem',
+				}}>
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: '0.4rem',
+					}}>
+					<strong style={{ fontSize: '0.85rem' }}>
+						Or auto-install via your PAT
+					</strong>
+				</div>
+				<p style={{ ...mutedText, fontSize: '0.82rem' }}>
+					Uses your stored GitHub PAT (Step 3 must be done first) to
+					POST <code>/repos/&lt;owner&gt;/&lt;repo&gt;/hooks</code>{' '}
+					with the URL and HMAC secret you just stored. Only repos in
+					your allowlist are eligible.
+				</p>
+				{repos.length === 0 ? (
+					<p style={{ ...mutedText, fontStyle: 'italic' }}>
+						Add at least one repo to the allowlist below before
+						auto-installing.
+					</p>
+				) : (
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'stretch',
+							gap: '0.4rem',
+							flexWrap: 'wrap',
+						}}>
+						<select
+							value={selectedRepo}
+							onChange={(e) =>
+								agents.setWebhookInstallSelected(
+									guild.id,
+									e.target.value,
+								)
+							}
+							disabled={installing}
+							style={{
+								...inputStyle,
+								fontFamily:
+									'var(--sl-font-mono, ui-monospace, monospace)',
+								flex: 1,
+								minWidth: 220,
+								width: 'auto',
+							}}>
+							{repos.map((r) => (
+								<option key={r} value={r}>
+									{r}
+								</option>
+							))}
+						</select>
+						<button
+							type="button"
+							onClick={() => void install()}
+							disabled={installing}
+							title={
+								installing
+									? 'Install in flight — wait for the GitHub API call to return.'
+									: 'POST /repos/<owner>/<repo>/hooks on GitHub using your stored PAT + HMAC.'
+							}
+							style={primaryBtn}>
+							{installing ? (
+								<Loader2 size={14} style={spinStyle} />
+							) : (
+								<CheckCircle2 size={14} />
+							)}
+							{installing
+								? 'Installing…'
+								: 'Install webhook on repo'}
+						</button>
+					</div>
+				)}
+				{actionBlockMsg && <p style={errText}>{actionBlockMsg}</p>}
+				{!hasWebhook && repos.length > 0 && (
+					<p style={{ ...mutedText, fontSize: '0.8rem' }}>
+						Finish Step 1 first — the HMAC row must exist in Vault
+						before gh-admin can read it.
+					</p>
+				)}
+				{installResult && !installResult.ok && (
+					<p style={errText}>{installResult.error}</p>
+				)}
+				{installResult && installResult.ok && (
+					<div
+						style={{
+							padding: '0.5rem 0.75rem',
+							borderRadius: 6,
+							background: 'rgba(74,222,128,0.08)',
+							border: '1px solid rgba(74,222,128,0.3)',
+							fontSize: '0.85rem',
+							lineHeight: 1.5,
+						}}>
+						<CheckCircle2
+							size={14}
+							color="#4ade80"
+							style={{ verticalAlign: '-2px', marginRight: 6 }}
+						/>
+						{installResult.alreadyPresent
+							? 'Webhook already present on this repo'
+							: 'Webhook installed'}
+						{installResult.hookId !== null && (
+							<>
+								{' · hook id '}
+								<code>{installResult.hookId}</code>
+							</>
+						)}
+					</div>
+				)}
+				{installResult && installResult.ok && hasWebhook && (
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: '0.5rem',
+							flexWrap: 'wrap',
+						}}>
+						<button
+							type="button"
+							onClick={() => void ping()}
+							disabled={pinging}
+							style={secondaryBtn}
+							title="Tells GitHub to redeliver a `ping` event to your gh-webhook URL. Server enforces 30s cooldown + 10 pings/hour per repo.">
+							{pinging ? (
+								<Loader2 size={14} style={spinStyle} />
+							) : (
+								<PlayCircle size={14} />
+							)}
+							{pinging ? 'Pinging…' : 'Send test ping'}
+						</button>
+						{pingResult && pingResult.ok && (
+							<span
+								style={{
+									fontSize: '0.82rem',
+									color: '#4ade80',
+								}}>
+								Ping sent · hook{' '}
+								<code>{pingResult.hookId}</code>. Check Recent
+								Deliveries on GitHub for the 200.
+							</span>
+						)}
+						{pingResult && !pingResult.ok && (
+							<span style={errText}>{pingResult.error}</span>
+						)}
+					</div>
+				)}
+				{installResult && installResult.ok && hasWebhook && (
+					<div
+						style={{
+							marginTop: '0.85rem',
+							padding: '0.75rem',
+							border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+							borderRadius: 8,
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '0.5rem',
+						}}>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								gap: '0.4rem',
+							}}>
+							<strong style={{ fontSize: '0.85rem' }}>
+								Recent deliveries
+							</strong>
+							<button
+								type="button"
+								onClick={() => void refreshDeliveries()}
+								disabled={deliveriesLoading}
+								style={{
+									...secondaryBtn,
+									marginLeft: 'auto',
+									padding: '0.25rem 0.5rem',
+									fontSize: '0.78rem',
+								}}>
+								{deliveriesLoading ? (
+									<Loader2 size={12} style={spinStyle} />
+								) : (
+									<RefreshCw size={12} />
+								)}
+								Refresh
+							</button>
+						</div>
+						{deliveriesError && (
+							<p style={errText}>{deliveriesError}</p>
+						)}
+						{!deliveriesError && deliveries.length === 0 && (
+							<p style={{ ...mutedText, fontStyle: 'italic' }}>
+								No deliveries fetched yet. Click Refresh to pull
+								the latest from GitHub.
+							</p>
+						)}
+						{deliveries.length > 0 && (
+							<ul
+								style={{
+									margin: 0,
+									padding: 0,
+									listStyle: 'none',
+									display: 'flex',
+									flexDirection: 'column',
+									gap: '0.2rem',
+								}}>
+								{deliveries.slice(0, 10).map((d) => {
+									const ok =
+										d.status_code >= 200 &&
+										d.status_code < 300;
+									return (
+										<li
+											key={d.id}
+											style={{
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'space-between',
+												padding: '0.3rem 0.5rem',
+												borderRadius: 6,
+												background: ok
+													? 'rgba(74,222,128,0.06)'
+													: 'rgba(239,68,68,0.06)',
+												border: ok
+													? '1px solid rgba(74,222,128,0.2)'
+													: '1px solid rgba(239,68,68,0.25)',
+												fontSize: '0.78rem',
+												gap: '0.5rem',
+											}}>
+											<code
+												style={{
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													color: ok
+														? '#4ade80'
+														: '#f87171',
+												}}>
+												{d.status_code}
+											</code>
+											<span
+												style={{
+													fontFamily:
+														'var(--sl-font-mono, ui-monospace, monospace)',
+													flex: 1,
+												}}>
+												{d.event}
+												{d.action ? `.${d.action}` : ''}
+												{d.redelivery
+													? ' (redeliver)'
+													: ''}
+											</span>
+											<span
+												style={{
+													color: 'var(--sl-color-gray-3, #9ca0aa)',
+												}}>
+												{new Date(
+													d.delivered_at,
+												).toLocaleTimeString()}
+											</span>
+										</li>
+									);
+								})}
+							</ul>
+						)}
+					</div>
+				)}
+				{installResult && installResult.ok && hasWebhook && (
+					<div
+						style={{
+							marginTop: '0.85rem',
+							padding: '0.75rem',
+							border: '1px solid rgba(239,68,68,0.25)',
+							borderRadius: 8,
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '0.5rem',
+						}}>
+						<strong style={{ fontSize: '0.85rem' }}>
+							Lifecycle
+						</strong>
+						<p style={{ ...mutedText, fontSize: '0.8rem' }}>
+							Rotate replaces the HMAC on GitHub + vault. Old
+							in-flight deliveries fail signature for a few
+							seconds. Delete removes the hook from GitHub but
+							leaves the vault HMAC row intact.
+						</p>
+						<div
+							style={{
+								display: 'flex',
+								gap: '0.4rem',
+								flexWrap: 'wrap',
+							}}>
+							<button
+								type="button"
+								onClick={() => void rotate()}
+								disabled={rotating}
+								title={
+									rotating
+										? 'Rotate in flight — wait for the GitHub PATCH + vault upsert to finish.'
+										: 'Generate a new HMAC secret, PATCH GitHub’s hook config, replace the vault row. Rate-limited 60s/5 per hour.'
+								}
+								style={secondaryBtn}>
+								{rotating ? (
+									<Loader2 size={14} style={spinStyle} />
+								) : (
+									<RefreshCw size={14} />
+								)}
+								{rotating ? 'Rotating…' : 'Rotate HMAC secret'}
+							</button>
+							<button
+								type="button"
+								onClick={() => void deleteHook()}
+								disabled={deleting}
+								title={
+									deleting
+										? 'Delete in flight — wait for the GitHub DELETE to return.'
+										: 'Remove the kbve hook from GitHub. Vault HMAC row stays so you can reinstall without rotating.'
+								}
+								style={{
+									...secondaryBtn,
+									color: '#f87171',
+									borderColor: 'rgba(239,68,68,0.4)',
+								}}>
+								{deleting ? (
+									<Loader2 size={14} style={spinStyle} />
+								) : (
+									<XCircle size={14} />
+								)}
+								{deleting
+									? 'Deleting…'
+									: confirmDelete
+										? 'Confirm delete?'
+										: 'Delete webhook'}
+							</button>
+						</div>
+						{rotateResult && rotateResult.ok && (
+							<span
+								style={{
+									fontSize: '0.82rem',
+									color: '#4ade80',
+								}}>
+								Rotated · hook{' '}
+								<code>{rotateResult.hookId}</code> updated. New
+								HMAC stored in vault.
+							</span>
+						)}
+						{rotateResult && !rotateResult.ok && (
+							<span style={errText}>{rotateResult.error}</span>
+						)}
+					</div>
+				)}
+			</div>
+		</StepCard>
+	);
+}
+
+function Step3Pat({
+	guildId,
+	existing,
+}: {
+	guildId: string;
+	existing: AgentTokenRow | null;
+}) {
+	const agents = useAgents();
+	const draftsMap = useStore(agents.$patDrafts);
+	const validatedMap = useStore(agents.$patValidatedFor);
+	const validatingMap = useStore(agents.$patValidatingFor);
+	const savingMap = useStore(agents.$patSavingFor);
+	const errorsMap = useStore(agents.$patErrors);
+
+	const validating = !!validatingMap[guildId];
+	const storing = !!savingMap[guildId];
+	const error = errorsMap[guildId] ?? null;
+	const validated = validatedMap[guildId] ?? null;
+	const draftPat = draftsMap[guildId] ?? '';
+
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const [hasInput, setHasInput] = useState<boolean>(draftPat.length > 0);
+
+	const stored = !!existing;
+
+	useEffect(() => {
+		if (!inputRef.current) return;
+		const snap = agents.$patDrafts.get()[guildId] ?? '';
+		if (inputRef.current.value !== snap) inputRef.current.value = snap;
+		setHasInput(snap.length > 0);
+	}, [guildId]);
+
+	function onPatBlur(_: FocusEvent<HTMLInputElement>) {
+		const v = inputRef.current?.value ?? '';
+		agents.setPatDraft(guildId, v);
+	}
+
+	function onPatInput() {
+		const v = inputRef.current?.value ?? '';
+		setHasInput(v.length > 0);
+	}
+
+	async function validate() {
+		const v = inputRef.current?.value ?? '';
+		agents.setPatDraft(guildId, v);
+		await agents.validatePatForGuild(guildId);
+	}
+
+	async function save() {
+		const v = inputRef.current?.value ?? '';
+		agents.setPatDraft(guildId, v);
+		const r = await agents.savePatForGuild(guildId, PAT_TOKEN_NAME);
+		if (r.ok && inputRef.current) inputRef.current.value = '';
+		if (r.ok) setHasInput(false);
+	}
+
+	return (
+		<StepCard
+			n={3}
+			title="GitHub PAT (for issue + comment reads)"
+			status={stored ? 'done' : validated ? 'pending' : 'todo'}>
+			{stored ? (
+				<p style={mutedText}>
+					<CheckCircle2
+						size={14}
+						color="#4ade80"
+						style={{ verticalAlign: '-2px', marginRight: 6 }}
+					/>
+					Already stored as <code>{PAT_SERVICE}</code> (token{' '}
+					<code>{existing!.token_name}</code>). Used by{' '}
+					<code>/gh claim</code>, <code>/github board</code>, and{' '}
+					<code>gh-backfill</code>.
+				</p>
+			) : (
+				<>
+					<p style={mutedText}>
+						Paste a GitHub fine-grained or classic PAT with at
+						minimum <code>public_repo</code> (read) or{' '}
+						<code>repo</code> scope on the repos you'll mirror. We
+						validate the token against GitHub's <code>/user</code>{' '}
+						endpoint before storing it.
+					</p>
+					<input
+						ref={inputRef}
+						type="password"
+						defaultValue={draftPat}
+						onBlur={onPatBlur}
+						onInput={onPatInput}
+						placeholder="ghp_… or github_pat_…"
+						style={{
+							...inputStyle,
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+						}}
+						autoComplete="off"
+						spellCheck={false}
+					/>
+					<div
+						style={{
+							display: 'flex',
+							gap: '0.4rem',
+							flexWrap: 'wrap',
+						}}>
+						<button
+							type="button"
+							onClick={validate}
+							disabled={validating}
+							title={
+								validating
+									? 'GitHub /user lookup in flight — wait for it to return.'
+									: 'Hit GitHub’s /user endpoint with the typed PAT to confirm it’s valid before storing.'
+							}
+							style={secondaryBtn}>
+							{validating ? (
+								<Loader2 size={14} style={spinStyle} />
+							) : (
+								<CheckCircle2 size={14} />
+							)}
+							{validating ? 'Validating…' : 'Validate'}
+						</button>
+						{validated && (
+							<button
+								type="button"
+								onClick={save}
+								disabled={storing}
+								title={
+									storing
+										? 'PAT save in flight — wait for the vault upsert to finish.'
+										: 'Store the validated PAT as `github` in the per-guild vault.'
+								}
+								style={primaryBtn}>
+								{storing ? (
+									<Loader2 size={14} style={spinStyle} />
+								) : (
+									<CheckCircle2 size={14} />
+								)}
+								{storing ? 'Saving…' : 'Save to Vault'}
+							</button>
+						)}
+					</div>
+					{validated && (
+						<div
+							style={{
+								padding: '0.5rem 0.75rem',
+								borderRadius: 6,
+								background: 'rgba(74,222,128,0.08)',
+								border: '1px solid rgba(74,222,128,0.3)',
+								fontSize: '0.85rem',
+								lineHeight: 1.5,
+							}}>
+							<div>
+								<strong>Login</strong>:{' '}
+								<code>{validated.login}</code>
+							</div>
+							<div>
+								<strong>Token type</strong>:{' '}
+								<code>{validated.tokenType}</code>
+							</div>
+							<div>
+								<strong>Scopes</strong>:{' '}
+								{validated.scopes.length === 0 ? (
+									<em>
+										(none reported — fine-grained PATs don't
+										surface scopes via this header)
+									</em>
+								) : (
+									validated.scopes.map((s) => (
+										<code
+											key={s}
+											style={{
+												marginRight: 4,
+												padding: '0 0.3rem',
+												borderRadius: 4,
+												background:
+													'rgba(255,255,255,0.06)',
+											}}>
+											{s}
+										</code>
+									))
+								)}
+							</div>
+						</div>
+					)}
+					{error && <p style={errText}>{error}</p>}
+				</>
+			)}
+		</StepCard>
+	);
+}
+
+function Step4SmokeBackfill({
+	guildId,
+	ready,
+}: {
+	guildId: string;
+	ready: boolean;
+}) {
+	const agents = useAgents();
+	const draftsMap = useStore(agents.$backfillDrafts);
+	const busyMap = useStore(agents.$backfillBusyFor);
+	const resultsMap = useStore(agents.$backfillResults);
+
+	const draft = draftsMap[guildId] ?? { owner: '', repo: '' };
+	const busy = !!busyMap[guildId];
+	const result = resultsMap[guildId] ?? null;
+
+	const ownerRef = useRef<HTMLInputElement | null>(null);
+	const repoRef = useRef<HTMLInputElement | null>(null);
+	const [draftValid, setDraftValid] = useState<boolean>(
+		GITHUB_OWNER_RE.test(draft.owner) && GITHUB_REPO_RE.test(draft.repo),
+	);
+
+	useEffect(() => {
+		const snap = agents.$backfillDrafts.get()[guildId] ?? {
+			owner: '',
+			repo: '',
+		};
+		if (ownerRef.current && ownerRef.current.value !== snap.owner) {
+			ownerRef.current.value = snap.owner;
+		}
+		if (repoRef.current && repoRef.current.value !== snap.repo) {
+			repoRef.current.value = snap.repo;
+		}
+		setDraftValid(
+			GITHUB_OWNER_RE.test(snap.owner) && GITHUB_REPO_RE.test(snap.repo),
+		);
+	}, [guildId]);
+
+	function refreshValid() {
+		const o = ownerRef.current?.value ?? '';
+		const r = repoRef.current?.value ?? '';
+		setDraftValid(GITHUB_OWNER_RE.test(o) && GITHUB_REPO_RE.test(r));
+	}
+
+	function commitOwner() {
+		agents.patchBackfillDraft(guildId, {
+			owner: ownerRef.current?.value ?? '',
+		});
+		refreshValid();
+	}
+
+	function commitRepo() {
+		agents.patchBackfillDraft(guildId, {
+			repo: repoRef.current?.value ?? '',
+		});
+		refreshValid();
+	}
+
+	const canRun = ready && draftValid && !busy;
+	const [runBlockMsg, setRunBlockMsg] = useState<string | null>(null);
+
+	async function run() {
+		if (busy) return;
+		const o = ownerRef.current?.value.trim() ?? '';
+		const r = repoRef.current?.value.trim() ?? '';
+		setRunBlockMsg(null);
+		if (!ready) {
+			setRunBlockMsg(
+				'Finish Steps 1 + 3 first — HMAC secret and PAT must be stored before the smoke can run.',
+			);
+			return;
+		}
+		if (!GITHUB_OWNER_RE.test(o) || !GITHUB_REPO_RE.test(r)) {
+			setRunBlockMsg('Enter a valid owner + repo (alphanumerics, ._-).');
+			if (!GITHUB_OWNER_RE.test(o)) ownerRef.current?.focus();
+			else repoRef.current?.focus();
+			return;
+		}
+		agents.patchBackfillDraft(guildId, { owner: o, repo: r });
+		await agents.runBackfillForGuild(guildId);
+	}
+
+	return (
+		<StepCard
+			n={4}
+			title="Smoke-test the backfill"
+			status={result?.ok ? 'done' : ready ? 'pending' : 'todo'}
+			disabled={!ready}>
+			<p style={mutedText}>
+				Calls <code>gh-backfill</code> against the repo you'll mirror
+				with <code>state=open</code> and <code>max_pages=1</code>.
+				Verifies the PAT, the per-guild Vault lookup, and the{' '}
+				<code>gh.upsert_issue</code> RPC end to end.
+			</p>
+			<div
+				style={{
+					display: 'grid',
+					gridTemplateColumns: '1fr 1fr',
+					gap: '0.4rem',
+				}}>
+				<input
+					ref={ownerRef}
+					placeholder="owner (e.g. KBVE)"
+					defaultValue={draft.owner}
+					onBlur={commitOwner}
+					onInput={refreshValid}
+					style={inputStyle}
+					spellCheck={false}
+					autoComplete="off"
+				/>
+				<input
+					ref={repoRef}
+					placeholder="repo (e.g. kbve)"
+					defaultValue={draft.repo}
+					onBlur={commitRepo}
+					onInput={refreshValid}
+					style={inputStyle}
+					spellCheck={false}
+					autoComplete="off"
+				/>
+			</div>
+			<button
+				type="button"
+				onClick={run}
+				disabled={busy}
+				title={
+					busy
+						? 'Smoke run in flight — wait for gh-backfill to finish.'
+						: 'Calls gh-backfill against the typed owner/repo with state=open + max_pages=1. Server rate-limits 15s cooldown / 20 per hour per guild.'
+				}
+				style={primaryBtn}>
+				{busy ? (
+					<Loader2 size={14} style={spinStyle} />
+				) : (
+					<PlayCircle size={14} />
+				)}
+				{busy ? 'Running…' : 'Run smoke test'}
+			</button>
+			{runBlockMsg && <p style={errText}>{runBlockMsg}</p>}
+			{result && !result.ok && <p style={errText}>{result.error}</p>}
+			{result && result.ok && (
+				<div
+					style={{
+						padding: '0.5rem 0.75rem',
+						borderRadius: 6,
+						background: 'rgba(74,222,128,0.08)',
+						border: '1px solid rgba(74,222,128,0.3)',
+						fontSize: '0.85rem',
+						lineHeight: 1.5,
+					}}>
+					<div>
+						<CheckCircle2
+							size={14}
+							color="#4ade80"
+							style={{ verticalAlign: '-2px', marginRight: 6 }}
+						/>
+						Upserted <strong>{result.upserted}</strong> issue rows
+						across <strong>{result.pages}</strong> page(s).
+					</div>
+					{typeof result.rateLimitRemaining === 'number' && (
+						<div
+							style={{
+								color: 'var(--sl-color-gray-3, #9ca0aa)',
+							}}>
+							GitHub API rate limit remaining:{' '}
+							{result.rateLimitRemaining}
+						</div>
+					)}
+					<div style={{ marginTop: '0.35rem' }}>
+						<a
+							href={`https://github.com/${draft.owner}/${draft.repo}/settings/hooks`}
+							target="_blank"
+							rel="noopener">
+							<ExternalLink
+								size={12}
+								style={{ verticalAlign: '-2px' }}
+							/>{' '}
+							Open repo webhook settings
+						</a>
+					</div>
+				</div>
+			)}
+		</StepCard>
+	);
+}
+
+type StepStatus = 'todo' | 'pending' | 'done';
+
+function StepCard({
+	n,
+	title,
+	status,
+	disabled,
+	children,
+}: {
+	n: number;
+	title: string;
+	status: StepStatus;
+	disabled?: boolean;
+	children: React.ReactNode;
+}) {
+	const palette = {
+		todo: { bg: 'rgba(148,163,184,0.12)', fg: '#94a3b8' },
+		pending: { bg: 'rgba(251,191,36,0.12)', fg: '#fbbf24' },
+		done: { bg: 'rgba(74,222,128,0.12)', fg: '#4ade80' },
+	}[status];
+
+	return (
+		<section
+			style={{
+				...styles.sectionBorder,
+				opacity: disabled ? 0.65 : 1,
+			}}>
+			<header
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.6rem',
+					padding: '0.7rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+				}}>
+				<span
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						width: 26,
+						height: 26,
+						borderRadius: 999,
+						background: palette.bg,
+						color: palette.fg,
+						fontSize: '0.78rem',
+						fontWeight: 700,
+					}}>
+					{n}
+				</span>
+				<strong style={{ flex: 1 }}>{title}</strong>
+				<span
+					style={{
+						fontSize: '0.72rem',
+						padding: '0.15rem 0.5rem',
+						borderRadius: 999,
+						background: palette.bg,
+						color: palette.fg,
+						textTransform: 'uppercase',
+						letterSpacing: '0.04em',
+						fontWeight: 600,
+					}}>
+					{status}
+				</span>
+			</header>
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.6rem',
+				}}>
+				{children}
+			</div>
+		</section>
+	);
+}
+
+function CenterMsg({
+	icon,
+	msg,
+	cta,
+}: {
+	icon: React.ReactNode;
+	msg: string;
+	cta?: React.ReactNode;
+}) {
+	return (
+		<div className="not-content" style={styles.fullCenter}>
+			<div style={styles.iconBadge('#58a6ff')}>{icon}</div>
+			<p
+				style={{
+					color: 'var(--sl-color-gray-3, #9ca0aa)',
+					maxWidth: 480,
+					margin: '0.5rem 0',
+				}}>
+				{msg}
+			</p>
+			{cta && <div style={{ marginTop: '0.5rem' }}>{cta}</div>}
+		</div>
+	);
+}
+
+const spinStyle: React.CSSProperties = {
+	animation: 'spin 1s linear infinite',
+	color: 'var(--sl-color-accent, #58a6ff)',
+};
+
+const mutedText: React.CSSProperties = {
+	margin: 0,
+	fontSize: '0.88rem',
+	color: 'var(--sl-color-gray-2, #c2c5cc)',
+	lineHeight: 1.55,
+};
+
+const errText: React.CSSProperties = {
+	margin: 0,
+	color: '#f87171',
+	fontSize: '0.85rem',
+};
+
+const inputStyle: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	width: '100%',
+	boxSizing: 'border-box',
+};
+
+const primaryBtn: React.CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.4rem',
+	padding: '0.45rem 0.9rem',
+	borderRadius: 8,
+	border: 'none',
+	background: '#58a6ff',
+	color: '#0d1117',
+	fontWeight: 600,
+	cursor: 'pointer',
+};
+
+const secondaryBtn: React.CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.4rem',
+	padding: '0.45rem 0.9rem',
+	borderRadius: 8,
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	background: 'transparent',
+	color: 'var(--sl-color-white, #fff)',
+	cursor: 'pointer',
+};
+
+const iconBtn: React.CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	gap: '0.25rem',
+	padding: '0.35rem 0.55rem',
+	borderRadius: 6,
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	background: 'transparent',
+	color: 'var(--sl-color-white, #fff)',
+	cursor: 'pointer',
+	fontSize: '0.78rem',
+};

--- a/packages/npm/astro/src/agents/ReactAgentGithubWizard.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentGithubWizard.tsx
@@ -226,6 +226,12 @@ function Step1Webhook({
 		setCopied(false);
 	}, [guild.id]);
 
+	useEffect(() => {
+		if (!copied) return;
+		const t = setTimeout(() => setCopied(false), 2500);
+		return () => clearTimeout(t);
+	}, [copied]);
+
 	async function generate() {
 		agents.setWebhookDraft(guild.id, genHex(32));
 		setReveal(true);
@@ -247,7 +253,6 @@ function Step1Webhook({
 		if (!secret) return;
 		const ok = await copyToClipboard(secret);
 		setCopied(ok);
-		if (ok) setTimeout(() => setCopied(false), 2500);
 	}
 
 	return (
@@ -406,10 +411,15 @@ function Step2WebhookConfig({
 		void agents.verifyWebhookInstall(guild.id, selectedRepo);
 	}, [guild.id, hasWebhook, selectedRepo]);
 
+	useEffect(() => {
+		if (!copied) return;
+		const t = setTimeout(() => setCopied(false), 2500);
+		return () => clearTimeout(t);
+	}, [copied]);
+
 	async function copy() {
 		const ok = await copyToClipboard(url);
 		setCopied(ok);
-		if (ok) setTimeout(() => setCopied(false), 2500);
 	}
 
 	const [actionBlockMsg, setActionBlockMsg] = useState<string | null>(null);

--- a/packages/npm/astro/src/agents/ReactAgentGuildPicker.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentGuildPicker.tsx
@@ -1,0 +1,239 @@
+import { useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { Loader2, RefreshCw, Users } from 'lucide-react';
+import { useAgents } from './context';
+import type { DiscordGuild } from '@kbve/droid';
+import { styles } from '../dashboard/dashboard-ui';
+
+const DISCORD_CDN = 'https://cdn.discordapp.com';
+
+function guildIconUrl(guild: DiscordGuild): string | null {
+	if (!guild.icon) return null;
+	return `${DISCORD_CDN}/icons/${guild.id}/${guild.icon}.png?size=64`;
+}
+
+function initials(name: string): string {
+	return name
+		.split(/\s+/)
+		.map((s) => s[0])
+		.filter(Boolean)
+		.slice(0, 2)
+		.join('')
+		.toUpperCase();
+}
+
+interface GuildPickerProps {
+	title?: string;
+}
+
+export default function ReactAgentGuildPicker({
+	title = 'Discord guilds you own',
+}: GuildPickerProps) {
+	const agents = useAgents();
+	const guilds = useStore(agents.$guilds);
+	const loading = useStore(agents.$guildsLoading);
+	const error = useStore(agents.$guildsError);
+	const selectedGuildId = useStore(agents.$selectedGuildId);
+
+	const [resyncing, setResyncing] = useState(false);
+	const [resyncMsg, setResyncMsg] = useState<{
+		kind: 'ok' | 'err';
+		text: string;
+	} | null>(null);
+
+	async function resync() {
+		if (resyncing) return;
+		setResyncing(true);
+		setResyncMsg(null);
+		const ok = await agents.resyncOwnedGuilds();
+		await agents.loadOwnedGuilds(true);
+		setResyncing(false);
+		setResyncMsg(
+			ok
+				? {
+						kind: 'ok',
+						text: 'Discord guilds refreshed. New servers should now be eligible.',
+					}
+				: {
+						kind: 'err',
+						text: 'Resync failed — try signing out and back in if the issue persists.',
+					},
+		);
+		setTimeout(() => setResyncMsg(null), 5000);
+	}
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<Users size={18} color="#58a6ff" />
+				<strong>{title}</strong>
+				{loading && (
+					<Loader2
+						size={14}
+						style={{
+							animation: 'spin 1s linear infinite',
+							marginLeft: '0.5rem',
+						}}
+					/>
+				)}
+				<button
+					type="button"
+					onClick={() => void resync()}
+					disabled={resyncing}
+					style={{
+						marginLeft: 'auto',
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+						padding: '0.3rem 0.6rem',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+						background: 'transparent',
+						color: 'var(--sl-color-white, #fff)',
+						cursor: resyncing ? 'wait' : 'pointer',
+						fontSize: '0.78rem',
+					}}
+					title="Re-fetch your owned Discord guilds + refresh the dashboard's session token so newly added servers become eligible without signing out.">
+					{resyncing ? (
+						<Loader2
+							size={12}
+							style={{ animation: 'spin 1s linear infinite' }}
+						/>
+					) : (
+						<RefreshCw size={12} />
+					)}
+					{resyncing ? 'Resyncing…' : 'Resync guilds'}
+				</button>
+			</header>
+
+			<div style={{ padding: '0.85rem 1rem' }}>
+				{resyncMsg && (
+					<p
+						style={{
+							color:
+								resyncMsg.kind === 'ok' ? '#4ade80' : '#f87171',
+							fontSize: '0.82rem',
+							margin: '0 0 0.5rem',
+						}}>
+						{resyncMsg.text}
+					</p>
+				)}
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+				{!error && !loading && guilds.length === 0 && (
+					<p
+						style={{
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+							margin: 0,
+						}}>
+						You don't own any Discord guilds. Only guild owners can
+						manage bot integration tokens.
+					</p>
+				)}
+				{guilds.length > 0 && (
+					<div
+						style={{
+							display: 'grid',
+							gridTemplateColumns:
+								'repeat(auto-fill, minmax(220px, 1fr))',
+							gap: '0.6rem',
+						}}>
+						{guilds.map((g) => {
+							const iconUrl = guildIconUrl(g);
+							const active = selectedGuildId === g.id;
+							return (
+								<button
+									key={g.id}
+									type="button"
+									onClick={() => agents.selectGuild(g.id)}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: '0.65rem',
+										padding: '0.6rem 0.75rem',
+										borderRadius: 10,
+										border: `1px solid ${active ? '#58a6ff' : 'var(--sl-color-gray-5, #2d2f36)'}`,
+										background: active
+											? 'rgba(88,166,255,0.08)'
+											: 'transparent',
+										color: 'var(--sl-color-white, #fff)',
+										cursor: 'pointer',
+										textAlign: 'left',
+										transition:
+											'border-color 0.15s ease, background 0.15s ease',
+									}}>
+									{iconUrl ? (
+										<img
+											src={iconUrl}
+											alt=""
+											width={36}
+											height={36}
+											style={{
+												borderRadius: 8,
+												flexShrink: 0,
+											}}
+										/>
+									) : (
+										<div
+											aria-hidden
+											style={{
+												width: 36,
+												height: 36,
+												borderRadius: 8,
+												background: '#374151',
+												color: '#e5e7eb',
+												display: 'flex',
+												alignItems: 'center',
+												justifyContent: 'center',
+												fontWeight: 700,
+												fontSize: '0.8rem',
+												flexShrink: 0,
+											}}>
+											{initials(g.name)}
+										</div>
+									)}
+									<div style={{ minWidth: 0 }}>
+										<div
+											style={{
+												fontWeight: 600,
+												overflow: 'hidden',
+												textOverflow: 'ellipsis',
+												whiteSpace: 'nowrap',
+											}}>
+											{g.name}
+										</div>
+										<div
+											style={{
+												fontSize: '0.7rem',
+												color: 'var(--sl-color-gray-3, #9ca0aa)',
+												fontFamily:
+													'var(--sl-font-mono, ui-monospace, monospace)',
+											}}>
+											{g.id}
+										</div>
+									</div>
+								</button>
+							);
+						})}
+					</div>
+				)}
+			</div>
+		</section>
+	);
+}

--- a/packages/npm/astro/src/agents/ReactAgentGuildPicker.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentGuildPicker.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import { Loader2, RefreshCw, Users } from 'lucide-react';
 import { useAgents } from './context';
@@ -41,6 +41,12 @@ export default function ReactAgentGuildPicker({
 		text: string;
 	} | null>(null);
 
+	useEffect(() => {
+		if (!resyncMsg) return;
+		const t = setTimeout(() => setResyncMsg(null), 5000);
+		return () => clearTimeout(t);
+	}, [resyncMsg]);
+
 	async function resync() {
 		if (resyncing) return;
 		setResyncing(true);
@@ -59,7 +65,6 @@ export default function ReactAgentGuildPicker({
 						text: 'Resync failed — try signing out and back in if the issue persists.',
 					},
 		);
-		setTimeout(() => setResyncMsg(null), 5000);
 	}
 
 	return (

--- a/packages/npm/astro/src/agents/ReactAgentRepoAllowlist.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentRepoAllowlist.tsx
@@ -1,0 +1,362 @@
+import {
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type FormEvent,
+} from 'react';
+import { useStore } from '@nanostores/react';
+import { GitBranch, Loader2, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { useAgents } from './context';
+import { styles } from '../dashboard/dashboard-ui';
+
+const REPO_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}\/[A-Za-z0-9._-]{1,100}$/;
+
+export default function ReactAgentRepoAllowlist() {
+	const agents = useAgents();
+	const guildId = useStore(agents.$selectedGuildId);
+	const guilds = useStore(agents.$guilds);
+	const draftsMap = useStore(agents.$repoAllowlistDrafts);
+	const savingMap = useStore(agents.$repoAllowlistSavingFor);
+	const errorsMap = useStore(agents.$repoAllowlistErrors);
+	const loadedMap = useStore(agents.$repoAllowlistLoadedFor);
+
+	const [loading, setLoading] = useState(false);
+	const [draftValid, setDraftValid] = useState(false);
+	const [draftRaw, setDraftRaw] = useState('');
+	const [blockMsg, setBlockMsg] = useState<string | null>(null);
+	const draftRef = useRef<HTMLInputElement | null>(null);
+
+	const repos = guildId ? (draftsMap[guildId] ?? []) : [];
+	const saving = guildId ? !!savingMap[guildId] : false;
+	const error = guildId ? (errorsMap[guildId] ?? null) : null;
+	const loaded = guildId ? !!loadedMap[guildId] : false;
+
+	const load = useCallback(
+		async (force = false) => {
+			if (!guildId) return;
+			setLoading(true);
+			await agents.ensureRepoAllowlistLoaded(guildId, force);
+			setLoading(false);
+		},
+		[guildId],
+	);
+
+	useEffect(() => {
+		if (guildId && !loaded) {
+			void load();
+		}
+	}, [guildId, loaded, load]);
+
+	useEffect(() => {
+		if (draftRef.current) draftRef.current.value = '';
+		setDraftRaw('');
+		setDraftValid(false);
+	}, [guildId]);
+
+	function onDraftInput() {
+		const v = draftRef.current?.value ?? '';
+		setDraftRaw(v);
+		setDraftValid(REPO_RE.test(v) && !repos.includes(v));
+	}
+
+	if (!guildId) {
+		return (
+			<section style={styles.sectionBorder}>
+				<div style={{ padding: '0.85rem 1rem' }}>
+					<p
+						style={{
+							margin: 0,
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontSize: '0.9rem',
+						}}>
+						Pick a guild above to manage its repo allowlist.
+					</p>
+				</div>
+			</section>
+		);
+	}
+
+	const guild = guilds.find((g) => g.id === guildId);
+	const draftOk = draftValid && !saving;
+
+	async function add(e?: FormEvent<HTMLFormElement>) {
+		e?.preventDefault();
+		if (!guildId || saving) return;
+		setBlockMsg(null);
+		const v = draftRef.current?.value?.trim() ?? '';
+		if (!v) {
+			setBlockMsg('Type owner/repo first.');
+			draftRef.current?.focus();
+			return;
+		}
+		if (!REPO_RE.test(v)) {
+			setBlockMsg('Expected owner/repo matching GitHub name rules.');
+			draftRef.current?.focus();
+			return;
+		}
+		if (repos.includes(v)) {
+			setBlockMsg(`${v} is already in the allowlist.`);
+			return;
+		}
+		const prev = repos;
+		const next = [...repos, v];
+		agents.patchRepoAllowlistDraft(guildId, next);
+		const r = await agents.saveRepoAllowlistDraft(guildId);
+		if (r.ok) {
+			if (draftRef.current) draftRef.current.value = '';
+			setDraftRaw('');
+			setDraftValid(false);
+		} else {
+			agents.patchRepoAllowlistDraft(guildId, prev);
+		}
+	}
+
+	async function remove(repo: string) {
+		if (!guildId || saving) return;
+		const prev = repos;
+		const next = repos.filter((r) => r !== repo);
+		agents.patchRepoAllowlistDraft(guildId, next);
+		const r = await agents.saveRepoAllowlistDraft(guildId);
+		if (!r.ok) {
+			agents.patchRepoAllowlistDraft(guildId, prev);
+		}
+	}
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+				}}>
+				<GitBranch size={18} color="#34d399" />
+				<strong>Repo allowlist</strong>
+				{guild && (
+					<span
+						style={{
+							marginLeft: '0.4rem',
+							fontSize: '0.75rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+						}}>
+						{guild.id}
+					</span>
+				)}
+				<button
+					type="button"
+					onClick={() => void load(true)}
+					disabled={loading || saving}
+					style={refreshBtn(loading || saving)}
+					aria-label="Refresh">
+					<RefreshCw
+						size={14}
+						style={loading ? spinIcon : undefined}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div
+				style={{
+					padding: '0.85rem 1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.65rem',
+				}}>
+				<p style={muted}>
+					Repos that gh-webhook will accept events for and that
+					gh-backfill defaults to. Stored as{' '}
+					<code>github_repos:&lt;guild&gt;</code> in Vault. Falls back
+					to the edge env <code>GH_WEBHOOK_ALLOWED_REPOS</code> when
+					no row is set.
+				</p>
+
+				{error && <p style={errText}>{error}</p>}
+
+				{!loading && repos.length === 0 && (
+					<p style={{ ...muted, fontStyle: 'italic' }}>
+						No repos in the allowlist yet. Add at least one for this
+						guild to receive webhook events.
+					</p>
+				)}
+
+				{repos.length > 0 && (
+					<ul
+						style={{
+							margin: 0,
+							padding: 0,
+							listStyle: 'none',
+							display: 'flex',
+							flexDirection: 'column',
+							gap: '0.3rem',
+						}}>
+						{repos.map((r) => (
+							<li
+								key={r}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									justifyContent: 'space-between',
+									padding: '0.4rem 0.6rem',
+									borderRadius: 6,
+									border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+									background: 'rgba(255,255,255,0.02)',
+								}}>
+								<code
+									style={{
+										fontFamily:
+											'var(--sl-font-mono, ui-monospace, monospace)',
+									}}>
+									{r}
+								</code>
+								<button
+									type="button"
+									onClick={() => void remove(r)}
+									disabled={saving}
+									title={
+										saving
+											? 'Allowlist save in flight — wait for it to finish.'
+											: `Drop ${r} from the allowlist. Reversible — just add it back.`
+									}
+									style={dangerSmallBtn(saving)}
+									aria-label={`Remove ${r}`}>
+									<Trash2 size={12} />
+									Remove
+								</button>
+							</li>
+						))}
+					</ul>
+				)}
+
+				<form
+					onSubmit={(e) => void add(e)}
+					autoComplete="off"
+					style={{
+						display: 'flex',
+						gap: '0.4rem',
+						alignItems: 'stretch',
+					}}>
+					<input
+						ref={draftRef}
+						type="text"
+						defaultValue=""
+						placeholder="owner/repo (e.g. KBVE/kbve)"
+						onInput={onDraftInput}
+						style={{
+							...inputStyle,
+							fontFamily:
+								'var(--sl-font-mono, ui-monospace, monospace)',
+							flex: 1,
+						}}
+						spellCheck={false}
+						autoComplete="off"
+					/>
+					<button
+						type="submit"
+						disabled={saving}
+						title={
+							saving
+								? 'Allowlist save in flight — wait for it to finish.'
+								: 'Add the typed owner/repo to this guild’s allowlist.'
+						}
+						style={primaryBtn(!saving)}>
+						{saving ? (
+							<Loader2 size={14} style={spinIcon} />
+						) : (
+							<Plus size={14} />
+						)}
+						{saving ? 'Saving…' : 'Add'}
+					</button>
+				</form>
+				{blockMsg && <p style={errText}>{blockMsg}</p>}
+				{!blockMsg &&
+					draftRaw.length > 0 &&
+					!REPO_RE.test(draftRaw) && (
+						<p style={errText}>
+							Expected <code>owner/repo</code> matching GitHub's
+							name rules.
+						</p>
+					)}
+			</div>
+		</section>
+	);
+}
+
+const muted: React.CSSProperties = {
+	margin: 0,
+	fontSize: '0.85rem',
+	color: 'var(--sl-color-gray-2, #c2c5cc)',
+	lineHeight: 1.5,
+};
+
+const errText: React.CSSProperties = {
+	margin: 0,
+	color: '#f87171',
+	fontSize: '0.82rem',
+};
+
+const inputStyle: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	boxSizing: 'border-box',
+};
+
+function primaryBtn(enabled: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+		padding: '0.45rem 0.9rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
+		color: '#0d1117',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		fontSize: '0.85rem',
+	};
+}
+
+function refreshBtn(busy: boolean): React.CSSProperties {
+	return {
+		marginLeft: 'auto',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.35rem',
+		padding: '0.3rem 0.6rem',
+		borderRadius: 6,
+		border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+		background: 'transparent',
+		color: 'var(--sl-color-white, #fff)',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.8rem',
+	};
+}
+
+function dangerSmallBtn(busy: boolean): React.CSSProperties {
+	return {
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.25rem',
+		padding: '0.25rem 0.5rem',
+		borderRadius: 6,
+		border: '1px solid rgba(239,68,68,0.4)',
+		background: 'transparent',
+		color: '#f87171',
+		cursor: busy ? 'wait' : 'pointer',
+		fontSize: '0.75rem',
+	};
+}
+
+const spinIcon: React.CSSProperties = {
+	animation: 'spin 1s linear infinite',
+};

--- a/packages/npm/astro/src/agents/ReactAgentSetupStatus.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentSetupStatus.tsx
@@ -1,0 +1,353 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	CheckCircle2,
+	Circle,
+	Loader2,
+	RefreshCw,
+	XCircle,
+} from 'lucide-react';
+import { useAgents } from './context';
+import type { DiscordshConfig, DiscordGuild } from '@kbve/droid';
+import { styles } from '../dashboard/dashboard-ui';
+
+const PAT_SERVICE = 'github';
+const WEBHOOK_SERVICE = 'github_webhook';
+
+type StepStatus = 'ok' | 'missing' | 'partial' | 'pending';
+
+interface StepRow {
+	id: string;
+	label: string;
+	status: StepStatus;
+	detail: string;
+	cta?: { label: string; href: string };
+}
+
+function statusIcon(status: StepStatus) {
+	if (status === 'ok') {
+		return <CheckCircle2 size={18} color="#4ade80" aria-label="complete" />;
+	}
+	if (status === 'partial') {
+		return <Circle size={18} color="#facc15" aria-label="partial" />;
+	}
+	if (status === 'pending') {
+		return (
+			<Loader2
+				size={18}
+				color="#94a3b8"
+				style={{ animation: 'spin 1s linear infinite' }}
+				aria-label="checking"
+			/>
+		);
+	}
+	return <XCircle size={18} color="#f87171" aria-label="missing" />;
+}
+
+function statusLabel(status: StepStatus): string {
+	if (status === 'ok') return 'Ready';
+	if (status === 'partial') return 'Partial';
+	if (status === 'pending') return 'Checking…';
+	return 'Missing';
+}
+
+function statusColor(status: StepStatus): string {
+	if (status === 'ok') return '#4ade80';
+	if (status === 'partial') return '#facc15';
+	if (status === 'pending') return '#94a3b8';
+	return '#f87171';
+}
+
+export default function ReactAgentSetupStatus() {
+	const agents = useAgents();
+	const guilds = useStore(agents.$guilds);
+	const selectedGuildId = useStore(agents.$selectedGuildId);
+	const tokens = useStore(agents.$tokens);
+	const tokensLoading = useStore(agents.$tokensLoading);
+
+	const [config, setConfig] = useState<DiscordshConfig | null>(null);
+	const [repoCount, setRepoCount] = useState<number | null>(null);
+	const [probeLoading, setProbeLoading] = useState(false);
+	const [probeError, setProbeError] = useState<string | null>(null);
+
+	const guild = useMemo<DiscordGuild | null>(
+		() => guilds.find((g) => g.id === selectedGuildId) ?? null,
+		[guilds, selectedGuildId],
+	);
+
+	async function probe() {
+		if (!selectedGuildId) return;
+		setProbeLoading(true);
+		setProbeError(null);
+		const [cfg, repos] = await Promise.all([
+			agents.getBotConfig(),
+			agents.getRepoAllowlist(),
+		]);
+		if (!cfg.ok) {
+			setProbeError(cfg.error);
+		} else {
+			setConfig(cfg.config);
+		}
+		if (repos.ok) {
+			setRepoCount(repos.repos.length);
+		} else {
+			setRepoCount(null);
+		}
+		setProbeLoading(false);
+	}
+
+	useEffect(() => {
+		setConfig(null);
+		setRepoCount(null);
+		if (selectedGuildId) void probe();
+	}, [selectedGuildId]);
+
+	if (!guild) return null;
+
+	const hasPat = tokens.some((t) => t.service === PAT_SERVICE && t.is_active);
+	const hasWebhook = tokens.some(
+		(t) => t.service === WEBHOOK_SERVICE && t.is_active,
+	);
+
+	const patStatus: StepStatus = tokensLoading
+		? 'pending'
+		: hasPat && hasWebhook
+			? 'ok'
+			: hasPat || hasWebhook
+				? 'partial'
+				: 'missing';
+
+	const reposStatus: StepStatus = probeLoading
+		? 'pending'
+		: (repoCount ?? 0) > 0
+			? 'ok'
+			: 'missing';
+
+	const forumId = config?.forum_channel_id?.trim();
+	const forumIdValid = !!forumId && /^\d{17,20}$/.test(forumId);
+	const forumStatus: StepStatus = probeLoading
+		? 'pending'
+		: forumIdValid
+			? 'ok'
+			: 'missing';
+
+	const activeStatus: StepStatus = probeLoading
+		? 'pending'
+		: config?.active === true
+			? 'ok'
+			: 'missing';
+
+	const allReady =
+		patStatus === 'ok' &&
+		reposStatus === 'ok' &&
+		forumStatus === 'ok' &&
+		activeStatus === 'ok';
+
+	const rows: StepRow[] = [
+		{
+			id: 'github',
+			label: '1. GitHub provider',
+			status: patStatus,
+			detail:
+				patStatus === 'ok'
+					? `PAT + webhook secret stored (${tokens.filter((t) => t.service === PAT_SERVICE || t.service === WEBHOOK_SERVICE).length} rows)`
+					: patStatus === 'partial'
+						? `Missing ${hasPat ? 'webhook secret' : 'PAT'} — finish the GitHub provider wizard`
+						: 'Run the GitHub provider wizard (generates webhook secret + PAT)',
+			cta: {
+				label: 'Open GitHub wizard',
+				href: '/dashboard/agents/github/',
+			},
+		},
+		{
+			id: 'repos',
+			label: '2. Repo allowlist',
+			status: reposStatus,
+			detail:
+				reposStatus === 'ok'
+					? `${repoCount} repo${repoCount === 1 ? '' : 's'} routed for ${guild.name}`
+					: 'Add at least one "owner/repo" entry below',
+		},
+		{
+			id: 'forum',
+			label: '3. Forum channel',
+			status: forumStatus,
+			detail: forumIdValid
+				? `Channel ${forumId} ready to receive issue threads`
+				: forumId
+					? 'forum_channel_id must be a Discord snowflake (17-20 digits)'
+					: 'Set forum_channel_id in the bot config below (right-click a forum channel → Copy Channel ID)',
+		},
+		{
+			id: 'active',
+			label: '4. Integration active',
+			status: activeStatus,
+			detail:
+				activeStatus === 'ok'
+					? 'Worker will route events for this guild on next refresh (≤ 5 min)'
+					: 'Flip the "active" toggle in the bot config — required even after channels are set',
+		},
+	];
+
+	return (
+		<section style={styles.sectionBorder}>
+			<header
+				style={{
+					padding: '0.85rem 1rem',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.6rem',
+				}}>
+				<div
+					style={{
+						width: 32,
+						height: 32,
+						borderRadius: 8,
+						background: allReady
+							? 'rgba(74,222,128,0.12)'
+							: 'rgba(250,204,21,0.12)',
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+					}}>
+					{allReady ? (
+						<CheckCircle2 size={18} color="#4ade80" />
+					) : (
+						<Circle size={18} color="#facc15" />
+					)}
+				</div>
+				<div style={{ flex: 1 }}>
+					<strong>Integration status — {guild.name}</strong>
+					<div
+						style={{
+							fontSize: '0.78rem',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+						}}>
+						{allReady
+							? 'Routed: GitHub events for the allowlisted repos will open new forum threads.'
+							: 'Finish each step below — the bot worker only routes events when all four are green.'}
+					</div>
+				</div>
+				<button
+					type="button"
+					onClick={() => void probe()}
+					disabled={probeLoading}
+					aria-label="Re-probe status"
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: '0.35rem',
+						padding: '0.3rem 0.6rem',
+						borderRadius: 6,
+						border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+						background: 'transparent',
+						color: 'var(--sl-color-white, #fff)',
+						cursor: probeLoading ? 'wait' : 'pointer',
+						fontSize: '0.78rem',
+					}}>
+					<RefreshCw
+						size={12}
+						style={
+							probeLoading
+								? { animation: 'spin 1s linear infinite' }
+								: undefined
+						}
+					/>
+					Refresh
+				</button>
+			</header>
+
+			<div style={{ padding: '0.5rem 0' }}>
+				{probeError && (
+					<p
+						style={{
+							margin: '0.5rem 1rem',
+							padding: '0.5rem 0.7rem',
+							borderRadius: 6,
+							background: 'rgba(248,113,113,0.1)',
+							color: '#f87171',
+							fontSize: '0.78rem',
+						}}>
+						Probe error: {probeError}
+					</p>
+				)}
+				<ul
+					style={{
+						listStyle: 'none',
+						margin: 0,
+						padding: 0,
+					}}>
+					{rows.map((r, i) => (
+						<li
+							key={r.id}
+							style={{
+								display: 'flex',
+								alignItems: 'flex-start',
+								gap: '0.7rem',
+								padding: '0.7rem 1rem',
+								borderTop:
+									i === 0
+										? 'none'
+										: '1px solid var(--sl-color-gray-5, #1f2024)',
+							}}>
+							<div style={{ paddingTop: 2 }}>
+								{statusIcon(r.status)}
+							</div>
+							<div style={{ flex: 1, minWidth: 0 }}>
+								<div
+									style={{
+										display: 'flex',
+										gap: '0.5rem',
+										alignItems: 'center',
+										marginBottom: 2,
+									}}>
+									<span
+										style={{
+											fontWeight: 600,
+											fontSize: '0.88rem',
+										}}>
+										{r.label}
+									</span>
+									<span
+										style={{
+											fontSize: '0.7rem',
+											padding: '0.05rem 0.45rem',
+											borderRadius: 999,
+											background: `${statusColor(r.status)}1f`,
+											color: statusColor(r.status),
+										}}>
+										{statusLabel(r.status)}
+									</span>
+								</div>
+								<div
+									style={{
+										fontSize: '0.78rem',
+										color: 'var(--sl-color-gray-3, #9ca0aa)',
+									}}>
+									{r.detail}
+								</div>
+							</div>
+							{r.cta && r.status !== 'ok' && (
+								<a
+									href={r.cta.href}
+									style={{
+										fontSize: '0.78rem',
+										padding: '0.3rem 0.6rem',
+										borderRadius: 6,
+										border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+										background: 'transparent',
+										color: 'var(--sl-color-accent, #58a6ff)',
+										textDecoration: 'none',
+										whiteSpace: 'nowrap',
+									}}>
+									{r.cta.label}
+								</a>
+							)}
+						</li>
+					))}
+				</ul>
+			</div>
+		</section>
+	);
+}

--- a/packages/npm/astro/src/agents/ReactAgentTokenModals.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentTokenModals.tsx
@@ -1,0 +1,562 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Loader2, RefreshCw, Shuffle, X } from 'lucide-react';
+import { useAgents } from './context';
+import type { AgentTokenRow } from '@kbve/droid';
+
+const TOKEN_NAME_RE = /^[a-z0-9_-]{3,64}$/;
+const SERVICE_RE = /^[a-z0-9_]{2,32}$/;
+
+const SERVICE_PRESETS: Array<{
+	value: string;
+	label: string;
+	hint?: string;
+}> = [
+	{
+		value: 'github',
+		label: 'github — PAT',
+		hint: 'GitHub personal access token. Used by /github board commands + /gh claim + gh-backfill.',
+	},
+	{
+		value: 'github_webhook',
+		label: 'github_webhook — HMAC',
+		hint: 'HMAC secret for the GitHub webhook delivery. Set the same value in your repo Settings → Webhooks → Secret.',
+	},
+	{
+		value: 'github_repos',
+		label: 'github_repos — repo allowlist (future)',
+		hint: 'Comma-separated owner/repo list for this guild. Used by P4 of the agents rollout.',
+	},
+	{
+		value: 'irc',
+		label: 'irc — bridge token',
+		hint: 'IRC gateway credential for this guild.',
+	},
+];
+
+interface BaseModalProps {
+	onClose: () => void;
+}
+
+function ModalShell({
+	children,
+	onClose,
+	title,
+}: BaseModalProps & { children: React.ReactNode; title: string }) {
+	const dialogRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		function onKey(e: KeyboardEvent) {
+			if (e.key === 'Escape') onClose();
+		}
+		document.addEventListener('keydown', onKey);
+		return () => document.removeEventListener('keydown', onKey);
+	}, [onClose]);
+
+	return (
+		<div
+			role="dialog"
+			aria-modal="true"
+			aria-label={title}
+			style={{
+				position: 'fixed',
+				inset: 0,
+				background: 'rgba(0,0,0,0.55)',
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				zIndex: 9999,
+				padding: '1rem',
+			}}
+			onClick={(e) => {
+				if (e.target === e.currentTarget) onClose();
+			}}>
+			<div
+				ref={dialogRef}
+				style={{
+					background: 'var(--sl-color-bg-nav, #0d1117)',
+					border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+					borderRadius: 12,
+					maxWidth: 560,
+					width: '100%',
+					maxHeight: '90vh',
+					overflowY: 'auto',
+					display: 'flex',
+					flexDirection: 'column',
+				}}>
+				<header
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						justifyContent: 'space-between',
+						padding: '0.85rem 1.1rem',
+						borderBottom:
+							'1px solid var(--sl-color-gray-5, #2d2f36)',
+					}}>
+					<h2 style={{ margin: 0, fontSize: '1rem' }}>{title}</h2>
+					<button
+						type="button"
+						onClick={onClose}
+						aria-label="Close"
+						style={{
+							background: 'transparent',
+							border: 'none',
+							color: 'var(--sl-color-gray-3, #9ca0aa)',
+							cursor: 'pointer',
+							padding: 4,
+						}}>
+						<X size={18} />
+					</button>
+				</header>
+				{children}
+			</div>
+		</div>
+	);
+}
+
+function genSecret(bytes = 32): string {
+	const arr = new Uint8Array(bytes);
+	crypto.getRandomValues(arr);
+	return Array.from(arr)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
+export function AddTokenModal({ onClose }: BaseModalProps) {
+	const agents = useAgents();
+	const [tokenName, setTokenName] = useState('');
+	const [service, setService] = useState('github_webhook');
+	const [tokenValue, setTokenValue] = useState('');
+	const [description, setDescription] = useState('');
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const preset = useMemo(
+		() => SERVICE_PRESETS.find((p) => p.value === service),
+		[service],
+	);
+
+	const nameOk = TOKEN_NAME_RE.test(tokenName);
+	const serviceOk = SERVICE_RE.test(service);
+	const valueOk = tokenValue.length >= 10 && tokenValue.length <= 8000;
+	const formValid = nameOk && serviceOk && valueOk && !busy;
+
+	async function submit(e: React.FormEvent) {
+		e.preventDefault();
+		if (busy) return;
+		setError(null);
+		if (!nameOk) {
+			setError(
+				'Token name must be 3–64 chars: lowercase a–z, 0–9, underscore, dash.',
+			);
+			return;
+		}
+		if (!serviceOk) {
+			setError(
+				'Service must be 2–32 chars: lowercase a–z, 0–9, underscore.',
+			);
+			return;
+		}
+		if (!valueOk) {
+			setError('Token value must be 10–8000 characters.');
+			return;
+		}
+		setBusy(true);
+		const r = await agents.addToken({
+			tokenName,
+			service,
+			tokenValue,
+			description: description.trim() || null,
+		});
+		setBusy(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		onClose();
+	}
+
+	return (
+		<ModalShell title="Add token" onClose={onClose}>
+			<form
+				onSubmit={submit}
+				style={{
+					padding: '1rem 1.1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<Field
+					label="Service"
+					hint={preset?.hint}
+					control={
+						<select
+							value={service}
+							onChange={(e) => setService(e.target.value)}
+							style={inputStyle}>
+							{SERVICE_PRESETS.map((p) => (
+								<option key={p.value} value={p.value}>
+									{p.label}
+								</option>
+							))}
+						</select>
+					}
+				/>
+
+				<Field
+					label="Token name"
+					hint="Friendly label for this row. 3–64 chars, lowercase a–z, 0–9, _ -"
+					error={
+						tokenName.length > 0 && !nameOk
+							? 'Must match ^[a-z0-9_-]{3,64}$'
+							: null
+					}
+					control={
+						<input
+							type="text"
+							value={tokenName}
+							placeholder={
+								service === 'github_webhook'
+									? 'github-webhook-hmac'
+									: 'github-pat'
+							}
+							onChange={(e) =>
+								setTokenName(e.target.value.toLowerCase())
+							}
+							style={inputStyle}
+							autoComplete="off"
+							spellCheck={false}
+						/>
+					}
+				/>
+
+				<Field
+					label="Token value"
+					hint="Stored encrypted in Supabase Vault. Never returned to the dashboard after submission."
+					error={
+						tokenValue.length > 0 && !valueOk
+							? 'Must be 10–8000 chars'
+							: null
+					}
+					control={
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: '0.4rem',
+							}}>
+							<textarea
+								value={tokenValue}
+								onChange={(e) => setTokenValue(e.target.value)}
+								rows={3}
+								spellCheck={false}
+								autoComplete="off"
+								style={{
+									...inputStyle,
+									fontFamily:
+										'var(--sl-font-mono, ui-monospace, monospace)',
+									resize: 'vertical',
+								}}
+							/>
+							{service === 'github_webhook' && (
+								<button
+									type="button"
+									onClick={() => setTokenValue(genSecret(32))}
+									style={smallButton}>
+									<Shuffle
+										size={14}
+										style={{ marginRight: 6 }}
+									/>
+									Generate random 32-byte hex
+								</button>
+							)}
+						</div>
+					}
+				/>
+
+				<Field
+					label="Description (optional)"
+					control={
+						<input
+							type="text"
+							value={description}
+							maxLength={256}
+							placeholder={
+								service === 'github_webhook'
+									? 'HMAC secret for KBVE/kbve webhook'
+									: ''
+							}
+							onChange={(e) => setDescription(e.target.value)}
+							style={inputStyle}
+						/>
+					}
+				/>
+
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '0.5rem',
+					}}>
+					<button
+						type="button"
+						onClick={onClose}
+						style={secondaryButton}>
+						Cancel
+					</button>
+					<button
+						type="submit"
+						disabled={busy}
+						title={
+							busy
+								? 'Vault upsert in flight — wait for it to finish.'
+								: 'Encrypt + store the token value into vault.secrets via discordsh.service_set_guild_token.'
+						}
+						style={primaryButton(!busy)}>
+						{busy ? (
+							<Loader2
+								size={14}
+								style={{ animation: 'spin 1s linear infinite' }}
+							/>
+						) : null}
+						{busy ? 'Saving…' : 'Save token'}
+					</button>
+				</div>
+			</form>
+		</ModalShell>
+	);
+}
+
+interface DeleteTokenModalProps extends BaseModalProps {
+	token: AgentTokenRow;
+}
+
+export function DeleteTokenModal({ token, onClose }: DeleteTokenModalProps) {
+	const agents = useAgents();
+	const [confirmText, setConfirmText] = useState('');
+	const [busy, setBusy] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	const match = confirmText === token.token_name;
+
+	async function submit() {
+		if (!match || busy) return;
+		setBusy(true);
+		setError(null);
+		const r = await agents.deleteToken(token.token_id);
+		setBusy(false);
+		if (!r.ok) {
+			setError(r.error);
+			return;
+		}
+		onClose();
+	}
+
+	return (
+		<ModalShell title="Delete token" onClose={onClose}>
+			<div
+				style={{
+					padding: '1rem 1.1rem',
+					display: 'flex',
+					flexDirection: 'column',
+					gap: '0.85rem',
+				}}>
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.9rem',
+						color: 'var(--sl-color-gray-2, #c2c5cc)',
+					}}>
+					This permanently removes the Vault row. The encrypted value
+					is destroyed and any service consuming this row stops
+					working immediately.
+				</p>
+				<p
+					style={{
+						margin: 0,
+						fontSize: '0.85rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					Type{' '}
+					<code
+						style={{
+							background: 'rgba(255,255,255,0.08)',
+							padding: '0 0.3rem',
+							borderRadius: 4,
+						}}>
+						{token.token_name}
+					</code>{' '}
+					to confirm.
+				</p>
+				<input
+					type="text"
+					value={confirmText}
+					onChange={(e) => setConfirmText(e.target.value)}
+					style={inputStyle}
+					autoComplete="off"
+					spellCheck={false}
+				/>
+				{error && (
+					<p
+						style={{
+							color: '#f87171',
+							fontSize: '0.85rem',
+							margin: 0,
+						}}>
+						{error}
+					</p>
+				)}
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'flex-end',
+						gap: '0.5rem',
+					}}>
+					<button
+						type="button"
+						onClick={onClose}
+						style={secondaryButton}>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={submit}
+						disabled={!match || busy}
+						title={
+							busy
+								? 'Vault delete in flight — wait for it to finish.'
+								: !match
+									? `Type the token name (${token.token_name}) to confirm. Safety gate prevents accidental clicks on irreversible deletes.`
+									: 'Permanently remove this vault row. Encrypted value is destroyed; downstream services using this token break immediately.'
+						}
+						style={dangerButton(match && !busy)}>
+						{busy ? (
+							<Loader2
+								size={14}
+								style={{ animation: 'spin 1s linear infinite' }}
+							/>
+						) : null}
+						{busy ? 'Deleting…' : 'Delete token'}
+					</button>
+				</div>
+			</div>
+		</ModalShell>
+	);
+}
+
+function Field({
+	label,
+	hint,
+	error,
+	control,
+}: {
+	label: string;
+	hint?: string;
+	error?: string | null;
+	control: React.ReactNode;
+}) {
+	return (
+		<label
+			style={{ display: 'flex', flexDirection: 'column', gap: '0.3rem' }}>
+			<span
+				style={{
+					fontSize: '0.8rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-white, #fff)',
+				}}>
+				{label}
+			</span>
+			{control}
+			{hint && !error && (
+				<span
+					style={{
+						fontSize: '0.75rem',
+						color: 'var(--sl-color-gray-3, #9ca0aa)',
+					}}>
+					{hint}
+				</span>
+			)}
+			{error && (
+				<span style={{ fontSize: '0.75rem', color: '#f87171' }}>
+					{error}
+				</span>
+			)}
+		</label>
+	);
+}
+
+const inputStyle: React.CSSProperties = {
+	background: 'rgba(255,255,255,0.04)',
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	borderRadius: 6,
+	color: 'var(--sl-color-white, #fff)',
+	padding: '0.5rem 0.65rem',
+	fontSize: '0.9rem',
+	width: '100%',
+	boxSizing: 'border-box',
+};
+
+const smallButton: React.CSSProperties = {
+	alignSelf: 'flex-start',
+	display: 'inline-flex',
+	alignItems: 'center',
+	padding: '0.3rem 0.6rem',
+	borderRadius: 6,
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	background: 'transparent',
+	color: 'var(--sl-color-white, #fff)',
+	cursor: 'pointer',
+	fontSize: '0.78rem',
+};
+
+const secondaryButton: React.CSSProperties = {
+	padding: '0.5rem 1rem',
+	borderRadius: 8,
+	border: '1px solid var(--sl-color-gray-5, #2d2f36)',
+	background: 'transparent',
+	color: 'var(--sl-color-white, #fff)',
+	cursor: 'pointer',
+	fontSize: '0.9rem',
+};
+
+function primaryButton(enabled: boolean): React.CSSProperties {
+	return {
+		padding: '0.5rem 1rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#58a6ff' : 'rgba(88,166,255,0.4)',
+		color: '#0d1117',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+	};
+}
+
+function dangerButton(enabled: boolean): React.CSSProperties {
+	return {
+		padding: '0.5rem 1rem',
+		borderRadius: 8,
+		border: 'none',
+		background: enabled ? '#ef4444' : 'rgba(239,68,68,0.4)',
+		color: '#fff',
+		fontWeight: 600,
+		cursor: enabled ? 'pointer' : 'not-allowed',
+		display: 'inline-flex',
+		alignItems: 'center',
+		gap: '0.4rem',
+	};
+}
+
+export const _refreshIcon = RefreshCw;

--- a/packages/npm/astro/src/agents/context.tsx
+++ b/packages/npm/astro/src/agents/context.tsx
@@ -1,0 +1,50 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { createAgents, type AgentsApi, type AgentsConfig } from '@kbve/droid';
+
+let _agents: AgentsApi | null = null;
+
+export function registerAgents(api: AgentsApi): AgentsApi {
+	_agents = api;
+	return api;
+}
+
+export function configureAgents(config: AgentsConfig): AgentsApi {
+	if (_agents) return _agents;
+	_agents = createAgents(config);
+	return _agents;
+}
+
+export function getAgents(): AgentsApi {
+	if (!_agents) {
+		throw new Error(
+			'@kbve/astro agents: no instance registered. Call configureAgents() / registerAgents() at app boot.',
+		);
+	}
+	return _agents;
+}
+
+export function peekAgents(): AgentsApi | null {
+	return _agents;
+}
+
+const AgentsContext = createContext<AgentsApi | null>(null);
+
+export function AgentsProvider({
+	value,
+	children,
+}: {
+	value: AgentsApi;
+	children: ReactNode;
+}) {
+	registerAgents(value);
+	return (
+		<AgentsContext.Provider value={value}>
+			{children}
+		</AgentsContext.Provider>
+	);
+}
+
+export function useAgents(): AgentsApi {
+	const ctx = useContext(AgentsContext);
+	return ctx ?? getAgents();
+}

--- a/packages/npm/astro/src/agents/index.ts
+++ b/packages/npm/astro/src/agents/index.ts
@@ -1,0 +1,18 @@
+export {
+	configureAgents,
+	registerAgents,
+	getAgents,
+	peekAgents,
+	AgentsProvider,
+	useAgents,
+} from './context';
+
+export { default as ReactAgentGuildPicker } from './ReactAgentGuildPicker';
+export { default as ReactAgentBotConfig } from './ReactAgentBotConfig';
+export { default as ReactAgentRepoAllowlist } from './ReactAgentRepoAllowlist';
+export { default as ReactAgentEventQueue } from './ReactAgentEventQueue';
+export { default as ReactAgentGithubWizard } from './ReactAgentGithubWizard';
+export { default as ReactAgentSetupStatus } from './ReactAgentSetupStatus';
+export { default as ReactAgentDiscordsh } from './ReactAgentDiscordsh';
+export { default as ReactAgentBotInstall } from './ReactAgentBotInstall';
+export { AddTokenModal, DeleteTokenModal } from './ReactAgentTokenModals';

--- a/packages/npm/astro/src/dashboard/dashboard-ui.tsx
+++ b/packages/npm/astro/src/dashboard/dashboard-ui.tsx
@@ -1,0 +1,306 @@
+import { useEffect, useRef, type ReactNode } from 'react';
+import { useStore } from '@nanostores/react';
+import type { ReadableAtom } from 'nanostores';
+import {
+	Loader2,
+	LogIn,
+	ShieldOff,
+	RefreshCw,
+	ChevronRight,
+} from 'lucide-react';
+
+export const styles = {
+	fullCenter: {
+		display: 'flex',
+		flexDirection: 'column',
+		alignItems: 'center',
+		justifyContent: 'center',
+		minHeight: '40vh',
+		textAlign: 'center',
+	} as React.CSSProperties,
+
+	iconBadge: (color: string) =>
+		({
+			width: 56,
+			height: 56,
+			borderRadius: 14,
+			background: `${color}18`,
+			display: 'flex',
+			alignItems: 'center',
+			justifyContent: 'center',
+			marginBottom: '0.5rem',
+		}) as React.CSSProperties,
+
+	sectionBorder: {
+		border: '1px solid var(--sl-color-gray-5, #262626)',
+		borderRadius: 12,
+		background: 'var(--sl-color-bg-nav, #111)',
+		overflow: 'hidden' as const,
+	},
+};
+
+type AuthState = 'loading' | 'authenticated' | 'unauthenticated' | 'forbidden';
+
+interface AuthGateProps {
+	$authState: ReadableAtom<AuthState>;
+	initAuth: () => void;
+	serviceName: string;
+	children: ReactNode;
+}
+
+export function AuthGate({
+	$authState,
+	initAuth,
+	serviceName,
+	children,
+}: AuthGateProps) {
+	const authState = useStore($authState);
+
+	useEffect(() => {
+		initAuth();
+	}, [initAuth]);
+
+	if (authState === 'loading') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<Loader2
+					size={28}
+					style={{
+						animation: 'spin 1s linear infinite',
+						color: 'var(--sl-color-accent, #06b6d4)',
+					}}
+				/>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						marginTop: 12,
+					}}>
+					Authenticating...
+				</p>
+			</div>
+		);
+	}
+
+	if (authState === 'unauthenticated') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<div style={styles.iconBadge('#8b5cf6')}>
+					<LogIn size={24} style={{ color: '#8b5cf6' }} />
+				</div>
+				<h2
+					style={{
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0.5rem 0 0.25rem',
+						fontSize: '1.25rem',
+						fontWeight: 600,
+					}}>
+					Sign In Required
+				</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						margin: 0,
+						fontSize: '0.85rem',
+					}}>
+					Authentication is required to access the {serviceName}.
+				</p>
+			</div>
+		);
+	}
+
+	if (authState === 'forbidden') {
+		return (
+			<div className="not-content" style={styles.fullCenter}>
+				<div style={styles.iconBadge('#ef4444')}>
+					<ShieldOff size={24} style={{ color: '#ef4444' }} />
+				</div>
+				<h2
+					style={{
+						color: 'var(--sl-color-text, #e6edf3)',
+						margin: '0.5rem 0 0.25rem',
+						fontSize: '1.25rem',
+						fontWeight: 600,
+					}}>
+					Access Restricted
+				</h2>
+				<p
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						margin: 0,
+						fontSize: '0.85rem',
+					}}>
+					You do not have permission to view this dashboard.
+				</p>
+			</div>
+		);
+	}
+
+	return <>{children}</>;
+}
+
+interface RefreshButtonProps {
+	onClick: () => void;
+	loading?: boolean;
+	label?: string;
+}
+
+export function RefreshButton({
+	onClick,
+	loading = false,
+	label = 'Refresh',
+}: RefreshButtonProps) {
+	return (
+		<button
+			onClick={onClick}
+			disabled={loading}
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 6,
+				padding: '0.4rem 0.8rem',
+				borderRadius: 8,
+				border: '1px solid var(--sl-color-gray-5, #30363d)',
+				background: 'var(--sl-color-gray-6, #161b22)',
+				color: 'var(--sl-color-text, #e6edf3)',
+				cursor: loading ? 'not-allowed' : 'pointer',
+				opacity: loading ? 0.6 : 1,
+				fontSize: '0.8rem',
+				fontWeight: 500,
+				transition: 'opacity 0.15s',
+			}}>
+			<RefreshCw
+				size={14}
+				style={
+					loading
+						? { animation: 'spin 1s linear infinite' }
+						: undefined
+				}
+			/>
+			{label}
+		</button>
+	);
+}
+
+interface SectionProps {
+	id: string;
+	title: string;
+	accentColor?: string;
+	defaultOpen?: boolean;
+	badge?: string;
+	children: ReactNode;
+}
+
+const STORAGE_PREFIX = 'dash-section-';
+
+export function Section({
+	id,
+	title,
+	accentColor = '#8b5cf6',
+	defaultOpen = true,
+	badge,
+	children,
+}: SectionProps) {
+	const contentRef = useRef<HTMLDivElement>(null);
+	const chevronRef = useRef<SVGSVGElement>(null);
+	const key = STORAGE_PREFIX + id;
+
+	useEffect(() => {
+		const saved = localStorage.getItem(key);
+		const isOpen = saved !== null ? saved === '1' : defaultOpen;
+		if (contentRef.current) {
+			contentRef.current.style.display = isOpen ? '' : 'none';
+		}
+		if (chevronRef.current) {
+			chevronRef.current.style.transform = isOpen
+				? 'rotate(90deg)'
+				: 'rotate(0deg)';
+		}
+	}, [key, defaultOpen]);
+
+	const toggle = () => {
+		const el = contentRef.current;
+		const chev = chevronRef.current;
+		if (!el) return;
+		const opening = el.style.display === 'none';
+		el.style.display = opening ? '' : 'none';
+		if (chev) {
+			chev.style.transform = opening ? 'rotate(90deg)' : 'rotate(0deg)';
+		}
+		localStorage.setItem(key, opening ? '1' : '0');
+	};
+
+	return (
+		<div style={styles.sectionBorder}>
+			<div
+				onClick={toggle}
+				role="button"
+				tabIndex={0}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter' || e.key === ' ') toggle();
+				}}
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: '0.5rem',
+					padding: '0.75rem 1rem',
+					cursor: 'pointer',
+					userSelect: 'none',
+					borderBottom: '1px solid var(--sl-color-gray-5, #262626)',
+				}}>
+				<ChevronRight
+					ref={chevronRef}
+					size={16}
+					style={{
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						transition: 'transform 0.15s ease',
+						flexShrink: 0,
+					}}
+				/>
+				<span
+					style={{
+						fontWeight: 600,
+						fontSize: '0.95rem',
+						color: 'var(--sl-color-text, #e6edf3)',
+					}}>
+					{title}
+				</span>
+				{badge && (
+					<span
+						style={{
+							fontSize: '0.7rem',
+							fontWeight: 600,
+							padding: '2px 8px',
+							borderRadius: 10,
+							background: `${accentColor}22`,
+							color: accentColor,
+						}}>
+						{badge}
+					</span>
+				)}
+			</div>
+			<div ref={contentRef} style={{ padding: '1rem' }}>
+				{children}
+			</div>
+		</div>
+	);
+}
+
+export function CachedBadge({ visible }: { visible: boolean }) {
+	if (!visible) return null;
+	return (
+		<span
+			style={{
+				marginLeft: '0.75rem',
+				padding: '2px 8px',
+				borderRadius: 4,
+				background: 'var(--sl-color-gray-6, #1c1c1c)',
+				color: 'var(--sl-color-gray-3, #8b949e)',
+				fontSize: '0.7rem',
+				fontWeight: 500,
+				textTransform: 'uppercase' as const,
+				letterSpacing: '0.05em',
+			}}>
+			cached
+		</span>
+	);
+}

--- a/packages/npm/astro/src/dashboard/index.ts
+++ b/packages/npm/astro/src/dashboard/index.ts
@@ -1,0 +1,7 @@
+export {
+	styles,
+	AuthGate,
+	RefreshButton,
+	Section,
+	CachedBadge,
+} from './dashboard-ui';

--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -135,3 +135,27 @@ export {
 	SITE_GRAPH_WORKER_SOURCE,
 	SiteGraphLoader,
 } from './sitegraph';
+
+// Agents dashboard (logic via @kbve/droid, render here)
+export * from './agents';
+export * from './dashboard';
+
+// Agents core pass-through from @kbve/droid
+export { createAgents } from '@kbve/droid';
+export type {
+	AgentsApi,
+	AgentsConfig,
+	AgentsNotice,
+	AgentsSession,
+	AgentTokenRow,
+	BotConfigFormDraft,
+	DiscordChannel,
+	DiscordGuild,
+	DiscordshConfig,
+	GuildChannels,
+} from '@kbve/droid';
+export {
+	emptyBotConfigFormDraft,
+	botConfigToFormDraft,
+	botConfigFromFormDraft,
+} from '@kbve/droid';

--- a/packages/npm/astro/vite.config.ts
+++ b/packages/npm/astro/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
 				'd3-force',
 				'nanostores',
 				'@nanostores/react',
+				'lucide-react',
 			],
 			output: {
 				globals: {

--- a/packages/npm/droid/package.json
+++ b/packages/npm/droid/package.json
@@ -35,6 +35,7 @@
 		"workers/",
 		"lib/workers/",
 		"lib/gateway/",
+		"lib/agents/",
 		"assets/",
 		"src/",
 		"comlink*.js",

--- a/packages/npm/droid/src/index.ts
+++ b/packages/npm/droid/src/index.ts
@@ -10,6 +10,7 @@ export * from './lib/workers/events';
 export * from './lib/mod/mod-urls';
 export * from './lib/gateway';
 export * from './lib/state';
+export * from './lib/agents';
 
 export type { VirtualNode } from './lib/types/modules';
 

--- a/packages/npm/droid/src/lib/agents/api-types.ts
+++ b/packages/npm/droid/src/lib/agents/api-types.ts
@@ -1,0 +1,166 @@
+import type { AgentsStore } from './state/atoms';
+import type {
+	AgentTokenRow,
+	BackfillResult,
+	BotConfigFormDraft,
+	DiscordForumChannel,
+	DiscordshConfig,
+	GithubRepoHook,
+	PatValidation,
+	Result,
+	WebhookInstallResult,
+} from './types';
+
+export interface AgentsMethods {
+	// auth
+	initAuth(force?: boolean): Promise<void>;
+	resyncOwnedGuilds(): Promise<boolean>;
+	signInWithDiscord(): Promise<void>;
+
+	// guilds
+	loadOwnedGuilds(force?: boolean): Promise<void>;
+	selectGuild(guildId: string): void;
+	refreshSelectedGuild(): Promise<void>;
+
+	// tokens
+	loadTokens(guildId: string, force?: boolean): Promise<void>;
+	addToken(input: {
+		tokenName: string;
+		service: string;
+		tokenValue: string;
+		description?: string | null;
+	}): Promise<Result<{ tokenId: string }>>;
+	deleteToken(tokenId: string): Promise<Result>;
+	peekToken(service: string): Promise<Result<{ value: string | null }>>;
+	toggleToken(tokenId: string, isActive: boolean): Promise<Result>;
+	hasService(service: string): AgentTokenRow | null;
+
+	// repo allowlist
+	getRepoAllowlist(): Promise<
+		Result<{ repos: string[]; raw: string | null }>
+	>;
+	setRepoAllowlist(repos: string[]): Promise<Result>;
+	hydrateRepoAllowlistDraft(guildId: string, repos: string[]): void;
+	patchRepoAllowlistDraft(guildId: string, repos: string[]): void;
+	clearRepoAllowlistDraft(guildId: string): void;
+	ensureRepoAllowlistLoaded(
+		guildId: string,
+		force?: boolean,
+	): Promise<Result>;
+	saveRepoAllowlistDraft(guildId: string): Promise<Result>;
+
+	// bot config
+	getBotConfig(): Promise<Result<{ config: DiscordshConfig }>>;
+	setBotConfig(config: DiscordshConfig): Promise<Result>;
+	hydrateBotConfigDraft(guildId: string, cfg: DiscordshConfig): void;
+	patchBotConfigDraft(
+		guildId: string,
+		patch: Partial<BotConfigFormDraft>,
+	): void;
+	clearBotConfigDraft(guildId: string): void;
+	ensureBotConfigLoaded(guildId: string, force?: boolean): Promise<Result>;
+	saveBotConfigDraft(guildId: string): Promise<Result>;
+
+	// webhook secret drafts
+	setWebhookDraft(guildId: string, secret: string | null): void;
+	clearWebhookError(guildId: string): void;
+	saveWebhookDraft(
+		guildId: string,
+		tokenName: string,
+		description: string,
+	): Promise<Result<{ tokenId: string }>>;
+
+	// PAT
+	setPatDraft(guildId: string, pat: string): void;
+	clearPatState(guildId: string): void;
+	validatePatForGuild(guildId: string): Promise<Result>;
+	savePatForGuild(
+		guildId: string,
+		tokenName: string,
+	): Promise<Result<{ tokenId: string }>>;
+	validateGithubPat(pat: string): Promise<Result<PatValidation>>;
+
+	// backfill
+	patchBackfillDraft(
+		guildId: string,
+		partial: Partial<{ owner: string; repo: string }>,
+	): void;
+	clearBackfillResult(guildId: string): void;
+	runBackfillForGuild(guildId: string): Promise<void>;
+	runBackfill(input: {
+		owner: string;
+		repo: string;
+		state?: 'open' | 'closed' | 'all';
+		maxPages?: number;
+		perPage?: number;
+	}): Promise<BackfillResult | { ok: false; error: string }>;
+
+	// webhook install / ping / verify
+	setWebhookInstallSelected(guildId: string, repo: string): void;
+	clearWebhookInstallResult(guildId: string): void;
+	installWebhookForGuild(guildId: string): Promise<void>;
+	pingWebhookForGuild(guildId: string): Promise<void>;
+	verifyWebhookInstall(guildId: string, repoFull: string): Promise<void>;
+	installRepoWebhook(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<WebhookInstallResult | { ok: false; error: string }>;
+	pingRepoWebhook(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<
+		| { ok: true; hookId: number; url: string }
+		| { ok: false; error: string; retryAfterMs?: number }
+	>;
+	listRepoWebhooks(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<Result<{ expectedUrl: string; hooks: GithubRepoHook[] }>>;
+	rotateWebhookForGuild(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<void>;
+	deleteWebhookForGuild(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<Result>;
+	loadWebhookDeliveries(
+		guildId: string,
+		owner: string,
+		repo: string,
+		limit?: number,
+	): Promise<void>;
+	webhookUrlFor(guildId: string): string;
+
+	// discord bot / channels
+	ensureGuildChannelsLoaded(guildId: string, force?: boolean): Promise<void>;
+	ensureBotMembershipLoaded(guildId: string, force?: boolean): Promise<void>;
+	invalidateBotMembership(guildId: string): void;
+	isBotMember(
+		guildId: string,
+	): Promise<
+		| { ok: true; isMember: boolean; joinedAt: string | null }
+		| { ok: false; error: string }
+	>;
+	listForumChannels(
+		guildId: string,
+	): Promise<Result<{ channels: DiscordForumChannel[] }>>;
+	botInstallUrl(guildId?: string): string | null;
+
+	// events
+	loadEventStats(guildId: string): Promise<void>;
+	loadFailedEvents(guildId: string, limit?: number): Promise<void>;
+	loadPendingEvents(guildId: string, limit?: number): Promise<void>;
+	requeueEvent(
+		guildId: string,
+		eventId: number,
+		reason?: string,
+	): Promise<Result>;
+}
+
+export type AgentsApi = AgentsStore & AgentsMethods;

--- a/packages/npm/droid/src/lib/agents/auth/init.ts
+++ b/packages/npm/droid/src/lib/agents/auth/init.ts
@@ -1,0 +1,200 @@
+import {
+	BOOTSTRAP_COOLDOWN_MS,
+	FORCED_REFRESH_COOLDOWN_MS,
+	INIT_DEDUP_MS,
+} from '../constants';
+import {
+	extractJwtOwnedGuildIds,
+	loadCachedGuilds,
+	parseJwtPayload,
+} from '../cache';
+import type { AgentsCtx } from '../ctx';
+import type { AgentsApi } from '../api-types';
+
+export function makeAuth(ctx: AgentsCtx, api: AgentsApi) {
+	const { store, config, endpoints, runtime } = ctx;
+
+	async function bootstrapDiscord(providerToken: string): Promise<boolean> {
+		const accessToken = store.$accessToken.get();
+		if (!accessToken) return false;
+		const now = Date.now();
+		if (
+			runtime.lastBootstrapOk &&
+			now - runtime.lastBootstrapAt < BOOTSTRAP_COOLDOWN_MS
+		) {
+			return true;
+		}
+		if (runtime.bootstrapInflight) return runtime.bootstrapInflight;
+		runtime.bootstrapInflight = (async () => {
+			try {
+				const resp = await fetch(endpoints.discordBootstrap, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${accessToken}`,
+					},
+					body: JSON.stringify({ provider_token: providerToken }),
+				});
+				if (!resp.ok) {
+					if (resp.status === 429) {
+						runtime.lastBootstrapAt = Date.now();
+						runtime.lastBootstrapOk = true;
+					}
+					return false;
+				}
+				runtime.lastBootstrapAt = Date.now();
+				runtime.lastBootstrapOk = true;
+				return true;
+			} catch {
+				return false;
+			} finally {
+				runtime.bootstrapInflight = null;
+			}
+		})();
+		return runtime.bootstrapInflight;
+	}
+
+	async function forceTokenRefresh(): Promise<boolean> {
+		const now = Date.now();
+		if (now - runtime.lastForcedRefreshAt < FORCED_REFRESH_COOLDOWN_MS) {
+			return false;
+		}
+		if (runtime.refreshInflight) return runtime.refreshInflight;
+		runtime.refreshInflight = (async () => {
+			try {
+				const accessToken = await config.refreshSession();
+				if (!accessToken) {
+					console.warn('[agents] refreshSession returned no session');
+					return false;
+				}
+				store.$accessToken.set(accessToken);
+				runtime.lastForcedRefreshAt = Date.now();
+				return true;
+			} catch (e) {
+				console.warn('[agents] refreshSession threw:', e);
+				return false;
+			} finally {
+				runtime.refreshInflight = null;
+			}
+		})();
+		return runtime.refreshInflight;
+	}
+
+	async function resyncOwnedGuilds(): Promise<boolean> {
+		const providerToken = store.$providerToken.get();
+		if (!providerToken) return false;
+		const ok = await bootstrapDiscord(providerToken);
+		if (!ok) return false;
+		return await forceTokenRefresh();
+	}
+
+	async function runInitAuth(): Promise<void> {
+		try {
+			const session = await config.loadSession();
+			const accessToken = session.accessToken;
+
+			if (!accessToken) {
+				store.$authState.set('unauthenticated');
+				return;
+			}
+
+			store.$accessToken.set(accessToken);
+
+			const jwtPayload = parseJwtPayload(accessToken);
+			const userId = (jwtPayload?.['sub'] as string | undefined) ?? null;
+			if (userId) store.$userId.set(userId);
+
+			let providerToken: string | null = session.providerToken;
+			if (!providerToken) {
+				providerToken = config.getDiscordProviderToken();
+			}
+
+			if (providerToken) {
+				store.$providerToken.set(providerToken);
+				store.$authState.set('authenticated');
+				const cachedOwned = userId ? loadCachedGuilds(userId) : null;
+				if (cachedOwned && cachedOwned.length > 0) {
+					store.$guilds.set(cachedOwned);
+					if (cachedOwned.length === 1) {
+						api.selectGuild(cachedOwned[0].id);
+					}
+				}
+				return;
+			}
+
+			const cached = userId ? loadCachedGuilds(userId) : null;
+			const jwtIds = extractJwtOwnedGuildIds(accessToken);
+			const jwtSet = new Set(jwtIds);
+
+			if (cached && cached.length > 0) {
+				const filtered =
+					jwtIds.length > 0
+						? cached.filter((g) => jwtSet.has(g.id))
+						: cached;
+				store.$guilds.set(filtered);
+				store.$guildsStale.set(true);
+				store.$authState.set('authenticated');
+				if (filtered.length === 1) {
+					api.selectGuild(filtered[0].id);
+				}
+				return;
+			}
+
+			if (jwtIds.length > 0) {
+				store.$guilds.set(
+					jwtIds.map((id) => ({
+						id,
+						name: `Guild #${id.slice(-6)}`,
+						icon: null,
+						owner: true,
+						permissions: '0',
+					})),
+				);
+				store.$guildsStale.set(true);
+				store.$authState.set('authenticated');
+				if (jwtIds.length === 1) api.selectGuild(jwtIds[0]);
+				return;
+			}
+
+			store.$authState.set('discord_reauth_required');
+		} catch {
+			store.$authState.set('unauthenticated');
+		} finally {
+			runtime.lastInitAt = Date.now();
+		}
+	}
+
+	async function initAuth(force = false): Promise<void> {
+		if (!force) {
+			if (runtime.initPromise) return runtime.initPromise;
+			if (
+				runtime.lastInitAt > 0 &&
+				Date.now() - runtime.lastInitAt < INIT_DEDUP_MS &&
+				store.$authState.get() !== 'loading'
+			) {
+				return;
+			}
+		}
+		runtime.initPromise = runInitAuth();
+		try {
+			await runtime.initPromise;
+		} finally {
+			runtime.initPromise = null;
+		}
+	}
+
+	async function signInWithDiscord(): Promise<void> {
+		try {
+			await config.signInWithDiscord();
+		} catch (e) {
+			config.notify({
+				message:
+					e instanceof Error ? e.message : 'Discord sign-in failed',
+				severity: 'error',
+				duration: 5000,
+			});
+		}
+	}
+
+	return { initAuth, resyncOwnedGuilds, signInWithDiscord };
+}

--- a/packages/npm/droid/src/lib/agents/cache.ts
+++ b/packages/npm/droid/src/lib/agents/cache.ts
@@ -1,0 +1,127 @@
+import {
+	GUILDS_CACHE_KEY,
+	GUILDS_CACHE_TTL_MS,
+	TOKENS_CACHE_KEY,
+	TOKENS_CACHE_TTL_MS,
+} from './constants';
+import type { AgentTokenRow, DiscordGuild } from './types';
+
+export function parseJwtPayload(jwt: string): Record<string, unknown> | null {
+	try {
+		const parts = jwt.split('.');
+		if (parts.length < 2) return null;
+		const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+		const padded = b64 + '==='.slice((b64.length + 3) % 4);
+		const json = atob(padded);
+		return JSON.parse(json) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+export function extractJwtOwnedGuildIds(jwt: string): string[] {
+	const payload = parseJwtPayload(jwt);
+	if (!payload || !Array.isArray(payload['owned_guilds'])) return [];
+	return payload['owned_guilds'].filter(
+		(g): g is string => typeof g === 'string' && /^[0-9]{17,20}$/.test(g),
+	);
+}
+
+interface CachedGuildsBlob {
+	user_id: string;
+	guilds: DiscordGuild[];
+	cached_at: number;
+}
+
+export function loadCachedGuilds(userId: string): DiscordGuild[] | null {
+	try {
+		const raw = localStorage.getItem(GUILDS_CACHE_KEY);
+		if (!raw) return null;
+		const blob = JSON.parse(raw) as CachedGuildsBlob;
+		if (blob.user_id !== userId) return null;
+		if (Date.now() - blob.cached_at > GUILDS_CACHE_TTL_MS) return null;
+		if (!Array.isArray(blob.guilds)) return null;
+		return blob.guilds;
+	} catch {
+		return null;
+	}
+}
+
+export function saveCachedGuilds(userId: string, guilds: DiscordGuild[]): void {
+	try {
+		const blob: CachedGuildsBlob = {
+			user_id: userId,
+			guilds,
+			cached_at: Date.now(),
+		};
+		localStorage.setItem(GUILDS_CACHE_KEY, JSON.stringify(blob));
+	} catch {
+		/* non-fatal */
+	}
+}
+
+interface CachedTokensBlob {
+	user_id: string;
+	tokens_by_guild: Record<
+		string,
+		{ tokens: AgentTokenRow[]; cached_at: number }
+	>;
+}
+
+export function loadCachedTokens(
+	userId: string,
+	guildId: string,
+): AgentTokenRow[] | null {
+	try {
+		const raw = localStorage.getItem(TOKENS_CACHE_KEY);
+		if (!raw) return null;
+		const blob = JSON.parse(raw) as CachedTokensBlob;
+		if (blob.user_id !== userId) return null;
+		const entry = blob.tokens_by_guild?.[guildId];
+		if (!entry) return null;
+		if (Date.now() - entry.cached_at > TOKENS_CACHE_TTL_MS) return null;
+		return entry.tokens;
+	} catch {
+		return null;
+	}
+}
+
+export function saveCachedTokens(
+	userId: string,
+	guildId: string,
+	tokens: AgentTokenRow[],
+): void {
+	try {
+		const raw = localStorage.getItem(TOKENS_CACHE_KEY);
+		let blob: CachedTokensBlob;
+		try {
+			blob = raw
+				? (JSON.parse(raw) as CachedTokensBlob)
+				: { user_id: userId, tokens_by_guild: {} };
+		} catch {
+			blob = { user_id: userId, tokens_by_guild: {} };
+		}
+		if (blob.user_id !== userId) {
+			blob = { user_id: userId, tokens_by_guild: {} };
+		}
+		blob.tokens_by_guild[guildId] = { tokens, cached_at: Date.now() };
+		localStorage.setItem(TOKENS_CACHE_KEY, JSON.stringify(blob));
+	} catch {
+		/* non-fatal */
+	}
+}
+
+export function invalidateCachedTokens(userId: string, guildId: string): void {
+	try {
+		const raw = localStorage.getItem(TOKENS_CACHE_KEY);
+		if (!raw) return;
+		const blob = JSON.parse(raw) as CachedTokensBlob;
+		if (blob.user_id !== userId) return;
+		if (blob.tokens_by_guild?.[guildId]) {
+			delete blob.tokens_by_guild[guildId];
+			localStorage.setItem(TOKENS_CACHE_KEY, JSON.stringify(blob));
+		}
+	} catch {
+		/* non-fatal */
+	}
+}

--- a/packages/npm/droid/src/lib/agents/client/callGuildVault.ts
+++ b/packages/npm/droid/src/lib/agents/client/callGuildVault.ts
@@ -1,0 +1,71 @@
+import type { AgentsCtx, CallGuildVault } from '../ctx';
+
+export function makeCallGuildVault(ctx: AgentsCtx): CallGuildVault {
+	return async function callGuildVault(
+		command: string,
+		accessToken: string,
+		extra: Record<string, unknown>,
+		opts: { retriedAfterResync?: boolean } = {},
+	) {
+		try {
+			const resp = await fetch(ctx.endpoints.guildVault, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify({ command, ...extra }),
+			});
+			const text = await resp.text();
+			let body: unknown;
+			try {
+				body = JSON.parse(text);
+			} catch {
+				return {
+					ok: false,
+					error: `HTTP ${resp.status}: ${text.slice(0, 200)}`,
+				};
+			}
+			if (!resp.ok) {
+				const b = body as {
+					error?: string;
+					sqlstate?: string | null;
+					hint?: string | null;
+					context?: string | null;
+				} | null;
+				const errMsg = b?.error ?? '';
+				const looksStale =
+					resp.status === 403 &&
+					/owned_guilds/i.test(errMsg) &&
+					!opts.retriedAfterResync;
+				if (looksStale) {
+					const resynced = await ctx.resyncOwnedGuilds();
+					if (resynced) {
+						const newToken = ctx.store.$accessToken.get();
+						if (newToken) {
+							return ctx.callGuildVault(
+								command,
+								newToken,
+								extra,
+								{
+									retriedAfterResync: true,
+								},
+							);
+						}
+					}
+				}
+				const parts: string[] = [errMsg || `HTTP ${resp.status}`];
+				if (b?.sqlstate) parts.push(`sqlstate=${b.sqlstate}`);
+				if (b?.hint) parts.push(`hint=${b.hint}`);
+				if (b?.context) parts.push(`context=${b.context}`);
+				return { ok: false, error: parts.join(' · ') };
+			}
+			return { ok: true, body };
+		} catch (e) {
+			return {
+				ok: false,
+				error: e instanceof Error ? e.message : 'Network error',
+			};
+		}
+	};
+}

--- a/packages/npm/droid/src/lib/agents/client/callJson.ts
+++ b/packages/npm/droid/src/lib/agents/client/callJson.ts
@@ -1,0 +1,64 @@
+import type { AgentsCtx, CallJson } from '../ctx';
+
+export function makeCallJson(ctx: AgentsCtx): CallJson {
+	return async function callJson<T>(
+		url: string,
+		body: Record<string, unknown>,
+		opts: { retriedAfterResync?: boolean } = {},
+	) {
+		const accessToken = ctx.store.$accessToken.get();
+		if (!accessToken) return { ok: false, error: 'Not authenticated' };
+		try {
+			const resp = await fetch(url, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify(body),
+			});
+			const text = await resp.text();
+			let parsed: unknown;
+			try {
+				parsed = text.length > 0 ? JSON.parse(text) : {};
+			} catch {
+				return {
+					ok: false,
+					error: `HTTP ${resp.status}: ${text.slice(0, 200)}`,
+				};
+			}
+			if (!resp.ok) {
+				const b = parsed as {
+					error?: string;
+					sqlstate?: string | null;
+					hint?: string | null;
+					context?: string | null;
+				} | null;
+				const errMsg = b?.error ?? '';
+				const looksStale =
+					resp.status === 403 &&
+					/owned_guilds/i.test(errMsg) &&
+					!opts.retriedAfterResync;
+				if (looksStale) {
+					const resynced = await ctx.resyncOwnedGuilds();
+					if (resynced) {
+						return ctx.callJson<T>(url, body, {
+							retriedAfterResync: true,
+						});
+					}
+				}
+				const parts: string[] = [errMsg || `HTTP ${resp.status}`];
+				if (b?.sqlstate) parts.push(`sqlstate=${b.sqlstate}`);
+				if (b?.hint) parts.push(`hint=${b.hint}`);
+				if (b?.context) parts.push(`context=${b.context}`);
+				return { ok: false, error: parts.join(' · ') };
+			}
+			return { ok: true, data: parsed as T };
+		} catch (e) {
+			return {
+				ok: false,
+				error: e instanceof Error ? e.message : 'Network error',
+			};
+		}
+	};
+}

--- a/packages/npm/droid/src/lib/agents/config.ts
+++ b/packages/npm/droid/src/lib/agents/config.ts
@@ -1,0 +1,83 @@
+import { addToast } from '../state/toasts';
+import type { ToastSeverity } from '../types/ui-event-types';
+
+export interface AgentsNotice {
+	message: string;
+	severity: ToastSeverity;
+	duration?: number;
+}
+
+export interface AgentsSession {
+	accessToken: string | null;
+	providerToken: string | null;
+}
+
+export interface AgentsConfig {
+	supabaseUrl: string;
+	discordBotClientId?: string;
+	discordClientId?: string;
+
+	loadSession(): Promise<AgentsSession>;
+	refreshSession(): Promise<string | null>;
+
+	getDiscordProviderToken(): string | null;
+	clearDiscordProviderToken(): void;
+
+	signInWithDiscord(): Promise<void>;
+
+	notify?(notice: AgentsNotice): void;
+}
+
+export interface ResolvedAgentsConfig extends Required<
+	Omit<AgentsConfig, 'notify'>
+> {
+	notify(notice: AgentsNotice): void;
+}
+
+function defaultNotify(notice: AgentsNotice): void {
+	addToast({
+		id: `agents-${notice.severity}-${Date.now()}`,
+		message: notice.message,
+		severity: notice.severity,
+		duration: notice.duration ?? 3500,
+	});
+}
+
+export function resolveAgentsConfig(
+	config: AgentsConfig,
+): ResolvedAgentsConfig {
+	return {
+		supabaseUrl: config.supabaseUrl.replace(/\/$/, ''),
+		discordBotClientId: config.discordBotClientId ?? '',
+		discordClientId: config.discordClientId ?? '',
+		loadSession: config.loadSession,
+		refreshSession: config.refreshSession,
+		getDiscordProviderToken: config.getDiscordProviderToken,
+		clearDiscordProviderToken: config.clearDiscordProviderToken,
+		signInWithDiscord: config.signInWithDiscord,
+		notify: config.notify ?? defaultNotify,
+	};
+}
+
+export interface AgentsEndpoints {
+	discordApiBase: string;
+	guildVault: string;
+	discordBootstrap: string;
+	discordBot: string;
+	ghAdmin: string;
+	ghBackfill: string;
+	ghWebhookBase: string;
+}
+
+export function buildEndpoints(supabaseUrl: string): AgentsEndpoints {
+	const base = supabaseUrl.replace(/\/$/, '');
+	return {
+		discordApiBase: 'https://discord.com/api/v10',
+		guildVault: `${base}/functions/v1/guild-vault`,
+		discordBootstrap: `${base}/functions/v1/discord-bootstrap`,
+		discordBot: `${base}/functions/v1/discord-bot`,
+		ghAdmin: `${base}/functions/v1/gh-admin`,
+		ghBackfill: `${base}/functions/v1/gh-backfill`,
+		ghWebhookBase: `${base}/functions/v1/gh-webhook`,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/constants.ts
+++ b/packages/npm/droid/src/lib/agents/constants.ts
@@ -1,0 +1,11 @@
+export const GUILDS_CACHE_KEY = 'kbve:agents:owned_guilds_cache:v1';
+export const TOKENS_CACHE_KEY = 'kbve:agents:tokens_cache:v1';
+
+export const GUILDS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const GUILDS_LIVE_TTL_MS = 60 * 1000;
+export const TOKENS_CACHE_TTL_MS = 60 * 1000;
+export const CHANNELS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const BOT_MEMBERSHIP_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+export const INIT_DEDUP_MS = 30 * 1000;
+export const BOOTSTRAP_COOLDOWN_MS = 5 * 60 * 1000;
+export const FORCED_REFRESH_COOLDOWN_MS = 5 * 1000;

--- a/packages/npm/droid/src/lib/agents/createAgents.ts
+++ b/packages/npm/droid/src/lib/agents/createAgents.ts
@@ -1,0 +1,62 @@
+import {
+	buildEndpoints,
+	resolveAgentsConfig,
+	type AgentsConfig,
+} from './config';
+import { createAgentsStore } from './state/atoms';
+import { createRuntime, type AgentsCtx } from './ctx';
+import { makeCallJson } from './client/callJson';
+import { makeCallGuildVault } from './client/callGuildVault';
+import { makeAuth } from './auth/init';
+import { makeGuilds } from './discord/guilds';
+import { makeDiscordBot } from './discord/bot';
+import { makeTokens } from './github/tokens';
+import { makeRepoConfig } from './github/repoConfig';
+import { makePat } from './github/pat';
+import { makeWebhook } from './github/webhook';
+import { makeBackfill } from './github/backfill';
+import { makeEvents } from './github/events';
+import type { AgentsApi } from './api-types';
+
+export function createAgents(config: AgentsConfig): AgentsApi {
+	const resolved = resolveAgentsConfig(config);
+	const store = createAgentsStore();
+	const runtime = createRuntime();
+
+	const ctx = {
+		config: resolved,
+		endpoints: buildEndpoints(resolved.supabaseUrl),
+		store,
+		runtime,
+		callJson: (() => {
+			throw new Error('agents: callJson used before init');
+		}) as AgentsCtx['callJson'],
+		callGuildVault: (() => {
+			throw new Error('agents: callGuildVault used before init');
+		}) as AgentsCtx['callGuildVault'],
+		resyncOwnedGuilds: async () => false,
+	} as AgentsCtx;
+
+	const api = { ...store } as AgentsApi;
+
+	ctx.callJson = makeCallJson(ctx);
+	ctx.callGuildVault = makeCallGuildVault(ctx);
+
+	const auth = makeAuth(ctx, api);
+	ctx.resyncOwnedGuilds = auth.resyncOwnedGuilds;
+
+	Object.assign(
+		api,
+		auth,
+		makeGuilds(ctx, api),
+		makeTokens(ctx, api),
+		makeRepoConfig(ctx, api),
+		makePat(ctx, api),
+		makeDiscordBot(ctx),
+		makeWebhook(ctx, api),
+		makeBackfill(ctx),
+		makeEvents(ctx, api),
+	);
+
+	return api;
+}

--- a/packages/npm/droid/src/lib/agents/ctx.ts
+++ b/packages/npm/droid/src/lib/agents/ctx.ts
@@ -1,0 +1,63 @@
+import type { AgentsEndpoints, ResolvedAgentsConfig } from './config';
+import type { AgentsStore } from './state/atoms';
+
+export type CallJsonResult<T> =
+	| { ok: true; data: T }
+	| { ok: false; error: string };
+
+export type CallVaultResult =
+	| { ok: true; body: unknown }
+	| { ok: false; error: string };
+
+export type CallJson = <T>(
+	url: string,
+	body: Record<string, unknown>,
+	opts?: { retriedAfterResync?: boolean },
+) => Promise<CallJsonResult<T>>;
+
+export type CallGuildVault = (
+	command: string,
+	accessToken: string,
+	extra: Record<string, unknown>,
+	opts?: { retriedAfterResync?: boolean },
+) => Promise<CallVaultResult>;
+
+export interface AgentsRuntime {
+	initPromise: Promise<void> | null;
+	lastInitAt: number;
+	lastGuildFetchAt: number;
+	guildsAbort: AbortController | null;
+	tokensInflight: Map<string, Promise<void>>;
+	tokensAbort: Map<string, AbortController>;
+	bootstrapInflight: Promise<boolean> | null;
+	lastBootstrapAt: number;
+	lastBootstrapOk: boolean;
+	refreshInflight: Promise<boolean> | null;
+	lastForcedRefreshAt: number;
+}
+
+export function createRuntime(): AgentsRuntime {
+	return {
+		initPromise: null,
+		lastInitAt: 0,
+		lastGuildFetchAt: 0,
+		guildsAbort: null,
+		tokensInflight: new Map(),
+		tokensAbort: new Map(),
+		bootstrapInflight: null,
+		lastBootstrapAt: 0,
+		lastBootstrapOk: false,
+		refreshInflight: null,
+		lastForcedRefreshAt: 0,
+	};
+}
+
+export interface AgentsCtx {
+	config: ResolvedAgentsConfig;
+	endpoints: AgentsEndpoints;
+	store: AgentsStore;
+	runtime: AgentsRuntime;
+	callJson: CallJson;
+	callGuildVault: CallGuildVault;
+	resyncOwnedGuilds: () => Promise<boolean>;
+}

--- a/packages/npm/droid/src/lib/agents/discord/bot.ts
+++ b/packages/npm/droid/src/lib/agents/discord/bot.ts
@@ -1,0 +1,149 @@
+import {
+	BOT_MEMBERSHIP_CACHE_TTL_MS,
+	CHANNELS_CACHE_TTL_MS,
+} from '../constants';
+import type { AgentsCtx } from '../ctx';
+import type { DiscordForumChannel, GuildChannels, Result } from '../types';
+
+export function makeDiscordBot(ctx: AgentsCtx) {
+	const { store, config, endpoints } = ctx;
+
+	async function ensureGuildChannelsLoaded(
+		guildId: string,
+		force = false,
+	): Promise<void> {
+		const cur = store.$guildChannels.get()[guildId];
+		const fresh =
+			!!cur && Date.now() - cur.cached_at < CHANNELS_CACHE_TTL_MS;
+		if (fresh && !force) return;
+		if (store.$guildChannelsLoading.get()[guildId]) return;
+		store.$guildChannelsLoading.set({
+			...store.$guildChannelsLoading.get(),
+			[guildId]: true,
+		});
+		store.$guildChannelsError.set({
+			...store.$guildChannelsError.get(),
+			[guildId]: null,
+		});
+		const r = await ctx.callJson<GuildChannels>(endpoints.discordBot, {
+			command: 'bot.list_channels',
+			server_id: guildId,
+		});
+		const loading = { ...store.$guildChannelsLoading.get() };
+		delete loading[guildId];
+		store.$guildChannelsLoading.set(loading);
+		if (!r.ok) {
+			store.$guildChannelsError.set({
+				...store.$guildChannelsError.get(),
+				[guildId]: r.error,
+			});
+			return;
+		}
+		store.$guildChannels.set({
+			...store.$guildChannels.get(),
+			[guildId]: {
+				forums: r.data.forums ?? [],
+				texts: r.data.texts ?? [],
+				cached_at: Date.now(),
+			},
+		});
+	}
+
+	async function ensureBotMembershipLoaded(
+		guildId: string,
+		force = false,
+	): Promise<void> {
+		const cur = store.$botMembership.get()[guildId];
+		const fresh =
+			!!cur && Date.now() - cur.cached_at < BOT_MEMBERSHIP_CACHE_TTL_MS;
+		if (fresh && !force) return;
+		if (store.$botMembershipLoading.get()[guildId]) return;
+		store.$botMembershipLoading.set({
+			...store.$botMembershipLoading.get(),
+			[guildId]: true,
+		});
+		store.$botMembershipError.set({
+			...store.$botMembershipError.get(),
+			[guildId]: null,
+		});
+		const r = await ctx.callJson<{ is_member: boolean }>(
+			endpoints.discordBot,
+			{ command: 'bot.is_member', server_id: guildId },
+		);
+		const loading = { ...store.$botMembershipLoading.get() };
+		delete loading[guildId];
+		store.$botMembershipLoading.set(loading);
+		if (!r.ok) {
+			store.$botMembershipError.set({
+				...store.$botMembershipError.get(),
+				[guildId]: r.error,
+			});
+			return;
+		}
+		store.$botMembership.set({
+			...store.$botMembership.get(),
+			[guildId]: {
+				isMember: !!r.data.is_member,
+				cached_at: Date.now(),
+			},
+		});
+	}
+
+	function invalidateBotMembership(guildId: string): void {
+		const m = { ...store.$botMembership.get() };
+		delete m[guildId];
+		store.$botMembership.set(m);
+	}
+
+	async function isBotMember(
+		guildId: string,
+	): Promise<
+		| { ok: true; isMember: boolean; joinedAt: string | null }
+		| { ok: false; error: string }
+	> {
+		const r = await ctx.callJson<{
+			is_member: boolean;
+			joined_at: string | null;
+		}>(endpoints.discordBot, {
+			command: 'bot.is_member',
+			server_id: guildId,
+		});
+		if (!r.ok) return r;
+		return {
+			ok: true,
+			isMember: !!r.data.is_member,
+			joinedAt: r.data.joined_at ?? null,
+		};
+	}
+
+	async function listForumChannels(
+		guildId: string,
+	): Promise<Result<{ channels: DiscordForumChannel[] }>> {
+		const r = await ctx.callJson<{ channels: DiscordForumChannel[] }>(
+			endpoints.discordBot,
+			{ command: 'bot.list_forum_channels', server_id: guildId },
+		);
+		if (!r.ok) return r;
+		return { ok: true, channels: r.data.channels ?? [] };
+	}
+
+	function botInstallUrl(guildId?: string): string | null {
+		const clientId = config.discordBotClientId || config.discordClientId;
+		if (!clientId || !/^[0-9]{17,20}$/.test(clientId)) return null;
+		const perms = '326417847872';
+		const scope = 'bot applications.commands';
+		const guildParam = guildId
+			? `&guild_id=${guildId}&disable_guild_select=true`
+			: '';
+		return `https://discord.com/oauth2/authorize?client_id=${clientId}&permissions=${perms}&scope=${encodeURIComponent(scope)}${guildParam}`;
+	}
+
+	return {
+		ensureGuildChannelsLoaded,
+		ensureBotMembershipLoaded,
+		invalidateBotMembership,
+		isBotMember,
+		listForumChannels,
+		botInstallUrl,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/discord/guilds.ts
+++ b/packages/npm/droid/src/lib/agents/discord/guilds.ts
@@ -1,0 +1,106 @@
+import { GUILDS_LIVE_TTL_MS } from '../constants';
+import { invalidateCachedTokens, saveCachedGuilds } from '../cache';
+import type { AgentsCtx } from '../ctx';
+import type { AgentsApi } from '../api-types';
+import type { DiscordGuild } from '../types';
+
+export function makeGuilds(ctx: AgentsCtx, api: AgentsApi) {
+	const { store, config, endpoints, runtime } = ctx;
+
+	function selectGuild(guildId: string): void {
+		const current = store.$selectedGuildId.get();
+		if (current === guildId) return;
+		store.$selectedGuildId.set(guildId);
+		void api.loadTokens(guildId);
+	}
+
+	async function loadOwnedGuilds(force = false): Promise<void> {
+		const providerToken = store.$providerToken.get();
+		if (!providerToken) return;
+
+		if (
+			!force &&
+			runtime.lastGuildFetchAt > 0 &&
+			Date.now() - runtime.lastGuildFetchAt < GUILDS_LIVE_TTL_MS &&
+			store.$guilds.get().length > 0
+		) {
+			return;
+		}
+
+		if (runtime.guildsAbort) runtime.guildsAbort.abort();
+		const abort = new AbortController();
+		runtime.guildsAbort = abort;
+
+		store.$guildsLoading.set(true);
+		store.$guildsError.set(null);
+
+		try {
+			const resp = await fetch(
+				`${endpoints.discordApiBase}/users/@me/guilds`,
+				{
+					headers: { Authorization: `Bearer ${providerToken}` },
+					signal: abort.signal,
+				},
+			);
+
+			if (resp.status === 401) {
+				store.$providerToken.set(null);
+				store.$guildsStale.set(true);
+				try {
+					config.clearDiscordProviderToken();
+				} catch {
+					/* non-fatal */
+				}
+				store.$guildsError.set(
+					'Discord session expired — guild list may be stale. Sign in with Discord to refresh.',
+				);
+				return;
+			}
+
+			if (!resp.ok) {
+				const body = await resp.text();
+				store.$guildsError.set(
+					`Discord API ${resp.status}: ${body.slice(0, 200)}`,
+				);
+				store.$guildsStale.set(true);
+				return;
+			}
+
+			const allGuilds = (await resp.json()) as DiscordGuild[];
+			const owned = allGuilds.filter((g) => g.owner === true);
+			store.$guilds.set(owned);
+			store.$guildsStale.set(false);
+			runtime.lastGuildFetchAt = Date.now();
+
+			const userId = store.$userId.get();
+			if (userId) saveCachedGuilds(userId, owned);
+
+			if (owned.length === 1) {
+				selectGuild(owned[0].id);
+			}
+		} catch (e) {
+			if (e instanceof DOMException && e.name === 'AbortError') {
+				return;
+			}
+			store.$guildsError.set(
+				e instanceof Error
+					? e.message
+					: 'Failed to load Discord guilds',
+			);
+			store.$guildsStale.set(true);
+		} finally {
+			store.$guildsLoading.set(false);
+			if (runtime.guildsAbort === abort) runtime.guildsAbort = null;
+		}
+	}
+
+	async function refreshSelectedGuild(): Promise<void> {
+		const guildId = store.$selectedGuildId.get();
+		if (!guildId) return;
+		const userId = store.$userId.get();
+		if (userId) invalidateCachedTokens(userId, guildId);
+		await api.loadTokens(guildId, true);
+	}
+
+	return { selectGuild, loadOwnedGuilds, refreshSelectedGuild };
+}

--- a/packages/npm/droid/src/lib/agents/formDrafts.ts
+++ b/packages/npm/droid/src/lib/agents/formDrafts.ts
@@ -1,0 +1,55 @@
+import type { BotConfigFormDraft, DiscordshConfig } from './types';
+
+export function emptyBotConfigFormDraft(): BotConfigFormDraft {
+	return {
+		default_repo: '',
+		claim_channel_id: '',
+		forum_channel_id: '',
+		noticeboard_channel_id: '',
+		taskboard_channel_id: '',
+		max_assignees: '2',
+		mirror_pr_events: true,
+		active: true,
+	};
+}
+
+export function botConfigToFormDraft(c: DiscordshConfig): BotConfigFormDraft {
+	const base = emptyBotConfigFormDraft();
+	return {
+		default_repo: c.default_repo ?? base.default_repo,
+		claim_channel_id: c.claim_channel_id ?? base.claim_channel_id,
+		forum_channel_id: c.forum_channel_id ?? base.forum_channel_id,
+		noticeboard_channel_id:
+			c.noticeboard_channel_id ?? base.noticeboard_channel_id,
+		taskboard_channel_id:
+			c.taskboard_channel_id ?? base.taskboard_channel_id,
+		max_assignees:
+			typeof c.max_assignees === 'number'
+				? String(c.max_assignees)
+				: base.max_assignees,
+		mirror_pr_events:
+			typeof c.mirror_pr_events === 'boolean'
+				? c.mirror_pr_events
+				: base.mirror_pr_events,
+		active: typeof c.active === 'boolean' ? c.active : base.active,
+	};
+}
+
+export function botConfigFromFormDraft(f: BotConfigFormDraft): DiscordshConfig {
+	const cfg: DiscordshConfig = {
+		mirror_pr_events: f.mirror_pr_events,
+		active: f.active,
+	};
+	if (f.default_repo.trim()) cfg.default_repo = f.default_repo.trim();
+	if (f.claim_channel_id.trim())
+		cfg.claim_channel_id = f.claim_channel_id.trim();
+	if (f.forum_channel_id.trim())
+		cfg.forum_channel_id = f.forum_channel_id.trim();
+	if (f.noticeboard_channel_id.trim())
+		cfg.noticeboard_channel_id = f.noticeboard_channel_id.trim();
+	if (f.taskboard_channel_id.trim())
+		cfg.taskboard_channel_id = f.taskboard_channel_id.trim();
+	const max = parseInt(f.max_assignees, 10);
+	if (!Number.isNaN(max) && max > 0) cfg.max_assignees = max;
+	return cfg;
+}

--- a/packages/npm/droid/src/lib/agents/github/backfill.ts
+++ b/packages/npm/droid/src/lib/agents/github/backfill.ts
@@ -1,0 +1,126 @@
+import type { AgentsCtx } from '../ctx';
+import type { BackfillResult } from '../types';
+
+type Fail = { ok: false; error: string };
+
+export function makeBackfill(ctx: AgentsCtx) {
+	const { store, endpoints } = ctx;
+
+	function patchBackfillDraft(
+		guildId: string,
+		partial: Partial<{ owner: string; repo: string }>,
+	): void {
+		const drafts = store.$backfillDrafts.get();
+		const cur = drafts[guildId] ?? { owner: '', repo: '' };
+		store.$backfillDrafts.set({
+			...drafts,
+			[guildId]: { ...cur, ...partial },
+		});
+	}
+
+	function clearBackfillResult(guildId: string): void {
+		const m = { ...store.$backfillResults.get() };
+		delete m[guildId];
+		store.$backfillResults.set(m);
+	}
+
+	async function runBackfill(input: {
+		owner: string;
+		repo: string;
+		state?: 'open' | 'closed' | 'all';
+		maxPages?: number;
+		perPage?: number;
+	}): Promise<BackfillResult | Fail> {
+		const accessToken = store.$accessToken.get();
+		const guildId = store.$selectedGuildId.get();
+		if (!accessToken || !guildId) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		try {
+			const resp = await fetch(endpoints.ghBackfill, {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify({
+					owner: input.owner,
+					repo: input.repo,
+					guild_id: guildId,
+					state: input.state ?? 'open',
+					max_pages: input.maxPages ?? 1,
+					per_page: input.perPage ?? 30,
+				}),
+			});
+			const text = await resp.text();
+			let body: unknown;
+			try {
+				body = JSON.parse(text);
+			} catch {
+				return {
+					ok: false,
+					error: `HTTP ${resp.status}: ${text.slice(0, 200)}`,
+				};
+			}
+			if (!resp.ok) {
+				const errMsg =
+					(body as { error?: string } | null)?.error ??
+					`HTTP ${resp.status}`;
+				return { ok: false, error: errMsg };
+			}
+			const b = body as {
+				upserted?: number;
+				pages_walked?: number;
+				rate_limit_remaining?: number | null;
+			};
+			return {
+				ok: true,
+				upserted: b.upserted ?? 0,
+				pages: b.pages_walked ?? 0,
+				rateLimitRemaining: b.rate_limit_remaining ?? null,
+			};
+		} catch (e) {
+			return {
+				ok: false,
+				error: e instanceof Error ? e.message : 'Network error',
+			};
+		}
+	}
+
+	async function runBackfillForGuild(guildId: string): Promise<void> {
+		const draft = store.$backfillDrafts.get()[guildId] ?? {
+			owner: '',
+			repo: '',
+		};
+		if (!draft.owner || !draft.repo) return;
+		store.$backfillBusyFor.set({
+			...store.$backfillBusyFor.get(),
+			[guildId]: true,
+		});
+		const resultsClear = { ...store.$backfillResults.get() };
+		delete resultsClear[guildId];
+		store.$backfillResults.set(resultsClear);
+		const r = await runBackfill({
+			owner: draft.owner,
+			repo: draft.repo,
+			state: 'open',
+			maxPages: 1,
+			perPage: 30,
+		});
+		const busyDone = { ...store.$backfillBusyFor.get() };
+		delete busyDone[guildId];
+		store.$backfillBusyFor.set(busyDone);
+		store.$backfillResults.set({
+			...store.$backfillResults.get(),
+			[guildId]: r,
+		});
+	}
+
+	return {
+		patchBackfillDraft,
+		clearBackfillResult,
+		runBackfill,
+		runBackfillForGuild,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/github/events.ts
+++ b/packages/npm/droid/src/lib/agents/github/events.ts
@@ -1,0 +1,118 @@
+import type { AgentsCtx } from '../ctx';
+import type { AgentsApi } from '../api-types';
+import type {
+	EventQueueStats,
+	FailedEvent,
+	PendingEvent,
+	Result,
+} from '../types';
+
+export function makeEvents(ctx: AgentsCtx, api: AgentsApi) {
+	const { store, endpoints } = ctx;
+
+	async function loadEventStats(guildId: string): Promise<void> {
+		store.$eventStatsLoading.set({
+			...store.$eventStatsLoading.get(),
+			[guildId]: true,
+		});
+		const r = await ctx.callJson<EventQueueStats>(endpoints.ghAdmin, {
+			command: 'events.stats',
+			server_id: guildId,
+		});
+		const loading = { ...store.$eventStatsLoading.get() };
+		delete loading[guildId];
+		store.$eventStatsLoading.set(loading);
+		if (!r.ok) return;
+		store.$eventStats.set({
+			...store.$eventStats.get(),
+			[guildId]: r.data,
+		});
+	}
+
+	async function loadFailedEvents(
+		guildId: string,
+		limit = 10,
+	): Promise<void> {
+		store.$failedEventsLoading.set({
+			...store.$failedEventsLoading.get(),
+			[guildId]: true,
+		});
+		const r = await ctx.callJson<{ events: FailedEvent[] }>(
+			endpoints.ghAdmin,
+			{ command: 'events.failed', server_id: guildId, limit },
+		);
+		const loading = { ...store.$failedEventsLoading.get() };
+		delete loading[guildId];
+		store.$failedEventsLoading.set(loading);
+		if (!r.ok) return;
+		store.$failedEvents.set({
+			...store.$failedEvents.get(),
+			[guildId]: r.data.events ?? [],
+		});
+	}
+
+	async function loadPendingEvents(
+		guildId: string,
+		limit = 10,
+	): Promise<void> {
+		store.$pendingEventsLoading.set({
+			...store.$pendingEventsLoading.get(),
+			[guildId]: true,
+		});
+		const r = await ctx.callJson<{ events: PendingEvent[] }>(
+			endpoints.ghAdmin,
+			{ command: 'events.pending', server_id: guildId, limit },
+		);
+		const loading = { ...store.$pendingEventsLoading.get() };
+		delete loading[guildId];
+		store.$pendingEventsLoading.set(loading);
+		if (!r.ok) return;
+		store.$pendingEvents.set({
+			...store.$pendingEvents.get(),
+			[guildId]: r.data.events ?? [],
+		});
+	}
+
+	async function requeueEvent(
+		guildId: string,
+		eventId: number,
+		reason?: string,
+	): Promise<Result> {
+		const key = `${guildId}:${eventId}`;
+		store.$eventRequeueBusyFor.set({
+			...store.$eventRequeueBusyFor.get(),
+			[key]: true,
+		});
+		const trimmedReason =
+			typeof reason === 'string' && reason.trim().length > 0
+				? reason.trim().slice(0, 512)
+				: undefined;
+		const r = await ctx.callJson<{ requeued: boolean; event_id: number }>(
+			endpoints.ghAdmin,
+			{
+				command: 'events.requeue',
+				server_id: guildId,
+				event_id: eventId,
+				...(trimmedReason ? { reason: trimmedReason } : {}),
+			},
+		);
+		const busy = { ...store.$eventRequeueBusyFor.get() };
+		delete busy[key];
+		store.$eventRequeueBusyFor.set(busy);
+		if (!r.ok) return { ok: false, error: r.error };
+		const cur = store.$failedEvents.get()[guildId] ?? [];
+		store.$failedEvents.set({
+			...store.$failedEvents.get(),
+			[guildId]: cur.filter((e) => e.id !== eventId),
+		});
+		void api.loadEventStats(guildId);
+		return { ok: true };
+	}
+
+	return {
+		loadEventStats,
+		loadFailedEvents,
+		loadPendingEvents,
+		requeueEvent,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/github/pat.ts
+++ b/packages/npm/droid/src/lib/agents/github/pat.ts
@@ -1,0 +1,150 @@
+import type { AgentsCtx } from '../ctx';
+import type { AgentsApi } from '../api-types';
+import type { PatValidation, Result } from '../types';
+
+export function makePat(ctx: AgentsCtx, api: AgentsApi) {
+	const { store } = ctx;
+
+	function setPatDraft(guildId: string, pat: string): void {
+		store.$patDrafts.set({ ...store.$patDrafts.get(), [guildId]: pat });
+		const validated = { ...store.$patValidatedFor.get() };
+		if (validated[guildId]) {
+			delete validated[guildId];
+			store.$patValidatedFor.set(validated);
+		}
+	}
+
+	function clearPatState(guildId: string): void {
+		const drafts = { ...store.$patDrafts.get() };
+		delete drafts[guildId];
+		store.$patDrafts.set(drafts);
+		const validated = { ...store.$patValidatedFor.get() };
+		delete validated[guildId];
+		store.$patValidatedFor.set(validated);
+		const errs = { ...store.$patErrors.get() };
+		delete errs[guildId];
+		store.$patErrors.set(errs);
+	}
+
+	async function validateGithubPat(
+		pat: string,
+	): Promise<Result<PatValidation>> {
+		try {
+			const resp = await fetch('https://api.github.com/user', {
+				headers: {
+					Authorization: `Bearer ${pat}`,
+					Accept: 'application/vnd.github+json',
+					'X-GitHub-Api-Version': '2022-11-28',
+				},
+			});
+			if (resp.status === 401) {
+				return { ok: false, error: 'GitHub rejected the token (401).' };
+			}
+			if (!resp.ok) {
+				return {
+					ok: false,
+					error: `GitHub /user returned ${resp.status}.`,
+				};
+			}
+			const user = (await resp.json()) as { login?: string };
+			if (!user.login) {
+				return { ok: false, error: 'GitHub response missing login.' };
+			}
+			const scopesHeader = resp.headers.get('x-oauth-scopes') ?? '';
+			const tokenTypeHeader =
+				resp.headers.get('x-github-authentication-token-type') ??
+				resp.headers.get('x-github-token-type') ??
+				'unknown';
+			const scopes = scopesHeader
+				.split(',')
+				.map((s) => s.trim())
+				.filter(Boolean);
+			return {
+				ok: true,
+				login: user.login,
+				scopes,
+				tokenType: tokenTypeHeader,
+			};
+		} catch (e) {
+			return {
+				ok: false,
+				error: e instanceof Error ? e.message : 'Network error',
+			};
+		}
+	}
+
+	async function validatePatForGuild(guildId: string): Promise<Result> {
+		const pat = store.$patDrafts.get()[guildId] ?? '';
+		if (!pat) return { ok: false, error: 'No PAT entered' };
+		store.$patValidatingFor.set({
+			...store.$patValidatingFor.get(),
+			[guildId]: true,
+		});
+		store.$patErrors.set({ ...store.$patErrors.get(), [guildId]: null });
+		const validatedClear = { ...store.$patValidatedFor.get() };
+		delete validatedClear[guildId];
+		store.$patValidatedFor.set(validatedClear);
+		const r = await validateGithubPat(pat);
+		const validatingDone = { ...store.$patValidatingFor.get() };
+		delete validatingDone[guildId];
+		store.$patValidatingFor.set(validatingDone);
+		if (!r.ok) {
+			store.$patErrors.set({
+				...store.$patErrors.get(),
+				[guildId]: r.error,
+			});
+			return r;
+		}
+		store.$patValidatedFor.set({
+			...store.$patValidatedFor.get(),
+			[guildId]: {
+				login: r.login,
+				scopes: r.scopes,
+				tokenType: r.tokenType,
+			},
+		});
+		return { ok: true };
+	}
+
+	async function savePatForGuild(
+		guildId: string,
+		tokenName: string,
+	): Promise<Result<{ tokenId: string }>> {
+		const pat = store.$patDrafts.get()[guildId] ?? '';
+		if (!pat) return { ok: false, error: 'No PAT entered' };
+		const validated = store.$patValidatedFor.get()[guildId] ?? null;
+		store.$patSavingFor.set({
+			...store.$patSavingFor.get(),
+			[guildId]: true,
+		});
+		store.$patErrors.set({ ...store.$patErrors.get(), [guildId]: null });
+		const r = await api.addToken({
+			tokenName,
+			service: 'github',
+			tokenValue: pat,
+			description: validated
+				? `GitHub PAT for ${validated.login}`
+				: 'GitHub PAT',
+		});
+		const savingDone = { ...store.$patSavingFor.get() };
+		delete savingDone[guildId];
+		store.$patSavingFor.set(savingDone);
+		if (r.ok) {
+			clearPatState(guildId);
+		} else {
+			store.$patErrors.set({
+				...store.$patErrors.get(),
+				[guildId]: r.error,
+			});
+		}
+		return r;
+	}
+
+	return {
+		setPatDraft,
+		clearPatState,
+		validateGithubPat,
+		validatePatForGuild,
+		savePatForGuild,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/github/repoConfig.ts
+++ b/packages/npm/droid/src/lib/agents/github/repoConfig.ts
@@ -1,0 +1,240 @@
+import {
+	botConfigFromFormDraft,
+	botConfigToFormDraft,
+	emptyBotConfigFormDraft,
+} from '../formDrafts';
+import type { AgentsCtx } from '../ctx';
+import type { AgentsApi } from '../api-types';
+import type { BotConfigFormDraft, DiscordshConfig, Result } from '../types';
+
+export function makeRepoConfig(ctx: AgentsCtx, api: AgentsApi) {
+	const { store } = ctx;
+
+	async function getRepoAllowlist(): Promise<
+		Result<{ repos: string[]; raw: string | null }>
+	> {
+		const r = await api.peekToken('github_repos');
+		if (!r.ok) return { ok: false, error: r.error };
+		if (!r.value) return { ok: true, repos: [], raw: null };
+		try {
+			const parsed = JSON.parse(r.value) as { repos?: unknown };
+			const repos = Array.isArray(parsed.repos)
+				? parsed.repos.filter((x): x is string => typeof x === 'string')
+				: [];
+			return { ok: true, repos, raw: r.value };
+		} catch {
+			return { ok: true, repos: [], raw: r.value };
+		}
+	}
+
+	async function setRepoAllowlist(repos: string[]): Promise<Result> {
+		const r = await api.addToken({
+			tokenName: 'github-repos',
+			service: 'github_repos',
+			tokenValue: JSON.stringify({ repos }),
+			description:
+				'Per-guild repo allowlist consumed by gh-webhook and gh-backfill',
+		});
+		if (!r.ok) return { ok: false, error: r.error };
+		return { ok: true };
+	}
+
+	function hydrateRepoAllowlistDraft(guildId: string, repos: string[]): void {
+		store.$repoAllowlistDrafts.set({
+			...store.$repoAllowlistDrafts.get(),
+			[guildId]: repos,
+		});
+		store.$repoAllowlistLoadedFor.set({
+			...store.$repoAllowlistLoadedFor.get(),
+			[guildId]: true,
+		});
+	}
+
+	function patchRepoAllowlistDraft(guildId: string, repos: string[]): void {
+		store.$repoAllowlistDrafts.set({
+			...store.$repoAllowlistDrafts.get(),
+			[guildId]: repos,
+		});
+	}
+
+	function clearRepoAllowlistDraft(guildId: string): void {
+		const drafts = { ...store.$repoAllowlistDrafts.get() };
+		delete drafts[guildId];
+		store.$repoAllowlistDrafts.set(drafts);
+		const loaded = { ...store.$repoAllowlistLoadedFor.get() };
+		delete loaded[guildId];
+		store.$repoAllowlistLoadedFor.set(loaded);
+	}
+
+	async function ensureRepoAllowlistLoaded(
+		guildId: string,
+		force = false,
+	): Promise<Result> {
+		if (!force && store.$repoAllowlistLoadedFor.get()[guildId]) {
+			return { ok: true };
+		}
+		const r = await getRepoAllowlist();
+		if (!r.ok) {
+			store.$repoAllowlistErrors.set({
+				...store.$repoAllowlistErrors.get(),
+				[guildId]: r.error,
+			});
+			return r;
+		}
+		hydrateRepoAllowlistDraft(guildId, r.repos);
+		store.$repoAllowlistErrors.set({
+			...store.$repoAllowlistErrors.get(),
+			[guildId]: null,
+		});
+		return { ok: true };
+	}
+
+	async function saveRepoAllowlistDraft(guildId: string): Promise<Result> {
+		const repos = store.$repoAllowlistDrafts.get()[guildId];
+		if (!repos) return { ok: false, error: 'No draft loaded yet' };
+		store.$repoAllowlistSavingFor.set({
+			...store.$repoAllowlistSavingFor.get(),
+			[guildId]: true,
+		});
+		store.$repoAllowlistErrors.set({
+			...store.$repoAllowlistErrors.get(),
+			[guildId]: null,
+		});
+		const r = await setRepoAllowlist(repos);
+		const savingDone = { ...store.$repoAllowlistSavingFor.get() };
+		delete savingDone[guildId];
+		store.$repoAllowlistSavingFor.set(savingDone);
+		if (!r.ok) {
+			store.$repoAllowlistErrors.set({
+				...store.$repoAllowlistErrors.get(),
+				[guildId]: r.error,
+			});
+		}
+		return r;
+	}
+
+	async function getBotConfig(): Promise<
+		Result<{ config: DiscordshConfig }>
+	> {
+		const r = await api.peekToken('discordsh_config');
+		if (!r.ok) return { ok: false, error: r.error };
+		if (!r.value) return { ok: true, config: {} };
+		try {
+			const parsed = JSON.parse(r.value) as Record<string, unknown>;
+			return { ok: true, config: parsed as DiscordshConfig };
+		} catch {
+			return { ok: true, config: {} };
+		}
+	}
+
+	async function setBotConfig(config: DiscordshConfig): Promise<Result> {
+		const r = await api.addToken({
+			tokenName: 'discordsh-config',
+			service: 'discordsh_config',
+			tokenValue: JSON.stringify(config),
+			description:
+				'Per-guild DiscordSH bot config (channels, defaults, toggles)',
+		});
+		if (!r.ok) return { ok: false, error: r.error };
+		return { ok: true };
+	}
+
+	function hydrateBotConfigDraft(
+		guildId: string,
+		cfg: DiscordshConfig,
+	): void {
+		store.$botConfigDrafts.set({
+			...store.$botConfigDrafts.get(),
+			[guildId]: botConfigToFormDraft(cfg),
+		});
+		store.$botConfigLoadedFor.set({
+			...store.$botConfigLoadedFor.get(),
+			[guildId]: true,
+		});
+	}
+
+	function patchBotConfigDraft(
+		guildId: string,
+		patch: Partial<BotConfigFormDraft>,
+	): void {
+		const drafts = store.$botConfigDrafts.get();
+		const cur = drafts[guildId] ?? emptyBotConfigFormDraft();
+		store.$botConfigDrafts.set({
+			...drafts,
+			[guildId]: { ...cur, ...patch },
+		});
+	}
+
+	function clearBotConfigDraft(guildId: string): void {
+		const drafts = { ...store.$botConfigDrafts.get() };
+		delete drafts[guildId];
+		store.$botConfigDrafts.set(drafts);
+		const loaded = { ...store.$botConfigLoadedFor.get() };
+		delete loaded[guildId];
+		store.$botConfigLoadedFor.set(loaded);
+	}
+
+	async function ensureBotConfigLoaded(
+		guildId: string,
+		force = false,
+	): Promise<Result> {
+		if (!force && store.$botConfigLoadedFor.get()[guildId]) {
+			return { ok: true };
+		}
+		const r = await getBotConfig();
+		if (!r.ok) {
+			store.$botConfigErrors.set({
+				...store.$botConfigErrors.get(),
+				[guildId]: r.error,
+			});
+			return r;
+		}
+		hydrateBotConfigDraft(guildId, r.config);
+		store.$botConfigErrors.set({
+			...store.$botConfigErrors.get(),
+			[guildId]: null,
+		});
+		return { ok: true };
+	}
+
+	async function saveBotConfigDraft(guildId: string): Promise<Result> {
+		const draft = store.$botConfigDrafts.get()[guildId];
+		if (!draft) return { ok: false, error: 'No draft loaded yet' };
+		store.$botConfigSavingFor.set({
+			...store.$botConfigSavingFor.get(),
+			[guildId]: true,
+		});
+		store.$botConfigErrors.set({
+			...store.$botConfigErrors.get(),
+			[guildId]: null,
+		});
+		const r = await setBotConfig(botConfigFromFormDraft(draft));
+		const savingDone = { ...store.$botConfigSavingFor.get() };
+		delete savingDone[guildId];
+		store.$botConfigSavingFor.set(savingDone);
+		if (!r.ok) {
+			store.$botConfigErrors.set({
+				...store.$botConfigErrors.get(),
+				[guildId]: r.error,
+			});
+		}
+		return r;
+	}
+
+	return {
+		getRepoAllowlist,
+		setRepoAllowlist,
+		hydrateRepoAllowlistDraft,
+		patchRepoAllowlistDraft,
+		clearRepoAllowlistDraft,
+		ensureRepoAllowlistLoaded,
+		saveRepoAllowlistDraft,
+		getBotConfig,
+		setBotConfig,
+		hydrateBotConfigDraft,
+		patchBotConfigDraft,
+		clearBotConfigDraft,
+		ensureBotConfigLoaded,
+		saveBotConfigDraft,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/github/tokens.ts
+++ b/packages/npm/droid/src/lib/agents/github/tokens.ts
@@ -1,0 +1,211 @@
+import { loadCachedTokens, saveCachedTokens } from '../cache';
+import type { AgentsCtx } from '../ctx';
+import type { AgentsApi } from '../api-types';
+import type { AgentTokenRow, Result } from '../types';
+
+export function makeTokens(ctx: AgentsCtx, api: AgentsApi) {
+	const { store, config, endpoints, runtime } = ctx;
+
+	async function loadTokens(guildId: string, force = false): Promise<void> {
+		const accessToken = store.$accessToken.get();
+		const providerToken = store.$providerToken.get();
+		if (!accessToken || !providerToken) return;
+
+		const userId = store.$userId.get();
+
+		if (!force && userId) {
+			const cached = loadCachedTokens(userId, guildId);
+			if (cached) {
+				store.$tokens.set(cached);
+				store.$tokensError.set(null);
+				return;
+			}
+		}
+
+		const existing = runtime.tokensInflight.get(guildId);
+		if (!force && existing) return existing;
+
+		const prevAbort = runtime.tokensAbort.get(guildId);
+		if (prevAbort) prevAbort.abort();
+		const abort = new AbortController();
+		runtime.tokensAbort.set(guildId, abort);
+
+		store.$tokensLoading.set(true);
+		store.$tokensError.set(null);
+
+		const promise = (async () => {
+			try {
+				const resp = await fetch(endpoints.guildVault, {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${accessToken}`,
+					},
+					body: JSON.stringify({
+						command: 'tokens.list_tokens',
+						server_id: guildId,
+					}),
+					signal: abort.signal,
+				});
+
+				const text = await resp.text();
+				let body: unknown;
+				try {
+					body = JSON.parse(text);
+				} catch {
+					store.$tokensError.set(
+						`HTTP ${resp.status}: ${text.slice(0, 200)}`,
+					);
+					return;
+				}
+
+				if (!resp.ok) {
+					const errMsg =
+						(body as { error?: string } | null)?.error ??
+						`HTTP ${resp.status}`;
+					store.$tokensError.set(errMsg);
+					return;
+				}
+
+				const rows =
+					(body as { tokens?: AgentTokenRow[] } | null)?.tokens ?? [];
+				store.$tokens.set(rows);
+				if (userId) saveCachedTokens(userId, guildId, rows);
+			} catch (e) {
+				if (e instanceof DOMException && e.name === 'AbortError') {
+					return;
+				}
+				store.$tokensError.set(
+					e instanceof Error ? e.message : 'Failed to load tokens',
+				);
+			} finally {
+				store.$tokensLoading.set(false);
+				runtime.tokensInflight.delete(guildId);
+				if (runtime.tokensAbort.get(guildId) === abort) {
+					runtime.tokensAbort.delete(guildId);
+				}
+			}
+		})();
+
+		runtime.tokensInflight.set(guildId, promise);
+		return promise;
+	}
+
+	async function addToken(input: {
+		tokenName: string;
+		service: string;
+		tokenValue: string;
+		description?: string | null;
+	}): Promise<Result<{ tokenId: string }>> {
+		const guildId = store.$selectedGuildId.get();
+		const accessToken = store.$accessToken.get();
+		if (!guildId || !accessToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await ctx.callGuildVault('tokens.set_token', accessToken, {
+			server_id: guildId,
+			token_name: input.tokenName,
+			service: input.service,
+			token_value: input.tokenValue,
+			description: input.description ?? null,
+		});
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		const tokenId =
+			(resp.body as { token_id?: string } | null)?.token_id ?? '';
+		await api.refreshSelectedGuild();
+		config.notify({
+			message: `Token "${input.tokenName}" registered.`,
+			severity: 'success',
+			duration: 3500,
+		});
+		return { ok: true, tokenId };
+	}
+
+	async function deleteToken(tokenId: string): Promise<Result> {
+		const guildId = store.$selectedGuildId.get();
+		const accessToken = store.$accessToken.get();
+		if (!guildId || !accessToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await ctx.callGuildVault(
+			'tokens.delete_token',
+			accessToken,
+			{ server_id: guildId, token_id: tokenId },
+		);
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		await api.refreshSelectedGuild();
+		config.notify({
+			message: 'Token deleted.',
+			severity: 'success',
+			duration: 3500,
+		});
+		return { ok: true };
+	}
+
+	async function peekToken(
+		service: string,
+	): Promise<Result<{ value: string | null }>> {
+		const guildId = store.$selectedGuildId.get();
+		const accessToken = store.$accessToken.get();
+		if (!guildId || !accessToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await ctx.callGuildVault(
+			'tokens.peek_token',
+			accessToken,
+			{
+				server_id: guildId,
+				service,
+			},
+		);
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		const value =
+			(resp.body as { value?: string | null } | null)?.value ?? null;
+		return { ok: true, value };
+	}
+
+	async function toggleToken(
+		tokenId: string,
+		isActive: boolean,
+	): Promise<Result> {
+		const guildId = store.$selectedGuildId.get();
+		const accessToken = store.$accessToken.get();
+		if (!guildId || !accessToken) {
+			return { ok: false, error: 'No guild selected or session missing' };
+		}
+
+		const resp = await ctx.callGuildVault(
+			'tokens.toggle_token',
+			accessToken,
+			{ server_id: guildId, token_id: tokenId, is_active: isActive },
+		);
+
+		if (!resp.ok) return { ok: false, error: resp.error };
+		await api.refreshSelectedGuild();
+		return { ok: true };
+	}
+
+	function hasService(service: string): AgentTokenRow | null {
+		const tokens = store.$tokens.get();
+		return (
+			tokens.find((t) => t.service === service && t.is_active) ??
+			tokens.find((t) => t.service === service) ??
+			null
+		);
+	}
+
+	return {
+		loadTokens,
+		addToken,
+		deleteToken,
+		peekToken,
+		toggleToken,
+		hasService,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/github/webhook.ts
+++ b/packages/npm/droid/src/lib/agents/github/webhook.ts
@@ -1,0 +1,326 @@
+import type { AgentsCtx } from '../ctx';
+import type { AgentsApi } from '../api-types';
+import type {
+	GithubRepoHook,
+	Result,
+	WebhookDelivery,
+	WebhookInstallResult,
+} from '../types';
+
+export function makeWebhook(ctx: AgentsCtx, api: AgentsApi) {
+	const { store, endpoints } = ctx;
+
+	function setWebhookDraft(guildId: string, secret: string | null): void {
+		const m = { ...store.$webhookDrafts.get() };
+		if (secret === null) delete m[guildId];
+		else m[guildId] = secret;
+		store.$webhookDrafts.set(m);
+	}
+
+	function clearWebhookError(guildId: string): void {
+		const m = { ...store.$webhookErrors.get() };
+		delete m[guildId];
+		store.$webhookErrors.set(m);
+	}
+
+	async function saveWebhookDraft(
+		guildId: string,
+		tokenName: string,
+		description: string,
+	): Promise<Result<{ tokenId: string }>> {
+		const secret = store.$webhookDrafts.get()[guildId];
+		if (!secret) return { ok: false, error: 'No secret to save' };
+		store.$webhookSavingFor.set({
+			...store.$webhookSavingFor.get(),
+			[guildId]: true,
+		});
+		store.$webhookErrors.set({
+			...store.$webhookErrors.get(),
+			[guildId]: null,
+		});
+		const r = await api.addToken({
+			tokenName,
+			service: 'github_webhook',
+			tokenValue: secret,
+			description,
+		});
+		const savingDone = { ...store.$webhookSavingFor.get() };
+		delete savingDone[guildId];
+		store.$webhookSavingFor.set(savingDone);
+		if (r.ok) {
+			setWebhookDraft(guildId, null);
+		} else {
+			store.$webhookErrors.set({
+				...store.$webhookErrors.get(),
+				[guildId]: r.error,
+			});
+		}
+		return r;
+	}
+
+	async function installRepoWebhook(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<WebhookInstallResult | { ok: false; error: string }> {
+		const r = await ctx.callJson<{
+			installed: boolean;
+			already_present: boolean;
+			hook_id: number | null;
+		}>(endpoints.ghAdmin, {
+			command: 'webhooks.install',
+			server_id: guildId,
+			owner,
+			repo,
+		});
+		if (!r.ok) return r;
+		return {
+			ok: true,
+			installed: !!r.data.installed,
+			alreadyPresent: !!r.data.already_present,
+			hookId: r.data.hook_id ?? null,
+		};
+	}
+
+	async function pingRepoWebhook(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<
+		| { ok: true; hookId: number; url: string }
+		| { ok: false; error: string; retryAfterMs?: number }
+	> {
+		const r = await ctx.callJson<{
+			pinged: boolean;
+			hook_id: number;
+			url: string;
+		}>(endpoints.ghAdmin, {
+			command: 'webhooks.ping',
+			server_id: guildId,
+			owner,
+			repo,
+		});
+		if (!r.ok) return { ok: false, error: r.error };
+		return { ok: true, hookId: r.data.hook_id, url: r.data.url };
+	}
+
+	async function listRepoWebhooks(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<Result<{ expectedUrl: string; hooks: GithubRepoHook[] }>> {
+		const r = await ctx.callJson<{
+			expected_url: string;
+			hooks: GithubRepoHook[];
+		}>(endpoints.ghAdmin, {
+			command: 'webhooks.list',
+			server_id: guildId,
+			owner,
+			repo,
+		});
+		if (!r.ok) return r;
+		return {
+			ok: true,
+			expectedUrl: r.data.expected_url,
+			hooks: r.data.hooks ?? [],
+		};
+	}
+
+	function setWebhookInstallSelected(guildId: string, repo: string): void {
+		store.$webhookInstallSelected.set({
+			...store.$webhookInstallSelected.get(),
+			[guildId]: repo,
+		});
+	}
+
+	function clearWebhookInstallResult(guildId: string): void {
+		const m = { ...store.$webhookInstallResults.get() };
+		delete m[guildId];
+		store.$webhookInstallResults.set(m);
+	}
+
+	async function installWebhookForGuild(guildId: string): Promise<void> {
+		const repoFull = store.$webhookInstallSelected.get()[guildId] ?? '';
+		const [owner, repo] = repoFull.split('/');
+		if (!owner || !repo) return;
+		store.$webhookInstallBusyFor.set({
+			...store.$webhookInstallBusyFor.get(),
+			[guildId]: true,
+		});
+		const resultsClear = { ...store.$webhookInstallResults.get() };
+		delete resultsClear[guildId];
+		store.$webhookInstallResults.set(resultsClear);
+		const r = await installRepoWebhook(guildId, owner, repo);
+		const busyDone = { ...store.$webhookInstallBusyFor.get() };
+		delete busyDone[guildId];
+		store.$webhookInstallBusyFor.set(busyDone);
+		store.$webhookInstallResults.set({
+			...store.$webhookInstallResults.get(),
+			[guildId]: r,
+		});
+	}
+
+	async function pingWebhookForGuild(guildId: string): Promise<void> {
+		const repoFull = store.$webhookInstallSelected.get()[guildId] ?? '';
+		const [owner, repo] = repoFull.split('/');
+		if (!owner || !repo) return;
+		store.$webhookPingBusyFor.set({
+			...store.$webhookPingBusyFor.get(),
+			[guildId]: true,
+		});
+		const r = await pingRepoWebhook(guildId, owner, repo);
+		const busyDone = { ...store.$webhookPingBusyFor.get() };
+		delete busyDone[guildId];
+		store.$webhookPingBusyFor.set(busyDone);
+		const result = r.ok
+			? { ok: true as const, hookId: r.hookId, at: Date.now() }
+			: { ok: false as const, error: r.error };
+		store.$webhookPingResults.set({
+			...store.$webhookPingResults.get(),
+			[guildId]: result,
+		});
+	}
+
+	async function verifyWebhookInstall(
+		guildId: string,
+		repoFull: string,
+	): Promise<void> {
+		const [owner, repo] = repoFull.split('/');
+		if (!owner || !repo) return;
+		const cur = store.$webhookInstallResults.get()[guildId];
+		if (cur && cur.ok && (cur.installed || cur.alreadyPresent)) return;
+		const r = await listRepoWebhooks(guildId, owner, repo);
+		if (!r.ok) return;
+		const kbveHook = r.hooks.find((h) => h.is_kbve);
+		if (!kbveHook) return;
+		store.$webhookInstallResults.set({
+			...store.$webhookInstallResults.get(),
+			[guildId]: {
+				ok: true as const,
+				installed: false,
+				alreadyPresent: true,
+				hookId: kbveHook.id,
+			},
+		});
+	}
+
+	async function rotateWebhookForGuild(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<void> {
+		store.$webhookRotateBusyFor.set({
+			...store.$webhookRotateBusyFor.get(),
+			[guildId]: true,
+		});
+		const r = await ctx.callJson<{ rotated: boolean; hook_id: number }>(
+			endpoints.ghAdmin,
+			{ command: 'webhooks.rotate', server_id: guildId, owner, repo },
+		);
+		const busy = { ...store.$webhookRotateBusyFor.get() };
+		delete busy[guildId];
+		store.$webhookRotateBusyFor.set(busy);
+		const result = r.ok
+			? { ok: true as const, hookId: r.data.hook_id, at: Date.now() }
+			: { ok: false as const, error: r.error };
+		store.$webhookRotateResults.set({
+			...store.$webhookRotateResults.get(),
+			[guildId]: result,
+		});
+		if (r.ok) {
+			await api.refreshSelectedGuild();
+		}
+	}
+
+	async function deleteWebhookForGuild(
+		guildId: string,
+		owner: string,
+		repo: string,
+	): Promise<Result> {
+		store.$webhookDeleteBusyFor.set({
+			...store.$webhookDeleteBusyFor.get(),
+			[guildId]: true,
+		});
+		const r = await ctx.callJson<{
+			deleted: boolean;
+			already_absent?: boolean;
+			hook_id?: number;
+		}>(endpoints.ghAdmin, {
+			command: 'webhooks.delete',
+			server_id: guildId,
+			owner,
+			repo,
+		});
+		const busy = { ...store.$webhookDeleteBusyFor.get() };
+		delete busy[guildId];
+		store.$webhookDeleteBusyFor.set(busy);
+		if (!r.ok) return { ok: false, error: r.error };
+		const results = { ...store.$webhookInstallResults.get() };
+		delete results[guildId];
+		store.$webhookInstallResults.set(results);
+		return { ok: true };
+	}
+
+	async function loadWebhookDeliveries(
+		guildId: string,
+		owner: string,
+		repo: string,
+		limit = 10,
+	): Promise<void> {
+		const key = `${guildId}:${owner}/${repo}`;
+		store.$webhookDeliveriesLoading.set({
+			...store.$webhookDeliveriesLoading.get(),
+			[key]: true,
+		});
+		store.$webhookDeliveriesError.set({
+			...store.$webhookDeliveriesError.get(),
+			[key]: null,
+		});
+		const r = await ctx.callJson<{
+			hook_id: number;
+			deliveries: WebhookDelivery[];
+		}>(endpoints.ghAdmin, {
+			command: 'webhooks.deliveries',
+			server_id: guildId,
+			owner,
+			repo,
+			limit,
+		});
+		const loading = { ...store.$webhookDeliveriesLoading.get() };
+		delete loading[key];
+		store.$webhookDeliveriesLoading.set(loading);
+		if (!r.ok) {
+			store.$webhookDeliveriesError.set({
+				...store.$webhookDeliveriesError.get(),
+				[key]: r.error,
+			});
+			return;
+		}
+		store.$webhookDeliveries.set({
+			...store.$webhookDeliveries.get(),
+			[key]: r.data.deliveries ?? [],
+		});
+	}
+
+	function webhookUrlFor(guildId: string): string {
+		return `${endpoints.ghWebhookBase}/${guildId}`;
+	}
+
+	return {
+		setWebhookDraft,
+		clearWebhookError,
+		saveWebhookDraft,
+		installRepoWebhook,
+		pingRepoWebhook,
+		listRepoWebhooks,
+		setWebhookInstallSelected,
+		clearWebhookInstallResult,
+		installWebhookForGuild,
+		pingWebhookForGuild,
+		verifyWebhookInstall,
+		rotateWebhookForGuild,
+		deleteWebhookForGuild,
+		loadWebhookDeliveries,
+		webhookUrlFor,
+	};
+}

--- a/packages/npm/droid/src/lib/agents/index.ts
+++ b/packages/npm/droid/src/lib/agents/index.ts
@@ -1,0 +1,35 @@
+export { createAgents } from './createAgents';
+export type { AgentsApi, AgentsMethods } from './api-types';
+export type { AgentsStore } from './state/atoms';
+export type {
+	AgentsConfig,
+	AgentsNotice,
+	AgentsSession,
+	ResolvedAgentsConfig,
+} from './config';
+export {
+	emptyBotConfigFormDraft,
+	botConfigToFormDraft,
+	botConfigFromFormDraft,
+} from './formDrafts';
+export { parseJwtPayload, extractJwtOwnedGuildIds } from './cache';
+export type {
+	AgentTokenRow,
+	AuthState as AgentsAuthState,
+	BackfillResult,
+	BotConfigFormDraft,
+	DiscordChannel,
+	DiscordForumChannel,
+	DiscordGuild,
+	DiscordshConfig,
+	EventQueueStats,
+	FailedEvent,
+	GithubRepoHook,
+	GuildChannels,
+	PatValidation,
+	PendingEvent,
+	Result as AgentsResult,
+	WebhookDelivery,
+	WebhookInstallResult,
+	WebhookOpResult,
+} from './types';

--- a/packages/npm/droid/src/lib/agents/state/atoms.ts
+++ b/packages/npm/droid/src/lib/agents/state/atoms.ts
@@ -1,0 +1,122 @@
+import { atom, type WritableAtom } from 'nanostores';
+import { persistentAtom } from '@nanostores/persistent';
+import type {
+	AgentTokenRow,
+	AuthState,
+	BackfillResult,
+	BotConfigFormDraft,
+	DiscordGuild,
+	EventQueueStats,
+	FailedEvent,
+	GuildChannels,
+	PatValidation,
+	PendingEvent,
+	WebhookDelivery,
+	WebhookInstallResult,
+	WebhookOpResult,
+} from '../types';
+
+type Fail = { ok: false; error: string };
+
+function jsonPersistent<T>(key: string, fallback: T): WritableAtom<T> {
+	return persistentAtom<T>(key, fallback, {
+		encode: (v) => JSON.stringify(v),
+		decode: (raw) => {
+			try {
+				return raw ? (JSON.parse(raw) as T) : fallback;
+			} catch {
+				return fallback;
+			}
+		},
+	});
+}
+
+export function createAgentsStore() {
+	return {
+		$authState: atom<AuthState>('loading'),
+		$accessToken: atom<string | null>(null),
+		$providerToken: atom<string | null>(null),
+		$userId: atom<string | null>(null),
+
+		$guilds: atom<DiscordGuild[]>([]),
+		$guildsLoading: atom<boolean>(false),
+		$guildsError: atom<string | null>(null),
+		$guildsStale: atom<boolean>(false),
+
+		$selectedGuildId: atom<string | null>(null),
+
+		$tokens: atom<AgentTokenRow[]>([]),
+		$tokensLoading: atom<boolean>(false),
+		$tokensError: atom<string | null>(null),
+
+		$botConfigDrafts: atom<Record<string, BotConfigFormDraft>>({}),
+		$botConfigSavingFor: atom<Record<string, boolean>>({}),
+		$botConfigErrors: atom<Record<string, string | null>>({}),
+		$botConfigLoadedFor: atom<Record<string, boolean>>({}),
+
+		$repoAllowlistDrafts: atom<Record<string, string[]>>({}),
+		$repoAllowlistSavingFor: atom<Record<string, boolean>>({}),
+		$repoAllowlistErrors: atom<Record<string, string | null>>({}),
+		$repoAllowlistLoadedFor: atom<Record<string, boolean>>({}),
+
+		$webhookDrafts: atom<Record<string, string | null>>({}),
+		$webhookSavingFor: atom<Record<string, boolean>>({}),
+		$webhookErrors: atom<Record<string, string | null>>({}),
+
+		$patDrafts: atom<Record<string, string>>({}),
+		$patValidatedFor: atom<Record<string, PatValidation | null>>({}),
+		$patValidatingFor: atom<Record<string, boolean>>({}),
+		$patSavingFor: atom<Record<string, boolean>>({}),
+		$patErrors: atom<Record<string, string | null>>({}),
+
+		$backfillDrafts: atom<Record<string, { owner: string; repo: string }>>(
+			{},
+		),
+		$backfillBusyFor: atom<Record<string, boolean>>({}),
+		$backfillResults: atom<Record<string, BackfillResult | Fail | null>>(
+			{},
+		),
+
+		$webhookInstallSelected: atom<Record<string, string>>({}),
+		$webhookInstallBusyFor: atom<Record<string, boolean>>({}),
+		$webhookInstallResults: atom<
+			Record<string, WebhookInstallResult | Fail | null>
+		>({}),
+		$webhookPingBusyFor: atom<Record<string, boolean>>({}),
+		$webhookPingResults: atom<
+			Record<string, WebhookOpResult | Fail | null>
+		>({}),
+
+		$guildChannels: jsonPersistent<
+			Record<string, GuildChannels & { cached_at: number }>
+		>('kbve:agents:guild_channels:v1', {}),
+		$guildChannelsLoading: atom<Record<string, boolean>>({}),
+		$guildChannelsError: atom<Record<string, string | null>>({}),
+
+		$botMembership: jsonPersistent<
+			Record<string, { isMember: boolean; cached_at: number }>
+		>('kbve:agents:bot_membership:v1', {}),
+		$botMembershipLoading: atom<Record<string, boolean>>({}),
+		$botMembershipError: atom<Record<string, string | null>>({}),
+
+		$webhookDeliveries: atom<Record<string, WebhookDelivery[]>>({}),
+		$webhookDeliveriesLoading: atom<Record<string, boolean>>({}),
+		$webhookDeliveriesError: atom<Record<string, string | null>>({}),
+
+		$webhookRotateBusyFor: atom<Record<string, boolean>>({}),
+		$webhookRotateResults: atom<
+			Record<string, WebhookOpResult | Fail | null>
+		>({}),
+		$webhookDeleteBusyFor: atom<Record<string, boolean>>({}),
+
+		$eventStats: atom<Record<string, EventQueueStats>>({}),
+		$eventStatsLoading: atom<Record<string, boolean>>({}),
+		$failedEvents: atom<Record<string, FailedEvent[]>>({}),
+		$failedEventsLoading: atom<Record<string, boolean>>({}),
+		$pendingEvents: atom<Record<string, PendingEvent[]>>({}),
+		$pendingEventsLoading: atom<Record<string, boolean>>({}),
+		$eventRequeueBusyFor: atom<Record<string, boolean>>({}),
+	};
+}
+
+export type AgentsStore = ReturnType<typeof createAgentsStore>;

--- a/packages/npm/droid/src/lib/agents/types.ts
+++ b/packages/npm/droid/src/lib/agents/types.ts
@@ -1,0 +1,152 @@
+export type AuthState =
+	| 'loading'
+	| 'authenticated'
+	| 'unauthenticated'
+	| 'discord_reauth_required';
+
+export interface DiscordGuild {
+	id: string;
+	name: string;
+	icon: string | null;
+	owner: boolean;
+	permissions: string;
+}
+
+export interface DiscordshConfig {
+	default_repo?: string;
+	claim_channel_id?: string;
+	forum_channel_id?: string;
+	noticeboard_channel_id?: string;
+	taskboard_channel_id?: string;
+	max_assignees?: number;
+	mirror_pr_events?: boolean;
+	active?: boolean;
+}
+
+export interface BotConfigFormDraft {
+	default_repo: string;
+	claim_channel_id: string;
+	forum_channel_id: string;
+	noticeboard_channel_id: string;
+	taskboard_channel_id: string;
+	max_assignees: string;
+	mirror_pr_events: boolean;
+	active: boolean;
+}
+
+export interface AgentTokenRow {
+	token_id: string;
+	token_name: string;
+	service: string;
+	description: string | null;
+	is_active: boolean;
+	created_at: string;
+	updated_at: string | null;
+}
+
+export interface DiscordForumChannel {
+	id: string;
+	name: string;
+	parent_id: string | null;
+	position: number;
+}
+
+export interface DiscordChannel {
+	id: string;
+	name: string;
+	parent_id: string | null;
+	position: number;
+}
+
+export interface GuildChannels {
+	forums: DiscordChannel[];
+	texts: DiscordChannel[];
+}
+
+export interface WebhookDelivery {
+	id: number;
+	guid: string;
+	delivered_at: string;
+	redelivery: boolean;
+	duration: number;
+	status: string;
+	status_code: number;
+	event: string;
+	action: string | null;
+}
+
+export interface EventQueueStats {
+	last_delivered_at: string | null;
+	last_recorded_at: string | null;
+	pending_count: number;
+	in_flight_count: number;
+	delivered_count: number;
+	failed_count: number;
+	oldest_pending_at: string | null;
+}
+
+export interface FailedEvent {
+	id: number;
+	owner: string;
+	repo: string;
+	number: number;
+	event_type: string;
+	actor: string | null;
+	delivery_attempts: number;
+	last_error: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+export interface PendingEvent {
+	id: number;
+	owner: string;
+	repo: string;
+	number: number;
+	event_type: string;
+	actor: string | null;
+	delivery_state: number;
+	delivery_attempts: number;
+	created_at: string;
+	claimed_at: string | null;
+}
+
+export interface GithubRepoHook {
+	id: number;
+	name: string;
+	active: boolean;
+	events: string[];
+	url: string | null;
+	is_kbve: boolean;
+	updated_at: string;
+}
+
+export interface PatValidation {
+	login: string;
+	scopes: string[];
+	tokenType: string;
+}
+
+export interface BackfillResult {
+	ok: true;
+	upserted: number;
+	pages: number;
+	rateLimitRemaining: number | null;
+}
+
+export interface WebhookInstallResult {
+	ok: true;
+	installed: boolean;
+	alreadyPresent: boolean;
+	hookId: number | null;
+}
+
+export interface WebhookOpResult {
+	ok: true;
+	hookId: number;
+	at: number;
+}
+
+export type Result<T = unknown> =
+	| ({ ok: true } & T)
+	| { ok: false; error: string };


### PR DESCRIPTION
## What

Split the 2225-line `apps/kbve/astro-kbve/src/components/dashboard/agentsService.ts` god-file into shared npm packages so the Discord/GitHub agents dashboard can be reused across **astro-kbve** and (next) **astro-discordsh** without duplicating code.

## Scope

Packages only — the app is **not** touched this round (still imports its local `agentsService.ts`). Zero app risk; the flip + local-file deletion lands in a follow-up PR.

## @kbve/droid — `src/lib/agents/` (logic)

Full functional rewrite of the `AgentsService` singleton class into composed module factories (`makeAuth` / `makeGuilds` / `makeTokens` / `makeRepoConfig` / `makePat` / `makeWebhook` / `makeBackfill` / `makeEvents` / `makeDiscordBot`) behind a `createAgents(config): AgentsApi` factory over a shared `AgentsCtx` (store + config + endpoints + runtime).

Framework-agnostic: **no `@/` imports, no `import.meta.env`, no React.** App coupling is inverted into an `AgentsConfig` DI contract:

- `loadSession()` → `{ accessToken, providerToken }`
- `refreshSession()`, `getDiscordProviderToken()`, `clearDiscordProviderToken()`, `signInWithDiscord()`
- `notify()` (defaults to droid `addToast`)
- `supabaseUrl`, `discordBotClientId` / `discordClientId`

## @kbve/astro (render)

- `src/agents/` — the 9 `ReactAgent*` components, consuming the logic via `useAgents()`
- `src/agents/context.tsx` — `useAgents()` + a **module registry** (`configureAgents` / `registerAgents` / `getAgents`), not React Context: Astro islands are independent React roots, so a Context provider can't bridge them. Mirrors the existing `registerSupabaseGateway` pattern.
- `src/dashboard/` — the shared `dashboard-ui` primitives (AuthGate / Section / RefreshButton / styles)
- `lucide-react` added as an externalized peer dependency

## Verification

- droid: `tsc -p tsconfig.lib.json --noEmit` → 0 errors; `vite build` bundles clean
- astro: typechecks clean against droid's built `.d.ts`; `vite build` bundles clean; `lucide-react` / `@kbve/droid` / nanostores all externalized
- Surface parity: all 60 `AgentsMethods` are runtime-assembled in `createAgents` (closes the `Object.assign as AgentsApi` gap tsc can't see); every component `agents.$atom` / `agents.method()` exists on `AgentsApi`
- No app coupling leaked into the ported components

## Follow-ups

1. Flip astro-kbve to consume `@kbve/astro` agents + delete the local `agentsService.ts` + 9 components + `dashboard-ui` (wire `configureAgents({...})` at boot)
2. Integrate the same packages into astro-discordsh