### PR TITLE
feat(arcade): add frontline grid tactics game

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/tactics/AstroTactics.astro
+++ b/apps/kbve/astro-kbve/src/arcade/tactics/AstroTactics.astro
@@ -1,0 +1,480 @@
+---
+import ReactTacticsApp from './ReactTacticsApp';
+---
+
+<div class="not-content tactics-stage" data-tactics-stage>
+	<div class="tactics-toolbar">
+		<button
+			type="button"
+			class="tactics-btn"
+			data-tactics-theater
+			aria-pressed="false"
+			title="Theater mode">
+			<span class="tactics-btn-icon" aria-hidden="true">▭</span>
+			<span class="tactics-btn-label">Theater</span>
+		</button>
+		<button
+			type="button"
+			class="tactics-btn"
+			data-tactics-fullscreen
+			aria-pressed="false"
+			title="Toggle fullscreen">
+			<span class="tactics-btn-icon" aria-hidden="true">⛶</span>
+			<span class="tactics-btn-label">Fullscreen</span>
+		</button>
+	</div>
+	<div
+		class="tactics-frame rounded-lg overflow-hidden border-2 border-gray-700 shadow-xl focus:outline-none relative bg-[#10151d]"
+		tabindex="0">
+		<ReactTacticsApp client:only="react" />
+	</div>
+	<p class="text-xs text-gray-400 mt-2 text-center">
+		Select a blue unit, tap highlighted tiles to move, tap red targets to
+		attack, then end the turn.
+	</p>
+</div>
+
+<style>
+	.tactics-stage {
+		width: 100%;
+		margin-inline: auto;
+	}
+	.tactics-toolbar {
+		display: flex;
+		gap: 8px;
+		justify-content: flex-end;
+		margin-bottom: 8px;
+	}
+	.tactics-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 6px;
+		padding: 6px 12px;
+		font-size: 12px;
+		font-weight: 500;
+		color: #e5e7eb;
+		background: rgba(15, 23, 42, 0.7);
+		border: 1px solid rgba(94, 234, 212, 0.36);
+		border-radius: 6px;
+		cursor: pointer;
+		transition:
+			background 120ms ease,
+			border-color 120ms ease;
+	}
+	.tactics-btn:hover {
+		background: rgba(15, 23, 42, 0.9);
+		border-color: rgba(94, 234, 212, 0.7);
+	}
+	.tactics-btn[aria-pressed='true'] {
+		background: rgba(20, 184, 166, 0.2);
+		border-color: rgba(94, 234, 212, 0.82);
+		color: #ccfbf1;
+	}
+	.tactics-btn-icon {
+		font-size: 14px;
+		line-height: 1;
+	}
+	.tactics-frame {
+		width: 100%;
+		aspect-ratio: 16 / 9;
+		touch-action: manipulation;
+		-webkit-user-select: none;
+		user-select: none;
+	}
+	.tactics-stage.is-theater {
+		position: fixed;
+		top: var(--sl-nav-height, 0px);
+		left: 0;
+		right: 0;
+		bottom: 0;
+		max-width: none;
+		width: 100vw;
+		height: calc(100vh - var(--sl-nav-height, 0px));
+		margin: 0;
+		padding: 16px;
+		z-index: 50;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 8px;
+		background: rgba(8, 13, 24, 0.97);
+		box-sizing: border-box;
+	}
+	.tactics-stage.is-theater .tactics-toolbar {
+		margin-bottom: 0;
+	}
+	.tactics-stage.is-theater .tactics-frame {
+		width: min(
+			100%,
+			calc((100vh - var(--sl-nav-height, 0px) - 110px) * 16 / 9)
+		);
+		max-width: 100%;
+		height: auto;
+	}
+	.tactics-stage:fullscreen {
+		width: 100vw;
+		height: 100vh;
+		max-width: none;
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		align-items: center;
+		background: #080d18;
+		padding: 16px;
+	}
+	.tactics-stage:fullscreen .tactics-frame {
+		width: min(100%, calc((100vh - 120px) * 16 / 9));
+		max-width: 100%;
+		aspect-ratio: 16 / 9;
+	}
+	:global(.tactics-shell) {
+		width: 100%;
+		height: 100%;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		padding: 16px;
+		box-sizing: border-box;
+		color: #e5e7eb;
+		background:
+			linear-gradient(rgba(148, 163, 184, 0.08) 1px, transparent 1px),
+			linear-gradient(
+				90deg,
+				rgba(148, 163, 184, 0.08) 1px,
+				transparent 1px
+			),
+			linear-gradient(135deg, #0f172a 0%, #111827 42%, #172554 100%);
+		background-size:
+			24px 24px,
+			24px 24px,
+			100% 100%;
+		font-family:
+			Inter,
+			ui-sans-serif,
+			system-ui,
+			-apple-system,
+			BlinkMacSystemFont,
+			'Segoe UI',
+			sans-serif;
+	}
+	:global(.tactics-topbar) {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 12px;
+		min-height: 54px;
+	}
+	:global(.tactics-kicker) {
+		margin: 0 0 2px;
+		font-size: 11px;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0;
+		color: #5eead4;
+	}
+	:global(.tactics-topbar h2) {
+		margin: 0;
+		font-size: 24px;
+		line-height: 1;
+		color: #f8fafc;
+	}
+	:global(.tactics-status) {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+	}
+	:global(.tactics-status span) {
+		border: 1px solid rgba(148, 163, 184, 0.35);
+		background: rgba(15, 23, 42, 0.72);
+		border-radius: 6px;
+		padding: 6px 9px;
+		font-size: 12px;
+		font-weight: 700;
+		color: #dbeafe;
+	}
+	:global(.tactics-layout) {
+		min-height: 0;
+		flex: 1;
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(210px, 260px);
+		gap: 14px;
+	}
+	:global(.tactics-board) {
+		min-height: 0;
+		aspect-ratio: 1;
+		height: 100%;
+		max-height: 100%;
+		margin-inline: auto;
+		display: grid;
+		grid-template-columns: repeat(8, minmax(0, 1fr));
+		grid-template-rows: repeat(8, minmax(0, 1fr));
+		gap: 3px;
+		padding: 6px;
+		border: 1px solid rgba(148, 163, 184, 0.35);
+		border-radius: 8px;
+		background: rgba(2, 6, 23, 0.68);
+		box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+	}
+	:global(.tactics-tile) {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0;
+		border: 1px solid rgba(15, 23, 42, 0.66);
+		border-radius: 4px;
+		cursor: pointer;
+		overflow: hidden;
+		transition:
+			transform 90ms ease,
+			outline-color 120ms ease,
+			filter 120ms ease;
+	}
+	:global(.tactics-tile:hover) {
+		transform: translateY(-1px);
+		filter: brightness(1.08);
+	}
+	:global(.terrain-plain) {
+		background: linear-gradient(135deg, #50672f 0%, #35471f 100%);
+	}
+	:global(.terrain-forest) {
+		background:
+			radial-gradient(
+				circle at 34% 38%,
+				rgba(187, 247, 208, 0.28) 0 8%,
+				transparent 9%
+			),
+			linear-gradient(135deg, #14532d 0%, #052e16 100%);
+	}
+	:global(.terrain-city) {
+		background:
+			linear-gradient(
+				90deg,
+				rgba(226, 232, 240, 0.18) 1px,
+				transparent 1px
+			),
+			linear-gradient(135deg, #475569 0%, #1e293b 100%);
+		background-size:
+			9px 100%,
+			100% 100%;
+	}
+	:global(.terrain-ridge) {
+		background:
+			linear-gradient(
+				135deg,
+				transparent 0 44%,
+				rgba(255, 255, 255, 0.22) 45% 48%,
+				transparent 49%
+			),
+			linear-gradient(135deg, #78716c 0%, #44403c 100%);
+	}
+	:global(.terrain-water) {
+		background:
+			linear-gradient(
+				90deg,
+				rgba(186, 230, 253, 0.2) 0 20%,
+				transparent 20% 45%,
+				rgba(186, 230, 253, 0.18) 45% 58%,
+				transparent 58%
+			),
+			linear-gradient(135deg, #075985 0%, #0c4a6e 100%);
+		cursor: not-allowed;
+	}
+	:global(.terrain-hq) {
+		background:
+			linear-gradient(
+				90deg,
+				rgba(248, 250, 252, 0.2) 0 50%,
+				transparent 50%
+			),
+			linear-gradient(135deg, #334155 0%, #111827 100%);
+		background-size:
+			12px 100%,
+			100% 100%;
+	}
+	:global(.terrain-mark) {
+		position: absolute;
+		left: 4px;
+		top: 3px;
+		font-size: 9px;
+		font-weight: 900;
+		color: rgba(248, 250, 252, 0.58);
+	}
+	:global(.tactics-tile.is-move) {
+		outline: 2px solid rgba(94, 234, 212, 0.78);
+		outline-offset: -3px;
+	}
+	:global(.tactics-tile.is-attack) {
+		outline: 2px solid rgba(248, 113, 113, 0.9);
+		outline-offset: -3px;
+	}
+	:global(.tactics-tile.is-selected) {
+		outline: 3px solid #fde047;
+		outline-offset: -4px;
+	}
+	:global(.unit) {
+		width: min(74%, 48px);
+		aspect-ratio: 1;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		gap: 3px;
+		border-radius: 7px;
+		border: 2px solid rgba(255, 255, 255, 0.7);
+		box-shadow: 0 8px 16px rgba(0, 0, 0, 0.3);
+		font-weight: 900;
+		font-size: 16px;
+		color: #f8fafc;
+	}
+	:global(.unit-blue) {
+		background: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+	}
+	:global(.unit-red) {
+		background: linear-gradient(135deg, #dc2626 0%, #991b1b 100%);
+	}
+	:global(.unit-rocket) {
+		border-radius: 50%;
+	}
+	:global(.unit meter) {
+		width: 72%;
+		height: 5px;
+	}
+	:global(.tactics-panel) {
+		min-height: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+		padding: 12px;
+		border: 1px solid rgba(148, 163, 184, 0.3);
+		border-radius: 8px;
+		background: rgba(15, 23, 42, 0.76);
+	}
+	:global(.panel-section) {
+		border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+		padding-bottom: 10px;
+	}
+	:global(.panel-label) {
+		margin: 0 0 5px;
+		font-size: 11px;
+		font-weight: 800;
+		text-transform: uppercase;
+		color: #5eead4;
+	}
+	:global(.panel-message),
+	:global(.panel-muted) {
+		margin: 0;
+		font-size: 13px;
+		line-height: 1.45;
+		color: #cbd5e1;
+	}
+	:global(.unit-card) {
+		display: grid;
+		gap: 4px;
+		font-size: 12px;
+		color: #cbd5e1;
+	}
+	:global(.unit-card strong) {
+		color: #f8fafc;
+		font-size: 15px;
+	}
+	:global(.score-row) {
+		display: flex;
+		justify-content: space-between;
+		gap: 10px;
+		font-size: 13px;
+		font-weight: 800;
+		color: #dbeafe;
+	}
+	:global(.panel-actions) {
+		margin-top: auto;
+		display: grid;
+		grid-template-columns: 1fr;
+		gap: 8px;
+	}
+	:global(.panel-actions button) {
+		min-height: 36px;
+		border: 1px solid rgba(94, 234, 212, 0.38);
+		border-radius: 6px;
+		background: rgba(20, 184, 166, 0.14);
+		color: #ccfbf1;
+		font-weight: 800;
+		cursor: pointer;
+	}
+	:global(.panel-actions button:hover:not(:disabled)) {
+		background: rgba(20, 184, 166, 0.24);
+	}
+	:global(.panel-actions button:disabled) {
+		opacity: 0.45;
+		cursor: not-allowed;
+	}
+	@media (max-width: 760px) {
+		.tactics-frame {
+			aspect-ratio: 9 / 12;
+		}
+		:global(.tactics-shell) {
+			padding: 10px;
+		}
+		:global(.tactics-layout) {
+			grid-template-columns: 1fr;
+			grid-template-rows: minmax(0, 1fr) auto;
+		}
+		:global(.tactics-board) {
+			width: 100%;
+			height: auto;
+		}
+		:global(.tactics-panel) {
+			padding: 10px;
+		}
+		:global(.panel-actions) {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
+		:global(.tactics-topbar h2) {
+			font-size: 19px;
+		}
+	}
+</style>
+
+<script>
+	const stage = document.querySelector<HTMLElement>('[data-tactics-stage]');
+	const theaterBtn = document.querySelector<HTMLButtonElement>(
+		'[data-tactics-theater]',
+	);
+	const fsBtn = document.querySelector<HTMLButtonElement>(
+		'[data-tactics-fullscreen]',
+	);
+
+	if (stage && theaterBtn) {
+		const setTheater = (on: boolean) => {
+			stage.classList.toggle('is-theater', on);
+			theaterBtn.setAttribute('aria-pressed', String(on));
+			window.dispatchEvent(new Event('resize'));
+		};
+		theaterBtn.addEventListener('click', () => {
+			setTheater(!stage.classList.contains('is-theater'));
+		});
+		document.addEventListener('keydown', (e) => {
+			if (e.key === 'Escape' && stage.classList.contains('is-theater')) {
+				setTheater(false);
+			}
+		});
+	}
+
+	if (stage && fsBtn) {
+		const updateFsLabel = () => {
+			const active = document.fullscreenElement === stage;
+			fsBtn.setAttribute('aria-pressed', String(active));
+		};
+		fsBtn.addEventListener('click', async () => {
+			if (document.fullscreenElement) {
+				await document.exitFullscreen();
+			} else {
+				await stage.requestFullscreen();
+			}
+		});
+		document.addEventListener('fullscreenchange', updateFsLabel);
+	}
+</script>

--- a/apps/kbve/astro-kbve/src/arcade/tactics/ReactTacticsApp.tsx
+++ b/apps/kbve/astro-kbve/src/arcade/tactics/ReactTacticsApp.tsx
@@ -1,0 +1,577 @@
+import { useMemo, useState } from 'react';
+
+type Team = 'blue' | 'red';
+type Terrain = 'plain' | 'forest' | 'city' | 'ridge' | 'water' | 'hq';
+type UnitType = 'infantry' | 'armor' | 'rocket';
+type Phase = 'player' | 'enemy' | 'victory' | 'defeat';
+
+interface Tile {
+	terrain: Terrain;
+	owner?: Team;
+}
+
+interface Unit {
+	id: string;
+	team: Team;
+	type: UnitType;
+	x: number;
+	y: number;
+	hp: number;
+	acted: boolean;
+}
+
+interface UnitSpec {
+	label: string;
+	short: string;
+	move: number;
+	range: number;
+	damage: number;
+	maxHp: number;
+}
+
+const WIDTH = 8;
+const HEIGHT = 8;
+
+const UNITS: Record<UnitType, UnitSpec> = {
+	infantry: {
+		label: 'Ranger',
+		short: 'R',
+		move: 3,
+		range: 1,
+		damage: 34,
+		maxHp: 100,
+	},
+	armor: {
+		label: 'Bulldog',
+		short: 'B',
+		move: 4,
+		range: 1,
+		damage: 48,
+		maxHp: 120,
+	},
+	rocket: {
+		label: 'Lancer',
+		short: 'L',
+		move: 2,
+		range: 3,
+		damage: 42,
+		maxHp: 90,
+	},
+};
+
+const TERRAIN_COST: Record<Terrain, number> = {
+	plain: 1,
+	forest: 2,
+	city: 1,
+	ridge: 2,
+	water: 99,
+	hq: 1,
+};
+
+const TERRAIN_DEFENSE: Record<Terrain, number> = {
+	plain: 0,
+	forest: 8,
+	city: 12,
+	ridge: 10,
+	water: 0,
+	hq: 16,
+};
+
+const TERRAIN_LABEL: Record<Terrain, string> = {
+	plain: 'Plain',
+	forest: 'Forest',
+	city: 'Depot',
+	ridge: 'Ridge',
+	water: 'Water',
+	hq: 'HQ',
+};
+
+const MAP_ROWS: Terrain[][] = [
+	['hq', 'plain', 'forest', 'plain', 'plain', 'ridge', 'plain', 'hq'],
+	['plain', 'plain', 'forest', 'water', 'plain', 'plain', 'city', 'plain'],
+	['city', 'plain', 'ridge', 'water', 'forest', 'plain', 'plain', 'plain'],
+	['plain', 'plain', 'plain', 'plain', 'plain', 'ridge', 'forest', 'plain'],
+	['plain', 'forest', 'ridge', 'plain', 'plain', 'plain', 'plain', 'plain'],
+	['plain', 'plain', 'plain', 'forest', 'water', 'ridge', 'plain', 'city'],
+	['plain', 'city', 'plain', 'plain', 'water', 'forest', 'plain', 'plain'],
+	['hq', 'plain', 'ridge', 'plain', 'plain', 'forest', 'plain', 'hq'],
+];
+
+const INITIAL_UNITS: Unit[] = [
+	{
+		id: 'b1',
+		team: 'blue',
+		type: 'infantry',
+		x: 0,
+		y: 7,
+		hp: 100,
+		acted: false,
+	},
+	{
+		id: 'b2',
+		team: 'blue',
+		type: 'armor',
+		x: 1,
+		y: 6,
+		hp: 120,
+		acted: false,
+	},
+	{
+		id: 'b3',
+		team: 'blue',
+		type: 'rocket',
+		x: 2,
+		y: 7,
+		hp: 90,
+		acted: false,
+	},
+	{
+		id: 'r1',
+		team: 'red',
+		type: 'infantry',
+		x: 7,
+		y: 0,
+		hp: 100,
+		acted: false,
+	},
+	{ id: 'r2', team: 'red', type: 'armor', x: 6, y: 1, hp: 120, acted: false },
+	{ id: 'r3', team: 'red', type: 'rocket', x: 5, y: 0, hp: 90, acted: false },
+];
+
+function makeMap(): Tile[] {
+	return MAP_ROWS.flatMap((row, y) =>
+		row.map((terrain) => ({
+			terrain,
+			owner:
+				terrain === 'hq'
+					? y < 2
+						? 'red'
+						: y > 5
+							? 'blue'
+							: undefined
+					: undefined,
+		})),
+	);
+}
+
+function key(x: number, y: number) {
+	return `${x},${y}`;
+}
+
+function distance(a: { x: number; y: number }, b: { x: number; y: number }) {
+	return Math.abs(a.x - b.x) + Math.abs(a.y - b.y);
+}
+
+function inBounds(x: number, y: number) {
+	return x >= 0 && x < WIDTH && y >= 0 && y < HEIGHT;
+}
+
+function tileAt(map: Tile[], x: number, y: number) {
+	return map[y * WIDTH + x];
+}
+
+function movementTiles(unit: Unit, units: Unit[], map: Tile[]) {
+	const occupied = new Set(
+		units
+			.filter((u) => u.id !== unit.id && u.hp > 0)
+			.map((u) => key(u.x, u.y)),
+	);
+	const frontier: Array<{ x: number; y: number; cost: number }> = [
+		{ x: unit.x, y: unit.y, cost: 0 },
+	];
+	const best = new Map<string, number>([[key(unit.x, unit.y), 0]]);
+
+	while (frontier.length) {
+		const current = frontier.shift()!;
+		for (const [dx, dy] of [
+			[1, 0],
+			[-1, 0],
+			[0, 1],
+			[0, -1],
+		]) {
+			const x = current.x + dx;
+			const y = current.y + dy;
+			const tileKey = key(x, y);
+			if (!inBounds(x, y) || occupied.has(tileKey)) continue;
+
+			const terrain = tileAt(map, x, y).terrain;
+			const nextCost = current.cost + TERRAIN_COST[terrain];
+			if (nextCost > UNITS[unit.type].move) continue;
+			if (best.has(tileKey) && best.get(tileKey)! <= nextCost) continue;
+
+			best.set(tileKey, nextCost);
+			frontier.push({ x, y, cost: nextCost });
+		}
+	}
+
+	best.delete(key(unit.x, unit.y));
+	return best;
+}
+
+function damageFor(attacker: Unit, defender: Unit, map: Tile[]) {
+	const attackerSpec = UNITS[attacker.type];
+	const defense =
+		TERRAIN_DEFENSE[tileAt(map, defender.x, defender.y).terrain];
+	const healthScale = Math.max(0.35, attacker.hp / attackerSpec.maxHp);
+	const armorPenalty =
+		defender.type === 'armor' && attacker.type === 'infantry' ? 12 : 0;
+	const rocketBonus =
+		attacker.type === 'rocket' && defender.type === 'armor' ? 18 : 0;
+	return Math.max(
+		12,
+		Math.round(
+			(attackerSpec.damage + rocketBonus - armorPenalty - defense) *
+				healthScale,
+		),
+	);
+}
+
+function unitAt(units: Unit[], x: number, y: number) {
+	return units.find((unit) => unit.hp > 0 && unit.x === x && unit.y === y);
+}
+
+function applyAttack(
+	units: Unit[],
+	attacker: Unit,
+	defender: Unit,
+	map: Tile[],
+) {
+	const damage = damageFor(attacker, defender, map);
+	return units
+		.map((unit) =>
+			unit.id === defender.id
+				? { ...unit, hp: Math.max(0, unit.hp - damage) }
+				: unit.id === attacker.id
+					? { ...unit, acted: true }
+					: unit,
+		)
+		.filter((unit) => unit.hp > 0);
+}
+
+function resetTeam(units: Unit[], team: Team) {
+	return units.map((unit) =>
+		unit.team === team ? { ...unit, acted: false } : unit,
+	);
+}
+
+function resolvePhase(units: Unit[], current: Phase): Phase {
+	const blueAlive = units.some((unit) => unit.team === 'blue' && unit.hp > 0);
+	const redAlive = units.some((unit) => unit.team === 'red' && unit.hp > 0);
+	if (!redAlive) return 'victory';
+	if (!blueAlive) return 'defeat';
+	return current;
+}
+
+function enemyTurn(units: Unit[], map: Tile[]) {
+	let nextUnits = resetTeam(units, 'red');
+	let log = 'Enemy convoy advances.';
+
+	for (const enemy of nextUnits.filter(
+		(unit) => unit.team === 'red' && unit.hp > 0,
+	)) {
+		const liveEnemy = nextUnits.find((unit) => unit.id === enemy.id);
+		if (!liveEnemy) continue;
+
+		const targets = nextUnits.filter(
+			(unit) => unit.team === 'blue' && unit.hp > 0,
+		);
+		if (!targets.length) break;
+
+		const inRange = targets
+			.filter(
+				(target) =>
+					distance(liveEnemy, target) <= UNITS[liveEnemy.type].range,
+			)
+			.sort((a, b) => a.hp - b.hp)[0];
+
+		if (inRange) {
+			nextUnits = applyAttack(nextUnits, liveEnemy, inRange, map);
+			log = `${UNITS[liveEnemy.type].label} hits ${UNITS[inRange.type].label}.`;
+			continue;
+		}
+
+		const target = targets.sort(
+			(a, b) => distance(liveEnemy, a) - distance(liveEnemy, b),
+		)[0];
+		const moves = [...movementTiles(liveEnemy, nextUnits, map).keys()]
+			.map((tileKey) => {
+				const [x, y] = tileKey.split(',').map(Number);
+				return { x, y, score: distance({ x, y }, target) };
+			})
+			.sort((a, b) => a.score - b.score);
+
+		const move = moves[0];
+		if (move) {
+			nextUnits = nextUnits.map((unit) =>
+				unit.id === liveEnemy.id
+					? { ...unit, x: move.x, y: move.y, acted: true }
+					: unit,
+			);
+		}
+	}
+
+	return { units: resetTeam(nextUnits, 'blue'), log };
+}
+
+export default function ReactTacticsApp() {
+	const [map] = useState<Tile[]>(() => makeMap());
+	const [units, setUnits] = useState<Unit[]>(() =>
+		INITIAL_UNITS.map((unit) => ({ ...unit })),
+	);
+	const [selectedId, setSelectedId] = useState<string | null>('b1');
+	const [phase, setPhase] = useState<Phase>('player');
+	const [turn, setTurn] = useState(1);
+	const [message, setMessage] = useState(
+		'Select a blue unit, move into range, and clear the red HQ guard.',
+	);
+
+	const selected = units.find(
+		(unit) => unit.id === selectedId && unit.hp > 0,
+	);
+	const reachable = useMemo(
+		() =>
+			selected && phase === 'player' && !selected.acted
+				? movementTiles(selected, units, map)
+				: new Map<string, number>(),
+		[selected, units, map, phase],
+	);
+	const attackable = useMemo(() => {
+		if (!selected || phase !== 'player' || selected.acted)
+			return new Set<string>();
+		return new Set(
+			units
+				.filter((unit) => unit.team !== selected.team && unit.hp > 0)
+				.filter(
+					(unit) =>
+						distance(selected, unit) <= UNITS[selected.type].range,
+				)
+				.map((unit) => key(unit.x, unit.y)),
+		);
+	}, [selected, units, phase]);
+
+	const activeBlueUnits = units.filter(
+		(unit) => unit.team === 'blue' && unit.hp > 0,
+	);
+	const activeRedUnits = units.filter(
+		(unit) => unit.team === 'red' && unit.hp > 0,
+	);
+	const canEndTurn = phase === 'player';
+
+	function commitUnits(nextUnits: Unit[], nextPhase: Phase = phase) {
+		const resolved = resolvePhase(nextUnits, nextPhase);
+		setUnits(nextUnits);
+		setPhase(resolved);
+		if (resolved === 'victory')
+			setMessage('Victory. The red convoy is off the board.');
+		if (resolved === 'defeat')
+			setMessage('Defeat. Your command group was routed.');
+	}
+
+	function selectNextReady(nextUnits: Unit[]) {
+		const nextReady = nextUnits.find(
+			(unit) => unit.team === 'blue' && unit.hp > 0 && !unit.acted,
+		);
+		setSelectedId(nextReady?.id ?? null);
+	}
+
+	function handleTileClick(x: number, y: number) {
+		if (phase !== 'player') return;
+		const clickedUnit = unitAt(units, x, y);
+
+		if (clickedUnit?.team === 'blue') {
+			setSelectedId(clickedUnit.id);
+			setMessage(
+				clickedUnit.acted
+					? `${UNITS[clickedUnit.type].label} already acted.`
+					: `${UNITS[clickedUnit.type].label} ready.`,
+			);
+			return;
+		}
+
+		if (!selected || selected.acted) return;
+
+		if (clickedUnit?.team === 'red' && attackable.has(key(x, y))) {
+			const nextUnits = applyAttack(units, selected, clickedUnit, map);
+			setMessage(
+				`${UNITS[selected.type].label} attacks for ${damageFor(selected, clickedUnit, map)}.`,
+			);
+			commitUnits(nextUnits);
+			selectNextReady(nextUnits);
+			return;
+		}
+
+		if (reachable.has(key(x, y))) {
+			const nextUnits = units.map((unit) =>
+				unit.id === selected.id ? { ...unit, x, y } : unit,
+			);
+			setUnits(nextUnits);
+			setMessage(
+				`${UNITS[selected.type].label} moved. Attack if a target is in range.`,
+			);
+		}
+	}
+
+	function handleWait() {
+		if (!selected || phase !== 'player') return;
+		const nextUnits = units.map((unit) =>
+			unit.id === selected.id ? { ...unit, acted: true } : unit,
+		);
+		setMessage(`${UNITS[selected.type].label} holds position.`);
+		commitUnits(nextUnits);
+		selectNextReady(nextUnits);
+	}
+
+	function endTurn() {
+		if (!canEndTurn) return;
+		setPhase('enemy');
+		const result = enemyTurn(units, map);
+		setTurn((value) => value + 1);
+		setSelectedId(
+			result.units.find((unit) => unit.team === 'blue' && unit.hp > 0)
+				?.id ?? null,
+		);
+		setMessage(result.log);
+		commitUnits(result.units, 'player');
+	}
+
+	function restart() {
+		setUnits(INITIAL_UNITS.map((unit) => ({ ...unit })));
+		setSelectedId('b1');
+		setPhase('player');
+		setTurn(1);
+		setMessage(
+			'Select a blue unit, move into range, and clear the red HQ guard.',
+		);
+	}
+
+	return (
+		<div className="tactics-shell" data-phase={phase}>
+			<div className="tactics-topbar">
+				<div>
+					<p className="tactics-kicker">KBVE Arcade</p>
+					<h2>Frontline Grid</h2>
+				</div>
+				<div className="tactics-status">
+					<span>Turn {turn}</span>
+					<span>
+						{phase === 'player'
+							? 'Blue command'
+							: phase === 'enemy'
+								? 'Red response'
+								: phase}
+					</span>
+				</div>
+			</div>
+
+			<div className="tactics-layout">
+				<div
+					className="tactics-board"
+					role="grid"
+					aria-label="Frontline Grid battlefield">
+					{map.map((tile, index) => {
+						const x = index % WIDTH;
+						const y = Math.floor(index / WIDTH);
+						const unit = unitAt(units, x, y);
+						const tileKey = key(x, y);
+						const isSelected = unit?.id === selectedId;
+						const isMove = reachable.has(tileKey);
+						const isAttack = attackable.has(tileKey);
+
+						return (
+							<button
+								key={tileKey}
+								type="button"
+								className={[
+									'tactics-tile',
+									`terrain-${tile.terrain}`,
+									isSelected ? 'is-selected' : '',
+									isMove ? 'is-move' : '',
+									isAttack ? 'is-attack' : '',
+								]
+									.filter(Boolean)
+									.join(' ')}
+								onClick={() => handleTileClick(x, y)}
+								role="gridcell"
+								aria-label={`${TERRAIN_LABEL[tile.terrain]} ${x + 1}, ${y + 1}`}>
+								<span className="terrain-mark">
+									{tile.terrain === 'hq'
+										? 'HQ'
+										: tile.terrain === 'city'
+											? 'D'
+											: ''}
+								</span>
+								{unit && (
+									<span
+										className={`unit unit-${unit.team} unit-${unit.type}`}>
+										<span>{UNITS[unit.type].short}</span>
+										<meter
+											min={0}
+											max={UNITS[unit.type].maxHp}
+											value={unit.hp}
+										/>
+									</span>
+								)}
+							</button>
+						);
+					})}
+				</div>
+
+				<aside className="tactics-panel">
+					<div className="panel-section">
+						<p className="panel-label">Orders</p>
+						<p className="panel-message">{message}</p>
+					</div>
+					<div className="panel-section">
+						<p className="panel-label">Selected</p>
+						{selected ? (
+							<div className="unit-card">
+								<strong>{UNITS[selected.type].label}</strong>
+								<span>
+									{selected.team === 'blue' ? 'Blue' : 'Red'}{' '}
+									unit
+								</span>
+								<span>
+									HP {selected.hp}/
+									{UNITS[selected.type].maxHp}
+								</span>
+								<span>
+									Move {UNITS[selected.type].move} · Range{' '}
+									{UNITS[selected.type].range}
+								</span>
+							</div>
+						) : (
+							<p className="panel-muted">
+								No ready unit selected.
+							</p>
+						)}
+					</div>
+					<div className="panel-section score-row">
+						<span>Blue {activeBlueUnits.length}</span>
+						<span>Red {activeRedUnits.length}</span>
+					</div>
+					<div className="panel-actions">
+						<button
+							type="button"
+							onClick={handleWait}
+							disabled={
+								!selected ||
+								selected.acted ||
+								phase !== 'player'
+							}>
+							Wait
+						</button>
+						<button
+							type="button"
+							onClick={endTurn}
+							disabled={!canEndTurn}>
+							End turn
+						</button>
+						<button type="button" onClick={restart}>
+							Restart
+						</button>
+					</div>
+				</aside>
+			</div>
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/arcade/index.mdx
@@ -26,7 +26,6 @@ import {
 
 import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
 
-
 <ArcadeTooltipController client:only="react" />
 
 <div class="">
@@ -35,7 +34,7 @@ import DeferredAdsense from '@/components/kbve/DeferredAdsense.astro';
 	title="KBVE Arcade"
 	tagline="Browser games we built ourselves — blackjack, Klondike with monsters, a WebGL action-RPG demo, an isometric WebGPU prototype, and an endless runner. Plus a Ruffle integration in the oven for Flash classics."
 	stats={[
-		{ value: '6', label: 'Live games' },
+		{ value: '7', label: 'Live games' },
 		{ value: 'WASM', label: 'Phaser · Bevy · R3F' },
 		{ value: 'Free', label: 'Enjoy the run!' },
 	]}
@@ -49,6 +48,15 @@ anywhere else.
 ## Available now
 
 <ArcadeGameGrid columns={2}>
+	<ArcadeGameCard
+		title="Frontline Grid"
+		href="/arcade/tactics/"
+		description="Compact turn-based tactics on an 8×8 battlefield. Move blue command units across terrain, focus fire, survive red counter turns, and clear the convoy guard."
+		tags={['Tactics', 'Strategy', 'React']}
+		status="live"
+		gradient="linear-gradient(135deg, #0f766e 0%, #1d4ed8 100%)"
+		icon="▦"
+	/>
 	<ArcadeGameCard
 		title="Blackjack"
 		href="/arcade/blackjack/"
@@ -104,7 +112,6 @@ anywhere else.
 		icon="✛"
 	/>
 </ArcadeGameGrid>
-
 
 <DeferredAdsense />
 
@@ -162,7 +169,6 @@ actually open the game's page — the rest of the site stays light.
 	Subsequent navigations inside the arcade share cached assets and feel
 	near-instant.
 </Aside>
-
 
 ## Controls cheatsheet
 

--- a/apps/kbve/astro-kbve/src/content/docs/arcade/tactics.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/arcade/tactics.mdx
@@ -1,0 +1,24 @@
+---
+title: Frontline Grid
+description: |
+    Play a compact turn-based tactics prototype with grid movement, terrain,
+    range control, and enemy counter turns.
+sidebar:
+    label: Frontline Grid
+    order: 7
+template: splash
+editUrl: false
+lastUpdated: false
+next: false
+unsplash: 1519074002996-a69e7ac46a42
+img: https://images.unsplash.com/photo-1519074002996-a69e7ac46a42?fit=crop&w=1400&h=700&q=75
+tags:
+    - games
+    - tactics
+    - strategy
+    - arcade
+---
+
+import AstroTactics from '@/arcade/tactics/AstroTactics.astro';
+
+<AstroTactics />


### PR DESCRIPTION
## What changed

- Added `Frontline Grid`, an original compact turn-based tactics game under `/arcade/tactics/`.
- Added the Astro arcade wrapper with theater/fullscreen controls and responsive game styling.
- Added the MDX route and listed the new game on the Arcade page, updating the live game count to 7.

## Impact

The arcade now has a playable tactics prototype with grid movement, terrain, unit selection, attacks, enemy turns, restart, and win/loss states.

## Validation

- `./kbve.sh -nx astro-kbve:test` passed: 35 test files, 285 tests.
- Playwright smoke passed against the local dev route: hydrated 64 tiles and 6 units, and a click interaction updated the orders panel.
- `/arcade/tactics/` returned `200 OK` locally.
- `./kbve.sh -nx astro-kbve:check` was run and still fails only on existing unrelated tower defense and Scalar dashboard diagnostics; the new tactics files have no diagnostics.