### PR TITLE
fix(rareicon): complete HexDB DrainHandle in 6 main-thread Lookup readers

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/WhaleSpawnerSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/WhaleSpawnerSystem.cs
@@ -34,7 +34,9 @@ namespace RareIcon
             if (_whaleQuery.CalculateEntityCount() >= MaxWhales) return;
 
             var em = EntityManager;
-            var lookup = SystemAPI.GetSingleton<HexDBSingleton>().Lookup;
+            var hexDB = SystemAPI.GetSingleton<HexDBSingleton>();
+            hexDB.DrainHandle.Complete();
+            var lookup = hexDB.Lookup;
 
             var keys = lookup.GetKeyArray(Allocator.Temp);
             if (keys.Length == 0) { keys.Dispose(); return; }

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BanditCampResourceScanSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BanditCampResourceScanSystem.cs
@@ -22,7 +22,9 @@ namespace RareIcon
         protected override void OnUpdate()
         {
             uint nowTick = (uint)(SystemAPI.Time.ElapsedTime * 1000d);
-            var hexLookup = SystemAPI.GetSingleton<HexDBSingleton>().Lookup;
+            var hexDB = SystemAPI.GetSingleton<HexDBSingleton>();
+            hexDB.DrainHandle.Complete();
+            var hexLookup = hexDB.Lookup;
             var resLookup = SystemAPI.GetComponentLookup<HexResources>(true);
 
             foreach (var (scanRef, building, cache) in

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BarracksHealExecutor.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/BarracksHealExecutor.cs
@@ -24,6 +24,7 @@ namespace RareIcon
         public void OnUpdate(ref SystemState state)
         {
             if (!SystemAPI.TryGetSingleton<HexDBSingleton>(out var hexLookup)) return;
+            hexLookup.DrainHandle.Complete();
             var itemDB = SystemAPI.GetSingleton<ItemDBSingleton>();
 
             ref var db = ref SystemAPI.GetSingletonRW<LogisticsDBSingleton>().ValueRW;

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/FurnaceInitSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/FurnaceInitSystem.cs
@@ -31,7 +31,9 @@ namespace RareIcon
             var ecb = SystemAPI.GetSingleton<BeginSimulationEntityCommandBufferSystem.Singleton>()
                                .CreateCommandBuffer(state.WorldUnmanaged);
 
-            var hexLookup    = SystemAPI.GetSingleton<HexDBSingleton>().Lookup;
+            var hexDB        = SystemAPI.GetSingleton<HexDBSingleton>();
+            hexDB.DrainHandle.Complete();
+            var hexLookup    = hexDB.Lookup;
             var biomeLookup  = SystemAPI.GetComponentLookup<BiomeType>(true);
             var buildingLookup = SystemAPI.GetComponentLookup<Building>(true);
 

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/InnRevenueSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/InnRevenueSystem.cs
@@ -52,6 +52,7 @@ namespace RareIcon
 
             if (_capitalQuery.IsEmpty) return;
             if (!SystemAPI.TryGetSingleton<HexDBSingleton>(out var hexDb)) return;
+            hexDb.DrainHandle.Complete();
 
             var inns       = _innQuery.ToEntityArray(Allocator.Temp);
             var sleepers   = _sleepersQuery.ToEntityArray(Allocator.Temp);

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/ShrineProductionSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/ShrineProductionSystem.cs
@@ -69,6 +69,7 @@ namespace RareIcon
 
             var territoryLookup = SystemAPI.GetComponentLookup<TerritoryVisual>(true);
             var hexDB           = SystemAPI.GetSingleton<HexDBSingleton>();
+            hexDB.DrainHandle.Complete();
 
             foreach (var (shrineRef, building, rewards) in
                      SystemAPI.Query<RefRW<LandmarkShrine>, RefRO<Building>, DynamicBuffer<LandmarkShrineRewardItem>>())


### PR DESCRIPTION
## Why this exists

These six fixes were follow-up commits on #12086 that were pushed **after** that PR was squash-merged, so they never reached `dev` — they stranded on the old branch and lingered uncommitted in the local tree. Re-PR'd standalone here.

## Problem

`WhaleSpawnerSystem`, `FurnaceInitSystem`, `BarracksHealExecutor`, `ShrineProductionSystem`, `InnRevenueSystem` and `BanditCampResourceScanSystem` each read `HexDBSingleton.Lookup` (`GetKeyArray` / `TryGetValue`) on the **main thread** without completing the HexDB drain job's `DrainHandle`.

Jobs that take `Lookup` as a field auto-chain through the NativeContainer safety system (the documented HexDB pattern). Main-thread reads do **not** — the drain `IJob` can still be writing the `NativeHashMap` when these systems read it. Same race class as the offer/threat fixes already merged in #12086: `InvalidOperationException` under JobsDebugger in the editor, a real data race in the player build.

These readers are cadence-gated (turn / scan-interval), so they fire rarely, but the race is real.

## Fix

Complete the drain handle before the main-thread access:

```csharp
var hexDB = SystemAPI.GetSingleton<HexDBSingleton>();
hexDB.DrainHandle.Complete();
var lookup = hexDB.Lookup;
```

(For `TryGetSingleton` callsites, the `.Complete()` is inserted right after the successful get.)

## Verification

No Unity compiler locally — reviewer must reopen in Unity and confirm compile. Behaviour-preserving: only adds a sync before reads that were already racing.