### PR TITLE
fix(KBVESQLite): sqlite Win64 export via raw __declspec (UE macro broke C build)

### DIFF
--- a/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
+++ b/packages/unreal/KBVESQLite/Source/KBVESQLite/KBVESQLite.Build.cs
@@ -20,8 +20,7 @@ public class KBVESQLite : ModuleRules
 
 		if (Target.Platform == UnrealTargetPlatform.Win64)
 		{
-			PublicDefinitions.Add("SQLITE_API=KBVESQLITE_API");
-			PublicDefinitions.Add("SQLITE_EXTERN=extern KBVESQLITE_API");
+			PrivateDefinitions.Add("SQLITE_API=__declspec(dllexport)");
 		}
 		else
 		{


### PR DESCRIPTION
Follow-up to #12106. `SQLITE_API=KBVESQLITE_API` broke the C-compiled sqlite3.c — the UE module macro expands to `DLLEXPORT`, undefined in that translation unit (no UE header), giving `identifier 'DLLEXPORT'` + `missing '{' before const`; and `SQLITE_EXTERN=extern KBVESQLITE_API` caused `C4141 'dllexport' used more than once`.

Fix: `PrivateDefinitions SQLITE_API=__declspec(dllexport)` — module TUs export the symbols; consumers (KBVEWorld) get sqlite3.h's empty default and link the functions via the import lib; `SQLITE_EXTERN` falls to sqlite3.h's `extern` default. Non-Win64 unchanged. Part of the Win64 audit (#11987).