### PR TITLE
feat(chuck): unreal-chuck-demo monorepo build + mc.kbve.com git route

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.188",
+			"version": "1.0.191",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -148,7 +148,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.39",
+			"version": "0.1.42",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -1007,6 +1007,27 @@
 	],
 	"unreal_game": [
 		{
+			"key": "unreal_chuck_demo",
+			"app_name": "chuck-demo",
+			"engine": {
+				"version": "5.7.4",
+				"project_path": "apps/chuckrpg/unreal-chuck",
+				"build_targets": [
+					"Win64"
+				]
+			},
+			"source_path": "apps/chuckrpg/unreal-chuck",
+			"version": "0.3.19",
+			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-demo.mdx",
+			"runner": "arc-runner-ue",
+			"external_publish": {
+				"itch_user": "kbve",
+				"itch_game": "chuckrpg",
+				"itch_channel": "demo"
+			}
+		},
+		{
 			"key": "unreal_chuck_game",
 			"app_name": "chuck",
 			"engine": {
@@ -1039,8 +1060,8 @@
 		"ue5_server": 2,
 		"unity": 1,
 		"godot": 1,
-		"unreal_game": 1,
+		"unreal_game": 2,
 		"bevy_game": 0,
-		"total": 86
+		"total": 87
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-demo.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-demo.mdx
@@ -1,0 +1,60 @@
+---
+title: Unreal Chuck Demo
+description: |
+    Chuck RPG UE5 demo client built straight from the monorepo apps/chuckrpg/unreal-chuck shell (no external repo) and shipped to itch.io as kbve/chuckrpg, alongside the full Unreal Chuck Game.
+sidebar:
+    label: Unreal Chuck Demo
+    order: 96
+tags:
+    - ue5
+    - game
+    - chuck
+    - demo
+key: unreal_chuck_demo
+pipeline: unreal_game
+app_name: chuck-demo
+source_path: apps/chuckrpg/unreal-chuck
+version_toml: apps/chuckrpg/unreal-chuck/version.toml
+version: "0.3.19"
+runner: arc-runner-ue
+author: h0lybyte
+license: KBVE
+status: beta
+homepage_url: https://kbve.itch.io/chuckrpg
+engine:
+    version: "5.7.4"
+    project_path: apps/chuckrpg/unreal-chuck
+    build_targets:
+        - Win64
+external_publish:
+    itch_user: kbve
+    itch_game: chuckrpg
+    itch_channel: demo
+---
+
+## Overview
+
+Chuck RPG UE5 demo client. Unlike the [Unreal Chuck Game](/project/unreal-chuck-game),
+which clones the external `KBVE/chuck` repo, this demo compiles the monorepo shell at
+`apps/chuckrpg/unreal-chuck` directly (the working copy with the KBVE plugins). Content is
+pulled from the same chuck Forgejo LFS endpoint (`git.kbve.com/KBVE/chuck`, HTTPS) declared
+in `apps/chuckrpg/unreal-chuck/.lfsconfig`, and the build ships to itch.io under
+`kbve/chuckrpg` on the `demo` channel.
+
+## Pipeline
+
+`pipeline: unreal_game` → `ci-main.yml` dispatches `ci-unreal.yml` (`task: game`)
+→ `ci-unreal-build.yml` (`mode: game`) whenever the MDX `version:` here outpaces
+`version.toml`, or `source_path` files change. With no `engine.external_repo_url`, the
+builder checks out the monorepo and builds the project under `engine.project_path` against
+the prebuilt UE5.7 installed on the `UE5-Win` KubeVirt VM (`C:\Program Files\Epic Games\UE_5.7`).
+
+## Build Matrix
+
+`engine.build_targets`:
+
+- `Win64` — native build on the `UE5-Win` KubeVirt VM (RunUAT.bat, prebuilt UE5.7)
+
+## Distribution
+
+Shipped to itch.io as `kbve/chuckrpg` (channel `demo`) when `deploy_to_itch` is set.

--- a/apps/kube/forgejo/manifest/kustomization.yaml
+++ b/apps/kube/forgejo/manifest/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 
 resources:
     - httproute.yaml
+    - mc-git-httproute.yaml
     - sealed-admin.yaml
     - sealed-lfs-jwt.yaml
     - rbac.yaml

--- a/apps/kube/forgejo/manifest/mc-git-httproute.yaml
+++ b/apps/kube/forgejo/manifest/mc-git-httproute.yaml
@@ -1,0 +1,40 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: mc-git-route
+    namespace: forgejo
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - mc.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /api/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /v2/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /-/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /KBVE/
+          backendRefs:
+              - name: forgejo-http
+                port: 3000


### PR DESCRIPTION
## What
- **unreal-chuck-demo.mdx** — new `unreal_chuck_demo` registry entry that builds the monorepo `apps/chuckrpg/unreal-chuck` shell directly (no external repo) against the prebuilt UE5.7 on the UE5-Win VM, shipping to itch `kbve/chuckrpg` (demo channel). Manifest regenerated (87 items).
- **mc-git-route HTTPRoute** — `mc.kbve.com` now forwards git/LFS paths (`/api/`, `/v2/`, `/-/`, `/KBVE/`) to `forgejo-http`; the existing `kbve-mc-redirect` still sends `/` → kbve.com/mc. Makes the external chuck repo's `ssh://mc.kbve.com` lfs endpoint resolvable over HTTPS.

## Context
The chuck Win64 build was failing at LFS pull (401/404). Root cause: `kbve-ci` (CI Forgejo user) wasn't a collaborator on the private `KBVE/chuck` repo (only Jezza was), so it couldn't pull chuck's LFS — while rareicon worked because kbve-ci is a member there. **Already granted kbve-ci read on KBVE/chuck** (verified: refs 200, LFS batch 200), which unblocks both the demo and game builds. The prebuilt UE5.7 engine pivot is validated (`Engine at C:\\Program Files\\Epic Games\\UE_5.7`).

Part of #11987.