### PR TITLE
fix(rows): audit P0/P1/P2 — auth gaps, destructive cleanup, lock race, error leaks

### DIFF
--- a/apps/rows/src/agones/pipeline.rs
+++ b/apps/rows/src/agones/pipeline.rs
@@ -129,17 +129,25 @@ impl<'a> AllocationPipeline<'a> {
         Ok(self)
     }
 
-    /// Errors with `Conflict` when another allocation is in progress for this zone.
+    /// Errors with `Conflict` when another allocation is in progress for this zone. The
+    /// check-and-insert is done through `entry()` so it is atomic per shard — a plain
+    /// `get()` then `insert()` let two concurrent allocations for the same zone both pass.
     pub fn acquire_lock(self, locks: &DashMap<String, Instant>) -> Result<Self, RowsError> {
-        if let Some(entry) = locks.get(&self.lock_key) {
-            let age = entry.value().elapsed();
-            if age < Duration::from_secs(spinup_timeout_secs() + 10) {
-                tracing::info!(zone = %self.zone, age_secs = age.as_secs(), "Spin-up already in progress, skipping");
-                return Err(RowsError::Conflict("Allocation already in progress".into()));
+        use dashmap::mapref::entry::Entry;
+        match locks.entry(self.lock_key.clone()) {
+            Entry::Occupied(mut e) => {
+                let age = e.get().elapsed();
+                if age < Duration::from_secs(spinup_timeout_secs() + 10) {
+                    tracing::info!(zone = %self.zone, age_secs = age.as_secs(), "Spin-up already in progress, skipping");
+                    return Err(RowsError::Conflict("Allocation already in progress".into()));
+                }
+                tracing::warn!(zone = %self.zone, age_secs = age.as_secs(), "Expired stale spin-up lock");
+                e.insert(Instant::now());
             }
-            tracing::warn!(zone = %self.zone, age_secs = age.as_secs(), "Expired stale spin-up lock");
+            Entry::Vacant(e) => {
+                e.insert(Instant::now());
+            }
         }
-        locks.insert(self.lock_key.clone(), Instant::now());
         Ok(self)
     }
 

--- a/apps/rows/src/error.rs
+++ b/apps/rows/src/error.rs
@@ -53,8 +53,24 @@ impl RowsError {
             Self::Forbidden(m) => tonic::Status::permission_denied(m),
             Self::BadRequest(m) => tonic::Status::invalid_argument(m),
             Self::Conflict(m) => tonic::Status::already_exists(m),
-            Self::Database(e) => tonic::Status::internal(e.to_string()),
+            Self::Database(e) => {
+                tracing::error!(error = %e, "database error");
+                tonic::Status::internal("database error")
+            }
             Self::Internal(m) => tonic::Status::internal(m),
+        }
+    }
+
+    /// Client-safe message. `sqlx::Error` strings carry SQL + schema detail (table and constraint
+    /// names, connection targets), so DB errors are logged server-side and collapsed to a generic
+    /// string before leaving the process. The other variants are application-authored.
+    fn client_message(&self) -> Cow<'static, str> {
+        match self {
+            Self::Database(e) => {
+                tracing::error!(error = %e, "database error");
+                Cow::Borrowed("database error")
+            }
+            other => Cow::Owned(other.to_string()),
         }
     }
 }
@@ -70,10 +86,11 @@ struct ApiErrorBody<'a> {
 impl IntoResponse for RowsError {
     fn into_response(self) -> Response {
         let status = self.status();
+        let code = self.code();
         let body = ApiErrorBody {
             success: false,
-            code: self.code(),
-            error_message: Cow::Owned(self.to_string()),
+            code,
+            error_message: self.client_message(),
         };
         (status, axum::Json(body)).into_response()
     }

--- a/apps/rows/src/grpc.rs
+++ b/apps/rows/src/grpc.rs
@@ -60,6 +60,25 @@ fn service_key_from_meta<T>(req: &Request<T>) -> Option<String> {
     }
 }
 
