### PR TITLE
feat(unreal): KBVECombat Mass DoT path

### DIFF
--- a/packages/unreal/KBVECombat/README.md
+++ b/packages/unreal/KBVECombat/README.md
@@ -71,10 +71,16 @@ The actor path (`UKBVECombatComponent` / `UKBVECombatStatics`) stays for hero/bo
 
 `UKBVEStatusEffectComponent` applies a `FKBVEStatusEffectDef` (authority): adds its `FKBVEStatModifierSpec` list to the owner via `IKBVEStatTarget::AddStatModifier` (Additive / Multiplicative), runs an optional DoT (`DotPerSecond` × `DotInterval`, routed through `ApplyDamage` so it composes with resists/feed), and removes the modifiers on expiry. Re-applying the same `EffectId` refreshes it; `OnStatusApplied` / `OnStatusRemoved` fire for UI.
 
+## Mass DoT path
+
+`FKBVECombatDotFragment` holds active DoTs (`FKBVEActiveDot`: element, damage/sec, remaining, interval) on a combatant entity. `UKBVECombatDotProcessor` (Mass `PrePhysics`) ticks them in parallel — decrement timers, and each interval **enqueue** a self-targeted `FKBVEDamageRequest` to the batch subsystem rather than mutating health in the worker. So DoT deaths, resists, and feed events flow through the same serial drain as everything else; dead entities clear their DoTs. `UKBVECombatStatics::ApplyDotToEntity` adds a DoT to an entity (which must carry the fragment).
+
+This is the swarm counterpart to the actor `UKBVEStatusEffectComponent` DoT.
+
 ## Roadmap
 
 - Status replication + stacking rules (stack count, diminishing returns).
-- Mass status/DoT path (fragment-side ticks) for the swarm.
+- Mass status (stat-modifier) fragment for non-DoT effects on the swarm.
 
 ## License
 

--- a/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatDotProcessor.cpp
+++ b/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatDotProcessor.cpp
@@ -1,0 +1,80 @@
+#include "KBVECombatDotProcessor.h"
+
+#include "MassExecutionContext.h"
+#include "KBVECombatMass.h"
+#include "KBVECombatTypes.h"
+#include "KBVECombatBatchSubsystem.h"
+#include "Engine/World.h"
+
+UKBVECombatDotProcessor::UKBVECombatDotProcessor()
+	: EntityQuery(*this)
+{
+	ExecutionFlags = (int32)EProcessorExecutionFlags::All;
+	ProcessingPhase = EMassProcessingPhase::PrePhysics;
+	bAutoRegisterWithProcessingPhases = true;
+}
+
+void UKBVECombatDotProcessor::ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager)
+{
+	EntityQuery.AddRequirement<FKBVECombatDotFragment>(EMassFragmentAccess::ReadWrite);
+	EntityQuery.AddRequirement<FKBVECombatFragment>(EMassFragmentAccess::ReadOnly);
+}
+
+void UKBVECombatDotProcessor::Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(KBVE_CombatDot_Execute);
+
+	const float DeltaSeconds = Context.GetDeltaTimeSeconds();
+	UWorld* World = EntityManager.GetWorld();
+	if (!World || World->GetNetMode() == NM_Client)
+	{
+		return;
+	}
+	UKBVECombatBatchSubsystem* Batch = World->GetSubsystem<UKBVECombatBatchSubsystem>();
+	if (!Batch)
+	{
+		return;
+	}
+
+	EntityQuery.ParallelForEachEntityChunk(EntityManager, Context,
+		[DeltaSeconds, Batch](FMassExecutionContext& Chunk)
+		{
+			const TArrayView<FKBVECombatDotFragment> DotViews = Chunk.GetMutableFragmentView<FKBVECombatDotFragment>();
+			const TConstArrayView<FKBVECombatFragment> CombatViews = Chunk.GetFragmentView<FKBVECombatFragment>();
+			const int32 Num = Chunk.GetNumEntities();
+
+			for (int32 i = 0; i < Num; ++i)
+			{
+				TArray<FKBVEActiveDot>& Dots = DotViews[i].Dots;
+				if (CombatViews[i].bDead)
+				{
+					Dots.Reset();
+					continue;
+				}
+
+				const FMassEntityHandle Entity = Chunk.GetEntity(i);
+				for (int32 d = Dots.Num() - 1; d >= 0; --d)
+				{
+					FKBVEActiveDot& Dot = Dots[d];
+					Dot.TimeRemaining -= DeltaSeconds;
+					Dot.Accumulator += DeltaSeconds;
+
+					while (Dot.Accumulator >= Dot.Interval && Dot.Interval > 0.0f)
+					{
+						Dot.Accumulator -= Dot.Interval;
+						FKBVEDamageRequest Request;
+						Request.Target = Entity;
+						Request.Instigator = Entity;
+						Request.Amount = Dot.DamagePerSecond * Dot.Interval;
+						Request.Element = Dot.Element;
+						Batch->EnqueueDamage(Request);
+					}
+
+					if (Dot.TimeRemaining <= 0.0f)
+					{
+						Dots.RemoveAt(d);
+					}
+				}
+			}
+		});
+}

