### PR TITLE
feat(cryptothrone): CloudCity world sim — NPCs, monsters, extensible simgrid (P2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4854,6 +4854,7 @@ version = "0.0.1"
 dependencies = [
  "agones",
  "axum 0.7.9",
+ "bevy",
  "simgrid",
  "tokio",
  "tracing",

--- a/apps/agones/cryptothrone/server/Cargo.toml
+++ b/apps/agones/cryptothrone/server/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 simgrid = { path = "../../../../packages/rust/simgrid" }
+bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
 axum = { version = "0.7", default-features = false, features = ["ws", "json", "http1", "tokio"] }
 tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net"] }
 tracing = "0.1"

--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -1,28 +1,80 @@
-use simgrid::SimConfig;
-use simgrid::grid::WalkableMap;
+use bevy::prelude::{Commands, Local};
 use simgrid::proto::Tile;
+use simgrid::{EntityKind, GridPos, Health, MoveSpeed, MoveTarget, SimConfig, WalkableMap, Wander};
 
-pub const MAP_WIDTH: i32 = 40;
-pub const MAP_HEIGHT: i32 = 30;
+pub const MAP_WIDTH: i32 = 64;
+pub const MAP_HEIGHT: i32 = 64;
 pub const MAX_PLAYERS: usize = 32;
 
-pub const PLAYER_KIND: u16 = 0;
-pub const PLAYER_HP: i32 = 100;
-pub const TICKS_PER_TILE: u8 = 4;
+pub const KIND_PLAYER: u16 = 0;
+pub const KIND_MONK: u16 = 1;
+pub const KIND_BIRD: u16 = 2;
 
-pub fn spawn_tile() -> Tile {
-    Tile::new(MAP_WIDTH / 2, MAP_HEIGHT / 2)
-}
+pub const PLAYER_HP: i32 = 100;
+pub const PLAYER_TICKS_PER_TILE: u8 = 4;
+
+pub const PLAYER_SPAWN: Tile = Tile::new(5, 12);
+
+pub const MONK_SPAWN: Tile = Tile::new(4, 10);
+pub const MONK_HP: i32 = 30;
+pub const MONK_WANDER_RADIUS: i32 = 3;
+pub const MONK_WANDER_PERIOD_TICKS: u32 = 30;
+pub const MONK_TICKS_PER_TILE: u8 = 6;
+
+pub const BIRD_COUNT: i32 = 10;
+pub const BIRD_ORIGIN: Tile = Tile::new(7, 7);
+pub const BIRD_HP: i32 = 10;
+pub const BIRD_WANDER_RADIUS: i32 = 20;
+pub const BIRD_WANDER_PERIOD_TICKS: u32 = 20;
+pub const BIRD_TICKS_PER_TILE: u8 = 3;
 
 pub fn config() -> SimConfig {
     SimConfig {
-        player_kind: PLAYER_KIND,
+        player_kind: KIND_PLAYER,
         player_hp: PLAYER_HP,
-        spawn: spawn_tile(),
-        ticks_per_tile: TICKS_PER_TILE,
+        spawn: PLAYER_SPAWN,
+        ticks_per_tile: PLAYER_TICKS_PER_TILE,
     }
 }
 
 pub fn walkable_map() -> WalkableMap {
     WalkableMap::open(MAP_WIDTH, MAP_HEIGHT)
+}
+
+pub fn spawn_world(mut done: Local<bool>, mut commands: Commands) {
+    if *done {
+        return;
+    }
+    *done = true;
+
+    commands.spawn((
+        EntityKind(KIND_MONK),
+        GridPos::at(MONK_SPAWN),
+        MoveTarget::default(),
+        MoveSpeed {
+            ticks_per_tile: MONK_TICKS_PER_TILE,
+        },
+        Health {
+            hp: MONK_HP,
+            max_hp: MONK_HP,
+        },
+        Wander::new(MONK_SPAWN, MONK_WANDER_RADIUS, MONK_WANDER_PERIOD_TICKS),
+    ));
+
+    for i in 0..BIRD_COUNT {
+        let origin = Tile::new(BIRD_ORIGIN.x, BIRD_ORIGIN.y + i);
+        commands.spawn((
+            EntityKind(KIND_BIRD),
+            GridPos::at(origin),
+            MoveTarget::default(),
+            MoveSpeed {
+                ticks_per_tile: BIRD_TICKS_PER_TILE,
+            },
+            Health {
+                hp: BIRD_HP,
+                max_hp: BIRD_HP,
+            },
+            Wander::new(origin, BIRD_WANDER_RADIUS, BIRD_WANDER_PERIOD_TICKS),
+        ));
+    }
 }

--- a/apps/agones/cryptothrone/server/src/main.rs
+++ b/apps/agones/cryptothrone/server/src/main.rs
@@ -3,6 +3,7 @@ mod game;
 
 use std::net::SocketAddr;
 
+use bevy::prelude::IntoScheduleConfigs;
 use simgrid::net::ServerState;
 use simgrid::{SNAPSHOT_BROADCAST_CAPACITY, build_app, run_sim_loop};
 use tokio::net::TcpListener;
@@ -56,7 +57,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .enable_time()
             .build()
             .expect("sim runtime");
-        let app = build_app(snap_tx, input_rx, roster, seed, config, map);
+        let mut app = build_app(snap_tx, input_rx, roster, seed, config, map);
+        app.add_systems(
+            bevy::prelude::Update,
+            game::spawn_world.in_set(simgrid::SimSet::Spawn),
+        );
         rt.block_on(run_sim_loop(app));
     });
 

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -6,5 +6,9 @@ pub mod sim;
 #[cfg(feature = "supabase-auth")]
 pub mod auth;
 