+/// Enforces a valid `x-service-key` for trusted server-to-server RPCs — the gRPC equivalent of the
+/// REST `require_service_key` gate. Without this, InstanceManagement / CharacterPersistence-write /
+/// GlobalData-write methods would be callable unauthenticated. Player/tenant RPCs use
+/// `confirm_login_parts` (bearer/session) instead.
+#[allow(clippy::result_large_err)]
+fn require_service_key<T>(svc: &OWSService, req: &Request<T>) -> Result<(), Status> {
+    let cfg = &svc.state().supabase;
+    if !cfg.service_key_enabled() {
+        return Err(Status::unauthenticated(
+            "service key auth is not configured on this server",
+        ));
+    }
+    let key = service_key_from_meta(req)
+        .ok_or_else(|| Status::unauthenticated("x-service-key metadata required"))?;
+    crate::supabase::validate_service_key(&key, cfg)
+        .map_err(|_| Status::unauthenticated("invalid service key"))?;
+    Ok(())
+}
+
 pub struct PublicApiService {
     svc: Arc<OWSService>,
 }
@@ -227,6 +246,7 @@ impl InstanceManagement for InstanceManagementService {
         &self,
         req: Request<RegisterLauncherRequest>,
     ) -> Result<Response<RegisterLauncherResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         let world_server_id = self
