### PR TITLE
fix(rows): chuckrpg-dev seed map is greenshire

### DIFF
--- a/apps/kube/rows/tenants/overlays/chuckrpg-dev/kustomization.yaml
+++ b/apps/kube/rows/tenants/overlays/chuckrpg-dev/kustomization.yaml
@@ -52,7 +52,7 @@ patches:
             path: /spec/template/spec/containers/0/env/-
             value:
                 name: MAP_NAME
-                value: Lvl_ThirdPerson
+                value: greenshire
           - op: add
             path: /spec/template/spec/containers/0/env/-
             value:


### PR DESCRIPTION
Chuck's starting zone is now the baked-static `greenshire` map (`Lvl_ThirdPerson` was removed from the project), so the chuckrpg-dev seed's `MAP_NAME` must match for `MainWorld` zone routing.

Note: the seed is insert-only, so the already-seeded `ows.maps` row needs a one-time `UPDATE ... SET mapname = 'greenshire' WHERE mapname = 'Lvl_ThirdPerson'` scoped to the tenant's customerguid (in the namespace's sealed secret — not reproduced here). Applying that update before this syncs avoids a duplicate MainWorld row.