### PR TITLE
fix(rareicon): reference Unity.InputSystem + UnityEngine.UI from RareIcon.Game asmdef

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/RareIcon.Game.asmdef
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/RareIcon.Game.asmdef
@@ -21,7 +21,9 @@
         "GUID:33661e06c33d31b4c9223810bf503247",
         "GUID:77221876cc6b8244180b96e320b1bcd4",
         "GUID:6055be8ebefd69e48b49212b09b47b2f",
-        "GUID:68bd7fdb68ef2684e982e8a9825b18a5"
+        "GUID:68bd7fdb68ef2684e982e8a9825b18a5",
+        "GUID:75469ad4d38634e559750d17036d5f7c",
+        "GUID:2bafac87e7f4b9b418d9448d219b01ab"
     ],
     "includePlatforms": [
         "Editor",


### PR DESCRIPTION
## Problem

The `RareIcon.Game` asmdef split (#12086) moved game code out of `Assembly-CSharp`. Predefined assemblies auto-reference every package; asmdefs do not — references must be explicit, even for `autoReferenced: true` packages. Two were missed:

```
CS0234: 'InputSystem' does not exist in namespace 'UnityEngine'
CS0246: 'Keyboard' could not be found
```
across `Services/{BuildInputSource,CameraService,EscapeMenuController,MouseStateSource,SelectionInput,SelectionMoveHandler}` and `UI/{DialogueController,DialogueVN,PauseIndicator,WorldHUD}`. `UnityEngine.UI` (Button/Toggle/RawImage in `ItemDetailsModal`, `ItemSpriteAtlasOps`, …) is used too and would error in the next compile wave.

## Fix

Add to `RareIcon.Game.asmdef` references:
- `Unity.InputSystem` (`75469ad4…`)
- `UnityEngine.UI` (`2bafac87…`)

Audited every `using` in `Scripts/` against the asmdef reference set — these two were the only gaps. Everything else is covered (engine modules `UnityEngine.LowLevel` / `UnityEngine.Rendering` / `UnityEngine.UIElements` need no asmdef ref; R3/ObservableCollections/Protobuf/Newtonsoft come via auto-referenced NuGet DLLs).

## Verification

No Unity compiler locally — reviewer must reopen in Unity and confirm the project compiles clean.