### PR TITLE
feat(rows): character persistence (position/stats/logout)

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCharacterPersistenceSubsystem.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCharacterPersistenceSubsystem.cpp
@@ -1,0 +1,73 @@
+#include "chuckCharacterPersistenceSubsystem.h"
+#include "chuckPlayerState.h"
+
+#include "ROWSCharacterSubsystem.h"
+#include "Engine/GameInstance.h"
+#include "Engine/World.h"
+#include "GameFramework/Pawn.h"
+#include "GameFramework/PlayerController.h"
+#include "TimerManager.h"
+
+bool UchuckCharacterPersistenceSubsystem::ShouldCreateSubsystem(UObject* Outer) const
+{
+	if (!Super::ShouldCreateSubsystem(Outer))
+	{
+		return false;
+	}
+	const UWorld* World = Cast<UWorld>(Outer);
+	return World && World->IsGameWorld() && IsRunningDedicatedServer();
+}
+
+void UchuckCharacterPersistenceSubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	const FString ZoneEnv = FPlatformMisc::GetEnvironmentVariable(TEXT("OWS_ZONE_NAME"));
+	if (!ZoneEnv.IsEmpty())
+	{
+		MapName = ZoneEnv;
+	}
+
+	if (UWorld* World = GetWorld())
+	{
+		World->GetTimerManager().SetTimer(SaveTimer, this, &UchuckCharacterPersistenceSubsystem::SaveAll, SaveInterval, true, SaveInterval);
+	}
+}
+
+void UchuckCharacterPersistenceSubsystem::Deinitialize()
+{
+	if (UWorld* World = GetWorld())
+	{
+		World->GetTimerManager().ClearTimer(SaveTimer);
+	}
+	Super::Deinitialize();
+}
+
+void UchuckCharacterPersistenceSubsystem::SaveAll()
+{
+	UWorld* World = GetWorld();
+	UGameInstance* GI = World ? World->GetGameInstance() : nullptr;
+	UROWSCharacterSubsystem* Chars = GI ? GI->GetSubsystem<UROWSCharacterSubsystem>() : nullptr;
+	if (!Chars)
+	{
+		return;
+	}
+
+	for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It; ++It)
+	{
+		APlayerController* PC = It->Get();
+		if (!PC)
+		{
+			continue;
+		}
+		const AchuckPlayerState* State = PC->GetPlayerState<AchuckPlayerState>();
+		const APawn* Pawn = PC->GetPawn();
+		if (!State || State->CharacterName.IsEmpty() || !Pawn)
+		{
+			continue;
+		}
+		const FVector Loc = Pawn->GetActorLocation();
+		const FRotator Rot = Pawn->GetActorRotation();
+		Chars->UpdatePosition(State->CharacterName, MapName, Loc.X, Loc.Y, Loc.Z, Rot.Roll, Rot.Pitch, Rot.Yaw);
+	}
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCharacterPersistenceSubsystem.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCharacterPersistenceSubsystem.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Subsystems/WorldSubsystem.h"
+#include "chuckCharacterPersistenceSubsystem.generated.h"
+
+UCLASS()
+class CHUCK_API UchuckCharacterPersistenceSubsystem : public UWorldSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	virtual bool ShouldCreateSubsystem(UObject* Outer) const override;
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	void SaveAll();
+
+private:
+	FString MapName = TEXT("HubWorld");
+	float SaveInterval = 30.0f;
+	FTimerHandle SaveTimer;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckPlayerState.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckPlayerState.cpp
@@ -1,0 +1,8 @@
+#include "chuckPlayerState.h"
+#include "Net/UnrealNetwork.h"
+
+void AchuckPlayerState::GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const
+{
+	Super::GetLifetimeReplicatedProps(OutLifetimeProps);
+	DOREPLIFETIME(AchuckPlayerState, CharacterName);
+}

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckPlayerState.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckPlayerState.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerState.h"
+#include "chuckPlayerState.generated.h"
+
+UCLASS()
+class CHUCK_API AchuckPlayerState : public APlayerState
+{
+	GENERATED_BODY()
+
+public:
+	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
+
+	UPROPERTY(Replicated, BlueprintReadOnly, Category = "Chuck|ROWS")
+	FString CharacterName;
+};

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.cpp
@@ -1,11 +1,60 @@
 // Copyright Epic Games, Inc. All Rights Reserved.
 
 #include "chuckServerGameMode.h"
+#include "chuckPlayerState.h"
 #include "Mass/chuckSlimeSubsystem.h"
 #include "Engine/World.h"
