### PR TITLE
feat(cryptothrone): hostile AI, persistence, consumables, respawns, chat

### DIFF
--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -1,8 +1,10 @@
+use std::collections::HashMap;
+
 use bevy::prelude::{Commands, Local, Res};
 use simgrid::proto::Tile;
 use simgrid::{
-    EntityKind, GridPos, Health, KindRegistry, Loot, MoveSpeed, MoveTarget, NpcDb, SimConfig,
-    WalkableMap, Wander, ground_item_bundle,
+    AggroSpec, ConsumableEffects, KindRegistry, NpcDb, NpcSpec, SIM_TICK_HZ, SimConfig,
+    WalkableMap, ground_item_bundle, spawn_npc_from_spec,
 };
 
 pub const MAP_WIDTH: i32 = 50;
@@ -18,17 +20,23 @@ pub const PLAYER_ATTACK: i32 = 5;
 pub const PLAYER_TICKS_PER_TILE: u8 = 4;
 pub const PLAYER_SPAWN: Tile = Tile::new(5, 12);
 
+pub const NPC_RESPAWN_TICKS: u32 = SIM_TICK_HZ * 30;
+
 pub const CLERIC_REF: &str = "cleric";
 pub const CLERIC_SPAWN: Tile = Tile::new(4, 10);
-pub const CLERIC_WANDER_RADIUS: i32 = 3;
-pub const CLERIC_WANDER_PERIOD_TICKS: u32 = 30;
 
 pub const BAT_REF: &str = "crystal-bat";
 pub const BAT_COUNT: i32 = 10;
 pub const BAT_ORIGIN: Tile = Tile::new(7, 7);
-pub const BAT_WANDER_RADIUS: i32 = 20;
-pub const BAT_WANDER_PERIOD_TICKS: u32 = 20;
 pub const BAT_LOOT_REF: &str = "potion";
+
+pub const GOBLIN_REF: &str = "goblin";
+pub const GOBLIN_COUNT: i32 = 4;
+pub const GOBLIN_ORIGIN: Tile = Tile::new(20, 20);
+pub const GOBLIN_LOOT_REF: &str = "coin";
+pub const GOBLIN_AGGRO_RANGE: i32 = 6;
+
+pub const POTION_HEAL: i32 = 25;
 
 pub const GROUND_ITEMS: &[(&str, u32, Tile)] = &[
     ("potion", 1, Tile::new(8, 12)),
@@ -44,10 +52,12 @@ pub fn registry() -> KindRegistry {
     let mut reg = KindRegistry::new();
     reg.register_npc(CLERIC_REF);
     reg.register_npc(BAT_REF);
+    reg.register_npc(GOBLIN_REF);
     for (item_ref, _, _) in GROUND_ITEMS {
         reg.register_item(item_ref);
     }
     reg.register_item(BAT_LOOT_REF);
+    reg.register_item(GOBLIN_LOOT_REF);
     reg
 }
 
@@ -61,6 +71,10 @@ pub fn config() -> SimConfig {
     }
 }
 
