### PR TITLE
fix(agents): make HMAC rotate reachable on any visit

### DIFF
--- a/packages/npm/astro/src/agents/ReactAgentGithubWizard.tsx
+++ b/packages/npm/astro/src/agents/ReactAgentGithubWizard.tsx
@@ -271,10 +271,10 @@ function Step1Webhook({
 					<code>
 						{WEBHOOK_SERVICE}:{guild.id}
 					</code>{' '}
-					(token <code>{existing!.token_name}</code>). To rotate,
-					delete the existing row from the per-guild{' '}
-					<a href="/dashboard/agents/discordsh/">token list</a> and
-					run this wizard again.
+					(token <code>{existing!.token_name}</code>). To rotate, use
+					the <strong>Rotate HMAC secret</strong> control in Step 2 —
+					it regenerates the secret and updates GitHub + the vault in
+					one step.
 				</p>
 			) : (
 				<>
@@ -870,7 +870,7 @@ function Step2WebhookConfig({
 						)}
 					</div>
 				)}
-				{installResult && installResult.ok && hasWebhook && (
+				{hasWebhook && selectedRepo && (
 					<div
 						style={{
 							marginTop: '0.85rem',


### PR DESCRIPTION
## Symptom

You can rotate the webhook HMAC right after installing, but on a **return visit** the Rotate button is gone — no way to rotate again.

## Cause

The Step 2 **Lifecycle** controls (Rotate HMAC / Delete hook) were gated on `installResult && installResult.ok && hasWebhook`. `installResult` is only populated by an install/verify action **in the current session**, so on a fresh load it's `null` and the whole section (including Rotate) is hidden — even though the hook + vault secret exist.

## Fix

Gate the Lifecycle section on `hasWebhook && selectedRepo` instead, so Rotate/Delete are reachable on any visit. `rotate()` already returns a clear "install one first" error if no hook is present on the selected repo, so the edge case is handled gracefully.

Also updated Step 1's "to rotate" guidance to point at the Step 2 **Rotate HMAC secret** control — the correct path (regenerate secret → PATCH GitHub hook config → upsert vault, all in `webhooks.rotate`) — instead of the old "delete the row and re-run" workaround, which left GitHub on the stale secret.

## Verify

`ReactAgentGithubWizard` typechecks clean. Pure JSX condition + copy change; `webhooks.rotate` backend already does the full rotation.