### PR TITLE
fix(rareicon): chain offer-build jobs + complete pipelines before main-thread reads

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/RareIcon.Proto.asmdef
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/RareIcon.Proto.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "RareIcon.Proto",
+    "rootNamespace": "KBVE.Proto",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/RareIcon.Proto.asmdef.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Generated/RareIcon.Proto.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9772b468fb8547638f63ce07401fbfe8
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionOffersSingleton.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Components/ProfessionOffersSingleton.cs
@@ -1,5 +1,6 @@
 using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 
 namespace RareIcon
@@ -31,6 +32,8 @@ namespace RareIcon
         public int2   FarmHex;
 
         public NativeList<NeedyCave> NeedyCaves;
+
+        public JobHandle PipelineHandle;
 
         public uint BuildVersion;
     }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionDispatchSystem.cs
@@ -80,7 +80,8 @@ namespace RareIcon
             var combatDB = SystemAPI.GetSingleton<CombatDBSingleton>();
             var itemDB   = SystemAPI.GetSingleton<ItemDBSingleton>();
 
-            state.Dependency = JobHandle.CombineDependencies(state.Dependency, combatDB.PipelineHandle);
+            offersDB.PipelineHandle.Complete();
+            combatDB.PipelineHandle.Complete();
 
             bool doFullDispatch = offersDB.BuildVersion != _lastSeenBuildVersion;
             if (doFullDispatch)

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionOfferBuildSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionOfferBuildSystem.cs
@@ -176,7 +176,7 @@ namespace RareIcon
                 offers.SetCapacity(math.max(required, offers.Capacity * 2));
 
             var hexHandle  = new BuildHexResourceOffersJob { Writer = offers.AsParallelWriter() }.ScheduleParallel(state.Dependency);
-            var dropHandle = new BuildItemDropOffersJob    { Writer = offers.AsParallelWriter() }.ScheduleParallel(state.Dependency);
+            var dropHandle = new BuildItemDropOffersJob    { Writer = offers.AsParallelWriter() }.ScheduleParallel(hexHandle);
 
             var finalizeJob = new FinalizeOffersJob
             {
@@ -186,8 +186,8 @@ namespace RareIcon
                 OfferKindStart     = db.OfferKindStart,
                 OfferKindCount     = db.OfferKindCount,
             };
-            state.Dependency = finalizeJob.Schedule(
-                JobHandle.CombineDependencies(hexHandle, dropHandle));
+            state.Dependency  = finalizeJob.Schedule(dropHandle);
+            db.PipelineHandle = state.Dependency;
 
             db.BuildVersion++;
         }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionPreemptSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Professions/Systems/ProfessionPreemptSystem.cs
