### PR TITLE
chore(chuck): drop unused Lvl_ThirdPerson from cooked maps

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -870,7 +870,7 @@ jobs:
                       -project="$($uproject.FullName)" `
                       -targetplatform=Win64 `
                       -clientconfig=Shipping `
-                      -cook -map=/Game/Menus/L_MainMenu+/Game/Map/L_ChuckWorld+/Game/ThirdPerson/Lvl_ThirdPerson `
+                      -cook -map=/Game/Menus/L_MainMenu+/Game/Map/L_ChuckWorld `
                       -build -stage -pak -archive `
                       -archivedirectory="$out" `
                       -nodebuginfo `

--- a/apps/chuckrpg/unreal-chuck/chuck.uproject
+++ b/apps/chuckrpg/unreal-chuck/chuck.uproject
@@ -23,6 +23,10 @@
 	],
 	"Plugins": [
 		{
+			"Name": "ChaosSolverPlugin",
+			"Enabled": true
+		},
+		{
 			"Name": "ModelingToolsEditorMode",
 			"Enabled": true,
 			"TargetAllowList": [


### PR DESCRIPTION
Clean re-do of #12137 (which conflicted after #12134 merged the 3-map line). Cook only L_MainMenu + L_ChuckWorld.