### PR TITLE
feat(cryptothrone): server-authoritative client + WSS reachability (B+C)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ReactGameGate.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { KbveUsernameSetup } from '@kbve/astro';
 import { authBridge, initSupa } from '@/lib/supa';
+import { setCtNetConfig, resolveWsUrl } from '@/lib/net-config';
 import ReactLoginButtons from '../auth/ReactLoginButtons';
 import GameWindowLoader from './GameWindowLoader';
 
@@ -44,6 +45,11 @@ export default function ReactGameGate() {
 			return;
 		}
 		setUsername(name);
+		setCtNetConfig({
+			jwt: accessToken,
+			username: name,
+			wsUrl: resolveWsUrl(),
+		});
 		setPhase('ready');
 	}
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -1,62 +1,37 @@
 import { Scene } from 'phaser';
-import {
-	Quadtree,
-	PlayerController,
-	SideMap,
-	laserEvents,
-	getBirdNum,
-	isBird,
-	createBirdSprites,
-	createShadowSprites,
-	createBirdAnimation,
-} from '@kbve/laser';
-import type { Bounds2D, Range, CharacterEventData } from '@kbve/laser';
-import {
-	createGameWorld,
-	spawnPlayer,
-	spawnNpc,
-	spawnMonster,
-	type GameWorld,
-} from '../ecs/world';
-import { Position } from '../ecs/components';
-import {
-	monstersNearPlayer,
-	nearestMonster,
-	cullMonsters,
-} from '../ecs/systems';
-
-interface PositionChangeEvent {
-	charId: string;
-	exitTile: { x: number; y: number };
-	enterTile: { x: number; y: number };
-}
+import { GameClient, laserEvents, createBirdAnimation } from '@kbve/laser';
+import type { Range, CharacterEventData, Dir, Snapshot } from '@kbve/laser';
+import { getCtNetConfig } from '@/lib/net-config';
 
 const MAP_SCALE = 3;
