### PR TITLE
fix(KBVESQLite,KBVEYYJson): export C symbols on Win64 (LNK2019)

### DIFF
--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
@@ -18,7 +18,12 @@ public class KBVESQLite : ModuleRules
 		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 
-		if (Target.Platform != UnrealTargetPlatform.Win64)
+		if (Target.Platform == UnrealTargetPlatform.Win64)
+		{
+			PublicDefinitions.Add("SQLITE_API=KBVESQLITE_API");
+			PublicDefinitions.Add("SQLITE_EXTERN=extern KBVESQLITE_API");
+		}
+		else
 		{
 			PublicDefinitions.Add("SQLITE_API=__attribute__((visibility(\"default\")))");
 			PublicDefinitions.Add("SQLITE_EXTERN=extern __attribute__((visibility(\"default\")))");

--- a/packages/unreal/KBVEYYJson/Source/KBVEYYJson/KBVEYYJson.Build.cs
+++ b/packages/unreal/KBVEYYJson/Source/KBVEYYJson/KBVEYYJson.Build.cs
@@ -16,6 +16,11 @@ public class KBVEYYJson : ModuleRules
 
 		PublicIncludePaths.Add(ThirdPartyDir);
 
+		if (Target.Platform == UnrealTargetPlatform.Win64)
+		{
+			PrivateDefinitions.Add("YYJSON_EXPORTS=1");
+		}
+
 		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 	}


### PR DESCRIPTION
Win64 audit follow-up. Modular Win64 builds link plugin DLLs, so the bundled C libs must export their symbols.

- **KBVESQLite**: prior empty `SQLITE_API` on Win64 stopped export -> KBVEWorld `LNK2019: sqlite3_open_v2` (×13). Now `SQLITE_API=KBVESQLITE_API` (UBT macro: dllexport building / dllimport consuming).
- **KBVEYYJson**: never set `YYJSON_EXPORTS`, so `yyjson.h` defaulted `yyjson_api` to dllimport even when building the module -> KBVEItemDB `LNK2019: yyjson_read_opts`. Now `PrivateDefinitions YYJSON_EXPORTS=1` on Win64.

Non-Win64 keeps the Clang/GCC visibility attribute. Part of the Win64 plugin audit (#11987). Remaining: KBVEZstd C4551, chuck C4458 (warnings-as-error), KBVELibGit git2.lib MinGW->MSVC.