+#include "Engine/GameInstance.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Pawn.h"
+#include "Kismet/GameplayStatics.h"
+#include "ROWSCharacterSubsystem.h"
 
 AchuckServerGameMode::AchuckServerGameMode()
 {
+	PlayerStateClass = AchuckPlayerState::StaticClass();
+}
+
+void AchuckServerGameMode::InitNewPlayer(AController* NewPlayerController, const FUniqueNetIdRepl& UniqueId, const FString& Options, const FString& Portal)
+{
+	Super::InitNewPlayer(NewPlayerController, UniqueId, Options, Portal);
+
+	const FString Character = UGameplayStatics::ParseOption(Options, TEXT("character"));
+	if (!Character.IsEmpty() && NewPlayerController)
+	{
+		if (AchuckPlayerState* State = NewPlayerController->GetPlayerState<AchuckPlayerState>())
+		{
+			State->CharacterName = Character;
+		}
+	}
+}
+
+void AchuckServerGameMode::Logout(AController* Exiting)
+{
+	if (Exiting)
+	{
+		if (const AchuckPlayerState* State = Exiting->GetPlayerState<AchuckPlayerState>())
+		{
+			if (!State->CharacterName.IsEmpty())
+			{
+				if (UGameInstance* GI = GetGameInstance())
+				{
+					if (UROWSCharacterSubsystem* Chars = GI->GetSubsystem<UROWSCharacterSubsystem>())
+					{
+						if (const APawn* Pawn = Exiting->GetPawn())
+						{
+							const FVector Loc = Pawn->GetActorLocation();
+							const FRotator Rot = Pawn->GetActorRotation();
+							Chars->UpdatePosition(State->CharacterName, TEXT("HubWorld"), Loc.X, Loc.Y, Loc.Z, Rot.Roll, Rot.Pitch, Rot.Yaw);
+						}
+						Chars->PlayerLogout(State->CharacterName);
+					}
+				}
+			}
+		}
+	}
+
+	Super::Logout(Exiting);
 }
 
 void AchuckServerGameMode::BeginPlay()

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckServerGameMode.h
@@ -21,6 +21,8 @@ public:
 	AchuckServerGameMode();
 
 	virtual void BeginPlay() override;
+	virtual void InitNewPlayer(AController* NewPlayerController, const FUniqueNetIdRepl& UniqueId, const FString& Options, const FString& Portal) override;
+	virtual void Logout(AController* Exiting) override;
 
 	UPROPERTY(EditDefaultsOnly, Category = "KBVE|Server")
 	int32 SlimeCount = 30;

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckSessionSubsystem.cpp
@@ -188,7 +188,11 @@ void UchuckSessionSubsystem::HandleZoneInstanceSuccess(const FROWSZoneInstance& 
 	{
 		if (APlayerController* PC = GI->GetFirstLocalPlayerController())
 		{
-			const FString Address = FString::Printf(TEXT("%s:%d"), *ZoneInstance.ServerIP, ZoneInstance.Port);
+			FString Address = FString::Printf(TEXT("%s:%d"), *ZoneInstance.ServerIP, ZoneInstance.Port);
+			if (!SelectedCharacter.IsEmpty())
+			{
+				Address += FString::Printf(TEXT("?character=%s"), *SelectedCharacter);
+			}
 			PC->ClientTravel(Address, TRAVEL_Absolute);
 		}
 	}

--- a/packages/unreal/KBVEROWS/Source/ROWS/Private/ROWSCharacterSubsystem.cpp
+++ b/packages/unreal/KBVEROWS/Source/ROWS/Private/ROWSCharacterSubsystem.cpp
@@ -226,3 +226,72 @@ void UROWSCharacterSubsystem::OnGetCustomDataResponse(FHttpRequestPtr Request, F
 
 	OnCustomDataReceived.Broadcast(JsonString);
 }
+
+void UROWSCharacterSubsystem::UpdatePosition(const FString& CharacterName, const FString& MapName, double X, double Y, double Z, double RX, double RY, double RZ)
+{
+	if (!Core)
+	{
+		return;
+	}
+	const FString Wire = FString::Printf(TEXT("%s:%f:%f:%f:%f:%f:%f"), *CharacterName, X, Y, Z, RX, RY, RZ);
+
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("serializedPlayerLocationData"), Wire);
+	Json->SetStringField(TEXT("mapName"), MapName);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Characters/UpdateAllPlayerPositions"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnPersistenceResponse));
+}
+
+void UROWSCharacterSubsystem::UpdateStats(const FString& CharacterName, const FString& StatsJson)
+{
+	if (!Core)
+	{
+		return;
+	}
+	TSharedPtr<FJsonObject> Json;
+	const TSharedRef<TJsonReader<>> Reader = TJsonReaderFactory<>::Create(StatsJson);
+	if (!FJsonSerializer::Deserialize(Reader, Json) || !Json.IsValid())
+	{
+		Json = MakeShareable(new FJsonObject);
+	}
+	Json->SetStringField(TEXT("characterName"), CharacterName);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Characters/UpdateCharacterStats"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnPersistenceResponse));
+}
+
+void UROWSCharacterSubsystem::PlayerLogout(const FString& CharacterName)
+{
+	if (!Core)
+	{
+		return;
+	}
+	TSharedPtr<FJsonObject> Json = MakeShareable(new FJsonObject);
+	Json->SetStringField(TEXT("characterName"), CharacterName);
+
+	FString Body;
+	TSharedRef<TJsonWriter<>> Writer = TJsonWriterFactory<>::Create(&Body);
+	FJsonSerializer::Serialize(Json.ToSharedRef(), Writer);
+
+	Core->PostRequest(Core->GetCharacterPersistencePath(), TEXT("api/Characters/PlayerLogout"), Body,
+		FHttpRequestCompleteDelegate::CreateUObject(this, &UROWSCharacterSubsystem::OnPersistenceResponse));
+}
+
+void UROWSCharacterSubsystem::OnPersistenceResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful)
+{
+	if (!bWasSuccessful || !Response.IsValid())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("[ROWS] Persistence request failed"));
+		return;
+	}
+	UE_LOG(LogTemp, Verbose, TEXT("[ROWS] Persistence ok: %d"), Response->GetResponseCode());
+}

