### PR TITLE
fix(chuck): Shipping compile (Mass) + cook only demo maps

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -870,7 +870,8 @@ jobs:
                       -project="$($uproject.FullName)" `
                       -targetplatform=Win64 `
                       -clientconfig=Shipping `
-                      -cook -allmaps -build -stage -pak -archive `
+                      -cook -map=/Game/Menus/L_MainMenu+/Game/Map/L_ChuckWorld+/Game/ThirdPerson/Lvl_ThirdPerson `
+                      -build -stage -pak -archive `
                       -archivedirectory="$out" `
                       -nodebuginfo `
                       -unattended -utf8output -NoP4

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -552,7 +552,9 @@ void AchuckCorePlayerController::OnToggleDevOverlayPressed(const FInputActionVal
 				{
 					if (UMassEntitySubsystem* Mass = W->GetSubsystem<UMassEntitySubsystem>())
 					{
+#if !UE_BUILD_SHIPPING
 						return (int32)Mass->GetEntityManager().DebugGetEntityCount();
+#endif
 					}
 				}
 				return 0;

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatRegenProcessor.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatRegenProcessor.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "MassProcessor.h"
+#include "MassEntityQuery.h"
 #include "KBVEStatRegenProcessor.generated.h"
 
 UCLASS()

--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldGrassMass.h
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldGrassMass.h
@@ -3,6 +3,7 @@
 #include "CoreMinimal.h"
 #include "MassCommonFragments.h"
 #include "MassEntityTypes.h"
+#include "MassEntityQuery.h"
 #include "MassProcessor.h"
 #include "KBVEWorldGrassMass.generated.h"
 


### PR DESCRIPTION
Off the Shipping build attempt (#12131). Two things:

**Shipping compile fixes** (Development hid these via transitive editor includes):
- `chuckCorePlayerController`: `FMassEntityManager::DebugGetEntityCount` is debug-only (stripped in Shipping) — guard the DevOverlay entity-count provider with `#if !UE_BUILD_SHIPPING`.
- `KBVEStatRegenProcessor.h` + `KBVEWorldGrassMass.h`: `FMassEntityQuery` undefined — moved to `MassEntityQuery.h` in UE5.5+; add the include (both modules already have the MassEntity dep).

**Size**: `-cook -allmaps` → `-map=/Game/Menus/L_MainMenu+/Game/Map/L_ChuckWorld+/Game/ThirdPerson/Lvl_ThirdPerson` so only the demo maps + their referenced assets cook (drops unused content incl. grass-library chunks).

Part of #11987.