### PR TITLE
fix(KBVEZstd): export ZSTD_* symbols on Win64 (LNK2019 in UEDevOps)

### DIFF
--- a/packages/unreal/KBVEZstd/Source/KBVEZstd/KBVEZstd.Build.cs
+++ b/packages/unreal/KBVEZstd/Source/KBVEZstd/KBVEZstd.Build.cs
@@ -19,6 +19,11 @@ public class KBVEZstd : ModuleRules
 		PublicIncludePaths.Add(Path.Combine(ThirdPartyDir, "compress"));
 		PublicIncludePaths.Add(Path.Combine(ThirdPartyDir, "decompress"));
 
+		if (Target.Platform == UnrealTargetPlatform.Win64)
+		{
+			PrivateDefinitions.Add("ZSTD_DLL_EXPORT=1");
+		}
+
 		// Suppress warnings in third-party code
 		CppCompileWarningSettings.UndefinedIdentifierWarningLevel = WarningLevel.Off;
 	}


### PR DESCRIPTION
Win64 audit. UEDevOpsTelemetrySubsystem got `LNK2019` on `ZSTD_compress`, `ZSTD_compressBound`, `ZSTD_isError`, `ZSTD_getErrorName`. `zstd.h` defines `ZSTDLIB_API` as `__declspec(dllexport)` only when `ZSTD_DLL_EXPORT==1`, else `dllimport` — KBVEZstd never set it, so even its own TUs declared the symbols `dllimport` and nothing was exported. Add `ZSTD_DLL_EXPORT=1` PrivateDefinition on Win64 (module exports; consumers import). Same shape as the KBVEYYJson fix.

Separately surfaced (yours, KBVEWorld): `KBVEWorldChunkActor.cpp` 441/534 use `UFoliageType_InstancedStaticMesh::SetStaticMesh()` which doesn't exist in UE5.7 — set the public `Mesh` property instead. Part of #11987.