### PR TITLE
feat(agents): derive row types from proto + full e2e schema validation

### DIFF
--- a/apps/kbve/edge/functions/_shared/agents-schema.ts
+++ b/apps/kbve/edge/functions/_shared/agents-schema.ts
@@ -3,7 +3,7 @@
  *
  * Source: ../descriptors/agents.binpb
  * Config: ../agents-zod-config.json
- * Generated: 2026-06-09T08:07:26.008Z
+ * Generated: 2026-06-10T23:51:25.025Z
  */
 
 import { z } from 'https://deno.land/x/zod@v3.23.8/mod.ts';
@@ -31,7 +31,7 @@ export type PeekTokenResponse = z.infer<typeof PeekTokenResponseSchema>;
 export const PeekTokenRequestSchema = z
 	.object({
 		server_id: z.string().regex(/^\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)'),
-		service: z.string(),
+		service: z.string().regex(/^[a-z0-9_]{2,32}$/, 'Service must be 2-32 chars: lowercase a-z, 0-9, underscore'),
 	});
 
 export type PeekTokenRequest = z.infer<typeof PeekTokenRequestSchema>;
@@ -40,7 +40,7 @@ export type PeekTokenRequest = z.infer<typeof PeekTokenRequestSchema>;
 export const ToggleTokenRequestSchema = z
 	.object({
 		server_id: z.string().regex(/^\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)'),
-		token_id: z.string(),
+		token_id: z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, 'token_id must be a UUID'),
 		is_active: z.boolean(),
 	});
 
@@ -50,7 +50,7 @@ export type ToggleTokenRequest = z.infer<typeof ToggleTokenRequestSchema>;
 export const DeleteTokenRequestSchema = z
 	.object({
 		server_id: z.string().regex(/^\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)'),
-		token_id: z.string(),
+		token_id: z.string().regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, 'token_id must be a UUID'),
 	});
 
 export type DeleteTokenRequest = z.infer<typeof DeleteTokenRequestSchema>;
@@ -61,10 +61,10 @@ export const AgentTokenRowSchema = z
 		token_id: z.string(),
 		token_name: z.string(),
 		service: z.string(),
-		description: z.string().optional(),
+		description: z.string().nullish(),
 		is_active: z.boolean(),
 		created_at: z.string(),
-		updated_at: z.string().optional(),
+		updated_at: z.string().nullish(),
 	});
 
 export type AgentTokenRow = z.infer<typeof AgentTokenRowSchema>;

--- a/apps/kbve/edge/functions/guild-vault/tokens.ts
+++ b/apps/kbve/edge/functions/guild-vault/tokens.ts
@@ -3,13 +3,16 @@ import {
   type GuildVaultRequest,
   invalidateOwnershipCache,
   jsonResponse,
-  validateService,
-  validateSnowflake,
-  validateUuid,
   verifyOwnedGuildsClaim,
 } from "./_shared.ts";
 import { safeRpcError } from "../_shared/validators.ts";
-import { SetTokenRequestSchema } from "../_shared/agents-schema.ts";
+import {
+  DeleteTokenRequestSchema,
+  ListTokensRequestSchema,
+  PeekTokenRequestSchema,
+  SetTokenRequestSchema,
+  ToggleTokenRequestSchema,
+} from "../_shared/agents-schema.ts";
 
 // ---------------------------------------------------------------------------
 // Guild token CRUD handlers — all use service client + Discord ownership
