### PR TITLE
fix(chuck): r.CreateShadersOnLoad=0 (headless cook GPU shader-create fatal)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Config/DefaultEngine.ini
+++ b/apps/chuckrpg/unreal-chuck/Config/DefaultEngine.ini
@@ -70,7 +70,7 @@ r.ShaderPipelineCache.SaveAfterPSOsLogged=1
 r.ShaderPipelineCache.SaveUserCache=1
 r.ShaderPipelineCache.GameFileMaskEnabled=0
 r.PSOPrecacheRecordPSOs=1
-r.CreateShadersOnLoad=1
+r.CreateShadersOnLoad=0
 r.PipelineFileCache.GameVersionKey=1
 
 r.DefaultFeature.LocalExposure.HighlightContrastScale=0.8


### PR DESCRIPTION
The chuck demo Win64 cook (GPU-less KubeVirt VM, software WARP) hit:
```
Fatal: FShaderMapResource_InlineCode::InitRHI unable to create a shader: frequency=6
```
`r.CreateShadersOnLoad=1` forces the cook to *create* shader RHI resources at load time, which needs a real GPU device; WARP can't create the compute/RT shader. Set it to **0** — shaders still cook to disk and are created at runtime on real hardware (the correct place for this hint). Offline shader compilation is unchanged.

Last gap before the first full chuck demo Win64 package — build + all plugins + LFS + water profile already green. Part of #11987.