### PR TITLE
feat(chuck): online lobby travel (ROWS flow stage 4)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.cpp
@@ -74,6 +74,8 @@ void AchuckMenuPlayerController::BeginPlay()
 		{
 			SessionSub->OnSessionReady.AddDynamic(this, &AchuckMenuPlayerController::HandleSessionReady);
 			SessionSub->OnCharactersUpdated.AddDynamic(this, &AchuckMenuPlayerController::HandleCharactersUpdated);
+			SessionSub->OnServerReady.AddDynamic(this, &AchuckMenuPlayerController::HandleServerReady);
+			SessionSub->OnSessionError.AddDynamic(this, &AchuckMenuPlayerController::HandleSessionError);
 		}
 	}
 
@@ -152,6 +154,8 @@ void AchuckMenuPlayerController::EndPlay(const EEndPlayReason::Type EndPlayReaso
 		{
 			SessionSub->OnSessionReady.RemoveAll(this);
 			SessionSub->OnCharactersUpdated.RemoveAll(this);
+			SessionSub->OnServerReady.RemoveAll(this);
+			SessionSub->OnSessionError.RemoveAll(this);
 		}
 	}
 
@@ -372,5 +376,43 @@ void AchuckMenuPlayerController::EnterSelectedWorld()
 	{
 		CharSelectWidget->SetVisibility(EVisibility::Collapsed);
 	}
+
+	if (bUseOnlineTravel)
+	{
+		if (UGameInstance* GI = GetGameInstance())
+		{
+			if (UchuckSessionSubsystem* SessionSub = GI->GetSubsystem<UchuckSessionSubsystem>())
+			{
+				if (SessionSub->RequestEnterWorld(DefaultZone))
+				{
+					if (LoadingWidget.IsValid())
+					{
+						LoadingWidget->SetVisibility(EVisibility::Visible);
+					}
+					return;
+				}
+			}
+		}
+		UE_LOG(LogTemp, Warning, TEXT("[chuck] Online travel unavailable, falling back to local play"));
+	}
+
 	HandlePlay();
+}
+
+void AchuckMenuPlayerController::HandleServerReady(const FString& ServerIP, int32 Port)
+{
+	UE_LOG(LogTemp, Display, TEXT("[chuck] ROWS server ready %s:%d — traveling"), *ServerIP, Port);
+}
+
+void AchuckMenuPlayerController::HandleSessionError(const FString& ErrorMessage)
+{
+	UE_LOG(LogTemp, Warning, TEXT("[chuck] Session error: %s"), *ErrorMessage);
+	if (LoadingWidget.IsValid())
+	{
+		LoadingWidget->SetVisibility(EVisibility::Collapsed);
+	}
+	if (CharSelectWidget.IsValid())
+	{
+		CharSelectWidget->SetVisibility(EVisibility::Visible);
+	}
 }

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/UI/chuckMenuPlayerController.h
@@ -24,6 +24,12 @@ public:
 	UPROPERTY(EditDefaultsOnly, Category = "Chuck|Menu")
 	FName PlayLevelName = TEXT("L_ChuckWorld");
 
+	UPROPERTY(EditDefaultsOnly, Category = "Chuck|Menu")
+	bool bUseOnlineTravel = false;
+
+	UPROPERTY(EditDefaultsOnly, Category = "Chuck|Menu")
+	FString DefaultZone = TEXT("HubWorld");
+
 protected:
 	virtual void BeginPlay() override;
 	virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
@@ -48,6 +54,12 @@ private:
 
 	UFUNCTION()
 	void HandleCharactersUpdated(const TArray<FROWSUserCharacter>& Characters);
+
+	UFUNCTION()
+	void HandleServerReady(const FString& ServerIP, int32 Port);
+
+	UFUNCTION()
+	void HandleSessionError(const FString& ErrorMessage);
 
 	void EnterSelectedWorld();
 


### PR DESCRIPTION
Stage 4 — completes the 4-stage ROWS flow. Enter World can now go through the dedicated-server lobby.

- `bUseOnlineTravel` + `DefaultZone` on `AchuckMenuPlayerController`.
- `EnterSelectedWorld` → if online, `UchuckSessionSubsystem::RequestEnterWorld(DefaultZone)` → ROWS `GetServerToConnectTo` → `ClientTravel` to `ServerIP:Port` (Iris transport) + show loading. Falls back to the local `OpenLevel` path if the session/subsystem isn't available.
- Binds `OnServerReady` (log/travel) + `OnSessionError` (drop loading, reshow character-select) for lobby feedback; unbinds in `EndPlay`.

**Default off** — single-player / dev keeps the local path; flip `bUseOnlineTravel` for the online lobby.

## Flow (end to end)
sign-in → Supabase→ROWS bridge → session ready → character-select → Enter World → ROWS server lookup → ClientTravel → Iris-replicated dedicated server.

Stages: 1 (#12141) ✅ · 2 (#12143, vault value pending) · 3 (#12147) ✅ · 4 this PR. UE 5.7, builds in ci-unreal. chuck-only.