### PR TITLE
fix(cryptothrone,nd-server): load image to daemon (load at config level, not metadata)

### DIFF
--- a/apps/agones/cryptothrone/server/project.json
+++ b/apps/agones/cryptothrone/server/project.json
@@ -70,20 +70,19 @@
 				"engine": "docker",
 				"context": ".",
 				"file": "apps/agones/cryptothrone/server/Dockerfile",
-				"metadata": {
-					"images": ["kbve/cryptothrone-server"],
-					"load": true,
-					"tags": ["latest"]
-				}
+				"load": true,
+				"tags": ["kbve/cryptothrone-server:latest"]
 			},
 			"configurations": {
 				"local": {
-					"tags": ["latest"],
-					"push": false
+					"load": true,
+					"push": false,
+					"tags": ["kbve/cryptothrone-server:latest"]
 				},
 				"production": {
-					"tags": ["latest"],
+					"load": true,
 					"push": false,
+					"tags": ["kbve/cryptothrone-server:latest"],
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/cryptothrone-server:buildcache"
 					],

--- a/apps/godot/nexus-defense/server/project.json
+++ b/apps/godot/nexus-defense/server/project.json
@@ -44,20 +44,19 @@
 				"engine": "docker",
 				"context": ".",
 				"file": "apps/godot/nexus-defense/server/Dockerfile",
-				"metadata": {
-					"images": ["kbve/nd-server"],
-					"load": true,
-					"tags": ["latest"]
-				}
+				"load": true,
+				"tags": ["kbve/nd-server:latest"]
 			},
 			"configurations": {
 				"local": {
-					"tags": ["latest"],
-					"push": false
+					"load": true,
+					"push": false,
+					"tags": ["kbve/nd-server:latest"]
 				},
 				"production": {
-					"tags": ["latest"],
+					"load": true,
 					"push": false,
+					"tags": ["kbve/nd-server:latest"],
 					"cache-from": [
 						"type=registry,ref=ghcr.io/kbve/nd-server:buildcache"
 					],


### PR DESCRIPTION
Third and final piece of the publish fix (after #12139/#12144 executor swap, #12148 push:false).

Run #27315180228 still failed `No images found`, with the smoking gun in the log:
> WARNING: No output specified with docker-container driver. Build result will only remain in the build cache.

`@nx-tools/nx-container` **ignores `load` when it's nested under `options.metadata`**. So `push:false` + `metadata.load:true` produced neither `--push` nor `--load` — the image stayed in the build cache, never reaching the daemon the push step greps.

Fix: move `load: true` to the **options + per-config** level (factorio's proven shape) with full-ref tags (`kbve/<image>:latest`). The docker-container driver now `--load`s the image into the daemon; the workflow's "Push Docker Images" step retags `version`+`latest` and pushes to GHCR + Docker Hub. Applied to both cryptothrone-server and nd-server.