--- a/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatStatics.cpp
+++ b/packages/unreal/KBVECombat/Source/KBVECombat/Private/KBVECombatStatics.cpp
@@ -105,3 +105,35 @@ bool UKBVECombatStatics::IsEntityAlive(const UObject* WorldContext, FMassEntityH
 	const FKBVECombatFragment* Fragment = EM.GetFragmentDataPtr<FKBVECombatFragment>(Target);
 	return Fragment && !Fragment->bDead;
 }
+
+bool UKBVECombatStatics::ApplyDotToEntity(const UObject* WorldContext, FMassEntityHandle Target, EKBVEDamageElement Element, float DamagePerSecond, float Duration, float Interval)
+{
+	const UWorld* World = GEngine ? GEngine->GetWorldFromContextObject(WorldContext, EGetWorldErrorMode::ReturnNull) : nullptr;
+	if (!World || DamagePerSecond <= 0.0f || Duration <= 0.0f)
+	{
+		return false;
+	}
+	UMassEntitySubsystem* MassSys = World->GetSubsystem<UMassEntitySubsystem>();
+	if (!MassSys)
+	{
+		return false;
+	}
+	FMassEntityManager& EM = MassSys->GetMutableEntityManager();
+	if (!EM.IsEntityValid(Target))
+	{
+		return false;
+	}
+	FKBVECombatDotFragment* DotFragment = EM.GetFragmentDataPtr<FKBVECombatDotFragment>(Target);
+	if (!DotFragment)
+	{
+		return false;
+	}
+
+	FKBVEActiveDot Dot;
+	Dot.Element = Element;
+	Dot.DamagePerSecond = DamagePerSecond;
+	Dot.TimeRemaining = Duration;
+	Dot.Interval = FMath::Max(0.05f, Interval);
+	DotFragment->Dots.Add(Dot);
+	return true;
+}

--- a/packages/unreal/KBVECombat/Source/KBVECombat/Public/KBVECombatDotProcessor.h
+++ b/packages/unreal/KBVECombat/Source/KBVECombat/Public/KBVECombatDotProcessor.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "MassProcessor.h"
+#include "KBVECombatDotProcessor.generated.h"
+
+UCLASS()
+class KBVECOMBAT_API UKBVECombatDotProcessor : public UMassProcessor
+{
+	GENERATED_BODY()
+
+public:
+	UKBVECombatDotProcessor();
+
+protected:
+	virtual void ConfigureQueries(const TSharedRef<FMassEntityManager>& EntityManager) override;
+	virtual void Execute(FMassEntityManager& EntityManager, FMassExecutionContext& Context) override;
+
+	FMassEntityQuery EntityQuery;
+};

--- a/packages/unreal/KBVECombat/Source/KBVECombat/Public/KBVECombatMass.h
+++ b/packages/unreal/KBVECombat/Source/KBVECombat/Public/KBVECombatMass.h
@@ -49,3 +49,33 @@ struct KBVECOMBAT_API FKBVECombatTag : public FMassTag
 {
 	GENERATED_BODY()
 };
+
+USTRUCT()
+struct KBVECOMBAT_API FKBVEActiveDot
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	EKBVEDamageElement Element = EKBVEDamageElement::Poison;
+
+	UPROPERTY()
+	float DamagePerSecond = 0.0f;
+
+	UPROPERTY()
+	float TimeRemaining = 0.0f;
+
+	UPROPERTY()
+	float Interval = 1.0f;
+
+	UPROPERTY()
+	float Accumulator = 0.0f;
+};
+
+USTRUCT()
+struct KBVECOMBAT_API FKBVECombatDotFragment : public FMassFragment
+{
+	GENERATED_BODY()
+
+	UPROPERTY()
+	TArray<FKBVEActiveDot> Dots;
+};

--- a/packages/unreal/KBVECombat/Source/KBVECombat/Public/KBVECombatStatics.h
+++ b/packages/unreal/KBVECombat/Source/KBVECombat/Public/KBVECombatStatics.h
@@ -34,4 +34,7 @@ public:
 
 	UFUNCTION(BlueprintPure, Category = "KBVE|Combat", meta = (WorldContext = "WorldContext"))
 	static bool IsEntityAlive(const UObject* WorldContext, FMassEntityHandle Target);
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Combat", meta = (WorldContext = "WorldContext"))
+	static bool ApplyDotToEntity(const UObject* WorldContext, FMassEntityHandle Target, EKBVEDamageElement Element, float DamagePerSecond, float Duration, float Interval = 1.0f);
 };


### PR DESCRIPTION
Follow-up to the combat plugin (#12121): the swarm-side damage-over-time path.

- **FKBVEActiveDot** + **FKBVECombatDotFragment** — per-entity DoT state (element, damage/sec, remaining, interval) on a Mass combatant.
- **UKBVECombatDotProcessor** (Mass `PrePhysics`) — parallel tick of DoT timers; each interval **enqueues** a self-targeted FKBVEDamageRequest to the batch subsystem instead of mutating health in the worker, so DoT deaths / resists / feed all flow through the same serial drain (parallel-produce / serial-apply). Dead entities clear their DoTs.
- **UKBVECombatStatics::ApplyDotToEntity** — add a DoT to an entity (which must carry the fragment).

Swarm counterpart to the actor `UKBVEStatusEffectComponent` DoT. Mirrors the `KBVEStatRegenProcessor` 5.7 Mass API.

UE 5.7, builds in ci-unreal. No manifest change (same plugin).

Roadmap remaining: status replication/stacking, Mass stat-modifier fragment for non-DoT swarm effects.