### PR TITLE
feat(rows): tenant edge — secrets, cross-ns RBAC, routing (Agones deferred)

### DIFF
--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -125,6 +125,48 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-rows-chuckrpg-dev
+          protocol: HTTPS
+          port: 443
+          hostname: api-dev.chuckrpg.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rows-chuckrpg-dev-api-tls
+                    namespace: rows-chuckrpg-dev
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-rows-chuckrpg-beta
+          protocol: HTTPS
+          port: 443
+          hostname: api-beta.chuckrpg.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rows-chuckrpg-beta-api-tls
+                    namespace: rows-chuckrpg-beta
+          allowedRoutes:
+              namespaces:
+                  from: All
+        - name: https-rows-rentearth-release
+          protocol: HTTPS
+          port: 443
+          hostname: api.rentearth.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rows-rentearth-release-api-tls
+                    namespace: rows-rentearth-release
+          allowedRoutes:
+              namespaces:
+                  from: All
         - name: https-cityvote
           protocol: HTTPS
           port: 443

--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -65,6 +65,15 @@ subjects:
       name: ows-external-secrets
       namespace: rows
     - kind: ServiceAccount
+      name: rows-external-secrets
+      namespace: rows-chuckrpg-dev
+    - kind: ServiceAccount
+      name: rows-external-secrets
+      namespace: rows-chuckrpg-beta
+    - kind: ServiceAccount
+      name: rows-external-secrets
+      namespace: rows-rentearth-release
+    - kind: ServiceAccount
       name: cryptothrone-external-secrets
       namespace: cryptothrone
     - kind: ServiceAccount

--- a/apps/kube/rabbitmq/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/rabbitmq/manifests/cross-namespace-rbac.yaml
@@ -27,3 +27,12 @@ subjects:
     - kind: ServiceAccount
       name: ows-launcher-external-secrets
       namespace: arc-runners
+    - kind: ServiceAccount
+      name: rows-external-secrets
+      namespace: rows-chuckrpg-dev
+    - kind: ServiceAccount
+      name: rows-external-secrets
+      namespace: rows-chuckrpg-beta
+    - kind: ServiceAccount
+      name: rows-external-secrets
+      namespace: rows-rentearth-release

--- a/apps/kube/rows/tenants/README.md
+++ b/apps/kube/rows/tenants/README.md
@@ -22,15 +22,16 @@ tenants/
 
 ## Tenants
 
-| Tenant slug         | Namespace                | `OWS_ENV` | Agones fleet            |
-| ------------------- | ------------------------ | --------- | ----------------------- |
-| `chuckrpg-dev`      | `rows-chuckrpg-dev`      | `dev`     | `ows-chuckrpg-dev`      |
-| `chuckrpg-beta`     | `rows-chuckrpg-beta`     | `beta`    | `ows-chuckrpg-beta`     |
-| `rentearth-release` | `rows-rentearth-release` | `release` | `ows-rentearth-release` |
+| Tenant slug         | Namespace                | `OWS_ENV` | Agones fleet             | Hostname                |
+| ------------------- | ------------------------ | --------- | ------------------------ | ----------------------- |
+| `chuckrpg-dev`      | `rows-chuckrpg-dev`      | `dev`     | `rows-chuckrpg-dev`      | `api-dev.chuckrpg.com`  |
+| `chuckrpg-beta`     | `rows-chuckrpg-beta`     | `beta`    | `rows-chuckrpg-beta`     | `api-beta.chuckrpg.com` |
+| `rentearth-release` | `rows-rentearth-release` | `release` | `rows-rentearth-release` | `api.rentearth.com`     |
 
 `customer_guid` is never committed — generated once per tenant, stored only in that
-namespace's sealed `ows-customer-guid` secret, and read from there by both the ROWS pod
-(`OWS_API_KEY`) and the seed Job.
+namespace's sealed `rrows-customer-guid` secret, and read from there by both the ROWS pod
+(`OWS_API_KEY`) and the seed Job. New tenant resources use the `rows-*` prefix; chuck's
+`ows-*` single-tenant manifests under `apps/kube/rows/manifest/` are untouched.
 
 ## Adding a new tenant (e.g. `chuckrpg-release`, `rentearth-dev`)
 
