### PR TITLE
feat(cryptothrone): data-driven NPCs/items, server actions, smarter movement

### DIFF
--- a/apps/agones/cryptothrone/server/Dockerfile
+++ b/apps/agones/cryptothrone/server/Dockerfile
@@ -57,6 +57,7 @@ COPY apps/agones/cryptothrone/server/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 
 COPY packages/rust/simgrid packages/rust/simgrid
+COPY packages/data/codegen/generated/npcdb-data.json packages/data/codegen/generated/npcdb-data.json
 COPY apps/agones/cryptothrone/server apps/agones/cryptothrone/server
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -1,39 +1,61 @@
-use bevy::prelude::{Commands, Local};
+use bevy::prelude::{Commands, Local, Res};
 use simgrid::proto::Tile;
-use simgrid::{EntityKind, GridPos, Health, MoveSpeed, MoveTarget, SimConfig, WalkableMap, Wander};
+use simgrid::{
+    EntityKind, GridPos, Health, KindRegistry, Loot, MoveSpeed, MoveTarget, NpcDb, SimConfig,
+    WalkableMap, Wander, ground_item_bundle,
+};
 
 pub const MAP_WIDTH: i32 = 50;
 pub const MAP_HEIGHT: i32 = 50;
 pub const MAX_PLAYERS: usize = 32;
 
 const CLOUD_CITY_MAP: &[u8] = include_bytes!("../assets/cloud_city_large.json");
-
-pub const KIND_PLAYER: u16 = 0;
-pub const KIND_MONK: u16 = 1;
-pub const KIND_BIRD: u16 = 2;
+const NPCDB_JSON: &[u8] =
+    include_bytes!("../../../../../packages/data/codegen/generated/npcdb-data.json");
 
 pub const PLAYER_HP: i32 = 100;
+pub const PLAYER_ATTACK: i32 = 5;
 pub const PLAYER_TICKS_PER_TILE: u8 = 4;
-
 pub const PLAYER_SPAWN: Tile = Tile::new(5, 12);
 
-pub const MONK_SPAWN: Tile = Tile::new(4, 10);
-pub const MONK_HP: i32 = 30;
-pub const MONK_WANDER_RADIUS: i32 = 3;
-pub const MONK_WANDER_PERIOD_TICKS: u32 = 30;
-pub const MONK_TICKS_PER_TILE: u8 = 6;
+pub const CLERIC_REF: &str = "cleric";
+pub const CLERIC_SPAWN: Tile = Tile::new(4, 10);
+pub const CLERIC_WANDER_RADIUS: i32 = 3;
+pub const CLERIC_WANDER_PERIOD_TICKS: u32 = 30;
 
-pub const BIRD_COUNT: i32 = 10;
-pub const BIRD_ORIGIN: Tile = Tile::new(7, 7);
-pub const BIRD_HP: i32 = 10;
-pub const BIRD_WANDER_RADIUS: i32 = 20;
-pub const BIRD_WANDER_PERIOD_TICKS: u32 = 20;
-pub const BIRD_TICKS_PER_TILE: u8 = 3;
+pub const BAT_REF: &str = "crystal-bat";
+pub const BAT_COUNT: i32 = 10;
+pub const BAT_ORIGIN: Tile = Tile::new(7, 7);
+pub const BAT_WANDER_RADIUS: i32 = 20;
+pub const BAT_WANDER_PERIOD_TICKS: u32 = 20;
+pub const BAT_LOOT_REF: &str = "potion";
+
+pub const GROUND_ITEMS: &[(&str, u32, Tile)] = &[
+    ("potion", 1, Tile::new(8, 12)),
+    ("coin", 5, Tile::new(12, 9)),
+    ("iron-sword", 1, Tile::new(6, 15)),
+];
+
+pub fn npc_db() -> NpcDb {
+    NpcDb::from_json(NPCDB_JSON).expect("npcdb-data.json parses")
+}
+
+pub fn registry() -> KindRegistry {
+    let mut reg = KindRegistry::new();
+    reg.register_npc(CLERIC_REF);
+    reg.register_npc(BAT_REF);
+    for (item_ref, _, _) in GROUND_ITEMS {
+        reg.register_item(item_ref);
+    }
+    reg.register_item(BAT_LOOT_REF);
+    reg
+}
 
 pub fn config() -> SimConfig {
     SimConfig {
-        player_kind: KIND_PLAYER,
+        player_kind: 0,
         player_hp: PLAYER_HP,
+        player_attack: PLAYER_ATTACK,
         spawn: PLAYER_SPAWN,
         ticks_per_tile: PLAYER_TICKS_PER_TILE,
     }
@@ -44,40 +66,77 @@ pub fn walkable_map() -> WalkableMap {
         .unwrap_or_else(|_| WalkableMap::open(MAP_WIDTH, MAP_HEIGHT))
 }
 
-pub fn spawn_world(mut done: Local<bool>, mut commands: Commands) {
+fn ticks_per_tile_for_speed(speed: i32) -> u8 {
+    (20 / speed.clamp(2, 10)).clamp(2, 10) as u8
+}
+
+fn spawn_npc(
+    commands: &mut Commands,
+    db: &NpcDb,
+    registry: &KindRegistry,
+    ref_id: &str,
+    tile: Tile,
+    wander: Wander,
+    loot: Option<&str>,
+) {
+    let Some(def) = db.get(ref_id) else { return };
+    let Some(kind) = registry.kind_of(ref_id) else {
+        return;
+    };
+    let hp = def.stats.max_hp.max(def.stats.hp).max(1);
+    commands.spawn((
+        EntityKind(kind),
+        GridPos::at(tile),
+        MoveTarget::default(),
+        MoveSpeed {
+            ticks_per_tile: ticks_per_tile_for_speed(def.stats.speed),
+        },
+        Health { hp, max_hp: hp },
+        wander,
+        Loot {
+            item_ref: loot.map(str::to_string),
+        },
+    ));
+}
+
+pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut commands: Commands) {
     if *done {
         return;
     }
     *done = true;
 
-    commands.spawn((
-        EntityKind(KIND_MONK),
-        GridPos::at(MONK_SPAWN),
-        MoveTarget::default(),
-        MoveSpeed {
-            ticks_per_tile: MONK_TICKS_PER_TILE,
-        },
-        Health {
-            hp: MONK_HP,
-            max_hp: MONK_HP,
-        },
-        Wander::new(MONK_SPAWN, MONK_WANDER_RADIUS, MONK_WANDER_PERIOD_TICKS),
-    ));
+    let db = npc_db();
 
-    for i in 0..BIRD_COUNT {
-        let origin = Tile::new(BIRD_ORIGIN.x, BIRD_ORIGIN.y + i);
-        commands.spawn((
-            EntityKind(KIND_BIRD),
-            GridPos::at(origin),
-            MoveTarget::default(),
-            MoveSpeed {
-                ticks_per_tile: BIRD_TICKS_PER_TILE,
-            },
-            Health {
-                hp: BIRD_HP,
-                max_hp: BIRD_HP,
-            },
-            Wander::new(origin, BIRD_WANDER_RADIUS, BIRD_WANDER_PERIOD_TICKS),
-        ));
+    spawn_npc(
+        &mut commands,
+        &db,
+        &registry,
+        CLERIC_REF,
+        CLERIC_SPAWN,
+        Wander::new(
+            CLERIC_SPAWN,
+            CLERIC_WANDER_RADIUS,
+            CLERIC_WANDER_PERIOD_TICKS,
+        ),
+        None,
+    );
+
+    for i in 0..BAT_COUNT {
+        let origin = Tile::new(BAT_ORIGIN.x, BAT_ORIGIN.y + i);
+        spawn_npc(
+            &mut commands,
+            &db,
+            &registry,
+            BAT_REF,
+            origin,
+            Wander::new(origin, BAT_WANDER_RADIUS, BAT_WANDER_PERIOD_TICKS),
+            Some(BAT_LOOT_REF),
+        );
+    }
+
+    for (item_ref, count, tile) in GROUND_ITEMS {
+        if let Some(bundle) = ground_item_bundle(&registry, item_ref, *count, *tile) {
+            commands.spawn(bundle);
+        }
     }
 }

--- a/apps/agones/cryptothrone/server/src/main.rs
+++ b/apps/agones/cryptothrone/server/src/main.rs
@@ -40,6 +40,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "supabase HS256"
     };
 
+    let registry = game::registry();
+
     let state = ServerState::new(
         snap_tx.clone(),
         input_tx,
@@ -47,7 +49,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         jwt_secret,
         true,
         game::MAX_PLAYERS,
-    );
+    )
+    .with_registry(registry.entries());
     let roster = state.roster.clone();
 
     let config = game::config();
@@ -58,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .enable_time()
             .build()
             .expect("sim runtime");
