### PR TITLE
fix(chuck,KBVEZstd): Win64 warnings (C4458/C4551) + disable editor-only KBVELibGit

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -992,24 +992,24 @@ void AchuckCorePlayerController::TickSpawnSnap(float DeltaSeconds)
 {
 	SpawnSnapElapsed += DeltaSeconds;
 
-	APawn* Pawn = GetPawn();
-	if (!Pawn) return;
+	APawn* ControlledPawn = GetPawn();
+	if (!ControlledPawn) return;
 
 	UWorld* W = GetWorld();
 	if (!W) return;
 
-	const FVector PawnLoc = Pawn->GetActorLocation();
+	const FVector PawnLoc = ControlledPawn->GetActorLocation();
 	const FVector Start(SpawnSnapAnchor.X, SpawnSnapAnchor.Y, PawnLoc.Z + 100.f);
 	const FVector End  (SpawnSnapAnchor.X, SpawnSnapAnchor.Y, -10000.f);
 
 	FHitResult Hit;
-	FCollisionQueryParams Params(SCENE_QUERY_STAT(chuckSpawnSnap), false, Pawn);
+	FCollisionQueryParams Params(SCENE_QUERY_STAT(chuckSpawnSnap), false, ControlledPawn);
 	const bool bHit = W->LineTraceSingleByChannel(Hit, Start, End, ECC_WorldStatic, Params);
 
-	if (bHit && Hit.GetActor() && Hit.GetActor() != Pawn)
+	if (bHit && Hit.GetActor() && Hit.GetActor() != ControlledPawn)
 	{
 		float CapsuleHalf = 90.f;
-		if (ACharacter* Char = Cast<ACharacter>(Pawn))
+		if (ACharacter* Char = Cast<ACharacter>(ControlledPawn))
 		{
 			if (UCapsuleComponent* Cap = Char->GetCapsuleComponent())
 			{
@@ -1018,9 +1018,9 @@ void AchuckCorePlayerController::TickSpawnSnap(float DeltaSeconds)
 		}
 
 		const FVector Snap(SpawnSnapAnchor.X, SpawnSnapAnchor.Y, Hit.ImpactPoint.Z + CapsuleHalf + 4.f);
-		Pawn->TeleportTo(Snap, Pawn->GetActorRotation(), false, true);
+		ControlledPawn->TeleportTo(Snap, ControlledPawn->GetActorRotation(), false, true);
 
-		if (ACharacter* Char = Cast<ACharacter>(Pawn))
+		if (ACharacter* Char = Cast<ACharacter>(ControlledPawn))
 		{
 			if (UCharacterMovementComponent* CM = Char->GetCharacterMovement())
 			{
@@ -1038,10 +1038,10 @@ void AchuckCorePlayerController::TickSpawnSnap(float DeltaSeconds)
 		{
 			bDidAutoSpawnArcade = true;
 
-			const FVector ArcadePawnLoc = Pawn->GetActorLocation();
-			const FVector PawnFwd       = Pawn->GetActorForwardVector();
+			const FVector ArcadePawnLoc = ControlledPawn->GetActorLocation();
+			const FVector PawnFwd       = ControlledPawn->GetActorForwardVector();
 			const FVector ArcadeLoc     = ArcadePawnLoc + PawnFwd * 400.f + FVector(0.f, 0.f, -90.f);
-			const FRotator ArcadeRot(0.f, Pawn->GetActorRotation().Yaw + 180.f, 0.f);
+			const FRotator ArcadeRot(0.f, ControlledPawn->GetActorRotation().Yaw + 180.f, 0.f);
 
 			UClass* ArcadeClass = CachedArcadeClass ? CachedArcadeClass.Get() : AchuckArcadeCabinet::StaticClass();
 
@@ -1062,7 +1062,7 @@ void AchuckCorePlayerController::TickSpawnSnap(float DeltaSeconds)
 			bDidAutoSpawnSlimes = true;
 			if (UchuckSlimeSubsystem* SlimeSys = GetWorld()->GetSubsystem<UchuckSlimeSubsystem>())
 			{
-				SlimeSys->SpawnSlimes(Pawn->GetActorLocation(), 8, 600.f);
+				SlimeSys->SpawnSlimes(ControlledPawn->GetActorLocation(), 8, 600.f);
 			}
 		}
 
@@ -1072,7 +1072,7 @@ void AchuckCorePlayerController::TickSpawnSnap(float DeltaSeconds)
 
 	if (SpawnSnapElapsed > 8.f)
 	{
-		if (ACharacter* Char = Cast<ACharacter>(Pawn))
+		if (ACharacter* Char = Cast<ACharacter>(ControlledPawn))
 		{
 			if (UCharacterMovementComponent* CM = Char->GetCharacterMovement())
 			{

--- a/apps/chuckrpg/unreal-chuck/chuck.uproject
+++ b/apps/chuckrpg/unreal-chuck/chuck.uproject
@@ -115,7 +115,7 @@
 		},
 		{
 			"Name": "KBVELibGit",
-			"Enabled": true
+			"Enabled": false
 		},
 		{
 			"Name": "UEDevOps",

--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
@@ -18,7 +18,12 @@ public class KBVESQLite : ModuleRules
 		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 
-		if (Target.Platform != UnrealTargetPlatform.Win64)
+		if (Target.Platform == UnrealTargetPlatform.Win64)
+		{
+			PublicDefinitions.Add("SQLITE_API=KBVESQLITE_API");
+			PublicDefinitions.Add("SQLITE_EXTERN=extern KBVESQLITE_API");
+		}
+		else
 		{
 			PublicDefinitions.Add("SQLITE_API=__attribute__((visibility(\"default\")))");
 			PublicDefinitions.Add("SQLITE_EXTERN=extern __attribute__((visibility(\"default\")))");

--- a/packages/unreal/KBVEYYJson/Source/KBVEYYJson/KBVEYYJson.Build.cs
+++ b/packages/unreal/KBVEYYJson/Source/KBVEYYJson/KBVEYYJson.Build.cs
@@ -16,6 +16,11 @@ public class KBVEYYJson : ModuleRules
 
 		PublicIncludePaths.Add(ThirdPartyDir);
 
+		if (Target.Platform == UnrealTargetPlatform.Win64)
+		{
+			PrivateDefinitions.Add("YYJSON_EXPORTS=1");
+		}
+
 		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 	}

--- a/packages/unreal/KBVEZstd/ThirdParty/zstd/compress/zstd_preSplit.c
+++ b/packages/unreal/KBVEZstd/ThirdParty/zstd/compress/zstd_preSplit.c
@@ -183,7 +183,7 @@ static size_t ZSTD_splitBlock_byChunks(const void* blockStart, size_t blockSize,
     }
     assert(pos == blockSize);
     return blockSize;
-    (void)flushEvents; (void)removeEvents;
+    (void)&flushEvents; (void)&removeEvents;
 }
 
 /* ZSTD_splitBlock_fromBorders(): very fast strategy :


### PR DESCRIPTION
Follow-up to #12106 (which merged before this commit was pushed — stranded by the squash merge).

- **chuckCorePlayerController**: rename local `Pawn` -> `ControlledPawn` in TickSpawnSnap; shadowed inherited `AController::Pawn` (MSVC **C4458**). Fixed, not suppressed — shadow-as-error stays on.
- **KBVEZstd** `zstd_preSplit.c`: `(void)flushEvents;` applied the `(void)var` idiom to a function -> MSVC **C4551**. Now `(void)&flushEvents;` (address-of).
- **chuck.uproject**: disable **KBVELibGit** for the build — editor-only git-repo installer the demo doesn't need; its prebuilt `git2.lib` is MinGW (unresolved `___chkstk_ms` under MSVC). Re-enable once a MSVC libgit2 is built.

Continues the Win64 plugin audit (#11987).