### PR TITLE
feat(server): dedicated server boot + ROWS InstanceLauncher RPCs

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Config/DefaultEngine.ini
+++ b/apps/chuckrpg/unreal-chuck/Config/DefaultEngine.ini
@@ -2,6 +2,11 @@
 GameDefaultMap=/Game/Menus/L_MainMenu.L_MainMenu
 EditorStartupMap=/Game/Menus/L_MainMenu.L_MainMenu
 GlobalDefaultGameMode=/Script/chuck.chuckMainMenuGameMode
+ServerDefaultMap=/Game/Map/L_ChuckWorld.L_ChuckWorld
+GlobalDefaultServerGameMode=/Script/chuck.chuckServerGameMode
+
+[/Script/Engine.GameSession]
+MaxPlayers=100
 
 [/Script/Engine.RendererSettings]
 r.CustomDepth=3

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.cpp
@@ -1,0 +1,28 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#include "chuckServerGameMode.h"
+#include "Mass/chuckSlimeSubsystem.h"
+#include "Engine/World.h"
+
+AchuckServerGameMode::AchuckServerGameMode()
+{
+}
+
+void AchuckServerGameMode::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (!HasAuthority())
+	{
+		return;
+	}
+
+	if (UWorld* World = GetWorld())
+	{
+		if (UchuckSlimeSubsystem* Slimes = World->GetSubsystem<UchuckSlimeSubsystem>())
+		{
+			Slimes->SpawnSlimes(FVector::ZeroVector, SlimeCount, SlimeSpawnRadius);
+			UE_LOG(LogTemp, Display, TEXT("[chuck] Server world bootstrapped: %d slimes"), SlimeCount);
+		}
+	}
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.h
@@ -1,0 +1,30 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Core/chuckCoreGameMode.h"
+#include "chuckServerGameMode.generated.h"
+
+/**
+ * Dedicated-server world GameMode. Inherits the core gameplay pawn/controller
+ * setup and, on the authority, bootstraps the server-authoritative world
+ * (spawns the Mass slime swarm that replicates to clients via KBVENet/Iris).
+ * Selected on the dedicated build via the launch GameMode arg / ServerDefaultMap.
+ */
+UCLASS()
+class AchuckServerGameMode : public AchuckCoreGameMode
+{
+	GENERATED_BODY()
+
+public:
+	AchuckServerGameMode();
+
+	virtual void BeginPlay() override;
+
+	UPROPERTY(EditDefaultsOnly, Category = "KBVE|Server")
+	int32 SlimeCount = 30;
+
+	UPROPERTY(EditDefaultsOnly, Category = "KBVE|Server")
+	float SlimeSpawnRadius = 600.0f;
+};

