### PR TITLE
fix(ows): seed scripts actually run (top-level statements) + kilobase seed smoke

### DIFF
--- a/packages/data/sql/dbmate/seed-smoke.sh
+++ b/packages/data/sql/dbmate/seed-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# seed-smoke.sh — smoke-test the OWS seed scripts (schema/ows/seed/*.sql)
+# against the kilobase prod-replica stack.
+#
+# The seeds are parameterized, secret-derived, gameops-run scripts — NOT
+# dbmate migrations — so the migration smoke (smoke.sh) does not cover
+# them. This runner brings up the kilobase stack + full migration chain
+# (via smoke.sh --keep), then applies each seed under `SET ROLE ows`
+# (real FORCE-RLS context) with dummy params, asserting:
+#   - the seed applies without error (catches psql :'var'-in-DO-block and
+#     quoting bugs that only surface at run time), and
+#   - insert seeds are idempotent (re-run leaves exactly one customer row).
+#
+# Usage:
+#   ./seed-smoke.sh            # reset stack, apply migrations + seeds, assert, down
+#   ./seed-smoke.sh --keep     # leave the stack up afterward
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+cd "$SCRIPT_DIR"
+
+KEEP=false
+[[ "${1:-}" == "--keep" ]] && KEEP=true
+
+SEED_DIR="$(cd ../schema/ows/seed && pwd)"
+DB_USER="supabase_admin"
+DB_PASS="postgres"
+PORT=54322
+DB_NAME="supabase"
+
+# Dummy, obviously-fake test GUIDs (valid hex) — never real tenant values.
+CG_CHUCK="0000c0c0-0000-0000-0000-000000000001"
+CG_TENANT="0000c0c0-0000-0000-0000-000000000002"
+LAUNCHER="0000c0c0-0000-0000-0000-0000000000aa"
+
+run_psql() { PGPASSWORD="$DB_PASS" psql -h localhost -p "$PORT" -U "$DB_USER" -d "$DB_NAME" -q -v ON_ERROR_STOP=1 "$@"; }
+
+# Apply a seed file as the `ows` role (RLS enforced), passing -v params.
+seed_as_ows() {
+    local file="$1"; shift
+    local wrapper; wrapper="$(mktemp)"
+    printf 'SET ROLE ows;\n\\i %s\n' "$file" > "$wrapper"
+    run_psql "$@" -f "$wrapper"
+    rm -f "$wrapper"
+}
+
+count_customers() {
+    PGPASSWORD="$DB_PASS" psql -h localhost -p "$PORT" -U "$DB_USER" -d "$DB_NAME" -tAc \
+        "SELECT count(*) FROM ows.Customers WHERE CustomerGUID = '$1'::uuid;"
+}
+
+echo "==> bringing up kilobase + migration chain (smoke.sh --keep)"
+./smoke.sh kilobase --keep
+
+FAIL=0
+assert_one() { # label guid
+    local n; n="$(count_customers "$2")"
+    if [[ "$n" == "1" ]]; then echo "    PASS: $1 → 1 customer row"; else echo "    FAIL: $1 → expected 1 customer, got $n"; FAIL=1; fi
+}
+
+echo "==> seed: chuck_init.sql (apply x2, idempotent)"
+seed_as_ows "$SEED_DIR/chuck_init.sql" -v customer_guid="$CG_CHUCK" -v server_ip="game.test" -v launcher_guid="$LAUNCHER"
+seed_as_ows "$SEED_DIR/chuck_init.sql" -v customer_guid="$CG_CHUCK" -v server_ip="game.test" -v launcher_guid="$LAUNCHER"
+assert_one "chuck_init" "$CG_CHUCK"
+
+echo "==> seed: tenants_init.sql (apply x2, idempotent)"
+seed_as_ows "$SEED_DIR/tenants_init.sql" -v customer_guid="$CG_TENANT" -v customer_name="Smoke Tenant" -v customer_email="smoke@test" -v map_name="Lvl_Smoke" -v zone_name="SmokeZone"
+seed_as_ows "$SEED_DIR/tenants_init.sql" -v customer_guid="$CG_TENANT" -v customer_name="Smoke Tenant" -v customer_email="smoke@test" -v map_name="Lvl_Smoke" -v zone_name="SmokeZone"
+assert_one "tenants_init" "$CG_TENANT"
+
+echo "==> seed: chuck_maintenance.sql (runs clean against seeded customer)"
+seed_as_ows "$SEED_DIR/chuck_maintenance.sql" -v customer_guid="$CG_CHUCK" -v launcher_guid="$LAUNCHER" >/dev/null
+echo "    PASS: chuck_maintenance applied"
+
+if [[ "$KEEP" == "true" ]]; then
+    echo "==> seed smoke complete; stack left up on localhost:$PORT (db=$DB_NAME)"
+else
+    echo "==> tearing down"
+    docker compose -f kilobase-docker-compose.yml down -v >/dev/null 2>&1
+fi
+
+if [[ "$FAIL" -ne 0 ]]; then echo "==> SEED SMOKE FAILED"; exit 1; fi
+echo "==> seed smoke passed"