@@ -86,8 +89,13 @@ const handlers: Record<string, Handler> = {
   async list_tokens({ userId, claims, body }) {
     const { server_id } = body;
 
-    const sidErr = validateSnowflake(server_id, "server_id");
-    if (sidErr) return sidErr;
+    const parsed = ListTokensRequestSchema.safeParse({ server_id });
+    if (!parsed.success) {
+      return jsonResponse(
+        { error: parsed.error.issues[0]?.message ?? "Invalid request" },
+        400,
+      );
+    }
 
     const ownerErr = verifyOwnedGuildsClaim(claims, server_id as string);
     if (ownerErr) return ownerErr;
@@ -110,11 +118,13 @@ const handlers: Record<string, Handler> = {
   async delete_token({ userId, claims, body }) {
     const { server_id, token_id } = body;
 
-    const sidErr = validateSnowflake(server_id, "server_id");
-    if (sidErr) return sidErr;
-
-    const tidErr = validateUuid(token_id, "token_id");
-    if (tidErr) return tidErr;
+    const parsed = DeleteTokenRequestSchema.safeParse({ server_id, token_id });
+    if (!parsed.success) {
+      return jsonResponse(
+        { error: parsed.error.issues[0]?.message ?? "Invalid request" },
+        400,
+      );
+    }
 
     const ownerErr = verifyOwnedGuildsClaim(claims, server_id as string);
     if (ownerErr) return ownerErr;
@@ -151,15 +161,14 @@ const handlers: Record<string, Handler> = {
   async toggle_token({ userId, claims, body }) {
     const { server_id, token_id, is_active } = body;
 
-    const sidErr = validateSnowflake(server_id, "server_id");
-    if (sidErr) return sidErr;
-
-    const tidErr = validateUuid(token_id, "token_id");
-    if (tidErr) return tidErr;
-
-    if (typeof is_active !== "boolean") {
+    const parsed = ToggleTokenRequestSchema.safeParse({
+      server_id,
+      token_id,
+      is_active,
+    });
+    if (!parsed.success) {
       return jsonResponse(
-        { error: "is_active (boolean) is required" },
+        { error: parsed.error.issues[0]?.message ?? "Invalid request" },
         400,
       );
     }
@@ -199,11 +208,13 @@ const handlers: Record<string, Handler> = {
 	async peek_token({ userId, claims, body }) {
 		const { server_id, service } = body;
 
-		const sidErr = validateSnowflake(server_id, "server_id");
-		if (sidErr) return sidErr;
-
-		const svcErr = validateService(service);
-		if (svcErr) return svcErr;
+		const parsed = PeekTokenRequestSchema.safeParse({ server_id, service });
+		if (!parsed.success) {
+			return jsonResponse(
+				{ error: parsed.error.issues[0]?.message ?? "Invalid request" },
+				400,
+			);
+		}
 
 		if (!PEEKABLE_SERVICES.has(service as string)) {
 			return jsonResponse(

--- a/packages/data/codegen/agents-zod-config.json
+++ b/packages/data/codegen/agents-zod-config.json
@@ -36,6 +36,14 @@
 		"kbve.agents.DeleteTokenRequest.server_id": ".regex(/^\\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)')",
 		"kbve.agents.ToggleTokenRequest.server_id": ".regex(/^\\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)')",
 		"kbve.agents.PeekTokenRequest.server_id": ".regex(/^\\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)')",
-		"kbve.agents.ListTokensRequest.server_id": ".regex(/^\\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)')"
+		"kbve.agents.PeekTokenRequest.service": ".regex(/^[a-z0-9_]{2,32}$/, 'Service must be 2-32 chars: lowercase a-z, 0-9, underscore')",
+		"kbve.agents.ListTokensRequest.server_id": ".regex(/^\\d{17,20}$/, 'Must be a valid Discord snowflake (17-20 digits)')",
+		"kbve.agents.DeleteTokenRequest.token_id": ".regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, 'token_id must be a UUID')",
+		"kbve.agents.ToggleTokenRequest.token_id": ".regex(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i, 'token_id must be a UUID')"
+	},
+
+	"fieldOverrides": {
+		"kbve.agents.AgentTokenRow.description": "z.string().nullish()",
+		"kbve.agents.AgentTokenRow.updated_at": "z.string().nullish()"
 	}
 }

--- a/packages/data/codegen/generated/agents-schema.ts
+++ b/packages/data/codegen/generated/agents-schema.ts
@@ -3,7 +3,7 @@
  *
  * Source: ../descriptors/agents.binpb
  * Config: ../agents-zod-config.json
- * Generated: 2026-06-09T08:07:26.008Z
+ * Generated: 2026-06-10T23:51:25.025Z
  */
 
 import { z } from 'zod';
@@ -34,7 +34,12 @@ export const PeekTokenRequestSchema = z.object({
 			/^\d{17,20}$/,
 			'Must be a valid Discord snowflake (17-20 digits)',
 		),
-	service: z.string(),
+	service: z
+		.string()
+		.regex(
+			/^[a-z0-9_]{2,32}$/,
+			'Service must be 2-32 chars: lowercase a-z, 0-9, underscore',
+		),
 });
 
 export type PeekTokenRequest = z.infer<typeof PeekTokenRequestSchema>;
@@ -47,7 +52,12 @@ export const ToggleTokenRequestSchema = z.object({
 			/^\d{17,20}$/,
 			'Must be a valid Discord snowflake (17-20 digits)',
 		),
-	token_id: z.string(),
+	token_id: z
+		.string()
+		.regex(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+			'token_id must be a UUID',
+		),
 	is_active: z.boolean(),
 });
 
@@ -61,7 +71,12 @@ export const DeleteTokenRequestSchema = z.object({
 			/^\d{17,20}$/,
 			'Must be a valid Discord snowflake (17-20 digits)',
 		),
-	token_id: z.string(),
+	token_id: z
+		.string()
+		.regex(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+			'token_id must be a UUID',
+		),
 });
 
 export type DeleteTokenRequest = z.infer<typeof DeleteTokenRequestSchema>;
@@ -71,10 +86,10 @@ export const AgentTokenRowSchema = z.object({
 	token_id: z.string(),
 	token_name: z.string(),
 	service: z.string(),
-	description: z.string().optional(),
+	description: z.string().nullish(),
 	is_active: z.boolean(),
 	created_at: z.string(),
-	updated_at: z.string().optional(),
+	updated_at: z.string().nullish(),
 });
 
 export type AgentTokenRow = z.infer<typeof AgentTokenRowSchema>;

--- a/packages/npm/droid/src/lib/agents/generated/agents-schema.ts
+++ b/packages/npm/droid/src/lib/agents/generated/agents-schema.ts
@@ -3,7 +3,7 @@
  *
  * Source: ../descriptors/agents.binpb
  * Config: ../agents-zod-config.json
- * Generated: 2026-06-09T08:07:26.008Z
+ * Generated: 2026-06-10T23:51:25.025Z
  */
 
 import { z } from 'zod';
@@ -34,7 +34,12 @@ export const PeekTokenRequestSchema = z.object({
 			/^\d{17,20}$/,
 			'Must be a valid Discord snowflake (17-20 digits)',
 		),
-	service: z.string(),
+	service: z
+		.string()
+		.regex(
+			/^[a-z0-9_]{2,32}$/,
+			'Service must be 2-32 chars: lowercase a-z, 0-9, underscore',
+		),
 });
 
 export type PeekTokenRequest = z.infer<typeof PeekTokenRequestSchema>;
@@ -47,7 +52,12 @@ export const ToggleTokenRequestSchema = z.object({
 			/^\d{17,20}$/,
 			'Must be a valid Discord snowflake (17-20 digits)',
 		),
-	token_id: z.string(),
+	token_id: z
+		.string()
+		.regex(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+			'token_id must be a UUID',
+		),
 	is_active: z.boolean(),
 });
 
@@ -61,7 +71,12 @@ export const DeleteTokenRequestSchema = z.object({
 			/^\d{17,20}$/,
 			'Must be a valid Discord snowflake (17-20 digits)',
 		),
-	token_id: z.string(),
+	token_id: z
+		.string()
+		.regex(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+			'token_id must be a UUID',
+		),
 });
 
 export type DeleteTokenRequest = z.infer<typeof DeleteTokenRequestSchema>;
@@ -71,10 +86,10 @@ export const AgentTokenRowSchema = z.object({
 	token_id: z.string(),
 	token_name: z.string(),
 	service: z.string(),
-	description: z.string().optional(),
+	description: z.string().nullish(),
 	is_active: z.boolean(),
 	created_at: z.string(),
-	updated_at: z.string().optional(),
+	updated_at: z.string().nullish(),
 });
 
 export type AgentTokenRow = z.infer<typeof AgentTokenRowSchema>;

--- a/packages/npm/droid/src/lib/agents/github/tokens.ts
+++ b/packages/npm/droid/src/lib/agents/github/tokens.ts
@@ -1,7 +1,10 @@
 import { loadCachedTokens, saveCachedTokens } from '../cache';
 import type { AgentsCtx } from '../ctx';
 import type { AgentsApi } from '../api-types';
-import type { TokenServiceValue } from '../generated/agents-schema';
+import {
+	AgentTokenRowSchema,
+	type TokenServiceValue,
+} from '../generated/agents-schema';
 import type { AgentTokenRow, Result } from '../types';
 
 export function makeTokens(ctx: AgentsCtx, api: AgentsApi) {
@@ -67,8 +70,16 @@ export function makeTokens(ctx: AgentsCtx, api: AgentsApi) {
 					return;
 				}
 
-				const rows =
-					(body as { tokens?: AgentTokenRow[] } | null)?.tokens ?? [];
+				const rawRows =
+					(body as { tokens?: unknown } | null)?.tokens ?? [];
+				const parsed = AgentTokenRowSchema.array().safeParse(rawRows);
+				if (!parsed.success) {
+					store.$tokensError.set(
+						'Token list failed schema validation',
+					);
+					return;
+				}
+				const rows = parsed.data;
 				store.$tokens.set(rows);
 				if (userId) saveCachedTokens(userId, guildId, rows);
 			} catch (e) {

--- a/packages/npm/droid/src/lib/agents/types.ts
+++ b/packages/npm/droid/src/lib/agents/types.ts
@@ -34,15 +34,7 @@ export interface BotConfigFormDraft {
 	active: boolean;
 }
 
-export interface AgentTokenRow {
-	token_id: string;
-	token_name: string;
-	service: string;
-	description: string | null;
-	is_active: boolean;
-	created_at: string;
-	updated_at: string | null;
-}
+export type { AgentTokenRow, AgentError } from './generated/agents-schema';
 
 export interface DiscordForumChannel {
 	id: string;


### PR DESCRIPTION
Completes the agents proto-contract wiring (follows #12083) so the token row shape and every token RPC are validated against the single source of truth, agent → edge → Postgres.

## Changes

- **zod config**: `AgentTokenRow.description` / `updated_at` → `.nullish()` so the schema validates the real `null` payloads from Postgres (proto `optional` alone is `undefined`-only and would reject `null`). Added `token_id` (UUID) + peek `service` refinements.
- **droid types**: `AgentTokenRow` + `AgentError` now derive from the vendored `agents-schema` — the hand-written interface is gone, so the row shape can't drift from the proto.
- **droid `loadTokens`**: the `tokens.list_tokens` response is runtime-validated with `AgentTokenRowSchema.array()`. A malformed row now surfaces an error instead of silently poisoning `$tokens`.
- **edge guild-vault**: `list` / `delete` / `toggle` / `peek` validate via the vendored Request schemas (snowflake, UUID, service slug, `is_active`), replacing the hand validators (`set_token` already did in #12083). Same `{error}` envelope, so the droid `callGuildVault` parser is unchanged.

## Verify

- codegen regenerates clean; both vendored copies (droid npm-zod, edge deno-zod) refreshed.
- droid `tsc --noEmit`: 0 errors.
- edge `tokens.ts` brace-balanced; zero remaining `validate*` calls.

## Note

The `.nullish()` makes `AgentTokenRow.description`/`updated_at` `string | null | undefined` (was `string | null`); both are falsy and the components already handle absence. No app changes in this PR.