### PR TITLE
feat(KBVEWorld): terrain render subsystem (merge chunks per region, ~547->~34 draw calls)

### DIFF
--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldChunkActor.cpp
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldChunkActor.cpp
@@ -6,6 +6,7 @@
 #include "KBVEWorldGrassData.h"
 #include "KBVEWorldGrassMass.h"
 #include "KBVEWorldGrassRenderSubsystem.h"
+#include "KBVEWorldTerrainRenderSubsystem.h"
 #include "KBVEWorldTerrainShader.h"
 #include "Components/HierarchicalInstancedStaticMeshComponent.h"
 #include "Components/StaticMeshComponent.h"
@@ -59,6 +60,18 @@ AKBVEWorldChunkActor::AKBVEWorldChunkActor()
 void AKBVEWorldChunkActor::BeginPlay()
 {
 	Super::BeginPlay();
+}
+
+void AKBVEWorldChunkActor::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+	if (UWorld* W = GetWorld())
+	{
+		if (UKBVEWorldTerrainRenderSubsystem* Terrain = W->GetSubsystem<UKBVEWorldTerrainRenderSubsystem>())
+		{
+			Terrain->ReleaseChunkTerrain(Coord);
+		}
+	}
+	Super::EndPlay(EndPlayReason);
 }
 
 void AKBVEWorldChunkActor::GenerateMeshData(FKBVEWorldChunkMesh& OutMesh) const
@@ -181,37 +194,16 @@ void AKBVEWorldChunkActor::GenerateMeshData(FKBVEWorldChunkMesh& OutMesh) const
 void AKBVEWorldChunkActor::UploadMesh(const FKBVEWorldChunkMesh& MeshData)
 {
 	KBVEPERF_SCOPE("Terrain.UploadMesh");
-	if (!Mesh) return;
-	const int32 VertCount = MeshData.Vertices.Num();
-	TArray<FColor> VertexColors; VertexColors.Init(FColor::White, VertCount);
+	if (Mesh)
 	{
-		KBVEPERF_SCOPE("Terrain.ClearSections");
 		Mesh->ClearAllMeshSections();
 	}
+	if (UWorld* W = GetWorld())
 	{
-		KBVEPERF_SCOPE("Terrain.CreateSection");
-		Mesh->CreateMeshSection(0, MeshData.Vertices, MeshData.Triangles, MeshData.Normals, MeshData.UVs, VertexColors, MeshData.Tangents, true);
-	}
-
-	TWeakObjectPtr<UProceduralMeshComponent> WeakMesh(Mesh);
-	FTimerHandle NavTimer;
-	GetWorldTimerManager().SetTimer(NavTimer, [WeakMesh]()
-	{
-		if (UProceduralMeshComponent* M = WeakMesh.Get())
+		if (UKBVEWorldTerrainRenderSubsystem* Terrain = W->GetSubsystem<UKBVEWorldTerrainRenderSubsystem>())
 		{
-			FNavigationSystem::UpdateComponentData(*M);
+			Terrain->RegisterChunkTerrain(Coord, GetActorLocation(), MeshData);
 		}
-	}, 0.5f, false);
-
-	UMaterialInterface* Apply = GroundMaterialOverride;
-	{
-		KBVEPERF_SCOPE("Terrain.GetGroundMaterial");
-		if (!Apply) Apply = FKBVEWorldTerrainShader::GetOrCreateGroundMaterial(this);
-	}
-	if (!Apply) Apply = GroundMaterial;
-	{
-		KBVEPERF_SCOPE("Terrain.SetMaterial");
-		if (Apply) Mesh->SetMaterial(0, Apply);
 	}
 }
 
@@ -601,6 +593,10 @@ void AKBVEWorldChunkActor::ClearFoliage()
 		if (UKBVEWorldGrassRenderSubsystem* Render = W->GetSubsystem<UKBVEWorldGrassRenderSubsystem>())
 		{
 			Render->ReleaseChunkInstances(Coord);
+		}
+		if (UKBVEWorldTerrainRenderSubsystem* Terrain = W->GetSubsystem<UKBVEWorldTerrainRenderSubsystem>())
+		{
+			Terrain->ReleaseChunkTerrain(Coord);
 		}
 	}
 }

