### PR TITLE
fix(cryptothrone): unblock web + game-server docker publishes (#12129, #12130)

### DIFF
--- a/apps/agones/cryptothrone/server/project.json
+++ b/apps/agones/cryptothrone/server/project.json
@@ -64,22 +64,32 @@
 			}
 		},
 		"container": {
-			"executor": "nx:run-commands",
+			"executor": "@nx-tools/nx-container:build",
 			"defaultConfiguration": "local",
 			"options": {
-				"parallel": false
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/agones/cryptothrone/server/Dockerfile",
+				"metadata": {
+					"images": ["kbve/cryptothrone-server"],
+					"load": true,
+					"tags": ["latest"]
+				}
 			},
 			"configurations": {
 				"local": {
-					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/cryptothrone-server:latest --file apps/agones/cryptothrone/server/Dockerfile .",
-						"VERSION=$(grep '^version' apps/agones/cryptothrone/server/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/cryptothrone-server:latest kbve/cryptothrone-server:$VERSION && echo \"Tagged kbve/cryptothrone-server:$VERSION\""
-					]
+					"tags": ["latest"],
+					"push": false
 				},
-				"ci": {
-					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/cryptothrone-server:latest --file apps/agones/cryptothrone/server/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/cryptothrone-server:buildcache --cache-to=type=registry,ref=ghcr.io/kbve/cryptothrone-server:buildcache,mode=max,image-manifest=true,oci-mediatypes=true ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
-						"VERSION=$(grep '^version' apps/agones/cryptothrone/server/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/cryptothrone-server:latest kbve/cryptothrone-server:$VERSION && echo \"Tagged kbve/cryptothrone-server:$VERSION\""
+				"production": {
+					"tags": ["latest"],
+					"push": true,
+					"customBuildOptions": "--push",
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/cryptothrone-server:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/cryptothrone-server:buildcache,mode=max"
 					]
 				}
 			}

--- a/packages/npm/astro/src/agents/ReactAgentTokenModals.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentTokenModals.tsx
@@ -163,7 +163,9 @@ export function AddTokenModal({ onClose }: BaseModalProps) {
 		setBusy(true);
 		const r = await agents.addToken({
 			tokenName,
-			service,
+			service: service as Parameters<
+				typeof agents.addToken
+			>[0]['service'],
 			tokenValue,
 			description: description.trim() || null,
 		});


### PR DESCRIPTION
Two distinct failures from the release run, both fixed.

## Web — #12130
`@kbve/astro` build died on `ReactAgentTokenModals.tsx:166 — TS2322`: the `service` `string` state isn't assignable to `addToken`'s `TokenServiceValue` union. (Pre-existing in the agents code; surfaced once the package cache invalidated.) It blocks **every** `@kbve/astro` consumer, including cryptothrone's `container-prep`. Cast at the call site — the value is already runtime-validated by `SERVICE_RE` + the preset list.

## Game server — #12129
Publish failed at **"Push Docker Images"** with `No images found matching 'kbve/cryptothrone-server'`. Trace:
- `has_test: false` → skips the test job that builds the promotable `ci-{sha}` image → publish takes the **full-rebuild** path.
- That path ran the raw `nx:run-commands` `docker buildx build --load`, which (with the CI docker-container buildx driver) never surfaced the image in `docker images` for the push step. The workflow's re-export fallback also fails here — its `find . -path "*/<project>/Dockerfile"` assumes the dir is named after the project, but the Dockerfile lives in `.../cryptothrone/server/`.
- Fix: switch the container target to **`@nx-tools/nx-container:build`** with `metadata.load: true` + a `production` push config — mirroring **kilobase**, the proven `has_test:false` publisher (and factorio's repo-root context). The image now lands in the daemon for the push step, which retags `:0.0.2` + `:latest` and pushes to GHCR.

Closes #12129, #12130.

Note: nd-server uses the same broken raw `--load` pattern and its MDX notes the image "hasn't landed" — it likely has the same latent bug; out of scope here but worth the same fix.