### PR TITLE
release(cryptothrone): web 0.1.10 + Fleet auto-bump wiring

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.9",
+			"version": "0.1.10",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -127,6 +127,7 @@
 			"source_path": "apps/agones/cryptothrone/server",
 			"runner": "arc-runner-set",
 			"image": "kbve/cryptothrone-server",
+			"deployment_yaml": "apps/kube/agones/cryptothrone/manifests/fleet.yaml",
 			"has_test": false
 		},
 		{

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -19,6 +19,7 @@ version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml
 runner: arc-runner-set
 image: kbve/cryptothrone-server
+deployment_yaml: apps/kube/agones/cryptothrone/manifests/fleet.yaml
 has_test: false
 author: h0lybyte
 license: MIT

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.9"
+version: "0.1.10"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
- **cryptothrone (web) 0.1.9 → 0.1.10** — ships the login/username gate (#12165) + the server-authoritative game client (#12168). Post-publish auto-bumps `cryptothrone-deployment.yaml`.
- **cryptothrone-server: `deployment_yaml: apps/kube/agones/cryptothrone/manifests/fleet.yaml`** — it had none, so the post-publish atom PR never synced the Fleet image tag (it sat at `:0.0.1`; I fixed it manually in #12168). With this, the **next** cryptothrone-server `version:` bump auto-bumps the Fleet image + `rollout-restart`, same as the web deployment. (Server stays `0.0.2`; no rebuild now.)
- Manifest regenerated (`astro-kbve:build` + `sync:ci-manifest`); diff is just the version + the new `deployment_yaml`.

After merge + dev→main: web rebuilds at 0.1.10 → the new client deploys; ArgoCD picks up the Fleet (pinned to 1, `:0.0.2`).