--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldTerrainRenderSubsystem.cpp
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Private/KBVEWorldTerrainRenderSubsystem.cpp
@@ -1,0 +1,200 @@
+#include "KBVEWorldTerrainRenderSubsystem.h"
+
+#include "KBVEWorldTerrainShader.h"
+#include "Components/SceneComponent.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "ProceduralMeshComponent.h"
+#include "NavigationSystem.h"
+
+namespace KBVETerrainCfg
+{
+	constexpr int32 RegionSize = 4;
+}
+
+bool UKBVEWorldTerrainRenderSubsystem::ShouldCreateSubsystem(UObject* Outer) const
+{
+	if (!Super::ShouldCreateSubsystem(Outer)) return false;
+	const UWorld* W = Cast<UWorld>(Outer);
+	return W && W->IsGameWorld();
+}
+
+void UKBVEWorldTerrainRenderSubsystem::Deinitialize()
+{
+	for (TPair<FIntPoint, FKBVEWorldTerrainRegion>& Pair : Regions)
+	{
+		if (Pair.Value.Section)
+		{
+			Pair.Value.Section->ClearAllMeshSections();
+		}
+	}
+	if (HostActor)
+	{
+		HostActor->Destroy();
+		HostActor = nullptr;
+	}
+	Regions.Reset();
+	PendingChunks.Reset();
+	DirtyRegions.Reset();
+	GroundMaterial = nullptr;
+	Super::Deinitialize();
+}
+
+void UKBVEWorldTerrainRenderSubsystem::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+	if (DirtyRegions.Num() == 0) return;
+	EnsureHost();
+	if (!HostActor) return;
+
+	TArray<FIntPoint> ToBuild = DirtyRegions.Array();
+	DirtyRegions.Reset();
+	for (const FIntPoint& Key : ToBuild)
+	{
+		RebuildRegion(Key);
+	}
+}
+
+FIntPoint UKBVEWorldTerrainRenderSubsystem::RegionKeyFor(FIntPoint ChunkCoord) const
+{
+	auto FloorDiv = [](int32 A, int32 B)
+	{
+		return (A >= 0) ? (A / B) : -(((-A) + B - 1) / B);
+	};
+	return FIntPoint(FloorDiv(ChunkCoord.X, KBVETerrainCfg::RegionSize), FloorDiv(ChunkCoord.Y, KBVETerrainCfg::RegionSize));
+}
+
+void UKBVEWorldTerrainRenderSubsystem::RegisterChunkTerrain(FIntPoint ChunkCoord, const FVector& ChunkWorldOrigin, const FKBVEWorldChunkMesh& Mesh)
+{
+	if (!Mesh.IsValidMesh()) return;
+
+	FKBVEWorldTerrainPendingChunk& P = PendingChunks.FindOrAdd(ChunkCoord);
+	P.WorldOrigin = ChunkWorldOrigin;
+	P.Mesh = Mesh;
+
+	const FIntPoint Key = RegionKeyFor(ChunkCoord);
+	Regions.FindOrAdd(Key).Members.Add(ChunkCoord);
+	DirtyRegions.Add(Key);
+}
+
+void UKBVEWorldTerrainRenderSubsystem::ReleaseChunkTerrain(FIntPoint ChunkCoord)
+{
+	if (PendingChunks.Remove(ChunkCoord) == 0) return;
+
+	const FIntPoint Key = RegionKeyFor(ChunkCoord);
+	if (FKBVEWorldTerrainRegion* R = Regions.Find(Key))
+	{
+		R->Members.Remove(ChunkCoord);
+		DirtyRegions.Add(Key);
+	}
+}
+
+void UKBVEWorldTerrainRenderSubsystem::EnsureHost()
+{
+	if (HostActor) return;
+	UWorld* W = GetWorld();
+	if (!W) return;
+
+	FActorSpawnParameters Params;
+	Params.ObjectFlags |= RF_Transient;
+	Params.SpawnCollisionHandlingOverride = ESpawnActorCollisionHandlingMethod::AlwaysSpawn;
+	HostActor = W->SpawnActor<AActor>(AActor::StaticClass(), FVector::ZeroVector, FRotator::ZeroRotator, Params);
+	if (!HostActor) return;
+
+	USceneComponent* Root = NewObject<USceneComponent>(HostActor, TEXT("TerrainRoot"), RF_Transient);
+	HostActor->SetRootComponent(Root);
+	Root->RegisterComponent();
+}
+
+UProceduralMeshComponent* UKBVEWorldTerrainRenderSubsystem::EnsureRegionSection(FIntPoint RegionKey)
+{
+	FKBVEWorldTerrainRegion& R = Regions.FindOrAdd(RegionKey);
+	if (R.Section) return R.Section;
+	if (!HostActor) return nullptr;
+
+	UProceduralMeshComponent* PMC = NewObject<UProceduralMeshComponent>(HostActor, NAME_None, RF_Transient);
+	PMC->SetMobility(EComponentMobility::Movable);
+	PMC->SetupAttachment(HostActor->GetRootComponent());
+	PMC->SetCanEverAffectNavigation(true);
+	PMC->RegisterComponent();
+	R.Section = PMC;
+	return PMC;
+}
+
+void UKBVEWorldTerrainRenderSubsystem::RebuildRegion(FIntPoint RegionKey)
+{
+	FKBVEWorldTerrainRegion* RPtr = Regions.Find(RegionKey);
+	if (!RPtr) return;
+	FKBVEWorldTerrainRegion& R = *RPtr;
+
+	if (R.Members.Num() == 0)
+	{
+		if (R.Section)
+		{
+			R.Section->DestroyComponent();
+			R.Section = nullptr;
+		}
+		Regions.Remove(RegionKey);
+		return;
+	}
+
+	int32 CellsPerEdge = 32;
+	float CellSize = 200.f;
+	for (const FIntPoint& C : R.Members)
+	{
+		if (const FKBVEWorldTerrainPendingChunk* P = PendingChunks.Find(C))
+		{
+			CellsPerEdge = P->Mesh.CellsPerEdge;
+			CellSize = P->Mesh.CellSize;
+			break;
+		}
+	}
+	const float RegionWorldSize = CellsPerEdge * CellSize * KBVETerrainCfg::RegionSize;
+	R.Origin = FVector(RegionKey.X * RegionWorldSize, RegionKey.Y * RegionWorldSize, 0.f);
+
+	TArray<FVector> Verts;
+	TArray<int32> Tris;
+	TArray<FVector> Normals;
+	TArray<FVector2D> UVs;
+	TArray<FProcMeshTangent> Tangents;
+
+	for (const FIntPoint& C : R.Members)
+	{
+		const FKBVEWorldTerrainPendingChunk* P = PendingChunks.Find(C);
+		if (!P || !P->Mesh.IsValidMesh()) continue;
+
+		const FVector Offset = P->WorldOrigin - R.Origin;
+		const int32 Base = Verts.Num();
+		const FKBVEWorldChunkMesh& M = P->Mesh;
+
+		Verts.Reserve(Verts.Num() + M.Vertices.Num());
+		for (const FVector& V : M.Vertices) Verts.Add(V + Offset);
+
+		Tris.Reserve(Tris.Num() + M.Triangles.Num());
+		for (int32 T : M.Triangles) Tris.Add(T + Base);
+
+		Normals.Append(M.Normals);
+		UVs.Append(M.UVs);
+		Tangents.Append(M.Tangents);
+	}
+
+	if (Verts.Num() == 0) return;
+
+	UProceduralMeshComponent* PMC = EnsureRegionSection(RegionKey);
+	if (!PMC) return;
+	PMC->SetWorldLocation(R.Origin);
+
+	if (!GroundMaterial)
+	{
+		GroundMaterial = FKBVEWorldTerrainShader::GetOrCreateGroundMaterial(this);
+	}
+
+	TArray<FColor> Colors;
+	Colors.Init(FColor::White, Verts.Num());
+
+	PMC->ClearAllMeshSections();
+	PMC->CreateMeshSection(0, Verts, Tris, Normals, UVs, Colors, Tangents, true);
+	if (GroundMaterial) PMC->SetMaterial(0, GroundMaterial);
+
+	FNavigationSystem::UpdateComponentData(*PMC);
+}