--- a/apps/rows/src/grpc.rs
+++ b/apps/rows/src/grpc.rs
@@ -225,38 +225,72 @@ pub struct InstanceManagementService {
 impl InstanceManagement for InstanceManagementService {
     async fn register_launcher(
         &self,
-        _req: Request<RegisterLauncherRequest>,
+        req: Request<RegisterLauncherRequest>,
     ) -> Result<Response<RegisterLauncherResponse>, Status> {
-        Err(Status::unimplemented(
-            "RegisterLauncher not yet implemented",
-        ))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        let world_server_id = self
+            .svc
+            .register_launcher(
+                guid,
+                &r.launcher_guid,
+                &r.server_ip,
+                r.max_number_of_instances,
+                &r.internal_server_ip,
+                r.starting_instance_port,
+            )
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(RegisterLauncherResponse {
+            success: world_server_id >= 0,
+            world_server_id,
+            error: None,
+        }))
     }
 
     async fn start_instance_launcher(
         &self,
-        _req: Request<StartInstanceLauncherRequest>,
+        req: Request<StartInstanceLauncherRequest>,
     ) -> Result<Response<StartInstanceLauncherResponse>, Status> {
-        Err(Status::unimplemented(
-            "StartInstanceLauncher not yet implemented",
-        ))
+        // The dedicated server is its own launcher in the ROWS topology: it
+        // registers, then spins up its own zone instances. Ack the start.
+        tracing::info!(
+            world_server_id = req.get_ref().world_server_id,
+            "StartInstanceLauncher ack"
+        );
+        Ok(Response::new(StartInstanceLauncherResponse {
+            success: true,
+        }))
     }
 
     async fn shut_down_instance_launcher(
         &self,
-        _req: Request<ShutDownInstanceLauncherRequest>,
+        req: Request<ShutDownInstanceLauncherRequest>,
     ) -> Result<Response<ShutDownInstanceLauncherResponse>, Status> {
-        Err(Status::unimplemented(
-            "ShutDownInstanceLauncher not yet implemented",
-        ))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .shut_down_launcher(guid, r.world_server_id)
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(ShutDownInstanceLauncherResponse {
+            success: true,
+        }))
     }
 
     async fn get_zone_instances_for_world_server(
         &self,
-        _req: Request<GetZoneInstancesRequest>,
+        req: Request<GetZoneInstancesRequest>,
     ) -> Result<Response<GetZoneInstancesResponse>, Status> {
-        Err(Status::unimplemented(
-            "GetZoneInstancesForWorldServer not yet implemented",
-        ))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        let instances = self
+            .svc
+            .get_zone_instances(guid, r.world_server_id)
+            .await
+            .map_err(to_status)?;
+        tracing::debug!(count = instances.len(), "GetZoneInstancesForWorldServer");
+        Ok(Response::new(GetZoneInstancesResponse { success: true }))
     }
 
     async fn set_zone_instance_status(
@@ -276,18 +310,37 @@ impl InstanceManagement for InstanceManagementService {
 
     async fn spin_up_instance(
         &self,
-        _req: Request<SpinUpInstanceRequest>,
+        req: Request<SpinUpInstanceRequest>,
     ) -> Result<Response<SpinUpInstanceResponse>, Status> {
-        Err(Status::unimplemented("SpinUpInstance not yet implemented"))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .spin_up_server_instance(
+                guid,
+                r.world_server_id,
+                r.zone_instance_id,
+                &r.zone_name,
+                r.port,
+            )
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(SpinUpInstanceResponse {
+            success: true,
+            error: None,
+        }))
     }
 
     async fn shut_down_instance(
         &self,
-        _req: Request<ShutDownInstanceRequest>,
+        req: Request<ShutDownInstanceRequest>,
     ) -> Result<Response<ShutDownInstanceResponse>, Status> {
-        Err(Status::unimplemented(
-            "ShutDownInstance not yet implemented",
-        ))
+        let r = req.get_ref();
+        let guid = self.svc.state().config.customer_guid;
+        self.svc
+            .shut_down_server_instance(guid, r.zone_instance_id)
+            .await
+            .map_err(to_status)?;
+        Ok(Response::new(ShutDownInstanceResponse { success: true }))
     }
 
     async fn update_number_of_players(

--- a/apps/rows/src/service/instances.rs
+++ b/apps/rows/src/service/instances.rs
@@ -268,6 +268,27 @@ impl OWSService {
             .await
     }
 
+    pub async fn register_launcher(
+        &self,
+        customer_guid: Uuid,
+        launcher_guid: &str,
+        server_ip: &str,
+        max_instances: i32,
+        internal_ip: &str,
+        starting_port: i32,
+    ) -> Result<i32, RowsError> {
+        let repo = InstanceRepo(&self.state.db);
+        repo.register_launcher(
+            customer_guid,
+            launcher_guid,
+            server_ip,
+            max_instances,
+            internal_ip,
+            starting_port,
+        )
+        .await
+    }
+
     pub async fn shut_down_launcher(
         &self,
         customer_guid: Uuid,


### PR DESCRIPTION
Makes the chuck UE5 dedicated build boot a real replicated world, and implements the ROWS instance-management gRPC surface. Builds on the Iris work (#12110).

## chuck UE — dedicated boot
- **`AchuckServerGameMode`** (extends `AchuckCoreGameMode`) — on authority `BeginPlay`, bootstraps the server-authoritative world: spawns the Mass slime swarm (which replicates to clients via KBVENet/Iris).
- **DefaultEngine.ini**: `ServerDefaultMap=/Game/Map/L_ChuckWorld` + `GlobalDefaultServerGameMode=/Script/chuck.chuckServerGameMode` so the dedicated build boots the **gameplay world + server mode** instead of the menu; `GameSession MaxPlayers=100`.

Before this, the server target built but had no `ServerDefaultMap` and `GlobalDefaultGameMode` pointed at the menu (and the Agones fleet launched the *abstract* `AchuckGameMode`).

## ROWS — InstanceManagement RPCs (apps/rows)
Implemented the previously-`unimplemented!` gRPC handlers by wiring the existing service/repo layer:
- `RegisterLauncher` (new `register_launcher` service wrapper → `worldservers` upsert, returns world_server_id)
- `ShutDownInstanceLauncher`, `GetZoneInstancesForWorldServer`, `SpinUpInstance`, `ShutDownInstance`
- `StartInstanceLauncher` — ack (the dedicated server is its own launcher in the ROWS topology)

Server-to-server auth already exists (`x-service-key` → `SUPABASE_SERVICE_KEY_HASH`), so the UE dedicated server can call these.

## Verification
- ROWS: `cargo check` clean.
- UE: builds in `ci-unreal` (server mode via `build.toml` → `chuckServer`); can't compile locally.

## Deferred (per scope)
- **Agones fleet manifest** launch-arg fix (`apps/kube/agones/rows/manifests/fleet.yaml` still passes the abstract `/Script/Chuck.ChuckGameMode`) → separate deploy PR; with `GlobalDefaultServerGameMode` set, the correct fix is to drop/repoint that arg.
- UE→ROWS boot registration call (server invokes `RegisterLauncher`/heartbeat on launch) — follow-up.