### PR TITLE
chore(ci): regenerate ci-dispatch-manifest — unblock stuck version gates

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.7",
+			"version": "0.1.9",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -120,7 +120,7 @@
 		{
 			"key": "cryptothrone_server",
 			"app_name": "cryptothrone-server",
-			"version": "0.0.1",
+			"version": "0.0.2",
 			"version_toml": "apps/agones/cryptothrone/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
 			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",
@@ -146,7 +146,7 @@
 		{
 			"key": "discordsh_bot",
 			"app_name": "discordsh-bot",
-			"version": "0.1.18",
+			"version": "0.1.19",
 			"version_toml": "apps/discordsh/discordsh-bot/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/discordsh-bot.mdx",
 			"version_target": "apps/discordsh/discordsh-bot/Cargo.toml",
@@ -1037,7 +1037,7 @@
 				"license_method": "personal"
 			},
 			"source_path": "apps/rareicon/unity-rareicon",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"version_toml": "apps/rareicon/unity-rareicon/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unity-rareicon.mdx",
 			"runner": "ubuntu-latest",


### PR DESCRIPTION
## Symptom

`unity-rareicon` publish skipped with `No version bump (local=0.1.8, published=0.1.8)` even though `unity-rareicon.mdx` was bumped to `0.1.9`.

## Root cause — publish deadlock

`ci-main.yml` dispatches each app with `manifest_version` read from the committed `.github/ci-dispatch-manifest.json` entry's `.version` field. The version_gate compares that to `version.toml` and skips when equal.

But the manifest's `.version` is only refreshed **post-publish**, by `utils-update-version-toml.yml` (`workflow_call`, regenerates the manifest at lines 152-155). And `ci-manifest-guard.yml` deliberately **allows version-field drift** (only blocks structural drift), so a prep commit that bumps the MDX without regenerating the manifest passes CI.

Result is circular:

1. Prep commit bumps MDX `0.1.8 → 0.1.9` (manifest untouched — commit `1e96dcd5c`).
2. Guard allows the version drift; PR merges with a stale manifest.
3. Dispatch reads `manifest_version = 0.1.8` (stale) → gate sees `0.1.8 == version.toml 0.1.8` → **skip**.
4. No publish → post-publish regen never runs → manifest stays `0.1.8` → **deadlock**.

A fresh MDX bump can never trigger its own first publish unless the manifest is regenerated up front. Four apps were stuck this way.

## This PR

Regenerated the manifest from a clean `astro-kbve` build (`build` + `sync:ci-manifest`), bringing `.version` back in line with the MDX sources:

| app | manifest was | now (MDX) |
|---|---|---|
| `unity_rareicon` | 0.1.8 | **0.1.9** |
| `cryptothrone` | 0.1.7 | 0.1.9 |
| `cryptothrone_server` | 0.0.1 | 0.0.2 |
| `discordsh_bot` | 0.1.18 | 0.1.19 |

Once merged, each app's gate sees `manifest_version > version.toml` and publishes; the post-publish auto-PR then keeps the manifest synced. **Note:** this unblocks 4 publishes, not 1.

## Follow-up (separate)

The deadlock will recur on the next prep bump. Durable fix options (not in this PR):
- **(A)** Make `ci-main` read the dispatch version from the MDX `version_source` directly instead of the manifest `.version` — removes the manifest as a gating-version surface entirely.
- **(B)** Make `ci-manifest-guard` block version drift too, forcing every MDX bump PR to include the regen.