### PR TITLE
feat(cryptothrone): login + username gate on /game/play (no guests)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -60,9 +60,15 @@ const PhaserCanvas = memo(function PhaserCanvas() {
  * Uses dispatch-only hook so this wrapper never re-renders on state changes.
  * Each child subscribes to its own state slice independently.
  */
-function GameUI() {
+function GameUI({ username }: { username?: string }) {
 	const dispatch = useGameDispatch();
 	useEventBridge(dispatch);
+
+	useEffect(() => {
+		if (username) {
+			dispatch({ type: 'SET_PLAYER_STATS', payload: { username } });
+		}
+	}, [dispatch, username]);
 
 	useEffect(() => {
 		if (import.meta.env.DEV) {
@@ -87,12 +93,12 @@ function GameUI() {
 	);
 }
 
-export default function GameWindow() {
+export default function GameWindow({ username }: { username?: string }) {
 	return (
 		<GameStoreProvider>
 			<div className="relative flex justify-center items-center w-full h-full">
 				<PhaserCanvas />
-				<GameUI />
+				<GameUI username={username} />
 			</div>
 		</GameStoreProvider>
 	);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindowLoader.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindowLoader.tsx
@@ -2,7 +2,7 @@ import { lazy, Suspense } from 'react';
 
 const GameWindow = lazy(() => import('./GameWindow'));
 
-export default function GameWindowLoader() {
+export default function GameWindowLoader({ username }: { username?: string }) {
 	return (
 		<Suspense
 			fallback={
@@ -12,7 +12,7 @@ export default function GameWindowLoader() {
 					Loading game…
 				</div>
 			}>
-			<GameWindow />
+			<GameWindow username={username} />
 		</Suspense>
 	);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { KbveUsernameSetup } from '@kbve/astro';
+import { authBridge, initSupa } from '@/lib/supa';
+import ReactLoginButtons from '../auth/ReactLoginButtons';
+import GameWindowLoader from './GameWindowLoader';
+
+const KBVE_API_BASE = 'https://kbve.com';
+
+type Phase = 'loading' | 'login' | 'username' | 'ready';
+
+function kbveUsernameFromToken(token: string): string {
+	try {
+		const payload = token.split('.')[1];
+		const json = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+		const claims = JSON.parse(json) as { kbve_username?: string };
+		return claims.kbve_username ?? '';
+	} catch {
+		return '';
+	}
+}
+
+export default function ReactGameGate() {
+	const [phase, setPhase] = useState<Phase>('loading');
+	const [token, setToken] = useState('');
+	const [username, setUsername] = useState('');
+
+	async function check() {
+		setPhase('loading');
+		try {
+			await initSupa();
+		} catch {
+			/* getSession resolves null when uninitialized */
+		}
+		const session = await authBridge.getSession();
+		const accessToken = session?.access_token ?? '';
+		if (!accessToken) {
+			setPhase('login');
+			return;
+		}
+		setToken(accessToken);
+		const name = kbveUsernameFromToken(accessToken);
+		if (!name) {
+			setPhase('username');
+			return;
+		}
+		setUsername(name);
+		setPhase('ready');
+	}
+
+	useEffect(() => {
+		check();
+	}, []);
+
+	if (phase === 'ready') return <GameWindowLoader username={username} />;
+
+	return (
+		<div style={shell}>
+			<div style={panel}>
+				{phase === 'loading' && <p style={muted}>Checking session…</p>}
+
+				{phase === 'login' && (
+					<>
+						<h2 style={title}>Sign in to play CryptoThrone</h2>
+						<p style={muted}>
+							CryptoThrone is members-only — no guests. Sign in
+							with your KBVE account to enter the world.
+						</p>
+						<ReactLoginButtons />
+					</>
+				)}
+
+				{phase === 'username' && (
+					<KbveUsernameSetup
+						accessToken={token}
+						apiBaseUrl={KBVE_API_BASE}
+						onComplete={async () => {
+							await authBridge.refreshSession();
+							await check();
+						}}
+					/>
+				)}
+			</div>
+		</div>
+	);
+}
+
+const shell: React.CSSProperties = {
+	display: 'flex',
+	justifyContent: 'center',
+	alignItems: 'center',
+	width: '100%',
+	height: '100%',
+	background: 'var(--ct-bg-deep, #1a1a2e)',
+	padding: '1rem',
+};
+
+const panel: React.CSSProperties = {
+	width: '100%',
+	maxWidth: 420,
+	textAlign: 'center',
+	color: '#e6edf3',
+};
+
+const title: React.CSSProperties = {
+	fontSize: '1.25rem',
+	fontWeight: 600,
+	margin: '0 0 0.5rem',
+};
+
+const muted: React.CSSProperties = {
+	fontSize: '0.875rem',
+	color: '#9ca0aa',
+	margin: '0 0 1rem',
+	lineHeight: 1.5,
+};

--- a/apps/cryptothrone/astro-cryptothrone/src/content/docs/game/play.mdx
+++ b/apps/cryptothrone/astro-cryptothrone/src/content/docs/game/play.mdx
@@ -7,8 +7,8 @@ hero:
   tagline: ' '
 ---
 
-import GameWindowLoader from '../../../components/game/GameWindowLoader';
+import ReactGameGate from '../../../components/game/ReactGameGate';
 
 <div class="game-fullscreen not-content">
-  <GameWindowLoader client:only="react" />
+  <ReactGameGate client:only="react" />
 </div>


### PR DESCRIPTION
You hit `cryptothrone.com/game/play/` and got the old single-player **Guest** client — because the page mounted `GameWindowLoader` directly, with no auth. This wires the gate.

`ReactGameGate` wraps the game:
1. `authBridge.getSession()` — **no session → login screen** (GitHub/Discord via `ReactLoginButtons`), members-only, no guests.
2. Session but **no `kbve_username` claim → `KbveUsernameSetup`** (the `@kbve/astro` island, POSTs to `kbve.com/api/v1/profile/username`), then `refreshSession()` so the new JWT carries the claim → re-check.
3. Session + username → mount the game, passing the real username into the store so the sidebar shows it instead of `Guest`.

Typechecks clean (3 pre-existing app errors unrelated).

**Not in this PR:** the multiplayer connect itself (`GameClient` → cryptothrone-server, render remote players) — that needs the game server reachable over WSS first. This PR is the auth gate; deploying it needs a `cryptothrone` web `version:` bump.