### PR TITLE
ci(registry): scheduled GHCR image cleanup (keep 20, protect releases)

### DIFF
--- a/.github/workflows/ci-registry-cleanup.yml
+++ b/.github/workflows/ci-registry-cleanup.yml
@@ -1,0 +1,52 @@
+name: CI - Registry Cleanup (GHCR)
+
+on:
+    schedule:
+        - cron: '0 4 * * 0'
+    workflow_dispatch:
+        inputs:
+            dry_run:
+                description: Preview deletions without executing them
+                type: boolean
+                default: true
+
+permissions:
+    packages: write
+
+concurrency:
+    group: registry-cleanup-ghcr
+    cancel-in-progress: false
+
+jobs:
+    collect:
+        if: github.repository == 'KBVE/kbve'
+        runs-on: ubuntu-latest
+        outputs:
+            image_names: ${{ steps.list.outputs.image_names }}
+        steps:
+            - uses: actions/checkout@v6
+
+            - id: list
+              run: |
+                  NAMES=$(jq -r '[.docker[].image | sub("^kbve/"; "")] | unique | join(" ")' .github/ci-dispatch-manifest.json)
+                  if [ -z "${NAMES}" ]; then
+                    echo "::error::No images resolved from ci-dispatch-manifest.json"
+                    exit 1
+                  fi
+                  echo "Resolved images: ${NAMES}"
+                  echo "image_names=${NAMES}" >> "$GITHUB_OUTPUT"
+
+    prune:
+        needs: collect
+        runs-on: ubuntu-latest
+        steps:
+            - uses: snok/container-retention-policy@v3.1.0
+              with:
+                  account: kbve
+                  token: ${{ secrets.UNITY_PAT }}
+                  image-names: ${{ needs.collect.outputs.image_names }}
+                  image-tags: '!latest !*.*.*'
+                  tag-selection: both
+                  cut-off: 1w
+                  keep-n-most-recent: 20
+                  dry-run: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && 'true' || 'false' }}


### PR DESCRIPTION
## What

New `ci-registry-cleanup.yml` — scheduled (weekly, Sun 04:00 UTC) + `workflow_dispatch` GHCR image pruning. **GHCR only**; Docker Hub cleanup is a separate follow-up PR.

## How

- **No hardcoded image list** — `collect` job reads `.github/ci-dispatch-manifest.json`, strips the `kbve/` prefix, and feeds all 30 tracked images to the pruner. New images tracked in the manifest are picked up automatically.
- `snok/container-retention-policy@v3.1.0` with:
  - `keep-n-most-recent: 20` — your ~20 retention ask.
  - `image-tags: '!latest !*.*.*'` — `latest` and any semver (`X.Y.Z`) tag is **never deletable**. Only `ci-<sha>` churn is eligible.
  - `cut-off: 1w` — age floor; nothing younger than a week is touched.
  - `tag-selection: both` — also clears dangling untagged layers.
- `workflow_dispatch` defaults `dry_run: true` → first manual run is a **preview**. Scheduled runs execute for real.
- Gated on `github.repository == 'KBVE/kbve'` so forks no-op.

## Token

Uses `secrets.UNITY_PAT` (org-level). **Requires `delete:packages` scope.** If the first dry-run 403s on delete, UNITY_PAT lacks the scope — fix is a dedicated `GHCR_CLEANUP_PAT` org secret with `delete:packages` (one-line swap).

## Suggested rollout

1. Merge.
2. Run manually with `dry_run: true`, read the preview log — confirm only `ci-<sha>` tags listed, no `latest`/semver.
3. Run with `dry_run: false` once, or let the weekly schedule take over.

## Follow-up

- PR2: Docker Hub prune (no native retention; API v2 script). Tracked separately.