### PR TITLE
feat(chuck): character-select UI (ROWS flow stage 3)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.cpp
@@ -25,6 +25,10 @@ void UchuckSessionSubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	{
 		Chars->OnGetCharactersSuccess.AddDynamic(this, &UchuckSessionSubsystem::HandleCharactersSuccess);
 		Chars->OnGetCharactersError.AddDynamic(this, &UchuckSessionSubsystem::HandleCharactersError);
+		Chars->OnCreateCharacterSuccess.AddDynamic(this, &UchuckSessionSubsystem::HandleCreateSuccess);
+		Chars->OnCreateCharacterError.AddDynamic(this, &UchuckSessionSubsystem::HandleMutationError);
+		Chars->OnRemoveCharacterSuccess.AddDynamic(this, &UchuckSessionSubsystem::HandleRemoveSuccess);
+		Chars->OnRemoveCharacterError.AddDynamic(this, &UchuckSessionSubsystem::HandleMutationError);
 	}
 	if (UROWSInstanceSubsystem* Instance = GI->GetSubsystem<UROWSInstanceSubsystem>())
 	{
@@ -46,6 +50,10 @@ void UchuckSessionSubsystem::Deinitialize()
 		{
 			Chars->OnGetCharactersSuccess.RemoveDynamic(this, &UchuckSessionSubsystem::HandleCharactersSuccess);
 			Chars->OnGetCharactersError.RemoveDynamic(this, &UchuckSessionSubsystem::HandleCharactersError);
+			Chars->OnCreateCharacterSuccess.RemoveDynamic(this, &UchuckSessionSubsystem::HandleCreateSuccess);
+			Chars->OnCreateCharacterError.RemoveDynamic(this, &UchuckSessionSubsystem::HandleMutationError);
+			Chars->OnRemoveCharacterSuccess.RemoveDynamic(this, &UchuckSessionSubsystem::HandleRemoveSuccess);
+			Chars->OnRemoveCharacterError.RemoveDynamic(this, &UchuckSessionSubsystem::HandleMutationError);
 		}
 		if (UROWSInstanceSubsystem* Instance = GI->GetSubsystem<UROWSInstanceSubsystem>())
 		{
@@ -101,6 +109,55 @@ void UchuckSessionSubsystem::HandleCharactersError(const FString& ErrorMessage)
 void UchuckSessionSubsystem::SelectCharacter(const FString& CharacterName)
 {
 	SelectedCharacter = CharacterName;
+}
+
+void UchuckSessionSubsystem::CreateCharacter(const FString& CharacterName, const FString& ClassName)
+{
+	if (UserSessionGUID.IsEmpty() || CharacterName.IsEmpty())
+	{
+		return;
+	}
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (UROWSCharacterSubsystem* Chars = GI->GetSubsystem<UROWSCharacterSubsystem>())
+		{
+			Chars->CreateCharacter(UserSessionGUID, CharacterName, ClassName);
+		}
+	}
+}
+
+void UchuckSessionSubsystem::RemoveCharacter(const FString& CharacterName)
+{
+	if (UserSessionGUID.IsEmpty() || CharacterName.IsEmpty())
+	{
+		return;
+	}
+	if (CharacterName == SelectedCharacter)
+	{
+		SelectedCharacter.Reset();
+	}
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (UROWSCharacterSubsystem* Chars = GI->GetSubsystem<UROWSCharacterSubsystem>())
+		{
+			Chars->RemoveCharacter(UserSessionGUID, CharacterName);
+		}
+	}
+}
+
+void UchuckSessionSubsystem::HandleCreateSuccess(const FROWSCreateCharacterResponse& Response)
+{
+	RefreshCharacters();
+}
+
+void UchuckSessionSubsystem::HandleRemoveSuccess()
+{
+	RefreshCharacters();
+}
+
+void UchuckSessionSubsystem::HandleMutationError(const FString& ErrorMessage)
+{
+	OnSessionError.Broadcast(ErrorMessage);
 }
 
 bool UchuckSessionSubsystem::RequestEnterWorld(const FString& ZoneName)

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.h
@@ -31,6 +31,12 @@ public:
 	void SelectCharacter(const FString& CharacterName);
 
 	UFUNCTION(BlueprintCallable, Category = "Chuck|Session")
+	void CreateCharacter(const FString& CharacterName, const FString& ClassName);
+
+	UFUNCTION(BlueprintCallable, Category = "Chuck|Session")
+	void RemoveCharacter(const FString& CharacterName);
+
+	UFUNCTION(BlueprintCallable, Category = "Chuck|Session")
 	bool RequestEnterWorld(const FString& ZoneName);
 
 	UFUNCTION(BlueprintPure, Category = "Chuck|Session")
