### PR TITLE
feat(KBVESupabaseChat): client-side chat anti-spam (token bucket + dedup)

### DIFF
--- a/packages/unreal/KBVESupabase/Source/KBVESupabase/Private/KBVESupabaseChat.cpp
+++ b/packages/unreal/KBVESupabase/Source/KBVESupabase/Private/KBVESupabaseChat.cpp
@@ -450,10 +450,47 @@ void UKBVESupabaseChat::DrainTxQueue()
 	}
 }
 
+bool UKBVESupabaseChat::AllowUserSend(const FString& Body)
+{
+	const double Now = FPlatformTime::Seconds();
+
+	constexpr double MaxTokens = 5.0;
+	constexpr double RefillPerSec = 1.0;
+	constexpr double DupWindowSec = 2.0;
+
+	if (Body.Equals(RlLastBody, ESearchCase::CaseSensitive) && (Now - RlLastBodyTime) < DupWindowSec)
+	{
+		UE_LOG(LogKBVESupabase, Warning, TEXT("Chat send dropped (duplicate within %.0fs): [%s]"), DupWindowSec, *Body);
+		return false;
+	}
+
+	if (RlLastRefill <= 0.0)
+	{
+		RlTokens = MaxTokens;
+	}
+	else
+	{
+		RlTokens = FMath::Min(MaxTokens, RlTokens + (Now - RlLastRefill) * RefillPerSec);
+	}
+	RlLastRefill = Now;
+
+	if (RlTokens < 1.0)
+	{
+		UE_LOG(LogKBVESupabase, Warning, TEXT("Chat send throttled (anti-spam rate limit): [%s]"), *Body);
+		return false;
+	}
+
+	RlTokens -= 1.0;
+	RlLastBody = Body;
+	RlLastBodyTime = Now;
+	return true;
+}
+
 bool UKBVESupabaseChat::SendPrivMsg(const FString& Channel, const FString& Body)
 {
 	const FString Target = NormalizeChannel(Channel);
 	if (Target.IsEmpty() || Body.IsEmpty()) return false;
+	if (!AllowUserSend(Body)) return false;
 	return SendRawLine(FString::Printf(TEXT("PRIVMSG %s :%s"), *Target, *SanitizeLine(Body)));
 }
 

--- a/packages/unreal/KBVESupabase/Source/KBVESupabase/Public/KBVESupabaseChat.h
+++ b/packages/unreal/KBVESupabase/Source/KBVESupabase/Public/KBVESupabaseChat.h
@@ -122,6 +122,12 @@ protected:
 	void StopKeepAlive();
 	void SendKeepAlivePing();
 
+	double RlTokens = 0.0;
+	double RlLastRefill = 0.0;
+	FString RlLastBody;
+	double RlLastBodyTime = 0.0;
+	bool AllowUserSend(const FString& Body);
+
 	TQueue<FString, EQueueMode::Mpsc> TxQueue;
 	void EnqueueTx(const FString& Clean);
 	void DrainTxQueue();


### PR DESCRIPTION
Defense-in-depth flood guard on the user-chat send path (`SendPrivMsg`):
- **Token bucket** — burst 5, refill 1/sec (sustained ~1 msg/sec).
- **Identical-message dedup** — drop the same body sent within 2s (also catches accidental double-sends).

Throttled/duplicate messages return `false` (dropped + logged) before `SendRawLine`. System traffic (PING/JOIN/PART/`/raw`) is unaffected. The authoritative limit still belongs server-side (and the actual triple-relay is in the discordsh bot, separate) — this is a client safety net so users can't flood from the UI.