### PR TITLE
ci(registry): issue ticket on GHCR cleanup failure + git.mdx docs

### DIFF
--- a/.github/workflows/ci-registry-cleanup.yml
+++ b/.github/workflows/ci-registry-cleanup.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
     packages: write
+    issues: write
 
 concurrency:
     group: registry-cleanup-ghcr
@@ -50,3 +51,45 @@ jobs:
                   cut-off: 1w
                   keep-n-most-recent: 20
                   dry-run: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && 'true' || 'false' }}
+
+    notify:
+        needs: [collect, prune]
+        if: failure() && github.event_name == 'schedule' && github.repository == 'KBVE/kbve'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/github-script@v9
+              with:
+                  script: |
+                      const label = 'registry-cleanup';
+                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      const title = 'Weekly GHCR registry cleanup failed';
+                      const body = [
+                        `The scheduled GHCR image cleanup run failed.`,
+                        ``,
+                        `- Run: ${runUrl}`,
+                        `- Commit: ${context.sha}`,
+                        ``,
+                        `Check the \`collect\` / \`prune\` job logs. Common causes: \`UNITY_PAT\` missing \`delete:packages\` scope, GHCR API rate limit, or a malformed \`ci-dispatch-manifest.json\`.`,
+                      ].join('\n');
+                      const existing = await github.rest.issues.listForRepo({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        state: 'open',
+                        labels: label,
+                      });
+                      if (existing.data.length > 0) {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: existing.data[0].number,
+                          body,
+                        });
+                      } else {
+                        await github.rest.issues.create({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          title,
+                          body,
+                          labels: [label],
+                        });
+                      }

--- a/apps/kbve/astro-kbve/src/content/docs/application/git.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/git.mdx
@@ -1194,3 +1194,112 @@ The following prefixes are permitted for auto-merge:
 <Aside type="caution" title="Adding New Apps">
 When onboarding a new app to the CI publish pipeline, add its title prefix to the allowlist in `ci-auto-merge-bot-prs.yml` or the version/kube PRs will not auto-merge.
 </Aside>
+
+## Registry Cleanup (GHCR)
+
+Every published image accumulates `ci-<sha>` tags on the GitHub Container Registry. The `ci-registry-cleanup.yml` workflow prunes that churn on a weekly schedule while keeping recent builds and never touching releases.
+
+### How It Works
+
+The image list is **not hardcoded** — the `collect` job reads `.github/ci-dispatch-manifest.json`, strips the `kbve/` prefix from every `docker[].image`, and feeds the full set to the pruner. Any new app tracked in the manifest is cleaned automatically.
+
+The `prune` job runs `snok/container-retention-policy` with a conservative policy:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| `keep-n-most-recent` | `20` | Keeps the 20 newest tagged versions per image |
+| `image-tags` | `!latest !*.*.*` | `latest` and any semver (`X.Y.Z`) tag is never deletable |
+| `cut-off` | `1w` | Nothing younger than a week is eligible |
+| `tag-selection` | `both` | Also clears dangling untagged layers |
+
+Only `ci-<sha>` tags older than a week and beyond the newest 20 are ever removed.
+
+### Triggers and Safety
+
+- **Schedule** — runs every Sunday at `04:00 UTC` and executes for real.
+- **`workflow_dispatch`** — manual runs default to `dry_run: true`, logging what *would* be deleted without removing anything. Flip the input to `false` to execute.
+- Gated on `github.repository == 'KBVE/kbve'` so forks no-op.
+- On a scheduled failure, a `notify` job opens (or comments on) a `registry-cleanup`-labelled issue with a link to the failed run.
+
+<Aside type="note" title="Token Scope">
+The workflow authenticates with the org-level `UNITY_PAT`, which must carry the `delete:packages` scope. If a run fails on delete with a `403`, mint a dedicated PAT with that scope and swap the `token:` input.
+</Aside>
+
+### Example Workflow
+
+```yaml
+name: CI - Registry Cleanup (GHCR)
+
+on:
+    schedule:
+        - cron: '0 4 * * 0'
+    workflow_dispatch:
+        inputs:
+            dry_run:
+                description: Preview deletions without executing them
+                type: boolean
+                default: true
+
+permissions:
+    packages: write
+    issues: write
+
+concurrency:
+    group: registry-cleanup-ghcr
+    cancel-in-progress: false
+
+jobs:
+    collect:
+        if: github.repository == 'KBVE/kbve'
+        runs-on: ubuntu-latest
+        outputs:
+            image_names: ${{ steps.list.outputs.image_names }}
+        steps:
+            - uses: actions/checkout@v6
+            - id: list
+              run: |
+                  NAMES=$(jq -r '[.docker[].image | sub("^kbve/"; "")] | unique | join(" ")' .github/ci-dispatch-manifest.json)
+                  echo "image_names=${NAMES}" >> "$GITHUB_OUTPUT"
+
+    prune:
+        needs: collect
+        runs-on: ubuntu-latest
+        steps:
+            - uses: snok/container-retention-policy@v3.1.0
+              with:
+                  account: kbve
+                  token: ${{ secrets.UNITY_PAT }}
+                  image-names: ${{ needs.collect.outputs.image_names }}
+                  image-tags: '!latest !*.*.*'
+                  tag-selection: both
+                  cut-off: 1w
+                  keep-n-most-recent: 20
+                  dry-run: ${{ (github.event_name == 'workflow_dispatch' && inputs.dry_run) && 'true' || 'false' }}
+
+    notify:
+        needs: [collect, prune]
+        if: failure() && github.event_name == 'schedule' && github.repository == 'KBVE/kbve'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/github-script@v9
+              with:
+                  script: |
+                      const label = 'registry-cleanup';
+                      const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+                      const existing = await github.rest.issues.listForRepo({
+                        owner: context.repo.owner, repo: context.repo.repo,
+                        state: 'open', labels: label,
+                      });
+                      const body = `Weekly GHCR cleanup failed. Run: ${runUrl}`;
+                      if (existing.data.length > 0) {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner, repo: context.repo.repo,
+                          issue_number: existing.data[0].number, body,
+                        });
+                      } else {
+                        await github.rest.issues.create({
+                          owner: context.repo.owner, repo: context.repo.repo,
+                          title: 'Weekly GHCR registry cleanup failed', body, labels: [label],
+                        });
+                      }
+```


### PR DESCRIPTION
Follow-up to #12177 (merged).

## What
- **`notify` job** on `ci-registry-cleanup.yml`: when the **scheduled** weekly run fails, `github-script` opens a `registry-cleanup`-labelled issue (or comments on the existing open one) with a link to the failed run. Adds `issues: write` permission. Manual `workflow_dispatch` runs do not file issues.
- **Docs**: new `## Registry Cleanup (GHCR)` section in `application/git.mdx` — policy table, triggers/safety, token-scope note, and the full example workflow.

Docker Hub cleanup dropped per direction — GHCR only.