### PR TITLE
feat(chuck): Energy stat — Mass fragment + actor + UI bus

### DIFF
--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCoreCharacter.cpp
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Core/chuckCoreCharacter.cpp
@@ -25,6 +25,7 @@
 #include "chuckItemDB.h"
 #include "KBVEMovementState.h"
 #include "KBVEStatFragment.h"
+#include "KBVEStatIds.h"
 #include "KBVEEffectComponent.h"
 #include "KBVEGameplayTypes.h"
 #include "chuckUIEvents.h"
@@ -212,6 +213,9 @@ void AchuckCoreCharacter::CreateStatEntity()
 		Frag->Mana                      = Stats.Mana;
 		Frag->MaxMana                   = Stats.MaxMana;
 		Frag->ManaRegenPerSec           = Stats.ManaRegenPerSec;
+		Frag->Energy                    = Stats.Energy;
+		Frag->MaxEnergy                 = Stats.MaxEnergy;
+		Frag->EnergyRegenPerSec         = Stats.EnergyRegenPerSec;
 		Frag->Stamina                   = Stats.Stamina;
 		Frag->MaxStamina                = Stats.MaxStamina;
 		Frag->StaminaRegenPerSec        = Stats.StaminaRegenPerSec;
@@ -281,6 +285,7 @@ void AchuckCoreCharacter::SyncStatsFragment(float DeltaSeconds)
 
 	Stats.Health           = Frag->Health;
 	Stats.Mana             = Frag->Mana;
+	Stats.Energy           = Frag->Energy;
 	Stats.Stamina          = Frag->Stamina;
 	Stats.StaminaRegenDelay = Frag->StaminaRegenDelay;
 
@@ -621,17 +626,19 @@ bool AchuckCoreCharacter::ServerConsumeSlot(int32 SlotIndex, bool bHotbar)
 
 float AchuckCoreCharacter::GetStatValue(FName StatId) const
 {
-	if (StatId == TEXT("Health"))  return Stats.Health;
-	if (StatId == TEXT("Mana"))    return Stats.Mana;
-	if (StatId == TEXT("Stamina")) return Stats.Stamina;
+	if (StatId == KBVEStats::Health)  return Stats.Health;
+	if (StatId == KBVEStats::Mana)    return Stats.Mana;
+	if (StatId == KBVEStats::Energy)  return Stats.Energy;
+	if (StatId == KBVEStats::Stamina) return Stats.Stamina;
 	return 0.f;
 }
 
 float AchuckCoreCharacter::GetStatMax(FName StatId) const
 {
-	if (StatId == TEXT("Health"))  return Stats.MaxHealth;
-	if (StatId == TEXT("Mana"))    return Stats.MaxMana;
-	if (StatId == TEXT("Stamina")) return Stats.MaxStamina;
+	if (StatId == KBVEStats::Health)  return Stats.MaxHealth;
+	if (StatId == KBVEStats::Mana)    return Stats.MaxMana;
+	if (StatId == KBVEStats::Energy)  return Stats.MaxEnergy;
+	if (StatId == KBVEStats::Stamina) return Stats.MaxStamina;
 	return 0.f;
 }
 
@@ -639,9 +646,10 @@ void AchuckCoreCharacter::ApplyStatDelta(FName StatId, float Delta)
 {
 	if (!HasAuthority() || Delta == 0.f) return;
 
-	if (StatId == TEXT("Health"))       Stats.Health  = FMath::Clamp(Stats.Health  + Delta, 0.f, Stats.MaxHealth);
-	else if (StatId == TEXT("Mana"))    Stats.Mana    = FMath::Clamp(Stats.Mana    + Delta, 0.f, Stats.MaxMana);
-	else if (StatId == TEXT("Stamina")) Stats.Stamina = FMath::Clamp(Stats.Stamina + Delta, 0.f, Stats.MaxStamina);
+	if (StatId == KBVEStats::Health)       Stats.Health  = FMath::Clamp(Stats.Health  + Delta, 0.f, Stats.MaxHealth);
+	else if (StatId == KBVEStats::Mana)    Stats.Mana    = FMath::Clamp(Stats.Mana    + Delta, 0.f, Stats.MaxMana);
+	else if (StatId == KBVEStats::Energy)  Stats.Energy  = FMath::Clamp(Stats.Energy  + Delta, 0.f, Stats.MaxEnergy);
+	else if (StatId == KBVEStats::Stamina) Stats.Stamina = FMath::Clamp(Stats.Stamina + Delta, 0.f, Stats.MaxStamina);
 	else return;
 
 	UWorld* World = GetWorld();
@@ -652,6 +660,7 @@ void AchuckCoreCharacter::ApplyStatDelta(FName StatId, float Delta)
 		{
 			Frag->Health  = Stats.Health;
 			Frag->Mana    = Stats.Mana;
+			Frag->Energy  = Stats.Energy;
 			Frag->Stamina = Stats.Stamina;
 		}
 	}