--- a/packages/unreal/KBVEROWS/Source/ROWS/Public/ROWSCharacterSubsystem.h
+++ b/packages/unreal/KBVEROWS/Source/ROWS/Public/ROWSCharacterSubsystem.h
@@ -45,6 +45,17 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
 	void GetCustomCharacterData(const FString& CharacterName);
 
+	// --- Persistence (server-authoritative; requires the x-service-key) ---
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void UpdatePosition(const FString& CharacterName, const FString& MapName, double X, double Y, double Z, double RX, double RY, double RZ);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void UpdateStats(const FString& CharacterName, const FString& StatsJson);
+
+	UFUNCTION(BlueprintCallable, Category = "ROWS|Characters")
+	void PlayerLogout(const FString& CharacterName);
+
 	// --- Delegates ---
 
 	UPROPERTY(BlueprintAssignable, Category = "ROWS|Characters")
@@ -85,4 +96,5 @@ protected:
 	void OnRemoveCharacterResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
 	void OnAddOrUpdateCustomDataResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
 	void OnGetCustomDataResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
+	void OnPersistenceResponse(FHttpRequestPtr Request, FHttpResponsePtr Response, bool bWasSuccessful);
 };


### PR DESCRIPTION
P1 ROWS gap — character persistence to ROWS. The Rust `CharacterPersistence` REST endpoints existed; the UE side had no methods + no server sync.

## Plugin API (`UROWSCharacterSubsystem`)
- `UpdatePosition` → `UpdateAllPlayerPositions` (OWS wire format `Name:X:Y:Z:RX:RY:RZ`).
- `UpdateStats` → `UpdateCharacterStats` (characterName + flattened stat JSON).
- `PlayerLogout` → `PlayerLogout`.
- camelCase bodies; authenticated server-side via the existing `x-service-key` (these endpoints `require_service_key`).

## chuck server chain
- `AchuckPlayerState` carries a replicated `CharacterName`.
- Session `ClientTravel` appends `?character=<selected>`; `AchuckServerGameMode` (`PlayerStateClass = AchuckPlayerState`) parses it in `InitNewPlayer` onto the state.
- `UchuckCharacterPersistenceSubsystem` (dedicated server) periodically (30s) `UpdatePosition`s every player by character name + pawn transform.
- GameMode `Logout` flushes a final position + `PlayerLogout`.

**End to end:** client picks character → travels with it → server identifies the player → persists position/logout to ROWS.

## Follow-ups
- `UpdateStats` is wired but not yet called from gameplay (hook to the stat/combat system on change).
- Streaming `HealthStream`, `GlobalData` subsystem, `GetZoneInstance` (earlier P1–P3 list).

UE 5.7, builds in ci-unreal.