### PR TITLE
release(cryptothrone): game server 0.0.2 + web 0.1.8

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.1"
+version: "0.0.2"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.7"
+version: "0.1.8"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
MDX `version:` bumps to ship the cryptothrone multiplayer stack now that the full server (sim, dual-wire, CloudCity collision, no-guest auth) and the web allocator/auth gate are on dev.

- **cryptothrone-server 0.0.1 → 0.0.2** — first image build. The Agones Fleet references `ghcr.io/kbve/cryptothrone-server` but no image had ever built (0.0.1 was the initial manifest entry, never dispatched). Bump fires the version-diff CI dispatch → builds + pushes the image the Fleet pulls.
- **cryptothrone (web) 0.1.7 → 0.1.8** — rebuild so the `/api/join` Agones allocator + Supabase bearer auth gate deploy.

MDX `version:` only — version.toml + k8s image tags auto-sync via the post-publish atom PR. CI reads `version_source` (the MDX) live at dispatch (`ci-docker.yml` `*.mdx` case), so no manifest regen needed; published versions (version.toml: game 0.0.1, web 0.1.7) are both below the bump → gate fires.