### PR TITLE
feat(rows): enforce per-tenant isolation across REST/MQ/Agones + docs

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
@@ -50,7 +50,7 @@ ROWS is a single-binary Rust reimplementation of the OWS (Open World Server) gam
 | Instance | `/api/instance/*` | Server instance lifecycle |
 | Global | `/api/global/*` | Key/value world state |
 | Health | `/health`, `/ready` | Liveness and readiness probes |
-| gRPC | Port 50051 | Internal service mesh |
+| gRPC | Port 4322 (multiplexed) | Internal service mesh |
 
 <Aside type="tip" title="Production">
     ROWS is the production game backend. The legacy .NET OWS microservices have been fully
@@ -59,10 +59,30 @@ ROWS is a single-binary Rust reimplementation of the OWS (Open World Server) gam
 
 ### Deployment
 
-ROWS deploys as a single Docker image (`ghcr.io/kbve/rows`) into the `rows` Kubernetes namespace. ArgoCD syncs the manifest from `apps/kube/rows/manifest/rows-deployment.yaml` with auto-prune and self-heal enabled.
+ROWS deploys as a single Docker image (`ghcr.io/kbve/rows`). ArgoCD syncs the manifest from `apps/kube/rows/manifest/rows-deployment.yaml` with auto-prune and self-heal enabled.
 
 The container exposes:
 - **Port 4322** — REST + gRPC multiplexed (Axum + Tonic on a single port)
+
+#### Per-tenant deployment
+
+Each game + environment is a **separate ROWS deployment** pinned to its own tenant via env. The config is loaded and validated once at boot (`RowsConfig::from_env`):
+
+| Env | Purpose | Notes |
+|-----|---------|-------|
+| `OWS_API_KEY` | Tenant `customer_guid` (UUID) | **Required** for `beta`/`release`; `dev` falls back to an ephemeral guid with a warning |
+| `OWS_TENANT_SLUG` | Human label (e.g. `chuckrpg-dev`) | Surfaced in logs, `DeploymentInfo`, and the Prometheus `service` label (`rows-<slug>`) |
+| `OWS_ENV` | `dev` \| `beta` \| `release` | Drives the required-env guards |
+| `AGONES_FLEET` | Per-tenant Agones fleet | **Required** for `beta`/`release`; the GameServer watcher filters by `agones.dev/fleet=<fleet>` |
+| `AGONES_NAMESPACE` | Agones namespace | **Required** for `beta`/`release` |
+| `SUPABASE_JWT_SECRET` / `SUPABASE_SERVICE_KEY_HASH` | Player + trusted-server auth | Optional; ROWS boots in legacy mode without them |
+
+`GET /api/System/DeploymentInfo` echoes the active `tenant_slug`, `environment`, and `customer_guid` for verification.
+
+<Aside type="note" title="Related">
+    - Unreal client glue: [KBVEROWS plugin](/project/kbverows/)
+    - Live operations: [ROWS dashboard](/dashboard/gameops/rows/)
+</Aside>
 
 ---
 
@@ -72,11 +92,13 @@ ROWS has three distinct identities. They are different axes — do not conflate 
 
 | Identity | What it is | Source | How ROWS reads it |
 |----------|-----------|--------|-------------------|
-| **Tenant** (`customer_guid`) | The *game* — Chuck. One fixed value for the whole deployment. | `OWS_API_KEY` env (secret `ows-customer-guid`) | `X-CustomerGUID` header on every request |
+| **Tenant** (`customer_guid`) | A *game + environment* — e.g. `chuckrpg-dev`, `chuckrpg-beta`, `xy-release`. One fixed value per deployment. | `OWS_API_KEY` env (per-tenant secret) | `X-CustomerGUID` header, **enforced equal to the process tenant** |
 | **Player** (`userguid`) | A *person*. | Supabase UUID (`sub`) | Supabase JWT, or a session GUID minted from it |
 | **Trusted server** | The UE dedicated server / Iris instances. | Service key | `x-service-key` header, argon2-verified against `SUPABASE_SERVICE_KEY_HASH` |
 
