### PR TITLE
fix(ci-unreal): safe.directory for monorepo LFS pull on Win VM

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -797,6 +797,7 @@ jobs:
                   if (-not (Test-Path $lfsConfig)) { Write-Host "::error::$lfsConfig not found"; exit 1 }
                   if (-not $env:FORGEJO_USER -or -not $env:FORGEJO_TOKEN) { Write-Host "::error::FORGEJO_USER / FORGEJO_TOKEN missing"; exit 1 }
                   Write-Host "::add-mask::$($env:FORGEJO_TOKEN)"
+                  git config --global --add safe.directory "$env:GITHUB_WORKSPACE"
                   $lfsUrl = (git config -f $lfsConfig lfs.url)
                   $authUrl = $lfsUrl -replace '^https://', "https://$($env:FORGEJO_USER):$($env:FORGEJO_TOKEN)@"
                   Write-Host "::notice::Pulling LFS for $proj from $lfsUrl"


### PR DESCRIPTION
## Problem
Chuck demo (monorepo) Win64 build got past Checkout + Locate UE5.7 but failed at `Pull game LFS (Forgejo)`:
```
Not in a Git repository.
```
`actions/checkout` adds the repo to a **per-step ephemeral** global gitconfig as a safe.directory. The separate PowerShell LFS step runs git without it; the runner is LocalSystem, so git's dubious-ownership guard rejects the repo and git-lfs surfaces it as 'Not in a Git repository'. (The external-repo path dodges this — it `git clone`s in the same step.)

## Fix
`git config --global --add safe.directory $env:GITHUB_WORKSPACE` right before the git-lfs install/pull in the monorepo LFS step.

This is the last blocker for the chuck demo build — kbve-ci already has chuck LFS access (refs 200, LFS batch 200) and the prebuilt UE5.7 is detected. Reusable is pinned @dev so this takes effect on dev merge.

Part of #11987.