-        let mut app = build_app(snap_tx, input_rx, roster, seed, config, map);
+        let mut app = build_app(snap_tx, input_rx, roster, seed, config, map, registry);
         app.add_systems(
             bevy::prelude::Update,
             game::spawn_world.in_set(simgrid::SimSet::Spawn),

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcs.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcs.ts
@@ -1,4 +1,23 @@
+import npcdbRaw from '@kbve/npcdb-data';
 import type { NPCData, DialogueNode } from '../types';
+
+interface NpcDbEntry {
+	ref: string;
+	name: string;
+	description?: string;
+	faction?: { factionId?: string };
+	stats?: { hp?: number; maxHp?: number; attack?: number };
+}
+
+const NPCDB: NpcDbEntry[] = (npcdbRaw as { npcs: NpcDbEntry[] }).npcs ?? [];
+const npcDbByRef = new Map(NPCDB.map((n) => [n.ref, n]));
+
+const REF_AVATARS: Record<string, string> = {
+	cleric: '/assets/entity/monks.png',
+	'crystal-bat': '/assets/entity/bird_original.png',
+};
+
+const DEFAULT_AVATAR = '/assets/entity/monks.png';
 
 const NPCS: NPCData[] = [
 	{
@@ -19,8 +38,41 @@ const NPCS: NPCData[] = [
 
 const npcMap = new Map(NPCS.map((n) => [n.id, n]));
 
+export function npcIdForRef(ref: string): string {
+	return `npc_${ref}`;
+}
+
+export function getNpcDbEntry(ref: string): NpcDbEntry | undefined {
+	return npcDbByRef.get(ref);
+}
+
+export function isHostileRef(ref: string): boolean {
+	return npcDbByRef.get(ref)?.faction?.factionId === 'hostile';
+}
+
+function buildNpcFromDb(ref: string): NPCData | undefined {
+	const entry = npcDbByRef.get(ref);
+	if (!entry) return undefined;
+	const npc: NPCData = {
+		id: npcIdForRef(ref),
+		name: entry.name,
+		avatar: REF_AVATARS[ref] ?? DEFAULT_AVATAR,
+		slug: `npc/${ref}`,
+		actions: isHostileRef(ref) ? ['inspect'] : ['talk', 'inspect'],
+	};
+	npcMap.set(npc.id, npc);
+	return npc;
+}
+
 export function getNPCById(id: string): NPCData | undefined {
-	return npcMap.get(id);
+	const known = npcMap.get(id);
+	if (known) return known;
+	if (id.startsWith('npc_')) return buildNpcFromDb(id.slice(4));
+	return undefined;
+}
+
+export function getNPCByRef(ref: string): NPCData | undefined {
+	return getNPCById(npcIdForRef(ref));
 }
 
 const DIALOGUES: Record<string, DialogueNode> = {
@@ -80,6 +132,31 @@ const DIALOGUES: Record<string, DialogueNode> = {
 	},
 };
 
+function buildDialogueFromDb(ref: string): DialogueNode | undefined {
+	const entry = npcDbByRef.get(ref);
+	if (!entry) return undefined;
+	const id = `dlg_${ref}_greeting`;
+	const dialogue: DialogueNode = {
+		id,
+		title: entry.name,
+		message:
+			entry.description?.trim() ||
+			`${entry.name} has nothing to say right now.`,
+	};
+	DIALOGUES[id] = dialogue;
+	return dialogue;
+}
+
 export function getDialogueById(id: string): DialogueNode | undefined {
-	return DIALOGUES[id];
+	const known = DIALOGUES[id];
+	if (known) return known;
+	const match = id.match(/^dlg_(.+)_greeting$/);
+	if (match) return buildDialogueFromDb(match[1]);
+	return undefined;
+}
+
+export function getGreetingDialogueId(npcId: string): string {
+	if (npcId === 'npc_barkeep') return 'dlg_barkeep_greeting';
+	if (npcId === 'npc_monk') return 'dlg_monk_greeting';
+	return `dlg_${npcId.replace(/^npc_/, '')}_greeting`;
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -1,20 +1,46 @@
-import { Scene } from 'phaser';
-import { GameClient, laserEvents, createBirdAnimation } from '@kbve/laser';
-import type { Range, CharacterEventData, Dir, Snapshot } from '@kbve/laser';
+import Phaser, { Scene } from 'phaser';
+import {
+	GameClient,
+	laserEvents,
+	createBirdAnimation,
+	ACTION_ATTACK,
+	ACTION_PICKUP,
+	KIND_CAT_ITEM,
+	KIND_CAT_NPC,
+	KIND_CAT_PLAYER,
+} from '@kbve/laser';
+import type {
+	Range,
+	CharacterEventData,
+	Dir,
+	Snapshot,
+	KindEntry,
+} from '@kbve/laser';
 import { getCtNetConfig } from '@/lib/net-config';
+import { getNPCByRef, npcIdForRef } from '../data/npcs';
 
 const MAP_SCALE = 3;
-const STEP_THROTTLE_MS = 180;
-
-const KIND_PLAYER = 0;
-const KIND_MONK = 1;
-const KIND_BIRD = 2;
+const STEP_THROTTLE_MS = 90;
 const SLOT_NONE = 0xffff;
+
+interface RefSprite {
+	key: string;
+	mapping?: number;
+	anim?: string;
+}
+
+const REF_SPRITES: Record<string, RefSprite> = {
+	cleric: { key: 'monks', mapping: 0 },
+	'crystal-bat': { key: 'monster_bird', anim: 'bird' },
+};
+
+const DEFAULT_NPC_SPRITE: RefSprite = { key: 'monks', mapping: 0 };
 
 interface Tracked {
 	sprite: Phaser.GameObjects.Sprite;
 	charId: string;
 	tile: { x: number; y: number };
+	kind: number;
 }
 
 export class CloudCityScene extends Scene {
@@ -24,9 +50,12 @@ export class CloudCityScene extends Scene {
 	private mySlot = SLOT_NONE;
 	private myEid = -1;
 	private tracked = new Map<number, Tracked>();
+	private registry = new Map<number, KindEntry>();
 	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
+	private attackKey!: Phaser.Input.Keyboard.Key;
 	private entityDepth = 0;
 	private lastStepAt = 0;
+	private tilePixels = 16;
 	private ranges: Range[] = [];
 	private rangeTile = { x: -1, y: -1 };
 
@@ -36,6 +65,7 @@ export class CloudCityScene extends Scene {
 
 	create() {
 		const tilemap = this.make.tilemap({ key: 'cloud-city-map-large' });
+		this.tilePixels = tilemap.tileWidth;
 		const tileset = tilemap.addTilesetImage(
 			'cloud_tileset',
 			'cloud-city-tiles',
@@ -58,11 +88,15 @@ export class CloudCityScene extends Scene {
 		);
 
 		createBirdAnimation(this);
+		this.makeGroundItemTexture();
 		this.gridEngine.create(tilemap, {
 			characters: [],
 			numberOfDirections: 8,
 		});
 		this.cursors = this.input.keyboard!.createCursorKeys();
+		this.attackKey = this.input.keyboard!.addKey(
+			Phaser.Input.Keyboard.KeyCodes.SPACE,
+		);
 		this.loadRanges();
 
 		const cfg = getCtNetConfig();
@@ -81,8 +115,21 @@ export class CloudCityScene extends Scene {
 		this.client = client;
 		client.on('welcome', (w) => {
 			this.mySlot = w.your_slot;
+			this.registry.clear();
+			for (const entry of w.registry ?? []) {
+				this.registry.set(entry.kind, entry);
+			}
 		});
 		client.on('snapshot', (s) => this.applySnapshot(s));
+		client.on('inventory', (inv) => {
+			laserEvents.emit('inventory:sync', inv);
+		});
+		client.on('pickup', (p) => {
+			laserEvents.emit('item:pickup', p);
+		});
+		client.on('combat', (c) => {
+			laserEvents.emit('combat:event', c);
+		});
 		client.on('reject', (reason) => {
 			laserEvents.emit('char:event', {
 				message: `Server rejected the connection: ${reason}`,
@@ -95,27 +142,56 @@ export class CloudCityScene extends Scene {
 		});
 		client.connect();
 
+		this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) =>
+			this.onPointerDown(pointer),
+		);
+
 		this.events.once('shutdown', () => this.client?.close());
+	}
+
+	private makeGroundItemTexture() {
+		if (this.textures.exists('ground-item')) return;
+		const g = this.add.graphics();
+		g.fillStyle(0xfacc15, 1);
+		g.fillCircle(8, 8, 5);
+		g.lineStyle(1.5, 0xfde68a, 1);
+		g.strokeCircle(8, 8, 6.5);
+		g.generateTexture('ground-item', 16, 16);
+		g.destroy();
+	}
+
+	private kindCat(kind: number): number {
+		return this.registry.get(kind)?.cat ?? KIND_CAT_NPC;
+	}
+
+	private kindRef(kind: number): string | null {
+		return this.registry.get(kind)?.ref ?? null;
 	}
 
 	private makeSprite(kind: number): {
 		sprite: Phaser.GameObjects.Sprite;
 		mapping?: number;
 	} {
-		let key = 'player';
-		let mapping: number | undefined = 6;
-		if (kind === KIND_MONK) {
-			key = 'monks';
-			mapping = 0;
-		} else if (kind === KIND_BIRD) {
-			key = 'monster_bird';
-			mapping = undefined;
+		const cat = this.kindCat(kind);
+		if (cat === KIND_CAT_PLAYER || this.registry.size === 0) {
+			const sprite = this.add.sprite(0, 0, 'player');
+			sprite.scale = 1.5;
+			sprite.setDepth(this.entityDepth);
+			return { sprite, mapping: 6 };
 		}
-		const sprite = this.add.sprite(0, 0, key);
+		if (cat === KIND_CAT_ITEM) {
+			const sprite = this.add.sprite(0, 0, 'ground-item');
+			sprite.scale = 1.5;
+			sprite.setDepth(this.entityDepth - 0.5);
+			return { sprite, mapping: undefined };
+		}
+		const ref = this.kindRef(kind);
+		const conf = (ref && REF_SPRITES[ref]) || DEFAULT_NPC_SPRITE;
+		const sprite = this.add.sprite(0, 0, conf.key);
 		sprite.scale = 1.5;
 		sprite.setDepth(this.entityDepth);
-		if (kind === KIND_BIRD) sprite.play('bird');
-		return { sprite, mapping };
+		if (conf.anim) sprite.play(conf.anim);
+		return { sprite, mapping: conf.mapping };
 	}
 
 	private applySnapshot(snap: Snapshot) {
@@ -142,9 +218,10 @@ export class CloudCityScene extends Scene {
 					sprite,
 					charId,
 					tile: { x: e.tile.x, y: e.tile.y },
+					kind: e.kind,
 				});
 				if (
-					e.kind === KIND_PLAYER &&
+					this.kindCat(e.kind) === KIND_CAT_PLAYER &&
 					e.owner === this.mySlot &&
 					this.myEid < 0
 				) {
@@ -174,6 +251,93 @@ export class CloudCityScene extends Scene {
 		}
 
 		this.checkRanges();
+	}
+
+	private myTile(): { x: number; y: number } | null {
+		if (this.myEid < 0) return null;
+		return this.tracked.get(this.myEid)?.tile ?? null;
+	}
+
+	private chebyshev(
+		a: { x: number; y: number },
+		b: { x: number; y: number },
+	): number {
+		return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+	}
+
+	private entityAt(tile: {
+		x: number;
+		y: number;
+	}): { eid: number; t: Tracked } | null {
+		for (const [eid, t] of this.tracked) {
+			if (eid === this.myEid) continue;
+			if (t.tile.x === tile.x && t.tile.y === tile.y) {
+				return { eid, t };
+			}
+		}
+		return null;
+	}
+
+	private onPointerDown(pointer: Phaser.Input.Pointer) {
+		if (!this.client) return;
+		const span = this.tilePixels * MAP_SCALE;
+		const tile = {
+			x: Math.floor(pointer.worldX / span),
+			y: Math.floor(pointer.worldY / span),
+		};
+
+		const hit = this.entityAt(tile);
+		if (hit) {
+			const cat = this.kindCat(hit.t.kind);
+			const me = this.myTile();
+			if (cat === KIND_CAT_ITEM) {
+				if (me && this.chebyshev(me, tile) <= 1) {
+					this.client.action(ACTION_PICKUP, hit.eid);
+				} else {
+					this.client.moveTo(tile);
+				}
+				return;
+			}
+			if (cat === KIND_CAT_NPC) {
+				const ref = this.kindRef(hit.t.kind);
+				if (ref && me && this.chebyshev(me, tile) <= 1) {
+					const npc = getNPCByRef(ref);
+					const ev = pointer.event as MouseEvent | undefined;
+					laserEvents.emit('npc:interact', {
+						npcId: npcIdForRef(ref),
+						npcName: npc?.name ?? ref,
+						actions: npc?.actions ?? ['talk'],
+						coords: {
+							x: ev?.clientX ?? pointer.x,
+							y: ev?.clientY ?? pointer.y,
+						},
+					});
+				} else {
+					this.client.moveTo(tile);
+				}
+				return;
+			}
+		}
+
+		this.client.moveTo(tile);
+	}
+
+	private attackNearby() {
+		if (!this.client) return;
+		const me = this.myTile();
+		if (!me) return;
+		let best: { eid: number; dist: number } | null = null;
+		for (const [eid, t] of this.tracked) {
+			if (eid === this.myEid) continue;
+			if (this.kindCat(t.kind) !== KIND_CAT_NPC) continue;
+			const dist = this.chebyshev(me, t.tile);
+			if (dist <= 1 && (!best || dist < best.dist)) {
+				best = { eid, dist };
+			}
+		}
+		if (best) {
+			this.client.action(ACTION_ATTACK, best.eid);
+		}
 	}
 
 	private checkRanges() {
@@ -243,6 +407,11 @@ export class CloudCityScene extends Scene {
 
 	update(time: number) {
 		if (!this.client) return;
+
+		if (Phaser.Input.Keyboard.JustDown(this.attackKey)) {
+			this.attackNearby();
+		}
+
 		if (time - this.lastStepAt < STEP_THROTTLE_MS) return;
 
 		let dir: Dir | null = null;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
@@ -29,6 +29,7 @@ export interface GameState {
 export type GameAction =
 	| { type: 'SET_PLAYER_STATS'; payload: Partial<PlayerStats> }
 	| { type: 'ADD_ITEM'; payload: { itemId: string } }
+	| { type: 'SET_BACKPACK'; payload: { itemIds: string[] } }
 	| { type: 'REMOVE_ITEM'; payload: { itemId: string } }
 	| {
 			type: 'EQUIP_ITEM';
@@ -130,6 +131,18 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 							...state.player.inventory.backpack,
 							action.payload.itemId,
 						],
+					},
+				},
+			};
+
+		case 'SET_BACKPACK':
+			return {
+				...state,
+				player: {
+					...state.player,
+					inventory: {
+						...state.player.inventory,
+						backpack: action.payload.itemIds,
 					},
 				},
 			};

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
@@ -91,6 +91,56 @@ export function useEventBridge(dispatch: Dispatch<GameAction>) {
 		);
 
 		unsubs.push(
+			laserEvents.on('inventory:sync', (data) => {
+				const sync = data as {
+					items: { ref: string; count: number }[];
+				};
+				const itemIds = sync.items.flatMap((i) =>
+					Array.from({ length: i.count }, () => i.ref),
+				);
+				dispatch({ type: 'SET_BACKPACK', payload: { itemIds } });
+			}),
+		);
+
+		unsubs.push(
+			laserEvents.on('item:pickup', (data) => {
+				const pickup = data as { item_ref: string; count: number };
+				dispatch({
+					type: 'ADD_NOTIFICATION',
+					payload: {
+						title: 'Picked up',
+						message:
+							pickup.count > 1
+								? `${pickup.item_ref} ×${pickup.count}`
+								: pickup.item_ref,
+						type: 'success',
+					},
+				});
+			}),
+		);
+
+		unsubs.push(
+			laserEvents.on('combat:event', (data) => {
+				const combat = data as {
+					target_ref: string | null;
+					dmg: number;
+					died: boolean;
+				};
+				const name = combat.target_ref ?? 'enemy';
+				dispatch({
+					type: 'ADD_NOTIFICATION',
+					payload: {
+						title: combat.died ? 'Defeated' : 'Combat',
+						message: combat.died
+							? `${name} slain!`
+							: `Hit ${name} for ${combat.dmg}`,
+						type: combat.died ? 'success' : 'info',
+					},
+				});
+			}),
+		);
+
+		unsubs.push(
 			laserEvents.on('dice:roll', (data) => {
 				dispatch({
 					type: 'SET_DICE_ROLL',

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ActionMenu.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ActionMenu.tsx
@@ -1,6 +1,10 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
-import { getNPCById, getDialogueById } from '../data/npcs';
+import {
+	getNPCById,
+	getDialogueById,
+	getGreetingDialogueId,
+} from '../data/npcs';
 import type { NPCAction } from '../types';
 
 export function ActionMenu() {
@@ -47,11 +51,9 @@ export function ActionMenu() {
 			case 'talk': {
 				const npcData = getNPCById(npc.npcId);
 				if (!npcData) break;
-				const dialogueId =
-					npc.npcId === 'npc_barkeep'
-						? 'dlg_barkeep_greeting'
-						: 'dlg_monk_greeting';
-				const dialogue = getDialogueById(dialogueId);
+				const dialogue = getDialogueById(
+					getGreetingDialogueId(npc.npcId),
+				);
 				if (dialogue) {
 					dispatch({
 						type: 'SET_DIALOGUE',

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -16,6 +16,9 @@
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
 			"@kbve/itemdb-data": [
 				"../../../packages/data/codegen/generated/itemdb-data.json"
+			],
+			"@kbve/npcdb-data": [
+				"../../../packages/data/codegen/generated/npcdb-data.json"
 			]
 		}
 	}

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -60,8 +60,17 @@ export type {
 export {
 	PROTOCOL_VERSION,
 	OWNER_NONE,
+	ACTION_ATTACK,
+	ACTION_PICKUP,
+	EPHEMERAL_INVENTORY,
+	EPHEMERAL_COMBAT,
+	EPHEMERAL_PICKUP,
+	KIND_CAT_PLAYER,
+	KIND_CAT_NPC,
+	KIND_CAT_ITEM,
 	joinFrame,
 	inputFrame,
+	decodeEphemeralPayload,
 } from './lib/net/protocol';
 export type {
 	Dir,
@@ -76,4 +85,10 @@ export type {
 	Welcome,
 	JoinMatch,
 	ClientFrame,
+	KindEntry,
+	Ephemeral,
+	InventoryItem,
+	InventorySync,
+	CombatEvent,
+	PickupEvent,
 } from './lib/net/protocol';

--- a/packages/npm/laser/src/lib/net/game-client.ts
+++ b/packages/npm/laser/src/lib/net/game-client.ts
@@ -1,12 +1,21 @@
 import { LaserEventBus } from '../core/events';
 import {
+	EPHEMERAL_COMBAT,
+	EPHEMERAL_INVENTORY,
+	EPHEMERAL_PICKUP,
 	type ClientMessage,
+	type CombatEvent,
 	type Dir,
+	type Ephemeral,
 	type Facing,
 	type Input,
+	type InventorySync,
+	type PickupEvent,
 	type ServerEvent,
 	type Snapshot,
+	type Tile,
 	type Welcome,
+	decodeEphemeralPayload,
 	inputFrame,
 	joinFrame,
 } from './protocol';
@@ -15,6 +24,10 @@ export type GameClientEventMap = {
 	open: void;
 	welcome: Welcome;
 	snapshot: Snapshot;
+	ephemeral: Ephemeral;
+	inventory: InventorySync;
+	combat: CombatEvent;
+	pickup: PickupEvent;
 	reject: string;
 	close: void;
 	error: string;
@@ -63,6 +76,7 @@ export class GameClient {
 			}
 			if ('Welcome' in msg) this.bus.emit('welcome', msg.Welcome);
 			else if ('Snapshot' in msg) this.bus.emit('snapshot', msg.Snapshot);
+			else if ('Ephemeral' in msg) this.handleEphemeral(msg.Ephemeral);
 			else if ('Reject' in msg)
 				this.bus.emit('reject', msg.Reject.reason);
 		});
@@ -73,6 +87,20 @@ export class GameClient {
 			this.ws = null;
 			this.bus.emit('close', undefined);
 		});
+	}
+
+	private handleEphemeral(evt: Ephemeral): void {
+		this.bus.emit('ephemeral', evt);
+		if (evt.kind === EPHEMERAL_INVENTORY) {
+			const data = decodeEphemeralPayload<InventorySync>(evt.payload);
+			if (data) this.bus.emit('inventory', data);
+		} else if (evt.kind === EPHEMERAL_COMBAT) {
+			const data = decodeEphemeralPayload<CombatEvent>(evt.payload);
+			if (data) this.bus.emit('combat', data);
+		} else if (evt.kind === EPHEMERAL_PICKUP) {
+			const data = decodeEphemeralPayload<PickupEvent>(evt.payload);
+			if (data) this.bus.emit('pickup', data);
+		}
 	}
 
 	private send(msg: ClientMessage): void {
@@ -92,6 +120,14 @@ export class GameClient {
 
 	step(dir: Dir): void {
 		this.sendInputs([{ Step: { dir } }]);
+	}
+
+	moveTo(tile: Tile): void {
+		this.sendInputs([{ MoveTo: { tile } }]);
+	}
+
+	action(id: number, target: number | null): void {
+		this.sendInputs([{ Action: { id, target } }]);
 	}
 
 	face(facing: Facing): void {

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -1,4 +1,15 @@
-export const PROTOCOL_VERSION = 1;
+export const PROTOCOL_VERSION = 2;
+
+export const ACTION_ATTACK = 1;
+export const ACTION_PICKUP = 2;
+
+export const EPHEMERAL_INVENTORY = 1;
+export const EPHEMERAL_COMBAT = 2;
+export const EPHEMERAL_PICKUP = 3;
+
+export const KIND_CAT_PLAYER = 0;
+export const KIND_CAT_NPC = 1;
+export const KIND_CAT_ITEM = 2;
 
 export type Dir = 'Up' | 'Down' | 'Left' | 'Right';
 export type Facing = 'Up' | 'Down' | 'Left' | 'Right';
@@ -56,19 +67,64 @@ export interface Snapshot {
 	keyframe: boolean;
 }
 
+export interface KindEntry {
+	kind: number;
+	ref: string;
+	cat: number;
+}
+
 export interface Welcome {
 	protocol: number;
 	your_slot: number;
 	seed: number;
+	registry: KindEntry[];
+}
+
+export interface Ephemeral {
+	kind: number;
+	to: number;
+	payload: number[];
+}
+
+export interface InventoryItem {
+	ref: string;
+	count: number;
+}
+
+export interface InventorySync {
+	items: InventoryItem[];
+}
+
+export interface CombatEvent {
+	attacker: number;
+	target: number;
+	target_ref: string | null;
+	dmg: number;
+	died: boolean;
+}
+
+export interface PickupEvent {
+	item_ref: string;
+	count: number;
 }
 
 export type ServerEvent =
 	| { Welcome: Welcome }
 	| { Snapshot: Snapshot }
-	| { Ephemeral: { kind: number; payload: number[] } }
+	| { Ephemeral: Ephemeral }
 	| { Reject: { reason: string } };
 
 export const OWNER_NONE = 0xffff;
+
+export function decodeEphemeralPayload<T>(payload: number[]): T | null {
+	try {
+		return JSON.parse(
+			new TextDecoder().decode(Uint8Array.from(payload)),
+		) as T;
+	} catch {
+		return null;
+	}
+}
 
 export function joinFrame(jwt: string, kbveUsername: string): ClientMessage {
 	return {

--- a/packages/rust/simgrid/src/data.rs
+++ b/packages/rust/simgrid/src/data.rs
@@ -1,0 +1,177 @@
+use std::collections::HashMap;
+
+use bevy::prelude::Resource;
+use serde::Deserialize;
+
+use crate::proto::{KIND_CAT_ITEM, KIND_CAT_NPC, KIND_CAT_PLAYER, KindEntry};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct NpcDb {
+    #[serde(default)]
+    pub npcs: Vec<NpcDef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NpcDef {
+    #[serde(rename = "ref")]
+    pub ref_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub stats: NpcStats,
+    #[serde(default)]
+    pub equipment: Option<NpcEquipment>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NpcStats {
+    #[serde(default)]
+    pub hp: i32,
+    #[serde(default)]
+    pub max_hp: i32,
+    #[serde(default)]
+    pub attack: i32,
+    #[serde(default)]
+    pub defense: i32,
+    #[serde(default)]
+    pub speed: i32,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct NpcEquipment {
+    #[serde(default)]
+    pub equipped: Vec<NpcEquipSlot>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NpcEquipSlot {
+    #[serde(default)]
+    pub item_ref: String,
+}
+
+impl NpcDb {
+    pub fn from_json(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+
+    pub fn get(&self, ref_id: &str) -> Option<&NpcDef> {
+        self.npcs.iter().find(|n| n.ref_id == ref_id)
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ItemDb {
+    #[serde(default)]
+    pub items: Vec<ItemDef>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ItemDef {
+    #[serde(rename = "ref")]
+    pub ref_id: String,
+    pub name: String,
+    #[serde(default)]
+    pub stackable: bool,
+    #[serde(default)]
+    pub consumable: bool,
+}
+
+impl ItemDb {
+    pub fn from_json(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        serde_json::from_slice(bytes)
+    }
+
+    pub fn get(&self, ref_id: &str) -> Option<&ItemDef> {
+        self.items.iter().find(|i| i.ref_id == ref_id)
+    }
+}
+
+#[derive(Resource, Debug, Clone, Default)]
+pub struct KindRegistry {
+    entries: Vec<KindEntry>,
+    by_ref: HashMap<String, u16>,
+}
+
+impl KindRegistry {
+    pub fn new() -> Self {
+        let mut reg = Self::default();
+        reg.insert("player", KIND_CAT_PLAYER);
+        reg
+    }
+
+    fn insert(&mut self, ref_id: &str, cat: u8) -> u16 {
+        if let Some(kind) = self.by_ref.get(ref_id) {
+            return *kind;
+        }
+        let kind = self.entries.len() as u16;
+        self.entries.push(KindEntry {
+            kind,
+            ref_id: ref_id.to_string(),
+            cat,
+        });
+        self.by_ref.insert(ref_id.to_string(), kind);
+        kind
+    }
+
+    pub fn register_npc(&mut self, ref_id: &str) -> u16 {
+        self.insert(ref_id, KIND_CAT_NPC)
+    }
+
+    pub fn register_item(&mut self, ref_id: &str) -> u16 {
+        self.insert(ref_id, KIND_CAT_ITEM)
+    }
+
+    pub fn kind_of(&self, ref_id: &str) -> Option<u16> {
+        self.by_ref.get(ref_id).copied()
+    }
+
+    pub fn ref_of(&self, kind: u16) -> Option<&str> {
+        self.entries.get(kind as usize).map(|e| e.ref_id.as_str())
+    }
+
+    pub fn entries(&self) -> Vec<KindEntry> {
+        self.entries.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn npcdb_parses_minimal() {
+        let json = r#"{"npcs":[{"ref":"cleric","name":"Cleric",
+            "stats":{"hp":40,"maxHp":40,"attack":3,"speed":4},
+            "equipment":{"equipped":[{"slot":"EQUIP_SLOT_CHEST","itemRef":"robe"}]}}]}"#;
+        let db = NpcDb::from_json(json.as_bytes()).expect("parse");
+        let npc = db.get("cleric").expect("cleric");
+        assert_eq!(npc.name, "Cleric");
+        assert_eq!(npc.stats.max_hp, 40);
+        assert_eq!(npc.equipment.as_ref().unwrap().equipped[0].item_ref, "robe");
+    }
+
+    #[test]
+    fn itemdb_parses_minimal() {
+        let json = r#"{"items":[{"ref":"potion","name":"Potion","stackable":true,
+            "consumable":true,"weight":0.5,"unknown_field":1}]}"#;
+        let db = ItemDb::from_json(json.as_bytes()).expect("parse");
+        let item = db.get("potion").expect("potion");
+        assert!(item.stackable);
+    }
+
+    #[test]
+    fn registry_assigns_stable_kinds() {
+        let mut reg = KindRegistry::new();
+        let cleric = reg.register_npc("cleric");
+        let bat = reg.register_npc("crystal-bat");
+        let potion = reg.register_item("potion");
+        assert_eq!(reg.kind_of("player"), Some(0));
+        assert_eq!((cleric, bat, potion), (1, 2, 3));
+        assert_eq!(reg.register_npc("cleric"), 1);
+        assert_eq!(reg.ref_of(3), Some("potion"));
+        assert_eq!(reg.entries().len(), 4);
+    }
+}

--- a/packages/rust/simgrid/src/grid.rs
+++ b/packages/rust/simgrid/src/grid.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use bevy::ecs::entity::Entity;
 use bevy::prelude::{Component, Resource};
@@ -136,6 +136,50 @@ impl WalkableMap {
     pub fn is_walkable(&self, tile: Tile) -> bool {
         self.index(tile).map(|i| !self.blocked[i]).unwrap_or(false)
     }
+
+    pub fn find_path(&self, from: Tile, to: Tile, max_len: usize) -> Option<Vec<Tile>> {
+        if from == to || !self.is_walkable(to) || !self.in_bounds(from) {
+            return None;
+        }
+        let start = self.index(from)?;
+        let goal = self.index(to)?;
+
+        let mut prev: Vec<i32> = vec![-1; (self.width * self.height) as usize];
+        prev[start] = start as i32;
+        let mut queue = VecDeque::from([start]);
+
+        'search: while let Some(cur) = queue.pop_front() {
+            let cx = cur as i32 % self.width;
+            let cy = cur as i32 / self.width;
+            for (dx, dy) in [(0, -1), (0, 1), (-1, 0), (1, 0)] {
+                let next = Tile::new(cx + dx, cy + dy);
+                let Some(ni) = self.index(next) else { continue };
+                if prev[ni] >= 0 || self.blocked[ni] {
+                    continue;
+                }
+                prev[ni] = cur as i32;
+                if ni == goal {
+                    break 'search;
+                }
+                queue.push_back(ni);
+            }
+        }
+
+        if prev[goal] < 0 {
+            return None;
+        }
+        let mut path = Vec::new();
+        let mut cur = goal;
+        while cur != start {
+            path.push(Tile::new(cur as i32 % self.width, cur as i32 / self.width));
+            cur = prev[cur] as usize;
+            if path.len() > max_len {
+                return None;
+            }
+        }
+        path.reverse();
+        Some(path)
+    }
 }
 
 #[derive(Resource, Default)]
@@ -212,6 +256,33 @@ mod tests {
         assert_eq!((m.width, m.height), (2, 1));
         assert!(!m.is_walkable(Tile::new(0, 0)));
         assert!(m.is_walkable(Tile::new(1, 0)));
+    }
+
+    #[test]
+    fn find_path_routes_around_walls() {
+        let mut m = WalkableMap::open(5, 5);
+        m.set_blocked(Tile::new(2, 0), true);
+        m.set_blocked(Tile::new(2, 1), true);
+        m.set_blocked(Tile::new(2, 2), true);
+        m.set_blocked(Tile::new(2, 3), true);
+        let path = m
+            .find_path(Tile::new(0, 0), Tile::new(4, 0), 64)
+            .expect("path exists");
+        assert_eq!(path.last(), Some(&Tile::new(4, 0)));
+        assert!(path.iter().all(|t| m.is_walkable(*t)));
+        assert!(path.len() >= 8, "must route around the wall");
+        for pair in path.windows(2) {
+            assert_eq!(pair[0].manhattan(pair[1]), 1, "path must be contiguous");
+        }
+    }
+
+    #[test]
+    fn find_path_rejects_unreachable() {
+        let mut m = WalkableMap::open(3, 3);
+        for y in 0..3 {
+            m.set_blocked(Tile::new(1, y), true);
+        }
+        assert!(m.find_path(Tile::new(0, 0), Tile::new(2, 0), 64).is_none());
     }
 
     #[test]

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod data;
 pub mod grid;
 pub mod net;
 pub mod proto;
@@ -6,9 +7,11 @@ pub mod sim;
 #[cfg(feature = "supabase-auth")]
 pub mod auth;
 
+pub use data::{ItemDb, KindRegistry, NpcDb};
 pub use grid::{GridPos, MoveSpeed, MoveTarget, WalkableMap};
 pub use net::{Roster, ServerState, SlotInput, router};
 pub use sim::{
-    EntityKind, Health, PlayerSlotTag, SIM_TICK_HZ, SNAPSHOT_BROADCAST_CAPACITY, SimConfig, SimSet,
-    Wander, build_app, run_sim_loop,
+    CombatStats, EntityKind, Health, Inventory, Loot, Path, PlayerSlotTag, SIM_TICK_HZ,
+    SNAPSHOT_BROADCAST_CAPACITY, SimConfig, SimSet, StepBuffer, Wander, build_app,
+    ground_item_bundle, run_sim_loop,
 };

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -32,7 +32,7 @@ impl Roster {
         self.slots.len()
     }
 
-    fn claim(&mut self, kbve_username: String) -> Option<proto::PlayerSlot> {
+    pub(crate) fn claim(&mut self, kbve_username: String) -> Option<proto::PlayerSlot> {
         for (i, s) in self.slots.iter_mut().enumerate() {
             if s.is_none() {
                 *s = Some(RosterEntry { kbve_username });
@@ -86,6 +86,7 @@ pub struct ServerState {
     pub jwt_secret: Vec<u8>,
     pub require_username: bool,
     pub roster: Arc<RwLock<Roster>>,
+    pub registry: Vec<proto::KindEntry>,
 }
 
 impl ServerState {
@@ -104,7 +105,13 @@ impl ServerState {
             jwt_secret,
             require_username,
             roster: Arc::new(RwLock::new(Roster::new(capacity))),
+            registry: Vec::new(),
         }
+    }
+
+    pub fn with_registry(mut self, registry: Vec<proto::KindEntry>) -> Self {
+        self.registry = registry;
+        self
     }
 }
 
@@ -168,6 +175,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
         protocol: proto::PROTOCOL_VERSION,
         your_slot: slot,
         seed: state.seed,
+        registry: state.registry.clone(),
     };
     if let Some(msg) = encode_event(&welcome, format)
         && socket.send(msg).await.is_err()
@@ -188,6 +196,12 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
                 }
             } => {
                 let Some(evt) = evt else { break };
+                if let ServerEvent::Ephemeral { to, .. } = &evt
+                    && *to != proto::PLAYER_SLOT_NONE
+                    && *to != slot
+                {
+                    continue;
+                }
                 let evt = inject_roster(evt, &state.roster);
                 let Some(msg) = encode_event(&evt, format) else { continue };
                 if socket.send(msg).await.is_err() {

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -1,7 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 pub const DEFAULT_MAX_PLAYERS: usize = 64;
+
+pub const ACTION_ATTACK: u16 = 1;
+pub const ACTION_PICKUP: u16 = 2;
+
+pub const EPHEMERAL_INVENTORY: u16 = 1;
+pub const EPHEMERAL_COMBAT: u16 = 2;
+pub const EPHEMERAL_PICKUP: u16 = 3;
+
+pub const KIND_CAT_PLAYER: u8 = 0;
+pub const KIND_CAT_NPC: u8 = 1;
+pub const KIND_CAT_ITEM: u8 = 2;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct EntityId(pub u32);
@@ -130,15 +141,25 @@ pub struct Snapshot {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct KindEntry {
+    pub kind: u16,
+    #[serde(rename = "ref")]
+    pub ref_id: String,
+    pub cat: u8,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ServerEvent {
     Welcome {
         protocol: u32,
         your_slot: PlayerSlot,
         seed: u64,
+        registry: Vec<KindEntry>,
     },
     Snapshot(Snapshot),
     Ephemeral {
         kind: u16,
+        to: PlayerSlot,
         payload: Vec<u8>,
     },
     Reject {
@@ -189,6 +210,11 @@ mod tests {
             protocol: PROTOCOL_VERSION,
             your_slot: PlayerSlot(3),
             seed: 0xC0FFEE,
+            registry: vec![KindEntry {
+                kind: 1,
+                ref_id: "cleric".into(),
+                cat: KIND_CAT_NPC,
+            }],
         };
         let mut buf = encode(&evt).expect("encode");
         let back: ServerEvent = decode(&mut buf).expect("decode");

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
@@ -6,11 +6,13 @@ use bevy::app::App;
 use bevy::ecs::entity::Entity;
 use bevy::ecs::schedule::SystemSet;
 use bevy::prelude::{
-    Commands, Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update,
+    Commands, Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update, With, Without,
 };
+use serde_json::json;
 use tokio::sync::{broadcast, mpsc};
 use tokio::time;
 
+use crate::data::KindRegistry;
 use crate::grid::{GridPos, MoveSpeed, MoveTarget, Occupancy, WalkableMap};
 use crate::net::Roster;
 use crate::proto::{self, Dir, Input, ServerEvent, Tile};
@@ -21,6 +23,7 @@ pub const SNAPSHOT_BROADCAST_CAPACITY: usize = 256;
 pub const KEYFRAME_EVERY_N_TICKS: u32 = SIM_TICK_HZ * 5;
 
 pub const PLAYER_KIND: u16 = 0;
+pub const MAX_PATH_LEN: usize = 64;
 
 #[derive(SystemSet, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum SimSet {
@@ -37,6 +40,7 @@ pub enum SimSet {
 pub struct SimConfig {
     pub player_kind: u16,
     pub player_hp: i32,
+    pub player_attack: i32,
     pub spawn: Tile,
     pub ticks_per_tile: u8,
 }
@@ -46,6 +50,7 @@ impl Default for SimConfig {
         Self {
             player_kind: PLAYER_KIND,
             player_hp: 100,
+            player_attack: 5,
             spawn: Tile::new(0, 0),
             ticks_per_tile: 4,
         }
@@ -79,6 +84,14 @@ pub struct SpawnedSlots {
     by_slot: HashMap<u16, Entity>,
 }
 
+#[derive(Resource, Default)]
+pub struct EidIndex {
+    by_eid: HashMap<u32, Entity>,
+}
+
+#[derive(Resource, Default)]
+pub struct PendingActions(Vec<(proto::PlayerSlot, u16, Option<proto::EntityId>)>);
+
 #[derive(Component, Clone, Copy)]
 pub struct PlayerSlotTag(pub proto::PlayerSlot);
 
@@ -89,6 +102,47 @@ pub struct EntityKind(pub u16);
 pub struct Health {
     pub hp: i32,
     pub max_hp: i32,
+}
+
+#[derive(Component, Clone, Copy)]
+pub struct CombatStats {
+    pub attack: i32,
+}
+
+#[derive(Component, Clone, Default)]
+pub struct Inventory {
+    pub slots: Vec<(String, u32)>,
+}
+
+impl Inventory {
+    pub fn add(&mut self, item_ref: &str, count: u32) {
+        if let Some(slot) = self.slots.iter_mut().find(|(r, _)| r == item_ref) {
+            slot.1 = slot.1.saturating_add(count);
+        } else {
+            self.slots.push((item_ref.to_string(), count));
+        }
+    }
+}
+
+#[derive(Component, Clone)]
+pub struct GroundItem {
+    pub item_ref: String,
+    pub count: u32,
+}
+
+#[derive(Component, Clone, Default)]
+pub struct Loot {
+    pub item_ref: Option<String>,
+}
+
+#[derive(Component, Clone, Default)]
+pub struct Path {
+    pub steps: VecDeque<Tile>,
+}
+
+#[derive(Component, Clone, Copy, Default)]
+pub struct StepBuffer {
+    pub dir: Option<Dir>,
 }
 
 #[derive(Component, Clone, Copy)]
@@ -110,6 +164,24 @@ impl Wander {
     }
 }
 
+pub fn ground_item_bundle(
+    registry: &KindRegistry,
+    item_ref: &str,
+    count: u32,
+    tile: Tile,
+) -> Option<(EntityKind, GridPos, MoveTarget, GroundItem)> {
+    let kind = registry.kind_of(item_ref)?;
+    Some((
+        EntityKind(kind),
+        GridPos::at(tile),
+        MoveTarget::default(),
+        GroundItem {
+            item_ref: item_ref.to_string(),
+            count,
+        },
+    ))
+}
+
 pub fn build_app(
     tx: broadcast::Sender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
@@ -117,6 +189,7 @@ pub fn build_app(
     seed: u64,
     config: SimConfig,
     map: WalkableMap,
+    registry: KindRegistry,
 ) -> App {
     let mut app = App::new();
     app.insert_resource(SimClock::default())
@@ -127,9 +200,12 @@ pub fn build_app(
         })
         .insert_resource(RosterHandle(roster))
         .insert_resource(SpawnedSlots::default())
+        .insert_resource(EidIndex::default())
+        .insert_resource(PendingActions::default())
         .insert_resource(Occupancy::default())
         .insert_resource(map)
         .insert_resource(config)
+        .insert_resource(registry)
         .configure_sets(
             Update,
             (
@@ -146,9 +222,20 @@ pub fn build_app(
         .add_systems(Update, tick_sim.in_set(SimSet::Tick))
         .add_systems(Update, sync_roster.in_set(SimSet::Spawn))
         .add_systems(Update, rebuild_occupancy.in_set(SimSet::Occupancy))
-        .add_systems(Update, drain_inputs.in_set(SimSet::Input))
-        .add_systems(Update, wander_system.in_set(SimSet::Ai))
-        .add_systems(Update, advance_movement.in_set(SimSet::Movement))
+        .add_systems(
+            Update,
+            (drain_inputs, apply_actions).chain().in_set(SimSet::Input),
+        )
+        .add_systems(
+            Update,
+            (follow_path, wander_system).chain().in_set(SimSet::Ai),
+        )
+        .add_systems(
+            Update,
+            (advance_movement, chain_steps)
+                .chain()
+                .in_set(SimSet::Movement),
+        )
         .add_systems(Update, emit_snapshot.in_set(SimSet::Snapshot));
     app
 }
@@ -187,6 +274,12 @@ fn sync_roster(
                     hp: config.player_hp,
                     max_hp: config.player_hp,
                 },
+                CombatStats {
+                    attack: config.player_attack,
+                },
+                Inventory::default(),
+                Path::default(),
+                StepBuffer::default(),
             ))
             .id();
         spawned.by_slot.insert(slot.0, entity);
@@ -205,21 +298,39 @@ fn sync_roster(
     }
 }
 
-fn rebuild_occupancy(mut occ: ResMut<Occupancy>, q: Query<(Entity, &GridPos, &MoveTarget)>) {
+fn rebuild_occupancy(
+    mut occ: ResMut<Occupancy>,
+    mut index: ResMut<EidIndex>,
+    q: Query<(Entity, &GridPos, Option<&MoveTarget>, Option<&GroundItem>)>,
+) {
     occ.clear();
-    for (entity, pos, mv) in q.iter() {
+    index.by_eid.clear();
+    for (entity, pos, mv, item) in q.iter() {
+        index.by_eid.insert(entity.index_u32(), entity);
+        if item.is_some() {
+            continue;
+        }
         occ.set(pos.tile, entity);
-        if let Some(t) = mv.target {
+        if let Some(t) = mv.and_then(|m| m.target) {
             occ.set(t, entity);
         }
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn drain_inputs(
     queue: Res<InputQueue>,
     map: Res<WalkableMap>,
     mut occ: ResMut<Occupancy>,
-    mut q: Query<(Entity, &PlayerSlotTag, &mut GridPos, &mut MoveTarget)>,
+    mut actions: ResMut<PendingActions>,
+    mut q: Query<(
+        Entity,
+        &PlayerSlotTag,
+        &mut GridPos,
+        &mut MoveTarget,
+        &mut Path,
+        &mut StepBuffer,
+    )>,
 ) {
     let mut pending: HashMap<u16, Vec<Input>> = HashMap::new();
     {
@@ -228,40 +339,213 @@ fn drain_inputs(
             Err(p) => p.into_inner(),
         };
         while let Ok((slot, input)) = guard.try_recv() {
-            pending.entry(slot.0).or_default().push(input);
+            if let Input::Action { id, target } = input {
+                actions.0.push((slot, id, target));
+            } else {
+                pending.entry(slot.0).or_default().push(input);
+            }
         }
     }
     if pending.is_empty() {
         return;
     }
 
-    for (entity, slot, mut pos, mut mv) in q.iter_mut() {
+    for (entity, slot, mut pos, mut mv, mut path, mut buffer) in q.iter_mut() {
         let Some(inputs) = pending.get(&slot.0.0) else {
             continue;
         };
         for input in inputs {
-            apply_step(entity, input, &map, &mut occ, &mut pos, &mut mv);
+            match input {
+                Input::Step { dir } => {
+                    path.steps.clear();
+                    pos.facing = dir.facing();
+                    if mv.target.is_some() {
+                        buffer.dir = Some(*dir);
+                    } else if try_move(entity, *dir, &map, &mut occ, &pos, &mut mv, None) {
+                        buffer.dir = None;
+                    }
+                }
+                Input::MoveTo { tile } => {
+                    buffer.dir = None;
+                    let from = mv.target.unwrap_or(pos.tile);
+                    match map.find_path(from, *tile, MAX_PATH_LEN) {
+                        Some(steps) => path.steps = steps.into(),
+                        None => path.steps.clear(),
+                    }
+                }
+                Input::Face { facing } => {
+                    pos.facing = *facing;
+                }
+                Input::Action { .. } | Input::Heartbeat { .. } | Input::Leave => {}
+            }
         }
     }
 }
 
-fn apply_step(
-    entity: Entity,
-    input: &Input,
-    map: &WalkableMap,
-    occ: &mut Occupancy,
-    pos: &mut GridPos,
-    mv: &mut MoveTarget,
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
+fn apply_actions(
+    mut actions: ResMut<PendingActions>,
+    index: Res<EidIndex>,
+    registry: Res<KindRegistry>,
+    bcast: Res<SnapshotBroadcast>,
+    mut commands: Commands,
+    mut q_players: Query<(
+        Entity,
+        &PlayerSlotTag,
+        &GridPos,
+        &CombatStats,
+        &mut Inventory,
+    )>,
+    mut q_mobs: Query<
+        (&GridPos, &mut Health, Option<&Loot>, &EntityKind),
+        (Without<PlayerSlotTag>, Without<GroundItem>),
+    >,
+    q_items: Query<(&GridPos, &GroundItem)>,
 ) {
-    match input {
-        Input::Step { dir } => {
+    if actions.0.is_empty() {
+        return;
+    }
+    let drained: Vec<_> = actions.0.drain(..).collect();
+
+    let mut by_slot: HashMap<u16, Entity> = HashMap::new();
+    for (entity, slot, ..) in q_players.iter() {
+        by_slot.insert(slot.0.0, entity);
+    }
+
+    for (slot, action_id, target) in drained {
+        let Some(&player_entity) = by_slot.get(&slot.0) else {
+            continue;
+        };
+        let Some(target_entity) = target.and_then(|t| index.by_eid.get(&t.0).copied()) else {
+            continue;
+        };
+
+        match action_id {
+            proto::ACTION_ATTACK => {
+                let Ok((_, _, pos, stats, _)) = q_players.get(player_entity) else {
+                    continue;
+                };
+                let (attacker_tile, damage) = (pos.tile, stats.attack.max(1));
+                let Ok((mob_pos, mut hp, loot, kind)) = q_mobs.get_mut(target_entity) else {
+                    continue;
+                };
+                if attacker_tile.chebyshev(mob_pos.tile) > 1 {
+                    continue;
+                }
+                hp.hp -= damage;
+                let died = hp.hp <= 0;
+                let payload = json!({
+                    "attacker": player_entity.index_u32(),
+                    "target": target_entity.index_u32(),
+                    "target_ref": registry.ref_of(kind.0),
+                    "dmg": damage,
+                    "died": died,
+                })
+                .to_string()
+                .into_bytes();
+                let _ = bcast.tx.send(ServerEvent::Ephemeral {
+                    kind: proto::EPHEMERAL_COMBAT,
+                    to: proto::PLAYER_SLOT_NONE,
+                    payload,
+                });
+                if died {
+                    let drop_tile = mob_pos.tile;
+                    let drop_ref = loot.and_then(|l| l.item_ref.clone());
+                    commands.entity(target_entity).despawn();
+                    if let Some(item_ref) = drop_ref
+                        && let Some(bundle) = ground_item_bundle(&registry, &item_ref, 1, drop_tile)
+                    {
+                        commands.spawn(bundle);
+                    }
+                }
+            }
+            proto::ACTION_PICKUP => {
+                let Ok((item_pos, item)) = q_items.get(target_entity) else {
+                    continue;
+                };
+                let (item_ref, count, item_tile) =
+                    (item.item_ref.clone(), item.count, item_pos.tile);
+                let Ok((_, _, pos, _, mut inv)) = q_players.get_mut(player_entity) else {
+                    continue;
+                };
+                if pos.tile.chebyshev(item_tile) > 1 {
+                    continue;
+                }
+                inv.add(&item_ref, count);
+                commands.entity(target_entity).despawn();
+                let pickup = json!({
+                    "item_ref": item_ref,
+                    "count": count,
+                })
+                .to_string()
+                .into_bytes();
+                let _ = bcast.tx.send(ServerEvent::Ephemeral {
+                    kind: proto::EPHEMERAL_PICKUP,
+                    to: proto::PlayerSlot(slot.0),
+                    payload: pickup,
+                });
+                send_inventory(&bcast, slot, &inv);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn send_inventory(bcast: &SnapshotBroadcast, slot: proto::PlayerSlot, inv: &Inventory) {
+    let items: Vec<_> = inv
+        .slots
+        .iter()
+        .map(|(r, c)| json!({ "ref": r, "count": c }))
+        .collect();
+    let payload = json!({ "items": items }).to_string().into_bytes();
+    let _ = bcast.tx.send(ServerEvent::Ephemeral {
+        kind: proto::EPHEMERAL_INVENTORY,
+        to: slot,
+        payload,
+    });
+}
+
+fn follow_path(
+    map: Res<WalkableMap>,
+    mut occ: ResMut<Occupancy>,
+    mut q: Query<(Entity, &mut GridPos, &mut MoveTarget, &mut Path)>,
+) {
+    for (entity, mut pos, mut mv, mut path) in q.iter_mut() {
+        if mv.target.is_some() {
+            continue;
+        }
+        let Some(&next) = path.steps.front() else {
+            continue;
+        };
+        if pos.tile.manhattan(next) != 1 {
+            path.steps.clear();
+            continue;
+        }
+        if !map.is_walkable(next) {
+            path.steps.clear();
+            continue;
+        }
+        if !occ.is_free(next) && occ.occupant(next) != Some(entity) {
+            continue;
+        }
+        let dir = dir_between(pos.tile, next);
+        if let Some(dir) = dir {
             pos.facing = dir.facing();
-            try_move(entity, *dir, map, occ, pos, mv, None);
         }
-        Input::Face { facing } => {
-            pos.facing = *facing;
-        }
-        Input::MoveTo { .. } | Input::Action { .. } | Input::Heartbeat { .. } | Input::Leave => {}
+        path.steps.pop_front();
+        mv.target = Some(next);
+        mv.progress = 0;
+        occ.set(next, entity);
+    }
+}
+
+fn dir_between(from: Tile, to: Tile) -> Option<Dir> {
+    match (to.x - from.x, to.y - from.y) {
+        (0, -1) => Some(Dir::Up),
+        (0, 1) => Some(Dir::Down),
+        (-1, 0) => Some(Dir::Left),
+        (1, 0) => Some(Dir::Right),
+        _ => None,
     }
 }
 
@@ -357,16 +641,35 @@ fn advance_movement(mut q: Query<(&mut GridPos, &mut MoveTarget, &MoveSpeed)>) {
 }
 
 #[allow(clippy::type_complexity)]
+fn chain_steps(
+    map: Res<WalkableMap>,
+    mut occ: ResMut<Occupancy>,
+    mut q: Query<(Entity, &mut GridPos, &mut MoveTarget, &mut StepBuffer), With<PlayerSlotTag>>,
+) {
+    for (entity, mut pos, mut mv, mut buffer) in q.iter_mut() {
+        let Some(dir) = buffer.dir else {
+            continue;
+        };
+        if mv.target.is_some() {
+            continue;
+        }
+        buffer.dir = None;
+        pos.facing = dir.facing();
+        try_move(entity, dir, &map, &mut occ, &pos, &mut mv, None);
+    }
+}
+
+#[allow(clippy::type_complexity)]
 fn emit_snapshot(
     clock: Res<SimClock>,
     bcast: Res<SnapshotBroadcast>,
-    config: Res<SimConfig>,
     q: Query<(
         Entity,
         &EntityKind,
         Option<&PlayerSlotTag>,
         &GridPos,
         &MoveTarget,
+        Option<&MoveSpeed>,
         Option<&Health>,
     )>,
 ) {
@@ -376,11 +679,11 @@ fn emit_snapshot(
 
     let entities: Vec<proto::EntityDelta> = q
         .iter()
-        .map(|(entity, kind, slot, pos, mv, hp)| {
+        .map(|(entity, kind, slot, pos, mv, speed, hp)| {
             let sub = mv
                 .target
                 .map(|_| {
-                    let span = config.ticks_per_tile.max(1) as u32;
+                    let span = speed.map(|s| s.ticks_per_tile).unwrap_or(1).max(1) as u32;
                     ((mv.progress as u32 * 255) / span).min(255) as u8
                 })
                 .unwrap_or(0);
@@ -423,18 +726,47 @@ mod tests {
     use super::*;
     use std::collections::HashSet;
 
-    fn harness(seed: u64) -> (App, broadcast::Receiver<ServerEvent>) {
+    type Harness = (
+        App,
+        broadcast::Receiver<ServerEvent>,
+        mpsc::UnboundedSender<(proto::PlayerSlot, Input)>,
+        Arc<RwLock<Roster>>,
+    );
+
+    fn harness(seed: u64) -> Harness {
         let (tx, rx) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
-        let (_input_tx, input_rx) = mpsc::unbounded_channel();
+        let (input_tx, input_rx) = mpsc::unbounded_channel();
         let roster = Arc::new(RwLock::new(Roster::new(4)));
         let map = WalkableMap::open(32, 32);
-        let app = build_app(tx, input_rx, roster, seed, SimConfig::default(), map);
-        (app, rx)
+        let mut registry = KindRegistry::new();
+        registry.register_npc("training-dummy");
+        registry.register_item("potion");
+        let app = build_app(
+            tx,
+            input_rx,
+            roster.clone(),
+            seed,
+            SimConfig {
+                spawn: Tile::new(8, 8),
+                ..SimConfig::default()
+            },
+            map,
+            registry,
+        );
+        (app, rx, input_tx, roster)
+    }
+
+    fn join(roster: &Arc<RwLock<Roster>>, name: &str) -> proto::PlayerSlot {
+        roster
+            .write()
+            .unwrap()
+            .claim(name.to_string())
+            .expect("slot available")
     }
 
     #[test]
     fn wanderer_relocates_and_emits_snapshots() {
-        let (mut app, mut rx) = harness(0xABCDEF);
+        let (mut app, mut rx, _tx, _roster) = harness(0xABCDEF);
         let origin = Tile::new(16, 16);
         app.world_mut().spawn((
             EntityKind(2),
@@ -477,7 +809,7 @@ mod tests {
 
     #[test]
     fn non_player_entity_snapshots_without_slot() {
-        let (mut app, mut rx) = harness(1);
+        let (mut app, mut rx, _tx, _roster) = harness(1);
         app.world_mut().spawn((
             EntityKind(7),
             GridPos::at(Tile::new(3, 3)),
@@ -499,5 +831,164 @@ mod tests {
             }
         }
         assert!(saw, "non-player entity missing from snapshot");
+    }
+
+    #[test]
+    fn move_to_walks_full_path() {
+        let (mut app, mut rx, input_tx, roster) = harness(7);
+        let slot = join(&roster, "walker");
+        app.update();
+
+        input_tx
+            .send((
+                slot,
+                Input::MoveTo {
+                    tile: Tile::new(12, 8),
+                },
+            ))
+            .unwrap();
+
+        for _ in 0..80 {
+            app.update();
+        }
+
+        let mut last_tile = None;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Snapshot(snap) = evt {
+                for e in snap.entities {
+                    if e.kind == PLAYER_KIND {
+                        last_tile = Some(e.tile);
+                    }
+                }
+            }
+        }
+        assert_eq!(last_tile, Some(Tile::new(12, 8)), "player did not arrive");
+    }
+
+    #[test]
+    fn buffered_step_chains_after_move() {
+        let (mut app, mut rx, input_tx, roster) = harness(9);
+        let slot = join(&roster, "chainer");
+        app.update();
+
+        input_tx
+            .send((slot, Input::Step { dir: Dir::Right }))
+            .unwrap();
+        app.update();
+        input_tx
+            .send((slot, Input::Step { dir: Dir::Right }))
+            .unwrap();
+
+        for _ in 0..20 {
+            app.update();
+        }
+
+        let mut last_tile = None;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Snapshot(snap) = evt {
+                for e in snap.entities {
+                    if e.kind == PLAYER_KIND {
+                        last_tile = Some(e.tile);
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            last_tile,
+            Some(Tile::new(10, 8)),
+            "second step was not buffered"
+        );
+    }
+
+    #[test]
+    fn attack_kills_mob_and_drops_loot() {
+        let (mut app, mut rx, input_tx, roster) = harness(11);
+        let slot = join(&roster, "fighter");
+        let registry = app.world().resource::<KindRegistry>().clone();
+        let dummy_kind = registry.kind_of("training-dummy").unwrap();
+        let potion_kind = registry.kind_of("potion").unwrap();
+
+        let mob = app
+            .world_mut()
+            .spawn((
+                EntityKind(dummy_kind),
+                GridPos::at(Tile::new(9, 8)),
+                MoveTarget::default(),
+                MoveSpeed::default(),
+                Health { hp: 5, max_hp: 5 },
+                Loot {
+                    item_ref: Some("potion".into()),
+                },
+            ))
+            .id();
+        app.update();
+
+        input_tx
+            .send((
+                slot,
+                Input::Action {
+                    id: proto::ACTION_ATTACK,
+                    target: Some(proto::EntityId(mob.index_u32())),
+                },
+            ))
+            .unwrap();
+        for _ in 0..6 {
+            app.update();
+        }
+
+        let mut saw_combat = false;
+        let mut saw_potion_drop = false;
+        while let Ok(evt) = rx.try_recv() {
+            match evt {
+                ServerEvent::Ephemeral { kind, .. } if kind == proto::EPHEMERAL_COMBAT => {
+                    saw_combat = true;
+                }
+                ServerEvent::Snapshot(snap) => {
+                    if snap.entities.iter().any(|e| e.kind == potion_kind) {
+                        saw_potion_drop = true;
+                    }
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_combat, "no combat ephemeral emitted");
+        assert!(saw_potion_drop, "loot did not drop");
+    }
+
+    #[test]
+    fn pickup_adds_to_inventory_and_syncs() {
+        let (mut app, mut rx, input_tx, roster) = harness(13);
+        let slot = join(&roster, "collector");
+        let registry = app.world().resource::<KindRegistry>().clone();
+
+        let bundle = ground_item_bundle(&registry, "potion", 2, Tile::new(9, 8)).unwrap();
+        let item = app.world_mut().spawn(bundle).id();
+        app.update();
+
+        input_tx
+            .send((
+                slot,
+                Input::Action {
+                    id: proto::ACTION_PICKUP,
+                    target: Some(proto::EntityId(item.index_u32())),
+                },
+            ))
+            .unwrap();
+        for _ in 0..6 {
+            app.update();
+        }
+
+        let mut inventory_payload = None;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, to, payload } = evt
+                && kind == proto::EPHEMERAL_INVENTORY
+            {
+                assert_eq!(to, slot);
+                inventory_payload = Some(String::from_utf8(payload).unwrap());
+            }
+        }
+        let payload = inventory_payload.expect("no inventory sync");
+        assert!(payload.contains("potion"), "payload: {payload}");
+        assert!(payload.contains("2"), "payload: {payload}");
     }
 }


### PR DESCRIPTION
## Summary

Full pass on cryptothrone online play: itemdb/npcdb integration, a working action system, and movement improvements — server-authoritative throughout.

### Protocol v2 (simgrid + @kbve/laser)
- `Welcome` now carries a **kind registry** (`ref` + category per entity kind) — client maps sprites/dialogue from data instead of hardcoded kind ids
- `Ephemeral` events gain per-slot targeting (`to`); net layer filters per socket
- New constants: `ACTION_ATTACK`/`ACTION_PICKUP`, `EPHEMERAL_INVENTORY`/`COMBAT`/`PICKUP`

### simgrid
- New `data` module: parses generated npcdb/itemdb JSON, `KindRegistry` resource
- `Action` input implemented: adjacent attack (damage, death, **loot drop**), ground-item pickup into server-authoritative `Inventory`, synced to the owning client via targeted Ephemeral
- `MoveTo` implemented: **BFS pathfinding** over the walkable map (cap 64 tiles), path-following system
- `Step` buffering: one queued move chains seamlessly after the current tile — smooth held-key movement
- Snapshot `sub` interpolation fixed to use each entity's own `MoveSpeed` (was global player speed)
- Ground items excluded from occupancy (don't block movement)

### Server (cryptothrone-server)
- Cloud City spawns **cleric + crystal bats from npcdb stats** (hp + speed-scaled tick rate); bats drop potions
- Seeded ground items from itemdb (potion, coin ×5, iron-sword)
- Dockerfile copies `npcdb-data.json` for `include_bytes!`

### Client (astro-cryptothrone)
- **Click-to-move** (server pathfinds), click adjacent item → pickup, click adjacent NPC → interact menu, **Space** attacks adjacent NPC
- NPC data + dialogues generated from `@kbve/npcdb-data` (legacy barkeep/monk entries kept); ActionMenu uses convention-based greeting dialogue ids
- Server inventory → `SET_BACKPACK` sync in game-store; combat/pickup toasts via event bridge
- Step throttle 180ms → 90ms (server buffers, movement chains)

## Testing
- simgrid: 17/17 tests (new: BFS path routing/unreachable, MoveTo walks full path, step chaining, attack+loot drop, pickup+inventory sync) + clippy clean
- cryptothrone-server: builds, clippy clean
- astro-cryptothrone: 28/28 vitest, site builds
- @kbve/laser: tests pass