### PR TITLE
fix(chuck): AddUniqueDynamic for chat bridge (stops 2-3x message dup)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCorePlayerController.cpp
@@ -663,17 +663,17 @@ void AchuckCorePlayerController::InitSupabaseBridge()
 	UKBVESupabaseSubsystem* Sub = SupabaseSubsystem.Get();
 	if (!Sub) return;
 
-	Sub->OnSignedIn.AddDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedIn);
-	Sub->OnSignedOut.AddDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedOut);
-	Sub->OnAuthError.AddDynamic(this, &AchuckCorePlayerController::HandleSupabaseAuthError);
+	Sub->OnSignedIn.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedIn);
+	Sub->OnSignedOut.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleSupabaseSignedOut);
+	Sub->OnAuthError.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleSupabaseAuthError);
 
 	if (UKBVESupabaseChat* Chat = Sub->GetChat())
 	{
-		Chat->OnConnected.AddDynamic(this, &AchuckCorePlayerController::HandleChatConnected);
-		Chat->OnDisconnected.AddDynamic(this, &AchuckCorePlayerController::HandleChatDisconnected);
-		Chat->OnMessage.AddDynamic(this, &AchuckCorePlayerController::HandleChatMessage);
-		Chat->OnChannelJoined.AddDynamic(this, &AchuckCorePlayerController::HandleChatChannelJoined);
-		Chat->OnChannelLeft.AddDynamic(this, &AchuckCorePlayerController::HandleChatChannelLeft);
+		Chat->OnConnected.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleChatConnected);
+		Chat->OnDisconnected.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleChatDisconnected);
+		Chat->OnMessage.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleChatMessage);
+		Chat->OnChannelJoined.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleChatChannelJoined);
+		Chat->OnChannelLeft.AddUniqueDynamic(this, &AchuckCorePlayerController::HandleChatChannelLeft);
 	}
 
 	const bool bSignedIn = Sub->IsSignedIn();


### PR DESCRIPTION
## Symptom
Typing one chat message renders it 2-3× (intermittent).

## Cause
`AchuckCorePlayerController::InitSupabaseBridge` binds `OnMessage`/`OnConnected`/`OnSignedIn`/etc with **`AddDynamic`**, which allows duplicate bindings. The symmetric `RemoveDynamic` only runs on `EndPlay` (controller destroy), so any re-init of the bridge (re-possess, UI rebuild, respawn) stacks the handlers — and each received line (including the server echo of your own message) fires `HandleChatMessage` 2-3×.

## Fix
Bind with **`AddUniqueDynamic`** → idempotent; re-running the bridge can't stack handlers.

## Re: threading
Not a threading bug. UE's WebSocket `Send` + `OnMessage` callbacks already run on the game thread, and `IWebSocket::Send` just enqueues (the WS module does network I/O async on its own threads). Moving send off-thread would add race risk for no benefit and wouldn't fix the dup.