### PR TITLE
feat(unreal): KBVENPCSprite module — billboarded pixel-art NPC sprites

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Content/NPC/Slime/mm-crawl.png
+++ b/apps/chuckrpg/unreal-chuck/Content/NPC/Slime/mm-crawl.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c1b78b63680b24507141fcb900ef11b808e2b5f3aa8a768f5808280c59841f76
+size 6583

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbvenpcdb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbvenpcdb.mdx
@@ -41,3 +41,17 @@ pattern but ships as a reusable plugin:
 
 NPC DATA stays in the shared npcdb MDX; the plugin owns the load + Mass bridge.
 ChuckRPG calls it to spawn data-driven NPC entities.
+
+## KBVENPCSprite module
+
+The plugin also ships a `KBVENPCSprite` render module for billboarded pixel-art NPC
+sprites in the 3D world (data/Mass stay in the `KBVENPCDB` module; this only draws):
+
+- **`UKBVENpcSpriteDef`** — UDataAsset: atlas + sprite material + grid (columns =
+  animation frames, rows = view directions front/side/back), fps, world size, pivot.
+- **`UKBVENpcSpriteRenderSubsystem`** — `Spawn/Update/Despawn` sprite handles; one HISM
+  per def, CPU Y-locked camera billboard, atlas cell driven by per-instance custom data
+  (offset/scale UV; right view is the side row mirrored via negative U scale).
+
+P1 is standalone (assign a `UKBVENpcSpriteDef`); later it keys off the npcdb `Ref`. The
+sprite material is authored in-editor — see the module README for the custom-data contract.

--- a/packages/unreal/KBVENPCDB/KBVENPCDB.uplugin
+++ b/packages/unreal/KBVENPCDB/KBVENPCDB.uplugin
@@ -24,6 +24,11 @@
 			"Name": "KBVENPCDB",
 			"Type": "Runtime",
 			"LoadingPhase": "Default"
