### PR TITLE
perf(rareicon): drop per-frame main-thread stalls in StatusEffect + OutpostVolley

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/OutpostVolleySystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/OutpostVolleySystem.cs
@@ -1,5 +1,7 @@
 using Unity.Burst;
+using Unity.Collections;
 using Unity.Entities;
+using Unity.Jobs;
 using Unity.Mathematics;
 using Unity.Transforms;
 
@@ -28,46 +30,62 @@ namespace RareIcon
 
             var combatDB = SystemAPI.GetSingleton<CombatDBSingleton>();
 
-            combatDB.PipelineHandle.Complete();
-            var threats  = combatDB.Threats;
-
             var ecb = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>()
                 .CreateCommandBuffer(state.WorldUnmanaged);
 
             uint tickSeed = (uint)(SystemAPI.Time.ElapsedTime * 1000d) + 1u;
 
-            foreach (var (volleyRW, poolRW, transformRO, factionRO, entity) in
-                     SystemAPI.Query<RefRW<OutpostVolley>, RefRW<OutpostArrowPool>, RefRO<LocalTransform>, RefRO<Faction>>().WithEntityAccess())
+            var dep = JobHandle.CombineDependencies(state.Dependency, combatDB.PipelineHandle);
+            state.Dependency = new OutpostVolleyJob
             {
-                if (factionRO.ValueRO.Value != FactionType.Player) continue;
+                Threats  = combatDB.Threats.AsDeferredJobArray(),
+                Ecb      = ecb.AsParallelWriter(),
+                Dt       = dt,
+                TickSeed = tickSeed,
+            }.ScheduleParallel(dep);
+        }
 
-                ref var volley = ref volleyRW.ValueRW;
-                ref var pool   = ref poolRW.ValueRW;
+        [BurstCompile]
+        partial struct OutpostVolleyJob : IJobEntity
+        {
+            [ReadOnly] public NativeArray<ThreatRecord> Threats;
+            public EntityCommandBuffer.ParallelWriter   Ecb;
+            public float Dt;
+            public uint  TickSeed;
 
-                volley.TimeSinceVolley += dt;
-                if (volley.TimeSinceVolley < volley.CooldownSeconds) continue;
-                if (pool.Stock < volley.ArrowCost) continue;
-                if (threats.Length == 0) continue;
+            void Execute([ChunkIndexInQuery] int sortKey,
+                         Entity entity,
+                         ref OutpostVolley volley,
+                         ref OutpostArrowPool pool,
+                         in LocalTransform transform,
+                         in Faction faction)
+            {
+                if (faction.Value != FactionType.Player) return;
 
-                float2 outpostPos = new float2(transformRO.ValueRO.Position.x, transformRO.ValueRO.Position.y);
+                volley.TimeSinceVolley += Dt;
+                if (volley.TimeSinceVolley < volley.CooldownSeconds) return;
+                if (pool.Stock < volley.ArrowCost) return;
+                if (Threats.Length == 0) return;
+
+                float2 outpostPos = new float2(transform.Position.x, transform.Position.y);
                 float rangeSq = volley.Range * volley.Range;
 
                 int bestIdx = -1;
                 float bestSq = rangeSq;
-                for (int i = 0; i < threats.Length; i++)
+                for (int i = 0; i < Threats.Length; i++)
                 {
-                    float d2 = math.distancesq(outpostPos, threats[i].Position);
+                    float d2 = math.distancesq(outpostPos, Threats[i].Position);
                     if (d2 < bestSq) { bestSq = d2; bestIdx = i; }
                 }
-                if (bestIdx < 0) continue;
+                if (bestIdx < 0) return;
 
-                float2 targetPos = threats[bestIdx].Position;
+                float2 targetPos = Threats[bestIdx].Position;
                 float2 toTarget  = targetPos - outpostPos;
                 float  toDist    = math.length(toTarget);
                 float2 baseDir   = toDist > 1e-5f ? toTarget / toDist : new float2(1f, 0f);
                 float  baseAngle = math.atan2(baseDir.y, baseDir.x);
 
-                var rng = Unity.Mathematics.Random.CreateFromIndex(tickSeed ^ (uint)entity.Index * 747796405u);
+                var rng = Unity.Mathematics.Random.CreateFromIndex(TickSeed ^ (uint)entity.Index * 747796405u);
 
                 int shots = volley.ArrowsPerVolley;
                 for (int a = 0; a < shots; a++)
@@ -76,13 +94,13 @@ namespace RareIcon
                     float angle       = baseAngle + angleOffset;
                     float2 dir        = new float2(math.cos(angle), math.sin(angle));
 
-                    var req = ecb.CreateEntity();
-                    ecb.AddComponent(req, new SpawnProjectileRequest
+                    var req = Ecb.CreateEntity(sortKey);
+                    Ecb.AddComponent(sortKey, req, new SpawnProjectileRequest
                     {
                         Type         = ProjectileType.Arrow,
                         Mod          = ArrowMod.None,
                         Facing       = FacingFromDir(dir.x, dir.y),
-                        OwnerFaction = factionRO.ValueRO.Value,
+                        OwnerFaction = faction.Value,
                         Position     = outpostPos,
                         Velocity     = dir * volley.ProjectileSpeed,
                         Lifetime     = volley.ProjectileLifetime,
@@ -90,7 +108,7 @@ namespace RareIcon
                     });
                 }
 
-                pool.Stock            = (ushort)(pool.Stock - volley.ArrowCost);
+                pool.Stock             = (ushort)(pool.Stock - volley.ArrowCost);
                 volley.TimeSinceVolley = 0f;
             }
         }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/StatusEffectSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/StatusEffectSystem.cs