--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldChunkActor.h
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldChunkActor.h
@@ -41,6 +41,7 @@ public:
 
 protected:
 	virtual void BeginPlay() override;
+	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
 
 	UPROPERTY(VisibleAnywhere)
 	TObjectPtr<UProceduralMeshComponent> Mesh;

--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldTerrainRenderSubsystem.h
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldTerrainRenderSubsystem.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "KBVEWorldChunkBlob.h"
+#include "KBVEWorldTerrainRenderSubsystem.generated.h"
+
+class AActor;
+class UProceduralMeshComponent;
+class UMaterialInterface;
+
+USTRUCT()
+struct FKBVEWorldTerrainPendingChunk
+{
+	GENERATED_BODY()
+
+	FVector WorldOrigin = FVector::ZeroVector;
+	FKBVEWorldChunkMesh Mesh;
+};
+
+USTRUCT()
+struct FKBVEWorldTerrainRegion
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Transient)
+	TObjectPtr<UProceduralMeshComponent> Section = nullptr;
+
+	FVector Origin = FVector::ZeroVector;
+	TSet<FIntPoint> Members;
+	bool bDirty = false;
+};
+
+UCLASS()
+class KBVEWORLD_API UKBVEWorldTerrainRenderSubsystem : public UTickableWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+	virtual void Deinitialize() override;
+	virtual void Tick(float DeltaTime) override;
+	virtual TStatId GetStatId() const override { RETURN_QUICK_DECLARE_CYCLE_STAT(UKBVEWorldTerrainRenderSubsystem, STATGROUP_Tickables); }
+
+	void RegisterChunkTerrain(FIntPoint ChunkCoord, const FVector& ChunkWorldOrigin, const FKBVEWorldChunkMesh& Mesh);
+	void ReleaseChunkTerrain(FIntPoint ChunkCoord);
+
+private:
+	FIntPoint RegionKeyFor(FIntPoint ChunkCoord) const;
+	void EnsureHost();
+	UProceduralMeshComponent* EnsureRegionSection(FIntPoint RegionKey);
+	void RebuildRegion(FIntPoint RegionKey);
+
+	UPROPERTY(Transient)
+	TObjectPtr<AActor> HostActor = nullptr;
+
+	UPROPERTY(Transient)
+	TObjectPtr<UMaterialInterface> GroundMaterial = nullptr;
+
+	TMap<FIntPoint, FKBVEWorldTerrainPendingChunk> PendingChunks;
+
+	UPROPERTY(Transient)
+	TMap<FIntPoint, FKBVEWorldTerrainRegion> Regions;
+
+	TSet<FIntPoint> DirtyRegions;
+};