-const AGGRO_RADIUS = 4;
-const ACTIVE_RADIUS = 9;
-const CULL_INTERVAL_MS = 250;
+const STEP_THROTTLE_MS = 180;
+
+const KIND_PLAYER = 0;
+const KIND_MONK = 1;
+const KIND_BIRD = 2;
+const SLOT_NONE = 0xffff;
+
+interface Tracked {
+	sprite: Phaser.GameObjects.Sprite;
+	charId: string;
+	tile: { x: number; y: number };
+}
 
 export class CloudCityScene extends Scene {
-	private npcSprite: Phaser.GameObjects.Sprite | undefined;
-	private monsterBirdSprites: Phaser.GameObjects.Sprite[] = [];
-	private monsterBirdShadows: Phaser.GameObjects.Sprite[] = [];
 	private gridEngine: any;
-	private quadtree: Quadtree;
-	private playerController: PlayerController | undefined;
+	private client: GameClient | null = null;
 
-	private world!: GameWorld;
-	private playerEid = -1;
-	private spriteByEid = new SideMap<Phaser.GameObjects.Sprite>();
-	private shadowByEid = new SideMap<Phaser.GameObjects.Sprite>();
-	private eidByChar = new Map<string, number>();
-	private charByEid = new Map<number, string>();
-	private monsterNearby = false;
-	private lastCull = 0;
+	private mySlot = SLOT_NONE;
+	private myEid = -1;
+	private tracked = new Map<number, Tracked>();
+	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+	private entityDepth = 0;
+	private lastStepAt = 0;
+	private ranges: Range[] = [];
+	private rangeTile = { x: -1, y: -1 };
 
 	constructor() {
 		super({ key: 'CloudCity' });
-		const bounds: Bounds2D = { xMin: 0, xMax: 50, yMin: 0, yMax: 50 };
-		this.quadtree = new Quadtree(bounds);
 	}
 
 	create() {
@@ -65,7 +40,6 @@ export class CloudCityScene extends Scene {
 			'cloud_tileset',
 			'cloud-city-tiles',
 		);
-
 		for (let i = 0; i < tilemap.layers.length; i++) {
 			const layer = tileset
 				? tilemap.createLayer(i, tileset, 0, 0)
@@ -75,186 +49,157 @@ export class CloudCityScene extends Scene {
 				layer.setDepth(i);
 			}
 		}
-
-		const worldWidth = tilemap.widthInPixels * MAP_SCALE;
-		const worldHeight = tilemap.heightInPixels * MAP_SCALE;
-		this.cameras.main.setBounds(0, 0, worldWidth, worldHeight);
-
-		const playerSprite = this.add.sprite(0, 0, 'player');
-		playerSprite.setDepth(tilemap.layers.length);
-		playerSprite.scale = 1.5;
-
-		this.npcSprite = this.add.sprite(0, 0, 'monks');
-		this.npcSprite.setDepth(tilemap.layers.length);
-		this.npcSprite.scale = 1.5;
-
-		this.cameras.main.startFollow(playerSprite, true);
-		this.cameras.main.setFollowOffset(
-			-playerSprite.width,
-			-playerSprite.height,
+		this.entityDepth = tilemap.layers.length + 1;
+		this.cameras.main.setBounds(
+			0,
+			0,
+			tilemap.widthInPixels * MAP_SCALE,
+			tilemap.heightInPixels * MAP_SCALE,
 		);
 
 		createBirdAnimation(this);
-		this.monsterBirdSprites = createBirdSprites(this);
-		this.monsterBirdShadows = createShadowSprites(this);
-		this.anims.staggerPlay('bird', this.monsterBirdSprites, 100);
-		const entityDepth = tilemap.layers.length;
-		this.monsterBirdShadows.forEach((s) => s.setDepth(entityDepth));
-		this.monsterBirdSprites.forEach((s) => s.setDepth(entityDepth + 1));
-
-		const gridEngineConfig = {
-			characters: [
-				{
-					id: 'player',
-					sprite: playerSprite,
-					walkingAnimationMapping: 6,
-					startPosition: { x: 5, y: 12 },
-				},
-				{
-					id: 'npc',
-					sprite: this.npcSprite,
-					walkingAnimationMapping: 0,
-					startPosition: { x: 4, y: 10 },
-					speed: 3,
-				},
-				...this.monsterBirdSprites.map((sprite, i) => ({
-					id: 'monster_bird_' + i,
-					sprite,
-					startPosition: { x: 7, y: 7 + i },
-					speed: 5,
-					collides: false,
-				})),
-				...this.monsterBirdShadows.map((sprite, i) => ({
-					id: 'monster_bird_shadow_' + i,
-					sprite,
-					startPosition: { x: 7, y: 7 + i },
-					speed: 5,
-					collides: false,
-				})),
-			],
+		this.gridEngine.create(tilemap, {
+			characters: [],
 			numberOfDirections: 8,
-		};
-
-		this.gridEngine.create(tilemap, gridEngineConfig);
+		});
+		this.cursors = this.input.keyboard!.createCursorKeys();
 		this.loadRanges();
 
-		if (import.meta.env.DEV) {
-			(
-				window as Window & { __ctGame?: { gridEngine: unknown } }
-			).__ctGame = { gridEngine: this.gridEngine };
-		}
-
-		this.playerController = new PlayerController(
-			this,
-			this.gridEngine,
-			this.quadtree,
-			{ tileSize: 48, joystick: true },
-		);
-
-		this.initEcs(playerSprite);
-
-		this.gridEngine.moveRandomly('npc', 1500, 3);
-
-		for (let i = 0; i < 10; i++) {
-			this.gridEngine.moveRandomly('monster_bird_' + i, 1000, 20);
-		}
-
-		this.gridEngine
-			.positionChangeStarted()
-			.subscribe(({ charId, enterTile }: PositionChangeEvent) => {
-				const eid = this.eidByChar.get(charId);
-				if (eid !== undefined) {
-					Position.x[eid] = enterTile.x;
-					Position.y[eid] = enterTile.y;
-				}
-				if (isBird(charId)) {
-					this.gridEngine.moveTo(
-						'monster_bird_shadow_' + getBirdNum(charId),
-						{ x: enterTile.x, y: enterTile.y },
-					);
-				}
+		const cfg = getCtNetConfig();
+		if (!cfg) {
+			laserEvents.emit('char:event', {
+				message: 'Not signed in — reload the page and log in to play.',
 			});
-	}
-
-	private initEcs(playerSprite: Phaser.GameObjects.Sprite) {
-		this.world = createGameWorld();
-
-		this.playerEid = spawnPlayer(this.world, 5, 12);
-		this.bind(this.playerEid, 'player', playerSprite);
-
-		if (this.npcSprite) {
-			const npcEid = spawnNpc(this.world, 4, 10);
-			this.bind(npcEid, 'npc', this.npcSprite);
+			return;
 		}
 
-		this.monsterBirdSprites.forEach((sprite, i) => {
-			const eid = spawnMonster(this.world, 7, 7 + i);
-			this.bind(eid, 'monster_bird_' + i, sprite);
-			const shadow = this.monsterBirdShadows[i];
-			if (shadow) this.shadowByEid.set(eid, shadow);
+		const client = new GameClient({
+			url: cfg.wsUrl,
+			jwt: cfg.jwt,
+			kbveUsername: cfg.username,
 		});
-	}
-
-	private bind(
-		eid: number,
-		charId: string,
-		sprite: Phaser.GameObjects.Sprite,
-	) {
-		this.spriteByEid.set(eid, sprite);
-		this.eidByChar.set(charId, eid);
-		this.charByEid.set(eid, charId);
-	}
-
-	private setMonsterActive(eid: number, active: boolean) {
-		const charId = this.charByEid.get(eid);
-		if (!charId) return;
-		const sprite = this.spriteByEid.get(eid);
-		const shadow = this.shadowByEid.get(eid);
-		sprite?.setVisible(active);
-		shadow?.setVisible(active);
-		const shadowChar = 'monster_bird_shadow_' + getBirdNum(charId);
-		if (active) {
-			this.gridEngine.moveRandomly(charId, 1000, 20);
-		} else {
-			this.gridEngine.stopMovement(charId);
-			this.gridEngine.stopMovement(shadowChar);
-		}
-	}
-
-	private updateProximity() {
-		if (this.playerEid < 0) return;
-
-		const near = monstersNearPlayer(
-			this.world,
-			this.playerEid,
-			AGGRO_RADIUS,
-		);
-
-		if (near.length > 0 && !this.monsterNearby) {
-			this.monsterNearby = true;
-			const nearest = nearestMonster(
-				this.world,
-				this.playerEid,
-				AGGRO_RADIUS,
-			);
-			const dx =
-				Position.x[nearest ?? this.playerEid] -
-				Position.x[this.playerEid];
-			const dy =
-				Position.y[nearest ?? this.playerEid] -
-				Position.y[this.playerEid];
-			laserEvents.emit('monster:nearby', {
-				count: near.length,
-				nearestEid: nearest ?? -1,
-				distance: Math.round(Math.hypot(dx, dy)),
+		this.client = client;
+		client.on('welcome', (w) => {
+			this.mySlot = w.your_slot;
+		});
+		client.on('snapshot', (s) => this.applySnapshot(s));
+		client.on('reject', (reason) => {
+			laserEvents.emit('char:event', {
+				message: `Server rejected the connection: ${reason}`,
 			});
-		} else if (near.length === 0) {
-			this.monsterNearby = false;
+		});
+		client.on('close', () => {
+			laserEvents.emit('char:event', {
+				message: 'Disconnected from the world.',
+			});
+		});
+		client.connect();
+
+		this.events.once('shutdown', () => this.client?.close());
+	}
+
+	private makeSprite(kind: number): {
+		sprite: Phaser.GameObjects.Sprite;
+		mapping?: number;
+	} {
+		let key = 'player';
+		let mapping: number | undefined = 6;
+		if (kind === KIND_MONK) {
+			key = 'monks';
+			mapping = 0;
+		} else if (kind === KIND_BIRD) {
+			key = 'monster_bird';
+			mapping = undefined;
+		}
+		const sprite = this.add.sprite(0, 0, key);
+		sprite.scale = 1.5;
+		sprite.setDepth(this.entityDepth);
+		if (kind === KIND_BIRD) sprite.play('bird');
+		return { sprite, mapping };
+	}
+
+	private applySnapshot(snap: Snapshot) {
+		const seen = new Set<number>();
+
+		for (const e of snap.entities) {
+			seen.add(e.eid);
+			const existing = this.tracked.get(e.eid);
+			if (!existing) {
+				const { sprite, mapping } = this.makeSprite(e.kind);
+				const charId = `e${e.eid}`;
+				const conf: Record<string, unknown> = {
+					id: charId,
+					sprite,
+					startPosition: { x: e.tile.x, y: e.tile.y },
+					speed: 4,
+					collides: false,
+				};
+				if (mapping !== undefined) {
+					conf.walkingAnimationMapping = mapping;
+				}
+				this.gridEngine.addCharacter(conf);
+				this.tracked.set(e.eid, {
+					sprite,
+					charId,
+					tile: { x: e.tile.x, y: e.tile.y },
+				});
+				if (
+					e.kind === KIND_PLAYER &&
+					e.owner === this.mySlot &&
+					this.myEid < 0
+				) {
+					this.myEid = e.eid;
+					this.cameras.main.startFollow(sprite, true);
+				}
+			} else if (
+				existing.tile.x !== e.tile.x ||
+				existing.tile.y !== e.tile.y
+			) {
+				this.gridEngine.moveTo(existing.charId, {
+					x: e.tile.x,
+					y: e.tile.y,
+				});
+				existing.tile = { x: e.tile.x, y: e.tile.y };
+			}
+		}
+
+		for (const [eid, t] of this.tracked) {
+			if (seen.has(eid)) continue;
+			if (this.gridEngine.hasCharacter(t.charId)) {
+				this.gridEngine.removeCharacter(t.charId);
+			}
+			t.sprite.destroy();
+			this.tracked.delete(eid);
+			if (eid === this.myEid) this.myEid = -1;
+		}
+
+		this.checkRanges();
+	}
+
+	private checkRanges() {
+		if (this.myEid < 0) return;
+		const me = this.tracked.get(this.myEid);
+		if (!me) return;
+		if (me.tile.x === this.rangeTile.x && me.tile.y === this.rangeTile.y) {
+			return;
+		}
+		this.rangeTile = { x: me.tile.x, y: me.tile.y };
+		for (const range of this.ranges) {
+			const b = range.bounds;
+			if (
+				me.tile.x >= b.xMin &&
+				me.tile.x <= b.xMax &&
+				me.tile.y >= b.yMin &&
+				me.tile.y <= b.yMax
+			) {
+				range.action();
+				break;
+			}
 		}
 	}
 
 	private loadRanges() {
-		const ranges: Range[] = [
+		this.ranges = [
 			{
 				name: 'well',
 				bounds: { xMin: 2, xMax: 5, yMin: 10, yMax: 14 },
@@ -279,19 +224,6 @@ export class CloudCityScene extends Scene {
 				},
 			},
 			{
-				name: 'building',
-				bounds: { xMin: 13, xMax: 13, yMin: 6, yMax: 7 },
-				action: () => {
-					const eventData: CharacterEventData = {
-						message: 'Sorry, we are closed!',
-						character_name: 'Evee The BarKeep',
-						character_image: '/assets/npc/barkeep.webp',
-						background_image: '/assets/background/animebar.webp',
-					};
-					laserEvents.emit('char:event', eventData);
-				},
-			},
-			{
 				name: 'tombstone',
 				bounds: { xMin: 7, xMax: 10, yMin: 9, yMax: 10 },
 				action: () => {
@@ -307,24 +239,21 @@ export class CloudCityScene extends Scene {
 				},
 			},
 		];
-
-		for (const range of ranges) {
-			this.quadtree.insert(range);
-		}
 	}
 
 	update(time: number) {
-		this.playerController?.handleMovement();
-		this.updateProximity();
+		if (!this.client) return;
+		if (time - this.lastStepAt < STEP_THROTTLE_MS) return;
 
-		if (time - this.lastCull >= CULL_INTERVAL_MS) {
-			this.lastCull = time;
-			cullMonsters(
-				this.world,
-				this.playerEid,
-				ACTIVE_RADIUS,
-				(eid, active) => this.setMonsterActive(eid, active),
-			);
+		let dir: Dir | null = null;
+		if (this.cursors.up.isDown) dir = 'Up';
+		else if (this.cursors.down.isDown) dir = 'Down';
+		else if (this.cursors.left.isDown) dir = 'Left';
+		else if (this.cursors.right.isDown) dir = 'Right';
+
+		if (dir) {
+			this.client.step(dir);
+			this.lastStepAt = time;
 		}
 	}
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/lib/net-config.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/lib/net-config.ts
@@ -1,0 +1,20 @@
+export interface CtNetConfig {
+	jwt: string;
+	username: string;
+	wsUrl: string;
+}
+
+let config: CtNetConfig | null = null;
+
+export function resolveWsUrl(): string {
+	const env = import.meta.env.PUBLIC_CT_GAME_WS as string | undefined;
+	return env && env.length > 0 ? env : 'wss://game.cryptothrone.com/ws';
+}
+
+export function setCtNetConfig(next: CtNetConfig): void {
+	config = next;
+}
+
+export function getCtNetConfig(): CtNetConfig | null {
+	return config;
+}

--- a/apps/kube/agones/cryptothrone/README.md
+++ b/apps/kube/agones/cryptothrone/README.md
@@ -19,26 +19,32 @@ changes how the browser reaches a GameServer:
   `wss://game.cryptothrone.com/ws`; the gateway terminates TLS and proxies the
   WS upgrade to container port 7979.
 
-### Remaining wiring (needs cluster validation — not committed)
+### Wired here
 
-1. **Pin the Fleet to one world.** A Service round-robins; with multiple Ready
-   pods players land on _different_ worlds. For a single shared world set the
-   autoscaler `minReplicas: maxReplicas: 1` (or a static Fleet `replicas: 1`).
-   Grow to sharded worlds later with a per-world Service + hostname.
-2. **Gateway listener + cert.** Add a `game.cryptothrone.com` listener to the
-   Cilium `kbve-gateway` (in the `kbve` namespace) with a cert-manager
-   `Certificate` (mirror `apps/kube/cryptothrone/manifest/certificate.yaml`), then
-   an `HTTPRoute` `game.cryptothrone.com → cryptothrone-game:7979`. Cilium/Envoy
-   proxies the WS upgrade on a normal HTTPRoute.
-    - ⚠ New public hostnames on the Cilium gateway VIP (.71) have returned
-      522/526 from Cloudflare; ingress-nginx (.74) works. Validate which path the
-      game hostname should take before relying on it.
-    - ⚠ Don't split apex/sub across listeners sharing one SAN cert — Cilium
-      derives Envoy SNI from cert SANs, not `listener.hostname`, and duplicate
-      filter chains fall through to 404 while reporting Programmed.
+- **Fleet pinned to one world** — autoscaler `minReplicas: maxReplicas: 1`, so
+  exactly one Ready server backs `cryptothrone-game`. (A Service round-robins;
+  multiple Ready pods would split players across separate worlds.) Image pinned
+  to `:0.0.2` (the published tag; post-publish never synced it because the
+  Docker Hub leg failed — see project memory).
+- **Service + cert + HTTPRoute** — `game-service.yaml` (`cryptothrone-game:7979`,
+  sessionAffinity ClientIP), `game-certificate.yaml` (`game.cryptothrone.com`),
+  `game-httproute.yaml` (`game.cryptothrone.com → cryptothrone-game:7979` on
+  `kbve-gateway`). The client connects to `wss://game.cryptothrone.com/ws`
+  (`PUBLIC_CT_GAME_WS` overrides for local dev).
 
-The Service here is the safe, validated piece. The gateway/cert/Fleet-pin steps
-need a cluster pass.
+### Remaining cluster step
+
+The Cilium `kbve-gateway` (in the `kbve` namespace) needs a **listener that
+accepts `game.cryptothrone.com`** and references the `cryptothrone-game-tls`
+secret. If the gateway already has a `*.cryptothrone.com` wildcard listener this
+is automatic; otherwise add the listener.
+
+- ⚠ New public hostnames on the Cilium gateway VIP (.71) have returned 522/526
+  from Cloudflare; ingress-nginx (.74) works. Validate which path the game
+  hostname takes before relying on it.
+- ⚠ Don't split apex/sub across listeners sharing one SAN cert — Cilium derives
+  Envoy SNI from cert SANs, not `listener.hostname`; duplicate filter chains fall
+  through to 404 while reporting Programmed.
 
 ## Wire format
 

--- a/apps/kube/agones/cryptothrone/manifests/fleet-autoscaler.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/fleet-autoscaler.yaml
@@ -12,8 +12,8 @@ spec:
         type: Buffer
         buffer:
             bufferSize: 1
-            minReplicas: 0
-            maxReplicas: 20
+            minReplicas: 1
+            maxReplicas: 1
     sync:
         type: FixedInterval
         fixedInterval:

--- a/apps/kube/agones/cryptothrone/manifests/fleet.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/fleet.yaml
@@ -42,7 +42,7 @@ spec:
                             type: RuntimeDefault
                     containers:
                         - name: cryptothrone-server
-                          image: ghcr.io/kbve/cryptothrone-server:0.0.1
+                          image: ghcr.io/kbve/cryptothrone-server:0.0.2
                           imagePullPolicy: IfNotPresent
                           env:
                               - name: CT_SERVER_ADDR

--- a/apps/kube/agones/cryptothrone/manifests/game-certificate.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/game-certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+    name: cryptothrone-game-tls
+    namespace: cryptothrone
+    labels:
+        app.kubernetes.io/part-of: cryptothrone
+spec:
+    secretName: cryptothrone-game-tls
+    dnsNames:
+        - game.cryptothrone.com
+    issuerRef:
+        name: letsencrypt-http
+        kind: ClusterIssuer
+        group: cert-manager.io

--- a/apps/kube/agones/cryptothrone/manifests/game-httproute.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/game-httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: cryptothrone-game-route
+    namespace: cryptothrone
+    labels:
+        app.kubernetes.io/part-of: cryptothrone
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - game.cryptothrone.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: cryptothrone-game
+                port: 7979


### PR DESCRIPTION
The actual multiplayer wiring — the game now connects to the world server and renders everyone from snapshots.

## B — CloudCityScene drives off GameClient snapshots
Dropped the local single-player bitecs world (`createGameWorld`/`spawnPlayer`/`spawnMonster`/`moveRandomly`). The scene is now a **pure renderer**:
- On `create()`, opens a `GameClient` (the `@kbve/laser` netcode) to the world server with the signed-in `jwt`+`username` (from the gate, via `lib/net-config`).
- Each **snapshot** upserts entities as GridEngine characters — **local player, remote players, monks, birds** — using `moveTo` for smooth tile tweening; despawns entities that drop out.
- **Cursor-key input → `Step` intents** to the server (throttled to the tile cadence). Server is authoritative; client renders confirmed positions.
- Camera follows the local player once identified by `owner == your_slot`. Sign/well/tombstone dialogue ranges preserved.

## C — reachability
- **Fleet pinned to one shared world** (`minReplicas = maxReplicas = 1`) so the Service backs a single world, not N; image pinned to the published `:0.0.2`.
- `game-service` + new `game-certificate` + `game-httproute` expose `wss://game.cryptothrone.com/ws → cryptothrone-game:7979` on `kbve-gateway`. Client defaults to that URL (`PUBLIC_CT_GAME_WS` overrides for local dev).

## Verify / caveats
- Typechecks clean (3 pre-existing app errors unrelated).
- **Runtime not yet verified in a browser** — the scene rewrite (GridEngine dynamic chars, interpolation) needs a real load against a running server. Best tested locally with `PUBLIC_CT_GAME_WS=ws://127.0.0.1:7979/ws` + the `cryptothrone-server` binary.
- **One cluster step left** (README): `kbve-gateway` needs a `game.cryptothrone.com` listener + the `cryptothrone-game-tls` secret (auto if a `*.cryptothrone.com` wildcard listener exists).
- Old `ecs/` world+systems files are now orphaned; left in place, remove in a follow-up.
- Deploying the client still needs a `cryptothrone` web `version:` bump.