### PR TITLE
fix(astro): unblock cryptothrone container-prep — astro:transitions/client TS2307 (#12061)

### DIFF
--- a/packages/npm/astro/src/components/hero/observer/_ringNav.ts
+++ b/packages/npm/astro/src/components/hero/observer/_ringNav.ts
@@ -25,6 +25,7 @@ export const ringNavigate = (href: string, dir: NavDir): void => {
 		}, 600);
 		return;
 	}
+	// @ts-ignore astro:transitions/client is an Astro runtime virtual module, absent during the standalone package typecheck
 	import('astro:transitions/client')
 		.then(({ navigate }) => {
 			w.__astroNavigate = navigate as AstroNav;


### PR DESCRIPTION
## Problem

CI - Docker / cryptothrone fails at `Nx e2e cryptothrone` → its dependency `axum-cryptothrone:container-prep` dies during the astro build:

```
packages/npm/astro/src/components/hero/observer/_ringNav.ts:28:9
error TS2307: Cannot find module 'astro:transitions/client'
```

`_ringNav.ts` lives in the **`@kbve/astro` package**, whose vite lib build (`vite-plugin-dts`) typechecks it standalone. `astro:transitions/client` is an Astro **runtime virtual module** — only resolvable inside an Astro app build, not in the package's own typecheck. (Surfaced now that the package split routes this build through container-prep.) The literal import is still resolved by vite at app-build runtime.

## Fix

One line: `@ts-ignore` the dynamic import so the standalone package typecheck passes, keeping the literal specifier vite needs at runtime.

`@ts-expect-error` would be wrong — the module **does** resolve in app builds, so the directive would flip to "unused" (TS2578) there. `@ts-ignore` is correct for a directive that must hold in one build context but not another.

## Verification
- `tsc -p packages/npm/astro/tsconfig.lib.json --noEmit` — reproduced the exact TS2307, now clean ✅
- Direct `vite-plugin-dts` build (worktree files) — no `_ringNav` error; `@ts-ignore` honored ✅ (remaining `@kbve/droid` errors are local-only, droid dist unbuilt; CI builds it first)
- Note: `npx nx build astro` *inside a worktree* misreports against the main-repo copy (known @nx/vite worktree path bug) — verified directly with tsc/vite instead.

Fixes #12061