@@ -15,6 +15,7 @@ namespace RareIcon
         public void OnCreate(ref SystemState state)
         {
             state.RequireForUpdate<StatusEffect>();
+            state.RequireForUpdate<EndSimulationEntityCommandBufferSystem.Singleton>();
         }
 
         [BurstCompile]
@@ -23,7 +24,8 @@ namespace RareIcon
         [BurstCompile]
         public void OnUpdate(ref SystemState state)
         {
-            var ecb = new EntityCommandBuffer(Allocator.TempJob);
+            var ecb = SystemAPI.GetSingleton<EndSimulationEntityCommandBufferSystem.Singleton>()
+                .CreateCommandBuffer(state.WorldUnmanaged);
 
             new StatusEffectTickJob
             {
@@ -31,10 +33,6 @@ namespace RareIcon
                 Ecb = ecb.AsParallelWriter(),
                 DeadLookup = SystemAPI.GetComponentLookup<DeadTag>(true),
             }.ScheduleParallel();
-
-            state.CompleteDependency();
-            ecb.Playback(state.EntityManager);
-            ecb.Dispose();
         }
     }
 


### PR DESCRIPTION
## Context

Follow-up to #12086 (job-safety crash fixes). That PR added the `Complete()` calls required to make cross-system singleton-container reads safe. An audit of *every* such `Complete()` / main-thread loop found most are load-bearing (they guard the exact race class #12086 fixes) — but two systems pay a per-frame main-thread stall that can be removed without changing behaviour.

## A5 — StatusEffectSystem

Was: `new EntityCommandBuffer(Allocator.TempJob)` → schedule tick job → `state.CompleteDependency()` → `ecb.Playback(main thread)` → dispose, **every frame**. The sync + main-thread playback defeats the parallel schedule and allocates an ECB per frame.

Now: uses the `EndSimulationEntityCommandBufferSystem.Singleton` ECB. The job runs async; the ECB system completes + plays back later, off the critical path. This matches `DamageSystem`, the sibling `DeadTag` producer in the same group. `DeadTag` is consumed only in `CleanupSystemGroup` (after EndSim playback), so behaviour is unchanged — it actually removes an immediate-vs-deferred ordering inconsistency between the two DeadTag producers.

## A4 — OutpostVolleySystem

Was: `combatDB.PipelineHandle.Complete()` every frame to read `Threats` on the main thread (stalling the combat group on the entire threat-scan pipeline), then a main-thread `foreach` over outposts.

Now: a parallel `IJobEntity` that takes `Threats` via `AsDeferredJobArray()` and chains `PipelineHandle` through `CombineDependencies`. The threat scan and the volley build overlap instead of serialising; the per-outpost loop leaves the main thread. `Threats` was already a one-frame snapshot, so no behaviour change.

## Not changed (audited, left as-is)

- **SpatialHashSystem** — already optimal. Double-buffered; `_writeHandle.Complete()` waits on a job scheduled a full frame ago → effectively free.
- **HexHoverSystem** — `ProbeHandle.Complete()` feeds main-thread MessagePipe publish + `EntityManager` write; can't jobify (managed), and the probe job is tiny.
- **BarracksHealExecutor** — its two completes are both required (LogisticsDB pipeline + ComponentLookups), not redundant. (Its missing HexDB `DrainHandle.Complete()` is fixed in #12086.)

## Verification

No Unity compiler locally. Reviewer must reopen in Unity and confirm compile + run PlayMode tests. Both changes are behaviour-preserving by construction (deferred work that was already frame-stale).