+		},
+		{
+			"Name": "KBVENPCSprite",
+			"Type": "Runtime",
+			"LoadingPhase": "Default"
 		}
 	]
 }

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/KBVENPCSprite.Build.cs
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/KBVENPCSprite.Build.cs
@@ -1,0 +1,17 @@
+using UnrealBuildTool;
+
+public class KBVENPCSprite : ModuleRules
+{
+	public KBVENPCSprite(ReadOnlyTargetRules Target) : base(Target)
+	{
+		PCHUsage = ModuleRules.PCHUsageMode.UseExplicitOrSharedPCHs;
+
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"KBVENPCDB"
+		});
+	}
+}

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENPCSpriteModule.cpp
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENPCSpriteModule.cpp
@@ -1,0 +1,3 @@
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_MODULE(FDefaultModuleImpl, KBVENPCSprite)

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Private/KBVENpcSpriteRenderSubsystem.cpp
@@ -1,0 +1,294 @@
+#include "KBVENpcSpriteRenderSubsystem.h"
+#include "KBVENpcSpriteDef.h"
+#include "KBVENpcSpriteDirection.h"
+
+#include "Components/HierarchicalInstancedStaticMeshComponent.h"
+#include "Engine/StaticMesh.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "Camera/PlayerCameraManager.h"
+#include "Materials/MaterialInstanceDynamic.h"
+#include "Materials/MaterialInterface.h"
+#include "UObject/ConstructorHelpers.h"
+
+namespace
+{
+	constexpr float PlaneUnit = 100.0f;
+}
+
+bool UKBVENpcSpriteRenderSubsystem::ShouldCreateSubsystem(UObject* Outer) const
+{
+	if (!Super::ShouldCreateSubsystem(Outer))
+	{
+		return false;
+	}
+	const UWorld* World = Cast<UWorld>(Outer);
+	return World && World->IsGameWorld();
+}
+
+void UKBVENpcSpriteRenderSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+}
+
+void UKBVENpcSpriteRenderSubsystem::Deinitialize()
+{
+	Instances.Reset();
+	IndexToHandle.Reset();
+	DefHISMs.Reset();
+	DefMIDs.Reset();
+	HostActor = nullptr;
+	Super::Deinitialize();
+}
+
+void UKBVENpcSpriteRenderSubsystem::EnsureHost()
+{
+	if (HostActor)
+	{
+		return;
+	}
+	UWorld* World = GetWorld();
+	if (!World)
+	{
+		return;
+	}
+
+	FActorSpawnParameters Params;
+	Params.ObjectFlags |= RF_Transient;
+	Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+	HostActor = World->SpawnActor<AActor>(AActor::StaticClass(), FVector::ZeroVector, FRotator::ZeroRotator, Params);
+	if (!HostActor)
+	{
+		return;
+	}
+	HostActor->SetActorEnableCollision(false);
+	HostActor->PrimaryActorTick.bCanEverTick = false;
+
+	USceneComponent* Root = NewObject<USceneComponent>(HostActor, TEXT("Root"), RF_Transient);
+	HostActor->SetRootComponent(Root);
+	Root->RegisterComponent();
+}
+
+UStaticMesh* UKBVENpcSpriteRenderSubsystem::GetPlaneMesh()
+{
+	if (!PlaneMesh)
+	{
+		PlaneMesh = LoadObject<UStaticMesh>(nullptr, TEXT("/Engine/BasicShapes/Plane.Plane"));
+	}
+	return PlaneMesh;
+}
+
+UHierarchicalInstancedStaticMeshComponent* UKBVENpcSpriteRenderSubsystem::GetOrCreateHISM(UKBVENpcSpriteDef* Def)
+{
+	if (!Def)
+	{
+		return nullptr;
+	}
+	if (TObjectPtr<UHierarchicalInstancedStaticMeshComponent>* Found = DefHISMs.Find(Def))
+	{
+		return *Found;
+	}
+
+	EnsureHost();
+	UStaticMesh* Mesh = GetPlaneMesh();
+	if (!HostActor || !Mesh)
+	{
+		return nullptr;
+	}
+
+	UHierarchicalInstancedStaticMeshComponent* HISM =
+		NewObject<UHierarchicalInstancedStaticMeshComponent>(HostActor, NAME_None, RF_Transient);
+	HISM->SetMobility(EComponentMobility::Movable);
+	HISM->SetupAttachment(HostActor->GetRootComponent());
+	HISM->NumCustomDataFloats = 4;
+	HISM->SetStaticMesh(Mesh);
+	HISM->SetCollisionEnabled(ECollisionEnabled::NoCollision);
+	HISM->SetCanEverAffectNavigation(false);
+	HISM->bDisableCollision = true;
+
+	if (Def->SpriteMaterial)
+	{
+		UMaterialInstanceDynamic* MID = UMaterialInstanceDynamic::Create(Def->SpriteMaterial, this);
+		if (MID && Def->Atlas)
+		{
+			MID->SetTextureParameterValue(TEXT("Atlas"), Def->Atlas);
+		}
+		HISM->SetMaterial(0, MID);
+		DefMIDs.Add(Def, MID);
+	}
+
+	HISM->RegisterComponent();
+	DefHISMs.Add(Def, HISM);
+	IndexToHandle.Add(HISM, {});
+	return HISM;
+}
+
+bool UKBVENpcSpriteRenderSubsystem::GetCameraLocation(FVector& OutLocation) const
+{
+	const UWorld* World = GetWorld();
+	if (!World)
+	{
+		return false;
+	}
+	if (APlayerController* PC = World->GetFirstPlayerController())
+	{
+		if (PC->PlayerCameraManager)
+		{
+			OutLocation = PC->PlayerCameraManager->GetCameraLocation();
+			return true;
+		}
+	}
+	return false;
+}
+
+FKBVENpcSpriteHandle UKBVENpcSpriteRenderSubsystem::SpawnSprite(UKBVENpcSpriteDef* Def, FVector Location, float FacingYawDeg)
+{
+	FKBVENpcSpriteHandle Handle;
+	UHierarchicalInstancedStaticMeshComponent* HISM = GetOrCreateHISM(Def);
+	if (!HISM)
+	{
+		return Handle;
+	}
+
+	const int32 Index = HISM->AddInstance(FTransform(Location), true);
+
+	FInstanceRec Rec;
+	Rec.Def = Def;
+	Rec.Location = Location;
+	Rec.FacingYaw = FacingYawDeg;
+	Rec.AnimTime = 0.0f;
+	Rec.Phase = FMath::FRand() * Def->FramesPerAnim;
+	Rec.HISM = HISM;
+	Rec.Index = Index;
+
+	Handle.Id = NextHandle++;
+	Instances.Add(Handle.Id, Rec);
+	IndexToHandle.FindChecked(HISM).Add(Handle.Id);
+	return Handle;
+}
+
+void UKBVENpcSpriteRenderSubsystem::UpdateSprite(FKBVENpcSpriteHandle Handle, FVector Location, float FacingYawDeg)
+{
+	if (FInstanceRec* Rec = Instances.Find(Handle.Id))
+	{
+		Rec->Location = Location;
+		Rec->FacingYaw = FacingYawDeg;
+	}
+}
+
+void UKBVENpcSpriteRenderSubsystem::DespawnSprite(FKBVENpcSpriteHandle Handle)
+{
+	FInstanceRec* Rec = Instances.Find(Handle.Id);
+	if (!Rec)
+	{
+		return;
+	}
+	UHierarchicalInstancedStaticMeshComponent* HISM = Rec->HISM;
+	TArray<int32>* Idx = HISM ? IndexToHandle.Find(HISM) : nullptr;
+	if (!HISM || !Idx)
+	{
+		Instances.Remove(Handle.Id);
+		return;
+	}
+
+	const int32 Slot = Rec->Index;
+	const int32 Last = HISM->GetInstanceCount() - 1;
+	if (Slot != Last && Idx->IsValidIndex(Last))
+	{
+		const int32 MovedHandle = (*Idx)[Last];
+		if (FInstanceRec* Moved = Instances.Find(MovedHandle))
+		{
+			Moved->Index = Slot;
+		}
+		(*Idx)[Slot] = MovedHandle;
+	}
+	if (Idx->Num() > 0)
+	{
+		Idx->Pop();
+	}
+	HISM->RemoveInstance(Last);
+	Instances.Remove(Handle.Id);
+}
+
+void UKBVENpcSpriteRenderSubsystem::Tick(float DeltaTime)
+{
+	if (Instances.Num() == 0)
+	{
+		return;
+	}
+	FVector CamLoc;
+	if (!GetCameraLocation(CamLoc))
+	{
+		return;
+	}
+
+	TSet<UHierarchicalInstancedStaticMeshComponent*> Touched;
+
+	for (TPair<int32, FInstanceRec>& Pair : Instances)
+	{
+		FInstanceRec& Rec = Pair.Value;
+		UKBVENpcSpriteDef* Def = Rec.Def;
+		UHierarchicalInstancedStaticMeshComponent* HISM = Rec.HISM;
+		if (!Def || !HISM)
+		{
+			continue;
+		}
+
+		Rec.AnimTime += DeltaTime;
+		int32 Frame = 0;
+		if (Def->Fps > 0.0f && Def->FramesPerAnim > 0)
+		{
+			Frame = FMath::FloorToInt(Rec.AnimTime * Def->Fps + Rec.Phase) % Def->FramesPerAnim;
+		}
+
+		const FKBVENpcSpriteView View = FKBVENpcSpriteDirection::Select(Rec.FacingYaw, Rec.Location, CamLoc, Def->bSwapSide);
+		int32 Row = Def->RowFront;
+		if (View.Facing == EKBVENpcSpriteFacing::Side)
+		{
+			Row = Def->RowSide;
+		}
+		else if (View.Facing == EKBVENpcSpriteFacing::Back)
+		{
+			Row = Def->RowBack;
+		}
+
+		const float InvCols = 1.0f / FMath::Max(1, Def->Columns);
+		const float InvRows = 1.0f / FMath::Max(1, Def->Rows);
+		float OffU = Frame * InvCols;
+		float ScaleU = InvCols;
+		if (View.bFlipX)
+		{
+			OffU = (Frame + 1) * InvCols;
+			ScaleU = -InvCols;
+		}
+		const float OffV = Row * InvRows;
+		const float ScaleV = InvRows;
+
+		HISM->SetCustomDataValue(Rec.Index, 0, OffU, false);
+		HISM->SetCustomDataValue(Rec.Index, 1, OffV, false);
+		HISM->SetCustomDataValue(Rec.Index, 2, ScaleU, false);
+		HISM->SetCustomDataValue(Rec.Index, 3, ScaleV, false);
+
+		FVector ToCam = CamLoc - Rec.Location;
+		ToCam.Z = 0.0f;
+		const FVector Face = ToCam.GetSafeNormal(1e-4f, FVector::ForwardVector);
+		const FVector Up = FVector::UpVector;
+		const FVector Right = FVector::CrossProduct(Up, Face).GetSafeNormal(1e-4f, FVector::RightVector);
+
+		const FMatrix Basis(Right, Up, Face, FVector::ZeroVector);
+		FTransform Transform(Basis);
+		Transform.SetScale3D(FVector(Def->WorldSize.X / PlaneUnit, Def->WorldSize.Y / PlaneUnit, 1.0f));
+
+		const float HalfHeight = 0.5f * Def->WorldSize.Y;
+		const FVector PivotOffset = Up * (HalfHeight * (1.0f - 2.0f * Def->PivotZ));
+		Transform.SetLocation(Rec.Location + PivotOffset);
+
+		HISM->UpdateInstanceTransform(Rec.Index, Transform, true, false, true);
+		Touched.Add(HISM);
+	}
+
+	for (UHierarchicalInstancedStaticMeshComponent* HISM : Touched)
+	{
+		HISM->MarkRenderStateDirty();
+	}
+}

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteDef.h
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteDef.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DataAsset.h"
+#include "KBVENpcSpriteDef.generated.h"
+
+class UMaterialInterface;
+class UTexture2D;
+
+/**
+ * Authoring data for a billboarded pixel-art NPC sprite. Atlas columns are animation
+ * frames, rows are view directions (front / side / back; right is the side row mirrored).
+ * Standalone for now; later keyed to an FKBVENpcDef Ref from the npcdb MDX pipeline.
+ */
+UCLASS(BlueprintType)
+class KBVENPCSPRITE_API UKBVENpcSpriteDef : public UDataAsset
+{
+	GENERATED_BODY()
+
+public:
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "NPC")
+	FName Ref;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Sprite")
+	TObjectPtr<UTexture2D> Atlas = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Sprite")
+	TObjectPtr<UMaterialInterface> SpriteMaterial = nullptr;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas", meta = (ClampMin = "1"))
+	int32 Columns = 5;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas", meta = (ClampMin = "1"))
+	int32 Rows = 3;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas")
+	int32 RowFront = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas")
+	int32 RowSide = 1;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas")
+	int32 RowBack = 2;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Atlas")
+	bool bSwapSide = false;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Animation", meta = (ClampMin = "1"))
+	int32 FramesPerAnim = 5;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Animation", meta = (ClampMin = "0.0"))
+	float Fps = 10.0f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World")
+	FVector2f WorldSize = FVector2f(128.0f, 128.0f);
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "World", meta = (ClampMin = "0.0", ClampMax = "1.0"))
+	float PivotZ = 0.0f;
+};

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteDirection.h
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteDirection.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+enum class EKBVENpcSpriteFacing : uint8
+{
+	Front,
+	Side,
+	Back
+};
+
+struct FKBVENpcSpriteView
+{
+	EKBVENpcSpriteFacing Facing = EKBVENpcSpriteFacing::Front;
+	bool bFlipX = false;
+};
+
+/**
+ * Picks which atlas direction row to show and whether to mirror, from the monster's
+ * world facing yaw and the camera position. Front when it faces the camera, Back when
+ * it faces away, Side otherwise (mirrored for the right-hand side). bSwapSide flips the
+ * left/right handedness if the art reads reversed.
+ */
+struct FKBVENpcSpriteDirection
+{
+	static FKBVENpcSpriteView Select(float FacingYawDeg, const FVector& NpcLocation, const FVector& CameraLocation, bool bSwapSide)
+	{
+		const FVector ToCam = CameraLocation - NpcLocation;
+		const float DirToCamYaw = FMath::RadiansToDegrees(FMath::Atan2(ToCam.Y, ToCam.X));
+		const float Delta = FMath::FindDeltaAngleDegrees(DirToCamYaw, FacingYawDeg);
+		const float AbsDelta = FMath::Abs(Delta);
+
+		FKBVENpcSpriteView View;
+		if (AbsDelta <= 45.0f)
+		{
+			View.Facing = EKBVENpcSpriteFacing::Front;
+		}
+		else if (AbsDelta >= 135.0f)
+		{
+			View.Facing = EKBVENpcSpriteFacing::Back;
+		}
+		else
+		{
+			View.Facing = EKBVENpcSpriteFacing::Side;
+		}
+
+		bool bRight = Delta < 0.0f;
+		if (bSwapSide)
+		{
+			bRight = !bRight;
+		}
+		View.bFlipX = (View.Facing == EKBVENpcSpriteFacing::Side) && bRight;
+		return View;
+	}
+};

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteRenderSubsystem.h
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/Public/KBVENpcSpriteRenderSubsystem.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "KBVENpcSpriteRenderSubsystem.generated.h"
+
+class UKBVENpcSpriteDef;
+class UHierarchicalInstancedStaticMeshComponent;
+class UMaterialInstanceDynamic;
+class UStaticMesh;
+
+USTRUCT(BlueprintType)
+struct FKBVENpcSpriteHandle
+{
+	GENERATED_BODY()
+
+	UPROPERTY(BlueprintReadOnly, Category = "KBVE|NPC|Sprite")
+	int32 Id = INDEX_NONE;
+
+	bool IsValid() const { return Id != INDEX_NONE; }
+};
+
+UCLASS()
+class KBVENPCSPRITE_API UKBVENpcSpriteRenderSubsystem : public UTickableWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+	virtual void Tick(float DeltaTime) override;
+	virtual TStatId GetStatId() const override { RETURN_QUICK_DECLARE_CYCLE_STAT(UKBVENpcSpriteRenderSubsystem, STATGROUP_Tickables); }
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|NPC|Sprite")
+	FKBVENpcSpriteHandle SpawnSprite(UKBVENpcSpriteDef* Def, FVector Location, float FacingYawDeg = 0.0f);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|NPC|Sprite")
+	void UpdateSprite(FKBVENpcSpriteHandle Handle, FVector Location, float FacingYawDeg);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|NPC|Sprite")
+	void DespawnSprite(FKBVENpcSpriteHandle Handle);
+
+private:
+	struct FInstanceRec
+	{
+		TObjectPtr<UKBVENpcSpriteDef> Def = nullptr;
+		FVector Location = FVector::ZeroVector;
+		float FacingYaw = 0.0f;
+		float AnimTime = 0.0f;
+		float Phase = 0.0f;
+		TObjectPtr<UHierarchicalInstancedStaticMeshComponent> HISM = nullptr;
+		int32 Index = INDEX_NONE;
+	};
+
+	void EnsureHost();
+	UStaticMesh* GetPlaneMesh();
+	UHierarchicalInstancedStaticMeshComponent* GetOrCreateHISM(UKBVENpcSpriteDef* Def);
+	bool GetCameraLocation(FVector& OutLocation) const;
+
+	UPROPERTY(Transient)
+	TObjectPtr<AActor> HostActor = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UStaticMesh> PlaneMesh = nullptr;
+
+	UPROPERTY(Transient)
+	TMap<TObjectPtr<UKBVENpcSpriteDef>, TObjectPtr<UHierarchicalInstancedStaticMeshComponent>> DefHISMs;
+
+	UPROPERTY(Transient)
+	TMap<TObjectPtr<UKBVENpcSpriteDef>, TObjectPtr<UMaterialInstanceDynamic>> DefMIDs;
+
+	TMap<int32, FInstanceRec> Instances;
+	TMap<UHierarchicalInstancedStaticMeshComponent*, TArray<int32>> IndexToHandle;
+	int32 NextHandle = 1;
+};