--- a/packages/data/sql/project.json
+++ b/packages/data/sql/project.json
@@ -74,6 +74,20 @@
 				"command": "./smoke.sh kilobase --rollback",
 				"cwd": "{projectRoot}/dbmate"
 			}
+		},
+		"smoke-seed": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "./seed-smoke.sh",
+				"cwd": "{projectRoot}/dbmate"
+			}
+		},
+		"smoke-seed-keep": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "./seed-smoke.sh --keep",
+				"cwd": "{projectRoot}/dbmate"
+			}
 		}
 	}
 }

--- a/packages/data/sql/schema/ows/seed/chuck_init.sql
+++ b/packages/data/sql/schema/ows/seed/chuck_init.sql
@@ -1,71 +1,61 @@
 -- Chuck OWS Seed Data
 -- Parameterized — no secrets in this file.
--- Wrapped in a transaction — all-or-nothing. Aborts if customer already exists.
+-- Idempotent: every INSERT is guarded by WHERE NOT EXISTS, so re-runs are no-ops.
+--
+-- psql :'var' interpolation does NOT work inside DO/dollar-quoted blocks, so all statements
+-- are top-level. Pass raw values (no surrounding single quotes) — the :'var' form quotes them.
 --
 -- Usage:
 --   kubectl port-forward -n kilobase svc/supabase-cluster-rw 54322:5432
 --   GUID=$(kubectl get secret ows-customer-guid -n ows -o jsonpath='{.data.customer-guid}' | base64 -d)
 --   LAUNCHER_GUID="42a499a7-77b1-493a-9f7c-d9784740e228"
 --   PGPASSWORD=<pass> psql -h localhost -p 54322 -U ows -d supabase \
---     -v customer_guid="'${GUID}'" \
---     -v server_ip="'game.chuckrpg.com'" \
---     -v launcher_guid="'${LAUNCHER_GUID}'" \
+--     -v customer_guid="${GUID}" \
+--     -v server_ip="game.chuckrpg.com" \
+--     -v launcher_guid="${LAUNCHER_GUID}" \
 --     -f packages/data/sql/schema/ows/seed/chuck_init.sql
 
 SET search_path TO ows, extensions, public;
 
 BEGIN;
 
-DO $$
-    DECLARE _CustomerGUID UUID;
-    DECLARE _ServerIP TEXT;
-    DECLARE _LauncherGUID UUID;
-    DECLARE _DefaultCharacterValuesID INT;
-    DECLARE _Existing INT;
-BEGIN
+INSERT INTO Customers (CustomerGUID, CustomerName, CustomerEmail, EnableAutoLoopBack, NoPortForwarding)
+SELECT :'customer_guid'::uuid, 'Chuck', 'admin@chuckrpg.com', true, true
+WHERE NOT EXISTS (SELECT 1 FROM Customers WHERE CustomerGUID = :'customer_guid'::uuid);
 
-    _CustomerGUID := :'customer_guid';
-    _ServerIP := :'server_ip';
-    _LauncherGUID := :'launcher_guid';
+INSERT INTO Maps (CustomerGUID, MapName, MapData, Width, Height, ZoneName, WorldCompContainsFilter, WorldCompListFilter, MapMode, SoftPlayerCap, HardPlayerCap, MinutesToShutdownAfterEmpty)
+SELECT :'customer_guid'::uuid, 'Lvl_ThirdPerson', NULL, 1, 1, 'MainWorld', '', '', 1, 60, 80, 1
+WHERE NOT EXISTS (
+    SELECT 1 FROM Maps WHERE CustomerGUID = :'customer_guid'::uuid AND MapName = 'Lvl_ThirdPerson'
+);
 