-**The tenant is not the player.** `customer_guid` partitions every table (users, characters, zones, world servers, maps). All players and all UE instances share the **one** Chuck `customer_guid` so they inhabit the same world — multiple Iris instances are just rows in `worldservers` / `mapinstances` under that single tenant, not separate tenants. The player is identified by their Supabase UUID, which becomes the OWS `userguid`.
+**The tenant is not the player.** `customer_guid` partitions every table (users, characters, zones, world servers, maps). Within one tenant, all players and all UE instances share that `customer_guid` so they inhabit the same world — multiple Iris instances are just rows in `worldservers` / `mapinstances` under that tenant. The player is identified by their Supabase UUID, which becomes the OWS `userguid`.
+
+**Multi-tenant by deployment, single-tenant by process.** ROWS runs **one process per tenant** (game + environment); each deployment pins its `customer_guid` from `OWS_API_KEY` at boot. The Postgres DB is shared across tenants and isolated only by the `customerguid` column, so the `require_customer_guid` middleware rejects (`403`) any request whose `X-CustomerGUID` differs from the process tenant — a client cannot reach another game's rows by swapping the header. gRPC, WebSocket, MQ consumers, and background jobs always use the process tenant directly.
 
 **Player login.** The client signs in via Supabase (GoTrue) and posts the JWT to `ExternalLoginAndCreateSession`. ROWS validates it (HS256, `SUPABASE_JWT_SECRET`), keys the OWS user on the Supabase `sub`, and returns a `UserSessionGUID`. The UE client glue lives in the `ROWSupabase` module of the `KBVESupabase` plugin.
 
@@ -84,7 +106,7 @@ ROWS has three distinct identities. They are different axes — do not conflate 
 - **World IP** (`GetServerToConnectTo` / `JoinMap`) requires a confirmed login — a Supabase bearer JWT *or* a live session GUID — and verifies the caller owns the requested character before returning a server address.
 - **Server-write endpoints** (position/stats/logout, zone status, launcher register, spin-up/down) require a valid **service key**; player credentials do not pass. The dedicated server loads the key from `OWS_SERVICE_KEY` only on `IsRunningDedicatedServer()`, so it never enters a client build, and talks to ROWS in-cluster over the ClusterIP — the key never crosses the public internet.
 
-`SUPABASE_SERVICE_KEY_HASH` (rows) and the plaintext `OWS_SERVICE_KEY` (fleet) both derive from the one kilobase secret `supabase-service-key` (`hash` + `key`). Single-tenant by design; the multi-game GoTrue `customer_guid` claim path is intentionally unused.
+`SUPABASE_SERVICE_KEY_HASH` (rows) and the plaintext `OWS_SERVICE_KEY` (fleet) both derive from the one kilobase secret `supabase-service-key` (`hash` + `key`). The GoTrue `customer_guid` JWT claim is intentionally unused — tenant identity comes from the process config (`OWS_API_KEY`), never from the token.
 
 ---
 

--- a/apps/rows/src/agones/watcher.rs
+++ b/apps/rows/src/agones/watcher.rs
@@ -64,9 +64,13 @@ async fn run_watcher(state: &AppState) -> WatcherExit {
         },
     );
 
-    info!(namespace, "GameServer watcher started");
+    let fleet = &state.config.agones_fleet;
+    info!(namespace, fleet, "GameServer watcher started");
 
-    let stream = watcher::watcher(api, watcher::Config::default());
+    let stream = watcher::watcher(
+        api,
+        watcher::Config::default().labels(&format!("agones.dev/fleet={fleet}")),
+    );
     tokio::pin!(stream);
 
     while let Some(event) = stream.next().await {

--- a/apps/rows/src/config.rs
+++ b/apps/rows/src/config.rs
@@ -34,6 +34,23 @@ impl Environment {
     }
 }
 