--- a/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/README.md
+++ b/packages/unreal/KBVENPCDB/Source/KBVENPCSprite/README.md
@@ -1,0 +1,45 @@
+# KBVENPCSprite
+
+Billboarded pixel-art NPC sprites for the 3D world — a render module inside the **KBVENPCDB** plugin (data/Mass stay in `KBVENPCDB`; this module only draws). Atlas columns are animation frames, rows are view directions (front / side / back; the right view is the side row mirrored). Rendered through a single HISM per sprite def so hundreds of monsters share one draw path.
+
+## Pieces
+
+- `UKBVENpcSpriteDef` — UDataAsset: atlas texture, sprite material, grid (`Columns`/`Rows`), per-direction row indices, `FramesPerAnim`, `Fps`, `WorldSize`, `PivotZ`. `Ref` ties it to an `FKBVENpcDef` later.
+- `FKBVENpcSpriteDirection::Select(...)` — pure: facing yaw + camera → which row + mirror.
+- `UKBVENpcSpriteRenderSubsystem` — `UTickableWorldSubsystem`. `SpawnSprite / UpdateSprite / DespawnSprite` by handle; each tick it CPU-billboards every instance (Y-locked, camera-facing) and writes the atlas cell to per-instance custom data.
+
+## Material contract
+
+The def's `SpriteMaterial` must be built once in-editor (engine `.uasset`, not shippable from this module). It needs:
+
+- A `Texture2D` parameter named **`Atlas`** (the subsystem sets it per def via a MID).
+- Sample `Atlas` at:
+  `UV = MeshUV * float2(CustomData2, CustomData3) + float2(CustomData0, CustomData1)`
+  where `CustomData0..3` are the 4 per-instance custom-data floats `(offsetU, offsetV, scaleU, scaleV)`. A negative `scaleU` (with `offsetU` at the next column edge) mirrors for the right-facing view.
+- **Nearest** texture sampling (crisp pixels), masked (or translucent) blend, two-sided off.
+
+No world-position-offset is required — the subsystem orients each instance transform toward the camera on the CPU. (A WPO instanced billboard is the planned P2 optimization for thousands of sprites.)
+
+## Custom data layout
+
+| Index | Meaning                          |
+| ----- | -------------------------------- |
+| 0     | UV offset U                      |
+| 1     | UV offset V                      |
+| 2     | UV scale U (negative = mirrored) |
+| 3     | UV scale V                       |
+
+## Atlas import
+
+Nearest filter, no mipmaps. For the sample slime sheet: 320×192, `Columns = 5`, `Rows = 3`, `FramesPerAnim = 5`, rows front=0 / side=1 / back=2.
+
+## Usage
+
+```cpp
+auto* R = World->GetSubsystem<UKBVENpcSpriteRenderSubsystem>();
+FKBVENpcSpriteHandle H = R->SpawnSprite(SlimeDef, Location, FacingYawDeg);
+// each frame as the monster moves / turns:
+R->UpdateSprite(H, NewLocation, NewFacingYaw);
+// on death:
+R->DespawnSprite(H);
+```


