### PR TITLE
feat(rows): chuckrpg-dev Agones fleet; park beta + rentearth

### DIFF
--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/application.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/application.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: agones-rows-chuckrpg-dev
+    namespace: argocd
+    labels:
+        app.kubernetes.io/part-of: rows
+        app.kubernetes.io/instance: chuckrpg-dev
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: main
+        path: apps/kube/agones/rows-tenants/chuckrpg-dev/manifests
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: arc-runners
+    ignoreDifferences:
+        - group: agones.dev
+          kind: Fleet
+          jsonPointers:
+              - /spec/replicas
+    syncPolicy:
+        automated:
+            prune: true
+        syncOptions:
+            - CreateNamespace=false
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet-autoscaler.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet-autoscaler.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling.agones.dev/v1
+kind: FleetAutoscaler
+metadata:
+    name: ows-chuckrpg-dev-autoscaler
+    namespace: arc-runners
+    labels:
+        app: ows-gameserver
+        app.kubernetes.io/part-of: ows
+        app.kubernetes.io/instance: chuckrpg-dev
+spec:
+    fleetName: ows-chuckrpg-dev
+    policy:
+        type: Buffer
+        buffer:
+            bufferSize: 2
+            minReplicas: 0
+            maxReplicas: 10
+    sync:
+        type: FixedInterval
+        fixedInterval:
+            seconds: 30

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
@@ -1,0 +1,112 @@
+apiVersion: agones.dev/v1
+kind: Fleet
+metadata:
+    name: ows-chuckrpg-dev
+    namespace: arc-runners
+    labels:
+        app: ows-gameserver
+        app.kubernetes.io/part-of: ows
+        app.kubernetes.io/instance: chuckrpg-dev
+spec:
+    replicas: 0
+    scheduling: Packed
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 25%
+            maxUnavailable: 25%
+    template:
+        metadata:
+            labels:
+                app: ows-gameserver
+                app.kubernetes.io/part-of: ows
+                app.kubernetes.io/instance: chuckrpg-dev
+        spec:
+            ports:
+                - name: game
+                  portPolicy: Dynamic
+                  containerPort: 7777
+                  protocol: UDP
+            health:
+                initialDelaySeconds: 30
+                periodSeconds: 15
+                failureThreshold: 5
+            template:
+                spec:
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        runAsGroup: 1000
+                        fsGroup: 1000
+                    containers:
+                        - name: ue5-server
+                          image: ubuntu:24.04
+                          command:
+                              - /bin/bash
+                              - -c
+                              - |
+                                  SERVER_DIR=$(find /server -maxdepth 2 -name "LinuxServer" -type d | sort -V | tail -1)
+                                  if [ -z "${SERVER_DIR}" ]; then
+                                    echo "ERROR: LinuxServer directory not found on PVC"
+                                    ls -la /server/ 2>/dev/null
+                                    exit 1
+                                  fi
+                                  SERVER_BIN=$(find "${SERVER_DIR}" -maxdepth 1 -name "*Server.sh" | head -1)
+                                  if [ -z "${SERVER_BIN}" ]; then
+                                    SERVER_BIN="${SERVER_DIR}/ChuckServer.sh"
+                                  fi
+                                  if [ ! -f "${SERVER_BIN}" ]; then
+                                    echo "ERROR: Server binary not found at ${SERVER_BIN}"
+                                    ls -la "${SERVER_DIR}/" 2>/dev/null
+                                    exit 1
+                                  fi
+                                  echo "Starting UE5 dedicated server from ${SERVER_BIN}"
+                                  exec "${SERVER_BIN}" \
+                                    -server \
+                                    -log \
+                                    -nosteam \
+                                    -unattended \
+                                    -port=${GAME_PORT:-7777} \
+                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    ${OWS_EXTRA_ARGS:-}
+                          env:
+                              - name: GAME_PORT
+                                value: '7777'
+                              - name: OWS_API_PATH
+                                value: http://rows.rows-chuckrpg-dev.svc.cluster.local:4322/
+                              - name: OWS_INSTANCE_MANAGEMENT_PATH
+                                value: http://rows.rows-chuckrpg-dev.svc.cluster.local:4322/
+                              - name: OWS_CHARACTER_PERSISTENCE_PATH
+                                value: http://rows.rows-chuckrpg-dev.svc.cluster.local:4322/
+                              - name: OWS_GLOBAL_DATA_PATH
+                                value: http://rows.rows-chuckrpg-dev.svc.cluster.local:4322/
+                              - name: OWS_API_CUSTOMER_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: ows-gameserver-secrets-chuckrpg-dev
+                                        key: customer-guid
+                              - name: OWS_ENCRYPTION_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: ows-gameserver-secrets-chuckrpg-dev
+                                        key: encryption-key
+                              - name: OWS_SERVICE_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: ows-service-key-chuckrpg-dev
+                                        key: service-key
+                                        optional: true
+                          resources:
+                              requests:
+                                  memory: 2Gi
+                                  cpu: '1'
+                              limits:
+                                  memory: 4Gi
+                                  cpu: '2'
+                          volumeMounts:
+                              - name: server-binary
+                                mountPath: /server
+                    volumes:
+                        - name: server-binary
+                          persistentVolumeClaim:
+                              claimName: ows-server-build

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/gameserver-secrets.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/gameserver-secrets.yaml
@@ -1,0 +1,74 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: rows-chuckrpg-dev-gs-reader
+    namespace: rows-chuckrpg-dev
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['rows-customer-guid', 'rows-encryption-key']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: agones-read-rows-chuckrpg-dev
+    namespace: rows-chuckrpg-dev
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rows-chuckrpg-dev-gs-reader
+subjects:
+    - kind: ServiceAccount
+      name: agones-rows-chuckrpg-dev-secrets
+      namespace: arc-runners
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: agones-rows-chuckrpg-dev-secrets
+    namespace: arc-runners
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: rows-chuckrpg-dev-gs-store
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rows-chuckrpg-dev
+            auth:
+                serviceAccount:
+                    name: agones-rows-chuckrpg-dev-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-gameserver-secrets-chuckrpg-dev
+    namespace: arc-runners
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: rows-chuckrpg-dev-gs-store
+        kind: SecretStore
+    target:
+        name: ows-gameserver-secrets-chuckrpg-dev
+        creationPolicy: Owner
+    data:
+        - secretKey: customer-guid
+          remoteRef:
+              key: rows-customer-guid
+              property: customer-guid
+        - secretKey: encryption-key
+          remoteRef:
+              key: rows-encryption-key
+              property: encryption-key

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/service-key-external-secret.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/service-key-external-secret.yaml
@@ -1,0 +1,64 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: supabase-service-key-reader-for-chuckrpg-dev
+    namespace: kilobase
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-service-key']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: agones-read-svckey-chuckrpg-dev
+    namespace: kilobase
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: supabase-service-key-reader-for-chuckrpg-dev
+subjects:
+    - kind: ServiceAccount
+      name: agones-rows-chuckrpg-dev-secrets
+      namespace: arc-runners
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-svckey-store-chuckrpg-dev
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: agones-rows-chuckrpg-dev-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-service-key-chuckrpg-dev
+    namespace: arc-runners
+spec:
+    refreshInterval: 15m
+    secretStoreRef:
+        name: kilobase-svckey-store-chuckrpg-dev
+        kind: SecretStore
+    target:
+        name: ows-service-key-chuckrpg-dev
+        creationPolicy: Owner
+    data:
+        - secretKey: service-key
+          remoteRef:
+              key: supabase-service-key
+              property: key

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -129,34 +129,6 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
-        - name: https-rows-chuckrpg-beta
-          protocol: HTTPS
-          port: 443
-          hostname: api-beta.chuckrpg.com
-          tls:
-              mode: Terminate
-              certificateRefs:
-                  - kind: Secret
-                    group: ''
-                    name: rows-chuckrpg-beta-api-tls
-                    namespace: rows-chuckrpg-beta
-          allowedRoutes:
-              namespaces:
-                  from: All
-        - name: https-rows-rentearth-release
-          protocol: HTTPS
-          port: 443
-          hostname: api.rentearth.com
-          tls:
-              mode: Terminate
-              certificateRefs:
-                  - kind: Secret
-                    group: ''
-                    name: rows-rentearth-release-api-tls
-                    namespace: rows-rentearth-release
-          allowedRoutes:
-              namespaces:
-                  from: All
         - name: https-cityvote
           protocol: HTTPS
           port: 443

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -55,12 +55,10 @@ resources:
     - memes/application.yaml
     - n8n/application.yaml
     - rabbitmq/application.yaml
