### PR TITLE
fix(astro-kbve): make floating Yuki avatar click-through

### DIFF
--- a/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
+++ b/apps/kbve/astro-kbve/src/components/jay/dock/YukiPanel.ts
@@ -198,14 +198,14 @@ function ensureFloatLayer(): HTMLElement {
 		width: 420px;
 		height: 640px;
 		z-index: 60;
-		pointer-events: auto;
+		pointer-events: none;
 		display: none;
 		filter: drop-shadow(0 8px 24px rgba(0,0,0,0.35));
 	`;
 	const handle = document.createElement('div');
 	handle.id = 'kbve-yuki-float-drag';
 	handle.style.cssText =
-		'position:absolute;inset:0 0 auto 0;height:18px;cursor:grab;user-select:none;';
+		'position:absolute;inset:0 0 auto 0;height:18px;user-select:none;pointer-events:none;';
 	const close = document.createElement('button');
 	close.id = 'kbve-yuki-float-close';
 	close.type = 'button';
@@ -216,7 +216,7 @@ function ensureFloatLayer(): HTMLElement {
 		display:grid;place-items:center;border-radius:999px;
 		background:rgba(15,23,42,0.65);color:rgba(255,255,255,0.9);
 		border:1px solid rgba(255,255,255,0.15);font-size:14px;
-		line-height:1;cursor:pointer;z-index:2;
+		line-height:1;cursor:pointer;z-index:2;display:none;
 	`;
 	const stage = document.createElement('div');
 	stage.id = FLOAT_HOST_ID;


### PR DESCRIPTION
## Problem

The floating 3D Yuki avatar is a fixed `420x640` layer with `pointer-events: auto`, so its transparent WebGL canvas swallowed every click in that rectangle and blocked page content underneath. It triggered even without opening the dock — a persisted `expanded` dock state auto-mounts the panel on load.

## Fix

Set the float layer (and its drag handle / close button) fully `pointer-events: none`. The floating avatar is now purely decorative and passes clicks through.

Interaction stays where it belongs:
- **FAB ring** (dock) opens the chat
- **Chat panel** is interactive when open; its **Dock** button un-floats Yuki

Scope: one file, `YukiPanel.ts`.