### PR DESCRIPTION
Adds a **`KBVENPCSprite`** render module to the **KBVENPCDB** plugin (data/Mass stay in the `KBVENPCDB` module; this one only draws) — billboarded pixel-art monster/NPC sprites in the 3D world, like the slime crawl sheet (320×192, 5 cols × 3 rows).

Atlas **columns = animation frames**, **rows = view directions** (front / side / back; the right view is the side row mirrored). Rendered through **one HISM per sprite def** so hundreds of monsters share a single draw path.

## Pieces

- `UKBVENpcSpriteDef` (UDataAsset) — atlas, sprite material, grid, per-direction row indices, fps, world size, pivot. `Ref` ties it to `FKBVENpcDef` later.
- `FKBVENpcSpriteDirection::Select` — pure facing-yaw + camera → row + mirror.
- `UKBVENpcSpriteRenderSubsystem` (`UTickableWorldSubsystem`) — `Spawn/Update/Despawn` by handle; per-tick CPU Y-locked camera billboard + writes the atlas cell to 4 per-instance custom-data floats (offsetU/V, scaleU/V; negative scaleU mirrors).

## Decisions (from design chat)

- Folded into KBVENPCDB as a **module** (mirrors `ROWSupabase` in KBVESupabase; and KBVEItemDB holding its own item actor).
- Standalone def now → **npcdb MDX `Ref`** wiring later.
- **CPU billboard** keeps the material trivial (sample atlas at custom-data UV, nearest, masked) — no `.uasset` WPO needed. **WPO-instanced billboard = P2** for thousands.

## Notes

- Sprite material is authored in-editor (engine `.uasset`, not shippable from the module) — custom-data contract + import settings in the module README.
- UE 5.7 — builds in `ci-unreal`, not locally.
- Module-level addition, so no ci-dispatch-manifest change (registry is plugin-level).