### PR TITLE
fix(KBVESQLite): skip GCC visibility attribute on Win64 (MSVC compile error)

### DIFF
--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
@@ -18,10 +18,10 @@ public class KBVESQLite : ModuleRules
 		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 
-		// Force default symbol visibility on sqlite3 entry points so consumer
-		// consumer modules can link directly against sqlite3_open/...etc
-		// from this plugin's .dylib/.so without re-bundling the amalgamation.
-		PublicDefinitions.Add("SQLITE_API=__attribute__((visibility(\"default\")))");
-		PublicDefinitions.Add("SQLITE_EXTERN=extern __attribute__((visibility(\"default\")))");
+		if (Target.Platform != UnrealTargetPlatform.Win64)
+		{
+			PublicDefinitions.Add("SQLITE_API=__attribute__((visibility(\"default\")))");
+			PublicDefinitions.Add("SQLITE_EXTERN=extern __attribute__((visibility(\"default\")))");
+		}
 	}
 }


### PR DESCRIPTION
## Problem
First Windows build of the chuck demo got all the way through engine + LFS + 510/523 module compiles, then failed compiling `KBVESQLite/ThirdParty/sqlite/sqlite3.h`:
```
error C3861: 'visibility': identifier not found
error C2374: '__attribute__': redefinition
Result: Failed (OtherCompilationError)  ExitCode=6
```
`KBVESQLite.Build.cs` defines `SQLITE_API`/`SQLITE_EXTERN` with `__attribute__((visibility("default")))` unconditionally — a Clang/GCC export construct. Linux builds (the old AngelScript docker path) compiled fine; MSVC doesn't support `__attribute__`, so the first Win64 build breaks.

## Fix
Gate those `PublicDefinitions` to non-Win64. On Windows `SQLITE_API` falls back to sqlite3.h's empty default (`#ifndef SQLITE_API`), fine for the monolithic packaged game build.

Unblocks the chuck demo Win64 compile. Reusable is @dev; dispatch `--ref dev` to test. Part of #11987.