### PR TITLE
feat(rows): wire SUPABASE_SERVICE_KEY_HASH into ROWS deployments

### DIFF
--- a/apps/kube/rows/manifest/externalsecret.yaml
+++ b/apps/kube/rows/manifest/externalsecret.yaml
@@ -117,3 +117,22 @@ spec:
           remoteRef:
               key: supabase-jwt
               property: secret
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: rows-supabase-service-key
+    namespace: rows
+spec:
+    refreshInterval: 15m
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: rows-supabase-service-key
+        creationPolicy: Owner
+    data:
+        - secretKey: hash
+          remoteRef:
+              key: supabase-service-key
+              property: hash

--- a/apps/kube/rows/manifest/rows-deployment.yaml
+++ b/apps/kube/rows/manifest/rows-deployment.yaml
@@ -75,6 +75,12 @@ spec:
                             secretKeyRef:
                                 name: rows-supabase-jwt
                                 key: jwt-secret
+                      - name: SUPABASE_SERVICE_KEY_HASH
+                        valueFrom:
+                            secretKeyRef:
+                                name: rows-supabase-service-key
+                                key: hash
+                                optional: true
                       - name: SUPABASE_URL
                         value: 'https://supabase.kbve.com'
                       # ─── Agones ──────────────────────────────

--- a/apps/kube/rows/tenants/base/deployment.yaml
+++ b/apps/kube/rows/tenants/base/deployment.yaml
@@ -61,6 +61,12 @@ spec:
                             secretKeyRef:
                                 name: rows-supabase-jwt
                                 key: jwt-secret
+                      - name: SUPABASE_SERVICE_KEY_HASH
+                        valueFrom:
+                            secretKeyRef:
+                                name: rows-supabase-service-key
+                                key: hash
+                                optional: true
                       - name: SUPABASE_URL
                         value: 'https://supabase.kbve.com'
                       - name: AGONES_NAMESPACE

--- a/apps/kube/rows/tenants/base/secrets.yaml
+++ b/apps/kube/rows/tenants/base/secrets.yaml
@@ -130,6 +130,24 @@ spec:
               key: supabase-jwt
               property: secret
 ---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: rows-supabase-service-key
+spec:
+    refreshInterval: 15m
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: rows-supabase-service-key
+        creationPolicy: Owner
+    data:
+        - secretKey: hash
+          remoteRef:
+              key: supabase-service-key
+              property: hash
+---
 # Lets the shared kbve-gateway (in the kbve namespace) reference this tenant's TLS Secret.
 apiVersion: gateway.networking.k8s.io/v1beta1
 kind: ReferenceGrant


### PR DESCRIPTION
Stage 2 (server-to-server key) of the ROWS flow. Completes the `x-service-key` auth loop so the chuck dedicated server can call ROWS instance-management RPCs.

## What was already there
- Agones `ows-service-key` ExternalSecret projects the **plaintext** key from `kilobase/supabase-service-key` (property `key`) into the GameServer pods → fleet `OWS_SERVICE_KEY`.
- ROWS validates `x-service-key` against an argon2 hash in `SUPABASE_SERVICE_KEY_HASH`.

## The gap (this PR)
`SUPABASE_SERVICE_KEY_HASH` was never wired into the ROWS deployments. Added to **both** paths:
- `rows/manifest`: new `rows-supabase-service-key` ExternalSecret (kilobase `supabase-service-key` property **`hash`**) + deployment env.
- `rows/tenants/base`: same ExternalSecret + deployment env (covers `chuckrpg-dev` / `chuckrpg-beta` / `rentearth` overlays).

`optional: true` on the env so ROWS keeps booting before the secret exists.

## Not in this PR (your action)
- Provision the kilobase **`supabase-service-key`** secret with both `key` (plaintext) + `hash` (argon2 of the service role key) properties — secret value, not committed.
- ArgoCD applies after the next **dev→main** release.
- Dedicated-server build must send the `x-service-key` header (from `OWS_SERVICE_KEY`) on ROWS calls — client-side follow-up.

No app code; manifests only.