### PR TITLE
fix(ci): game-engine dispatch reads version from MDX source, not stale manifest

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -173,6 +173,20 @@ jobs:
                     is_newer "$local_v" "$pub_v"
                   }
 
+                  read_source_version() {
+                    local source_file="$1" v="0.0.0"
+                    if [ -f "$source_file" ]; then
+                      case "$source_file" in
+                        *.json)    v=$(jq -r '.version // "0.0.0"' "$source_file" 2>/dev/null || echo "0.0.0") ;;
+                        *.uplugin) v=$(jq -r '.VersionName // "0.0.0"' "$source_file" 2>/dev/null || echo "0.0.0") ;;
+                        *.mdx)     v=$(sed -n 's/^version: *"\([^"]*\)"/\1/p' "$source_file" | head -1); [ -z "$v" ] && v="0.0.0" ;;
+                        *.csproj)  v=$(sed -n 's/.*<Version>\([^<]*\)<\/Version>.*/\1/p' "$source_file" | head -1); [ -z "$v" ] && v="0.0.0" ;;
+                        *)         v=$(grep -m1 '^version' "$source_file" | sed 's/version = "\(.*\)"/\1/' 2>/dev/null || echo "0.0.0") ;;
+                      esac
+                    fi
+                    echo "$v"
+                  }
+
                   # --- Check if alteration key is true ---
                   is_altered() {
                     local key="$1"
@@ -489,7 +503,7 @@ jobs:
                   # =================================================================
                   dispatch_game_engine() {
                     local pipeline="$1"; local workflow="$2"; local entry="$3"
-                    local key app src vtoml ver vtgt run has_test
+                    local key app src vtoml ver sv vtgt run has_test
                     local engine_version proj_path build_targets features dotnet ext_repo lic
                     local itch_user itch_game itch_chan deploy_itch
                     key=$(echo "$entry" | jq -r '.key')
@@ -497,6 +511,10 @@ jobs:
                     src=$(echo "$entry" | jq -r '.version_source // empty')
                     vtoml=$(echo "$entry" | jq -r '.version_toml // empty')
                     ver=$(echo "$entry" | jq -r '.version // empty')
+                    if [ -n "$src" ]; then
+                      sv=$(read_source_version "$src")
+                      [ -n "$sv" ] && [ "$sv" != "0.0.0" ] && ver="$sv"
+                    fi
                     vtgt=$(echo "$entry" | jq -r '.version_target // empty')
                     run=$(echo "$entry" | jq -r '.runner // empty')
                     has_test=$(echo "$entry" | jq -r '.has_test // empty')


### PR DESCRIPTION
## Durable fix for the manifest-version publish deadlock

Follow-up to #12163 (which manually regenerated the drifted manifest). This removes the failure mode so it can't recur.

### The deadlock

`dispatch_game_engine` in `ci-main.yml` passed each manifest entry's `.version` field as `manifest_version` to the engine workflow (ci-unity/ci-godot/ci-unreal). The downstream `version_gate` compares `manifest_version` to `version.toml` and skips when equal.

But the manifest `.version` is only refreshed **post-publish** (`utils-update-version-toml.yml`, `workflow_call`). So a fresh MDX bump was invisible:

1. Prep commit bumps MDX `0.1.8 → 0.1.9` (manifest untouched; `ci-manifest-guard` allows version drift).
2. ci-main's dispatch *decision* uses `check_version` on the MDX → fires the dispatch.
3. …but hands the stale manifest `.version` (`0.1.8`) downstream as `manifest_version`.
4. The engine `version_gate` sees `0.1.8 == version.toml 0.1.8` → **skip**.
5. No publish → no post-publish manifest regen → stuck forever.

### Fix

Add `read_source_version()` and resolve `ver` from the entry's `version_source` file (MDX/json/uplugin/csproj/toml) at dispatch time, falling back to the manifest field. The dispatch *decision* already read the live source via `check_version`; this makes the version handed downstream match it. The manifest `.version` is no longer a gating surface for game engines.

Scoped to `dispatch_game_engine` (unity / godot / unreal_game) — the demonstrably-stuck path. Rust/python/npm/unreal-plugin sections publish today and gate differently; changing their version source blind would risk regressing working pipelines, so they're left as-is.

### Verification

Can't exercise CI locally. YAML validated; the embedded bash change is a one-line override (`ver` ← live source) plus the helper. The first real test is the next game-engine dispatch on `dev`.