+pub use grid::{GridPos, MoveSpeed, MoveTarget, WalkableMap};
 pub use net::{Roster, ServerState, SlotInput, router};
-pub use sim::{SIM_TICK_HZ, SNAPSHOT_BROADCAST_CAPACITY, SimConfig, build_app, run_sim_loop};
+pub use sim::{
+    EntityKind, Health, PlayerSlotTag, SIM_TICK_HZ, SNAPSHOT_BROADCAST_CAPACITY, SimConfig, SimSet,
+    Wander, build_app, run_sim_loop,
+};

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -9,6 +9,8 @@ pub struct EntityId(pub u32);
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct PlayerSlot(pub u16);
 
+pub const PLAYER_SLOT_NONE: PlayerSlot = PlayerSlot(u16::MAX);
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Tile {
     pub x: i32,

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use bevy::app::App;
 use bevy::ecs::entity::Entity;
+use bevy::ecs::schedule::SystemSet;
 use bevy::prelude::{
     Commands, Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update,
 };
@@ -20,6 +21,17 @@ pub const SNAPSHOT_BROADCAST_CAPACITY: usize = 256;
 pub const KEYFRAME_EVERY_N_TICKS: u32 = SIM_TICK_HZ * 5;
 
 pub const PLAYER_KIND: u16 = 0;
+
+#[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum SimSet {
+    Tick,
+    Spawn,
+    Occupancy,
+    Input,
+    Ai,
+    Movement,
+    Snapshot,
+}
 
 #[derive(Resource, Clone)]
 pub struct SimConfig {
@@ -79,6 +91,25 @@ pub struct Health {
     pub max_hp: i32,
 }
 
+#[derive(Component, Clone, Copy)]
+pub struct Wander {
+    pub origin: Tile,
+    pub radius: i32,
+    pub period_ticks: u32,
+    pub next_tick: u32,
+}
+
+impl Wander {
+    pub fn new(origin: Tile, radius: i32, period_ticks: u32) -> Self {
+        Self {
+            origin,
+            radius: radius.max(0),
+            period_ticks: period_ticks.max(1),
+            next_tick: 0,
+        }
+    }
+}
+
 pub fn build_app(
     tx: broadcast::Sender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
@@ -99,18 +130,26 @@ pub fn build_app(
         .insert_resource(Occupancy::default())
         .insert_resource(map)
         .insert_resource(config)
-        .add_systems(
+        .configure_sets(
             Update,
             (
-                tick_sim,
-                sync_roster,
-                rebuild_occupancy,
-                drain_inputs,
-                advance_movement,
-                emit_snapshot,
+                SimSet::Tick,
+                SimSet::Spawn,
+                SimSet::Occupancy,
+                SimSet::Input,
+                SimSet::Ai,
+                SimSet::Movement,
+                SimSet::Snapshot,
             )
                 .chain(),
-        );
+        )
+        .add_systems(Update, tick_sim.in_set(SimSet::Tick))
+        .add_systems(Update, sync_roster.in_set(SimSet::Spawn))
+        .add_systems(Update, rebuild_occupancy.in_set(SimSet::Occupancy))
+        .add_systems(Update, drain_inputs.in_set(SimSet::Input))
+        .add_systems(Update, wander_system.in_set(SimSet::Ai))
+        .add_systems(Update, advance_movement.in_set(SimSet::Movement))
+        .add_systems(Update, emit_snapshot.in_set(SimSet::Snapshot));
     app
 }
 
@@ -201,12 +240,12 @@ fn drain_inputs(
             continue;
         };
         for input in inputs {
-            apply_input(entity, input, &map, &mut occ, &mut pos, &mut mv);
+            apply_step(entity, input, &map, &mut occ, &mut pos, &mut mv);
         }
     }
 }
 