@@ -68,10 +74,19 @@ private:
 	void HandleCharactersError(const FString& ErrorMessage);
 
 	UFUNCTION()
+	void HandleCreateSuccess(const FROWSCreateCharacterResponse& Response);
+
+	UFUNCTION()
+	void HandleRemoveSuccess();
+
+	UFUNCTION()
 	void HandleZoneInstanceSuccess(const FROWSZoneInstance& ZoneInstance);
 
 	UFUNCTION()
 	void HandleZoneInstanceError(const FString& ErrorMessage);
+
+	UFUNCTION()
+	void HandleMutationError(const FString& ErrorMessage);
 
 	FString UserSessionGUID;
 	FString SelectedCharacter;

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckCharacterSelect.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckCharacterSelect.cpp
@@ -1,0 +1,131 @@
+#include "SchuckCharacterSelect.h"
+#include "chuckSessionSubsystem.h"
+
+#include "Widgets/SBoxPanel.h"
+#include "Widgets/Text/STextBlock.h"
+#include "Widgets/Input/SButton.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Views/STableRow.h"
+#include "Widgets/Layout/SBorder.h"
+
+void SchuckCharacterSelect::Construct(const FArguments& InArgs)
+{
+	Session = InArgs._Session;
+	OnEnterWorld = InArgs._OnEnterWorld;
+
+	ChildSlot
+	[
+		SNew(SBorder)
+		.Padding(16.0f)
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot().AutoHeight().Padding(4.0f)
+			[
+				SNew(STextBlock).Text(NSLOCTEXT("chuck", "CharSelectTitle", "Select Character"))
+			]
+			+ SVerticalBox::Slot().FillHeight(1.0f).Padding(4.0f)
+			[
+				SAssignNew(ListView, SListView<TSharedPtr<FROWSUserCharacter>>)
+				.ListItemsSource(&Items)
+				.OnGenerateRow(this, &SchuckCharacterSelect::OnGenerateRow)
+				.OnSelectionChanged(this, &SchuckCharacterSelect::OnSelectionChanged)
+				.SelectionMode(ESelectionMode::Single)
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(4.0f)
+			[
+				SNew(SHorizontalBox)
+				+ SHorizontalBox::Slot().FillWidth(1.0f)
+				[
+					SAssignNew(NameBox, SEditableTextBox)
+					.HintText(NSLOCTEXT("chuck", "CharNameHint", "New character name"))
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(4.0f, 0.0f)
+				[
+					SNew(SButton)
+					.Text(NSLOCTEXT("chuck", "CharCreate", "Create"))
+					.OnClicked(this, &SchuckCharacterSelect::HandleCreate)
+				]
+				+ SHorizontalBox::Slot().AutoWidth().Padding(4.0f, 0.0f)
+				[
+					SNew(SButton)
+					.Text(NSLOCTEXT("chuck", "CharDelete", "Delete"))
+					.OnClicked(this, &SchuckCharacterSelect::HandleDelete)
+				]
+			]
+			+ SVerticalBox::Slot().AutoHeight().Padding(4.0f)
+			[
+				SNew(SButton)
+				.Text(NSLOCTEXT("chuck", "CharEnter", "Enter World"))
+				.OnClicked(this, &SchuckCharacterSelect::HandleEnter)
+			]
+		]
+	];
+}
+
+void SchuckCharacterSelect::RefreshList(const TArray<FROWSUserCharacter>& Characters)
+{
+	Items.Reset();
+	for (const FROWSUserCharacter& Character : Characters)
+	{
+		Items.Add(MakeShared<FROWSUserCharacter>(Character));
+	}
+	if (ListView.IsValid())
+	{
+		ListView->RequestListRefresh();
+	}
+}
+
+TSharedRef<ITableRow> SchuckCharacterSelect::OnGenerateRow(TSharedPtr<FROWSUserCharacter> Item, const TSharedRef<STableViewBase>& OwnerTable)
+{
+	const FText Label = FText::FromString(FString::Printf(TEXT("%s  (Lv %d %s)"), *Item->CharacterName, Item->Level, *Item->ClassName));
+	return SNew(STableRow<TSharedPtr<FROWSUserCharacter>>, OwnerTable)
+		[
+			SNew(STextBlock).Text(Label)
+		];
+}
+
+void SchuckCharacterSelect::OnSelectionChanged(TSharedPtr<FROWSUserCharacter> Item, ESelectInfo::Type SelectInfo)
+{
+	if (!Item.IsValid())
+	{
+		return;
+	}
+	SelectedName = Item->CharacterName;
+	if (Session.IsValid())
+	{
+		Session->SelectCharacter(SelectedName);
+	}
+}
+
+FReply SchuckCharacterSelect::HandleCreate()
+{
+	if (Session.IsValid() && NameBox.IsValid())
+	{
+		const FString Name = NameBox->GetText().ToString().TrimStartAndEnd();
+		if (!Name.IsEmpty())
+		{
+			Session->CreateCharacter(Name, TEXT("Adventurer"));
+			NameBox->SetText(FText::GetEmpty());
+		}
+	}
+	return FReply::Handled();
+}
+
+FReply SchuckCharacterSelect::HandleDelete()
+{
+	if (Session.IsValid() && !SelectedName.IsEmpty())
+	{
+		Session->RemoveCharacter(SelectedName);
+		SelectedName.Reset();
+	}
+	return FReply::Handled();
+}
+
+FReply SchuckCharacterSelect::HandleEnter()
+{
+	if (!SelectedName.IsEmpty())
+	{
+		OnEnterWorld.ExecuteIfBound();
+	}
+	return FReply::Handled();
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckCharacterSelect.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/SchuckCharacterSelect.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+#include "Widgets/Views/SListView.h"
+#include "Input/Reply.h"
+#include "Framework/SlateDelegates.h"
+#include "ROWSTypes.h"
+
+class UchuckSessionSubsystem;
+class SEditableTextBox;
+class STableViewBase;
+class ITableRow;
+
+class SchuckCharacterSelect : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SchuckCharacterSelect) {}
+		SLATE_ARGUMENT(TWeakObjectPtr<UchuckSessionSubsystem>, Session)
+		SLATE_EVENT(FSimpleDelegate, OnEnterWorld)
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+	void RefreshList(const TArray<FROWSUserCharacter>& Characters);
+
+private:
+	TSharedRef<ITableRow> OnGenerateRow(TSharedPtr<FROWSUserCharacter> Item, const TSharedRef<STableViewBase>& OwnerTable);
+	void OnSelectionChanged(TSharedPtr<FROWSUserCharacter> Item, ESelectInfo::Type SelectInfo);
+
+	FReply HandleCreate();
+	FReply HandleDelete();
+	FReply HandleEnter();
+
+	TWeakObjectPtr<UchuckSessionSubsystem> Session;
+	FSimpleDelegate OnEnterWorld;
+
+	TArray<TSharedPtr<FROWSUserCharacter>> Items;
+	TSharedPtr<SListView<TSharedPtr<FROWSUserCharacter>>> ListView;
+	TSharedPtr<SEditableTextBox> NameBox;
+	FString SelectedName;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.cpp
@@ -1,6 +1,8 @@
 #include "chuckMenuPlayerController.h"
 
 #include "SchuckMainMenu.h"
+#include "SchuckCharacterSelect.h"
+#include "Core/chuckSessionSubsystem.h"
 #include "SKBVELoginWidget.h"
 #include "SKBVEAccountPanel.h"
 #include "SKBVELoadingPanel.h"
@@ -47,12 +49,32 @@ void AchuckMenuPlayerController::BeginPlay()
 	LoadingWidget = SNew(SKBVELoadingPanel).UnitLabel(TEXT("chunks"));
 	LoadingWidget->SetVisibility(EVisibility::Collapsed);
 
+	TWeakObjectPtr<UchuckSessionSubsystem> SessionWeak;
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		SessionWeak = GI->GetSubsystem<UchuckSessionSubsystem>();
+	}
+	CharSelectWidget = SNew(SchuckCharacterSelect)
+		.Session(SessionWeak)
+		.OnEnterWorld(FSimpleDelegate::CreateUObject(this, &AchuckMenuPlayerController::EnterSelectedWorld));
+	CharSelectWidget->SetVisibility(EVisibility::Collapsed);
+
 	if (UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr)
 	{
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), MenuWidget.ToSharedRef(),    10);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), AccountWidget.ToSharedRef(), 40);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), LoginWidget.ToSharedRef(),   45);
+		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), CharSelectWidget.ToSharedRef(), 50);
 		Viewport->AddViewportWidgetForPlayer(GetLocalPlayer(), LoadingWidget.ToSharedRef(), 60);