@@ -252,6 +272,7 @@ impl InstanceManagement for InstanceManagementService {
         &self,
         req: Request<StartInstanceLauncherRequest>,
     ) -> Result<Response<StartInstanceLauncherResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         // The dedicated server is its own launcher in the ROWS topology: it
         // registers, then spins up its own zone instances. Ack the start.
         tracing::info!(
@@ -267,6 +288,7 @@ impl InstanceManagement for InstanceManagementService {
         &self,
         req: Request<ShutDownInstanceLauncherRequest>,
     ) -> Result<Response<ShutDownInstanceLauncherResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -297,6 +319,7 @@ impl InstanceManagement for InstanceManagementService {
         &self,
         req: Request<SetZoneInstanceStatusRequest>,
     ) -> Result<Response<SetZoneInstanceStatusResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -312,6 +335,7 @@ impl InstanceManagement for InstanceManagementService {
         &self,
         req: Request<SpinUpInstanceRequest>,
     ) -> Result<Response<SpinUpInstanceResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -334,6 +358,7 @@ impl InstanceManagement for InstanceManagementService {
         &self,
         req: Request<ShutDownInstanceRequest>,
     ) -> Result<Response<ShutDownInstanceResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -347,6 +372,7 @@ impl InstanceManagement for InstanceManagementService {
         &self,
         req: Request<UpdateNumberOfPlayersRequest>,
     ) -> Result<Response<UpdateNumberOfPlayersResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -383,6 +409,7 @@ impl CharacterPersistence for CharacterPersistenceService {
         &self,
         req: Request<UpdatePositionRequest>,
     ) -> Result<Response<UpdatePositionResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -396,6 +423,7 @@ impl CharacterPersistence for CharacterPersistenceService {
         &self,
         req: Request<UpdateStatsRequest>,
     ) -> Result<Response<UpdateStatsResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -409,6 +437,7 @@ impl CharacterPersistence for CharacterPersistenceService {
         &self,
         req: Request<PlayerLogoutRequest>,
     ) -> Result<Response<PlayerLogoutResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let session_guid = parse_session(&r.user_session_guid)?;
         self.svc.logout(session_guid).await.map_err(to_status)?;
@@ -457,6 +486,7 @@ impl CharacterPersistence for CharacterPersistenceService {
         &self,
         req: Request<LeaveMapRequest>,
     ) -> Result<Response<LeaveMapResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc
@@ -493,6 +523,7 @@ impl GlobalDataService for GlobalDataServiceImpl {
         &self,
         req: Request<SetGlobalDataRequest>,
     ) -> Result<Response<SetGlobalDataResponse>, Status> {
+        require_service_key(&self.svc, &req)?;
         let r = req.get_ref();
         let guid = self.svc.state().config.customer_guid;
         self.svc

--- a/apps/rows/src/repo/instances.rs
+++ b/apps/rows/src/repo/instances.rs
@@ -314,7 +314,9 @@ impl<'a> InstanceRepo<'a> {
                     m.minutestoshutdownafterempty AS minutes_to_shutdown_after_empty
              FROM mapinstances mi
              JOIN maps m ON m.mapid = mi.mapid AND m.customerguid = mi.customerguid
-             WHERE mi.customerguid = $1 AND mi.status = 0",
+             WHERE mi.customerguid = $1 AND mi.status = 0
+             ORDER BY mi.mapinstanceid
+             LIMIT 500",
         )
         .bind(customer_guid)
         .fetch_all(self.0)

--- a/apps/rows/src/service/instances.rs
+++ b/apps/rows/src/service/instances.rs
@@ -120,10 +120,14 @@ impl OWSService {
         if let Some(ref agones) = self.state.agones {
             let mq_ref = self.state.mq.as_ref();
             let instance_log = &self.state.instance_log;
+            let mut created_instance_id: Option<i32> = None;
+            let mut allocated_gs: Option<String> = None;
             let result = async {
                 let p = pipeline.allocate_via_agones(agones).await?;
+                allocated_gs = p.game_server_name().map(|s| s.to_string());
                 let p = p.register_world_server().await?;
                 let p = p.create_instance().await?;
+                created_instance_id = Some(p.instance_id());
                 let p = p.tag_gameserver(agones).await?;
 
                 if let Some(mq) = mq_ref {
@@ -159,25 +163,32 @@ impl OWSService {
             .await;
 
             if let Err(ref e) = result {
-                tracing::error!(error = %e, zone, "Agones pipeline failed — cleaning up");
+                tracing::error!(error = %e, zone, "Agones pipeline failed — cleaning up this allocation");
 
                 let lock_key = format!("{customer_guid}:{zone}");
                 self.state.zone_spinup_locks.remove(&lock_key);
 
-                let repo = crate::repo::InstanceRepo(&self.state.db);
-                if let Err(cleanup_err) = repo.delete_all_map_instances(customer_guid).await {
-                    tracing::warn!(error = %cleanup_err, "Failed to clean up stale mapinstances after pipeline failure");
+                if let Some(instance_id) = created_instance_id {
+                    self.state.zone_servers.remove(&instance_id);
+                    let repo = crate::repo::InstanceRepo(&self.state.db);
+                    if let Err(cleanup_err) =
+                        repo.delete_map_instance(customer_guid, instance_id).await
+                    {
+                        tracing::warn!(error = %cleanup_err, instance_id, "Failed to delete failed mapinstance");
+                    }
                 }
-                if let Err(cleanup_err) = repo.deactivate_all_world_servers(customer_guid).await {
-                    tracing::warn!(error = %cleanup_err, "Failed to deactivate world servers after pipeline failure");
+                if let Some(ref gs) = allocated_gs {
+                    if let Err(dealloc_err) = agones.deallocate(gs).await {
+                        tracing::warn!(error = %dealloc_err, gs = %gs, "Failed to deallocate orphaned GameServer");
+                    }
                 }
 
                 instance_log.push(crate::rest::system::InstanceEvent {
                     timestamp: chrono::Utc::now(),
                     event: "allocation_failed".into(),
-                    zone_instance_id: 0,
+                    zone_instance_id: created_instance_id.unwrap_or(0),
                     map_name: zone.to_string(),
-                    game_server: "unknown".into(),
+                    game_server: allocated_gs.clone().unwrap_or_else(|| "unknown".into()),
                     trigger: format!("error: {e}"),
                 });
             }

--- a/apps/rows/src/ws.rs
+++ b/apps/rows/src/ws.rs
@@ -117,6 +117,19 @@ async fn handle_ws(mut socket: WebSocket, svc: Arc<OWSService>) {
     info!("WebSocket client disconnected");
 }
 
+/// Validates a `service_key` param for trusted server-to-server WS methods — the WS equivalent of
+/// the REST `require_service_key` gate. Player reads stay gated by their session GUID.
+fn ws_service_key_ok(svc: &OWSService, req: &WsRequest) -> bool {
+    let cfg = &svc.state().supabase;
+    if !cfg.service_key_enabled() {
+        return false;
+    }
+    match req.params.get("service_key").and_then(|v| v.as_str()) {
+        Some(k) if !k.is_empty() => crate::supabase::validate_service_key(k, cfg).is_ok(),
+        _ => false,
+    }
+}
+
 async fn dispatch(svc: &OWSService, req: &WsRequest) -> WsResponse {
     let id = req.id;
     let guid = svc.state().config.customer_guid;
@@ -184,6 +197,9 @@ async fn dispatch(svc: &OWSService, req: &WsRequest) -> WsResponse {
         }
 
         "update_position" => {
+            if !ws_service_key_ok(svc, req) {
+                return WsResponse::err(id, "UNAUTHENTICATED", "service key required");
+            }
             let name = req
                 .params
                 .get("name")
@@ -210,6 +226,9 @@ async fn dispatch(svc: &OWSService, req: &WsRequest) -> WsResponse {
         }
 
         "set_global_data" => {
+            if !ws_service_key_ok(svc, req) {
+                return WsResponse::err(id, "UNAUTHENTICATED", "service key required");
+            }
             let key = req.params.get("key").and_then(|v| v.as_str()).unwrap_or("");
             let value = req
                 .params


### PR DESCRIPTION
From the apps/rows source audit. Findings were verified against the code before fixing (several agent claims were overstated and are noted as deliberately not-changed).

## P0 (verified, serious)
- **Failed allocation no longer nukes the tenant.** A failed Agones spin-up called `delete_all_map_instances` + `deactivate_all_world_servers` for the *whole* customer — tearing down every other live zone. Now scoped: capture the failed allocation's instance_id + GameServer, delete only that mapinstance, deallocate only that GS, leave the world server + other zones intact. (Also fixes the GS-leak-on-timeout finding.)
- **gRPC auth.** InstanceManagement (all writes), CharacterPersistence writes (update_position/stats, player_logout, leave_map) and GlobalData set were unauthenticated. Added `require_service_key` — the gRPC equivalent of the REST gate. Player/tenant RPCs keep `confirm_login_parts`.
- **WS auth.** `update_position` + `set_global_data` were callable with no auth; gated behind a service_key param.

## P1
- **Atomic spin-up lock** — `acquire_lock` used get()-then-insert(); two concurrent allocs for one zone could both pass. Now uses DashMap `entry()`.
- **DB error sanitization** — sqlx error strings (table/constraint names, connection targets) were returned to clients; now logged server-side, generic "database error" over REST + gRPC.

## P2
- **Bounded cleanup query** — `get_all_inactive_map_instances` (60s loop) fetched all rows unbounded; added ORDER BY + LIMIT 500 (drains in batches).

## Deliberately NOT changed
- JWT `validate_aud=false` — flipping risks breaking Supabase logins; the HS256 signature is the real gate (downgraded to low).
- `extract_customer_guid` nil fallback — moot: `require_customer_guid` is mounted on all routers and rejects first.
- Dead repo methods + serde rename inconsistencies — client-contract risk, low value.
- 24h session TTL — design choice.

## Needs a design decision (not fixed)
- **MQ allocation fallback is non-functional**: publish routes to `ows.serverspinup.{real_id}`, consumer binds `...{0}`, and the consumer path uses Agones despite being the "Agones-unavailable" fallback. Re-architecting blind would be worse — needs the intended MQ topology decided first.
- **reconcile** can double-count / leak untagged Allocated GameServers on restart — needs the labeling/ownership model nailed down.

cargo check clean; each P0/P1/P2 is a separate commit.