### PR TITLE
feat(ci): scaffold unreal-rentearth CI registry entry

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -1116,6 +1116,27 @@
 				"itch_user": "kbve",
 				"itch_game": "chuckrpg"
 			}
+		},
+		{
+			"key": "unreal_rentearth",
+			"app_name": "rentearth",
+			"engine": {
+				"version": "5.7.4",
+				"project_path": "apps/rentearth/unreal-rentearth",
+				"build_targets": [
+					"Win64",
+					"Linux"
+				]
+			},
+			"source_path": "apps/rentearth/unreal-rentearth",
+			"version": "0.0.1",
+			"version_toml": "apps/rentearth/unreal-rentearth/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-rentearth.mdx",
+			"runner": "arc-runner-ue",
+			"external_publish": {
+				"itch_user": "kbve",
+				"itch_game": "rentearth"
+			}
 		}
 	],
 	"bevy_game": [],
@@ -1128,8 +1149,8 @@
 		"ue5_server": 1,
 		"unity": 1,
 		"godot": 1,
-		"unreal_game": 2,
+		"unreal_game": 3,
 		"bevy_game": 0,
-		"total": 92
+		"total": 93
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-rentearth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-rentearth.mdx
@@ -1,0 +1,62 @@
+---
+title: Unreal RentEarth
+description: |
+    RentEarth UE5 game client built from the monorepo shell at apps/rentearth/unreal-rentearth via the unreal_game pipeline. Separate Unreal project from Chuck.
+sidebar:
+    label: Unreal RentEarth
+    order: 98
+tags:
+    - ue5
+    - game
+    - rentearth
+key: unreal_rentearth
+pipeline: unreal_game
+app_name: rentearth
+source_path: apps/rentearth/unreal-rentearth
+version_toml: apps/rentearth/unreal-rentearth/version.toml
+version: "0.0.1"
+runner: arc-runner-ue
+author: h0lybyte
+license: KBVE
+status: beta
+engine:
+    version: "5.7.4"
+    project_path: apps/rentearth/unreal-rentearth
+    build_targets:
+        - Win64
+        - Linux
+external_publish:
+    itch_user: kbve
+    itch_game: rentearth
+---
+
+## Overview
+
+RentEarth UE5 game client — a separate Unreal project from [Chuck](/project/unreal-chuck-game).
+It compiles the monorepo shell at `apps/rentearth/unreal-rentearth` directly (no external game
+repo), the same way the early Chuck demo did, and is wired to the shared `unreal_game` pipeline.
+
+## Pipeline
+
+`pipeline: unreal_game` → `ci-main.yml` dispatches `ci-unreal.yml` (`task: game`) when the MDX
+`version:` here outpaces `version.toml`, or `source_path` files change. With no
+`engine.external_repo_url`, the builder checks out the monorepo and builds the `.uproject` under
+`engine.project_path` against the prebuilt UE5.7 on the `UE5-Win` KubeVirt VM
+(`C:\Program Files\Epic Games\UE_5.7`); the Linux client builds in the cached
+`ghcr.io/epicgames/unreal-engine:dev-5.7.4` image on `arc-runner-ue`.
+
+## Build Matrix
+
+`engine.build_targets`:
+
+- `Win64` — native build on the `UE5-Win` KubeVirt VM (RunUAT.bat, prebuilt UE5.7)
+- `Linux` — `arc-runner-ue` in the Epic UE5.7 Docker image
+
+The dedicated server is not wired yet — add `shell_path` + a `build.toml` (`server_target`,
+`repo`, UE image) under `apps/rentearth/unreal-rentearth` to fan the server build off this same
+version gate, matching the Chuck setup, once the server target exists.
+
+## Distribution
+
+Client shipped to itch.io as `kbve/rentearth` when `deploy_to_itch` is set. Client and the
+shared `version.toml` advance together.


### PR DESCRIPTION
RentEarth is a separate UE5 project (not a Chuck variant). Adds its unreal_game pipeline entry.

## Entry (apps/.../project/unreal-rentearth.mdx)
- Monorepo-shell build at apps/rentearth/unreal-rentearth (no external_repo_url), Win64 + Linux, UE 5.7.4.
- key unreal_rentearth, app_name rentearth, version 0.0.1, status beta.
- Dispatch manifest regenerated (sync:ci-manifest) — unreal_game 2 → 3; diff scoped to the new entry.

## Confirm / follow-up
- **itch target** external_publish kbve/rentearth — placeholder, confirm.
- **version 0.0.1** — no build shipped yet.
- **Dedicated server deferred** — add shell_path + build.toml (server_target) under the shell when the server target exists, to fan the rentearth-release rows tenant's server off this version gate (mirrors Chuck).
- The shell apps/rentearth/unreal-rentearth isn't on dev yet, so the version gate won't fire a build until it + version.toml land.