-    -- Guard: abort if customer already seeded
-    SELECT COUNT(*) INTO _Existing FROM Customers WHERE CustomerGUID = _CustomerGUID;
-    IF _Existing > 0 THEN
-        RAISE NOTICE 'Customer % already exists — skipping seed.', _CustomerGUID;
-        RETURN;
-    END IF;
+INSERT INTO WorldServers (CustomerGUID, ServerIP, InternalServerIP, MaxNumberOfInstances, Port, ServerStatus, StartingMapInstancePort, ZoneServerGUID)
+SELECT :'customer_guid'::uuid, :'server_ip', '127.0.0.1', 10, 8181, 1, 7778, :'launcher_guid'::uuid
+WHERE NOT EXISTS (
+    SELECT 1 FROM WorldServers WHERE CustomerGUID = :'customer_guid'::uuid AND ZoneServerGUID = :'launcher_guid'::uuid
+);
 
-    RAISE NOTICE 'Chuck seed: CustomerGUID=%, ServerIP=%', _CustomerGUID, _ServerIP;
+INSERT INTO DefaultCharacterValues (CustomerGUID, DefaultSetName, StartingMapName, X, Y, Z, RX, RY, RZ)
+SELECT :'customer_guid'::uuid, 'Default', 'MainWorld', -11, 19, 310, 0, 0, 0
+WHERE NOT EXISTS (
+    SELECT 1 FROM DefaultCharacterValues WHERE CustomerGUID = :'customer_guid'::uuid AND DefaultSetName = 'Default'
+);
 
-    -- Customer record
-    INSERT INTO Customers (CustomerGUID, CustomerName, CustomerEmail, EnableAutoLoopBack, NoPortForwarding)
-    VALUES (_CustomerGUID, 'Chuck', 'admin@chuckrpg.com', true, true);
-
-    -- MainWorld zone
-    INSERT INTO Maps (CustomerGUID, MapName, MapData, Width, Height, ZoneName, WorldCompContainsFilter, WorldCompListFilter, MapMode, SoftPlayerCap, HardPlayerCap, MinutesToShutdownAfterEmpty)
-    VALUES (_CustomerGUID, 'Lvl_ThirdPerson', NULL, 1, 1, 'MainWorld', '', '', 1, 60, 80, 1);
-    RAISE NOTICE 'Created MainWorld zone';
-
-    -- World server (active, with stable launcher GUID for upsert)
-    INSERT INTO WorldServers (CustomerGUID, ServerIP, InternalServerIP, MaxNumberOfInstances, Port, ServerStatus, StartingMapInstancePort, ZoneServerGUID)
-    VALUES (_CustomerGUID, _ServerIP, '127.0.0.1', 10, 8181, 1, 7778, _LauncherGUID);
-    RAISE NOTICE 'Created world server: % (active, launcher=%)', _ServerIP, _LauncherGUID;
-
-    -- Default character values
-    INSERT INTO DefaultCharacterValues (CustomerGUID, DefaultSetName, StartingMapName, X, Y, Z, RX, RY, RZ)
-    VALUES (_CustomerGUID, 'Default', 'MainWorld', -11, 19, 310, 0, 0, 0);
-
-    _DefaultCharacterValuesID := CURRVAL(PG_GET_SERIAL_SEQUENCE('defaultcharactervalues', 'defaultcharactervaluesid'));
-
-    INSERT INTO DefaultCustomCharacterData (CustomerGUID, DefaultCharacterValuesID, CustomFieldName, FieldValue) VALUES
-        (_CustomerGUID, _DefaultCharacterValuesID, 'SkillTrees', '{"active": [], "saved": {}}'),
-        (_CustomerGUID, _DefaultCharacterValuesID, 'Professions', '{"major": [], "minor": {}}'),
-        (_CustomerGUID, _DefaultCharacterValuesID, 'ActionBars', '{"bars": []}'),
-        (_CustomerGUID, _DefaultCharacterValuesID, 'BagInventory', '{"items": []}'),
-        (_CustomerGUID, _DefaultCharacterValuesID, 'BaseCharacterStats', '{"Strength": 10, "Agility": 10, "Constitution": 10, "Intellect": 10, "Wisdom": 10, "Charisma": 10}');
-
-    RAISE NOTICE 'Created default character values with ID: %', _DefaultCharacterValuesID;
-    RAISE NOTICE '=== Chuck seed complete ===';
-END $$;
+INSERT INTO DefaultCustomCharacterData (CustomerGUID, DefaultCharacterValuesID, CustomFieldName, FieldValue)
+SELECT :'customer_guid'::uuid, dcv.DefaultCharacterValuesID, f.field_name, f.field_value
+FROM DefaultCharacterValues dcv
+CROSS JOIN (VALUES
+    ('SkillTrees',        '{"active": [], "saved": {}}'),
+    ('Professions',       '{"major": [], "minor": {}}'),
+    ('ActionBars',        '{"bars": []}'),
+    ('BagInventory',      '{"items": []}'),
+    ('BaseCharacterStats','{"Strength": 10, "Agility": 10, "Constitution": 10, "Intellect": 10, "Wisdom": 10, "Charisma": 10}')
+) AS f(field_name, field_value)
+WHERE dcv.CustomerGUID = :'customer_guid'::uuid
+  AND dcv.DefaultSetName = 'Default'
+  AND NOT EXISTS (
+      SELECT 1 FROM DefaultCustomCharacterData d
+      WHERE d.CustomerGUID = :'customer_guid'::uuid AND d.CustomFieldName = f.field_name
+  );
 
 COMMIT;