+	}
+
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (UchuckSessionSubsystem* SessionSub = GI->GetSubsystem<UchuckSessionSubsystem>())
+		{
+			SessionSub->OnSessionReady.AddDynamic(this, &AchuckMenuPlayerController::HandleSessionReady);
+			SessionSub->OnCharactersUpdated.AddDynamic(this, &AchuckMenuPlayerController::HandleCharactersUpdated);
+		}
 	}
 
 	if (UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get())
@@ -122,6 +144,15 @@ void AchuckMenuPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReaso
 		Sub->OnSignedIn.RemoveAll(this);
 		Sub->OnSignedOut.RemoveAll(this);
 		Sub->OnSessionRefreshed.RemoveAll(this);
+	}
+
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (UchuckSessionSubsystem* SessionSub = GI->GetSubsystem<UchuckSessionSubsystem>())
+		{
+			SessionSub->OnSessionReady.RemoveAll(this);
+			SessionSub->OnCharactersUpdated.RemoveAll(this);
+		}
 	}
 
 	UGameViewportClient* Viewport = GetWorld() ? GetWorld()->GetGameViewport() : nullptr;
@@ -310,4 +341,36 @@ void AchuckMenuPlayerController::RefreshAuthVisibility(bool bSignedIn)
 	{
 		AccountWidget->SetVisibility(bSignedIn ? EVisibility::SelfHitTestInvisible : EVisibility::Collapsed);
 	}