@@ -25,7 +25,7 @@ namespace RareIcon
         public void OnUpdate(ref SystemState state)
         {
             var combatDB = SystemAPI.GetSingleton<CombatDBSingleton>();
-            state.Dependency = Unity.Jobs.JobHandle.CombineDependencies(state.Dependency, combatDB.PipelineHandle);
+            combatDB.PipelineHandle.Complete();
 
             if (combatDB.Threats.Length == 0)
                 return;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/RareIcon.Game.asmdef
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/RareIcon.Game.asmdef
@@ -1,0 +1,41 @@
+{
+    "name": "RareIcon.Game",
+    "rootNamespace": "RareIcon",
+    "references": [
+        "GUID:7b5e9d6c4f8a4e3a8b1c2d3e4f5a6b7c",
+        "GUID:9772b468fb8547638f63ce07401fbfe8",
+        "GUID:c392f14e218c4157a4465b27cac38e0b",
+        "GUID:734d92eba21c94caba915361bd5ac177",
+        "GUID:8819f35a0fc84499b990e90a4ca1911f",
+        "GUID:7a450cf7ca9694b5a8bfa3fd83ec635a",
+        "GUID:a5baed0c9693541a5bd947d336ec7659",
+        "GUID:e0cd26848372d4e5c891c569017e11f1",
+        "GUID:2665a8d13d1b3f18800f46e256720795",
+        "GUID:d8b63aba1907145bea998dd612889d6b",
+        "GUID:953adc2a6b8b4e3c8df5b728bcd546e9",
+        "GUID:f2d49d9fa7e7eb3418e39723a7d3b92f",
+        "GUID:08b38f39e2d9e594389b7a4cf4c2c338",
+        "GUID:4f682e06dbb3e624faedad9cc27106cc",
+        "GUID:b0214a6008ed146ff8f122a6a9c2f6cc",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:33661e06c33d31b4c9223810bf503247",
+        "GUID:77221876cc6b8244180b96e320b1bcd4",
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:68bd7fdb68ef2684e982e8a9825b18a5"
+    ],
+    "includePlatforms": [
+        "Editor",
+        "LinuxStandalone64",
+        "macOSStandalone",
+        "WindowsStandalone32",
+        "WindowsStandalone64"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/RareIcon.Game.asmdef.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/RareIcon.Game.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 060f5cc5ebf14ccab751c643869bef78
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bf8387caf0314361b25369cc2212dcf8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/ProfessionOfferBuildPlayTests.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/ProfessionOfferBuildPlayTests.cs
@@ -1,0 +1,97 @@
+using System.Collections;
+using NUnit.Framework;
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine.TestTools;
+
+namespace RareIcon.Tests
+{
+    public class ProfessionOfferBuildPlayTests
+    {
+        [UnityTest]
+        public IEnumerator OfferBuild_TicksWithoutJobSafetyViolation()
+        {
+            var world = new World("RareIcon.OfferBuildTest");
+            Entity itemDB = Entity.Null;
+            try
+            {
+                itemDB = CreateItemDB(world);
+                SpawnHexResource(world, 0, 0, wood: 50, stone: 10, berries: 5);
+                SpawnHexResource(world, 1, 0, wood: 0, stone: 30, berries: 0);
+                SpawnHexResource(world, 2, 0, wood: 12, stone: 0, berries: 20);
+                SpawnItemDrop(world, 3, 0, itemId: 1, count: 3);
+                SpawnItemDrop(world, 4, 0, itemId: 2, count: 1);
+
+                var sys = world.CreateSystem<ProfessionOfferBuildSystem>();
+
+                for (int i = 0; i < 3; i++)
+                {
+                    sys.Update(world.Unmanaged);
+                    yield return null;
+                }
+
+                world.EntityManager.CompleteAllTrackedJobs();
+
+                var offers = world.EntityManager
+                    .CreateEntityQuery(ComponentType.ReadOnly<ProfessionOffersSingleton>())
+                    .GetSingleton<ProfessionOffersSingleton>();
+
+                Assert.IsTrue(offers.OffersSortedByKind.IsCreated);
+                Assert.AreEqual(offers.Offers.Length, offers.OffersSortedByKind.Length);
+                Assert.GreaterOrEqual(offers.Offers.Length, 5);
+
+                LogAssert.NoUnexpectedReceived();
+            }
+            finally
+            {
+                if (itemDB != Entity.Null && world.IsCreated)
+                    DisposeItemDB(world, itemDB);
+                if (world.IsCreated)
+                    world.Dispose();
+            }
+        }
+
+        static Entity CreateItemDB(World world)
+        {
+            var em = world.EntityManager;
+            var e = em.CreateEntity();
+            em.AddComponentData(e, new ItemDBSingleton
+            {
+                Defs           = new NativeArray<ItemDefRuntime>(1, Allocator.Persistent),
+                ValidBits      = new NativeArray<ulong>(1, Allocator.Persistent),
+                EdibleBits     = new NativeArray<ulong>(1, Allocator.Persistent),
+                FoodPoolBits   = new NativeArray<ulong>(1, Allocator.Persistent),
+                PerishableBits = new NativeArray<ulong>(1, Allocator.Persistent),
+                MaxItemId      = 0,
+            });
+            return e;
+        }
+
+        static void DisposeItemDB(World world, Entity e)
+        {
+            var db = world.EntityManager.GetComponentData<ItemDBSingleton>(e);
+            if (db.Defs.IsCreated)           db.Defs.Dispose();
+            if (db.ValidBits.IsCreated)      db.ValidBits.Dispose();
+            if (db.EdibleBits.IsCreated)     db.EdibleBits.Dispose();
+            if (db.FoodPoolBits.IsCreated)   db.FoodPoolBits.Dispose();
+            if (db.PerishableBits.IsCreated) db.PerishableBits.Dispose();
+        }
+
+        static void SpawnHexResource(World world, int q, int r, byte wood, byte stone, byte berries)
+        {
+            var em = world.EntityManager;
+            var e = em.CreateEntity();
+            em.AddComponentData(e, new HexCoord { Q = q, R = r });
+            em.AddComponentData(e, new HexResources { Wood = wood, Stone = stone, Berries = berries });
+        }
+
+        static void SpawnItemDrop(World world, int q, int r, ushort itemId, ushort count)
+        {
+            var em = world.EntityManager;
+            var e = em.CreateEntity();
+            em.AddComponentData(e, new HexCoord { Q = q, R = r });
+            var buf = em.AddBuffer<ItemDrop>(e);
+            buf.Add(new ItemDrop { ItemId = itemId, Count = count, Hp = 0 });
+        }
+    }
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/ProfessionOfferBuildPlayTests.cs.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/ProfessionOfferBuildPlayTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 185b4968949b41199146479fea353c18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/RareIcon.PlayTests.asmdef
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/RareIcon.PlayTests.asmdef
@@ -1,0 +1,27 @@
+{
+    "name": "RareIcon.PlayTests",
+    "rootNamespace": "RareIcon.Tests",
+    "references": [
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner",
+        "GUID:060f5cc5ebf14ccab751c643869bef78",
+        "GUID:734d92eba21c94caba915361bd5ac177",
+        "GUID:e0cd26848372d4e5c891c569017e11f1",
+        "GUID:d8b63aba1907145bea998dd612889d6b",
+        "GUID:a5baed0c9693541a5bd947d336ec7659",
+        "GUID:2665a8d13d1b3f18800f46e256720795"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/RareIcon.PlayTests.asmdef.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Tests/PlayMode/RareIcon.PlayTests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a117dfef397146acb1cd8549e9fc17ba
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/ThirdParty/RareIcon.ThirdParty.asmdef
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/ThirdParty/RareIcon.ThirdParty.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "RareIcon.ThirdParty",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/ThirdParty/RareIcon.ThirdParty.asmdef.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/ThirdParty/RareIcon.ThirdParty.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c392f14e218c4157a4465b27cac38e0b
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Problem

Three Unity DOTS job-safety violations crashed the macOS Steam demo. In the editor they surface as `InvalidOperationException` under JobsDebugger; in the player build (safety checks off) they are real data races → crash:

- `FinalizeOffersJob` writes `OffersSortedByKind` then it's cast/read before `Complete()`
- `BuildHexResourceOffersJob` + `BuildItemDropOffersJob` write the same writer with no dependency between them
- `ThreatScanJob` writes `Threats` then read before `Complete()`

## Root cause

All three are cross-system access to `NativeContainer`s stored **inside ECS singletons**. Unity's dependency system auto-tracks access by **component type**, not by native containers nested in a singleton — so those jobs need explicit hand-chaining, and main-thread readers need `Complete()` (not just `CombineDependencies`, which only orders *scheduled* jobs).

## Fixes

- **ProfessionOfferBuildSystem** — `BuildItemDropOffersJob` now schedules on `hexHandle` instead of `state.Dependency`, so the two parallel jobs no longer race on the shared `offers` ParallelWriter.
- **ProfessionOffersSingleton** — add a `PipelineHandle` field (mirrors `CombatDBSingleton`); the build system publishes the finalize-job handle to it.
- **ProfessionDispatchSystem / ProfessionPreemptSystem** — replace `CombineDependencies(...)` with `PipelineHandle.Complete()` before the main-thread `.AsArray()` / `.Length` reads of the offers + threat lists.

## PlayMode test infrastructure

Game code lived in the default `Assembly-CSharp`, which no test assembly can reference — so these runtime races were untestable. This PR extracts:

- `RareIcon.Game` (Scripts/), `RareIcon.Proto` (Generated/), `RareIcon.ThirdParty` (FastNoiseLite). `Editor/` stays a Unity special folder → `Assembly-CSharp-Editor` auto-references the new asmdefs.
- `RareIcon.PlayTests` (Tests/PlayMode/) + `ProfessionOfferBuildPlayTests` — builds a `World`, adds the real `ProfessionOfferBuildSystem`, spawns hex/drop entities and ticks. With JobsDebugger on, the writer race throws → the test fails on the old code and passes on the fix.

## Verification

Local environment has no Unity compiler. **Reviewer/author must** reopen the project in Unity (the asmdef split recompiles the whole game assembly — watch the console for missing-reference errors) and run Test Runner → PlayMode → `OfferBuild_TicksWithoutJobSafetyViolation`.

Coverage note: the test covers the offer-build writer race. The dispatch/threat read fixes (#1/#3) are shipped but their full integration test needs a `CombatDBSingleton` + `ProfessionsDBSingleton` bootstrap — deferred as follow-up.