### PR DESCRIPTION
## Problem
Each terrain chunk (`AKBVEWorldChunkActor`) owned its own `UProceduralMeshComponent` + section → **547 chunks = 547 draw calls (~9.5ms render)**.

## Module
New `UKBVEWorldTerrainRenderSubsystem` (UTickableWorldSubsystem), mirroring `KBVEWorldGrassRenderSubsystem`:
- Chunks call `RegisterChunkTerrain(coord, worldOrigin, mesh)` / `ReleaseChunkTerrain(coord)` instead of building their own PMC.
- Groups chunks by **super-region** (`coord / RegionSize`, RegionSize=4) and keeps **one** PMC per resident region with **one merged section** — member chunk meshes concatenated (verts offset to region space, triangle indices rebased), per-region nav update, dirty-region rebuild in Tick.
- 4×4 → ~34 draw calls; the register/release API is unchanged so `RebuildRegion` can later swap to a 1-draw-call heightmap-HISM without touching chunks.

## Cutover
`AKBVEWorldChunkActor::UploadMesh` registers with the subsystem + clears its own (now-empty) PMC; terrain released on recycle (`ClearFoliage`) and destroy (`EndPlay`). `Regions` is a UPROPERTY so GC tracks the region PMCs.

Confirmed design: RegionSize=4, per-region nav. CI compiles it on the Win64 chuck build. Part of #11987.