+pub fn consumables() -> ConsumableEffects {
+    ConsumableEffects(HashMap::from([("potion".to_string(), POTION_HEAL)]))
+}
+
 pub fn walkable_map() -> WalkableMap {
     WalkableMap::from_tiled_json(CLOUD_CITY_MAP)
         .unwrap_or_else(|_| WalkableMap::open(MAP_WIDTH, MAP_HEIGHT))
@@ -70,33 +84,32 @@ fn ticks_per_tile_for_speed(speed: i32) -> u8 {
     (20 / speed.clamp(2, 10)).clamp(2, 10) as u8
 }
 
-fn spawn_npc(
-    commands: &mut Commands,
+fn npc_spec(
     db: &NpcDb,
     registry: &KindRegistry,
     ref_id: &str,
-    tile: Tile,
-    wander: Wander,
+    origin: Tile,
+    wander: Option<(i32, u32)>,
     loot: Option<&str>,
-) {
-    let Some(def) = db.get(ref_id) else { return };
-    let Some(kind) = registry.kind_of(ref_id) else {
-        return;
-    };
-    let hp = def.stats.max_hp.max(def.stats.hp).max(1);
-    commands.spawn((
-        EntityKind(kind),
-        GridPos::at(tile),
-        MoveTarget::default(),
-        MoveSpeed {
-            ticks_per_tile: ticks_per_tile_for_speed(def.stats.speed),
-        },
-        Health { hp, max_hp: hp },
+    aggro_range: Option<i32>,
+) -> Option<NpcSpec> {
+    let def = db.get(ref_id)?;
+    let kind = registry.kind_of(ref_id)?;
+    let max_hp = def.stats.max_hp.max(def.stats.hp).max(1);
+    Some(NpcSpec {
+        kind,
+        origin,
+        ticks_per_tile: ticks_per_tile_for_speed(def.stats.speed),
+        max_hp,
         wander,
-        Loot {
-            item_ref: loot.map(str::to_string),
-        },
-    ));
+        aggro: aggro_range.map(|range| AggroSpec {
+            range,
+            damage: def.stats.attack.max(1),
+            period_ticks: SIM_TICK_HZ,
+        }),
+        loot: loot.map(str::to_string),
+        respawn_ticks: NPC_RESPAWN_TICKS,
+    })
 }
 
 pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut commands: Commands) {
@@ -107,31 +120,46 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
 
     let db = npc_db();
 
-    spawn_npc(
-        &mut commands,
+    if let Some(spec) = npc_spec(
         &db,
         &registry,
         CLERIC_REF,
         CLERIC_SPAWN,
-        Wander::new(
-            CLERIC_SPAWN,
-            CLERIC_WANDER_RADIUS,
-            CLERIC_WANDER_PERIOD_TICKS,
-        ),
+        Some((3, 30)),
         None,
-    );
+        None,
+    ) {
+        spawn_npc_from_spec(&mut commands, &spec);
+    }
 
     for i in 0..BAT_COUNT {
         let origin = Tile::new(BAT_ORIGIN.x, BAT_ORIGIN.y + i);
-        spawn_npc(
-            &mut commands,
+        if let Some(spec) = npc_spec(
             &db,
             &registry,
             BAT_REF,
             origin,
-            Wander::new(origin, BAT_WANDER_RADIUS, BAT_WANDER_PERIOD_TICKS),
+            Some((20, 20)),
             Some(BAT_LOOT_REF),
-        );
+            None,
+        ) {
+            spawn_npc_from_spec(&mut commands, &spec);
+        }
+    }
+
+    for i in 0..GOBLIN_COUNT {
+        let origin = Tile::new(GOBLIN_ORIGIN.x + (i % 2) * 2, GOBLIN_ORIGIN.y + (i / 2) * 2);
+        if let Some(spec) = npc_spec(
+            &db,
+            &registry,
+            GOBLIN_REF,
+            origin,
+            Some((8, 25)),
+            Some(GOBLIN_LOOT_REF),
+            Some(GOBLIN_AGGRO_RANGE),
+        ) {
+            spawn_npc_from_spec(&mut commands, &spec);
+        }
     }
 
     for (item_ref, count, tile) in GROUND_ITEMS {

--- a/apps/agones/cryptothrone/server/src/main.rs
+++ b/apps/agones/cryptothrone/server/src/main.rs
@@ -62,6 +62,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .build()
             .expect("sim runtime");
         let mut app = build_app(snap_tx, input_rx, roster, seed, config, map, registry);
+        app.insert_resource(game::consumables());
         app.add_systems(
             bevy::prelude::Update,
             game::spawn_world.in_set(simgrid::SimSet::Spawn),

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -13,6 +13,7 @@ import { StickySidebar } from './ui/StickySidebar';
 import { ActionMenu } from './ui/ActionMenu';
 import { DialogueModal } from './ui/DialogueModal';
 import { DiceRollModal } from './ui/DiceRollModal';
+import { ChatBar } from './ui/ChatBar';
 
 /**
  * Isolated Phaser canvas — never re-renders when game store changes.
@@ -89,6 +90,7 @@ function GameUI({ username }: { username?: string }) {
 			<DiceRollModal />
 			<CharacterDialog />
 			<NotificationToast />
+			<ChatBar />
 		</>
 	);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -58,6 +58,9 @@ export class CloudCityScene extends Scene {
 	private tilePixels = 16;
 	private ranges: Range[] = [];
 	private rangeTile = { x: -1, y: -1 };
+	private myHp = -1;
+	private myMaxHp = -1;
+	private laserUnsubs: (() => void)[] = [];
 
 	constructor() {
 		super({ key: 'CloudCity' });
@@ -129,6 +132,18 @@ export class CloudCityScene extends Scene {
 		});
 		client.on('combat', (c) => {
 			laserEvents.emit('combat:event', c);
+			if (c.died && c.target === this.myEid) {
+				laserEvents.emit('char:event', {
+					message:
+						'You died! The well pulls you back to the plaza, body intact, pride bruised.',
+				});
+			}
+		});
+		client.on('chat', (c) => {
+			laserEvents.emit('chat:message', c);
+		});
+		client.on('itemUsed', (u) => {
+			laserEvents.emit('item:used', u);
 		});
 		client.on('reject', (reason) => {
 			laserEvents.emit('char:event', {
@@ -146,7 +161,22 @@ export class CloudCityScene extends Scene {
 			this.onPointerDown(pointer),
 		);
 
-		this.events.once('shutdown', () => this.client?.close());
+		this.laserUnsubs.push(
+			laserEvents.on('item:use', (data) => {
+				const d = data as { ref: string };
+				if (d?.ref) this.client?.useItem(d.ref);
+			}),
+			laserEvents.on('chat:send', (data) => {
+				const d = data as { text: string };
+				if (d?.text) this.client?.say(d.text);
+			}),
+		);
+
+		this.events.once('shutdown', () => {
+			this.laserUnsubs.forEach((off) => off());
+			this.laserUnsubs = [];
+			this.client?.close();
+		});
 	}
 
 	private makeGroundItemTexture() {
@@ -198,6 +228,16 @@ export class CloudCityScene extends Scene {
 		const seen = new Set<number>();
 
 		for (const e of snap.entities) {
+			if (
+				e.eid === this.myEid &&
+				(e.hp !== this.myHp || e.max_hp !== this.myMaxHp)
+			) {
+				this.myHp = e.hp;
+				this.myMaxHp = e.max_hp;
+				laserEvents.emit('player:stats', {
+					stats: { hp: e.hp, maxHp: e.max_hp },
+				});
+			}
 			seen.add(e.eid);
 			const existing = this.tracked.get(e.eid);
 			if (!existing) {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
@@ -141,6 +141,23 @@ export function useEventBridge(dispatch: Dispatch<GameAction>) {
 		);
 
 		unsubs.push(
+			laserEvents.on('item:used', (data) => {
+				const used = data as { item_ref: string; heal: number };
+				dispatch({
+					type: 'ADD_NOTIFICATION',
+					payload: {
+						title: 'Used',
+						message:
+							used.heal > 0
+								? `${used.item_ref} (+${used.heal} HP)`
+								: used.item_ref,
+						type: 'success',
+					},
+				});
+			}),
+		);
+
+		unsubs.push(
 			laserEvents.on('dice:roll', (data) => {
 				dispatch({
 					type: 'SET_DICE_ROLL',

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+interface ChatLine {
+	id: number;
+	from: string;
+	text: string;
+}
+
+const MAX_LINES = 6;
+const MAX_INPUT = 200;
+
+let lineCounter = 0;
+
+export function ChatBar() {
+	const [lines, setLines] = useState<ChatLine[]>([]);
+	const [draft, setDraft] = useState('');
+	const inputRef = useRef<HTMLInputElement>(null);
+
+	useEffect(() => {
+		return laserEvents.on('chat:message', (data) => {
+			const msg = data as { from: string; text: string };
+			setLines((prev) =>
+				[
+					...prev,
+					{ id: ++lineCounter, from: msg.from, text: msg.text },
+				].slice(-MAX_LINES),
+			);
+		});
+	}, []);
+
+	const submit = (e: React.FormEvent) => {
+		e.preventDefault();
+		const text = draft.trim();
+		if (!text) return;
+		laserEvents.emit('chat:send', { text });
+		setDraft('');
+		inputRef.current?.blur();
+	};
+
+	return (
+		<div className="absolute bottom-2 left-2 z-40 w-72 select-none">
+			{lines.length > 0 && (
+				<ul className="mb-1 space-y-0.5 rounded bg-black/50 p-2 text-xs text-white backdrop-blur-sm">
+					{lines.map((line) => (
+						<li key={line.id} className="break-words">
+							<span className="font-semibold text-cyan-300">
+								{line.from}:
+							</span>{' '}
+							{line.text}
+						</li>
+					))}
+				</ul>
+			)}
+			<form onSubmit={submit}>
+				<input
+					ref={inputRef}
+					type="text"
+					value={draft}
+					maxLength={MAX_INPUT}
+					onChange={(e) => setDraft(e.target.value)}
+					onKeyDown={(e) => e.stopPropagation()}
+					placeholder="Say something…"
+					aria-label="Chat message"
+					className="w-full rounded border border-white/20 bg-black/60 px-2 py-1 text-xs text-white placeholder-gray-400 outline-none backdrop-blur-sm focus:border-cyan-400"
+				/>
+			</form>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { laserEvents } from '@kbve/laser';
 import { getItemById } from '../data/items';
 
 interface InventoryGridProps {
@@ -38,11 +39,31 @@ export function InventoryGrid({ backpack }: InventoryGridProps) {
 							className="relative hover:scale-[1.3] transition ease-in-out duration-100"
 							onMouseEnter={(e) => showTooltip(item.id, e)}
 							onMouseLeave={hideTooltip}>
-							<img
-								src={item.img}
-								alt={item.name}
-								className="w-8 h-8 border border-yellow-400/50"
-							/>
+							<button
+								type="button"
+								aria-label={
+									item.type === 'consumable'
+										? `Use ${item.name}`
+										: item.name
+								}
+								className={
+									item.type === 'consumable'
+										? 'cursor-pointer'
+										: 'cursor-default'
+								}
+								onClick={() => {
+									if (item.type === 'consumable') {
+										laserEvents.emit('item:use', {
+											ref: item.id,
+										});
+									}
+								}}>
+								<img
+									src={item.img}
+									alt={item.name}
+									className="w-8 h-8 border border-yellow-400/50"
+								/>
+							</button>
 						</li>
 					);
 				})}

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -65,6 +65,8 @@ export {
 	EPHEMERAL_INVENTORY,
 	EPHEMERAL_COMBAT,
 	EPHEMERAL_PICKUP,
+	EPHEMERAL_CHAT,
+	EPHEMERAL_ITEM_USED,
 	KIND_CAT_PLAYER,
 	KIND_CAT_NPC,
 	KIND_CAT_ITEM,
@@ -91,4 +93,6 @@ export type {
 	InventorySync,
 	CombatEvent,
 	PickupEvent,
+	ChatEvent,
+	ItemUsedEvent,
 } from './lib/net/protocol';

--- a/packages/npm/laser/src/lib/net/game-client.ts
+++ b/packages/npm/laser/src/lib/net/game-client.ts
@@ -1,8 +1,11 @@
 import { LaserEventBus } from '../core/events';
 import {
+	EPHEMERAL_CHAT,
 	EPHEMERAL_COMBAT,
 	EPHEMERAL_INVENTORY,
+	EPHEMERAL_ITEM_USED,
 	EPHEMERAL_PICKUP,
+	type ChatEvent,
 	type ClientMessage,
 	type CombatEvent,
 	type Dir,
@@ -10,6 +13,7 @@ import {
 	type Facing,
 	type Input,
 	type InventorySync,
+	type ItemUsedEvent,
 	type PickupEvent,
 	type ServerEvent,
 	type Snapshot,
@@ -28,6 +32,8 @@ export type GameClientEventMap = {
 	inventory: InventorySync;
 	combat: CombatEvent;
 	pickup: PickupEvent;
+	chat: ChatEvent;
+	itemUsed: ItemUsedEvent;
 	reject: string;
 	close: void;
 	error: string;
@@ -100,6 +106,12 @@ export class GameClient {
 		} else if (evt.kind === EPHEMERAL_PICKUP) {
 			const data = decodeEphemeralPayload<PickupEvent>(evt.payload);
 			if (data) this.bus.emit('pickup', data);
+		} else if (evt.kind === EPHEMERAL_CHAT) {
+			const data = decodeEphemeralPayload<ChatEvent>(evt.payload);
+			if (data) this.bus.emit('chat', data);
+		} else if (evt.kind === EPHEMERAL_ITEM_USED) {
+			const data = decodeEphemeralPayload<ItemUsedEvent>(evt.payload);
+			if (data) this.bus.emit('itemUsed', data);
 		}
 	}
 
@@ -128,6 +140,14 @@ export class GameClient {
 
 	action(id: number, target: number | null): void {
 		this.sendInputs([{ Action: { id, target } }]);
+	}
+
+	useItem(itemRef: string): void {
+		this.sendInputs([{ UseItem: { item_ref: itemRef } }]);
+	}
+
+	say(text: string): void {
+		this.sendInputs([{ Say: { text } }]);
 	}
 
 	face(facing: Facing): void {

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 2;
+export const PROTOCOL_VERSION = 3;
 
 export const ACTION_ATTACK = 1;
 export const ACTION_PICKUP = 2;
@@ -6,6 +6,8 @@ export const ACTION_PICKUP = 2;
 export const EPHEMERAL_INVENTORY = 1;
 export const EPHEMERAL_COMBAT = 2;
 export const EPHEMERAL_PICKUP = 3;
+export const EPHEMERAL_CHAT = 4;
+export const EPHEMERAL_ITEM_USED = 5;
 
 export const KIND_CAT_PLAYER = 0;
 export const KIND_CAT_NPC = 1;
@@ -24,6 +26,8 @@ export type Input =
 	| { MoveTo: { tile: Tile } }
 	| { Face: { facing: Facing } }
 	| { Action: { id: number; target: number | null } }
+	| { UseItem: { item_ref: string } }
+	| { Say: { text: string } }
 	| { Heartbeat: { client_tick: number } }
 	| 'Leave';
 
@@ -106,6 +110,16 @@ export interface CombatEvent {
 export interface PickupEvent {
 	item_ref: string;
 	count: number;
+}
+
+export interface ChatEvent {
+	from: string;
+	text: string;
+}
+
+export interface ItemUsedEvent {
+	item_ref: string;
+	heal: number;
 }
 
 export type ServerEvent =

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -11,7 +11,8 @@ pub use data::{ItemDb, KindRegistry, NpcDb};
 pub use grid::{GridPos, MoveSpeed, MoveTarget, WalkableMap};
 pub use net::{Roster, ServerState, SlotInput, router};
 pub use sim::{
-    CombatStats, EntityKind, Health, Inventory, Loot, Path, PlayerSlotTag, SIM_TICK_HZ,
-    SNAPSHOT_BROADCAST_CAPACITY, SimConfig, SimSet, StepBuffer, Wander, build_app,
-    ground_item_bundle, run_sim_loop,
+    Aggro, AggroSpec, CombatStats, ConsumableEffects, EntityKind, Health, Inventory, Loot, NpcSpec,
+    Path, PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, SNAPSHOT_BROADCAST_CAPACITY,
+    SimConfig, SimSet, StepBuffer, Wander, build_app, ground_item_bundle, run_sim_loop,
+    spawn_npc_from_spec,
 };

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -42,7 +42,7 @@ impl Roster {
         None
     }
 
-    fn release(&mut self, slot: proto::PlayerSlot) {
+    pub(crate) fn release(&mut self, slot: proto::PlayerSlot) {
         if let Some(s) = self.slots.get_mut(slot.0 as usize) {
             *s = None;
         }

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 2;
+pub const PROTOCOL_VERSION: u32 = 3;
 pub const DEFAULT_MAX_PLAYERS: usize = 64;
 
 pub const ACTION_ATTACK: u16 = 1;
@@ -9,6 +9,10 @@ pub const ACTION_PICKUP: u16 = 2;
 pub const EPHEMERAL_INVENTORY: u16 = 1;
 pub const EPHEMERAL_COMBAT: u16 = 2;
 pub const EPHEMERAL_PICKUP: u16 = 3;
+pub const EPHEMERAL_CHAT: u16 = 4;
+pub const EPHEMERAL_ITEM_USED: u16 = 5;
+
+pub const MAX_CHAT_LEN: usize = 200;
 
 pub const KIND_CAT_PLAYER: u8 = 0;
 pub const KIND_CAT_NPC: u8 = 1;
@@ -100,6 +104,8 @@ pub enum Input {
     MoveTo { tile: Tile },
     Face { facing: Facing },
     Action { id: u16, target: Option<EntityId> },
+    UseItem { item_ref: String },
+    Say { text: String },
     Heartbeat { client_tick: u32 },
     Leave,
 }

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -81,7 +81,7 @@ pub struct RosterHandle(pub Arc<RwLock<Roster>>);
 
 #[derive(Resource, Default)]
 pub struct SpawnedSlots {
-    by_slot: HashMap<u16, Entity>,
+    by_slot: HashMap<u16, (Entity, String)>,
 }
 
 #[derive(Resource, Default)]
@@ -91,6 +91,55 @@ pub struct EidIndex {
 
 #[derive(Resource, Default)]
 pub struct PendingActions(Vec<(proto::PlayerSlot, u16, Option<proto::EntityId>)>);
+
+#[derive(Clone, Default)]
+pub struct SavedPlayer {
+    pub slots: Vec<(String, u32)>,
+    pub hp: i32,
+}
+
+#[derive(Resource, Default)]
+pub struct PlayerStore {
+    by_username: HashMap<String, SavedPlayer>,
+}
+
+#[derive(Resource, Default, Clone)]
+pub struct ConsumableEffects(pub HashMap<String, i32>);
+
+#[derive(Resource, Default)]
+pub struct RespawnQueue(Vec<(u32, NpcSpec)>);
+
+#[derive(Clone, Copy)]
+pub struct AggroSpec {
+    pub range: i32,
+    pub damage: i32,
+    pub period_ticks: u32,
+}
+
+#[derive(Clone)]
+pub struct NpcSpec {
+    pub kind: u16,
+    pub origin: Tile,
+    pub ticks_per_tile: u8,
+    pub max_hp: i32,
+    pub wander: Option<(i32, u32)>,
+    pub aggro: Option<AggroSpec>,
+    pub loot: Option<String>,
+    pub respawn_ticks: u32,
+}
+
+#[derive(Component, Clone, Copy)]
+pub struct Aggro {
+    pub range: i32,
+    pub damage: i32,
+    pub period_ticks: u32,
+    pub next_tick: u32,
+}
+
+#[derive(Component, Clone)]
+pub struct RespawnOnDeath {
+    pub spec: NpcSpec,
+}
 
 #[derive(Component, Clone, Copy)]
 pub struct PlayerSlotTag(pub proto::PlayerSlot);
@@ -182,6 +231,38 @@ pub fn ground_item_bundle(
     ))
 }
 
+pub fn spawn_npc_from_spec(commands: &mut Commands, spec: &NpcSpec) {
+    let mut e = commands.spawn((
+        EntityKind(spec.kind),
+        GridPos::at(spec.origin),
+        MoveTarget::default(),
+        MoveSpeed {
+            ticks_per_tile: spec.ticks_per_tile,
+        },
+        Health {
+            hp: spec.max_hp,
+            max_hp: spec.max_hp,
+        },
+        Loot {
+            item_ref: spec.loot.clone(),
+        },
+    ));
+    if let Some((radius, period)) = spec.wander {
+        e.insert(Wander::new(spec.origin, radius, period));
+    }
+    if let Some(a) = spec.aggro {
+        e.insert(Aggro {
+            range: a.range,
+            damage: a.damage,
+            period_ticks: a.period_ticks,
+            next_tick: 0,
+        });
+    }
+    if spec.respawn_ticks > 0 {
+        e.insert(RespawnOnDeath { spec: spec.clone() });
+    }
+}
+
 pub fn build_app(
     tx: broadcast::Sender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
@@ -202,6 +283,9 @@ pub fn build_app(
         .insert_resource(SpawnedSlots::default())
         .insert_resource(EidIndex::default())
         .insert_resource(PendingActions::default())
+        .insert_resource(PlayerStore::default())
+        .insert_resource(ConsumableEffects::default())
+        .insert_resource(RespawnQueue::default())
         .insert_resource(Occupancy::default())
         .insert_resource(map)
         .insert_resource(config)
@@ -220,7 +304,10 @@ pub fn build_app(
                 .chain(),
         )
         .add_systems(Update, tick_sim.in_set(SimSet::Tick))
-        .add_systems(Update, sync_roster.in_set(SimSet::Spawn))
+        .add_systems(
+            Update,
+            (sync_roster, respawn_npcs).chain().in_set(SimSet::Spawn),
+        )
         .add_systems(Update, rebuild_occupancy.in_set(SimSet::Occupancy))
         .add_systems(
             Update,
@@ -228,11 +315,13 @@ pub fn build_app(
         )
         .add_systems(
             Update,
-            (follow_path, wander_system).chain().in_set(SimSet::Ai),
+            (follow_path, hostile_ai, wander_system)
+                .chain()
+                .in_set(SimSet::Ai),
         )
         .add_systems(
             Update,
-            (advance_movement, chain_steps)
+            (advance_movement, chain_steps, respawn_players)
                 .chain()
                 .in_set(SimSet::Movement),
         )
@@ -245,21 +334,44 @@ fn tick_sim(mut clock: ResMut<SimClock>) {
     clock.elapsed_ms = clock.elapsed_ms.wrapping_add(1000 / SIM_TICK_HZ);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn sync_roster(
     roster: Res<RosterHandle>,
     config: Res<SimConfig>,
+    bcast: Res<SnapshotBroadcast>,
     mut spawned: ResMut<SpawnedSlots>,
+    mut store: ResMut<PlayerStore>,
+    q_saved: Query<(&Inventory, &Health)>,
     mut commands: Commands,
 ) {
-    let active = match roster.0.read() {
-        Ok(r) => r.active_slots(),
-        Err(p) => p.into_inner().active_slots(),
+    let active: Vec<(proto::PlayerSlot, String)> = {
+        let guard = match roster.0.read() {
+            Ok(r) => r,
+            Err(p) => p.into_inner(),
+        };
+        guard
+            .active_slots()
+            .into_iter()
+            .map(|s| (s, guard.username(s).unwrap_or_default()))
+            .collect()
     };
-    let active_keys: Vec<u16> = active.iter().map(|s| s.0).collect();
+    let active_keys: Vec<u16> = active.iter().map(|(s, _)| s.0).collect();
 
-    for slot in &active {
+    for (slot, username) in &active {
         if spawned.by_slot.contains_key(&slot.0) {
             continue;
+        }
+        let saved = store.by_username.get(username).cloned();
+        let hp = saved
+            .as_ref()
+            .map(|s| s.hp)
+            .filter(|hp| *hp > 0)
+            .unwrap_or(config.player_hp);
+        let inventory = Inventory {
+            slots: saved.map(|s| s.slots).unwrap_or_default(),
+        };
+        if !inventory.slots.is_empty() {
+            send_inventory(&bcast, *slot, &inventory);
         }
         let entity = commands
             .spawn((
@@ -271,18 +383,18 @@ fn sync_roster(
                     ticks_per_tile: config.ticks_per_tile,
                 },
                 Health {
-                    hp: config.player_hp,
+                    hp,
                     max_hp: config.player_hp,
                 },
                 CombatStats {
                     attack: config.player_attack,
                 },
-                Inventory::default(),
+                inventory,
                 Path::default(),
                 StepBuffer::default(),
             ))
             .id();
-        spawned.by_slot.insert(slot.0, entity);
+        spawned.by_slot.insert(slot.0, (entity, username.clone()));
     }
 
     let gone: Vec<u16> = spawned
@@ -292,7 +404,18 @@ fn sync_roster(
         .filter(|k| !active_keys.contains(k))
         .collect();
     for k in gone {
-        if let Some(entity) = spawned.by_slot.remove(&k) {
+        if let Some((entity, username)) = spawned.by_slot.remove(&k) {
+            if !username.is_empty()
+                && let Ok((inv, hp)) = q_saved.get(entity)
+            {
+                store.by_username.insert(
+                    username,
+                    SavedPlayer {
+                        slots: inv.slots.clone(),
+                        hp: hp.hp,
+                    },
+                );
+            }
             commands.entity(entity).despawn();
         }
     }
@@ -317,10 +440,13 @@ fn rebuild_occupancy(
     }
 }
 
-#[allow(clippy::type_complexity)]
+#[allow(clippy::type_complexity, clippy::too_many_arguments)]
 fn drain_inputs(
     queue: Res<InputQueue>,
     map: Res<WalkableMap>,
+    roster: Res<RosterHandle>,
+    effects: Res<ConsumableEffects>,
+    bcast: Res<SnapshotBroadcast>,
     mut occ: ResMut<Occupancy>,
     mut actions: ResMut<PendingActions>,
     mut q: Query<(
@@ -330,6 +456,8 @@ fn drain_inputs(
         &mut MoveTarget,
         &mut Path,
         &mut StepBuffer,
+        &mut Health,
+        &mut Inventory,
     )>,
 ) {
     let mut pending: HashMap<u16, Vec<Input>> = HashMap::new();
@@ -350,7 +478,7 @@ fn drain_inputs(
         return;
     }
 
-    for (entity, slot, mut pos, mut mv, mut path, mut buffer) in q.iter_mut() {
+    for (entity, slot, mut pos, mut mv, mut path, mut buffer, mut hp, mut inv) in q.iter_mut() {
         let Some(inputs) = pending.get(&slot.0.0) else {
             continue;
         };
@@ -376,10 +504,62 @@ fn drain_inputs(
                 Input::Face { facing } => {
                     pos.facing = *facing;
                 }
+                Input::UseItem { item_ref } => {
+                    use_item(&effects, &bcast, slot.0, item_ref, &mut hp, &mut inv);
+                }
+                Input::Say { text } => {
+                    let trimmed = text.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let msg: String = trimmed.chars().take(proto::MAX_CHAT_LEN).collect();
+                    let from = match roster.0.read() {
+                        Ok(r) => r.username(slot.0).unwrap_or_default(),
+                        Err(p) => p.into_inner().username(slot.0).unwrap_or_default(),
+                    };
+                    let payload = json!({ "from": from, "text": msg })
+                        .to_string()
+                        .into_bytes();
+                    let _ = bcast.tx.send(ServerEvent::Ephemeral {
+                        kind: proto::EPHEMERAL_CHAT,
+                        to: proto::PLAYER_SLOT_NONE,
+                        payload,
+                    });
+                }
                 Input::Action { .. } | Input::Heartbeat { .. } | Input::Leave => {}
             }
         }
     }
+}
+
+fn use_item(
+    effects: &ConsumableEffects,
+    bcast: &SnapshotBroadcast,
+    slot: proto::PlayerSlot,
+    item_ref: &str,
+    hp: &mut Health,
+    inv: &mut Inventory,
+) {
+    let Some(&heal) = effects.0.get(item_ref) else {
+        return;
+    };
+    let Some(idx) = inv.slots.iter().position(|(r, c)| r == item_ref && *c > 0) else {
+        return;
+    };
+    inv.slots[idx].1 -= 1;
+    if inv.slots[idx].1 == 0 {
+        inv.slots.remove(idx);
+    }
+    hp.hp = (hp.hp + heal).min(hp.max_hp);
+    let payload = json!({ "item_ref": item_ref, "heal": heal })
+        .to_string()
+        .into_bytes();
+    let _ = bcast.tx.send(ServerEvent::Ephemeral {
+        kind: proto::EPHEMERAL_ITEM_USED,
+        to: slot,
+        payload,
+    });
+    send_inventory(bcast, slot, inv);
 }
 
 #[allow(clippy::type_complexity, clippy::too_many_arguments)]
@@ -388,6 +568,8 @@ fn apply_actions(
     index: Res<EidIndex>,
     registry: Res<KindRegistry>,
     bcast: Res<SnapshotBroadcast>,
+    clock: Res<SimClock>,
+    mut respawns: ResMut<RespawnQueue>,
     mut commands: Commands,
     mut q_players: Query<(
         Entity,
@@ -397,7 +579,13 @@ fn apply_actions(
         &mut Inventory,
     )>,
     mut q_mobs: Query<
-        (&GridPos, &mut Health, Option<&Loot>, &EntityKind),
+        (
+            &GridPos,
+            &mut Health,
+            Option<&Loot>,
+            Option<&RespawnOnDeath>,
+            &EntityKind,
+        ),
         (Without<PlayerSlotTag>, Without<GroundItem>),
     >,
     q_items: Query<(&GridPos, &GroundItem)>,
@@ -426,7 +614,8 @@ fn apply_actions(
                     continue;
                 };
                 let (attacker_tile, damage) = (pos.tile, stats.attack.max(1));
-                let Ok((mob_pos, mut hp, loot, kind)) = q_mobs.get_mut(target_entity) else {
+                let Ok((mob_pos, mut hp, loot, respawn, kind)) = q_mobs.get_mut(target_entity)
+                else {
                     continue;
                 };
                 if attacker_tile.chebyshev(mob_pos.tile) > 1 {
@@ -451,6 +640,12 @@ fn apply_actions(
                 if died {
                     let drop_tile = mob_pos.tile;
                     let drop_ref = loot.and_then(|l| l.item_ref.clone());
+                    if let Some(r) = respawn {
+                        respawns.0.push((
+                            clock.tick.saturating_add(r.spec.respawn_ticks),
+                            r.spec.clone(),
+                        ));
+                    }
                     commands.entity(target_entity).despawn();
                     if let Some(item_ref) = drop_ref
                         && let Some(bundle) = ground_item_bundle(&registry, &item_ref, 1, drop_tile)
@@ -546,6 +741,125 @@ fn dir_between(from: Tile, to: Tile) -> Option<Dir> {
         (-1, 0) => Some(Dir::Left),
         (1, 0) => Some(Dir::Right),
         _ => None,
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn hostile_ai(
+    clock: Res<SimClock>,
+    map: Res<WalkableMap>,
+    bcast: Res<SnapshotBroadcast>,
+    mut occ: ResMut<Occupancy>,
+    mut q_mobs: Query<(Entity, &mut GridPos, &mut MoveTarget, &mut Aggro), Without<PlayerSlotTag>>,
+    mut q_players: Query<(Entity, &GridPos, &mut Health), With<PlayerSlotTag>>,
+) {
+    for (mob, mut pos, mut mv, mut aggro) in q_mobs.iter_mut() {
+        let mut nearest: Option<(Entity, Tile, i32)> = None;
+        for (pe, ppos, hp) in q_players.iter() {
+            if hp.hp <= 0 {
+                continue;
+            }
+            let d = pos.tile.chebyshev(ppos.tile);
+            if d <= aggro.range && nearest.is_none_or(|(_, _, nd)| d < nd) {
+                nearest = Some((pe, ppos.tile, d));
+            }
+        }
+        let Some((player_entity, player_tile, dist)) = nearest else {
+            continue;
+        };
+
+        if dist <= 1 {
+            if let Some(d) = dir_between(pos.tile, player_tile) {
+                pos.facing = d.facing();
+            }
+            if clock.tick < aggro.next_tick {
+                continue;
+            }
+            aggro.next_tick = clock.tick.saturating_add(aggro.period_ticks);
+            let Ok((_, _, mut hp)) = q_players.get_mut(player_entity) else {
+                continue;
+            };
+            hp.hp -= aggro.damage.max(1);
+            let died = hp.hp <= 0;
+            let payload = json!({
+                "attacker": mob.index_u32(),
+                "target": player_entity.index_u32(),
+                "target_ref": "player",
+                "dmg": aggro.damage.max(1),
+                "died": died,
+            })
+            .to_string()
+            .into_bytes();
+            let _ = bcast.tx.send(ServerEvent::Ephemeral {
+                kind: proto::EPHEMERAL_COMBAT,
+                to: proto::PLAYER_SLOT_NONE,
+                payload,
+            });
+            continue;
+        }
+
+        if mv.target.is_some() {
+            continue;
+        }
+        let dx = player_tile.x - pos.tile.x;
+        let dy = player_tile.y - pos.tile.y;
+        let horizontal = if dx > 0 { Dir::Right } else { Dir::Left };
+        let vertical = if dy > 0 { Dir::Down } else { Dir::Up };
+        let (primary, secondary) = if dx.abs() >= dy.abs() {
+            (horizontal, if dy != 0 { vertical } else { horizontal })
+        } else {
+            (vertical, if dx != 0 { horizontal } else { vertical })
+        };
+        pos.facing = primary.facing();
+        if !try_move(mob, primary, &map, &mut occ, &pos, &mut mv, None) && secondary != primary {
+            try_move(mob, secondary, &map, &mut occ, &pos, &mut mv, None);
+        }
+    }
+}
+
+#[allow(clippy::type_complexity)]
+fn respawn_players(
+    config: Res<SimConfig>,
+    mut q: Query<
+        (
+            &mut GridPos,
+            &mut MoveTarget,
+            &mut Path,
+            &mut StepBuffer,
+            &mut Health,
+        ),
+        With<PlayerSlotTag>,
+    >,
+) {
+    for (mut pos, mut mv, mut path, mut buffer, mut hp) in q.iter_mut() {
+        if hp.hp > 0 {
+            continue;
+        }
+        pos.tile = config.spawn;
+        mv.target = None;
+        mv.progress = 0;
+        path.steps.clear();
+        buffer.dir = None;
+        hp.hp = hp.max_hp;
+    }
+}
+
+fn respawn_npcs(clock: Res<SimClock>, mut queue: ResMut<RespawnQueue>, mut commands: Commands) {
+    if queue.0.is_empty() {
+        return;
+    }
+    let now = clock.tick;
+    let mut due = Vec::new();
+    queue.0.retain(|(t, spec)| {
+        if *t <= now {
+            due.push(spec.clone());
+            false
+        } else {
+            true
+        }
+    });
+    for spec in due {
+        spawn_npc_from_spec(&mut commands, &spec);
     }
 }
 
@@ -953,6 +1267,254 @@ mod tests {
         }
         assert!(saw_combat, "no combat ephemeral emitted");
         assert!(saw_potion_drop, "loot did not drop");
+    }
+
+    fn hostile_spec(kind: u16, origin: Tile) -> NpcSpec {
+        NpcSpec {
+            kind,
+            origin,
+            ticks_per_tile: 1,
+            max_hp: 30,
+            wander: None,
+            aggro: Some(AggroSpec {
+                range: 8,
+                damage: 60,
+                period_ticks: 1,
+            }),
+            loot: None,
+            respawn_ticks: 4,
+        }
+    }
+
+    fn player_entity(app: &mut App) -> Entity {
+        let mut q = app
+            .world_mut()
+            .query_filtered::<Entity, With<PlayerSlotTag>>();
+        q.iter(app.world()).next().expect("player spawned")
+    }
+
+    #[test]
+    fn hostile_chases_and_damages_player() {
+        let (mut app, mut rx, _tx, roster) = harness(21);
+        let _slot = join(&roster, "victim");
+        app.update();
+
+        let registry = app.world().resource::<KindRegistry>().clone();
+        let kind = registry.kind_of("training-dummy").unwrap();
+        let spec = hostile_spec(kind, Tile::new(13, 8));
+        {
+            let mut commands_queue = bevy::ecs::world::CommandQueue::default();
+            let mut commands = Commands::new(&mut commands_queue, app.world());
+            spawn_npc_from_spec(&mut commands, &spec);
+            commands_queue.apply(app.world_mut());
+        }
+
+        for _ in 0..120 {
+            app.update();
+        }
+
+        let mut saw_player_hit = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, payload, .. } = evt
+                && kind == proto::EPHEMERAL_COMBAT
+            {
+                let text = String::from_utf8(payload).unwrap();
+                if text.contains("\"target_ref\":\"player\"") {
+                    saw_player_hit = true;
+                }
+            }
+        }
+        assert!(saw_player_hit, "hostile never reached/attacked the player");
+    }
+
+    #[test]
+    fn dead_player_respawns_at_spawn_with_full_hp() {
+        let (mut app, _rx, _tx, roster) = harness(23);
+        let _slot = join(&roster, "phoenix");
+        app.update();
+
+        let player = player_entity(&mut app);
+        {
+            let mut pos = app.world_mut().get_mut::<GridPos>(player).unwrap();
+            pos.tile = Tile::new(20, 20);
+        }
+        {
+            let mut hp = app.world_mut().get_mut::<Health>(player).unwrap();
+            hp.hp = 0;
+        }
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let hp = app.world().get::<Health>(player).unwrap();
+        let pos = app.world().get::<GridPos>(player).unwrap();
+        assert_eq!(hp.hp, hp.max_hp, "hp not restored");
+        assert_eq!(pos.tile, Tile::new(8, 8), "not back at spawn");
+    }
+
+    #[test]
+    fn use_item_heals_and_consumes() {
+        let (mut app, mut rx, input_tx, roster) = harness(25);
+        let slot = join(&roster, "drinker");
+        app.update();
+
+        app.world_mut()
+            .insert_resource(ConsumableEffects(HashMap::from([(
+                "potion".to_string(),
+                25,
+            )])));
+
+        let player = player_entity(&mut app);
+        {
+            let mut inv = app.world_mut().get_mut::<Inventory>(player).unwrap();
+            inv.add("potion", 2);
+        }
+        {
+            let mut hp = app.world_mut().get_mut::<Health>(player).unwrap();
+            hp.hp = 50;
+        }
+
+        input_tx
+            .send((
+                slot,
+                Input::UseItem {
+                    item_ref: "potion".into(),
+                },
+            ))
+            .unwrap();
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let hp = app.world().get::<Health>(player).unwrap();
+        let inv = app.world().get::<Inventory>(player).unwrap();
+        assert_eq!(hp.hp, 75, "potion did not heal");
+        assert_eq!(inv.slots, vec![("potion".to_string(), 1)]);
+
+        let mut saw_used = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, .. } = evt
+                && kind == proto::EPHEMERAL_ITEM_USED
+            {
+                saw_used = true;
+            }
+        }
+        assert!(saw_used, "no item-used ephemeral");
+    }
+
+    #[test]
+    fn inventory_persists_across_rejoin() {
+        let (mut app, mut rx, _tx, roster) = harness(27);
+        let slot = join(&roster, "returning");
+        app.update();
+
+        let player = player_entity(&mut app);
+        {
+            let mut inv = app.world_mut().get_mut::<Inventory>(player).unwrap();
+            inv.add("potion", 3);
+        }
+
+        roster.write().unwrap().release(slot);
+        app.update();
+        while rx.try_recv().is_ok() {}
+
+        let slot2 = join(&roster, "returning");
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let mut restored = None;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, to, payload } = evt
+                && kind == proto::EPHEMERAL_INVENTORY
+            {
+                assert_eq!(to, slot2);
+                restored = Some(String::from_utf8(payload).unwrap());
+            }
+        }
+        let payload = restored.expect("no inventory restore on rejoin");
+        assert!(payload.contains("potion"), "payload: {payload}");
+        assert!(payload.contains("3"), "payload: {payload}");
+    }
+
+    #[test]
+    fn say_broadcasts_chat() {
+        let (mut app, mut rx, input_tx, roster) = harness(29);
+        let slot = join(&roster, "talker");
+        app.update();
+
+        input_tx
+            .send((
+                slot,
+                Input::Say {
+                    text: "  hello world  ".into(),
+                },
+            ))
+            .unwrap();
+        for _ in 0..3 {
+            app.update();
+        }
+
+        let mut chat = None;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, to, payload } = evt
+                && kind == proto::EPHEMERAL_CHAT
+            {
+                assert_eq!(to, proto::PLAYER_SLOT_NONE);
+                chat = Some(String::from_utf8(payload).unwrap());
+            }
+        }
+        let payload = chat.expect("no chat broadcast");
+        assert!(payload.contains("hello world"), "payload: {payload}");
+        assert!(payload.contains("talker"), "payload: {payload}");
+    }
+
+    #[test]
+    fn slain_npc_respawns_after_delay() {
+        let (mut app, mut rx, input_tx, roster) = harness(31);
+        let slot = join(&roster, "slayer");
+        app.update();
+
+        let registry = app.world().resource::<KindRegistry>().clone();
+        let kind = registry.kind_of("training-dummy").unwrap();
+        let mut spec = hostile_spec(kind, Tile::new(9, 8));
+        spec.aggro = None;
+        spec.max_hp = 1;
+        spec.respawn_ticks = 4;
+        let mob = {
+            let mut commands_queue = bevy::ecs::world::CommandQueue::default();
+            let mut commands = Commands::new(&mut commands_queue, app.world());
+            spawn_npc_from_spec(&mut commands, &spec);
+            commands_queue.apply(app.world_mut());
+            let mut q = app
+                .world_mut()
+                .query_filtered::<(Entity, &EntityKind), Without<PlayerSlotTag>>();
+            q.iter(app.world())
+                .find(|(_, k)| k.0 == kind)
+                .map(|(e, _)| e)
+                .expect("mob spawned")
+        };
+        app.update();
+
+        input_tx
+            .send((
+                slot,
+                Input::Action {
+                    id: proto::ACTION_ATTACK,
+                    target: Some(proto::EntityId(mob.index_u32())),
+                },
+            ))
+            .unwrap();
+        for _ in 0..12 {
+            app.update();
+        }
+        while rx.try_recv().is_ok() {}
+
+        let mut q = app
+            .world_mut()
+            .query_filtered::<&EntityKind, Without<PlayerSlotTag>>();
+        let alive = q.iter(app.world()).filter(|k| k.0 == kind).count();
+        assert_eq!(alive, 1, "npc did not respawn");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Follow-up sweep to #12188 — covers the known gaps (persistence, hostile AI, consumables) plus respawn loops, chat, and HUD sync.

### Protocol v3 (simgrid + @kbve/laser)
- New inputs: `UseItem { item_ref }`, `Say { text }`
- New ephemerals: `EPHEMERAL_CHAT` (broadcast), `EPHEMERAL_ITEM_USED` (targeted)

### simgrid
- **Hostile AI**: `Aggro` component — greedy chase toward nearest living player in range, adjacent attacks on a tick cooldown, combat ephemerals broadcast; players with 0 hp ignored
- **Persistence**: `PlayerStore` keeps inventory + hp keyed by username; disconnect saves, rejoin restores and replays the inventory ephemeral so the UI hydrates
- **Consumables**: `UseItem` consumes from server inventory and heals via a `ConsumableEffects` table; emits item-used + inventory sync
- **Player respawn**: hp ≤ 0 → back to spawn tile, full hp, movement state cleared
- **NPC respawn**: mobs spawned from `NpcSpec` re-enter via `RespawnQueue` after a delay when slain
- **Chat**: `Say` broadcasts trimmed, 200-char-capped messages with the sender's username
- 6 new tests → **23 total**, clippy clean

### Server (cryptothrone-server)
- Goblin pack (npcdb `goblin`, hostile faction) at (20,20): aggro range 6, 1 attack/sec from npcdb attack stat, drops coins
- All NPCs respawn after 30s; `potion` heals 25
- Spawn tables refactored onto `NpcSpec` (single source for spawn/respawn)

### Client (astro-cryptothrone + @kbve/laser)
- **ChatBar** overlay: input + last 6 messages, Enter to send
- Clicking a consumable in the inventory grid uses it (server-authoritative heal)
- HUD hp/maxHp syncs from snapshots via `player:stats`
- Death modal when you die; item-used success toasts
- `GameClient.useItem()` / `.say()` + `chat`/`itemUsed` events

## Testing
- simgrid: 23/23 (new: hostile chase+damage, player respawn, item use+consume, rejoin persistence, chat broadcast, NPC respawn), clippy clean
- cryptothrone-server: builds + clippy clean
- astro-cryptothrone: 28/28 vitest, site builds
- @kbve/laser: tests pass