### PR TITLE
feat(astro): reusable StepCard shell + useStepCardStatus controller

### DIFF
--- a/packages/npm/astro/package.json
+++ b/packages/npm/astro/package.json
@@ -30,6 +30,7 @@
 		},
 		"./components/DroidProvider.astro": "./components/DroidProvider.astro",
 		"./components/DroidStatus.astro": "./components/DroidStatus.astro",
+		"./components/StepCard.astro": "./components/StepCard.astro",
 		"./components/AskamaFragment.astro": "./components/AskamaFragment.astro",
 		"./components/AskamaCard.astro": "./components/AskamaCard.astro",
 		"./components/AskamaHero.astro": "./components/AskamaHero.astro",

--- a/packages/npm/astro/src/components/StepCard.astro
+++ b/packages/npm/astro/src/components/StepCard.astro
@@ -1,0 +1,86 @@
+---
+interface Props {
+	n: number;
+	title: string;
+	status?: 'todo' | 'pending' | 'done';
+	disabled?: boolean;
+}
+const { n, title, status = 'todo', disabled = false } = Astro.props;
+---
+
+<section
+	class="sc-root"
+	data-stepcard-root
+	data-status={status}
+	data-disabled={disabled ? 'true' : 'false'}>
+	<header class="sc-header">
+		<span class="sc-badge" data-slot="badge">{n}</span>
+		<strong class="sc-title">{title}</strong>
+		<span class="sc-pill" data-slot="status">{status}</span>
+	</header>
+	<div class="sc-body">
+		<slot />
+	</div>
+</section>
+
+<style>
+	.sc-root {
+		border: 1px solid var(--sl-color-gray-5, #262626);
+		border-radius: 12px;
+		background: var(--sl-color-bg-nav, #111);
+		overflow: hidden;
+		transition: opacity 0.15s ease;
+	}
+	.sc-root[data-disabled='true'] {
+		opacity: 0.65;
+	}
+	.sc-header {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		padding: 0.7rem 1rem;
+		border-bottom: 1px solid var(--sl-color-gray-5, #262626);
+	}
+	.sc-badge {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 26px;
+		height: 26px;
+		border-radius: 999px;
+		font-size: 0.78rem;
+		font-weight: 700;
+	}
+	.sc-title {
+		flex: 1;
+	}
+	.sc-pill {
+		font-size: 0.72rem;
+		padding: 0.15rem 0.5rem;
+		border-radius: 999px;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		font-weight: 600;
+	}
+	.sc-body {
+		padding: 0.85rem 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+	}
+	.sc-root[data-status='todo'] .sc-badge,
+	.sc-root[data-status='todo'] .sc-pill {
+		background: rgba(148, 163, 184, 0.12);
+		color: #94a3b8;
+	}
+	.sc-root[data-status='pending'] .sc-badge,
+	.sc-root[data-status='pending'] .sc-pill {
+		background: rgba(251, 191, 36, 0.12);
+		color: #fbbf24;
+	}
+	.sc-root[data-status='done'] .sc-badge,
+	.sc-root[data-status='done'] .sc-pill {
+		background: rgba(74, 222, 128, 0.12);
+		color: #4ade80;
+	}
+</style>

--- a/packages/npm/astro/src/dashboard/STEPCARD_PATTERN.md
+++ b/packages/npm/astro/src/dashboard/STEPCARD_PATTERN.md
@@ -22,7 +22,7 @@ vDOM tree for the static structure.
 
 ```astro
 ---
-import { StepCard } from '@kbve/astro/components/StepCard.astro';
+import StepCard from '@kbve/astro/components/StepCard.astro';
 import ReactStep1 from './ReactStep1';
 ---
 

--- a/packages/npm/astro/src/dashboard/STEPCARD_PATTERN.md
+++ b/packages/npm/astro/src/dashboard/STEPCARD_PATTERN.md
@@ -1,0 +1,49 @@
+# Astro-shell + nanostore controller
+
+Reusable pattern for dashboard cards: render the static chrome as server HTML in
+Astro, drive the few dynamic slots imperatively from a thin React island. No
+vDOM tree for the static structure.
+
+## Pieces
+
+- **`@kbve/astro/components/StepCard.astro`** — the static card shell. Renders
+  the border, numbered badge, title, and a status pill, wrapped in
+  `[data-stepcard-root]`. The palette is pure CSS keyed off `data-status`
+  (`todo` / `pending` / `done`) — switching status is a single attribute write,
+  no per-node style patching. Body content comes through `<slot/>`.
+
+- **`useStepCardStatus(status, disabled?)`** — the controller hook. Returns a
+  ref; attach it to a hidden anchor inside the card body. On status change it
+  walks `closest('[data-stepcard-root]')` (scoped — no global ids, safe with
+  multiple cards on a page) and writes `data-status` / `data-disabled` + the
+  pill text. CSS does the rest.
+
+## Usage
+
+```astro
+---
+import { StepCard } from '@kbve/astro/components/StepCard.astro';
+import ReactStep1 from './ReactStep1';
+---
+
+<StepCard n={1} title="HMAC webhook secret">
+	<ReactStep1 client:only="react" />
+</StepCard>
+```
+
+```tsx
+function ReactStep1() {
+  const agents = useAgents();
+  const stored = /* derived from a nanostore */;
+  const anchor = useStepCardStatus(stored ? 'done' : 'todo');
+  return (
+    <>
+      <span ref={anchor} hidden aria-hidden="true" />
+      {/* dynamic body controls */}
+    </>
+  );
+}
+```
+
+The static structure (border, badge, title, layout, status colors) ships as
+HTML+CSS with zero hydration cost; React only owns the interactive body.

--- a/packages/npm/astro/src/dashboard/index.ts
+++ b/packages/npm/astro/src/dashboard/index.ts
@@ -5,3 +5,4 @@ export {
 	Section,
 	CachedBadge,
 } from './dashboard-ui';
+export { useStepCardStatus, type StepStatus } from './useStepCardStatus';

--- a/packages/npm/astro/src/dashboard/useStepCardStatus.ts
+++ b/packages/npm/astro/src/dashboard/useStepCardStatus.ts
@@ -1,0 +1,18 @@
+import { useEffect, useRef } from 'react';
+
+export type StepStatus = 'todo' | 'pending' | 'done';
+
+export function useStepCardStatus(status: StepStatus, disabled = false) {
+	const anchorRef = useRef<HTMLSpanElement>(null);
+	useEffect(() => {
+		const root = anchorRef.current?.closest(
+			'[data-stepcard-root]',
+		) as HTMLElement | null;
+		if (!root) return;
+		root.dataset.status = status;
+		root.dataset.disabled = disabled ? 'true' : 'false';
+		const pill = root.querySelector('[data-slot="status"]');
+		if (pill) pill.textContent = status;
+	}, [status, disabled]);
+	return anchorRef;
+}


### PR DESCRIPTION
First piece of the agents-surface rearchitecture: a reusable **Astro-shell + nanostore-controller** primitive in `@kbve/astro`. Render the static card chrome as server HTML, drive the few dynamic slots imperatively from a thin React island — no vDOM for the static tree (our own "Million.js-style" lean, on React 19 + Astro, no extra lib).

## What

- **`@kbve/astro/components/StepCard.astro`** — static card: border, numbered badge, title, status pill, body `<slot/>`, wrapped in `[data-stepcard-root]`. The palette is **pure CSS keyed off `data-status`** (`todo`/`pending`/`done`), so a status change is a single attribute write — no per-node style patching, zero hydration cost for the chrome.
- **`useStepCardStatus(status, disabled?)`** — controller hook. Returns a ref for a hidden anchor inside the card body; on change it scopes via `closest('[data-stepcard-root]')` (no global ids — safe with multiple cards on one page) and writes `data-status`/`data-disabled` + the pill text. CSS does the colours.
- **`STEPCARD_PATTERN.md`** documents the convention + usage.

## Why

The GithubWizard's StepCards + static step descriptions are hundreds of lines of pure-static JSX wrapping a handful of dynamic slots. Moving that chrome to Astro HTML (controlled by one `data-*` write) is where the vDOM savings actually land. This is the reusable shell the rest of the agents surface — and any future dashboard — composes against.

## Scope

Foundation only — the StepCard primitive + hook + doc. The GithubWizard step conversion and the rollout across the other agents components follow in separate PRs. Pure addition; nothing consumes it yet, so no behaviour change.

## Verify

Hook + dashboard exports typecheck clean. `.astro` frontmatter is a trivial props destructure (validated by `astro check` at app build).