### PR TITLE
feat(cryptothrone): no-guest auth + @kbve/laser netcode foundation

### DIFF
--- a/apps/agones/cryptothrone/server/src/main.rs
+++ b/apps/agones/cryptothrone/server/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         input_tx,
         seed,
         jwt_secret,
+        true,
         game::MAX_PLAYERS,
     );
     let roster = state.roster.clone();

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -50,3 +50,30 @@ export {
 
 // Physics (Rapier)
 export { RAPIER, createRapierPhysics } from './lib/physics/rapier';
+
+// Net — WS client speaking the simgrid JSON wire
+export { GameClient } from './lib/net/game-client';
+export type {
+	GameClientOptions,
+	GameClientEventMap,
+} from './lib/net/game-client';
+export {
+	PROTOCOL_VERSION,
+	OWNER_NONE,
+	joinFrame,
+	inputFrame,
+} from './lib/net/protocol';
+export type {
+	Dir,
+	Facing,
+	Tile,
+	Input,
+	ClientMessage,
+	ServerEvent,
+	Snapshot,
+	EntityDelta,
+	PlayerView,
+	Welcome,
+	JoinMatch,
+	ClientFrame,
+} from './lib/net/protocol';

--- a/packages/npm/laser/src/lib/net/game-client.ts
+++ b/packages/npm/laser/src/lib/net/game-client.ts
@@ -1,0 +1,107 @@
+import { LaserEventBus } from '../core/events';
+import {
+	type ClientMessage,
+	type Dir,
+	type Facing,
+	type Input,
+	type ServerEvent,
+	type Snapshot,
+	type Welcome,
+	inputFrame,
+	joinFrame,
+} from './protocol';
+
+export type GameClientEventMap = {
+	open: void;
+	welcome: Welcome;
+	snapshot: Snapshot;
+	reject: string;
+	close: void;
+	error: string;
+};
+
+export interface GameClientOptions {
+	url: string;
+	jwt: string;
+	kbveUsername: string;
+}
+
+export class GameClient {
+	private ws: WebSocket | null = null;
+	private clientTick = 0;
+	private readonly bus = new LaserEventBus<GameClientEventMap>();
+	private readonly opts: GameClientOptions;
+
+	constructor(opts: GameClientOptions) {
+		this.opts = opts;
+	}
+
+	on<K extends keyof GameClientEventMap>(
+		event: K,
+		handler: (data: GameClientEventMap[K]) => void,
+	): () => void {
+		return this.bus.on(event, handler);
+	}
+
+	connect(): void {
+		if (this.ws) return;
+		const ws = new WebSocket(this.opts.url);
+		this.ws = ws;
+
+		ws.addEventListener('open', () => {
+			this.send(joinFrame(this.opts.jwt, this.opts.kbveUsername));
+			this.bus.emit('open', undefined);
+		});
+		ws.addEventListener('message', (ev: MessageEvent) => {
+			let msg: ServerEvent;
+			try {
+				msg = JSON.parse(
+					typeof ev.data === 'string' ? ev.data : String(ev.data),
+				);
+			} catch {
+				return;
+			}
+			if ('Welcome' in msg) this.bus.emit('welcome', msg.Welcome);
+			else if ('Snapshot' in msg) this.bus.emit('snapshot', msg.Snapshot);
+			else if ('Reject' in msg)
+				this.bus.emit('reject', msg.Reject.reason);
+		});
+		ws.addEventListener('error', () =>
+			this.bus.emit('error', 'socket error'),
+		);
+		ws.addEventListener('close', () => {
+			this.ws = null;
+			this.bus.emit('close', undefined);
+		});
+	}
+
+	private send(msg: ClientMessage): void {
+		this.ws?.send(JSON.stringify(msg));
+	}
+
+	sendInputs(inputs: Input[]): void {
+		if (
+			!this.ws ||
+			this.ws.readyState !== WebSocket.OPEN ||
+			inputs.length === 0
+		)
+			return;
+		this.clientTick += 1;
+		this.send(inputFrame(this.clientTick, inputs));
+	}
+
+	step(dir: Dir): void {
+		this.sendInputs([{ Step: { dir } }]);
+	}
+
+	face(facing: Facing): void {
+		this.sendInputs([{ Face: { facing } }]);
+	}
+
+	close(): void {
+		if (!this.ws) return;
+		this.sendInputs(['Leave']);
+		this.ws.close();
+		this.ws = null;
+	}
+}

--- a/packages/npm/laser/src/lib/net/protocol.spec.ts
+++ b/packages/npm/laser/src/lib/net/protocol.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { joinFrame, inputFrame, PROTOCOL_VERSION } from './protocol';
+
+describe('simgrid JSON wire (serde externally-tagged)', () => {
+	it('joinFrame matches the server JoinMatch shape', () => {
+		expect(joinFrame('tok', 'ann')).toEqual({
+			JoinMatch: {
+				protocol: PROTOCOL_VERSION,
+				jwt: 'tok',
+				kbve_username: 'ann',
+			},
+		});
+	});
+
+	it('inputFrame wraps a Step input', () => {
+		expect(inputFrame(5, [{ Step: { dir: 'Up' } }])).toEqual({
+			Frame: { client_tick: 5, inputs: [{ Step: { dir: 'Up' } }] },
+		});
+	});
+
+	it('unit-variant Leave serializes as a bare string', () => {
+		expect(JSON.stringify(inputFrame(1, ['Leave']))).toBe(
+			'{"Frame":{"client_tick":1,"inputs":["Leave"]}}',
+		);
+	});
+});

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -1,0 +1,85 @@
+export const PROTOCOL_VERSION = 1;
+
+export type Dir = 'Up' | 'Down' | 'Left' | 'Right';
+export type Facing = 'Up' | 'Down' | 'Left' | 'Right';
+
+export interface Tile {
+	x: number;
+	y: number;
+}
+
+export type Input =
+	| { Step: { dir: Dir } }
+	| { MoveTo: { tile: Tile } }
+	| { Face: { facing: Facing } }
+	| { Action: { id: number; target: number | null } }
+	| { Heartbeat: { client_tick: number } }
+	| 'Leave';
+
+export interface JoinMatch {
+	protocol: number;
+	jwt: string;
+	kbve_username: string;
+}
+
+export interface ClientFrame {
+	client_tick: number;
+	inputs: Input[];
+}
+
+export type ClientMessage = { JoinMatch: JoinMatch } | { Frame: ClientFrame };
+
+export interface PlayerView {
+	slot: number;
+	kbve_username: string;
+	connected: boolean;
+}
+
+export interface EntityDelta {
+	eid: number;
+	kind: number;
+	owner: number;
+	tile: Tile;
+	facing: Facing;
+	sub: number;
+	hp: number;
+	max_hp: number;
+	destroyed: boolean;
+}
+
+export interface Snapshot {
+	tick: number;
+	server_time_ms: number;
+	input_ack: number;
+	players: PlayerView[];
+	entities: EntityDelta[];
+	keyframe: boolean;
+}
+
+export interface Welcome {
+	protocol: number;
+	your_slot: number;
+	seed: number;
+}
+
+export type ServerEvent =
+	| { Welcome: Welcome }
+	| { Snapshot: Snapshot }
+	| { Ephemeral: { kind: number; payload: number[] } }
+	| { Reject: { reason: string } };
+
+export const OWNER_NONE = 0xffff;
+
+export function joinFrame(jwt: string, kbveUsername: string): ClientMessage {
+	return {
+		JoinMatch: {
+			protocol: PROTOCOL_VERSION,
+			jwt,
+			kbve_username: kbveUsername,
+		},
+	};
+}
+
+export function inputFrame(clientTick: number, inputs: Input[]): ClientMessage {
+	return { Frame: { client_tick: clientTick, inputs } };
+}

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -84,6 +84,7 @@ pub struct ServerState {
     pub input_tx: Option<mpsc::UnboundedSender<SlotInput>>,
     pub seed: u64,
     pub jwt_secret: Vec<u8>,
+    pub require_username: bool,
     pub roster: Arc<RwLock<Roster>>,
 }
 
@@ -93,6 +94,7 @@ impl ServerState {
         input_tx: mpsc::UnboundedSender<SlotInput>,
         seed: u64,
         jwt_secret: Vec<u8>,
+        require_username: bool,
         capacity: usize,
     ) -> Self {
         Self {
@@ -100,6 +102,7 @@ impl ServerState {
             input_tx: Some(input_tx),
             seed,
             jwt_secret,
+            require_username,
             roster: Arc::new(RwLock::new(Roster::new(capacity))),
         }
     }
@@ -262,8 +265,8 @@ async fn admit(
     jm: proto::JoinMatch,
     format: WireFormat,
 ) -> Option<AdmittedPlayer> {
-    let kbve_username = if state.jwt_secret.is_empty() {
-        fallback_username(jm.kbve_username)
+    let raw = if state.jwt_secret.is_empty() {
+        jm.kbve_username
     } else {
         match crate::auth::verify_supabase_jwt(&jm.jwt, &state.jwt_secret) {
             Ok(claims) => claims.kbve_username,
@@ -273,7 +276,11 @@ async fn admit(
             }
         }
     };
-    claim_slot(state, socket, kbve_username, format).await
+    let Some(username) = resolve_username(state.require_username, raw) else {
+        send_reject(socket, format, "username required").await;
+        return None;
+    };
+    claim_slot(state, socket, username, format).await
 }
 
 #[cfg(not(feature = "supabase-auth"))]
@@ -283,14 +290,20 @@ async fn admit(
     jm: proto::JoinMatch,
     format: WireFormat,
 ) -> Option<AdmittedPlayer> {
-    claim_slot(state, socket, fallback_username(jm.kbve_username), format).await
+    let Some(username) = resolve_username(state.require_username, jm.kbve_username) else {
+        send_reject(socket, format, "username required").await;
+        return None;
+    };
+    claim_slot(state, socket, username, format).await
 }
 
-fn fallback_username(name: String) -> String {
-    if name.is_empty() {
-        "guest".into()
+fn resolve_username(require_username: bool, name: String) -> Option<String> {
+    if !name.is_empty() {
+        Some(name)
+    } else if require_username {
+        None
     } else {
-        name
+        Some("guest".into())
     }
 }
 
@@ -339,5 +352,25 @@ fn inject_roster(evt: ServerEvent, roster: &Arc<RwLock<Roster>>) -> ServerEvent 
             ServerEvent::Snapshot(snap)
         }
         other => other,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_username;
+
+    #[test]
+    fn require_username_rejects_empty() {
+        assert_eq!(resolve_username(true, String::new()), None);
+        assert_eq!(
+            resolve_username(true, "h0lybyte".into()),
+            Some("h0lybyte".into())
+        );
+    }
+
+    #[test]
+    fn guest_allowed_when_not_required() {
+        assert_eq!(resolve_username(false, String::new()), Some("guest".into()));
+        assert_eq!(resolve_username(false, "ann".into()), Some("ann".into()));
     }
 }


### PR DESCRIPTION
First step of the verified-login + multiplayer arc. Foundation pieces (server enforcement + the reusable client transport); the client auth/username UI + remote-player rendering follow.

## simgrid — no guest
`ServerState.require_username`: when set, a JoinMatch whose `kbve_username` is empty (no verified profile name) is rejected with `username required` instead of getting a guest slot. `cryptothrone-server` enables it — only logged-in users with a registered username reach the world. (Prod already verifies the JWT; this also closes the empty-claim case.) +2 tests.

## @kbve/laser — net module
The reusable client side of the transport:
- `protocol.ts` — TS mirror of the simgrid JSON wire (serde externally-tagged: `{JoinMatch:…}`, `{Frame:…}`, `{Snapshot:…}`, unit variants as bare strings). +spec locking the shape.
- `GameClient` — WS class: connect with `jwt`+`kbve_username`, emits `welcome`/`snapshot`/`reject` via `LaserEventBus`, `sendInputs`/`step`/`face`/`close`. Browser global WebSocket.

Verified: `cargo clippy -p simgrid -p cryptothrone-server -- -D warnings` clean; simgrid 8 tests; laser net spec (3) passes; net module typechecks against `tsconfig.lib.json`.

## Next (not in this PR)
- Client auth/username gate: reuse `UsernameSetup.tsx` (astro-kbve) — after OAuth, if `jwt.kbve_username` empty → prompt → `POST /api/v1/profile/username` → refresh session → proceed.
- Connect + see each other: drive the Phaser scene from server snapshots (remote players + NPCs/monsters server-authoritative, interpolated) instead of the local-only bitecs world; send movement intents via `GameClient`.