--- a/packages/data/sql/schema/ows/seed/chuck_maintenance.sql
+++ b/packages/data/sql/schema/ows/seed/chuck_maintenance.sql
@@ -1,69 +1,43 @@
 -- Chuck OWS Maintenance Queries
--- Run when WorldServer data gets corrupted (e.g. launcher restarts creating duplicates)
+-- Run when WorldServer data gets corrupted (e.g. launcher restarts creating duplicates).
 --
--- Usage:
---   kubectl exec -n kilobase $(kubectl get pods -n kilobase -l role=primary -o jsonpath='{.items[0].metadata.name}') -c postgres -- \
---     psql -U postgres -d supabase -f packages/data/sql/schema/ows/seed/chuck_maintenance.sql
+-- psql :'var' interpolation does NOT work inside DO/dollar-quoted blocks, so all statements
+-- are top-level. Pass raw values (no surrounding single quotes) — the :'var' form quotes them.
 --
--- Or via port-forward:
+-- Usage (port-forward):
 --   psql -h localhost -p 54322 -U ows -d supabase \
---     -v customer_guid="'83d88046-...'" \
---     -v launcher_guid="'42a499a7-...'" \
---     -f chuck_maintenance.sql
+--     -v customer_guid="${GUID}" \
+--     -v launcher_guid="${LAUNCHER_GUID}" \
+--     -f packages/data/sql/schema/ows/seed/chuck_maintenance.sql
 
 SET search_path TO ows, extensions, public;
 
 BEGIN;
 
-DO $$
-    DECLARE _CustomerGUID UUID := :'customer_guid';
-    DECLARE _LauncherGUID UUID := :'launcher_guid';
-    DECLARE _Deleted INT;
-    DECLARE _ActiveCount INT;
-BEGIN
-    RAISE NOTICE 'Chuck maintenance: CustomerGUID=%, LauncherGUID=%', _CustomerGUID, _LauncherGUID;
+-- 1. Remove duplicate WorldServer rows (keep lowest ID).
+DELETE FROM WorldServers
+WHERE CustomerGUID = :'customer_guid'::uuid
+  AND WorldServerID NOT IN (
+      SELECT MIN(WorldServerID) FROM WorldServers WHERE CustomerGUID = :'customer_guid'::uuid
+  );
 
