### PR TITLE
feat(chuck): ROWS session orchestrator (stage 1)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.cpp
@@ -1,0 +1,143 @@
+#include "chuckSessionSubsystem.h"
+
+#include "ROWSAuthSubsystem.h"
+#include "ROWSCharacterSubsystem.h"
+#include "ROWSInstanceSubsystem.h"
+#include "Engine/GameInstance.h"
+#include "GameFramework/PlayerController.h"
+
+void UchuckSessionSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	UGameInstance* GI = GetGameInstance();
+	if (!GI)
+	{
+		return;
+	}
+
+	if (UROWSAuthSubsystem* Auth = GI->GetSubsystem<UROWSAuthSubsystem>())
+	{
+		Auth->OnLoginSuccess.AddDynamic(this, &UchuckSessionSubsystem::HandleLoginSuccess);
+		Auth->OnLoginError.AddDynamic(this, &UchuckSessionSubsystem::HandleLoginError);
+	}
+	if (UROWSCharacterSubsystem* Chars = GI->GetSubsystem<UROWSCharacterSubsystem>())
+	{
+		Chars->OnGetCharactersSuccess.AddDynamic(this, &UchuckSessionSubsystem::HandleCharactersSuccess);
+		Chars->OnGetCharactersError.AddDynamic(this, &UchuckSessionSubsystem::HandleCharactersError);
+	}
+	if (UROWSInstanceSubsystem* Instance = GI->GetSubsystem<UROWSInstanceSubsystem>())
+	{
+		Instance->OnGetZoneInstanceSuccess.AddDynamic(this, &UchuckSessionSubsystem::HandleZoneInstanceSuccess);
+		Instance->OnGetZoneInstanceError.AddDynamic(this, &UchuckSessionSubsystem::HandleZoneInstanceError);
+	}
+}
+
+void UchuckSessionSubsystem::Deinitialize()
+{
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (UROWSAuthSubsystem* Auth = GI->GetSubsystem<UROWSAuthSubsystem>())
+		{
+			Auth->OnLoginSuccess.RemoveDynamic(this, &UchuckSessionSubsystem::HandleLoginSuccess);
+			Auth->OnLoginError.RemoveDynamic(this, &UchuckSessionSubsystem::HandleLoginError);
+		}
+		if (UROWSCharacterSubsystem* Chars = GI->GetSubsystem<UROWSCharacterSubsystem>())
+		{
+			Chars->OnGetCharactersSuccess.RemoveDynamic(this, &UchuckSessionSubsystem::HandleCharactersSuccess);
+			Chars->OnGetCharactersError.RemoveDynamic(this, &UchuckSessionSubsystem::HandleCharactersError);
+		}
+		if (UROWSInstanceSubsystem* Instance = GI->GetSubsystem<UROWSInstanceSubsystem>())
+		{
+			Instance->OnGetZoneInstanceSuccess.RemoveDynamic(this, &UchuckSessionSubsystem::HandleZoneInstanceSuccess);
+			Instance->OnGetZoneInstanceError.RemoveDynamic(this, &UchuckSessionSubsystem::HandleZoneInstanceError);
+		}
+	}
+	Super::Deinitialize();
+}
+
+void UchuckSessionSubsystem::HandleLoginSuccess(const FString& InUserSessionGUID)
+{
+	UserSessionGUID = InUserSessionGUID;
+	OnSessionReady.Broadcast(UserSessionGUID);
+	RefreshCharacters();
+}
+
+void UchuckSessionSubsystem::HandleLoginError(const FString& ErrorMessage)
+{
+	OnSessionError.Broadcast(ErrorMessage);
+}
+
+void UchuckSessionSubsystem::RefreshCharacters()
+{
+	if (UserSessionGUID.IsEmpty())
+	{
+		return;
+	}
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (UROWSCharacterSubsystem* Chars = GI->GetSubsystem<UROWSCharacterSubsystem>())
+		{
+			Chars->GetAllCharacters(UserSessionGUID);
+		}
+	}
+}
+
+void UchuckSessionSubsystem::HandleCharactersSuccess(const TArray<FROWSUserCharacter>& InCharacters)
+{
+	Characters = InCharacters;
+	if (SelectedCharacter.IsEmpty() && Characters.Num() > 0)
+	{
+		SelectedCharacter = Characters[0].CharacterName;
+	}
+	OnCharactersUpdated.Broadcast(Characters);
+}
+
+void UchuckSessionSubsystem::HandleCharactersError(const FString& ErrorMessage)
+{
+	OnSessionError.Broadcast(ErrorMessage);
+}
+
+void UchuckSessionSubsystem::SelectCharacter(const FString& CharacterName)
+{
+	SelectedCharacter = CharacterName;
+}
+
+bool UchuckSessionSubsystem::RequestEnterWorld(const FString& ZoneName)
+{
+	if (SelectedCharacter.IsEmpty())
+	{
+		return false;
+	}
+	UGameInstance* GI = GetGameInstance();
+	UROWSInstanceSubsystem* Instance = GI ? GI->GetSubsystem<UROWSInstanceSubsystem>() : nullptr;
+	if (!Instance)
+	{
+		return false;
+	}
+	Instance->GetServerToConnectTo(SelectedCharacter, ZoneName);
+	return true;
+}
+
+void UchuckSessionSubsystem::HandleZoneInstanceSuccess(const FROWSZoneInstance& ZoneInstance)
+{
+	OnServerReady.Broadcast(ZoneInstance.ServerIP, ZoneInstance.Port);
+
+	if (ZoneInstance.ServerIP.IsEmpty() || ZoneInstance.Port <= 0)
+	{
+		return;
+	}
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (APlayerController* PC = GI->GetFirstLocalPlayerController())
+		{
+			const FString Address = FString::Printf(TEXT("%s:%d"), *ZoneInstance.ServerIP, ZoneInstance.Port);
+			PC->ClientTravel(Address, TRAVEL_Absolute);
+		}
+	}
+}
+
+void UchuckSessionSubsystem::HandleZoneInstanceError(const FString& ErrorMessage)
+{
+	OnSessionError.Broadcast(ErrorMessage);
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "ROWSTypes.h"
+#include "chuckSessionSubsystem.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnChuckSessionReady, const FString&, UserSessionGUID);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnChuckCharactersUpdated, const TArray<FROWSUserCharacter>&, Characters);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_TwoParams(FOnChuckServerReady, const FString&, ServerIP, int32, Port);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnChuckSessionError, const FString&, ErrorMessage);
+
+/**
+ * Orchestrates the chuck client session flow over KBVEROWS: ROWS login (driven by the
+ * Supabase bridge) -> fetch characters -> select -> request a server -> travel. UI binds
+ * to the delegates; gameplay calls SelectCharacter / RequestEnterWorld.
+ */
+UCLASS()
+class CHUCK_API UchuckSessionSubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	UFUNCTION(BlueprintCallable, Category = "Chuck|Session")
+	void RefreshCharacters();
+
+	UFUNCTION(BlueprintCallable, Category = "Chuck|Session")
+	void SelectCharacter(const FString& CharacterName);
+
+	UFUNCTION(BlueprintCallable, Category = "Chuck|Session")
+	bool RequestEnterWorld(const FString& ZoneName);
+
+	UFUNCTION(BlueprintPure, Category = "Chuck|Session")
+	const TArray<FROWSUserCharacter>& GetCharacters() const { return Characters; }
+
+	UFUNCTION(BlueprintPure, Category = "Chuck|Session")
+	const FString& GetSelectedCharacter() const { return SelectedCharacter; }
+
+	UFUNCTION(BlueprintPure, Category = "Chuck|Session")
+	bool IsSessionReady() const { return !UserSessionGUID.IsEmpty(); }
+
+	UPROPERTY(BlueprintAssignable, Category = "Chuck|Session")
+	FOnChuckSessionReady OnSessionReady;
+
+	UPROPERTY(BlueprintAssignable, Category = "Chuck|Session")
+	FOnChuckCharactersUpdated OnCharactersUpdated;
+
+	UPROPERTY(BlueprintAssignable, Category = "Chuck|Session")
+	FOnChuckServerReady OnServerReady;
+
+	UPROPERTY(BlueprintAssignable, Category = "Chuck|Session")
+	FOnChuckSessionError OnSessionError;
+
+private:
+	UFUNCTION()
+	void HandleLoginSuccess(const FString& InUserSessionGUID);
+
+	UFUNCTION()
+	void HandleLoginError(const FString& ErrorMessage);
+
+	UFUNCTION()
+	void HandleCharactersSuccess(const TArray<FROWSUserCharacter>& InCharacters);
+
+	UFUNCTION()
+	void HandleCharactersError(const FString& ErrorMessage);
+
+	UFUNCTION()
+	void HandleZoneInstanceSuccess(const FROWSZoneInstance& ZoneInstance);
+
+	UFUNCTION()
+	void HandleZoneInstanceError(const FString& ErrorMessage);
+
+	FString UserSessionGUID;
+	FString SelectedCharacter;
+
+	UPROPERTY()
+	TArray<FROWSUserCharacter> Characters;
+};


