### PR TITLE
feat(KBVESupabaseChat): thread-safe send via MPSC TX queue + game-thread drain

### DIFF
--- a/packages/unreal/KBVESupabase/Source/KBVESupabase/Private/KBVESupabaseChat.cpp
+++ b/packages/unreal/KBVESupabase/Source/KBVESupabase/Private/KBVESupabaseChat.cpp
@@ -4,6 +4,7 @@
 #include "KBVESupabaseModule.h"
 #include "WebSocketsModule.h"
 #include "IWebSocket.h"
+#include "Async/Async.h"
 #include "Engine/GameInstance.h"
 #include "Engine/World.h"
 #include "TimerManager.h"
@@ -406,16 +407,47 @@ void UKBVESupabaseChat::DoAutoJoin()
 
 bool UKBVESupabaseChat::SendRawLine(const FString& Line)
 {
-	if (!Socket.IsValid() || !Socket->IsConnected())
-	{
-		UE_LOG(LogKBVESupabase, Warning, TEXT("Chat TX dropped (socket not connected) line=[%s]"), *Line);
-		return false;
-	}
 	const FString Clean = SanitizeLine(Line);
 	if (Clean.IsEmpty()) return false;
-	UE_LOG(LogKBVESupabase, Log, TEXT("Chat TX [%s]"), *Clean);
-	Socket->Send(Clean + TEXT("\r\n"));
+	EnqueueTx(Clean);
 	return true;
+}
+
+void UKBVESupabaseChat::EnqueueTx(const FString& Clean)
+{
+	TxQueue.Enqueue(Clean);
+
+	if (IsInGameThread())
+	{
+		DrainTxQueue();
+		return;
+	}
+
+	TWeakObjectPtr<UKBVESupabaseChat> WeakThis(this);
+	AsyncTask(ENamedThreads::GameThread, [WeakThis]()
+	{
+		if (UKBVESupabaseChat* Self = WeakThis.Get())
+		{
+			Self->DrainTxQueue();
+		}
+	});
+}
+
+void UKBVESupabaseChat::DrainTxQueue()
+{
+	FString L;
+	while (TxQueue.Dequeue(L))
+	{
+		if (Socket.IsValid() && Socket->IsConnected())
+		{
+			UE_LOG(LogKBVESupabase, Log, TEXT("Chat TX [%s]"), *L);
+			Socket->Send(L + TEXT("\r\n"));
+		}
+		else
+		{
+			UE_LOG(LogKBVESupabase, Warning, TEXT("Chat TX dropped (socket not connected) line=[%s]"), *L);
+		}
+	}
 }
 
 bool UKBVESupabaseChat::SendPrivMsg(const FString& Channel, const FString& Body)

--- a/packages/unreal/KBVESupabase/Source/KBVESupabase/Public/KBVESupabaseChat.h
+++ b/packages/unreal/KBVESupabase/Source/KBVESupabase/Public/KBVESupabaseChat.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "UObject/Object.h"
+#include "Containers/Queue.h"
 #include "KBVESupabaseTypes.h"
 #include "KBVESupabaseChat.generated.h"
 
@@ -120,4 +121,8 @@ protected:
 	void StartKeepAlive();
 	void StopKeepAlive();
 	void SendKeepAlivePing();
+
+	TQueue<FString, EQueueMode::Mpsc> TxQueue;
+	void EnqueueTx(const FString& Clean);
+	void DrainTxQueue();
 };


### PR DESCRIPTION
Decouples chat send from the game thread *for the caller* while keeping it safe.

`SendRawLine` (and thus `SendPrivMsg`) can now be called from any thread: it sanitizes, enqueues into an `MPSC TQueue<FString>`, and drains to `Socket->Send` on the game thread (inline if already there, else `AsyncTask(ENamedThreads::GameThread)`).

**Why not Send off-thread:** UE's `IWebSocket` is game-thread-affined — the WS module ticks/flushes the send buffer on the game thread, so calling `Send` from a worker races it. The real network I/O is already async inside the module; `Send` only enqueues a frame. So the safe decoupling is a thread-safe producer queue drained on the game thread.

**Re blittable:** `FString` through an MPSC `TQueue` is already an owned copy (enqueue moves it in; dequeuer owns it outright, no shared buffer; UE's allocator is thread-safe across the worker-alloc/game-free). A POD buffer would truncate variable-length lines for no safety gain.

Pairs with #12149 (the actual chat-dup fix).