-fn apply_input(
+fn apply_step(
     entity: Entity,
     input: &Input,
     map: &WalkableMap,
@@ -217,19 +256,7 @@ fn apply_input(
     match input {
         Input::Step { dir } => {
             pos.facing = dir.facing();
-            if mv.target.is_some() {
-                return;
-            }
-            let candidate = step_tile(pos.tile, *dir);
-            if !map.is_walkable(candidate) {
-                return;
-            }
-            if !occ.is_free(candidate) && occ.occupant(candidate) != Some(entity) {
-                return;
-            }
-            mv.target = Some(candidate);
-            mv.progress = 0;
-            occ.set(candidate, entity);
+            try_move(entity, *dir, map, occ, pos, mv, None);
         }
         Input::Face { facing } => {
             pos.facing = *facing;
@@ -238,9 +265,81 @@ fn apply_input(
     }
 }
 
+fn try_move(
+    entity: Entity,
+    dir: Dir,
+    map: &WalkableMap,
+    occ: &mut Occupancy,
+    pos: &GridPos,
+    mv: &mut MoveTarget,
+    bound: Option<(Tile, i32)>,
+) -> bool {
+    if mv.target.is_some() {
+        return false;
+    }
+    let candidate = step_tile(pos.tile, dir);
+    if let Some((origin, radius)) = bound
+        && candidate.chebyshev(origin) > radius
+    {
+        return false;
+    }
+    if !map.is_walkable(candidate) {
+        return false;
+    }
+    if !occ.is_free(candidate) && occ.occupant(candidate) != Some(entity) {
+        return false;
+    }
+    mv.target = Some(candidate);
+    mv.progress = 0;
+    occ.set(candidate, entity);
+    true
+}
+
 fn step_tile(tile: Tile, dir: Dir) -> Tile {
     let (dx, dy) = dir.delta();
     Tile::new(tile.x + dx, tile.y + dy)
+}
+
+fn dir_from_u64(v: u64) -> Dir {
+    match v & 3 {
+        0 => Dir::Up,
+        1 => Dir::Down,
+        2 => Dir::Left,
+        _ => Dir::Right,
+    }
+}
+
+fn hash3(a: u64, b: u64, c: u64) -> u64 {
+    let mut x = a ^ b.rotate_left(17) ^ c.rotate_left(31);
+    x = (x ^ (x >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x = (x ^ (x >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
+}
+
+fn wander_system(
+    clock: Res<SimClock>,
+    seed: Res<SimSeed>,
+    map: Res<WalkableMap>,
+    mut occ: ResMut<Occupancy>,
+    mut q: Query<(Entity, &mut GridPos, &mut MoveTarget, &mut Wander)>,
+) {
+    for (entity, mut pos, mut mv, mut w) in q.iter_mut() {
+        if mv.target.is_some() || clock.tick < w.next_tick {
+            continue;
+        }
+        w.next_tick = clock.tick.saturating_add(w.period_ticks);
+        let dir = dir_from_u64(hash3(seed.0, entity.index_u32() as u64, clock.tick as u64));
+        pos.facing = dir.facing();
+        try_move(
+            entity,
+            dir,
+            &map,
+            &mut occ,
+            &pos,
+            &mut mv,
+            Some((w.origin, w.radius)),
+        );
+    }
 }
 
 fn advance_movement(mut q: Query<(&mut GridPos, &mut MoveTarget, &MoveSpeed)>) {
@@ -257,6 +356,7 @@ fn advance_movement(mut q: Query<(&mut GridPos, &mut MoveTarget, &MoveSpeed)>) {
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn emit_snapshot(
     clock: Res<SimClock>,
     bcast: Res<SnapshotBroadcast>,
@@ -264,10 +364,10 @@ fn emit_snapshot(
     q: Query<(
         Entity,
         &EntityKind,
-        &PlayerSlotTag,
+        Option<&PlayerSlotTag>,
         &GridPos,
         &MoveTarget,
-        &Health,
+        Option<&Health>,
     )>,
 ) {
     if !clock.tick.is_multiple_of(SNAPSHOT_EVERY_N_TICKS) {
@@ -287,12 +387,12 @@ fn emit_snapshot(
             proto::EntityDelta {
                 eid: proto::EntityId(entity.index_u32()),
                 kind: kind.0,
-                owner: slot.0,
+                owner: slot.map(|s| s.0).unwrap_or(proto::PLAYER_SLOT_NONE),
                 tile: pos.tile,
                 facing: pos.facing,
                 sub,
-                hp: hp.hp,
-                max_hp: hp.max_hp,
+                hp: hp.map(|h| h.hp).unwrap_or(0),
+                max_hp: hp.map(|h| h.max_hp).unwrap_or(0),
                 destroyed: false,
             }
         })
@@ -315,5 +415,89 @@ pub async fn run_sim_loop(mut app: App) {
     loop {
         ticker.tick().await;
         app.update();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    fn harness(seed: u64) -> (App, broadcast::Receiver<ServerEvent>) {
+        let (tx, rx) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+        let (_input_tx, input_rx) = mpsc::unbounded_channel();
+        let roster = Arc::new(RwLock::new(Roster::new(4)));
+        let map = WalkableMap::open(32, 32);
+        let app = build_app(tx, input_rx, roster, seed, SimConfig::default(), map);
+        (app, rx)
+    }
+
+    #[test]
+    fn wanderer_relocates_and_emits_snapshots() {
+        let (mut app, mut rx) = harness(0xABCDEF);
+        let origin = Tile::new(16, 16);
+        app.world_mut().spawn((
+            EntityKind(2),
+            GridPos::at(origin),
+            MoveTarget::default(),
+            MoveSpeed { ticks_per_tile: 1 },
+            Wander::new(origin, 5, 1),
+        ));
+
+        for _ in 0..200 {
+            app.update();
+        }
+
+        let mut snapshots = 0usize;
+        let mut tiles: HashSet<(i32, i32)> = HashSet::new();
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Snapshot(snap) = evt {
+                snapshots += 1;
+                for e in snap.entities {
+                    if e.kind == 2 {
+                        tiles.insert((e.tile.x, e.tile.y));
+                    }
+                }
+            }
+        }
+
+        assert!(snapshots > 0, "no snapshots emitted");
+        assert!(
+            tiles.len() > 1,
+            "wanderer never moved (visited {} tile)",
+            tiles.len()
+        );
+        assert!(
+            tiles
+                .iter()
+                .all(|(x, y)| { Tile::new(*x, *y).chebyshev(origin) <= 5 }),
+            "wanderer left its radius"
+        );
+    }
+
+    #[test]
+    fn non_player_entity_snapshots_without_slot() {
+        let (mut app, mut rx) = harness(1);
+        app.world_mut().spawn((
+            EntityKind(7),
+            GridPos::at(Tile::new(3, 3)),
+            MoveTarget::default(),
+            MoveSpeed::default(),
+        ));
+        for _ in 0..4 {
+            app.update();
+        }
+        let mut saw = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Snapshot(snap) = evt {
+                for e in snap.entities {
+                    if e.kind == 7 {
+                        saw = true;
+                        assert_eq!(e.owner, proto::PLAYER_SLOT_NONE);
+                    }
+                }
+            }
+        }
+        assert!(saw, "non-player entity missing from snapshot");
     }
 }


### PR DESCRIPTION
## What

Builds the real shared-world sim on top of the P0/P1 foundation (#12046).

### simgrid — made extensible (reusable engine work)
- **Ordered `SimSet` system sets** (Tick → Spawn → Occupancy → Input → Ai → Movement → Snapshot). Game crates inject systems at the right stage instead of forking the engine; `build_app` returns the `App` for the host to extend.
- **Generalized snapshots** — `emit_snapshot` now takes optional `PlayerSlotTag`/`Health`, so non-player entities (NPCs, monsters) replicate. Non-owned entities carry `proto::PLAYER_SLOT_NONE`.
- **Generic `Wander`** component + system — deterministic `(seed, entity, tick)` hash picks a direction, bounded to a Chebyshev radius around an origin. No RNG, replay-safe.

### cryptothrone-server — CloudCity world
Spawns the world to match the Phaser client: player start tile **(5,12)**, one wandering **monk** (radius 3), ten wandering **bird-monsters** (radius 20). Host registers `spawn_world` in `SimSet::Spawn`.

## Verification
- `cargo test -p simgrid` ✅ 4 tests (wanderer relocates within radius + emits snapshots; non-player entity snapshots with NONE owner; 2 proto round-trips)
- `cargo clippy -p simgrid -p cryptothrone-server --all-targets -- -D warnings` ✅
- Boot smoke: host runs the extended schedule, `/healthz` 200, no panic ✅

## Deferred
- Walkable map is still a **64×64 open grid** — real CloudCity collision import (parse the Tiled map) is a later pass.
- Monsters **wander** (matching the current client); chase AI + `bevy_pathfinder` come when gameplay needs it.
- Next: P3 Phaser WS client (remote-entity render + interpolation, postcard TS decode) + the WSS-to-dynamic-port edge; `/api/join` auth gate.