-    # ROWS per-tenant deployments (game + environment); see apps/kube/rows/tenants/
     - rows/tenants/overlays/chuckrpg-dev/application.yaml
-    - rows/tenants/overlays/chuckrpg-beta/application.yaml
-    - rows/tenants/overlays/rentearth-release/application.yaml
     - agones/application.yaml
     - agones/rows/application.yaml
+    - agones/rows-tenants/chuckrpg-dev/application.yaml
     - agones/mc/application.yaml
     - agones/nd-server/application.yaml
     - agones/factorio/application.yaml


### PR DESCRIPTION
Pilots the first per-tenant game-server fleet (chuckrpg-dev, which owns api.chuckrpg.com) and parks the not-yet-operational tenants.

## chuckrpg-dev Agones fleet (apps/kube/agones/rows-tenants/chuckrpg-dev/)
- **Fleet** ows-chuckrpg-dev + autoscaler in arc-runners, reading the shared ows-server-build PVC. The chuck server binary is **tenant-agnostic** — customer_guid is injected at runtime, so dev reuses the existing chuck build; no rebuild needed.
- **Per-tenant secrets**: gameserver-secrets + service-key ExternalSecrets sync from the rows-chuckrpg-dev namespace's sealed rows-customer-guid / rows-encryption-key and from kilobase, into uniquely-named secrets in the shared arc-runners/kilobase namespaces (+ the cross-ns RBAC).
- **OWS_API_PATH** → the tenant's rows service (rows.rows-chuckrpg-dev). ArgoCD app agones-rows-chuckrpg-dev registered in the app-of-apps.

## Diminish beta + rentearth (not operational)
- Dropped chuckrpg-beta + rentearth-release from the app-of-apps and removed their gateway listeners (rentearth has no game; beta has no fleet/DNS). Their overlay manifests + sealed secrets stay in the repo — re-add the app-of-apps lines + listeners when they have a build/DNS.

## Notes / next
- **Pruning the beta/rentearth Applications tears down their live namespaces** (deployed in #12136). Intended.
- Fleet stays at **0 replicas** until a chuck LinuxServer build exists on the PVC (the autoscaler buffer scales it once the binary is present). Verify the build is on ows-server-build.
- Build-channel split (dev vs beta vs future rentearth-dev) deferred — dev reuses the shared chuck build for now.
- Validated: all YAML parses; app-of-apps kustomize build emits agones-rows-chuckrpg-dev and no longer emits the beta/rentearth tenant apps.