@@ -49,7 +50,7 @@ No `base/` edits, no SQL copy — `base/` is shared. (If the repo later adopts A
 ```sh
 SLUG=chuckrpg-dev; NS=rows-chuckrpg-dev
 GUID=$(uuidgen | tr 'A-Z' 'a-z')   # generate once; do NOT commit this value
-kubectl create secret generic ows-customer-guid \
+kubectl create secret generic rows-customer-guid \
   --namespace "$NS" --from-literal=customer-guid="$GUID" --dry-run=client -o yaml \
 | kubeseal --format yaml --controller-namespace sealed-secrets --controller-name sealed-secrets \
 > "overlays/$SLUG/sealed-customer-guid.yaml"
@@ -71,14 +72,29 @@ gameops `psql` step.
 (kustomize cannot read files outside its root). `nx run data-sql:verify-seed-sync` diffs the
 two and fails if they diverge — run it in CI / before merge. Update both together.
 
-## Deferred to follow-up (edge)
+## Wired in `base/` + overlays
 
-- **Secrets per namespace**: `ows-customer-guid` (sealed), `ows-db-credentials`,
-  `ows-rabbitmq-credentials`, `rows-supabase-jwt` (ExternalSecrets, as in `manifest/externalsecret.yaml`).
-  Pods + seed Job stay pending until these exist.
-- **Agones**: per-tenant `Fleet` + `FleetAutoscaler` under `apps/kube/agones/rows/`, plus
-  `ows-instancelauncher` ServiceAccount + cross-ns RBAC.
-- **Public routing**: per-tenant `HTTPRoute` + `Certificate` + gateway listener.
+- **Secrets**: ServiceAccounts `rows-external-secrets` / `rows-instancelauncher`; SecretStores
+  (kilobase, rabbitmq) + ExternalSecrets → `rows-db-credentials`, `rows-rabbitmq-credentials`,
+  `rows-supabase-jwt`. Cross-ns read RBAC for these SAs is appended in
+  `apps/kube/kilobase/manifests/cross-namespace-rbac.yaml` + `apps/kube/rabbitmq/manifests/cross-namespace-rbac.yaml`.
+- **Sealed**: `rows-customer-guid` + `rows-encryption-key` are committed as STUBS per overlay —
+  replace via kubeseal before deploy (below).
+- **Routing**: per-tenant `Certificate` + `HTTPRoute` (overlay patches the hostname), `ReferenceGrant`,
+  and a gateway listener in `apps/kube/kbve/manifest/kbve-gateway.yaml`.
+
+## Steps you must do per tenant (cannot be committed)
+
+1. **Seal** `rows-customer-guid` (+ `rows-encryption-key`) — replace the stub (below).
+2. **DNS** — add an A/CNAME for the tenant hostname (e.g. `api-dev.chuckrpg.com`) to the gateway VIP,
+   or the Certificate stays `Pending` (ACME HTTP-01) and the listener won't serve.
+
+## Deferred to a later PR
+
+- **Agones**: per-tenant `Fleet` + `FleetAutoscaler` + gameserver/service-key ExternalSecrets in
+  `arc-runners`. **Blocked**: a fleet needs a per-tenant UE5 `LinuxServer` build on a
+  `rows-<slug>-server-build` PVC — that build pipeline does not exist yet for dev/beta/rentearth.
+  Until then the ROWS API runs but no game servers allocate.
 
 ## Register the ArgoCD Applications
 

--- a/apps/kube/rows/tenants/base/deployment.yaml
+++ b/apps/kube/rows/tenants/base/deployment.yaml
@@ -25,8 +25,7 @@ spec:
                 app: rows
                 app.kubernetes.io/part-of: ows
         spec:
-            # TODO(follow-up): serviceAccountName ows-instancelauncher + cross-ns RBAC
-            # required before Agones allocation works in this namespace.
+            serviceAccountName: rows-instancelauncher
             containers:
                 - name: rows
                   image: ghcr.io/kbve/rows:0.1.25
@@ -45,17 +44,17 @@ spec:
                       - name: OWS_API_KEY
                         valueFrom:
                             secretKeyRef:
-                                name: ows-customer-guid
+                                name: rows-customer-guid
                                 key: customer-guid
                       - name: DATABASE_URL
                         valueFrom:
                             secretKeyRef:
-                                name: ows-db-credentials
+                                name: rows-db-credentials
                                 key: db-url
                       - name: RABBITMQ_URL
                         valueFrom:
                             secretKeyRef:
-                                name: ows-rabbitmq-credentials
+                                name: rows-rabbitmq-credentials
                                 key: amqp-url
                       - name: SUPABASE_JWT_SECRET
                         valueFrom:

--- a/apps/kube/rows/tenants/base/kustomization.yaml
+++ b/apps/kube/rows/tenants/base/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
     - deployment.yaml
     - seed-job.yaml
+    - secrets.yaml
+    - routing.yaml
 
 # tenants_init.sql is a copy of packages/data/sql/schema/ows/seed/tenants_init.sql.
 # kustomize cannot read files outside its root (no LoadRestrictionsNone configured),

--- a/apps/kube/rows/tenants/base/routing.yaml
+++ b/apps/kube/rows/tenants/base/routing.yaml
@@ -1,0 +1,33 @@
+---
+# Per-tenant public routing. Hostname + cert names are patched by the overlay.
+# The matching gateway listener lives in apps/kube/kbve/manifest/kbve-gateway.yaml.
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: rows-api-tls
+spec:
+    secretName: rows-api-tls
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+    dnsNames:
+        - REPLACE.example.com
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: ows-api-routes
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - REPLACE.example.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: rows
+                port: 4322

--- a/apps/kube/rows/tenants/base/secrets.yaml
+++ b/apps/kube/rows/tenants/base/secrets.yaml
@@ -1,0 +1,145 @@
+---
+# Per-tenant secret plumbing. Namespace is injected by the overlay; the SecretStore
+# auth.serviceAccount.namespace is intentionally omitted so it resolves to this namespace.
+# Cross-namespace RBAC that lets ows-external-secrets read the remote stores lives in the
+# agones/cross-ns tree (apps/kube/agones/rows-tenants/), since those Roles sit in
+# rabbitmq-system / kilobase and must not be namespace-transformed into rows-<slug>.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: rows-external-secrets
+    labels:
+        app.kubernetes.io/part-of: ows
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: rows-instancelauncher
+    labels:
+        app.kubernetes.io/part-of: ows
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-remote-secret-store
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: rows-external-secrets
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: rabbitmq-remote-secret-store
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rabbitmq-system
+            auth:
+                serviceAccount:
+                    name: rows-external-secrets
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-db-secrets
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: rows-db-credentials
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                db-connection-string: 'Host=supabase-cluster-rw.kilobase.svc.cluster.local;Port=5432;Database=supabase;Username=ows;Password={{ .dbpassword }};Options=-c search_path=ows,extensions,public;Maximum Pool Size=6;'
+                db-url: 'postgres://ows:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
+    data:
+        - secretKey: dbpassword
+          remoteRef:
+              key: ows-db-password
+              property: password
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-rabbitmq-secrets
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: rabbitmq-remote-secret-store
+        kind: SecretStore
+    target:
+        name: rows-rabbitmq-credentials
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                username: '{{ .username }}'
+                password: '{{ .password }}'
+                host: '{{ .host }}'
+                amqp-url: 'amqp://{{ .username }}:{{ .password }}@{{ .host }}:5672'
+    data:
+        - secretKey: username
+          remoteRef:
+              key: rabbitmq-default-user
+              property: username
+        - secretKey: password
+          remoteRef:
+              key: rabbitmq-default-user
+              property: password
+        - secretKey: host
+          remoteRef:
+              key: rabbitmq-default-user
+              property: host
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: rows-supabase-jwt
+spec:
+    refreshInterval: 15m
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: rows-supabase-jwt
+        creationPolicy: Owner
+    data:
+        - secretKey: jwt-secret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+---
+# Lets the shared kbve-gateway (in the kbve namespace) reference this tenant's TLS Secret.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+    name: allow-gateway-tls
+spec:
+    from:
+        - group: gateway.networking.k8s.io
+          kind: Gateway
+          namespace: kbve
+    to:
+        - group: ''
+          kind: Secret

--- a/apps/kube/rows/tenants/base/seed-job.yaml
+++ b/apps/kube/rows/tenants/base/seed-job.yaml
@@ -38,12 +38,12 @@ spec:
                       - name: OWS_API_KEY
                         valueFrom:
                             secretKeyRef:
-                                name: ows-customer-guid
+                                name: rows-customer-guid
                                 key: customer-guid
                       - name: DATABASE_URL
                         valueFrom:
                             secretKeyRef:
-                                name: ows-db-credentials
+                                name: rows-db-credentials
                                 key: db-url
                   volumeMounts:
                       - name: seed

--- a/apps/kube/rows/tenants/overlays/chuckrpg-beta/kustomization.yaml
+++ b/apps/kube/rows/tenants/overlays/chuckrpg-beta/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: rows-chuckrpg-beta
 
 resources:
     - namespace.yaml
+    - sealed-customer-guid.yaml
+    - sealed-encryption-key.yaml
     - ../../base
 
 labels:
@@ -31,7 +33,7 @@ patches:
             path: /spec/template/spec/containers/0/env/-
             value:
                 name: AGONES_FLEET
-                value: ows-chuckrpg-beta
+                value: rows-chuckrpg-beta
     - target:
           kind: Job
           name: rows-seed
@@ -56,3 +58,20 @@ patches:
             value:
                 name: ZONE_NAME
                 value: MainWorld
+    - target:
+          kind: Certificate
+          name: rows-api-tls
+      patch: |-
+          - op: replace
+            path: /spec/secretName
+            value: rows-chuckrpg-beta-api-tls
+          - op: replace
+            path: /spec/dnsNames/0
+            value: api-beta.chuckrpg.com
+    - target:
+          kind: HTTPRoute
+          name: ows-api-routes
+      patch: |-
+          - op: replace
+            path: /spec/hostnames/0
+            value: api-beta.chuckrpg.com

--- a/apps/kube/rows/tenants/overlays/chuckrpg-beta/sealed-customer-guid.yaml
+++ b/apps/kube/rows/tenants/overlays/chuckrpg-beta/sealed-customer-guid.yaml
@@ -1,0 +1,12 @@
+# STUB — replace before deploy. Generate the real SealedSecret with kubeseal (see
+# tenants/README.md "Seal the customer_guid"); the placeholder below will NOT decrypt.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: rows-customer-guid
+spec:
+    encryptedData:
+        customer-guid: REPLACE_VIA_KUBESEAL
+    template:
+        metadata:
+            name: rows-customer-guid

--- a/apps/kube/rows/tenants/overlays/chuckrpg-beta/sealed-encryption-key.yaml
+++ b/apps/kube/rows/tenants/overlays/chuckrpg-beta/sealed-encryption-key.yaml
@@ -1,0 +1,12 @@
+# STUB — replace before deploy. Generate with kubeseal (see tenants/README.md).
+# Consumed by the Agones gameserver ExternalSecret (rows-encryption-key).
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: rows-encryption-key
+spec:
+    encryptedData:
+        encryption-key: REPLACE_VIA_KUBESEAL
+    template:
+        metadata:
+            name: rows-encryption-key

--- a/apps/kube/rows/tenants/overlays/chuckrpg-dev/kustomization.yaml
+++ b/apps/kube/rows/tenants/overlays/chuckrpg-dev/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: rows-chuckrpg-dev
 
 resources:
     - namespace.yaml
+    - sealed-customer-guid.yaml
+    - sealed-encryption-key.yaml
     - ../../base
 
 labels:
@@ -31,7 +33,7 @@ patches:
             path: /spec/template/spec/containers/0/env/-
             value:
                 name: AGONES_FLEET
-                value: ows-chuckrpg-dev
+                value: rows-chuckrpg-dev
     - target:
           kind: Job
           name: rows-seed
@@ -56,3 +58,20 @@ patches:
             value:
                 name: ZONE_NAME
                 value: MainWorld
+    - target:
+          kind: Certificate
+          name: rows-api-tls
+      patch: |-
+          - op: replace
+            path: /spec/secretName
+            value: rows-chuckrpg-dev-api-tls
+          - op: replace
+            path: /spec/dnsNames/0
+            value: api-dev.chuckrpg.com
+    - target:
+          kind: HTTPRoute
+          name: ows-api-routes
+      patch: |-
+          - op: replace
+            path: /spec/hostnames/0
+            value: api-dev.chuckrpg.com

--- a/apps/kube/rows/tenants/overlays/chuckrpg-dev/sealed-customer-guid.yaml
+++ b/apps/kube/rows/tenants/overlays/chuckrpg-dev/sealed-customer-guid.yaml
@@ -1,0 +1,12 @@
+# STUB — replace before deploy. Generate the real SealedSecret with kubeseal (see
+# tenants/README.md "Seal the customer_guid"); the placeholder below will NOT decrypt.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: rows-customer-guid
+spec:
+    encryptedData:
+        customer-guid: REPLACE_VIA_KUBESEAL
+    template:
+        metadata:
+            name: rows-customer-guid

--- a/apps/kube/rows/tenants/overlays/chuckrpg-dev/sealed-encryption-key.yaml
+++ b/apps/kube/rows/tenants/overlays/chuckrpg-dev/sealed-encryption-key.yaml
@@ -1,0 +1,12 @@
+# STUB — replace before deploy. Generate with kubeseal (see tenants/README.md).
+# Consumed by the Agones gameserver ExternalSecret (rows-encryption-key).
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: rows-encryption-key
+spec:
+    encryptedData:
+        encryption-key: REPLACE_VIA_KUBESEAL
+    template:
+        metadata:
+            name: rows-encryption-key

--- a/apps/kube/rows/tenants/overlays/rentearth-release/kustomization.yaml
+++ b/apps/kube/rows/tenants/overlays/rentearth-release/kustomization.yaml
@@ -5,6 +5,8 @@ namespace: rows-rentearth-release
 
 resources:
     - namespace.yaml
+    - sealed-customer-guid.yaml
+    - sealed-encryption-key.yaml
     - ../../base
 
 labels:
@@ -31,7 +33,7 @@ patches:
             path: /spec/template/spec/containers/0/env/-
             value:
                 name: AGONES_FLEET
-                value: ows-rentearth-release
+                value: rows-rentearth-release
     - target:
           kind: Job
           name: rows-seed
@@ -56,3 +58,20 @@ patches:
             value:
                 name: ZONE_NAME
                 value: Origin
+    - target:
+          kind: Certificate
+          name: rows-api-tls
+      patch: |-
+          - op: replace
+            path: /spec/secretName
+            value: rows-rentearth-release-api-tls
+          - op: replace
+            path: /spec/dnsNames/0
+            value: api.rentearth.com
+    - target:
+          kind: HTTPRoute
+          name: ows-api-routes
+      patch: |-
+          - op: replace
+            path: /spec/hostnames/0
+            value: api.rentearth.com

--- a/apps/kube/rows/tenants/overlays/rentearth-release/sealed-customer-guid.yaml
+++ b/apps/kube/rows/tenants/overlays/rentearth-release/sealed-customer-guid.yaml
@@ -1,0 +1,12 @@
+# STUB — replace before deploy. Generate the real SealedSecret with kubeseal (see
+# tenants/README.md "Seal the customer_guid"); the placeholder below will NOT decrypt.
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: rows-customer-guid
+spec:
+    encryptedData:
+        customer-guid: REPLACE_VIA_KUBESEAL
+    template:
+        metadata:
+            name: rows-customer-guid

--- a/apps/kube/rows/tenants/overlays/rentearth-release/sealed-encryption-key.yaml
+++ b/apps/kube/rows/tenants/overlays/rentearth-release/sealed-encryption-key.yaml
@@ -1,0 +1,12 @@
+# STUB — replace before deploy. Generate with kubeseal (see tenants/README.md).
+# Consumed by the Agones gameserver ExternalSecret (rows-encryption-key).
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+    name: rows-encryption-key
+spec:
+    encryptedData:
+        encryption-key: REPLACE_VIA_KUBESEAL
+    template:
+        metadata:
+            name: rows-encryption-key


### PR DESCRIPTION
Builds on the merged kustomize base+overlays (#12122) to wire the per-tenant edge so each tenant's ROWS pod + seed Job can actually get their secrets and be publicly routable.

## Commits
1. **In-namespace edge** — into tenant base+overlays: ServiceAccounts (rows-external-secrets, rows-instancelauncher), SecretStores (kilobase, rabbitmq) + ExternalSecrets (rows-db-credentials, rows-rabbitmq-credentials, rows-supabase-jwt), Certificate + HTTPRoute (per-tenant host via overlay patch) + ReferenceGrant, deployment uses rows-instancelauncher SA. sealed-customer-guid / sealed-encryption-key committed as **STUBS** per overlay.
2. **Cross-ns RBAC + gateway** — append the 3 tenant SAs to the kilobase + rabbitmq reader RoleBindings; add 3 HTTPS listeners to kbve-gateway (api-dev.chuckrpg.com, api-beta.chuckrpg.com, api.rentearth.com).

## Naming
New tenant resources use the **rows-*** prefix (per your call); chuck's ows-* single-tenant manifests under apps/kube/rows/manifest/ are untouched.

## Validation
kustomize build of all 3 overlays → 18 resources each; gateway + RBAC YAML parse; overlay renders correct rows-* names + hostnames.

## Operator-gated (cannot be committed)
- **kubeseal** the rows-customer-guid (+ rows-encryption-key) stubs per namespace — they will NOT decrypt as-is.
- **DNS** for each hostname → gateway VIP, else the ACME cert stays Pending and the listener won't serve.

## Deferred (separate PR)
- **Agones** per-tenant Fleet + autoscaler + gameserver/service-key ExternalSecrets. **Blocked** on a per-tenant UE5 LinuxServer build on a rows-<slug>-server-build PVC — that build pipeline doesn't exist yet for dev/beta/rentearth. ROWS API runs without it; no game servers allocate until then.

⚠️ Edits the shared kbve-gateway + kilobase/rabbitmq RBAC (additive). Review those hunks.