### PR TITLE
fix(nd-server): @nx-tools/nx-container container target so its image publishes

### DIFF
--- a/apps/godot/nexus-defense/server/project.json
+++ b/apps/godot/nexus-defense/server/project.json
@@ -38,22 +38,32 @@
 			}
 		},
 		"container": {
-			"executor": "nx:run-commands",
+			"executor": "@nx-tools/nx-container:build",
 			"defaultConfiguration": "local",
 			"options": {
-				"parallel": false
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/godot/nexus-defense/server/Dockerfile",
+				"metadata": {
+					"images": ["kbve/nd-server"],
+					"load": true,
+					"tags": ["latest"]
+				}
 			},
 			"configurations": {
 				"local": {
-					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/nd-server:latest --file apps/godot/nexus-defense/server/Dockerfile .",
-						"VERSION=$(grep '^version' apps/godot/nexus-defense/server/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/nd-server:latest kbve/nd-server:$VERSION && echo \"Tagged kbve/nd-server:$VERSION\""
-					]
+					"tags": ["latest"],
+					"push": false
 				},
-				"ci": {
-					"commands": [
-						"BUILDKIT_PROGRESS=plain docker buildx build --load --tag kbve/nd-server:latest --file apps/godot/nexus-defense/server/Dockerfile --cache-from=type=registry,ref=ghcr.io/kbve/nd-server:buildcache --cache-to=type=registry,ref=ghcr.io/kbve/nd-server:buildcache,mode=max,image-manifest=true,oci-mediatypes=true ${VALKEY_PASSWORD:+--secret id=valkey_password,env=VALKEY_PASSWORD} .",
-						"VERSION=$(grep '^version' apps/godot/nexus-defense/server/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/nd-server:latest kbve/nd-server:$VERSION && echo \"Tagged kbve/nd-server:$VERSION\""
+				"production": {
+					"tags": ["latest"],
+					"push": true,
+					"customBuildOptions": "--push",
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/nd-server:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/nd-server:buildcache,mode=max"
 					]
 				}
 			}


### PR DESCRIPTION
Same latent publish bug fixed for cryptothrone-server in #12139, now for nd-server.

nd-server's container target used raw `nx:run-commands` `docker buildx build --load`. On the publish workflow's full-rebuild path (`has_test:false`), that `--load` never surfaces the image in the daemon for the "Push Docker Images" step → `No images found` → the image never lands on `ghcr.io/kbve/nd-server` (its MDX even notes the image hasn't landed yet).

Fix: switch to `@nx-tools/nx-container:build` with `metadata.load: true` + a `production` push config, mirroring kilobase (the proven `has_test:false` publisher).