### PR TITLE
fix(KBVEWorld): UFoliageType_InstancedStaticMesh.Mesh assignment (UE5.7 C2039)

### DIFF
--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldChunkActor.cpp
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldChunkActor.cpp
@@ -438,7 +438,7 @@ void AKBVEWorldChunkActor::LoadBucket(const FKBVEWorldFoliageBucketConfig& Cfg)
 		{
 			if (Added >= Cap || !Built[i]) break;
 			UFoliageType_InstancedStaticMesh* RuntimeFT = NewObject<UFoliageType_InstancedStaticMesh>(this);
-			RuntimeFT->SetStaticMesh(Built[i]);
+			RuntimeFT->Mesh = Built[i];
 			FKBVEWorldFoliageMeta M;
 			M.Tier = Cfg.Tier;
 			FoliageTypes.Add(RuntimeFT);
@@ -531,7 +531,7 @@ void AKBVEWorldChunkActor::LoadBucket(const FKBVEWorldFoliageBucketConfig& Cfg)
 				if (!KBVEWorld_NameMatchesFilters(Obj->GetName().ToLower(), Cfg.NameIncludes, Cfg.NameExcludes)) continue;
 
 				UFoliageType_InstancedStaticMesh* RuntimeFT = NewObject<UFoliageType_InstancedStaticMesh>(this);
-				RuntimeFT->SetStaticMesh(SM);
+				RuntimeFT->Mesh = SM;
 
 				FKBVEWorldFoliageMeta M;
 				M.Tier = Cfg.Tier;


### PR DESCRIPTION
Win64 audit. `KBVEWorldChunkActor.cpp` 441/534 call `RuntimeFT->SetStaticMesh(...)` on `UFoliageType_InstancedStaticMesh`, which has no `SetStaticMesh` in UE5.7 (C2039). Assign the public `Mesh` property directly. (Line 50's `Water->SetStaticMesh` is on a UStaticMeshComponent and is fine.) Part of #11987.