### PR TITLE
feat(chuck): bridge UE combat template into KBVECombat

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatBridgeComponent.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatBridgeComponent.cpp
@@ -1,0 +1,18 @@
+#include "chuckCombatBridgeComponent.h"
+#include "CombatDamageable.h"
+#include "GameFramework/Actor.h"
+
+float UchuckCombatBridgeComponent::ApplyDamage_Implementation(const FKBVEDamageEvent& DamageEvent)
+{
+	AActor* Owner = GetOwner();
+	if (!Owner || bDead || DamageEvent.Amount <= 0.0f)
+	{
+		return 0.0f;
+	}
+	if (ICombatDamageable* Damageable = Cast<ICombatDamageable>(Owner))
+	{
+		Damageable->ApplyDamage(DamageEvent.Amount, DamageEvent.Instigator, DamageEvent.HitLocation, FVector::ZeroVector);
+		return DamageEvent.Amount;
+	}
+	return 0.0f;
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatBridgeComponent.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatBridgeComponent.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "KBVECombatant.h"
+#include "KBVECombatTypes.h"
+#include "chuckCombatBridgeComponent.generated.h"
+
+UCLASS(ClassGroup = (KBVE), meta = (BlueprintSpawnableComponent))
+class UchuckCombatBridgeComponent : public UActorComponent, public IKBVECombatant
+{
+	GENERATED_BODY()
+
+public:
+	virtual int32 GetTeamId_Implementation() const override { return TeamId; }
+	virtual bool IsAlive_Implementation() const override { return !bDead; }
+	virtual float ApplyDamage_Implementation(const FKBVEDamageEvent& DamageEvent) override;
+
+	UFUNCTION(BlueprintCallable, Category = "KBVE|Combat")
+	void MarkDead() { bDead = true; }
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|Combat")
+	int32 TeamId = 1;
+
+private:
+	bool bDead = false;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatCharacter.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatCharacter.cpp
@@ -1,0 +1,44 @@
+#include "chuckCombatCharacter.h"
+#include "chuckCombatBridgeComponent.h"
+#include "KBVECombatFeedSubsystem.h"
+#include "KBVECombatTypes.h"
+
+AchuckCombatCharacter::AchuckCombatCharacter()
+{
+	CombatBridge = CreateDefaultSubobject<UchuckCombatBridgeComponent>(TEXT("CombatBridge"));
+}
+
+void AchuckCombatCharacter::ApplyDamage(float Damage, AActor* DamageCauser, const FVector& DamageLocation, const FVector& DamageImpulse)
+{
+	Super::ApplyDamage(Damage, DamageCauser, DamageLocation, DamageImpulse);
+
+	if (UKBVECombatFeedSubsystem* Feed = UKBVECombatFeedSubsystem::Get(this))
+	{
+		FKBVECombatFeedEntry Entry;
+		Entry.Type = EKBVECombatEventType::Damage;
+		Entry.Instigator = DamageCauser;
+		Entry.Target = this;
+		Entry.Amount = Damage;
+		Entry.WorldLocation = DamageLocation;
+		Feed->PushEvent(Entry);
+	}
+}
+
+void AchuckCombatCharacter::HandleDeath()
+{
+	Super::HandleDeath();
+
+	if (CombatBridge)
+	{
+		CombatBridge->MarkDead();
+	}
+
+	if (UKBVECombatFeedSubsystem* Feed = UKBVECombatFeedSubsystem::Get(this))
+	{
+		FKBVECombatFeedEntry Entry;
+		Entry.Type = EKBVECombatEventType::Death;
+		Entry.Target = this;
+		Entry.WorldLocation = GetActorLocation();
+		Feed->PushEvent(Entry);
+	}
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatCharacter.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatCharacter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CombatCharacter.h"
+#include "chuckCombatCharacter.generated.h"
+
+class UchuckCombatBridgeComponent;
+
+UCLASS()
+class AchuckCombatCharacter : public ACombatCharacter
+{
+	GENERATED_BODY()
+
+public:
+	AchuckCombatCharacter();
+
+	virtual void ApplyDamage(float Damage, AActor* DamageCauser, const FVector& DamageLocation, const FVector& DamageImpulse) override;
+	virtual void HandleDeath() override;
+
+protected:
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "KBVE|Combat")
+	TObjectPtr<UchuckCombatBridgeComponent> CombatBridge;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatGameMode.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatGameMode.cpp
@@ -1,0 +1,7 @@
+#include "chuckCombatGameMode.h"
+#include "chuckCombatCharacter.h"
+
+AchuckCombatGameMode::AchuckCombatGameMode()
+{
+	DefaultPawnClass = AchuckCombatCharacter::StaticClass();
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatGameMode.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Combat/chuckCombatGameMode.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CombatGameMode.h"
+#include "chuckCombatGameMode.generated.h"
+
+UCLASS()
+class AchuckCombatGameMode : public ACombatGameMode
+{
+	GENERATED_BODY()
+
+public:
+	AchuckCombatGameMode();
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/chuck.Build.cs
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/chuck.Build.cs
@@ -51,7 +51,8 @@ public class chuck : ModuleRules
 			"ROWS",
 			"KBVENet",
 			"KBVENPCDB",
-			"KBVENPCSprite"
+			"KBVENPCSprite",
+			"KBVECombat"
 		});
 
 
@@ -78,7 +79,8 @@ public class chuck : ModuleRules
 			"chuck/Variant_SideScrolling/Gameplay",
 			"chuck/Variant_SideScrolling/Interfaces",
 			"chuck/Variant_SideScrolling/UI",
-			"chuck/NPC"
+			"chuck/NPC",
+			"chuck/Combat"
 		});
 
 		if (Target.bBuildEditor)

--- a/apps/chuckrpg/unreal-chuck/chuck.uproject
+++ b/apps/chuckrpg/unreal-chuck/chuck.uproject
@@ -143,6 +143,10 @@
 		{
 			"Name": "KBVEMover",
 			"Enabled": true
+		},
+		{
+			"Name": "KBVECombat",
+			"Enabled": true
 		}
 	]
 }


### PR DESCRIPTION
Integrates Epic's third-person **Variant_Combat** template into the KBVECombat ecosystem — non-invasively.

`UchuckCombatBridgeComponent` implements **`IKBVECombatant`** and forwards to the owner's **`ICombatDamageable`** (the template's damage contract). Drop it on any template combat actor — `CombatCharacter`, `CombatEnemy`, `CombatDummy`, `CombatDamageableBox` (all implement `ICombatDamageable`) — and KBVECombat systems can damage it through `UKBVECombatStatics::ApplyDamage`:

- KBVE abilities (`UKBVEAbilityComponent`)
- the Mass batch subsystem + DoTs
- status-effect DoTs

`TeamId` drives KBVE hostility (`AreHostile`). No edits to Epic's template files — the bridge adapts the two interface worlds.

## Wiring
- `chuck.Build.cs` + `chuck.uproject`: depend on / enable `KBVECombat`; added the `chuck/Combat` include path.

## Notes
One-directional for now (KBVE → template damage). The reverse (template melee feeding the KBVE feed/stats) is a follow-up: route `ACombatCharacter` HP through `IKBVEStatTarget`, or have the template's `ICombatDamageable::ApplyDamage` mirror into the combat feed. UE 5.7, builds in ci-unreal.