### PR TITLE
fix(cryptothrone,nd-server): load image for publish instead of build-time push

### DIFF
--- a/apps/agones/cryptothrone/server/project.json
+++ b/apps/agones/cryptothrone/server/project.json
@@ -83,8 +83,7 @@
 				},
 				"production": {
 					"tags": ["latest"],
-					"push": true,
-					"customBuildOptions": "--push",
+					"push": false,
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/cryptothrone-server:buildcache"
 					],

--- a/apps/godot/nexus-defense/server/project.json
+++ b/apps/godot/nexus-defense/server/project.json
@@ -57,8 +57,7 @@
 				},
 				"production": {
 					"tags": ["latest"],
-					"push": true,
-					"customBuildOptions": "--push",
+					"push": false,
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/nd-server:buildcache"
 					],


### PR DESCRIPTION
Follow-up to #12139 / #12144. The `@nx-tools/nx-container` switch got the build working, but `production` had `push: true` + `customBuildOptions: --push`, so the nx build pushed `kbve/<image>:latest` directly — which resolves to **Docker Hub** (`docker.io/kbve/<image>`) and fails `insufficient_scope: push access denied` because the Docker Hub repo doesn't exist yet (run #27310330368).

The build should only **load** the image into the daemon; the publish workflow's dedicated "Push Docker Images" step logs into GHCR + Docker Hub with the correct creds, retags `version`+`latest`, and pushes. That's why kilobase works.

Fix: `push: false` on both `cryptothrone-server` and `nd-server` production configs (drop `--push`). The build loads via `metadata.load: true`; the workflow pushes.