@@ -678,6 +687,11 @@ void AchuckCoreCharacter::PublishStatChanges()
 		!FMath::IsNearlyEqual(Stats.MaxMana, LastPublishedStats.MaxMana))
 	{
 		Bus->Mana.Publish({ Stats.Mana, Stats.MaxMana });
+	}
+	if (!FMath::IsNearlyEqual(Stats.Energy, LastPublishedStats.Energy) ||
+		!FMath::IsNearlyEqual(Stats.MaxEnergy, LastPublishedStats.MaxEnergy))
+	{
+		Bus->Energy.Publish({ Stats.Energy, Stats.MaxEnergy });
 	}
 	if (!FMath::IsNearlyEqual(Stats.Stamina, LastPublishedStats.Stamina) ||
 		!FMath::IsNearlyEqual(Stats.MaxStamina, LastPublishedStats.MaxStamina) ||

--- a/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckUIEvents.h
+++ b/apps/chuckrpg/unreal-chuck/Source/chuck/Events/chuckUIEvents.h
@@ -25,6 +25,7 @@ public:
 
 	TKBVEChannel<FKBVEHealthChangedPayload>   Health;
 	TKBVEChannel<FKBVEManaChangedPayload>     Mana;
+	TKBVEChannel<FKBVEEnergyChangedPayload>   Energy;
 	TKBVEChannel<FKBVEStaminaChangedPayload>  Stamina;
 	TKBVEChannel<FchuckInventoryDirtyPayload>  InventoryDirty;
 	TKBVEChannel<FKBVEDamageReceivedPayload>  DamageReceived;

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEStatRegenProcessor.cpp
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Private/KBVEStatRegenProcessor.cpp
@@ -30,6 +30,7 @@ void UKBVEStatRegenProcessor::Execute(FMassEntityManager& EntityManager, FMassEx
 			{
 				S.Health = FMath::Min(S.Health + S.HealthRegenPerSec * DeltaSeconds, S.MaxHealth);
 				S.Mana   = FMath::Min(S.Mana   + S.ManaRegenPerSec   * DeltaSeconds, S.MaxMana);
+				S.Energy = FMath::Min(S.Energy + S.EnergyRegenPerSec * DeltaSeconds, S.MaxEnergy);
 
 				const bool bDraining =
 					KBVEMove::Has(S.MoveState, EKBVEMovementState::Sprinting) &&

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEGameplayEvents.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEGameplayEvents.h
@@ -19,6 +19,12 @@ struct FKBVEManaChangedPayload
 	float Max     = 0.f;
 };
 
+struct FKBVEEnergyChangedPayload
+{
+	float Current = 0.f;
+	float Max     = 0.f;
+};
+
 struct FKBVEStaminaChangedPayload
 {
 	float Current    = 0.f;

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatBlock.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatBlock.h
@@ -27,6 +27,15 @@ struct FKBVEStatBlock
 	float ManaRegenPerSec = 3.f;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float MaxEnergy = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float Energy = 100.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
+	float EnergyRegenPerSec = 4.f;
+
+	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
 	float MaxStamina = 100.f;
 
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "KBVE|Stats")
@@ -54,5 +63,6 @@ struct FKBVEStatBlock
 
 	float HealthFraction()  const { return MaxHealth  > 0.f ? FMath::Clamp(Health  / MaxHealth,  0.f, 1.f) : 0.f; }
 	float ManaFraction()    const { return MaxMana    > 0.f ? FMath::Clamp(Mana    / MaxMana,    0.f, 1.f) : 0.f; }
+	float EnergyFraction()  const { return MaxEnergy  > 0.f ? FMath::Clamp(Energy  / MaxEnergy,  0.f, 1.f) : 0.f; }
 	float StaminaFraction() const { return MaxStamina > 0.f ? FMath::Clamp(Stamina / MaxStamina, 0.f, 1.f) : 0.f; }
 };

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatFragment.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatFragment.h
@@ -18,6 +18,10 @@ struct KBVEGAMEPLAY_API FKBVEStatFragment : public FMassFragment
 	float MaxMana = 100.f;
 	float ManaRegenPerSec = 3.f;
 
+	float Energy = 100.f;
+	float MaxEnergy = 100.f;
+	float EnergyRegenPerSec = 4.f;
+
 	float Stamina = 100.f;
 	float MaxStamina = 100.f;
 	float StaminaRegenPerSec = 10.f;

--- a/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatIds.h
+++ b/packages/unreal/KBVEGameplay/Source/KBVEGameplay/Public/KBVEStatIds.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+namespace KBVEStats
+{
+	inline const FName Health(TEXT("Health"));
+	inline const FName Mana(TEXT("Mana"));
+	inline const FName Energy(TEXT("Energy"));
+	inline const FName Stamina(TEXT("Stamina"));
+}


### PR DESCRIPTION
## What

Adds **Energy** as a first-class stat alongside Health / Mana / Stamina, wired end to end and on the multithread-ready path.

### Model (KBVEGameplay, game-agnostic)
- `FKBVEStatFragment` — `Energy` / `MaxEnergy` / `EnergyRegenPerSec`
- `KBVEStatRegenProcessor::Execute` — Energy regen added to the `ParallelForEachEntityChunk` loop (same parallel path as Health/Mana)
- `FKBVEStatBlock` — Energy fields + `EnergyFraction()`
- `FKBVEEnergyChangedPayload` event payload
- **NEW** `KBVEStatIds.h` — canonical `KBVEStats::{Health,Mana,Energy,Stamina}` FName ids, replacing ad-hoc `TEXT("...")` literals

### chuck integration
- `UchuckUIEvents` — `Energy` channel
- `AchuckCoreCharacter` — push/read-back Energy in the Stats↔Mass fragment sync, publish on change, `IKBVEStatTarget` Get/ApplyStatDelta now handle Energy via canonical ids

## Why
Health/Mana/Energy now share the Mass `FKBVEStatFragment` + parallel regen processor, so the swarm path and the hero actor both scale on the same future-proof multithreaded seam. The actor mirrors its block into the fragment and reads results back.

## Notes
- HUD `Energy` channel is published but not yet drawn (current 3 bars stay HP/MP/EP-as-stamina); adding a visible Energy bar is a follow-up UI/layout decision.