### PR TITLE
fix(agents): don't gate loadTokens on Discord provider_token

### DIFF
--- a/packages/npm/droid/src/lib/agents/github/tokens.ts
+++ b/packages/npm/droid/src/lib/agents/github/tokens.ts
@@ -8,8 +8,7 @@ export function makeTokens(ctx: AgentsCtx, api: AgentsApi) {
 
 	async function loadTokens(guildId: string, force = false): Promise<void> {
 		const accessToken = store.$accessToken.get();
-		const providerToken = store.$providerToken.get();
-		if (!accessToken || !providerToken) return;
+		if (!accessToken) return;
 
 		const userId = store.$userId.get();
 


### PR DESCRIPTION
## Symptom

GitHub wizard Step 1 (HMAC secret) stays on **TODO** even after generating + saving the secret successfully (no error, draft cleared). Same for the other token-backed steps.

## Cause

`loadTokens` early-returned when `$providerToken` (the Discord OAuth token) was null:

```ts
if (!accessToken || !providerToken) return;
```

But `tokens.list_tokens` (guild-vault → `service_list_guild_tokens`) only needs the **access token** — guild ownership is verified from the JWT `owned_guilds` claim, not the Discord provider token. With a stale Discord session:

- **save** (`set_token`, access-token auth) succeeds → row stored, draft cleared, no error
- the follow-up **list refresh** bails at the gate → `$tokens` stays empty
- the wizard computes each step's status from `$tokens` → never sees the stored `github_webhook` / `github` rows → permanent TODO

This is the same provider-token-staleness class the rest of the agents code already tolerates (JWT-claim/cached guild fallbacks); `loadTokens` was the one path still hard-gated.

## Fix

List with `accessToken` alone. `provider_token` stays required only for the Discord-direct call (`loadOwnedGuilds` → `discord.com/users/@me/guilds`), which genuinely needs it.

## Verify

droid `tsc --noEmit` clean. Immediate confirmation on the live dashboard: re-syncing Discord (refreshes provider_token) makes the step flip with the *old* code — this fix removes that dependency so it works with a stale session too.