### PR TITLE
feat(chuck): dedicated server registers + heartbeats to ROWS

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerRegistrationSubsystem.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerRegistrationSubsystem.cpp
@@ -1,0 +1,114 @@
+#include "chuckServerRegistrationSubsystem.h"
+
+#include "ROWSInstanceSubsystem.h"
+#include "Engine/GameInstance.h"
+#include "Engine/World.h"
+#include "GameFramework/PlayerController.h"
+#include "TimerManager.h"
+
+bool UchuckServerRegistrationSubsystem::ShouldCreateSubsystem(UObject* Outer) const
+{
+	if (!Super::ShouldCreateSubsystem(Outer))
+	{
+		return false;
+	}
+	const UWorld* World = Cast<UWorld>(Outer);
+	return World && World->IsGameWorld() && IsRunningDedicatedServer();
+}
+
+void UchuckServerRegistrationSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	ServerIP = FPlatformMisc::GetEnvironmentVariable(TEXT("OWS_SERVER_IP"));
+
+	const FString PortEnv = FPlatformMisc::GetEnvironmentVariable(TEXT("GAME_PORT"));
+	if (!PortEnv.IsEmpty())
+	{
+		Port = FCString::Atoi(*PortEnv);
+	}
+	const FString ZoneEnv = FPlatformMisc::GetEnvironmentVariable(TEXT("OWS_ZONE_INSTANCE_ID"));
+	if (!ZoneEnv.IsEmpty())
+	{
+		ZoneInstanceID = FCString::Atoi(*ZoneEnv);
+	}
+	const FString MaxEnv = FPlatformMisc::GetEnvironmentVariable(TEXT("OWS_MAX_INSTANCES"));
+	if (!MaxEnv.IsEmpty())
+	{
+		MaxInstances = FCString::Atoi(*MaxEnv);
+	}
+
+	UGameInstance* GI = GetWorld() ? GetWorld()->GetGameInstance() : nullptr;
+	UROWSInstanceSubsystem* Instance = GI ? GI->GetSubsystem<UROWSInstanceSubsystem>() : nullptr;
+	if (!Instance)
+	{
+		return;
+	}
+
+	Instance->OnRegisterLauncherSuccess.AddDynamic(this, &UchuckServerRegistrationSubsystem::HandleRegisterSuccess);
+	Instance->OnRegisterLauncherError.AddDynamic(this, &UchuckServerRegistrationSubsystem::HandleRegisterError);
+	Instance->RegisterLauncher(ServerIP, Port, MaxInstances);
+
+	UE_LOG(LogTemp, Display, TEXT("[chuck] ROWS RegisterLauncher %s:%d max=%d zone=%d"), *ServerIP, Port, MaxInstances, ZoneInstanceID);
+}
+
+void UchuckServerRegistrationSubsystem::Deinitialize()
+{
+	if (UWorld* World = GetWorld())
+	{
+		World->GetTimerManager().ClearTimer(HeartbeatTimer);
+		if (UGameInstance* GI = World->GetGameInstance())
+		{
+			if (UROWSInstanceSubsystem* Instance = GI->GetSubsystem<UROWSInstanceSubsystem>())
+			{
+				Instance->OnRegisterLauncherSuccess.RemoveAll(this);
+				Instance->OnRegisterLauncherError.RemoveAll(this);
+			}
+		}
+	}
+	Super::Deinitialize();
+}
+
+void UchuckServerRegistrationSubsystem::HandleRegisterSuccess(const FString& ResponseBody)
+{
+	bRegistered = true;
+	UE_LOG(LogTemp, Display, TEXT("[chuck] ROWS launcher registered: %s"), *ResponseBody);
+
+	if (UWorld* World = GetWorld())
+	{
+		World->GetTimerManager().SetTimer(
+			HeartbeatTimer, this, &UchuckServerRegistrationSubsystem::SendHeartbeat,
+			HeartbeatInterval, true, HeartbeatInterval);
+	}
+}
+
+void UchuckServerRegistrationSubsystem::HandleRegisterError(const FString& ErrorMessage)
+{
+	UE_LOG(LogTemp, Warning, TEXT("[chuck] ROWS RegisterLauncher failed: %s"), *ErrorMessage);
+}
+
+void UchuckServerRegistrationSubsystem::SendHeartbeat()
+{
+	UWorld* World = GetWorld();
+	if (!World)
+	{
+		return;
+	}
+
+	int32 PlayerCount = 0;
+	for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It; ++It)
+	{
+		if (It->IsValid())
+		{
+			++PlayerCount;
+		}
+	}
+
+	if (UGameInstance* GI = World->GetGameInstance())
+	{
+		if (UROWSInstanceSubsystem* Instance = GI->GetSubsystem<UROWSInstanceSubsystem>())
+		{
+			Instance->UpdateNumberOfPlayers(ZoneInstanceID, PlayerCount);
+		}
+	}
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerRegistrationSubsystem.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerRegistrationSubsystem.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "chuckServerRegistrationSubsystem.generated.h"
+
+UCLASS()
+class CHUCK_API UchuckServerRegistrationSubsystem : public UWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+private:
+	UFUNCTION()
+	void HandleRegisterSuccess(const FString& ResponseBody);
+
+	UFUNCTION()
+	void HandleRegisterError(const FString& ErrorMessage);
+
+	void SendHeartbeat();
+
+	FString ServerIP;
+	int32 Port = 7777;
+	int32 MaxInstances = 5;
+	int32 ZoneInstanceID = 1;
+	float HeartbeatInterval = 15.0f;
+
+	FTimerHandle HeartbeatTimer;
+	bool bRegistered = false;
+};


### PR DESCRIPTION
Closes the **P0 server-side ROWS gap**. The client flow (login → character → lobby travel) and the `x-service-key` send path were already in; the dedicated server never announced itself to ROWS. Now it does.

**`UchuckServerRegistrationSubsystem`** (`UWorldSubsystem`, dedicated-server game world only):
- `Initialize` reads `OWS_SERVER_IP` / `GAME_PORT` / `OWS_ZONE_INSTANCE_ID` / `OWS_MAX_INSTANCES`, calls `UROWSInstanceSubsystem::RegisterLauncher`.
- On `OnRegisterLauncherSuccess` → starts a `UpdateNumberOfPlayers` heartbeat (default 15s) reporting the live player count.
- Clears timer + unbinds on `Deinitialize`.

The dedicated server already attaches `x-service-key` (`OWS_SERVICE_KEY`, dedicated-only) on ROWS requests (KBVEROWS), so these authenticate server-to-server against `SUPABASE_SERVICE_KEY_HASH` (#12143). Server is now **visible to ROWS + reports health**.

## Remaining ROWS gaps (follow-ups, prioritized)
- **P1** character persistence: `UpdatePosition` / `UpdateStats` / `JoinMap` / `LeaveMap` / `PlayerLogout` — no UE methods yet (Rust side exists). Needs new methods on `UROWSCharacterSubsystem` + a player-character sync hook.
- **P1** streaming `GameServerHealth.HealthStream` (bidirectional) as an alternative to the polling heartbeat (+ receives shutdown commands).
- **P2** `UROWSGlobalDataSubsystem` (get/set) — delegates declared, no subsystem.
- **P3** `GetZoneInstance` by id.

UE 5.7, builds in ci-unreal. chuck-only.