+}
+
+void AchuckMenuPlayerController::HandleSessionReady(const FString& UserSessionGUID)
+{
+	if (CharSelectWidget.IsValid())
+	{
+		CharSelectWidget->SetVisibility(EVisibility::Visible);
+	}
+	if (UGameInstance* GI = GetGameInstance())
+	{
+		if (UchuckSessionSubsystem* SessionSub = GI->GetSubsystem<UchuckSessionSubsystem>())
+		{
+			SessionSub->RefreshCharacters();
+		}
+	}
+}
+
+void AchuckMenuPlayerController::HandleCharactersUpdated(const TArray<FROWSUserCharacter>& Characters)
+{
+	if (CharSelectWidget.IsValid())
+	{
+		CharSelectWidget->RefreshList(Characters);
+	}
+}
+
+void AchuckMenuPlayerController::EnterSelectedWorld()
+{
+	if (CharSelectWidget.IsValid())
+	{
+		CharSelectWidget->SetVisibility(EVisibility::Collapsed);
+	}
+	HandlePlay();
 }

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.h
@@ -5,11 +5,13 @@
 #include "chuckMenuPlayerController.generated.h"
 
 class SchuckMainMenu;
+class SchuckCharacterSelect;
 class SKBVELoginWidget;
 class SKBVEAccountPanel;
 class SKBVELoadingPanel;
 class UKBVESupabaseSubsystem;
 struct FKBVESupabaseSession;
+struct FROWSUserCharacter;
 
 UCLASS()
 class AchuckMenuPlayerController : public APlayerController
@@ -41,9 +43,18 @@ private:
 	UFUNCTION()
 	void HandleSupabaseSessionRefreshed(const FKBVESupabaseSession& Session);
 
+	UFUNCTION()
+	void HandleSessionReady(const FString& UserSessionGUID);
+
+	UFUNCTION()
+	void HandleCharactersUpdated(const TArray<FROWSUserCharacter>& Characters);
+
+	void EnterSelectedWorld();
+
 	void ApplyAccountFromSession(const FKBVESupabaseSession& Session);
 
 	TSharedPtr<SchuckMainMenu>     MenuWidget;
+	TSharedPtr<SchuckCharacterSelect> CharSelectWidget;
 	TSharedPtr<SKBVELoginWidget>  LoginWidget;
 	TSharedPtr<SKBVEAccountPanel> AccountWidget;
 	TSharedPtr<SKBVELoadingPanel> LoadingWidget;


### PR DESCRIPTION
Stage 3 of the ROWS flow — character selection on top of the session orchestrator (#12141).

- **`UchuckSessionSubsystem`** gains `CreateCharacter` / `RemoveCharacter` passthroughs (→ `UROWSCharacterSubsystem`) and refreshes the list on create/remove success.
- **`SchuckCharacterSelect`** Slate widget: lists `FROWSUserCharacter` (name / level / class), row-select → `SelectCharacter`, a name box + **Create**, **Delete**, **Enter World**. Drives the session subsystem directly; exposes `RefreshList`.
- **`AchuckMenuPlayerController`** owns the widget + the dynamic binds (it's the UObject): `OnSessionReady` shows it + refreshes; `OnCharactersUpdated` → `RefreshList`; **Enter World** → `EnterSelectedWorld` → existing play/loading path (selected character already stored in the session). Unbinds + removes the widget in `EndPlay`.

## Flow
sign-in → Supabase→ROWS bridge → `OnSessionReady` → character-select appears → create/pick → Enter World → play.

## Notes
Slate UI; `Slate`/`SlateCore` already in chuck.Build.cs. Enter World currently routes to the local play path; **stage 4** swaps in the session's `RequestEnterWorld` (ROWS `GetServerToConnectTo` → `ClientTravel`, Iris) for the dedicated-server lobby. UE 5.7, builds in ci-unreal. chuck-only.