+/// Defaults are only safe in dev; for beta/release an unset value would silently collide
+/// multiple tenants onto the same fleet/namespace, so require it explicitly there.
+fn require_or_default(
+    var: &str,
+    default: &str,
+    environment: Environment,
+) -> anyhow::Result<String> {
+    match std::env::var(var) {
+        Ok(v) => Ok(v),
+        Err(_) if environment.requires_explicit_guid() => Err(anyhow!(
+            "{var} is required for OWS_ENV={}",
+            environment.as_str()
+        )),
+        Err(_) => Ok(default.to_string()),
+    }
+}
+
 #[derive(Clone)]
 pub struct TenantConfig {
     pub customer_guid: Uuid,
@@ -84,8 +101,8 @@ impl RowsConfig {
             .unwrap_or_else(|_| "postgres://postgres:postgres@localhost:5432/ows".into());
         let rabbitmq_url = std::env::var("RABBITMQ_URL")
             .unwrap_or_else(|_| "amqp://dev:test@localhost:5672".into());
-        let agones_namespace = std::env::var("AGONES_NAMESPACE").unwrap_or_else(|_| "ows".into());
-        let agones_fleet = std::env::var("AGONES_FLEET").unwrap_or_else(|_| "ows-hubworld".into());
+        let agones_namespace = require_or_default("AGONES_NAMESPACE", "ows", environment)?;
+        let agones_fleet = require_or_default("AGONES_FLEET", "ows-hubworld", environment)?;
 
         let host = std::env::var("HTTP_HOST").unwrap_or_else(|_| "0.0.0.0".into());
         let port: u16 = std::env::var("HTTP_PORT")

--- a/apps/rows/src/main.rs
+++ b/apps/rows/src/main.rs
@@ -127,7 +127,12 @@ async fn main() -> anyhow::Result<()> {
     let rest_router = rest::router(app_state, svc.clone());
     let ws_router = ws::router(svc);
 
-    let (prom_layer, prom_handle) = jedi::entity::pipe_prometheus::build_metrics_layer("rows");
+    // Per-tenant service label so multiple ROWS deployments don't collide in Prometheus.
+    // Leaked once at startup; jedi's metrics API takes a &'static str.
+    let metrics_service: &'static str =
+        Box::leak(format!("rows-{}", cfg.tenant.slug).into_boxed_str());
+    let (prom_layer, prom_handle) =
+        jedi::entity::pipe_prometheus::build_metrics_layer(metrics_service);
 
     let app = rest_router
         .merge(ws_router)
@@ -143,7 +148,7 @@ async fn main() -> anyhow::Result<()> {
 
     tokio::spawn(jedi::entity::pipe_prometheus::serve_metrics(
         jedi::entity::pipe_prometheus::MetricsConfig {
-            service_name: "rows",
+            service_name: metrics_service,
             port: cfg.metrics_port,
         },
         prom_handle,

--- a/apps/rows/src/middleware.rs
+++ b/apps/rows/src/middleware.rs
@@ -1,5 +1,6 @@
+use crate::rest::HandlerState;
 use axum::{
-    extract::Request,
+    extract::{Request, State},
     http::StatusCode,
     middleware::Next,
     response::{IntoResponse, Response},
@@ -8,8 +9,15 @@ use uuid::Uuid;
 
 pub const CUSTOMER_GUID_HEADER: &str = "x-customerguid";
 
-/// Mirrors C# StoreCustomerGUIDMiddleware: skips `/health`, otherwise demands a valid GUID.
-pub async fn require_customer_guid(req: Request, next: Next) -> Response {
+/// Demands a valid `x-customerguid` header that matches THIS process's tenant
+/// (`config.customer_guid`). The DB is shared across tenants and scoped only by the
+/// `customerguid` column, so a client-supplied header that differs from the process
+/// tenant would otherwise read/write another tenant's rows. `/health` is exempt.
+pub async fn require_customer_guid(
+    State(hs): State<HandlerState>,
+    req: Request,
+    next: Next,
+) -> Response {
     if req.uri().path() == "/health" {
         return next.run(req).await;
     }
@@ -21,7 +29,23 @@ pub async fn require_customer_guid(req: Request, next: Next) -> Response {
         .and_then(|s| Uuid::parse_str(s).ok());
 
     match guid {
-        Some(_) => next.run(req).await,
+        Some(g) if g == hs.app.config.customer_guid => next.run(req).await,
+        Some(g) => {
+            tracing::warn!(
+                request_guid = %g,
+                tenant_guid = %hs.app.config.customer_guid,
+                tenant = %hs.app.config.tenant_slug,
+                "Rejected cross-tenant request: x-customerguid does not match process tenant"
+            );
+            (
+                StatusCode::FORBIDDEN,
+                axum::Json(serde_json::json!({
+                    "success": false,
+                    "errorMessage": "X-CustomerGUID does not match this server's tenant"
+                })),
+            )
+                .into_response()
+        }
         None => (
             StatusCode::UNAUTHORIZED,
             axum::Json(serde_json::json!({

--- a/apps/rows/src/mq.rs
+++ b/apps/rows/src/mq.rs
@@ -211,6 +211,12 @@ pub async fn spawn_consumer(url: &str, world_server_id: i32, svc: Arc<OWSService
     }
 }
 
+fn tenant_matches(msg_guid: &str, tenant: uuid::Uuid) -> bool {
+    uuid::Uuid::parse_str(msg_guid)
+        .map(|g| g == tenant)
+        .unwrap_or(false)
+}
+
 async fn consume_spin_up(mut consumer: Consumer, svc: Arc<OWSService>) {
     use futures_lite::StreamExt;
 
@@ -232,13 +238,23 @@ async fn consume_spin_up(mut consumer: Consumer, svc: Arc<OWSService>) {
             }
         };
 
+        let guid = svc.state().config.customer_guid;
+        if !tenant_matches(&msg.customer_guid, guid) {
+            warn!(
+                msg_guid = %msg.customer_guid,
+                tenant_guid = %guid,
+                "Dropping spin-up message for a different tenant"
+            );
+            let _ = delivery.ack(BasicAckOptions::default()).await;
+            continue;
+        }
+
         info!(
             map = %msg.map_name,
             zone = msg.zone_instance_id,
             "Processing spin-up message"
         );
 
-        let guid = svc.state().config.customer_guid;
         if let Some(ref agones) = svc.state().agones {
             use crate::agones::AllocationPipeline;
 
@@ -304,6 +320,17 @@ async fn consume_shut_down(mut consumer: Consumer, svc: Arc<OWSService>) {
                 continue;
             }
         };
+
+        let guid = svc.state().config.customer_guid;
+        if !tenant_matches(&msg.customer_guid, guid) {
+            warn!(
+                msg_guid = %msg.customer_guid,
+                tenant_guid = %guid,
+                "Dropping shutdown message for a different tenant"
+            );
+            let _ = delivery.ack(BasicAckOptions::default()).await;
+            continue;
+        }
 
         info!(zone = msg.zone_instance_id, "Processing shutdown message");
 

--- a/apps/rows/src/rest/abilities.rs
+++ b/apps/rows/src/rest/abilities.rs
@@ -31,7 +31,10 @@ pub(super) fn abilities_routes(hs: HandlerState) -> Router {
             post(get_ability_bars_and_abilities),
         )
         .route("/api/Abilities/GetAbilities", get(get_abilities_list))
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 

--- a/apps/rows/src/rest/auth.rs
+++ b/apps/rows/src/rest/auth.rs
@@ -51,7 +51,10 @@ pub(super) fn public_api_routes(hs: HandlerState) -> Router {
             post(get_default_custom_data),
         )
         .route("/api/System/Status", get(system_status))
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 

--- a/apps/rows/src/rest/characters.rs
+++ b/apps/rows/src/rest/characters.rs
@@ -32,7 +32,10 @@ pub(super) fn character_persistence_routes(hs: HandlerState) -> Router {
             "/api/Status/GetCharacterStatuses",
             post(get_character_statuses),
         )
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 

--- a/apps/rows/src/rest/global_data.rs
+++ b/apps/rows/src/rest/global_data.rs
@@ -20,7 +20,10 @@ pub(super) fn global_data_routes(hs: HandlerState) -> Router {
             "/api/GlobalData/GetGlobalDataItem/{globalDataKey}",
             get(get_global_data),
         )
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 

--- a/apps/rows/src/rest/instances.rs
+++ b/apps/rows/src/rest/instances.rs
@@ -63,7 +63,10 @@ pub(super) fn instance_mgmt_routes(hs: HandlerState) -> Router {
             post(get_current_world_time),
         )
         .route("/api/Instance/GetZoneAssignment", post(get_zone_assignment))
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 

--- a/apps/rows/src/rest/management.rs
+++ b/apps/rows/src/rest/management.rs
@@ -11,7 +11,10 @@ pub(super) fn management_routes(hs: HandlerState) -> Router {
             "/api/Users",
             get(list_users).post(create_user_admin).put(edit_user_admin),
         )
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 

--- a/apps/rows/src/rest/system.rs
+++ b/apps/rows/src/rest/system.rs
@@ -25,7 +25,10 @@ pub fn system_routes(hs: HandlerState) -> Router {
             "/api/System/VerifyDeployment",
             axum::routing::post(verify_deployment),
         )
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 

--- a/apps/rows/src/rest/zones.rs
+++ b/apps/rows/src/rest/zones.rs
@@ -7,7 +7,10 @@ use serde::Deserialize;
 pub(super) fn zones_routes(hs: HandlerState) -> Router {
     Router::new()
         .route("/api/Zones/AddZone", post(add_zone))
-        .layer(middleware::from_fn(require_customer_guid))
+        .layer(middleware::from_fn_with_state(
+            hs.clone(),
+            require_customer_guid,
+        ))
         .with_state(hs)
 }
 


### PR DESCRIPTION
## Summary

Hardens ROWS for the multi-tenant deployment model (one process per game+environment, shared DB scoped by `customerguid`) **before** seeding multiple tenants into the database. Without this, trusting the client `X-CustomerGUID` header would be a live cross-tenant read/write hole once the SQL seed lands.

## Changes

**P0 — cross-tenant DB hole**
- `require_customer_guid` is now stateful and rejects (`403`) any request whose `X-CustomerGUID` differs from the process tenant (`config.customer_guid`). Applied across all 8 REST routers / 52 handlers. gRPC, WebSocket, MQ consumers, and jobs already used the process tenant.

**P1 — multi-tenant infra hygiene**
- MQ spin-up/shutdown consumers drop messages whose `customer_guid` does not match the process tenant.
- Agones GameServer watcher filters by `agones.dev/fleet=<fleet>` instead of watching the whole namespace.
- `AGONES_FLEET` and `AGONES_NAMESPACE` required for `beta`/`release` so unset values cannot silently collide tenants onto one fleet.
- Prometheus `service` label is per-tenant (`rows-<slug>`).

**Docs** (`project/rows.mdx`)
- Rewrote the now-inaccurate single-tenant section → multi-tenant-by-deployment / single-tenant-by-process.
- Added the per-tenant env-var table (`OWS_API_KEY`, `OWS_TENANT_SLUG`, `OWS_ENV`, `AGONES_FLEET`, `AGONES_NAMESPACE`).
- Fixed stale gRPC port (50051 → 4322 multiplexed).
- Cross-linked the KBVEROWS plugin page and the ROWS dashboard.

## Notes
- `cargo check -p rows` passes clean.
- No SQL/schema changes here — tenant isolation stays pure `customer_guid`. The DB seed (customers + maps per tenant) and the per-tenant K8s Deployments are the next step.
- Builds on the earlier `RowsConfig`/`TenantConfig` commit already on dev.