### PR TITLE
ci(cryptothrone): register cryptothrone-server for image builds

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.188",
+			"version": "1.0.191",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -118,6 +118,18 @@
 			"has_test": true
 		},
 		{
+			"key": "cryptothrone_server",
+			"app_name": "cryptothrone-server",
+			"version": "0.0.1",
+			"version_toml": "apps/agones/cryptothrone/server/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
+			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",
+			"source_path": "apps/agones/cryptothrone/server",
+			"runner": "arc-runner-set",
+			"image": "kbve/cryptothrone-server",
+			"has_test": false
+		},
+		{
 			"key": "discordsh",
 			"app_name": "discordsh",
 			"version": "0.1.44",
@@ -148,7 +160,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.39",
+			"version": "0.1.42",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -1031,7 +1043,7 @@
 	],
 	"bevy_game": [],
 	"summary": {
-		"docker": 29,
+		"docker": 30,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -1041,6 +1053,6 @@
 		"godot": 1,
 		"unreal_game": 1,
 		"bevy_game": 0,
-		"total": 86
+		"total": 87
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -1,0 +1,87 @@
+---
+title: CryptoThrone Server
+description: |
+    CryptoThrone authoritative grid game server — axum + tokio + simgrid headless bevy sim, hosted from a chiseled Ubuntu runtime.
+sidebar:
+    label: CryptoThrone Server
+    order: 58
+tags:
+    - docker
+    - rust
+    - game-server
+    - cryptothrone
+key: cryptothrone_server
+pipeline: docker
+app_name: cryptothrone-server
+version: "0.0.1"
+source_path: apps/agones/cryptothrone/server
+version_toml: apps/agones/cryptothrone/server/version.toml
+version_target: apps/agones/cryptothrone/server/Cargo.toml
+runner: arc-runner-set
+image: kbve/cryptothrone-server
+has_test: false
+author: h0lybyte
+license: MIT
+status: beta
+---
+
+## Overview
+
+`cryptothrone-server` is the authoritative shared-world host for **CryptoThrone**. It pairs an `axum` WebSocket router with the `simgrid` headless bevy grid simulation, so movement validation, occupancy, and snapshot framing stay server-owned. Unlike `nd-server`'s rapier2d match sim, CryptoThrone is grid-authoritative — collision is tile occupancy and "physics" is integer grid math, so the runtime stays light.
+
+### Responsibilities
+
+- Terminate the `/ws` WebSocket upgrade and verify the inbound Supabase JWT (dev-accept fallback when the secret is unset).
+- Drive the `simgrid` sim tick (20 Hz) on a tokio multi-thread runtime, fanning out 10 Hz snapshots.
+- Admit players into roster slots and spawn the CloudCity world — wandering NPCs and monsters — for everyone in the shared map.
+- Run the Agones SDK lifecycle (`Ready` / `Health` / `Shutdown`) so the Fleet can manage the pod; degrades gracefully outside Agones for local dev.
+
+### Layout
+
+```
+apps/agones/cryptothrone/server/
+├── Cargo.toml         # package manifest (path-dep to ../../../../packages/rust/simgrid)
+├── Dockerfile         # multi-stage chisel build (cargo-chef + sccache); no webkit stage
+├── project.json       # nx build / run / container targets
+├── version.toml       # ci-publish version sentinel
+└── src/
+    ├── main.rs        # tokio entry + Agones lifecycle + graceful shutdown
+    ├── agones.rs      # Agones SDK heartbeat
+    └── game.rs        # CloudCity spawn config (player tile, monks, birds)
+```
+
+## Build
+
+Local build via nx:
+
+```bash
+nx run cryptothrone-server:build-release
+```
+
+Or directly through cargo:
+
+```bash
+cargo build --release -p cryptothrone-server
+```
+
+The release binary lands at `dist/target/release/cryptothrone-server` per the workspace target dir convention.
+
+## Container
+
+```bash
+nx run cryptothrone-server:container
+```
+
+Drops a `kbve/cryptothrone-server:latest` + version tag locally. CI uses the `ci` configuration with sccache + registry buildcache (`ghcr.io/kbve/cryptothrone-server:buildcache`). The runtime image uses the same `ghcr.io/kbve/chisel-ubuntu-axum` chisel base as the other Axum services. Default listen is `0.0.0.0:7979` (override via `CT_SERVER_ADDR`).
+
+## Sim core
+
+The grid sim lives in the shared `simgrid` crate (`packages/rust/simgrid`): postcard wire types, Supabase HS256 auth, axum WS transport, and the bevy headless `build_app` / `run_sim_loop`. The host registers its CloudCity spawn systems into `simgrid`'s ordered `SimSet` stages, so game content stays in the app crate while transport and movement stay generic.
+
+## Deployment
+
+An Agones `Fleet` (`apps/kube/agones/cryptothrone/`) runs the GameServer pods; the web tier (`axum-cryptothrone`) allocates one via `POST /api/join`. Image must land on `ghcr.io/kbve/cryptothrone-server` before the Fleet can scale up.
+
+## Status
+
+Beta. Shared-world sim with wandering NPCs/monsters; browser client + WSS edge for allocated dynamic ports still in progress.

--- a/packages/npm/devops/src/lib/ci/registry.ts
+++ b/packages/npm/devops/src/lib/ci/registry.ts
@@ -175,6 +175,23 @@ export const CI_PROJECTS: CiProject[] = ProjectArraySchema.parse([
 		status: 'beta',
 		tags: ['docker', 'game-server', 'nexus-defense'],
 	},
+	{
+		key: 'cryptothrone_server',
+		name: 'CryptoThrone Server',
+		pipeline: 'docker',
+		app_name: 'cryptothrone-server',
+		test_framework: 'rust',
+		description:
+			'CryptoThrone authoritative grid game server (axum + simgrid bevy sim)',
+		source_path: 'apps/agones/cryptothrone/server',
+		version_toml: 'apps/agones/cryptothrone/server/version.toml',
+		runner: 'arc-runner-set',
+		image: 'kbve/cryptothrone-server',
+		author: 'h0lybyte',
+		license: 'MIT',
+		status: 'beta',
+		tags: ['docker', 'game-server', 'cryptothrone'],
+	},
 
 	{
 		key: 'chisel_ubuntu_axum',


### PR DESCRIPTION
## Why

P1 added the Agones Fleet which pulls `ghcr.io/kbve/cryptothrone-server`, but **nothing builds that image** — the game server was never registered in the CI dispatch registry, so `ci-docker` never dispatched a build. The Fleet would sit with `ErrImagePull`.

## What

Register `cryptothrone-server` as a docker-pipeline project (mirrors `nd-server`):
- **`cryptothrone-server.mdx`** — the project-collection frontmatter that is the source of truth for the dispatch manifest (`MDX → /api/ci-registry.json → ci-dispatch-manifest.json`).
- **`registry.ts`** — the matching `@kbve/devops` registry entry, keeping that list complete.
- **`.github/ci-dispatch-manifest.json`** — regenerated via `astro-kbve:build` + `astro-kbve:sync:ci-manifest` (full regen, not hand-edited). New `cryptothrone-server` docker entry; docker count 29→30, total 86→87.

The regenerated manifest also carries two pending MDX `version:` bumps already on dev (unrelated, expected side effect of a full regen).

## Notes
- ArgoCD needs no change — `kube-root` recurses `apps/kube`, so the Fleet's `apps/kube/agones/cryptothrone/application.yaml` (from P1) is already auto-discovered, same as nd-server.
- Build verified: `astro-kbve:build` exits 0 and emits the entry into `api/ci-registry.json`.