-    -- 1. Remove duplicate WorldServer rows (keep lowest ID)
-    WITH keep AS (
-        SELECT MIN(WorldServerID) AS id
-        FROM WorldServers
-        WHERE CustomerGUID = _CustomerGUID
-    )
-    DELETE FROM WorldServers
-    WHERE CustomerGUID = _CustomerGUID
-      AND WorldServerID NOT IN (SELECT id FROM keep);
+-- 2. Set the remaining WorldServer active with the stable launcher GUID.
+UPDATE WorldServers
+SET ServerStatus = 1,
+    ZoneServerGUID = :'launcher_guid'::uuid,
+    ServerIP = 'game.chuckrpg.com',
+    ActiveStartTime = NOW()
+WHERE CustomerGUID = :'customer_guid'::uuid;
 
-    GET DIAGNOSTICS _Deleted = ROW_COUNT;
-    IF _Deleted > 0 THEN
-        RAISE NOTICE 'Removed % duplicate WorldServer rows', _Deleted;
-    END IF;
+-- 3. Clean up orphaned MapInstances (status != 2 and older than 1 hour).
+DELETE FROM MapInstances
+WHERE CustomerGUID = :'customer_guid'::uuid
+  AND Status != 2
+  AND LastUpdateFromServer < NOW() - INTERVAL '1 hour';
 
-    -- 2. Set the remaining WorldServer to active with the stable launcher GUID
-    UPDATE WorldServers
-    SET ServerStatus = 1,
-        ZoneServerGUID = _LauncherGUID,
-        ServerIP = 'game.chuckrpg.com',
-        ActiveStartTime = NOW()
-    WHERE CustomerGUID = _CustomerGUID;
-
-    -- 3. Clean up orphaned MapInstances (status != 2 and older than 1 hour)
-    DELETE FROM MapInstances
-    WHERE CustomerGUID = _CustomerGUID
-      AND Status != 2
-      AND LastUpdateFromServer < NOW() - INTERVAL '1 hour';
-
-    GET DIAGNOSTICS _Deleted = ROW_COUNT;
-    IF _Deleted > 0 THEN
-        RAISE NOTICE 'Cleaned up % stale MapInstances', _Deleted;
-    END IF;
-
-    -- 4. Verify
-    SELECT COUNT(*) INTO _ActiveCount
-    FROM WorldServers
-    WHERE CustomerGUID = _CustomerGUID AND ServerStatus = 1;
-
-    RAISE NOTICE 'Active WorldServers: %', _ActiveCount;
-    RAISE NOTICE '=== Maintenance complete ===';
-END $$;
+-- 4. Verify — count of active world servers for this customer.
+SELECT COUNT(*) AS active_world_servers
+FROM WorldServers
+WHERE CustomerGUID = :'customer_guid'::uuid AND ServerStatus = 1;
 
 COMMIT;


### PR DESCRIPTION
## Problem

The OWS seed scripts referenced `:'customer_guid'` etc. **inside `DO $$` blocks**. psql does not interpolate `:'var'` inside dollar-quoted bodies, so they errored at run time (`syntax error at or near ":"`), and the documented `-v` values were pre-quoted (double-quoting the `:'var'` form). Affected `chuck_init.sql` **and** `chuck_maintenance.sql`.

Surfaced building the multi-tenant `tenants_init.sql` (#12111), which hit the identical bug. Root cause it slipped through: the dbmate `smoke` only covers **migrations** — `ows/seed/*.sql` had **no test coverage**.

## Fix

- `chuck_init.sql` + `chuck_maintenance.sql`: rewritten as **top-level** statements (interpolation works; `chuck_init` now idempotent via `WHERE NOT EXISTS`). Usage passes **raw** `-v` values.
- New `dbmate/seed-smoke.sh` + nx targets `smoke-seed` / `smoke-seed-keep`: brings up the kilobase stack + full migration chain (via `smoke.sh --keep`), then applies each `ows/seed/*.sql` under `SET ROLE ows` (real FORCE-RLS context) with dummy params, asserting apply + idempotency. Closes the seed-coverage gap.

## Verification

`./seed-smoke.sh` green on the kilobase prod-replica image (62 migrations applied, then chuck_init / tenants_init / chuck_maintenance all PASS, idempotent, under enforced RLS as the `ows` role). No secrets in any seed; `customer_guid` still supplied at apply time.