### PR DESCRIPTION
Stage 1 of the ROWS client flow. KBVEROWS was enabled in chuck but only `AdoptSupabaseSession` was ever called — the character + instance subsystems were unused. This wires them into a single orchestrator.

`UchuckSessionSubsystem` (GameInstance subsystem):
- Binds `UROWSAuthSubsystem::OnLoginSuccess` (the Supabase→ROWS bridge drives it) → caches `UserSessionGUID` → fetches characters (`UROWSCharacterSubsystem::GetAllCharacters`).
- Caches the `FROWSUserCharacter` list + selection; `SelectCharacter` / `RequestEnterWorld`.
- `RequestEnterWorld` → `UROWSInstanceSubsystem::GetServerToConnectTo` → on `OnGetZoneInstanceSuccess`, `ClientTravel` to `ServerIP:Port` (Iris already enabled).
- Exposes `OnSessionReady` / `OnCharactersUpdated` / `OnServerReady` / `OnSessionError` for the character-select + lobby UI.

## The 4-stage plan
1. **ROWS plugin integration** — this PR (the flow backbone; plugin was already enabled).
2. **ROWS key** — customer/service keys: config plumbing already exists (`UROWSSubsystem` reads `DefaultGame.ini` OWS keys + env). Values stay **env/sealed-secret, not committed**. Server side needs `SUPABASE_SERVICE_KEY_HASH` in the rows k8s deployment (separate ops PR).
3. **Character selection UI** — Slate widget binding `OnCharactersUpdated` + `Create/RemoveCharacter`.
4. **Lobby + Iris** — already half-done here (server request + travel); stage 4 = the lobby UI/zone pick polish.

UE 5.7, builds in ci-unreal. chuck-only, no new plugin / manifest change.