### PR TITLE
chore(osrs): migrate 200 v2 items to v3 schema (batch 25)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-longsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/3rd-age-longsword.mdx
@@ -12,69 +12,105 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: 3rd age
+    tier: high
+  properties:
+    release_date: "2010-08-13"
+    update: "3rd Age Weapons"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
     type: longsword
-    attack_style: melee
+    attack_style: slash
     attack_speed: 5
+    attack_range: 1
+    weight: 1.814
     requirements:
       attack: 65
-    stats:
-      attack_stab: 58
-      attack_slash: 72
-      attack_crush: -2
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 3
-      defence_crush: 2
-      defence_magic: 0
-      defence_ranged: 0
+    attack_bonus:
+      stab: 58
+      slash: 72
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
       melee_strength: 75
-      prayer_bonus: 0
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Master clue scroll casket
+        quantity: "1"
         rarity: Very Rare
-        description: Extremely rare reward from master clue scrolls
+        notes: "Extremely rare reward from master clue scrolls; the only obtain source."
+  treasure_trail:
+    tier: master
+    notes: "Drops from rewards casket (master); part of the 3rd age weapon rare reward pool."
   related_items:
     - item_id: 12424
       item_name: 3rd age bow
       slug: 3rd-age-bow
       relationship: alternative
-      description: 3rd age ranged weapon
+      description: 3rd age ranged weapon counterpart.
     - item_id: 12422
       item_name: 3rd age wand
       slug: 3rd-age-wand
       relationship: alternative
-      description: 3rd age magic weapon
+      description: 3rd age magic weapon counterpart.
     - item_id: 20014
       item_name: 3rd age pickaxe
       slug: 3rd-age-pickaxe
       relationship: alternative
-      description: 3rd age skilling tool
+      description: 3rd age skilling tool variant.
     - item_id: 20011
       item_name: 3rd age axe
       slug: 3rd-age-axe
       relationship: alternative
-      description: 3rd age skilling tool
+      description: 3rd age skilling tool variant.
   about: |-
-    The 3rd age longsword is a rare weapon obtained from Treasure Trails. It requires 65 Attack to wield and has stats comparable to a dragon longsword but with the prestigious 3rd age appearance.
+    The 3rd age longsword is a rare melee weapon obtained from master Treasure Trails. It requires 65 Attack to wield and shares stats comparable to a dragon longsword while carrying the prestigious 3rd age appearance.
 
-    3rd age weapons are highly sought after due to their extreme rarity and status symbol value. The longsword was added as part of the 3rd age weapon expansion.
+    3rd age weapons are highly sought after due to their extreme rarity and status symbol value. The longsword was introduced as part of the 3rd age weapon expansion in 2010.
   market_strategy:
-    title: Investment Notes
     notes:
-      - Extremely valuable due to rarity
-      - Price fluctuates based on collector demand
-      - More common than druidic but still very rare
-      - Verify authenticity when trading high-value items
-      - Use Grand Exchange for secure trades
-      - Monitor price trends before purchasing
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Investment Notes"
+      - "Extremely valuable due to rarity"
+      - "Price fluctuates based on collector demand"
+      - "More common than druidic but still very rare"
+      - "Verify authenticity when trading high-value items"
+      - "Use Grand Exchange for secure trades"
+      - "Monitor price trends before purchasing"
+  trading_tips:
+    - "Watch master clue release events for short-term supply spikes."
+    - "Confirm with multiple price sources before committing to GE max-cash flips."
+  history:
+    - date: "2010-08-13"
+      description: "Released as part of the 3rd age weapon expansion."
+    - date: "2013-02-22"
+      description: "Carried into OSRS at the game's release."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-cane.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-cane.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant cane | OSRS Price Data
-description: "Adamant cane is a members weapon slot item with +23 melee strength requiring 28 Attack. High alch: 864 GP, GE limit: 4."
+description: "Adamant cane is the Medium clue cosmetic crush weapon, +25 crush attack and +3 prayer bonus requiring 28 Attack. High alch: 864 GP, GE limit: 4."
 osrs:
   id: 12377
   name: Adamant cane
@@ -12,10 +12,36 @@ osrs:
   lowalch: 576
   highalch: 864
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2009-11-09"
+    update: "Treasure Trails Reloaded"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: spiked
+    weapon_type: spiked
     attack_speed: 5
+    attack_range: 1
+    weight: 0.453
+    requirements:
+      attack: 28
     attack_bonus:
       stab: 13
       slash: -2
@@ -33,65 +59,48 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 3
-    requirements:
-      attack: 28
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Medium
-        drop_rate: 1/1,133
-        description: Rare reward from medium clue scrolls
+  drop_table:
+    sources:
+      - source: Medium clue scroll casket
+        quantity: "1"
+        rarity: 1/1133
+        notes: "Rare reward from a Medium Treasure Trail."
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
   related_items:
-    - item_id: 12379
-      item_name: Rune cane
-      slug: rune-cane
-      relationship: upgrade
-      description: Higher-tier cane from hard clues
-    - item_id: 12375
-      item_name: Mithril cane
+    - item_name: Mithril cane
       slug: mithril-cane
       relationship: downgrade
-      description: Lower-tier cane from easy clues
-    - item_id: 12381
-      item_name: Dragon cane
+      description: "Lower-tier cane from Easy clues"
+    - item_name: Rune cane
+      slug: rune-cane
+      relationship: upgrade
+      description: "Higher-tier cane from Hard clues"
+    - item_name: Dragon cane
       slug: dragon-cane
       relationship: upgrade
-      description: Highest-tier cane from elite clues
-  about: |-
-    > *"A diamond topped cane."*
-
-    | Style | Type | Experience |
-    |-------|------|-----------|
-    | Pound | Crush | Attack |
-    | Pummel | Crush | Strength |
-    | Spike | Stab | Shared |
-    | Block | Crush | Defence |
-
-    | Property | Mithril Cane | Adamant Cane | Rune Cane | Dragon Cane |
-    |----------|-------------|--------------|-----------|-------------|
-    | Crush Attack | +17 | +25 | +39 | +50 |
-    | Strength | +16 | +23 | +36 | +48 |
-    | Prayer | +2 | +3 | +4 | +5 |
-    | Attack Req | 20 | 28 | 40 | 60 |
-    | Clue Tier | Easy | Medium | Hard | Elite |
-
-    Each cane tier increases in stats and prayer bonus, matching progressively harder clue scroll requirements.
+      description: "Highest-tier cane from Elite clues"
+  about: "Adamant cane is the Medium clue exclusive cosmetic crush weapon, requiring 28 Attack and giving +25 crush attack, +23 melee strength, and +3 prayer bonus. It belongs to the cane progression (Mithril/Adamant/Rune/Dragon) where each tier ups the strength, crush, prayer bonus, and Attack requirement. The cane pairs with Gentleman's outfit fashionscape (top hat, monocle) and is primarily a collection log target rather than a combat weapon."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Medium clue exclusive cosmetic weapon
-      - Low Attack requirement makes it accessible
-      - Prayer bonus is notable for the tier
-      - Primarily a fashionscape and collection log item
-      - Not efficient for combat compared to adamant scimitar
-      - Gentleman's outfit fashionscape pairs well with top hat and monocle
-      - Medium clues are fast to farm, so supply is reasonable
-      - Collection log completionists provide steady demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Medium clue exclusive cosmetic; demand is split with the other cane tiers"
+      - "Low Attack requirement makes it accessible to pures and early accounts"
+      - "Prayer bonus is unusual for the tier and modestly props the price floor"
+      - "GE limit of 4 per 4 hours strongly throttles bulk flipping"
+  trading_tips:
+    - "Compare cane tier prices against their clue rarity; cheapest cosmetic per gp wins"
+    - "Stockpile during Medium clue event weekends when supply temporarily spikes"
+    - "Pair with top hat and monocle listings to catch full Gentleman's outfit buyers"
+  history:
+    - date: "2009-11-09"
+      description: "Released with the Treasure Trails Reloaded cane reward expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-p-5646.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-javelin-p-5646.mdx
@@ -1,10 +1,10 @@
 ---
 title: Adamant javelin(p+) | OSRS Price Data
-description: "Adamant javelin(p+): An adamant tipped javelin.. High alch: 96 GP, GE limit: 11,000."
+description: "Adamant javelin(p+): An adamant tipped javelin. High alch: 96 GP, GE limit: 11,000."
 osrs:
   id: 5646
   name: Adamant javelin(p+)
-  slug: adamant-javelin-p
+  slug: adamant-javelin-p-5646
   examine: An adamant tipped javelin.
   members: true
   icon: Adamant javelin(p+).png
@@ -12,9 +12,71 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 11000
-  about: "Adamant javelin(p+) is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: adamant
+    tier: mid-high
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    attack_speed: 6
+    attack_range: 5
+    weight: 0
+    requirements:
+      ranged: 30
+    attack_bonus:
+      ranged: 0
+    defence_bonus: {}
+    other_bonus:
+      ranged_strength: 102
+  related_items:
+    - item_name: Adamant javelin
+      slug: adamant-javelin
+      relationship: variant
+      description: Unpoisoned variant
+    - item_name: Adamant javelin(p)
+      slug: adamant-javelin-p
+      relationship: variant
+      description: Weak poison variant
+    - item_name: Adamant javelin(p++)
+      slug: adamant-javelin-p-5652
+      relationship: variant
+      description: Strongest poison variant
+    - item_name: Rune javelin(p+)
+      slug: rune-javelin-p-5647
+      relationship: upgrade
+      description: Higher tier poisoned javelin
+  about: "Adamant javelin(p+) is the stronger poisoned variant of the adamant javelin, used as ammunition for the Heavy ballista. It applies a stronger weapon poison than the base p variant and shares the +102 Ranged strength bonus, making it a popular pick for slayer and PvM where extra poison damage helps soften enemies."
+  market_strategy:
+    notes:
+      - "Demand tracks Heavy ballista usage at slayer and PvM bosses"
+      - "Sits between standard p and p++ variants on price"
+  trading_tips:
+    - Buy in bulk while ballista metas are quiet for cheap stock
+    - Compare against p and p++ variants for best per-cast poison value
+  history:
+    - date: "2005-07-11"
+      description: "Poisoned javelin variants added to the game."
+    - date: "2016-05-06"
+      description: "Moved to ammunition slot only; ranged strength increased significantly."
+    - date: "2016-10-31"
+      description: "Ranged strength adjusted to +102."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platelegs-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-platelegs-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant platelegs (g) | OSRS Price Data
-description: "Adamant platelegs (g) is a F2P legs slot item requiring 30 Defence. High alch: 3,840 GP, GE limit: 8."
+description: "Adamant platelegs (g) is a F2P gold-trimmed cosmetic variant of standard adamant platelegs requiring 30 Defence, from medium clue caskets. High alch: 3,840 GP, GE limit: 8."
 osrs:
   id: 2609
   name: Adamant platelegs (g)
@@ -12,30 +12,89 @@ osrs:
   lowalch: 2560
   highalch: 3840
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2004-05-05"
+    update: "Bigger Banks & Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 10.432
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: legs
+    weight: 10.432
     requirements:
       defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -11
+      ranged: -11
+    defence_bonus:
+      stab: 33
+      slash: 31
+      crush: 29
+      magic: -4
+      ranged: 31
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   related_items:
     - item_id: 2607
       item_name: Adamant platebody (g)
       slug: adamant-platebody-g
       relationship: set-piece
-      description: Matching gold-trimmed platebody
+      description: "Matching gold-trimmed platebody from the same clue tier."
     - item_id: 2601
       item_name: Adamant platelegs (t)
       slug: adamant-platelegs-t
       relationship: variant
-      description: Trimmed variant
-  about: |-
-    > *"Adamant platelegs with gold trim."*
-
-    The adamant platelegs (g) are a gold-trimmed cosmetic variant of standard adamant platelegs. Identical stats, requiring 30 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Trimmed cosmetic variant with identical stats."
+    - item_id: 1123
+      item_name: Adamant platelegs
+      slug: adamant-platelegs
+      relationship: variant
+      description: "Standard untrimmed adamant platelegs - same combat stats."
+  about: "Adamant platelegs (g) are the gold-trimmed cosmetic variant of standard adamant platelegs, awarded from medium Treasure Trails reward caskets at roughly 1/1,133. They carry identical combat stats to the base platelegs and require 30 Defence to wear, making them a popular F2P cosmetic flex on free worlds where high-tier gear is unavailable. They cannot be smithed."
+  market_strategy:
+    notes:
+      - "GE buy limit of 8 per 4 hours caps daily flips."
+      - "Supply tied to medium clue completion rates - heavier in Leagues lulls."
+      - "Demand spikes during F2P PK and BH events where gold trim cosmetics signal status."
+      - "High alch of 3,840 gp is well below GE - never alch."
+  trading_tips:
+    - "Pair with Adamant platebody (g) for full-set arbitrage."
+    - "Buy after Leagues launches - clue activity drops, prices stiffen."
+    - "Cross-monitor easy clue ranges (Black (g)) - mid-clue economic shifts trickle up."
+  history:
+    - date: "2004-05-05"
+      description: "Released with the Bigger Banks & Treasure Trails update as a medium clue casket reward."
+    - date: "2014-06-12"
+      description: "Renamed from 'Adam platelegs (g)' to 'Adamant platelegs (g)' for naming consistency."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -7 to -11 in a wide armor rebalance pass."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-spear-p-5712.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-spear-p-5712.mdx
@@ -1,10 +1,10 @@
 ---
 title: Adamant spear(p+) | OSRS Price Data
-description: "Adamant spear(p+): A poisoned adamantite tipped spear.. High alch: 1,248 GP, GE limit: 125."
+description: "Adamant spear(p+) is the extra-strong-poisoned variant of the adamant spear, applying P+ poison on hit. High alch: 1,248 GP, GE limit: 125."
 osrs:
   id: 5712
   name: Adamant spear(p+)
-  slug: adamant-spear-p
+  slug: adamant-spear-p-5712
   examine: A poisoned adamantite tipped spear.
   members: true
   icon: Adamant spear(p+).png
@@ -12,12 +12,97 @@ osrs:
   lowalch: 832
   highalch: 1248
   limit: 125
-  about: "Adamant spear(p+) is a members-only item in Old School RuneScape. High alchemy value: 1,248 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: adamant
+    tier: mid
+  properties:
+    release_date: "2004-08-23"
+    update: "Poisoned Weapons"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    attack_range: 1
+    weight: 2.721
+    requirements:
+      attack: 30
+    attack_bonus:
+      stab: 24
+      slash: 24
+      crush: 24
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 1
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 28
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Extra-strong poison
+      description: "Successful hits have a chance to inflict extra-strong poison (P+), dealing 6 damage initially and decaying over time."
+      trigger: on_hit
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Adamant spear
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      output_quantity: 1
+      notes: "Apply weapon poison(+) to an unpoisoned adamant spear at 73 Herblore."
+  related_items:
+    - item_name: Adamant spear
+      slug: adamant-spear
+      relationship: variant
+      description: "Unpoisoned adamant spear with identical stats"
+    - item_name: Adamant spear(p)
+      slug: adamant-spear-p
+      relationship: variant
+      description: "Standard poisoned variant using weapon poison"
+    - item_name: Rune spear(p+)
+      slug: rune-spear-p-5714
+      relationship: upgrade
+      description: "Higher-tier rune spear with extra-strong poison"
+  about: "Adamant spear(p+) is the extra-strong-poisoned variant of the adamant spear, created by applying weapon poison(+) at 73 Herblore. It carries the same combat stats as the base spear but has a chance to inflict P+ poison on successful hits, useful in low-to-mid level PvM and at minigames where poison ticks add meaningful damage. The poison runs out over use and the spear reverts to the unpoisoned profile."
+  market_strategy:
+    notes:
+      - "Demand is thin since most poisoned-weapon users prefer hastae or dragon variants"
+      - "Bound to weapon poison(+) market; shifts with herb supply"
+      - "Limit 125 per 4 hours throttles bulk flipping"
+  trading_tips:
+    - "Buy unpoisoned adamant spear and craft the (p+) variant when poison margin opens"
+    - "Compare (p), (p+), (p++) prices for the cheapest poison tier per kill"
+  history:
+    - date: "2004-08-23"
+      description: "Released with the Poisoned Weapons update introducing weapon poison(+) variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robeskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robeskirt.mdx
@@ -12,87 +12,90 @@ osrs:
   lowalch: 18800
   highalch: 28200
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: barrows-robe
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 11.339
+    degradeable: true
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+      - Check
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
   equipment:
     slot: legs
-    type: barrows
-    set: Ahrim
-    tradeable: true
-    degradeable: true
-    weight: 11.3
     requirements:
       defence: 70
       magic: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: 22
-      attack_ranged: -7
-      defence_stab: 33
-      defence_slash: 30
-      defence_crush: 36
-      defence_magic: 22
-      defence_ranged: 0
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 22
+      ranged: -7
+    defence_bonus:
+      stab: 33
+      slash: 30
+      crush: 36
+      magic: 22
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 1
       prayer: 0
   set_effect:
     name: Blighted Aura
     pieces_required: 4
-    description: 25% chance to lower opponent's Strength by 5 levels
-    amulet_of_damned: 25% chance for +30% damage on hits; can autocast Ancient Magicks
+    description: "25% chance per Ahrim's staff magic hit to lower opponent's Strength by 5 levels; with Amulet of the Damned, 25% chance for +30% damage and Ancient Magicks autocast"
+  drop_table:
+    sources:
+      - source: Ahrim the Blighted
+        quantity: "1"
+        rarity: "1/392 per Barrows reward roll"
   related_items:
-    - item_id: 4708
-      item_name: Ahrim's hood
+    - item_name: Ahrim's hood
       slug: ahrims-hood
       relationship: set-piece
-      description: Head slot set piece
-    - item_id: 4712
-      item_name: Ahrim's robetop
+      description: "Head slot set piece"
+    - item_name: Ahrim's robetop
       slug: ahrims-robetop
       relationship: set-piece
-      description: Body slot set piece
-    - item_id: 4710
-      item_name: Ahrim's staff
+      description: "Body slot set piece"
+    - item_name: Ahrim's staff
       slug: ahrims-staff
       relationship: set-piece
-      description: Weapon set piece
-    - item_id: 21024
-      item_name: Ancestral robe bottom
+      description: "Weapon set piece"
+    - item_name: Ancestral robe bottom
       slug: ancestral-robe-bottom
       relationship: upgrade
-      description: Upgrade path
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Magic attack | +22 |
-    | Magic defence | +22 |
-    | Stab defence | +33 |
-    | Slash defence | +30 |
-    | Crush defence | +36 |
-    | Magic damage | +1% |
-    | Ranged attack | -7 |
-
-    Blighted Aura:
-    When wearing full Ahrim's (hood, robetop, robeskirt, staff):
-    - 25% chance to lower opponent's Strength by 5 levels
-    - Stacks with Enfeeble spell
-
-    With Amulet of the Damned:
-    - 25% chance for +30% damage on hits
-    - Can autocast Ancient Magicks
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
-    - Repair cost: ~90k for full set at Bob
+      description: "Non-degrading upgrade path with stronger magic stats"
+  about: "Ahrim's robeskirt is the legs piece of Ahrim's Barrows magic set, dropped from Ahrim the Blighted with a 70 Defence and 70 Magic requirement. It contributes +22 magic attack and defence, +1% magic damage, and degrades over 15 combat hours through 100/75/50/25/0 stages, repaired for ~80,000 gp at Bob in Lumbridge or cheaper at a POH armour stand with Smithing."
   market_strategy:
     notes:
-      - Best magic legs before Ancestral
-      - Magic damage bonus rare on legs
-      - Often used with Slayer helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Best pre-Ancestral magic legs, with a rare +1% magic damage on the slot"
+      - "Common Slayer-helm-on-task pairing for mid-game magic DPS"
+      - "Repair cost scales with use, factor when comparing to Virtus or Ancestral upgrades"
+  trading_tips:
+    - "Pick up Barrows-event spikes when supply lifts and price dips"
+    - "Hold a charged backup for ironman switches to avoid downtime mid-trip"
+  history:
+    - date: "2005-05-09"
+      description: "Released as part of the Barrows minigame update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-blessing.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ancient-blessing.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ancient blessing | OSRS Price Data
-description: "Ancient blessing is a members ammo slot item. High alch: 48 GP, GE limit: 5."
+description: "Ancient blessing is the Zaros-aligned ammo-slot blessing dropped from clue caskets, granting +1 Prayer and Nex-prison protection. High alch: 48 GP, GE limit: 5."
 osrs:
   id: 20235
   name: Ancient blessing
@@ -12,69 +12,108 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 5
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: blessing
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.51
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    type: blessing
-    attack_style: none
-    stats:
-      prayer_bonus: 1
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
   obtaining:
     methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Master
-        rarity: Rare
-        description: Reward from master clue scrolls
-      - source: Treasure Trails
-        requirements:
-          clue_type: Elite
-        rarity: Rare
-        description: Reward from elite clue scrolls
+      - source: Reward casket (master)
+        rarity: 1/606.4
+        description: "Random blessing roll from master clue caskets."
+      - source: Reward casket (elite)
+        rarity: 1/645.8
+        description: "Random blessing roll from elite clue caskets."
+      - source: Reward casket (hard)
+        rarity: 1/541.7
+        description: "Random blessing roll from hard clue caskets."
+      - source: Reward casket (medium)
+        rarity: Uncommon
+        description: "Lower-rate blessing roll from medium clue caskets."
+      - source: Reward casket (easy)
+        rarity: Uncommon
+        description: "Lower-rate blessing roll from easy clue caskets."
+  passive_effects:
+    - name: Zaros protection
+      description: "Counts as a Zarosian item in the God Wars Dungeon; Zaros followers in Nex's prison stay non-aggressive while worn."
   related_items:
     - item_id: 20220
       item_name: Holy blessing
       slug: holy-blessing
       relationship: alternative
-      description: Saradomin blessing
+      description: "Saradomin variant of the +1 Prayer ammo-slot blessing."
     - item_id: 20223
       item_name: Unholy blessing
       slug: unholy-blessing
       relationship: alternative
-      description: Zamorak blessing
+      description: "Zamorak variant of the +1 Prayer ammo-slot blessing."
     - item_id: 20226
       item_name: Peaceful blessing
       slug: peaceful-blessing
       relationship: alternative
-      description: Guthix blessing
+      description: "Guthix variant of the +1 Prayer ammo-slot blessing."
     - item_id: 20229
       item_name: Honourable blessing
       slug: honourable-blessing
       relationship: alternative
-      description: Armadyl blessing
+      description: "Armadyl variant of the +1 Prayer ammo-slot blessing."
     - item_id: 20232
       item_name: War blessing
       slug: war-blessing
       relationship: alternative
-      description: Bandos blessing
-  about: |-
-    The ancient blessing is a Zaros-aligned item worn in the ammunition slot, providing +1 prayer bonus. It is the Zaros equivalent of other god blessings.
-
-    Blessings are valuable because they provide prayer bonus in the ammunition slot, which normally has no prayer-boosting options. This makes them useful for any build that wants to maximize prayer bonus without sacrificing ranging capability.
-
-    God Wars Protection:
-    - Counts as a Zaros item in the God Wars Dungeon
-    - Zaros followers (in Nex's prison) will not be aggressive when worn
+      description: "Bandos variant of the +1 Prayer ammo-slot blessing."
+  about: "Ancient blessing is the Zaros-aligned member of the six god blessings, released 6 July 2016 with the Treasure Trail Expansion. Worn in the ammunition slot for +1 Prayer bonus - normally the only Prayer source available in that slot - and dropped from hard, elite, and master clue caskets at single-roll rates around 1/540-1/650. The Zarosian alignment grants non-aggressive passage through Nex's prison in the God Wars Dungeon."
   market_strategy:
-    title: Investment Notes
     notes:
-      - Prices vary between different god blessings
-      - Zaros version useful for Nex
-      - Good investment for high-level PvM accounts
-      - Compare prices between all six blessings
-      - Consider God Wars Dungeon utility when pricing
-      - Popular with players wanting prayer bonus in ammo slot
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Buy limit of only 5 per 4 hours keeps liquidity tight"
+      - "Supply is entirely clue-casket driven - clue activity sets price"
+      - "Prayer +1 in the ammo slot makes it core to Prayer-bonus stacks"
+      - "Cross-blessing spread is driven by god-faction PvM demand"
+  trading_tips:
+    - "Compare ancient blessing price against the other five god blessings to spot Zaros-specific demand"
+    - "Stockpile around Nex re-releases and Wilderness Boss reworks"
+    - "Spreads tighten after master clue droprate buffs"
+  history:
+    - date: "2016-07-06"
+      description: "Released with the Treasure Trail Expansion update, adding all six god blessings to the clue reward pool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/anti-odour-salt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/anti-odour-salt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Anti-odour salt | OSRS Price Data
-description: "Anti-odour salt: A special salt used by experienced hunters to remove their sent from traps.. High alch: 6 GP."
+description: "Anti-odour salt is a members Herblore-made hunter consumable used to mask scent on traps. High alch: 6 GP."
 osrs:
   id: 31712
   name: Anti-odour salt
@@ -11,10 +11,72 @@ osrs:
   value: 11
   lowalch: 4
   highalch: 6
-  limit: null
-  about: "Anti-odour salt is a members-only item in Old School RuneScape. High alchemy value: 6 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  material:
+    type: consumable
+    tier: mid
+  recipes:
+    - skill: herblore
+      level: 49
+      xp: 11
+      materials:
+        - item_name: Elkhorn coral
+          quantity: 1
+        - item_name: Crab paste
+          quantity: 5
+      tools:
+        - Pestle and mortar
+      product: Anti-odour salt
+      product_id: 31712
+      output_quantity: 15
+      members_only: true
+  related_items:
+    - item_name: Elkhorn coral
+      slug: elkhorn-coral
+      relationship: component
+      description: Coral ingredient ground with crab paste to make the salt.
+    - item_name: Crab paste
+      slug: crab-paste
+      relationship: component
+      description: Paste consumed alongside elkhorn coral in the recipe.
+    - item_name: Huntsman's kit
+      slug: huntsmans-kit
+      relationship: alternative
+      description: Hunter storage kit; anti-odour salt cannot be stored inside it.
+  about: |-
+    Anti-odour salt is a Sailing-era Herblore product that members rub onto hunter traps to mask player scent.
+    Each salt is consumed automatically when a trap is laid and gives a small uplift to catch rate, making it
+    a routine consumable for high-volume hunter trips rather than a one-off luxury item.
+  market_strategy:
+    title: Salt Margins
+    notes:
+      - Tracks the spread between elkhorn coral, crab paste, and the 15-yield batch output
+      - Herblore margin tightens with coral price spikes; check both ingredients before bulk crafting
+      - Demand spikes when Sailing/Hunter content is featured in seasonal events
+      - Buy limit is uncapped so suppliers can flood the GE during community goals
+  trading_tips:
+    - Sample a single batch before committing 1,000+ corals to confirm margin after GE tax
+    - Stockpile during Sailing content droughts when coral suppliers undercut
+    - List finished salt slightly below instant-buy to clear before the next hunter event
+  history:
+    - date: "2025-11-19"
+      description: Introduced with the Sailing skill launch as a Hunter consumable.
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-mix-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antidote+ mix(2) | OSRS Price Data
-description: "Antidote+ mix(2): Two doses of fishy extra strength antidote potion.. High alch: 129 GP, GE limit: 2,000."
+description: "Antidote+ mix(2) is a Barbarian Herblore poison-cure mix granting 9 minutes of poison immunity. High alch: 129 GP, GE limit: 2,000."
 osrs:
   id: 11501
   name: Antidote+ mix(2)
@@ -12,9 +12,87 @@ osrs:
   lowalch: 86
   highalch: 129
   limit: 2000
-  about: "Antidote+ mix(2) is a members-only item in Old School RuneScape. High alchemy value: 129 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    doses: 2
+    herblore_level: 74
+    herblore_xp: 52
+    effect: Cures poison, grants 9 minutes of immunity, and restores 6 Hitpoints.
+    effects:
+      - stat: hitpoints
+        boost_type: heal
+        boost_value: 6
+        description: Restores 6 Hitpoints on consumption.
+      - stat: hitpoints
+        boost_type: poison-immunity
+        duration: 540
+        description: Grants 9 minutes (540 seconds) of poison immunity.
+  recipes:
+    - skill: herblore
+      level: 74
+      xp: 52
+      materials:
+        - item_name: Antidote+(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      product: Antidote+ mix(2)
+      product_id: 11501
+      output_quantity: 1
+      facility: Barbarian Herblore training
+      members_only: true
+  related_items:
+    - item_id: 11503
+      item_name: Antidote+ mix(1)
+      slug: antidote-mix-1
+      relationship: variant
+      description: Single-dose Barbarian mix; consume one dose at a time.
+    - item_id: 5945
+      item_name: Antidote+(4)
+      slug: antidote-4-5945
+      relationship: upgrade
+      description: Full four-dose antidote+ potion brewed without caviar.
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore secondary added to base antidote+.
+  about: |-
+    Antidote+ mix(2) is the two-dose Barbarian Herblore variant of the antidote+ potion, brewed by adding
+    caviar to a regular Antidote+(2). On top of curing and immunising against poison, it heals 6 Hitpoints
+    per dose, making it a compact combo-food option for poison-heavy slayer tasks and quest bosses.
+  market_strategy:
+    title: Barbarian Mix Margins
+    notes:
+      - "Ingredient stack: Antidote+(2) plus caviar; both are members tradeables with mid-tier liquidity"
+      - Profit per mix is thin; success depends on caviar buy-ins during low-demand periods
+      - Demand rises around high-poison content releases and PvM events
+      - 2,000 buy limit per four hours lets dedicated brewers move full inventories
+  trading_tips:
+    - Watch the caviar market closely; it is the volatile input
+    - Pre-stack base antidote+(2) before brewing to avoid mid-session price jumps
+    - List doses in stacks to clear faster against PvM consumers
+  history:
+    - date: "2007-07-03"
+      description: Released with the Barbarian Herblore training update.
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-potion-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antifire potion(2) | OSRS Price Data
-description: "Antifire potion(2): 2 doses of anti-firebreath potion.. High alch: 118 GP, GE limit: 2,000."
+description: "Antifire potion(2): 2 doses of anti-firebreath potion. High alch: 118 GP, GE limit: 2,000."
 osrs:
   id: 2456
   name: Antifire potion(2)
@@ -12,9 +12,87 @@ osrs:
   lowalch: 79
   highalch: 118
   limit: 2000
-  about: "Antifire potion(2) is a members-only item in Old School RuneScape. High alchemy value: 118 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    doses: 2
+    herblore_level: 69
+    herblore_xp: 0
+    effects:
+      - description: "Provides partial dragonfire protection per dose, reducing dragon breath damage by approximately 90%."
+        duration: 360
+      - description: "Grants complete dragonfire immunity when paired with an anti-dragon shield or dragonfire shield."
+        duration: 360
+  recipes:
+    - skill: herblore
+      level: 69
+      xp: 78.75
+      materials:
+        - item_id: 2452
+          item_name: Antifire potion(4)
+          quantity: 1
+      output:
+        item_id: 2456
+        item_name: Antifire potion(2)
+        output_quantity: 2
+      tools: []
+      facility: Decanting
+      members: true
+      notes: "Decanted from 4-dose antifire potions into 2-dose vials."
+  related_items:
+    - item_id: 2452
+      item_name: Antifire potion(4)
+      slug: antifire-potion-4
+      relationship: variant
+      description: "4-dose variant for decanting."
+    - item_id: 2454
+      item_name: Antifire potion(3)
+      slug: antifire-potion-3
+      relationship: variant
+      description: "3-dose variant for decanting."
+    - item_id: 2458
+      item_name: Antifire potion(1)
+      slug: antifire-potion-1
+      relationship: variant
+      description: "1-dose variant for decanting."
+    - item_id: 1540
+      item_name: Anti-dragon shield
+      slug: anti-dragon-shield
+      relationship: alternative
+      description: "Pairs with the potion for full dragonfire immunity."
+    - item_id: 11951
+      item_name: Extended antifire(2)
+      slug: extended-antifire-2
+      relationship: upgrade
+      description: "Longer-duration upgrade made by adding lava scale shards."
+  about: "Antifire potion(2) is a 2-dose Herblore potion that grants partial dragonfire protection for 6 minutes per dose and full immunity when paired with an anti-dragon shield or dragonfire shield, primarily obtained by decanting larger Antifire potions."
+  market_strategy:
+    notes:
+      - "Per-dose price tracks the 4-dose antifire price tightly via decanter arbitrage."
+      - "Demand spikes during Slayer dragon task surges and Vorkath farm metas."
+      - "Buy limit 2,000 per 4 hours caps high-volume flipping."
+  trading_tips:
+    - "Watch 4-dose vs 2-dose spread to spot decant arbitrage."
+    - "Sell into Slayer reset events and Vorkath supply pushes."
+  history:
+    - date: "2004-03-29"
+      description: "Antifire potion released with the RS2 launch as the original dragonfire protection consumable."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-potion-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antifire potion(4) | OSRS Price Data
-description: "Antifire potion(4) is a 3-dose members potion that dragonfire. High alch: 198 GP, GE limit: 2,000."
+description: "Antifire potion(4): 4 doses of anti-firebreath potion. High alch: 198 GP, GE limit: 2,000."
 osrs:
   id: 2452
   name: Antifire potion(4)
@@ -12,14 +12,33 @@ osrs:
   lowalch: 132
   highalch: 198
   limit: 2000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2004-03-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   potion:
-    doses: 3
-    type: protection
-    effect: dragonfire
-    duration: 360
-  herblore:
-    level: 69
-    xp: 157.5
+    doses: 4
+    herblore_level: 69
+    herblore_xp: 157.5
+    effects:
+      - description: "Provides partial dragonfire protection per dose, reducing dragon breath damage by approximately 90%."
+        duration: 360
+      - description: "Grants complete dragonfire immunity when paired with an anti-dragon shield or dragonfire shield."
+        duration: 360
   recipes:
     - skill: herblore
       level: 69
@@ -31,59 +50,61 @@ osrs:
         - item_name: Dragon scale dust
           item_id: 241
           quantity: 1
+      tools: []
       product: Antifire potion(3)
       product_id: 2452
-      product_quantity: 1
-      facility: None
-      members_only: true
+      output_quantity: 1
+      notes: "Mix Lantadyme potion (unf) with Dragon scale dust at 69 Herblore."
   related_items:
+    - item_id: 2454
+      item_name: Antifire potion(3)
+      slug: antifire-potion-3
+      relationship: variant
+      description: "3-dose variant for decanting."
+    - item_id: 2456
+      item_name: Antifire potion(2)
+      slug: antifire-potion-2
+      relationship: variant
+      description: "2-dose variant for decanting."
+    - item_id: 2458
+      item_name: Antifire potion(1)
+      slug: antifire-potion-1
+      relationship: variant
+      description: "1-dose variant for decanting."
     - item_id: 2481
       item_name: Lantadyme
       slug: lantadyme
       relationship: component
-      description: Primary herb
+      description: "Primary herb cleaned into lantadyme potion (unf)."
     - item_id: 241
       item_name: Dragon scale dust
       slug: dragon-scale-dust
       relationship: component
-      description: Secondary
+      description: "Secondary ingredient ground from blue dragon scales."
     - item_id: 11951
-      item_name: Extended antifire(3)
-      slug: extended-antifire-3
-      relationship: product
-      description: Upgrade
+      item_name: Extended antifire(4)
+      slug: extended-antifire-4
+      relationship: upgrade
+      description: "Longer-duration upgrade made by adding lava scale shards."
     - item_id: 1540
       item_name: Anti-dragon shield
       slug: anti-dragon-shield
       relationship: alternative
-      description: Full protection
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 69 |
-    | XP | 157.5 |
-    | Ingredients | Lantadyme + Dragon scale dust |
-
-    | Effect | Value |
-    |--------|-------|
-    | Dragonfire protection | Partial (slight) |
-    | With anti-dragon shield | Full immunity |
-    | Duration | 6 minutes |
+      description: "Pairs with the potion for full dragonfire immunity."
+  about: "Antifire potion(4) is a 4-dose Herblore potion that grants partial dragonfire protection for 6 minutes per dose, and full immunity when paired with an anti-dragon shield or dragonfire shield. Made at 69 Herblore by combining lantadyme potion (unf) with dragon scale dust for 157.5 XP per batch, it is a staple supply for Dragon Slayer tasks, Vorkath farming, and brutal black dragon Slayer trips."
   market_strategy:
     notes:
-      - Required for dragon tasks
-      - Partial protection alone
-      - Full protection with shield
-      - Dragon Slayer tasks
-      - Vorkath preparation
-      - Blue/black dragon farming
-      - Brutal black dragons
-      - Low buy limit (2,000)
-      - Lantadyme herb base
-      - Dragon scale dust expensive
-      - Upgrade to extended
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand peaks during Slayer dragon task surges and Vorkath farm metas."
+      - "Lantadyme + dragon scale dust spread sets a hard input floor; arbitrage when raw potions dump."
+      - "Buy limit 2,000 per 4 hours caps high-volume flipping."
+      - "Decant ratio matters: 4-dose price tracks the 3-dose tightly on a per-dose basis."
+  trading_tips:
+    - "Stock lantadyme and dragon scale dust during dragon-task metas to lock in margin on conversions."
+    - "Watch Extended antifire(4) price as the upgrade ceiling that caps base antifire highs."
+    - "Sell into Slayer reset events and Vorkath supply pushes."
+  history:
+    - date: "2004-03-29"
+      description: "Antifire potion released with the RS2 launch as the original dragonfire protection consumable."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/araxyte-venom-sack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/araxyte-venom-sack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Araxyte venom sack | OSRS Price Data
-description: "Araxyte venom sack: Looks spicy!. High alch: 300 GP, GE limit: 11,000."
+description: "Araxyte venom sack is a stackable Araxxor drop that doubles as a Herblore secondary for extended anti-venom+ and as a venom-curing snack. High alch: 300 GP, GE limit: 11,000."
 osrs:
   id: 29784
   name: Araxyte venom sack
@@ -12,12 +12,97 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
-  about: "Araxyte venom sack is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: secondary
+    tier: high
+  properties:
+    release_date: "2024-08-28"
+    update: "Araxxor"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  consumable:
+    type: food
+    effects:
+      - description: "Cures venom and poison on consumption."
+      - description: "Causes a 3-tick attack delay when eaten (combo-eat compatible with karambwans)."
+  recipes:
+    - skill: herblore
+      level: 94
+      xp: 80
+      materials:
+        - item_name: Anti-venom+(4)
+          quantity: 1
+        - item_name: Araxyte venom sack
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      product: Extended anti-venom+(4)
+      notes: "Used as the secondary on Anti-venom+ doses (1-4) at 94 Herblore to brew Extended anti-venom+ potions. XP scales 20/40/60/80 with dose count."
+  drops:
+    - source: Araxxor
+      combat_level: 890
+      quantity: "1 (always), +1 at 5/115, +2 at 2/115"
+      rarity: always
+    - source: Araxyte
+      combat_level: 96
+      quantity: "1 (always), +2 at 5/127"
+      rarity: always
+    - source: Araxyte
+      combat_level: 146
+      quantity: "1 (always), +4 at 5/127"
+      rarity: always
+    - source: Dreadborn araxyte
+      combat_level: 281
+      quantity: "1 (always), +4 at 3 x 5/127 rolls"
+      rarity: always
+  related_items:
+    - item_name: Anti-venom+(4)
+      slug: anti-venom-plus-4
+      relationship: component
+      description: "Base potion combined with the venom sack to brew Extended anti-venom+."
+    - item_name: Extended anti-venom+(4)
+      slug: extended-anti-venom-plus-4
+      relationship: product
+      description: "Resulting potion brewed using the venom sack at 94 Herblore."
+    - item_name: Araxyte fang
+      slug: araxyte-fang
+      relationship: alternative
+      description: "Other Araxxor common drop used in venom upgrade recipes."
+    - item_name: Karambwan
+      slug: cooked-karambwan
+      relationship: alternative
+      description: "Combo-eat partner for araxyte venom sack during PvM tick-eating."
+  about: "Araxyte venom sack is a venom-cleansing snack dropped in bulk by Araxxor and the araxyte family, doubling as the Herblore secondary used at 94 Herblore to brew Extended anti-venom+ potions (20-80 XP per dose). Players keep stacks for tick-eating venom in PvM, while Herblorists buy them in bulk off the GE to feed the extended anti-venom+ pipeline that gears up future Araxxor / Toxic content."
+  market_strategy:
+    notes:
+      - "Supply scales directly with Araxxor / araxyte kill rates; demand tracks anti-venom+ Herblore consumption"
+      - "Combo-eat utility in PvM keeps a steady consumer base independent of Herblore crafters"
+      - "Buy limit of 11,000 per 4 hours keeps this a high-volume bulk flip"
+      - "Price ceiling capped by Extended anti-venom+ margin - if margin compresses, sack price stalls"
+  trading_tips:
+    - "Track Extended anti-venom+ GE price as the upstream demand signal"
+    - "Bulk-buy after Araxxor farm streamer events that flood supply"
+    - "Watch venom-heavy PvM updates - new venom bosses spike combo-eat demand"
+  history:
+    - date: "2024-08-28"
+      description: "Released with the Araxxor boss update as both a venom-curing food and Herblore secondary."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ardougne-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ardougne-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ardougne teleport (tablet) | OSRS Price Data
-description: "Ardougne teleport (tablet): A teleport to East Ardougne.. High alch: 1 GP, GE limit: 10,000."
+description: "Ardougne teleport (tablet) is a members Magic tablet that breaks to teleport the user to East Ardougne. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 8011
   name: Ardougne teleport (tablet)
@@ -12,9 +12,80 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Ardougne teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: tablet
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    update: "Player-Owned Houses"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  teleport:
+    destinations:
+      - name: East Ardougne
+        type: tablet
+        members: true
+  recipes:
+    - skill: magic
+      level: 51
+      xp: 61
+      materials:
+        - item_name: Soft clay
+          quantity: 1
+        - item_name: Law rune
+          quantity: 2
+        - item_name: Water rune
+          quantity: 2
+      tools:
+        - Teak eagle lectern
+      output_quantity: 1
+      notes: "Requires Plague City completion to use the resulting teleport."
+  related_items:
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: "Tablet base material made at the lectern."
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: "Runecrafting component for the tablet."
+    - item_name: Water rune
+      slug: water-rune
+      relationship: component
+      description: "Runecrafting component for the tablet."
+    - item_name: Ardougne teleport
+      slug: ardougne-teleport
+      relationship: alternative
+      description: "Standard spellbook cast that delivers the same East Ardougne teleport."
+  about: "Ardougne teleport (tablet) is a stackable Magic tablet crafted at a teak eagle lectern or better at 51 Magic for 61 Magic XP using soft clay, 2 law runes, and 2 water runes. Breaking the tablet teleports the user to East Ardougne without requiring runes, making it a popular convenience teleport for Plague City completers running PvM, Slayer, Fight Caves prep, or Ardougne diary tasks."
+  market_strategy:
+    notes:
+      - "Steady POH crafter supply versus questing/Slayer demand keeps prices range-bound"
+      - "GE buy limit of 10,000 supports bulk merching"
+      - "High alch backstop is only 1 GP - price is purely market-driven"
+      - "Convenience-fee exemption since 29 May 2025 removed GE tax friction"
+  trading_tips:
+    - "Cross-check raw cast cost (2 law + 2 water + soft clay) versus tablet price for crafting arbitrage"
+    - "Watch Ardougne diary and Fight Caves training cycles for demand spikes"
+    - "Bulk buy when soft clay or law rune prices crash to flip tablets after restock"
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Player-Owned Houses update as a craftable Magic tablet at the eagle lectern."
+    - date: "2025-05-29"
+      description: "Exempted from Grand Exchange convenience fees alongside other standard teleport tablets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-chaps.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-chaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Armadyl chaps | OSRS Price Data
-description: "Armadyl chaps is a members legs slot item requiring 70 Ranged. High alch: 3,600 GP, GE limit: 8."
+description: "Armadyl chaps is a members blessed dragonhide legs piece requiring 70 Ranged (no Defence requirement) rewarded from hard Treasure Trails. High alch: 3,600 GP, GE limit: 8."
 osrs:
   id: 12510
   name: Armadyl chaps
@@ -12,8 +12,33 @@ osrs:
   lowalch: 2400
   highalch: 3600
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: blessed_dragonhide
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weight: 5
+    requirements:
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -31,54 +56,58 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  passive_effects:
+    - name: Armadyl alignment
+      description: "Worn in the God Wars Dungeon to prevent aggression from Armadyl-aligned followers."
+    - name: No Defence requirement
+      description: "Unlike standard black d'hide chaps, blessed dragonhide chaps require no Defence level - ideal for pures."
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        rarity: "1/1,625"
+        members_only: true
   related_items:
     - item_id: 10380
       item_name: Guthix chaps
       slug: guthix-chaps
       relationship: variant
+      description: Guthix-blessed god variant with identical stats.
     - item_id: 10372
       item_name: Zamorak chaps
       slug: zamorak-chaps
       relationship: variant
+      description: Zamorak-blessed god variant with identical stats.
     - item_id: 12502
       item_name: Bandos chaps
       slug: bandos-chaps
       relationship: variant
+      description: Bandos-blessed god variant with identical stats.
     - item_id: 12494
       item_name: Ancient chaps
       slug: ancient-chaps
       relationship: variant
+      description: Ancient-blessed god variant with identical stats.
     - item_id: 2497
       item_name: Black d'hide chaps
       slug: black-d-hide-chaps
       relationship: downgrade
-      description: Standard version requiring 40 Defence
-  about: |-
-    > *"Armadyl blessed dragonhide chaps."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +8 | +8 |
-    | Stab Defence | +17 | +17 |
-    | Slash Defence | +20 | +20 |
-    | Crush Defence | +16 | +16 |
-    | Magic Defence | +18 | +18 |
-    | Ranged Defence | +17 | +17 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    The key advantage: blessed chaps have no Defence requirement, making them ideal for pures and ranged-focused accounts. They also offer a +1 prayer bonus.
+      description: Unblessed legs with the same stats but a 40 Defence requirement.
+  about: "Armadyl chaps are the Armadyl-blessed variant of black dragonhide chaps in OSRS, released with the Treasure Trail Expansion on 12 June 2014. They share black d'hide chaps' offensive and defensive bonuses but waive the 40 Defence requirement and add a +1 prayer bonus, making them best-in-slot legs for 1-Defence ranged pures. Supply is exclusive to hard clue reward caskets at roughly 1/1,625, with Armadyl alignment providing aggression protection in the God Wars Dungeon."
   market_strategy:
     notes:
-      - Hard clue exclusive — supply tied to clue completion rates
-      - Popular with 1-Defence pures who need best-in-slot ranged legs
-      - All god variants are functionally identical
-      - Armadyl and Ancient variants tend to have slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand concentrated in 1-Defence pures, mid-level rangers, and clue-set collectors."
+      - "GE buy limit of 8 per 4 hours severely caps merchant volume."
+      - "High alch of 3,600 gp is far below GE price - never alch."
+      - "Supply tracks hard clue completion velocity - droughts can spike price quickly."
+  trading_tips:
+    - "Compare the four god variants - Armadyl and Ancient often command a small fashionscape premium."
+    - "Watch clue-rebalance patch notes - prayer bonus and DR changes have moved prices historically."
+    - "Low-limit item - small bid-ask spreads can produce respectable per-flip margin."
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion as one of four new god-aligned blessed dragonhide sets."
+    - date: "2021-09-22"
+      description: "Defence requirement removed, making the blessed chaps fully pure-accessible."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-robe-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-robe-legs.mdx
@@ -12,24 +12,95 @@ osrs:
   lowalch: 2800
   highalch: 4200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: vestment
+    tier: mid
+  properties:
+    release_date: "2014-06-12"
+    update: Treasure Trail Expansion
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.8
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: unarmed
+    attack_speed: 4
+    weight: 1.8
     requirements:
       prayer: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
     other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 5
+  drop_table:
+    sources:
+      - source: Easy Treasure Trails reward casket
+        quantity: "1"
+        rarity: 1/1404
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
     - item_id: 12253
       item_name: Armadyl robe top
       slug: armadyl-robe-top
       relationship: set-piece
-      description: Armadyl vestment body
-  about: |-
-    > *"Leggings from the Armadyl Vestments."*
-
-    The Armadyl robe legs are the legs piece of the Armadyl vestment set. They provide a +5 Prayer bonus and require 20 Prayer to equip. Counts as an Armadylean item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Vestment body companion piece
+    - item_id: 12259
+      item_name: Armadyl mitre
+      slug: armadyl-mitre
+      relationship: set-piece
+      description: Vestment headwear companion piece
+    - item_id: 12257
+      item_name: Armadyl stole
+      slug: armadyl-stole
+      relationship: set-piece
+      description: Vestment stole completing the set
+    - item_id: 12251
+      item_name: Armadyl crozier
+      slug: armadyl-crozier
+      relationship: set-piece
+      description: Vestment crozier weapon companion piece
+  about: "Armadyl robe legs are the leg piece of the Armadyl vestment set, granting a +5 Prayer bonus at 20 Prayer and counting as an Armadylean item inside the God Wars Dungeon. Like the rest of the vestments, they drop exclusively from easy clue scroll caskets and are popular Prayer-bonus fashionscape."
+  market_strategy:
+    notes:
+      - "Drops exclusively from easy clue caskets at roughly 1 in 1,404"
+      - "Buy limit of 8 keeps the market thin around clue update cycles"
+      - "Pair pricing with the rest of the set since collectors usually buy together"
+  trading_tips:
+    - Watch easy clue droprate or QoL updates for supply shocks
+    - Bundle pricing with mitre, stole, and robe top often outperforms solo flips
+  history:
+    - date: "2014-06-12"
+      description: "Released with the Treasure Trail Expansion alongside the other vestment sets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-plateskirt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bandos plateskirt | OSRS Price Data
-description: "Bandos plateskirt: Rune plateskirt in the colours of Bandos.. High alch: 38,400 GP, GE limit: 8."
+description: "Bandos plateskirt: Rune plateskirt in the colours of Bandos. High alch: 38,400 GP, GE limit: 8."
 osrs:
   id: 12484
   name: Bandos plateskirt
@@ -12,9 +12,95 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
-  about: "Bandos plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2014-06-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type:
+    weight: 9.071
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 51
+      slash: 49
+      crush: 47
+      magic: -4
+      ranged: 49
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  treasure_trail:
+    tier: hard
+    obtainable: true
+    rarity: "1/1625"
+    notes: "Reward from hard Treasure Trails clue caskets."
+  related_items:
+    - item_id: 12482
+      item_name: Bandos platebody
+      slug: bandos-platebody
+      relationship: set-piece
+      description: "Matching Bandos cosmetic body piece."
+    - item_id: 12486
+      item_name: Bandos full helm
+      slug: bandos-full-helm
+      relationship: set-piece
+      description: "Matching Bandos cosmetic helm."
+    - item_id: 12488
+      item_name: Bandos kiteshield
+      slug: bandos-kiteshield
+      relationship: set-piece
+      description: "Matching Bandos cosmetic shield."
+    - item_id: 1093
+      item_name: Rune plateskirt
+      slug: rune-plateskirt
+      relationship: variant
+      description: "Mechanically identical untrimmed base item."
+    - item_id: 12490
+      item_name: Zamorak plateskirt
+      slug: zamorak-plateskirt
+      relationship: variant
+      description: "Alternate god-aligned cosmetic variant."
+  about: "Bandos plateskirt is a free-to-play melee leg slot armour with identical defensive stats to a standard rune plateskirt, dyed in the green colours of Bandos. Requiring 40 Defence to wear, it offers a +1 prayer bonus on top of rune-tier defence. It is obtained exclusively from hard Treasure Trail clue caskets at roughly 1/1,625 rarity, which keeps GE supply scarce and locks the price well above the rune plateskirt floor."
+  market_strategy:
+    notes:
+      - "Cosmetic god-aligned variant of rune plateskirt; price dominated by clue-scroll rarity not combat utility."
+      - "Hard clue rarity of 1/1,625 keeps supply thin; price tracks hard clue popularity."
+      - "Low GE buy limit (8) caps daily flip volume but lifts thin-order arbitrage."
+      - "+1 prayer bonus is a marginal premium over standard rune plateskirt."
+  trading_tips:
+    - "Track hard clue scroll demand and Master clue chains that funnel hard caskets into the GE."
+    - "Buy on dumps from clue-meta events; sell into fashionscape spikes when god-aligned cosmetics trend."
+    - "Compare to Zamorak and Saradomin plateskirt variants for relative fashionscape pricing."
+  history:
+    - date: "2014-06-12"
+      description: "Bandos plateskirt added as a hard Treasure Trail reward alongside the god-themed rune cosmetic family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/barracuda-paint.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/barracuda-paint.mdx
@@ -1,6 +1,6 @@
 ---
 title: Barracuda paint | OSRS Price Data
-description: "Barracuda paint: A light blue paint. This might look good on a boat.. High alch: 1 GP."
+description: "Barracuda paint is a Sailing cosmetic boat-trim paint earned from Marlin-rank Barracuda Trials; applied at 25 Sailing and 20 Construction. High alch: 1 GP."
 osrs:
   id: 32087
   name: Barracuda paint
@@ -11,10 +11,66 @@ osrs:
   value: 1
   lowalch: 1
   highalch: 1
-  limit: null
-  about: "Barracuda paint is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  effects:
+    - skill: Construction
+      boost: 10
+      type: xp
+      description: Grants 10 Construction XP per application to a boat.
+  passive_effects:
+    - name: Boat trim recolour
+      description: "Applied at the Shipyard schematics board to recolour the trim of a player-owned skiff (1 paint) or sloop (2 paints) light blue."
+  drop_table:
+    sources:
+      - source: The Tempor Tantrum (Marlin-rank target time)
+        rarity: "1/240"
+        members_only: true
+      - source: The Jubbly Jive (Marlin-rank target time)
+        rarity: "1/220"
+        members_only: true
+      - source: The Gwenith Glide (Marlin-rank target time)
+        rarity: "1/400"
+        members_only: true
+  related_items:
+    - item_id: 32088
+      item_name: Merchant's paint
+      slug: merchants-paint
+      relationship: alternative
+      description: Tradeable paint received by handing Trader Stan a set of paint variants including Barracuda paint.
+  about: "Barracuda paint is a Sailing-skill cosmetic paint released with the Sailing update on 19 November 2025. It is a rare reward from Marlin-rank Barracuda Trials (Tempor Tantrum 1/240, Jubbly Jive 1/220, Gwenith Glide 1/400) and is applied at the Shipyard schematics board to recolour a player skiff or sloop trim light blue. Application requires 25 Sailing and 20 Construction and grants 10 Construction XP per use; alternatively it can be traded to Trader Stan with four other paint variants to obtain merchant's paint."
+  market_strategy:
+    notes:
+      - "Item is untradeable - no GE market and no buy limit applies."
+      - "High alch return of 1 gp - never an alch target."
+      - "Effective acquisition cost is hours of Marlin-rank Trial runs, not coins."
+      - "Demand sits with cosmetic boat builders and Trader Stan paint-set completionists."
+  trading_tips:
+    - "Untradeable - cannot be bought or sold on the GE; obtain via Trials directly."
+    - "Track Sailing balance patches - Trial drop rates have historically moved post-launch."
+    - "Hold one copy if you plan to chase merchant's paint via Trader Stan exchange."
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the Sailing skill launch as a Marlin-rank Barracuda Trial reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-kiteshield-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-kiteshield-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black kiteshield (g) | OSRS Price Data
-description: "Black kiteshield (g) is a F2P shield slot item requiring 10 Defence. High alch: 979 GP, GE limit: 8."
+description: "Black kiteshield (g) is a F2P gold-trimmed kiteshield requiring 10 Defence, obtained from easy Treasure Trails reward caskets. High alch: 979 GP, GE limit: 8."
 osrs:
   id: 2597
   name: Black kiteshield (g)
@@ -12,25 +12,87 @@ osrs:
   lowalch: 652
   highalch: 979
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2004-05-05"
+    update: "Bigger Banks & Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
+    weapon_type: shield
+    weight: 5.443
     requirements:
       defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -8
+      ranged: -3
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 18
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   related_items:
     - item_id: 2589
       item_name: Black kiteshield (t)
       slug: black-kiteshield-t
       relationship: variant
-      description: Trimmed variant
-  about: |-
-    > *"Black kiteshield with gold trim."*
-
-    The black kiteshield (g) is a gold-trimmed cosmetic variant of the standard black kiteshield. Identical stats, requiring 10 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Trimmed cosmetic variant with identical stats from easy clue caskets."
+    - item_id: 1195
+      item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: variant
+      description: "Standard untrimmed black kiteshield with the same stats."
+    - item_id: 2599
+      item_name: Adamant kiteshield (g)
+      slug: adamant-kiteshield-g
+      relationship: upgrade
+      description: "Next-tier gold-trimmed kiteshield with stronger defensive bonuses."
+  about: "Black kiteshield (g) is the gold-trimmed cosmetic variant of the standard black kiteshield, awarded from easy Treasure Trails reward caskets at roughly 1/1,404. It carries the same combat stats as the base shield, requires 10 Defence to wield, and is one of the few F2P clue rewards usable on free worlds, making it a budget cosmetic flex for low-level PKers and clue enthusiasts."
+  market_strategy:
+    notes:
+      - "GE buy limit of 8 per 4 hours keeps daily flips tight."
+      - "Supply is bottlenecked by easy clue completion rates - rises during DMM/Leagues lulls when clue grinders multiply."
+      - "Demand spikes around free-trade or F2P PK events where gold trims show off without member gear."
+      - "High alch of 979 gp is far below GE price; never alch."
+  trading_tips:
+    - "Watch easy clue casket droprate threads for supply surges after major QoL changes."
+    - "Pair flips with other easy-clue gold trims (Black platelegs (g), Black platebody (g)) for set-piece arbitrage."
+    - "Hold through Leagues launches - clue activity falls, supply tightens."
+  history:
+    - date: "2004-05-05"
+      description: "Released in the Bigger Banks & Treasure Trails update as an easy clue reward casket drop."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus decreased from -2 to -3 in a wide armor rebalance pass."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-mace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-mace.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black mace | OSRS Price Data
-description: "Black mace is a F2P weapon slot item requiring 10 Attack. High alch: 259 GP, GE limit: 125."
+description: "Black mace is a F2P one-handed crush weapon with +2 prayer bonus requiring 10 Attack. High alch: 259 GP, GE limit: 125."
 osrs:
   id: 1426
   name: Black mace
@@ -12,44 +12,96 @@ osrs:
   lowalch: 172
   highalch: 259
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: black
+    tier: low
+  properties:
+    release_date: "2001-09-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: mace
-    tradeable: true
+    weapon_type: mace
+    attack_speed: 5
+    attack_range: 1
     weight: 1.814
     requirements:
       attack: 10
-    stats:
-      attack_stab: 8
-      attack_slash: -2
-      attack_crush: 16
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 13
+    attack_bonus:
+      stab: 8
+      slash: -2
+      crush: 16
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 13
       ranged_strength: 0
       magic_damage: 0
       prayer: 2
+  drop_table:
+    sources:
+      - source: Skeleton
+        quantity: "1"
+        rarity: Uncommon
+      - source: Hobgoblin
+        quantity: "1"
+        rarity: Uncommon
+      - source: Ice warrior
+        quantity: "1"
+        rarity: Uncommon
   related_items:
-    - item_id: 1428
-      item_name: Mithril mace
+    - item_name: Steel mace
+      slug: steel-mace
+      relationship: downgrade
+      description: "Lower-tier steel variant with weaker crush bonus"
+    - item_name: Mithril mace
       slug: mithril-mace
       relationship: upgrade
-      description: Higher tier mace
-    - item_id: 1341
-      item_name: Black warhammer
+      description: "Higher-tier mithril variant requiring 20 Attack"
+    - item_name: Black warhammer
       slug: black-warhammer
       relationship: alternative
-      description: Higher strength alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Two-handed crush alternative at the same tier with no prayer bonus"
+    - item_name: Black scimitar
+      slug: black-scimitar
+      relationship: alternative
+      description: "One-handed slash alternative at the same tier"
+  about: "Black mace is a free-to-play one-handed crush weapon requiring 10 Attack. It cannot be smithed and is only obtained from monster drops, shops, or trade. The +2 prayer bonus makes it a popular budget weapon for low-level prayer-flicking in F2P training spots like Stronghold of Security and the Lumbridge graveyard."
+  market_strategy:
+    notes:
+      - "F2P prayer bonus weapon - niche but consistent demand"
+      - "Shop stock keeps the floor close to the 432 gp value"
+      - "Low volume per 4 hours caps bulk flipping upside"
+  trading_tips:
+    - "Watch for spikes around F2P Combat events and ironman PvP weekends"
+    - "Compare against the smithable mithril mace - players may switch tiers based on spread"
+  history:
+    - date: "2001-09-11"
+      description: "Released alongside the rest of the black weapon tier."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-platebody-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black platebody (g) | OSRS Price Data
-description: "Black platebody (g) is a F2P body slot item requiring 10 Defence. High alch: 2,304 GP, GE limit: 8."
+description: "Black platebody (g) is a gold-trimmed cosmetic black platebody from easy clue scrolls, identical in stats to the standard black platebody and requiring 10 Defence. High alch: 2,304 GP, GE limit: 8."
 osrs:
   id: 2591
   name: Black platebody (g)
@@ -12,36 +12,99 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: black
+    tier: mid
+  properties:
+    release_date: "2004-05-05"
+    update: "Bigger Banks & Treasure Trails"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type: platebody
+    weight: 9.979
     requirements:
       defence: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     defence_bonus:
       stab: 41
       slash: 40
       crush: 30
       magic: -6
-      ranged: 40
+      ranged: -15
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drops:
+    - source: Easy clue scroll reward casket
+      rarity: 1/1404
+      notes: "Standard easy clue casket loot; exclusive to clue rewards (cannot be smithed)."
   related_items:
-    - item_id: 2593
-      item_name: Black platelegs (g)
-      slug: black-platelegs-g
-      relationship: set-piece
-      description: Matching gold-trimmed platelegs
+    - item_id: 2589
+      item_name: Black platebody
+      slug: black-platebody
+      relationship: variant
+      description: "Standard untrimmed black platebody with identical stats."
     - item_id: 2583
       item_name: Black platebody (t)
       slug: black-platebody-t
       relationship: variant
-      description: Trimmed variant
-  about: |-
-    > *"Black platebody with gold trim."*
-
-    The black platebody (g) is a gold-trimmed cosmetic variant of the standard black platebody. Identical stats, requiring 10 Defence. Clue scroll exclusive. More prestigious appearance than the trimmed variant.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "White-trimmed variant from easy clue scrolls."
+    - item_id: 2593
+      item_name: Black platelegs (g)
+      slug: black-platelegs-g
+      relationship: set-piece
+      description: "Matching gold-trimmed platelegs from easy clue rewards."
+    - item_id: 2587
+      item_name: Black full helm (g)
+      slug: black-full-helm-g
+      relationship: set-piece
+      description: "Matching gold-trimmed full helm from easy clue rewards."
+    - item_id: 2595
+      item_name: Black kiteshield (g)
+      slug: black-kiteshield-g
+      relationship: set-piece
+      description: "Matching gold-trimmed kiteshield from easy clue rewards."
+  about: "Black platebody (g) is the gold-trimmed cosmetic variant of the standard black platebody, awarded only as a 1/1,404 reward from easy clue scroll caskets. It carries identical 41/40/30 stab/slash/crush defence stats to the standard piece (no Strength or Prayer bonuses) and a 10 Defence requirement, so it is purely a Treasure Trails fashionscape and costume room piece for F2P clue hunters."
+  market_strategy:
+    notes:
+      - "Pure cosmetic - price tracks easy clue completion rates, not combat utility"
+      - "GE buy limit of 8 per 4 hours keeps spreads thin"
+      - "Costume room storage acts as a permanent supply sink"
+      - "Set-piece bundles (g full helm + platelegs + kiteshield) trade at a premium versus single pieces"
+  trading_tips:
+    - "Build the full (g) set in one buy window - bundle resale carries a 10-20% set premium"
+    - "Avoid longs ahead of easy clue rebalances - new reward additions dilute (g) drop weight"
+    - "Watch costume room popularity - fashionscape metas push demand seasonally"
+  history:
+    - date: "2004-05-05"
+      description: "Released with the Bigger Banks & Treasure Trails update as a clue-exclusive cosmetic variant."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-wizard-hat-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-wizard-hat-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black wizard hat (t) | OSRS Price Data
-description: "Black wizard hat (t) is a F2P head slot item. High alch: 1 GP, GE limit: 4."
+description: "Black wizard hat (t) is a F2P trimmed wizard hat reward from easy Treasure Trails, +2 magic attack and defence with no requirements. High alch: 1 GP, GE limit: 4."
 osrs:
   id: 12455
   name: Black wizard hat (t)
@@ -12,25 +12,86 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weight: 0.453
     requirements: {}
     attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
+      ranged: 0
     defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
       magic: 2
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        quantity: "1"
+        rarity: "1/1,404"
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
   related_items:
-    - item_id: 12451
+    - item_id: 12453
       item_name: Black wizard robe (t)
       slug: black-wizard-robe-t
       relationship: set-piece
-      description: Matching trimmed wizard robe
-  about: |-
-    > *"A silly pointed hat, with colourful trim."*
-
-    The black wizard hat (t) is a trimmed cosmetic variant of the wizard hat. It provides +2 magic attack and defence with no requirements. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching trimmed black wizard robe."
+    - item_id: 1015
+      item_name: Black wizard hat
+      slug: black-wizard-hat
+      relationship: alternative
+      description: "Untrimmed black wizard hat variant."
+    - item_id: 2635
+      item_name: Wizard hat (t)
+      slug: wizard-hat-t
+      relationship: alternative
+      description: "Blue trimmed wizard hat counterpart from the same clue tier."
+  about: "Black wizard hat (t) is a free-to-play trimmed cosmetic variant of the black wizard hat distributed as a 1/1,404 reward from easy reward caskets. It provides the same +2 magic attack and defence as the regular wizard hat with no requirements, and serves primarily as a wealth-signalling cosmetic for low-level mages and rare-item collectors."
+  market_strategy:
+    notes:
+      - "Supply is entirely easy clue casket pulls - thin and inconsistent."
+      - "GE buy limit of 4 per 4 hours throttles accumulation."
+      - "High alch of 1 gp is irrelevant; never alch trim-tier rares."
+      - "Demand is collector-driven; F2P access broadens the buyer pool slightly vs members-only trims."
+  trading_tips:
+    - "Watch easy clue meta shifts (Hill Giants, Implings) that bump casket throughput."
+    - "Cross-reference Black wizard robe (t) - set buyers move both together."
+    - "Treat as a slow flip - thin volume rewards patience, not active merchant churn."
+  history:
+    - date: "2014-06-12"
+      description: "Added as part of the Treasure Trail Expansion update, distributed via easy reward caskets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bloody-bracer.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bloody-bracer.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bloody bracer | OSRS Price Data
-description: "Bloody bracer: A coagulated concoction.. High alch: 6 GP, GE limit: 2,000."
+description: "Bloody bracer is a members Morytania tincture from the Rat & Bat that overheals once and drains Prayer on drink. High alch: 6 GP, GE limit: 2,000."
 osrs:
   id: 22430
   name: Bloody bracer
@@ -12,9 +12,64 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 2000
-  about: "Bloody bracer is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: tincture
+    tier: low
+  properties:
+    release_date: "2018-05-24"
+    update: "A Taste of Hope"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.55
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  obtaining:
+    methods:
+      - source: Rat & Bat pub (Slepe)
+        price: 99
+        description: "Purchasable from the Rat & Bat in Slepe for 99 coins after starting A Taste of Hope."
+  passive_effects:
+    - name: Overheal proc
+      description: "May heal you above your maximum Hitpoints once per drink, restoring 2 Hitpoints."
+    - name: Prayer drain
+      description: "Drains Prayer by 4% + 2 points on consumption, making it a risk/reward sip."
+  related_items:
+    - item_name: Blood pint
+      slug: blood-pint
+      relationship: alternative
+      description: "Other A Taste of Hope tincture sold at the Rat & Bat in Slepe."
+    - item_name: Bloody bracer (m)
+      slug: bloody-bracer-m
+      relationship: variant
+      description: "Mature variant of the tincture - only obtainable as drop, untradeable."
+  about: "Bloody bracer is a members-only Morytania tincture introduced with A Taste of Hope (24 May 2018), sold for 99 gp from the Rat & Bat pub in Slepe. Drinking it restores 2 Hitpoints (with a chance to overheal above max once) at the cost of 4% + 2 Prayer points - a niche overheal sipper used in some Vampyre and Morytania combat strategies but otherwise low-traffic."
+  market_strategy:
+    notes:
+      - "Player supply is gated by Rat & Bat shop visits and 99 gp base buy"
+      - "Buy limit of 2,000 caps merch volume per 4 hours"
+      - "Niche overheal demand from PvM theorycrafters keeps the price floating well above buy cost"
+      - "High alch backstop is only 6 gp - price purely market-driven"
+  trading_tips:
+    - "Compare GE price to 99 gp shop buy when planning bulk flips"
+    - "Demand sometimes spikes around Vampyre Slayer task changes"
+    - "Steady low-volume flip; not a primary profit driver"
+  history:
+    - date: "2018-05-24"
+      description: "Released with the A Taste of Hope quest and Slepe town content."
+    - date: "2018-05-31"
+      description: "Shop value reduced to 2 coins."
+    - date: "2024-03-20"
+      description: "Shop value adjusted to 10 coins."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-boater.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blue boater | OSRS Price Data
-description: "Blue boater: Stylish!. High alch: 135 GP, GE limit: 4."
+description: "Blue boater is a members head-slot cosmetic hat from medium clue scrolls with no stats and no Defence requirement. High alch: 135 GP, GE limit: 4."
 osrs:
   id: 7325
   name: Blue boater
@@ -12,12 +12,106 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "Blue boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: hat
+    weight: 0.01
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drops:
+    - source: Medium clue scroll reward casket
+      rarity: 1/1133
+      notes: "Standard medium clue casket loot; one of eight boater colour rolls."
+  related_items:
+    - item_id: 7327
+      item_name: Red boater
+      slug: red-boater
+      relationship: variant
+      description: "Red colour variant from medium clue scrolls."
+    - item_id: 7329
+      item_name: Orange boater
+      slug: orange-boater
+      relationship: variant
+      description: "Orange colour variant from medium clue scrolls."
+    - item_id: 7331
+      item_name: Green boater
+      slug: green-boater
+      relationship: variant
+      description: "Green colour variant from medium clue scrolls."
+    - item_id: 7321
+      item_name: Black boater
+      slug: black-boater
+      relationship: variant
+      description: "Black colour variant from medium clue scrolls."
+    - item_id: 12309
+      item_name: Pink boater
+      slug: pink-boater
+      relationship: variant
+      description: "Pink colour variant from medium clue scrolls."
+    - item_id: 12311
+      item_name: Purple boater
+      slug: purple-boater
+      relationship: variant
+      description: "Purple colour variant from medium clue scrolls."
+    - item_id: 12313
+      item_name: White boater
+      slug: white-boater
+      relationship: variant
+      description: "White colour variant from medium clue scrolls."
+  about: "Blue boater is one of the eight boater colour variants awarded from medium clue scroll caskets at a 1/1,133 drop rate, with no stats, no Defence requirement, and a tiny 0.01 kg weight. It serves purely as a fashionscape head-slot piece - storable in the costume room treasure chest - and pairs well with the matching boater set for collectors completing their clue cosmetics."
+  market_strategy:
+    notes:
+      - "Pure cosmetic - price tracks medium clue completion rates and boater fashionscape demand"
+      - "Tiny buy limit of 4 per 4 hours makes large repositioning slow"
+      - "Costume room storage and account collectors permanently sink supply"
+      - "Cross-colour pricing varies - rarer colour drops command premium when fashionscape trends shift"
+  trading_tips:
+    - "Track boater colour pricing across the full 8-piece set to spot mispriced colours"
+    - "Stockpile during medium clue rework speculation - reward table tweaks shift drop weights"
+    - "Avoid buying above the high alch * 20 rule of thumb for cosmetics - downside is illiquidity"
+  history:
+    - date: "2006-02-20"
+      description: "Released as one of the original boater colour rewards from medium clue scrolls."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blue boots | OSRS Price Data
-description: "Blue boots is a members feet slot item. High alch: 120 GP, GE limit: 150."
+description: "Blue boots is a members feet slot cosmetic item from the gnome clothing line. High alch: 120 GP, GE limit: 150."
 osrs:
   id: 630
   name: Blue boots
@@ -12,20 +12,84 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2003-04-29"
+    update: "Gnome Stronghold"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: feet
+    weight: 0.4
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Gnome Stronghold Clothes Shop"
+      location: Tree Gnome Stronghold
+      price: 200
+      currency: coins
+      notes: "Sold by Heckel Funch alongside the rest of the gnome cosmetic line."
   related_items:
     - item_id: 640
       item_name: Blue robe top
       slug: blue-robe-top
       relationship: set-piece
-      description: Matching top
+      description: Matching gnome top in the blue colour scheme.
+    - item_id: 636
+      item_name: Blue hat
+      slug: blue-hat
+      relationship: set-piece
+      description: Headwear option from the gnome cosmetic line.
+    - item_name: Red boots
+      slug: red-boots
+      relationship: alternative
+      description: Red colour variant of the gnome boots.
   about: |-
-    > _"A pair of blue boots."_
+    Blue boots are a cosmetic feet-slot item sold by Heckel Funch in the Tree Gnome Stronghold Clothes Shop. They provide no combat bonuses and are worn purely for fashion alongside other gnome clothing pieces.
 
-    Blue boots are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Blue boots are part of the wider gnome cosmetic line that includes robe tops, hats, and skirts in several colours.
+  market_strategy:
+    notes:
+      - "Demand is purely cosmetic and from fashionscape collectors."
+      - "Shop supply at the Tree Gnome Stronghold keeps prices near alch value."
+      - "GE limit of 150 enables modest bulk flips during fashionscape events."
+  trading_tips:
+    - "Restock from Heckel Funch when GE prices spike above 200 coins."
+    - "Bundle with matching gnome tops and hats for resale to fashionscape players."
+  history:
+    - date: "2003-04-29"
+      description: "Released with the Tree Gnome Stronghold and gnome cosmetic line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-crab.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-crab.mdx
@@ -1,6 +1,6 @@
 ---
 title: Blue crab | OSRS Price Data
-description: "Blue crab: You'll need something to break through that shell.. High alch: 75 GP."
+description: "Blue crab is an untradeable raw catch from Varlamore's Sunset Coast fishing spots, cracked open for blue crab meat. High alch: 75 GP."
 osrs:
   id: 31674
   name: Blue crab
@@ -11,10 +11,74 @@ osrs:
   value: 125
   lowalch: 50
   highalch: 75
-  limit: null
-  about: "Blue crab is a members-only item in Old School RuneScape. High alchemy value: 75 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: raw-food
+    tier: mid
+  properties:
+    release_date: "2024-09-25"
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Crack
+      - Drop
+    destroy: "Drop"
+  skilling_sources:
+    - skill: fishing
+      level: 79
+      xp: 100
+      tool: Crab claw
+      location: Sunset Coast (Varlamore)
+      method: "Crab pot - catches Varlamore blue crabs"
+      members_only: true
+  recipes:
+    - skill: cooking
+      level: 84
+      xp: 215
+      tools:
+        - Hammer
+      materials:
+        - item_id: 31674
+          item_name: Blue crab
+          quantity: 1
+      product: Blue crab meat
+      output_quantity: 1
+      notes: "Crack the shell open with a hammer to extract raw blue crab meat for cooking"
+  related_items:
+    - item_name: Blue crab meat
+      slug: blue-crab-meat
+      relationship: product
+      description: Raw meat extracted by cracking the blue crab shell
+    - item_name: Cooked blue crab meat
+      slug: cooked-blue-crab-meat
+      relationship: product
+      description: Cooked blue crab meat, a Varlamore food healing roughly 16 HP
+    - item_id: 7944
+      item_name: Monkfish
+      slug: monkfish
+      relationship: alternative
+      description: Comparable mid-tier fishing target for XP/hr
+  market_strategy:
+    notes:
+      - "Untradeable; market only meaningful via meat/cooked outputs"
+      - "Sunset Coast spots are an XP/hr Fishing meta in Varlamore"
+      - "Crack with a hammer immediately to extract meat for cooking XP"
+      - "Stockpile cooked blue crab meat for combat food on alt accounts"
+  trading_tips:
+    - Always carry a hammer at Sunset Coast to convert crabs into meat in-place
+    - Pair Fishing trips with Cooking turn-ins for double XP value
+    - Compare cooked blue crab healing vs sharks before substituting in combat
+  about: Blue crab is a Varlamore raw fishing catch from the Sunset Coast crab pots, requiring 79 Fishing. It must be cracked open with a hammer to yield blue crab meat, which is then cooked at 84 Cooking.
+  history:
+    - date: "2024-09-25"
+      description: "Released as part of the Varlamore - The Final Dawn expansion with new Sunset Coast Fishing content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bottled-dragonbreath.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bottled-dragonbreath.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bottled dragonbreath | OSRS Price Data
-description: "Bottled dragonbreath is a members-only OSRS item. High alch: 300 GP, GE limit: 50."
+description: "Bottled dragonbreath is a Mount Karuulm-charged vial of dragonfruit used as a secondary in the dragonfire-related Herblore line. High alch: 300 GP, GE limit: 50."
 osrs:
   id: 23002
   name: Bottled dragonbreath
@@ -12,9 +12,71 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 50
-  about: "Bottled dragonbreath is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: ingredient
+    tier: mid
+  properties:
+    release_date: "2019-01-10"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.02
+    options:
+      - Drink
+      - Drop
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 85
+      xp: 175
+      facility: Mount Karuulm
+      materials:
+        - item_id: 22998
+          item_name: Dragonfruit
+          quantity: 4
+        - item_id: 229
+          item_name: Vial
+          quantity: 1
+      product: Bottled dragonbreath
+      product_id: 23002
+      output_quantity: 1
+      members: true
+      notes: "Created at Mount Karuulm by squeezing dragonfruit into a vial above the forge fires"
+  related_items:
+    - item_id: 22998
+      item_name: Dragonfruit
+      slug: dragonfruit
+      relationship: component
+      description: Tropical fruit grown at level 81 Farming, four are needed per vial
+    - item_id: 229
+      item_name: Vial
+      slug: vial
+      relationship: component
+      description: Empty vial container required to bottle the dragonbreath
+    - item_name: Antifire potion
+      slug: antifire-potion
+      relationship: alternative
+      description: Standard dragonfire mitigation potion using dragon scale dust
+  market_strategy:
+    notes:
+      - "Buy limit only 50 per 4 hours — niche, low liquidity"
+      - "Demand driven by ironmen finishing the dragonfruit Farming chain"
+      - "Mount Karuulm crafting requires access to Kourend"
+      - "Track GE price against 4x dragonfruit + vial cost for margin"
+      - "High alch is barely break-even after nature rune cost"
+  trading_tips:
+    - Compare against dragonfruit price plus a vial to spot crafting arbitrage
+    - Stock up before Mount Karuulm-themed events or Herblore reworks
+    - Use Mount Karuulm Farming Guild lift to fast-travel for production
+  about: Bottled dragonbreath is a vial of charged dragonfruit juice produced at Mount Karuulm. It is used as a Herblore secondary tied to the dragonfruit Farming chain and the broader Kourend production loop.
+  history:
+    - date: "2019-01-10"
+      description: "Released alongside the Mount Karuulm slayer dungeon and dragonfruit Farming content in the Kebos expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broken-bark-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broken-bark-snelm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Broken bark snelm | OSRS Price Data
-description: "Broken bark snelm: An orange and bark coloured snail shell helmet.. High alch: 180 GP, GE limit: 150."
+description: "Broken bark snelm: An orange and bark coloured snail shell helmet. High alch: 180 GP, GE limit: 150."
 osrs:
   id: 3335
   name: Broken bark snelm
@@ -12,9 +12,84 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Broken bark snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: snail-shell
+    tier: low
+  properties:
+    release_date: "2004-10-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -3
+      ranged: -1
+    defence_bonus:
+      stab: 7
+      slash: 8
+      crush: 6
+      magic: -1
+      ranged: 7
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 15
+      xp: 32.5
+      materials:
+        - item_name: Blamish bark shell
+          quantity: 1
+        - item_name: Chisel
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+  related_items:
+    - item_name: Blamish bark shell
+      slug: blamish-bark-shell
+      relationship: component
+      description: "Raw shell harvested from Bark Blamish snails before crafting"
+    - item_name: Broken myre snelm
+      slug: broken-myre-snelm
+      relationship: variant
+      description: "Alternative snelm variant crafted from a different snail shell"
+    - item_name: Broken bark helm
+      slug: broken-bark-helm
+      relationship: alternative
+      description: "Pointed snelm shape; broken bark variant lacks the pointed option"
+  about: "The broken bark snelm is a low-tier members-only helmet crafted at 15 Crafting from a Blamish bark shell. Worn for snail damage reduction in Mort Myre during Nature Spirit and related slayer activities, it offers modest melee and ranged defence with small magic and ranged attack penalties, sitting well below leather coif in mainstream ranged gear."
+  market_strategy:
+    notes:
+      - "Demand is niche, tied to Nature Spirit prep and Mort Myre snail tasks"
+      - "Crafting supply outpaces buys, keeping price close to high-alch value"
+      - "Unattractive for alch flipping due to thin spread above 180 gp"
+  trading_tips:
+    - "Buy on slayer-task spikes when snail blocks come up in rotation"
+    - "Keep restock volume low, GE limit of 150 caps any flip upside"
+  history:
+    - date: "2004-10-14"
+      description: "Released alongside the Nature Spirit quest and Mort Myre snail content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow-p-5622.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow-p-5622.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze arrow(p++) | OSRS Price Data
-description: "Bronze arrow(p++): Venomous-looking arrows.. High alch: 1 GP, GE limit: 7,000."
+description: "Bronze arrow(p++): Venomous-looking arrows. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 5622
   name: Bronze arrow(p++)
@@ -12,9 +12,117 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Bronze arrow(p++) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2005-02-23"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: ammo
+    weapon_type: thrown
+    weight: 0.0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 7
+      magic_damage: 0
+      prayer: 0
+  ammunition:
+    type: arrow
+    tier: bronze
+    ranged_strength: 7
+    enchanted: false
+    proc_rate_pvm: 1.0
+    proc_rate_pvp: 1.0
+    compatible_weapons:
+      - Shortbow
+      - Longbow
+      - Oak shortbow
+      - Oak longbow
+      - Crystal bow
+  passive_effects:
+    - name: Poison++
+      description: "Has a chance on hit to apply the enhanced poison (++) damage-over-time effect for 6 damage per tick."
+      trigger: on_hit
+  recipes:
+    - skill: fletching
+      level: 0
+      xp: 0
+      materials:
+        - item_id: 882
+          item_name: Bronze arrow
+          quantity: 1
+        - item_id: 5940
+          item_name: Weapon poison++
+          quantity: 1
+      product: Bronze arrow(p++)
+      product_id: 5622
+      output_quantity: 1
+      notes: "Use Weapon poison++ on a stack of bronze arrows to upgrade to the (p++) variant."
+  related_items:
+    - item_id: 882
+      item_name: Bronze arrow
+      slug: bronze-arrow
+      relationship: variant
+      description: "Base unpoisoned bronze arrow."
+    - item_id: 883
+      item_name: Bronze arrow(p)
+      slug: bronze-arrow-p
+      relationship: variant
+      description: "Standard poisoned variant."
+    - item_id: 5616
+      item_name: Bronze arrow(p+)
+      slug: bronze-arrow-p-5616
+      relationship: variant
+      description: "Stronger poisoned variant."
+    - item_id: 5623
+      item_name: Iron arrow(p++)
+      slug: iron-arrow-p-5623
+      relationship: upgrade
+      description: "Next-tier poisoned arrow."
+  about: "Bronze arrow(p++) is the enhanced-poison variant of the bronze arrow, the lowest-tier standard arrow in Old School RuneScape. Applying the strongest tier of weapon poison on hit, it is a niche PvP and Slayer ammunition mostly traded for poison-stack flips rather than DPS."
+  market_strategy:
+    notes:
+      - "Niche PvP poison-stack ammunition; demand thin compared to mid-tier arrows."
+      - "Supply driven by players burning Weapon poison++ on bulk bronze arrows."
+      - "Buy limit 7,000 per 4 hours scales easily for bulk fletchers."
+      - "1 gp alch means no alch route; spread-only profit."
+  trading_tips:
+    - "Track Weapon poison++ price as the dominant input cost."
+    - "Sell into Bounty Hunter / DMM windows for the widest spreads."
+    - "Bulk-buy on weekday dumps; flip into PvP-event weekends."
+  history:
+    - date: "2005-02-23"
+      description: "Bronze arrow(p++) released alongside the Weapon poison++ Herblore recipe."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-arrow-p.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze arrow(p) | OSRS Price Data
-description: "Bronze arrow(p) is a members ammo slot item. High alch: 1 GP, GE limit: 7,000."
+description: "Bronze arrow(p) is a stackable basic-poison ammo variant of the bronze arrow with +7 ranged strength, usable in any bow that accepts bronze arrows. High alch: 1 GP, GE limit: 7,000."
 osrs:
   id: 883
   name: Bronze arrow(p)
@@ -12,19 +12,105 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    ranged_strength: 7
-  related_items: []
-  about: |-
-    > _"Bronze arrows with a poisoned tip."_
-
-    Bronze arrows tipped with basic weapon poison. Poison deals 2-4 damage over time. Usable with any bow.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    weapon_type: arrow
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 7
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Weapon Poison
+      description: "Basic weapon poison; 2-4 venomous damage over time on a successful hit (members worlds only)."
+  recipes:
+    - skill: herblore
+      level: 5
+      xp: 0
+      materials:
+        - item_name: Bronze arrow
+          quantity: 5
+        - item_name: Weapon poison
+          quantity: 1
+      tools: []
+      output_quantity: 5
+      notes: "Use a vial of Weapon poison on a stack of bronze arrows (5 per dose) to apply the (p) tip."
+  related_items:
+    - item_id: 882
+      item_name: Bronze arrow
+      slug: bronze-arrow
+      relationship: variant
+      description: "Standard untipped bronze arrow."
+    - item_id: 5616
+      item_name: Bronze arrow(p+)
+      slug: bronze-arrow-p-plus
+      relationship: variant
+      description: "Stronger weapon poison(+) variant."
+    - item_id: 5622
+      item_name: Bronze arrow(p++)
+      slug: bronze-arrow-p-plus-plus
+      relationship: variant
+      description: "Strongest weapon poison(++) variant."
+    - item_name: Weapon poison
+      slug: weapon-poison
+      relationship: component
+      description: "Herblore-brewed poison applied to bronze arrows to create the (p) tip."
+    - item_name: Shortbow
+      slug: shortbow
+      relationship: alternative
+      description: "Lowest-tier bow that fires bronze arrows."
+  about: "Bronze arrow(p) is the basic-poison variant of the bronze arrow, made by applying a vial of Weapon poison to a stack of 5 bronze arrows. It keeps the +7 ranged strength of the base arrow and adds a 2-4 damage poison hit-over-time on successful shots in members worlds, but is rarely used in practice since stronger poison tiers (p+/p++) and any higher arrow tier outclass it for both training and combat."
+  market_strategy:
+    notes:
+      - "Almost zero combat demand - players poison their own arrows in bulk"
+      - "Value-locked at 1 gp floor; high alch yields 1 gp so it cannot be alch farmed"
+      - "Buy limit 7,000 per 4 hours, but volume is mostly Herblore practice supply"
+      - "Functionally a sentiment / completionist item rather than a flip"
+  trading_tips:
+    - "Skip as a flip target - margin per arrow is below GE tax noise"
+    - "Buy in bulk only if seeding a Ranged ironman alt who needs poison ammo"
+    - "Watch weapon poison recipe reworks - any buff to the (p) damage could revive minor demand"
+  history:
+    - date: "2001-01-04"
+      description: "Released as part of the original Ranged ammunition line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-chainbody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze chainbody | OSRS Price Data
-description: "Bronze chainbody: A series of connected metal rings.. High alch: 36 GP, GE limit: 125."
+description: "Bronze chainbody is an entry-tier F2P body slot armour smelted at level 11 Smithing. High alch: 36 GP, GE limit: 125."
 osrs:
   id: 1103
   name: Bronze chainbody
@@ -12,25 +12,124 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 125
-  item_id: 1103
-  item_type: armor
-  slot: body
-  type: chainbody
-  tradeable: true
-  weight: 6.803
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 7
-    slash_defence: 11
-    crush_defence: 13
-    magic_defence: -3
-    ranged_defence: 9
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    update: "RuneScape Classic launch"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 6.803
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: chainbody
+    weight: 6.803
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 7
+      slash: 11
+      crush: 13
+      magic: -3
+      ranged: 9
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 11
+      xp: 37.5
+      facility: Anvil
+      tools:
+        - Hammer
+      materials:
+        - item_id: 2349
+          item_name: Bronze bar
+          quantity: 3
+      product: Bronze chainbody
+      product_id: 1103
+      output_quantity: 1
+      members: false
+      notes: "Smithed on any anvil; F2P-accessible early Smithing milestone"
+  drop_table:
+    sources:
+      - source: Skeleton (level 22)
+        combat_level: 22
+        quantity: "1"
+        rarity: uncommon
+        notes: "Common low-level humanoid drop"
+      - source: Zombie (level 18)
+        combat_level: 18
+        quantity: "1"
+        rarity: uncommon
+        notes: "Wilderness and graveyard zombies"
+      - source: Reward casket (beginner)
+        combat_level: 0
+        quantity: "1"
+        rarity: uncommon
+        notes: "Rolled from beginner clue scroll rewards"
+  shops:
+    - shop_name: Wayne's Chains - Chainmail Specialist
+      location: Falador
+      price: 60
+      stock: 5
+      currency: coins
+    - shop_name: Brian's Archery Supplies
+      location: Rimmington
+      price: 60
+      stock: 0
+      currency: coins
   related_items:
-    - slug: iron-chainbody
-    - slug: bronze-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1101
+      item_name: Iron chainbody
+      slug: iron-chainbody
+      relationship: upgrade
+      description: Next tier chainbody requiring level 26 Defence
+    - item_id: 1117
+      item_name: Bronze platebody
+      slug: bronze-platebody
+      relationship: alternative
+      description: Stronger bronze body slot armour smithed at level 18 Smithing
+    - item_id: 1105
+      item_name: Steel chainbody
+      slug: steel-chainbody
+      relationship: upgrade
+      description: Higher tier steel-grade chainbody
+  market_strategy:
+    notes:
+      - "Demand from low-level Defence trainers and ironman starter gear"
+      - "Smithed in bulk for Smithing XP; pushes supply during XP grinds"
+      - "Low margins; treat as Smithing XP byproduct rather than alch target"
+      - "Buy limit only 125 per 4 hours — not a flip target"
+  trading_tips:
+    - Compare chainbody price against 3 bronze bars to check Smithing margin
+    - Use shop arbitrage at Falador Wayne's Chains when GE price spikes
+    - Avoid high-alching due to negative profit vs nature rune cost
+  about: Bronze chainbody is an entry-tier free-to-play body armour smithed from three bronze bars at level 11 Smithing. It is one of the earliest body slot pieces available and is commonly farmed from low-level skeletons and zombies.
+  history:
+    - date: "2001-01-04"
+      description: "Released alongside RuneScape Classic launch as part of the original bronze armour set."
+    - date: "2004-05-05"
+      description: "Graphical update applied with the RuneScape 2 transition."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dagger-p-5688.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-dagger-p-5688.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze dagger(p++) | OSRS Price Data
-description: "Bronze dagger(p++): This dagger is poisoned.. High alch: 6 GP, GE limit: 125."
+description: "Bronze dagger(p++) is the strongest poison variant of the bronze dagger, applied with weapon poison(++). High alch: 6 GP, GE limit: 125."
 osrs:
   id: 5688
   name: Bronze dagger(p++)
@@ -12,9 +12,101 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 125
-  about: "Bronze dagger(p++) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2005-08-30"
+    update: "Slayer Skill"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    weight: 0.453
+    attack_speed: 4
+    requirements: {}
+    attack_bonus:
+      stab: 4
+      slash: 2
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      melee_strength: 3
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: none
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Bronze dagger
+          item_id: 1205
+          quantity: 1
+        - item_name: Weapon poison(++)
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      notes: "Use Weapon poison(++) on a Bronze dagger to produce the p++ variant; no skill XP awarded."
+  passive_effects:
+    - name: Weapon poison(++)
+      description: "Applies the strongest weapon poison tier on hit, dealing 6 damage on the initial proc and decaying over time."
+  related_items:
+    - item_id: 1205
+      item_name: Bronze dagger
+      slug: bronze-dagger
+      relationship: component
+      description: "Unpoisoned base weapon that receives the poison coating."
+    - item_id: 5680
+      item_name: Bronze dagger(p)
+      slug: bronze-dagger-p-5680
+      relationship: variant
+      description: "Standard weapon poison variant of the bronze dagger."
+    - item_id: 5684
+      item_name: Bronze dagger(p+)
+      slug: bronze-dagger-p-plus
+      relationship: variant
+      description: "Stronger weapon poison(+) variant of the bronze dagger."
+    - item_name: Weapon poison(++)
+      slug: weapon-poison-plus-plus
+      relationship: component
+      description: "Herblore tincture applied to the dagger for the p++ effect."
+  about: "Bronze dagger(p++) is the strongest poison variant of the bronze dagger, produced by applying Weapon poison(++) to a standard Bronze dagger. Combat stats match the base dagger (+4 stab, +3 strength, 4-tick speed) but the p++ coating procs the highest poison tier in OSRS, dealing 6 damage on initial hit. Mostly used as a low-tier PvP and Slayer novelty rather than a competitive weapon."
+  market_strategy:
+    notes:
+      - "Effectively priced as a Bronze dagger + Weapon poison(++) bundle"
+      - "Buy limit of 125 per 4 hours keeps merch volume thin"
+      - "Niche demand - mostly PKers stocking poisoned alts and meme builds"
+      - "Herblore output of weapon poison(++) drives supply"
+  trading_tips:
+    - "Compare to (Bronze dagger + Weapon poison(++)) cost to find application arbitrage"
+    - "Demand spikes around PvP events and Wilderness skull updates"
+    - "Stable low-volume flip - not a primary profit driver"
+  history:
+    - date: "2005-08-30"
+      description: "Introduced alongside the Slayer skill and the broader weapon poison(++) variant lineup."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-hasta-p-11384.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-hasta-p-11384.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze hasta(p++) | OSRS Price Data
-description: "Bronze hasta(p++): A poison-tipped, one-handed bronze hasta.. High alch: 15 GP, GE limit: 125."
+description: "Bronze hasta(p++): A poison-tipped, one-handed bronze hasta. High alch: 15 GP, GE limit: 125."
 osrs:
   id: 11384
   name: Bronze hasta(p++)
@@ -12,9 +12,108 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 125
-  about: "Bronze hasta(p++) is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    attack_range: 1
+    weight: 2.267
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 5
+      slash: 5
+      crush: 5
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: -1
+      crush: -1
+      magic: 0
+      ranged: -1
+    other_bonus:
+      melee_strength: 6
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Poison++
+      description: "Has a chance on hit to apply the enhanced poison (++) damage-over-time effect for 6 damage per tick."
+      trigger: on_hit
+  recipes:
+    - skill: fletching
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Bronze hasta
+          item_id: 11367
+          quantity: 1
+        - item_name: Weapon poison++
+          item_id: 5940
+          quantity: 1
+      product: Bronze hasta(p++)
+      product_id: 11384
+      output_quantity: 1
+      notes: "Use Weapon poison++ on a bronze hasta to upgrade to the (p++) variant."
+  related_items:
+    - item_id: 11367
+      item_name: Bronze hasta
+      slug: bronze-hasta
+      relationship: variant
+      description: "Base unpoisoned bronze hasta."
+    - item_id: 11380
+      item_name: Bronze hasta(p)
+      slug: bronze-hasta-p-11380
+      relationship: variant
+      description: "Standard poisoned variant."
+    - item_id: 11382
+      item_name: Bronze hasta(p+)
+      slug: bronze-hasta-p-11382
+      relationship: variant
+      description: "Stronger poisoned variant."
+    - item_id: 11386
+      item_name: Iron hasta(p++)
+      slug: iron-hasta-p-11386
+      relationship: upgrade
+      description: "Next-tier poisoned hasta."
+  about: "Bronze hasta(p++) is the enhanced-poison variant of the bronze hasta, a one-handed spear-type weapon created via the Barbarian Training miniquest Smithing path. The (p++) tier inflicts the strongest poison damage-over-time on hit and is most often used as a niche PvP or specific PvM ammunition for spear loadouts."
+  market_strategy:
+    notes:
+      - "Niche poison-stack spear variant; demand limited to spear-PvP and specific Slayer setups."
+      - "Input cost dominated by Weapon poison++ price, not the base hasta."
+      - "Low GE buy limit of 125 caps daily flip volume."
+      - "High alch of 15 gp leaves no alch headroom; profits come from spreads only."
+  trading_tips:
+    - "Track Weapon poison++ price as the dominant input cost when valuing the (p++) variant."
+    - "Buy base bronze hastas in bulk and apply poison++ if the spread justifies the conversion."
+    - "Watch Barbarian Training miniquest popularity for downstream demand on hasta variants."
+  history:
+    - date: "2007-07-03"
+      description: "Bronze hasta(p++) released with the Barbarian Training miniquest and the hasta weapon line."
+    - date: "2021-04-21"
+      description: "Hasta attack speed decreased from 5 ticks (3.0s) to 4 ticks (2.4s), improving the weapon class significantly."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-platelegs-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-platelegs-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze platelegs (g) | OSRS Price Data
-description: "Bronze platelegs (g): Bronze platelegs with gold trim.. High alch: 48 GP, GE limit: 4."
+description: "Bronze platelegs (g): Bronze platelegs with gold trim. High alch: 48 GP, GE limit: 4."
 osrs:
   id: 12207
   name: Bronze platelegs (g)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 4
-  about: "Bronze platelegs (g) is a free-to-play item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: bronze
+    tier: low
+  properties:
+    release_date: "2009-12-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.072
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weight: 9.072
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: -7
+    defence_bonus:
+      stab: 4
+      slash: 5
+      crush: 3
+      magic: -4
+      ranged: 4
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  related_items:
+    - item_id: 1075
+      item_name: Bronze platelegs
+      slug: bronze-platelegs
+      relationship: alternative
+      description: "Untrimmed standard variant with identical stats."
+    - item_id: 12205
+      item_name: Bronze platebody (g)
+      slug: bronze-platebody-g
+      relationship: set-piece
+      description: "Body piece of the gold-trimmed bronze set."
+    - item_id: 12211
+      item_name: Bronze full helm (g)
+      slug: bronze-full-helm-g
+      relationship: set-piece
+      description: "Head piece of the gold-trimmed bronze set."
+  about: "Bronze platelegs (g) is a free-to-play gold-trimmed cosmetic variant of bronze platelegs with the same level 1 Defence requirement and stats, obtainable only as an easy clue scroll reward."
+  market_strategy:
+    notes:
+      - "Cosmetic-only clue reward; demand driven by fashionscape and full-set displays."
+      - "Buy limit of 4 per 4 hours throttles flips."
+      - "Pairs with platebody (g) and full helm (g) for the trimmed bronze set."
+  trading_tips:
+    - "Stock alongside other trimmed bronze pieces to sell as a set."
+    - "Watch easy clue scroll content launches for supply pulses."
+  history:
+    - date: "2009-12-14"
+      description: "Released as an easy treasure trail reward in the trimmed armour update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-wire.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-wire.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze wire | OSRS Price Data
-description: "Bronze wire: Useful for Crafting items.. High alch: 12 GP, GE limit: 15."
+description: "Bronze wire is a members Crafting material made from a bronze bar. High alch: 12 GP, GE limit: 15."
 osrs:
   id: 1794
   name: Bronze wire
@@ -12,9 +12,90 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 15
-  about: "Bronze wire is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2002-09-23"
+    update: "Crafting skill update"
+    quest_item: false
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    weight: 0.453
+    destroy: "Drop"
+    options:
+      - Drop
+    examine_options:
+      - Examine
+    alchable: true
+  recipes:
+    - skill: crafting
+      level: 4
+      xp: 12.5
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_id: 2349
+          item_name: Bronze bar
+          quantity: 1
+      output:
+        item_id: 1794
+        item_name: Bronze wire
+        output_quantity: 1
+      members: true
+      notes: "Use a bronze bar on an anvil with a hammer to produce bronze wire"
+    - skill: fletching
+      level: 23
+      xp: 6
+      materials:
+        - item_id: 1794
+          item_name: Bronze wire
+          quantity: 1
+        - item_id: 9420
+          item_name: Bronze limbs
+          quantity: 1
+        - item_id: 9440
+          item_name: Wooden stock
+          quantity: 1
+      output:
+        item_id: 9174
+        item_name: Bronze crossbow (u)
+        output_quantity: 1
+      members: true
+      notes: "Combined with bronze limbs and a wooden stock to assemble a bronze crossbow"
+  related_items:
+    - item_id: 2349
+      item_name: Bronze bar
+      slug: bronze-bar
+      relationship: component
+      description: Source material for bronze wire
+    - item_id: 9174
+      item_name: Bronze crossbow (u)
+      slug: bronze-crossbow-u
+      relationship: product
+      description: Unstrung bronze crossbow assembled with bronze wire
+    - item_id: 1796
+      item_name: Silver wire
+      slug: silver-wire
+      relationship: upgrade
+      description: Higher tier wire variant
+  market_strategy:
+    notes:
+      - "Niche Crafting/Fletching component with tiny 15 GE limit"
+      - "Supply usually scarce; hand-rolled by ironmen"
+      - "Margins exist on small-scale flips for crossbow makers"
+      - "Quick-alch only when nature runes are cheap"
+  history:
+    - date: "2002-09-23"
+      description: "Released with the Crafting skill update"
+    - date: "2006-07-04"
+      description: "Made usable in Bronze crossbow assembly via Fletching"
+  about: "Bronze wire is a Crafting and Fletching material produced by using a bronze bar on an anvil with a hammer at level 4 Crafting. It is primarily used to assemble bronze crossbows alongside bronze limbs and wooden stocks."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-combat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-combat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Broodoo shield (combat) | OSRS Price Data
-description: "Broodoo shield (combat): A scary broodoo shield.. High alch: 1,800 GP, GE limit: 125."
+description: "Broodoo shield (combat) is a members tribal shield requiring 25 Defence and 25 Magic, +5 prayer and 10 charges that proc Attack drains on hit. High alch: 1,800 GP, GE limit: 125."
 osrs:
   id: 6279
   name: Broodoo shield (combat)
@@ -12,9 +12,99 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
-  about: "Broodoo shield (combat) is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2005-08-09"
+    update: "Tai Bwo Wannai Clean-Up"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 25
+      magic: 25
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 10
+      slash: 10
+      crush: 15
+      magic: 5
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 5
+  passive_effects:
+    - name: "Attack drain charge"
+      description: "Starts with 10 charges. When the wearer takes damage, there is a 10% chance to drain 1 point of the attacker's Attack stat plus 5% of their remaining total. Each proc consumes one charge; defensive stats remain after charges deplete."
+  recipes:
+    - skill: crafting
+      level: 35
+      xp: 100
+      materials:
+        - item_name: Snakeskin
+          item_id: 6287
+          quantity: 5
+        - item_name: Combat tribal mask
+          item_id: 6335
+          quantity: 1
+        - item_name: Nails
+          item_id: 1539
+          quantity: 15
+      facility: Tai Bwo Wannai
+      product: Broodoo shield (combat)
+      product_id: 6279
+      output_quantity: 1
+  related_items:
+    - item_id: 6235
+      item_name: Broodoo shield (magic)
+      slug: broodoo-shield-magic
+      relationship: alternative
+      description: "Magic-themed broodoo shield variant draining the attacker's Magic stat instead of Attack."
+    - item_id: 6237
+      item_name: Broodoo shield (ranged)
+      slug: broodoo-shield-ranged
+      relationship: alternative
+      description: "Ranged-themed broodoo shield variant draining the attacker's Ranged stat instead of Attack."
+    - item_id: 6335
+      item_name: Combat tribal mask
+      slug: combat-tribal-mask
+      relationship: component
+      description: "Tribal mask required as the central component when crafting the combat variant."
+  about: "Broodoo shield (combat) is the combat-themed tribal shield from Tai Bwo Wannai, crafted at 35 Crafting from a combat tribal mask, snakeskin and nails. It requires 25 Defence and 25 Magic to wield, carries a +5 prayer bonus and 10 charges. Each charge has a 10% chance on damage taken to drain the attacker's Attack stat by 1 plus 5% of the remaining total - a niche debuff option for low-Defence Magic content."
+  market_strategy:
+    notes:
+      - "Supply is fully crafter-side - snakeskin, combat tribal mask, and nail costs are the floor."
+      - "GE buy limit of 125 per 4 hours caps single flips."
+      - "High alch of 1,800 gp can sit close to GE price - alching is sometimes break-even."
+      - "Demand is niche - mostly collectors and the occasional themed Slayer or Magic build."
+  trading_tips:
+    - "Watch snakeskin and combat tribal mask supply to detect crafter arbitrage windows."
+    - "Cross-reference the magic and ranged variants - all three move together as a tribal set."
+    - "Low volume and slow turnover - treat as a long-tail flip, not active merchanting."
+  history:
+    - date: "2005-08-09"
+      description: "Released as part of the Tai Bwo Wannai Clean-Up minigame update alongside the broodoo shield variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-logs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/camphor-logs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Camphor logs | OSRS Price Data
-description: "Camphor logs: Logs cut from a camphor tree.. High alch: 132 GP."
+description: "Camphor logs are 66 Woodcutting Sailing-skill logs harvested on The Great Conch, converted into camphor planks for boat upgrades. High alch: 132 GP."
 osrs:
   id: 32904
   name: Camphor logs
@@ -11,10 +11,73 @@ osrs:
   value: 220
   lowalch: 88
   highalch: 132
-  limit: null
-  about: "Camphor logs is a members-only item in Old School RuneScape. High alchemy value: 132 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: logs
+    tier: mid
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: woodcutting
+      level: 66
+      xp: 143.5
+      materials:
+        - item_name: Camphor tree
+          quantity: 1
+      tools:
+        - Axe
+      product: Camphor logs
+      output_quantity: 1
+  passive_effects:
+    - name: Firemaking fuel
+      description: "Burned with a tinderbox at 66 Firemaking for 180 Firemaking XP per log."
+    - name: Sailing plank source
+      description: "Primary input for camphor planks, the mid-tier Sailing-skill construction material used in Sailing boat upgrades."
+  related_items:
+    - item_name: Camphor planks
+      slug: camphor-planks
+      relationship: product
+      description: Sailing-skill construction planks made from camphor logs
+    - item_name: Camphor pyre logs
+      slug: camphor-pyre-logs
+      relationship: variant
+      description: Sacred-oil-treated variant burned at Shades of Mort'ton funeral pyres
+    - item_name: Camphor sapling
+      slug: camphor-sapling
+      relationship: component
+      description: Hardwood-patch sapling grown at 66 Farming to produce camphor trees
+    - item_name: Mahogany logs
+      slug: mahogany-logs
+      relationship: alternative
+      description: Tropical hardwood log tier near camphor in Woodcutting and construction use
+  about: "Camphor logs are members-only Woodcutting logs harvested at 66 Woodcutting from camphor trees on The Great Conch (Troubled Tortugans) or grown at hardwood Farming patches, primarily processed into camphor planks for Sailing-skill boat upgrades but also burnable for 180 Firemaking XP."
+  market_strategy:
+    notes:
+      - "New Sailing-skill log tier - demand still settling against Sailing plank consumption"
+      - "Supply gated by 66 Woodcutting and access to The Great Conch via Troubled Tortugans progress"
+      - "No GE buy limit listed - liquidity tracks Sailing plank converter throughput"
+      - "Firemaking XP rate (180) is competitive but logs are usually too valuable to burn"
+  trading_tips:
+    - "Track camphor plank GE price - converters set the floor for camphor logs"
+    - "Stockpile around Sailing skill updates and new boat-upgrade content drops"
+    - "Watch Farming patch yield buffs - hardwood-patch supply spikes compress margins"
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill launch, introducing mid-tier hardwood logs harvested on The Great Conch."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/carved-oak-magic-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/carved-oak-magic-wardrobe-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Carved oak magic wardrobe (flatpack) | OSRS Price Data
-description: "Carved oak magic wardrobe (flatpack): Carved oak magic wardrobe.. High alch: 6 GP, GE limit: 500."
+description: "Carved oak magic wardrobe (flatpack): Carved oak magic wardrobe. High alch: 6 GP, GE limit: 500."
 osrs:
   id: 9853
   name: Carved oak magic wardrobe (flatpack)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Carved oak magic wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: oak
+    tier: low
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 51
+      xp: 360
+      materials:
+        - item_name: Oak plank
+          quantity: 6
+      tools:
+        - Hammer
+        - Saw
+      facility: "Steel framed workbench"
+      output_quantity: 1
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: "Construction material used to make the flatpack"
+    - item_name: Oak magic wardrobe (flatpack)
+      slug: oak-magic-wardrobe-flatpack
+      relationship: downgrade
+      description: "Lower-tier flatpack version with reduced costume room storage"
+    - item_name: Teak magic wardrobe (flatpack)
+      slug: teak-magic-wardrobe-flatpack
+      relationship: upgrade
+      description: "Higher-tier teak flatpack with more capacity"
+  about: "The carved oak magic wardrobe flatpack is a Construction storage upgrade for the costume room in a player-owned house. Players craft it at 51 Construction on a steel framed workbench using six oak planks for 360 xp, then use it on a magic wardrobe space to deploy without needing a hotspot built first."
+  market_strategy:
+    notes:
+      - "Construction xp methods rely on planks, not flatpacks, so demand is thin"
+      - "Net Construction profit per flatpack is negative once GE oak plank cost is factored"
+      - "Stable low-margin item, used mostly by costume room finishers"
+  trading_tips:
+    - "Restock against players outfitting POH costume rooms in bulk"
+    - "Keep buy price under high-alch value to avoid loss flips"
+  history:
+    - date: "2006-10-18"
+      description: "Released with the costume room update to the player-owned house."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cheese-tom-batta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cheese-tom-batta.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cheese+tom batta | OSRS Price Data
-description: "Cheese+tom batta: This smells really good.. High alch: 1 GP, GE limit: 6,000."
+description: "Cheese+tom batta is a members Gnome food cooked at 29 Cooking from cheese, tomato, and a Gianne batta tin; heals 11 Hitpoints and grants 158 Cooking XP. High alch: 1 GP, GE limit: 6,000."
 osrs:
   id: 2259
   name: Cheese+tom batta
@@ -12,9 +12,89 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Cheese+tom batta is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    update: "Agility skill online"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  effects:
+    - description: Heals 11 Hitpoints on consumption.
+  recipes:
+    - skill: cooking
+      level: 29
+      xp: 158
+      materials:
+        - item_name: Cheese batta
+          item_id: 2253
+          quantity: 1
+        - item_name: Tomato
+          item_id: 1982
+          quantity: 1
+        - item_name: Equa leaves
+          item_id: 2128
+          quantity: 1
+      product: Cheese+tom batta
+      output_quantity: 1
+      facility: Range (Gnome Stronghold or any range)
+      members_only: true
+  shop:
+    - location: Grand Tree
+      npc: Gnome waiter
+      shop_name: Gnome Stronghold restaurants
+      base_price: 120 coins
+      stock: 3
+  related_items:
+    - item_id: 2253
+      item_name: Cheese batta
+      slug: cheese-batta
+      relationship: component
+      description: Intermediate batta used as the base before adding tomato.
+    - item_id: 2261
+      item_name: Toad batta
+      slug: toad-batta
+      relationship: alternative
+      description: Alternate Gnome batta recipe used in Gnome Restaurant orders.
+    - item_id: 2249
+      item_name: Gianne dough
+      slug: gianne-dough
+      relationship: component
+      description: Base dough required to make any batta tin.
+    - item_id: 2255
+      item_name: Cheese+tom batta (raw)
+      slug: raw-cheese-tom-batta
+      relationship: component
+      description: Uncooked variant baked on a range into the finished batta.
+  about: "Cheese+tom batta is a members-only Gnome food released alongside the original Gnome Cuisine cooking line. It is cooked at 29 Cooking from a cheese batta plus a tomato and equa leaves for 158 Cooking XP, stops burning at 38 Cooking, and heals 11 Hitpoints per bite. It is one of the most XP-efficient low-level Cooking targets per inventory and is also required for Gnome Restaurant minigame deliveries; the Grand Tree waiters sell pre-made battas for 120 coins."
+  market_strategy:
+    notes:
+      - "Demand is dominated by Cooking trainers chasing 158 XP per cook and Gnome Restaurant runners."
+      - "GE buy limit of 6,000 per 4 hours leaves plenty of headroom for bulk."
+      - "High alch return of 1 gp - never an alch target."
+      - "Supply is fed by player Cooking sessions; cheese and tomato spot prices drive cost."
+  trading_tips:
+    - "Cross-check Cheese batta plus Tomato spot prices to track Cooking-trainer arbitrage windows."
+    - "Watch Cooking XP rate guides - shifts in meta food choice move batta demand."
+    - "Bulk-low-margin item - flip in volume or skip."
+  history:
+    - date: "2002-12-12"
+      description: "Released with the Agility skill update that brought Gnome Stronghold content online."
+    - date: "2006-08-07"
+      description: "Graphical rework alongside the Gnome Cuisine update that overhauled the Gnome Restaurant minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chromium-ingot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chromium-ingot.mdx
@@ -1,6 +1,6 @@
 ---
 title: Chromium ingot | OSRS Price Data
-description: "Chromium ingot: A dense clump of corroded metal.. High alch: 30,000 GP, GE limit: 8."
+description: "Chromium ingot is a dense clump of corroded metal used to craft the four ancient rings. High alch: 30,000 GP, GE limit: 8."
 osrs:
   id: 28276
   name: Chromium ingot
@@ -12,73 +12,153 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
-  item:
-    type: material
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2023-07-26"
     tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
     weight: 3
-  obtaining:
-    methods:
+    options:
+      - Drop
+      - Examine
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Duke Sucellus
+        combat_level: 272
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/1000"
+        notes: "DT2 boss; rolled on a successful kill"
+      - source: The Whisperer
+        combat_level: 270
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/1000"
+        notes: "DT2 boss; rolled on a successful kill"
+      - source: Vardorvis
+        combat_level: 528
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/1000"
+        notes: "DT2 boss; rolled on a successful kill"
+      - source: Leviathan
+        combat_level: 736
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/1000"
+        notes: "DT2 boss; rolled on a successful kill"
+      - source: Stranglewood big net fishing
+        combat_level: 0
+        quantity: "1"
+        rarity: very-rare
+        notes: "Extremely rare fishing catch in the Stranglewood"
       - source: Blast Furnace smelting
-        requirements:
-          smithing: 85
-        cost: 40 adamantite ore + 40 runite ore + 170K gp
-      - source: DT2 boss drops
-        note: Any of the four bosses
-      - source: Stranglewood fishing
-        note: Extremely rare
+        combat_level: 0
+        quantity: "1"
+        rarity: always
+        notes: "Combine 40 adamantite ore + 40 runite ore + 170k gp at level 85 Smithing"
   recipes:
     - skill: crafting
       level: 80
-      requirements:
-        magic: 90
+      xp: 200
+      facility: Anvil
+      tools:
+        - Hammer
       materials:
         - item_id: 28276
           item_name: Chromium ingot
           quantity: 3
-      product: Ancient rings
-      notes: Ultor, Bellator, Magus, or Venator ring
+      product: Ultor vestige
+      product_id: 28289
+      output_quantity: 1
+      notes: "Combined with the ultor vestige to produce the Ultor ring (requires 90 Magic, 80 Crafting)"
+    - skill: crafting
+      level: 80
+      xp: 200
+      facility: Anvil
+      tools:
+        - Hammer
+      materials:
+        - item_id: 28276
+          item_name: Chromium ingot
+          quantity: 3
+      product: Magus ring
+      product_id: 28313
+      output_quantity: 1
+      notes: "Requires 90 Magic and 80 Crafting; combined with the magus vestige"
+    - skill: crafting
+      level: 80
+      xp: 200
+      facility: Anvil
+      tools:
+        - Hammer
+      materials:
+        - item_id: 28276
+          item_name: Chromium ingot
+          quantity: 3
+      product: Bellator ring
+      product_id: 28310
+      output_quantity: 1
+      notes: "Requires 90 Magic and 80 Crafting; combined with the bellator vestige"
+    - skill: crafting
+      level: 80
+      xp: 200
+      facility: Anvil
+      tools:
+        - Hammer
+      materials:
+        - item_id: 28276
+          item_name: Chromium ingot
+          quantity: 3
+      product: Venator ring
+      product_id: 28316
+      output_quantity: 1
+      notes: "Requires 90 Magic and 80 Crafting; combined with the venator vestige"
   related_items:
     - item_id: 28307
       item_name: Ultor ring
       slug: ultor-ring
       relationship: product
-      description: Created BiS melee strength ring
-    - item_id: 28313
-      item_name: Magus ring
-      slug: magus-ring
-      relationship: product
-      description: Created BiS magic ring
-    - item_id: 28316
-      item_name: Venator ring
-      slug: venator-ring
-      relationship: product
-      description: Created BiS ranged ring
+      description: BiS melee strength ring forged from a chromium ingot
     - item_id: 28310
       item_name: Bellator ring
       slug: bellator-ring
       relationship: product
-      description: Created BiS melee accuracy ring
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 3 kg |
-
-    Required for ancient rings (3 per ring):
-    - Ultor ring
-    - Bellator ring
-    - Magus ring
-    - Venator ring
-
-    All require 90 Magic, 80 Crafting.
+      description: BiS melee accuracy ring forged from a chromium ingot
+    - item_id: 28313
+      item_name: Magus ring
+      slug: magus-ring
+      relationship: product
+      description: BiS magic ring forged from a chromium ingot
+    - item_id: 28316
+      item_name: Venator ring
+      slug: venator-ring
+      relationship: product
+      description: BiS ranged ring forged from a chromium ingot
   market_strategy:
     notes:
-      - Farm DT2 bosses for drops
-      - Smelting is massive loss
-      - Essential for BiS rings
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "DT2 boss farming is the only profitable source"
+      - "Blast Furnace smelting is a massive GP loss vs market price"
+      - "Demand is gated by ancient vestige drops; price tracks ring meta"
+      - "Buy limit only 8 per 4 hours — flippers stack across alts"
+      - "Use as direct ring crafting component, never high-alch fodder"
+  trading_tips:
+    - Time purchases around DT2 droprate buffs and ring meta shifts
+    - Stockpile when DT2 bossing is incentivised by leagues or events
+    - Cross-reference ingot price against vestige price to confirm ring margin
+  about: Chromium ingot is a high-tier crafting material dropped by the four Desert Treasure 2 bosses and used three at a time to forge the ancient rings (Ultor, Bellator, Magus, Venator) at level 80 Crafting and 90 Magic.
+  history:
+    - date: "2023-07-26"
+      description: "Released with the Desert Treasure 2 - The Awakening quest as the crafting material for ancient rings."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cider-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cider-m4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cider(m4) | OSRS Price Data
-description: "Cider(m4): This keg contains 4 pints of mature Cider.. High alch: 1 GP, GE limit: 2,000."
+description: "Cider(m4) is a 4-pint mature cider keg used in the Keldagrim brewery, giving a +2 Farming boost when sipped. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5929
   name: Cider(m4)
@@ -12,12 +12,95 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Cider(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "2005-03-21"
+    update: "The Giant Dwarf"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.0
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    doses: 4
+    effect: "Each sip boosts Farming by +2 and lowers Strength, Attack, and Defence by 3."
+    effects:
+      - stat: farming
+        boost_type: flat
+        boost_formula: "+2"
+        duration: 0
+        description: "Boosts Farming by 2 levels per pint."
+      - stat: strength
+        boost_type: flat
+        boost_formula: "-3"
+        duration: 0
+        description: "Lowers Strength by 3 levels per pint."
+      - stat: attack
+        boost_type: flat
+        boost_formula: "-3"
+        duration: 0
+        description: "Lowers Attack by 3 levels per pint."
+      - stat: defence
+        boost_type: flat
+        boost_formula: "-3"
+        duration: 0
+        description: "Lowers Defence by 3 levels per pint."
+  recipes:
+    - skill: cooking
+      level: 14
+      xp: 0
+      materials:
+        - item_name: Cider(4)
+          quantity: 1
+      tools:
+        - Keldagrim brewery
+      output_quantity: 1
+      notes: "Brew cider in the Keldagrim brewery and leave it to mature for one month for the m4 variant."
+  related_items:
+    - item_name: Cider(4)
+      slug: cider-4
+      relationship: variant
+      description: "Standard 4-pint cider keg before maturation"
+    - item_name: Cider(m1)
+      slug: cider-m1
+      relationship: variant
+      description: "1-pint mature cider keg"
+    - item_name: Cider(m2)
+      slug: cider-m2
+      relationship: variant
+      description: "2-pint mature cider keg"
+    - item_name: Cider(m3)
+      slug: cider-m3
+      relationship: variant
+      description: "3-pint mature cider keg"
+  about: "Cider(m4) is the full 4-pint keg of mature cider, brewed in the Keldagrim brewery and aged for a month before the m variant appears. Each pint sipped boosts the player's Farming level by 2 while lowering Attack, Strength, and Defence by 3, making it a niche temporary Farming booster for protect-from-disease checks and herb pulls."
+  market_strategy:
+    notes:
+      - "Niche Farming booster; volume is low and steady"
+      - "Brewing cycle takes a full month real time, locking supply tightly"
+      - "Stat-drain side effect rules out combat use, narrowing buyer pool"
+  trading_tips:
+    - "Brew in bulk during major Farming xp event weekends"
+    - "Decant into smaller m kegs if the per-pint premium opens up"
+  history:
+    - date: "2005-03-21"
+      description: "Released with The Giant Dwarf quest and the Keldagrim brewery system."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/citizen-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/citizen-top.mdx
@@ -1,6 +1,6 @@
 ---
 title: Citizen top | OSRS Price Data
-description: "Citizen top: Ghetto disguise!. High alch: 3 GP, GE limit: 150."
+description: "Citizen top: Ghetto disguise. High alch: 3 GP, GE limit: 150."
 osrs:
   id: 9640
   name: Citizen top
@@ -12,9 +12,78 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 150
-  about: "Citizen top is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2006-09-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Trader Sven's Black-market Goods"
+      location: Meiyerditch
+      price: 6
+      currency: coins
+      stock: 10
+      members_only: true
+  related_items:
+    - item_id: 9642
+      item_name: Citizen trousers
+      slug: citizen-trousers
+      relationship: set-piece
+      description: "Leg piece of the citizen disguise outfit."
+    - item_id: 9644
+      item_name: Citizen shoes
+      slug: citizen-shoes
+      relationship: set-piece
+      description: "Footwear piece of the citizen disguise outfit."
+  about: "Citizen top is a members disguise body piece introduced with Darkness of Hallowvale, required to blend in with Meiyerditch citizens as part of the citizen outfit (top, trousers, shoes)."
+  market_strategy:
+    notes:
+      - "Demand spikes when players begin Darkness of Hallowvale or related Morytania content."
+      - "Trader Sven's shop in Meiyerditch keeps shop prices low; GE markup driven by convenience."
+      - "Useful for fashionscape disguise outfits in clue scroll outfit collections."
+  trading_tips:
+    - "Buy directly from Trader Sven in Meiyerditch for the cheapest source."
+    - "Stock all three citizen pieces together when reselling on the GE."
+  history:
+    - date: "2006-09-04"
+      description: "Added with the Darkness of Hallowvale (Myreque Pt III) quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Combat potion(1) | OSRS Price Data
-description: "Combat potion(1): 1 dose of combat potion.. High alch: 31 GP, GE limit: 2,000."
+description: "Combat potion(1): 1 dose of combat potion. High alch: 31 GP, GE limit: 2,000."
 osrs:
   id: 9745
   name: Combat potion(1)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 20
   highalch: 31
   limit: 2000
-  about: "Combat potion(1) is a members-only item in Old School RuneScape. High alchemy value: 31 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2002-04-11"
+    update: "Member Skills"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - name: Attack boost
+        description: "Temporarily raises Attack by 3 plus 10% of the player's current Attack level."
+        duration: 300
+      - name: Strength boost
+        description: "Temporarily raises Strength by 3 plus 10% of the player's current Strength level."
+        duration: 300
+  recipes:
+    - skill: herblore
+      level: 36
+      xp: 84
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Goat horn dust
+          quantity: 1
+      output_quantity: 1
+      notes: "1-dose result usually arrives from decanting; native Herblore output is 3-dose."
+  related_items:
+    - item_name: Combat potion(2)
+      slug: combat-potion-2
+      relationship: variant
+      description: 2-dose variant of the same potion.
+    - item_name: Combat potion(3)
+      slug: combat-potion-3
+      relationship: variant
+      description: 3-dose variant brewed natively at the Herblore skill.
+    - item_name: Combat potion(4)
+      slug: combat-potion-4
+      relationship: variant
+      description: 4-dose variant after decanting.
+    - item_name: Harralander potion (unf)
+      slug: harralander-potion-unf
+      relationship: component
+      description: Unfinished base used in the brewing recipe.
+    - item_name: Goat horn dust
+      slug: goat-horn-dust
+      relationship: component
+      description: Secondary required to finish the combat potion.
+  about: |-
+    Combat potion(1) is a one-dose Herblore potion that briefly boosts both Attack and Strength. Each dose raises Attack and Strength by 3 plus 10% of the corresponding stat (rounded down).
+
+    The 1-dose form usually originates from decanting 3- or 4-dose combat potions; native brewing at 36 Herblore yields a 3-dose Combat potion(3).
+  market_strategy:
+    notes:
+      - "Cheap melee boost for low/mid-level training and quest stat unlocks."
+      - "Demand sits below higher-dose alternatives but supports decant arbitrage."
+      - "Quest requirements (e.g. Heroes' Quest) provide a steady consumption floor."
+  trading_tips:
+    - "Compare per-dose value vs 3- and 4-dose combat potions before buying."
+    - "Stock during weekend events when boost demand spikes."
+  history:
+    - date: "2002-04-11"
+      description: "Combat potions introduced with the Herblore expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/combat-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Combat potion(3) | OSRS Price Data
-description: "Combat potion(3): 3 doses of combat potion.. High alch: 96 GP, GE limit: 2,000."
+description: "Combat potion(3): 3 doses of combat potion. High alch: 96 GP, GE limit: 2,000."
 osrs:
   id: 9741
   name: Combat potion(3)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 2000
-  about: "Combat potion(3) is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2002-04-11"
+    update: "Member Skills"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - name: Attack boost
+        description: "Temporarily raises Attack by 3 plus 10% of the player's current Attack level."
+        duration: 300
+      - name: Strength boost
+        description: "Temporarily raises Strength by 3 plus 10% of the player's current Strength level."
+        duration: 300
+  recipes:
+    - skill: herblore
+      level: 36
+      xp: 84
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: 1
+        - item_name: Goat horn dust
+          quantity: 1
+      output_quantity: 1
+      notes: "Native brewing output is a 3-dose Combat potion(3)."
+  related_items:
+    - item_name: Combat potion(1)
+      slug: combat-potion-1
+      relationship: variant
+      description: 1-dose form created by decanting.
+    - item_name: Combat potion(2)
+      slug: combat-potion-2
+      relationship: variant
+      description: 2-dose form created by decanting.
+    - item_name: Combat potion(4)
+      slug: combat-potion-4
+      relationship: variant
+      description: 4-dose form created by decanting.
+    - item_name: Harralander potion (unf)
+      slug: harralander-potion-unf
+      relationship: component
+      description: Unfinished base used in the brewing recipe.
+    - item_name: Goat horn dust
+      slug: goat-horn-dust
+      relationship: component
+      description: Secondary required to finish the combat potion.
+  about: |-
+    Combat potion(3) is the standard 3-dose brew of the Herblore combat potion. Each dose raises both Attack and Strength by 3 plus 10% of the corresponding base level (rounded down).
+
+    The potion is brewed at 36 Herblore from a Harralander potion (unf) and goat horn dust, granting 84 Herblore experience per finish.
+  market_strategy:
+    notes:
+      - "Low-cost combat boost for early melee training and quest stat unlocks."
+      - "Demand is steady but supply is large from Herblore training."
+      - "Decant arbitrage with 4-dose form is the main source of price movement."
+  trading_tips:
+    - "Compare per-dose price against Combat potion(4) before flipping."
+    - "Watch for Herblore weekend events that flood supply."
+  history:
+    - date: "2002-04-11"
+      description: "Combat potions introduced with the Herblore expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/common-kebbit-fur.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/common-kebbit-fur.mdx
@@ -1,6 +1,6 @@
 ---
 title: Common kebbit fur | OSRS Price Data
-description: "Common kebbit fur: Common fur from a common kebbit.. High alch: 7 GP, GE limit: 10,000."
+description: "Common kebbit fur is a members Hunter resource from Common kebbits. High alch: 7 GP, GE limit: 10,000."
 osrs:
   id: 10121
   name: Common kebbit fur
@@ -12,9 +12,85 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 10000
-  about: "Common kebbit fur is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: fur
+    tier: low
+  properties:
+    release_date: "2006-11-27"
+    update: "Hunter skill release"
+    quest_item: false
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    weight: 0.4
+    destroy: "Drop"
+    options:
+      - Drop
+    examine_options:
+      - Examine
+    alchable: true
+  obtaining:
+    - method: Hunter
+      level: 1
+      xp: 30
+      source: Common kebbit
+      location: Piscatoris Hunter area
+      tools:
+        - Noose wand
+      notes: "Caught via Tracking using a noose wand"
+  recipes:
+    - skill: crafting
+      level: 1
+      xp: 0
+      tools:
+        - Fancy Dress Shop
+      materials:
+        - item_id: 10121
+          item_name: Common kebbit fur
+          quantity: 1
+        - item_id: 995
+          item_name: Coins
+          quantity: 500
+      output:
+        item_id: 10063
+        item_name: Spotted cape
+        output_quantity: 1
+      members: true
+      notes: "Trade to the Varrock Fancy Dress Shop for spotted cape"
+  related_items:
+    - item_id: 10095
+      item_name: Dark kebbit fur
+      slug: dark-kebbit-fur
+      relationship: upgrade
+      description: Higher tier kebbit fur from Dark kebbits
+    - item_id: 10117
+      item_name: Polar kebbit fur
+      slug: polar-kebbit-fur
+      relationship: alternative
+      description: Polar variant from Polar kebbits
+    - item_id: 10119
+      item_name: Feldip weasel fur
+      slug: feldip-weasel-fur
+      relationship: alternative
+      description: Feldip Hills kebbit fur variant
+    - item_id: 10063
+      item_name: Spotted cape
+      slug: spotted-cape
+      relationship: product
+      description: Crafted cape from common kebbit fur
+  market_strategy:
+    notes:
+      - "Low-tier Hunter byproduct, abundant supply"
+      - "Mainly used for spotted cape unlock"
+      - "Floor-priced; bulk supply from Hunter trainers"
+      - "Buy off GE rather than train Hunter for it"
+  history:
+    - date: "2006-11-27"
+      description: "Released with the Hunter skill"
+  about: "Common kebbit fur is a Hunter byproduct obtained by tracking and snaring common kebbits in the Piscatoris Hunter area. The fur can be exchanged at the Varrock Fancy Dress Shop to craft a spotted cape."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-oomlie-wrap.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-oomlie-wrap.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cooked oomlie wrap | OSRS Price Data
-description: "Cooked oomlie wrap: Deliciously cooked oomlie meat in a palm leaf pouch.. High alch: 21 GP, GE limit: 15."
+description: "Cooked oomlie wrap is a 50 Cooking Karamja dish that heals 14 HP, cooked from raw oomlie meat wrapped in a palm leaf. High alch: 21 GP, GE limit: 15."
 osrs:
   id: 2343
   name: Cooked oomlie wrap
@@ -12,9 +12,71 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 15
-  about: "Cooked oomlie wrap is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2003-08-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 50
+      xp: 30
+      materials:
+        - item_name: Oomlie meat parcel
+          quantity: 1
+      tools:
+        - Range
+      product: Cooked oomlie wrap
+      output_quantity: 1
+  passive_effects:
+    - name: Healing food
+      description: "Restores 14 Hitpoints when consumed; counts toward the Hard Karamja Diary 'eat an oomlie wrap' task."
+  related_items:
+    - item_name: Raw oomlie meat
+      slug: raw-oomlie-meat
+      relationship: component
+      description: Raw oomlie meat hunted from Jungle birds in the Kharazi Jungle
+    - item_name: Palm leaf
+      slug: palm-leaf
+      relationship: component
+      description: Combined with raw oomlie meat to make an Oomlie meat parcel before cooking
+    - item_name: Oomlie meat parcel
+      slug: oomlie-meat-parcel
+      relationship: component
+      description: Wrapped raw oomlie cooked on a range at 50 Cooking for 30 XP
+    - item_name: Burnt oomlie wrap
+      slug: burnt-oomlie-wrap
+      relationship: variant
+      description: Failure result when cooking an Oomlie meat parcel below mastery level
+  about: "Cooked oomlie wrap is a Karamja-themed Cooking dish made by wrapping raw oomlie meat in a palm leaf to create an Oomlie meat parcel, then cooking it on a range at 50 Cooking for 30 XP; the finished wrap heals 14 Hitpoints and is required for a Hard Karamja Diary task."
+  market_strategy:
+    notes:
+      - "Heals 14 HP - matches Swordfish at a higher Cooking requirement, so not a meta food"
+      - "Most demand comes from Hard Karamja Diary completionists, not regular PvM consumers"
+      - "GE buy limit of 15 per 4 hours throttles bulk flips and is the main supply story"
+      - "Raw oomlie + palm leaf supply chain runs through Kharazi Jungle hunters"
+  trading_tips:
+    - "Watch Karamja Diary content updates - any reward changes spike completionist demand"
+    - "Low GE limit makes this a thin-volume slow-burn flip, not a margin play"
+    - "Cross-check Raw oomlie meat and Palm leaf spot prices to gauge cooker margin"
+  history:
+    - date: "2003-08-20"
+      description: "Released with the Legends' Quest update introducing Karamja jungle resources and the oomlie cooking chain."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-armadyl-godsword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/corrupted-armadyl-godsword.mdx
@@ -1,6 +1,6 @@
 ---
 title: Corrupted armadyl godsword | OSRS Price Data
-description: "Corrupted armadyl godsword: A beautiful, heavy sword.. High alch: 150,000 GP."
+description: "Corrupted armadyl godsword: A beautiful, heavy sword. High alch: 150,000 GP."
 osrs:
   id: 28537
   name: Corrupted armadyl godsword
@@ -11,10 +11,92 @@ osrs:
   value: 250000
   lowalch: 100000
   highalch: 150000
-  limit: null
-  about: "Corrupted armadyl godsword is a members-only item in Old School RuneScape. High alchemy value: 150,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: corrupted
+    tier: high
+  properties:
+    release_date: "2023-08-23"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.072
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: 2h
+    weapon_type: 2h_sword
+    attack_speed: 6
+    attack_range: 1
+    weight: 9.072
+    requirements:
+      attack: 60
+    attack_bonus:
+      stab: 0
+      slash: 108
+      crush: 108
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 2
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 108
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  special_attack:
+    name: The Judgement
+    energy: 50
+    description: "Increases accuracy by 100% and damage by 37.5%. Bonuses are 20% lower than the standard Armadyl godsword."
+  drop_table:
+    sources:
+      - source: Trinket of advanced weaponry (Deadman Mode)
+        quantity: "1"
+        rarity: 1/8
+        notes: "Deadman Mode exclusive trinket drop from breaches."
+  related_items:
+    - item_id: 11802
+      item_name: Armadyl godsword
+      slug: armadyl-godsword
+      relationship: variant
+      description: "Standard variant with 20% higher stats."
+    - item_id: 28530
+      item_name: Corrupted bandos godsword
+      slug: corrupted-bandos-godsword
+      relationship: alternative
+      description: "Alternate Deadman corrupted godsword variant."
+    - item_id: 28534
+      item_name: Corrupted dragon claws
+      slug: corrupted-dragon-claws
+      relationship: alternative
+      description: "Another Deadman Mode corrupted special-attack weapon."
+  about: "Corrupted armadyl godsword is a Deadman Mode-exclusive variant of the Armadyl godsword obtained from trinkets of advanced weaponry, sharing The Judgement special attack but with 20% lower bonuses than the standard godsword."
+  market_strategy:
+    notes:
+      - "Deadman Mode seasonal exclusive; not always obtainable outside events."
+      - "Same The Judgement special attack as the standard Armadyl godsword."
+      - "20% lower stats than the standard variant."
+      - "Collection log piece for Deadman Mode completionists."
+  trading_tips:
+    - "Track Deadman season schedules to time supply spikes."
+    - "Compare against standard Armadyl godsword pricing for value perception."
+  history:
+    - date: "2023-08-23"
+      description: "Released as part of Deadman Mode Apocalypse trinket of advanced weaponry pool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-tea.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cup-of-tea.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cup of tea | OSRS Price Data
-description: "Cup of tea: A nice cup of tea.. High alch: 6 GP, GE limit: 2,000."
+description: "Cup of tea is a members food that restores 3 HP and boosts Attack by 2 + 2 percent. High alch: 6 GP, GE limit: 2,000."
 osrs:
   id: 1978
   name: Cup of tea
@@ -12,12 +12,70 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 2000
-  about: "Cup of tea is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2002-07-23"
+    update: "Members' quests"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.15
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  consumable:
+    heals: 3
+    effects:
+      - description: "Restores 3 Hitpoints when drunk."
+        duration: 0
+      - description: "Boosts Attack level by 2 + 2 percent of base Attack (rounded down)."
+        duration: 0
+      - description: "Cancels Goading potion stat drain effect."
+        duration: 0
+  related_items:
+    - item_id: 4242
+      item_name: Tea flask
+      slug: tea-flask
+      relationship: variant
+      description: "Multi-dose flask holding up to 5 cups of tea, used in Temple Trekking."
+    - item_id: 1980
+      item_name: Empty cup
+      slug: empty-cup
+      relationship: alternative
+      description: "Left in inventory after drinking the tea."
+    - item_id: 4239
+      item_name: Nettle tea
+      slug: nettle-tea
+      relationship: alternative
+      description: "Self-brewed Attack-boost tea variant."
+  about: "Cup of tea is a utility consumable that restores 3 Hitpoints and provides a small Attack level boost when drunk, leaving an empty cup behind. It is sold at Ye olde Tea Shoppe in Varrock, stolen from tea stalls at level 5 Thieving, and spawns at fixed locations across Gielinor. Primarily a quest item for The Dig Site Panning Guide bribe and a flavor-boost niche for low-level Attack training, it remains one of the oldest items in the game."
+  market_strategy:
+    notes:
+      - "Demand is driven by The Dig Site questing and Temple Trekking flask supply, not combat."
+      - "Supply is steady via the tea stall thieving meta plus NPC shop spawns."
+      - "GE buy limit of 2,000 keeps flips small but consistent."
+      - "High alch return of 6 gp - not viable as an alching target."
+  trading_tips:
+    - "Spike alerts on quest guide spikes - new players running The Dig Site demand small clusters."
+    - "Cross-monitor tea stall thieving meta - heavier stall activity floods supply."
+    - "Low-margin item; volume is rarely high enough for serious flips."
+  history:
+    - date: "2002-07-23"
+      description: "Added in the Members' quests update as part of early Varrock content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cured-yak-hide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cured-yak-hide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cured yak-hide | OSRS Price Data
-description: "Cured yak-hide: Ready to be cut and sewn into armour.. High alch: 60 GP, GE limit: 13,000."
+description: "Cured yak-hide is a tanned yak-hide used to craft yak-hide armour at the Neitiznot tanner. High alch: 60 GP, GE limit: 13,000."
 osrs:
   id: 10820
   name: Cured yak-hide
@@ -12,9 +12,90 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 13000
-  about: "Cured yak-hide is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: hide
+    tier: low
+  properties:
+    release_date: "2007-02-06"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+      - Examine
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 38
+      xp: 32
+      tools:
+        - Needle
+        - Thread
+      materials:
+        - item_id: 10820
+          item_name: Cured yak-hide
+          quantity: 2
+      product: Yak-hide armour (top)
+      product_id: 10822
+      output_quantity: 1
+      quest_required: The Fremennik Isles
+      notes: "Sewn at the Neitiznot tanner; grants Fremennik Isles favour"
+    - skill: crafting
+      level: 43
+      xp: 32
+      tools:
+        - Needle
+        - Thread
+      materials:
+        - item_id: 10820
+          item_name: Cured yak-hide
+          quantity: 2
+      product: Yak-hide armour (legs)
+      product_id: 10824
+      output_quantity: 1
+      quest_required: The Fremennik Isles
+      notes: "Sewn at the Neitiznot tanner; legs piece of the yak-hide set"
+  related_items:
+    - item_id: 10818
+      item_name: Yak-hide
+      slug: yak-hide
+      relationship: component
+      description: Raw yak-hide that must be cured at a tanner for 5 gp each
+    - item_id: 10822
+      item_name: Yak-hide armour (top)
+      slug: yak-hide-armour-top
+      relationship: product
+      description: Crafted top using two cured yak-hides at level 38 Crafting
+    - item_id: 10824
+      item_name: Yak-hide armour (legs)
+      slug: yak-hide-armour-legs
+      relationship: product
+      description: Crafted legs using two cured yak-hides at level 43 Crafting
+    - item_name: Hard leather
+      slug: hard-leather
+      relationship: alternative
+      description: Lower-tier cured hide used for d'hide-style armour crafting
+  market_strategy:
+    notes:
+      - "Supply driven by Fremennik Isles yak farmers and ironman alt training"
+      - "Demand from Honour Guard task and yak-hide armour crafters"
+      - "Price tracks Crafting XP/hr methods more than combat meta"
+      - "Cured at the Neitiznot tanner for 5 gp per raw yak-hide"
+      - "Buy limit 13,000 per 4 hours; comfortably absorbs bulk orders"
+  trading_tips:
+    - Compare cured yak-hide price to raw yak-hide + 5 gp tan cost for arbitrage
+    - Stock up before Honour Guard or Halls of Honour content drops
+    - Sell into bulk demand from Fremennik favour grinders
+  about: Cured yak-hide is the tanned form of yak-hide, sewn into yak-hide armour at the Neitiznot tanner after completion of The Fremennik Isles. Two cured hides are needed per armour piece.
+  history:
+    - date: "2007-02-06"
+      description: "Released alongside The Fremennik Isles quest and Neitiznot yak farming content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/curry.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/curry.mdx
@@ -1,6 +1,6 @@
 ---
 title: Curry | OSRS Price Data
-description: "Curry: It's a spicy hot curry.. High alch: 12 GP, GE limit: 10,000."
+description: "Curry is a 60 Cooking dish that heals 19 HP, made from uncooked curry on a range. High alch: 12 GP, GE limit: 10,000."
 osrs:
   id: 2011
   name: Curry
@@ -12,9 +12,72 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 10000
-  about: "Curry is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2002-05-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 60
+      xp: 280
+      materials:
+        - item_name: Uncooked curry
+          quantity: 1
+      tools:
+        - Range
+      product: Curry
+      output_quantity: 1
+  related_items:
+    - item_name: Uncooked curry
+      slug: uncooked-curry
+      relationship: component
+      description: "Raw curry mix cooked on a range at level 60 Cooking."
+    - item_name: Spice
+      slug: spice
+      relationship: component
+      description: "Optional spice ingredient that combines with uncooked stew to form uncooked curry."
+    - item_name: Curry leaf
+      slug: curry-leaf
+      relationship: component
+      description: "Three leaves can be used in place of a spice to make uncooked curry."
+    - item_name: Burnt curry
+      slug: burnt-curry
+      relationship: alternative
+      description: "Result of a failed curry cook under level 74 Cooking."
+    - item_name: Stew
+      slug: stew
+      relationship: variant
+      description: "Stew base from which curry diverges by adding spice or curry leaves."
+  about: "Curry is a members-only Cooking dish that heals 19 Hitpoints in a single bite, leaving an empty bowl behind. It requires level 60 Cooking to make and grants 280 xp per success, with burn rate dropping to zero at level 74. The recipe layers potato, water, cooked meat or chicken, and either 1 spice or 3 curry leaves to form uncooked curry before cooking on a range."
+  market_strategy:
+    notes:
+      - "Niche food - undercut by sharks and karambwans on heal-per-tick."
+      - "Buy limit of 10,000 keeps merchanting volume reasonable."
+      - "High alch of 12 gp is purely cosmetic - never an alch target."
+      - "Cooking trainers at level 60 are the primary supply pipeline."
+  trading_tips:
+    - "Cross-check uncooked curry input cost vs cooked GE price for skiller margins."
+    - "Watch Cooking xp metas for short-term supply spikes."
+    - "Bowl recovery makes it a niche pick for Chaos Fanatic / Crazy Archaeologist inventories."
+  history:
+    - date: "2002-05-08"
+      description: "Released as part of the Gnome Cooking expansion alongside other exotic dishes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dharok-s-platelegs.mdx
@@ -12,70 +12,95 @@ osrs:
   lowalch: 110000
   highalch: 165000
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: barrows
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
-    type: barrows
-    set: Dharok
-    tradeable: true
-    degradeable: true
+    weapon_type: unarmed
+    attack_speed: 4
     weight: 9
     requirements:
       defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -21
-      attack_ranged: -11
-      defence_stab: 85
-      defence_slash: 82
-      defence_crush: 83
-      defence_magic: -4
-      defence_ranged: 92
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -21
+      ranged: -11
+    defence_bonus:
+      stab: 85
+      slash: 82
+      crush: 83
+      magic: -4
+      ranged: 92
+    other_bonus:
       strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  set_effect:
-    name: Wretched Strength
-    pieces_required: 4
-    description: Damage increases as HP decreases. Up to +98.9% damage at 1 HP with 99 max HP
+  drop_table:
+    sources:
+      - source: Barrows chest (Dharok the Wretched)
+        quantity: "1"
+        rarity: "1/2500"
+        notes: "Dropped from the Barrows minigame when Dharok is among the killed brothers."
+  passive_effects:
+    - name: Wretched Strength
+      description: "When wearing the full Dharok's set (helm, platebody, platelegs, greataxe), Melee damage scales up as Hitpoints drop, peaking near +98.9% damage at 1 HP with 99 base HP."
   related_items:
     - item_id: 4716
       item_name: Dharok's helm
-      slug: dharoks-helm
+      slug: dharok-s-helm
       relationship: set-piece
       description: Head slot set piece
     - item_id: 4720
       item_name: Dharok's platebody
-      slug: dharoks-platebody
+      slug: dharok-s-platebody
       relationship: set-piece
       description: Body slot set piece
     - item_id: 4718
       item_name: Dharok's greataxe
-      slug: dharoks-greataxe
+      slug: dharok-s-greataxe
       relationship: set-piece
       description: Weapon set piece
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +85 |
-    | Slash defence | +82 |
-    | Crush defence | +83 |
-    | Magic defence | -4 |
-    | Ranged defence | +92 |
-    | Magic attack | -21 |
-    | Ranged attack | -11 |
-
-    Wretched Strength:
-    When wearing full Dharok's (helm, platebody, platelegs, greataxe):
-    - Damage increases as HP decreases
-    - Up to +98.9% damage at 1 HP with 99 max HP
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 4902
+      item_name: Dharok's platelegs 0
+      slug: dharok-s-platelegs-0
+      relationship: variant
+      description: Fully degraded variant with no charges remaining
+  about: "Dharok's platelegs are the leg piece of Dharok the Wretched's Barrows set, granting heavy melee defence (+85 stab, +82 slash, +83 crush, +92 ranged defence) and feeding the set's Wretched Strength effect that boosts damage as HP drops. They require 70 Defence, degrade over ~15 hours of combat, and are repaired by Bob in Lumbridge or at a POH armour stand."
+  market_strategy:
+    notes:
+      - "Price tracks Barrows brother loot tables and Dharok pure demand"
+      - "Cheap among the Dharok pieces; supply driven by Barrows runs"
+      - "Bulk demand from low-HP PvP / Dharok pure account builders"
+  trading_tips:
+    - Watch Barrows efficiency updates that shift Dharok piece supply
+    - Compare against degraded 0/25/50/75 charge variants for repair-flip arbitrage
+  history:
+    - date: "2005-05-09"
+      description: "Released as part of the Barrows minigame and Dharok's set."
+    - date: "2007-12-10"
+      description: "Defence bonuses rebalanced alongside other Barrows armour."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-ranging-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine ranging potion(3) | OSRS Price Data
-description: "Divine ranging potion(3): 3 doses of divine ranging potion.. High alch: 102 GP, GE limit: 2,000."
+description: "Divine ranging potion(3): 3 doses of divine ranging potion. High alch: 102 GP, GE limit: 2,000."
 osrs:
   id: 23736
   name: Divine ranging potion(3)
@@ -12,9 +12,74 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 2000
-  about: "Divine ranging potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: divine-potion
+    tier: high
+  properties:
+    release_date: "2019-07-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.03
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  consumable:
+    action: Drink
+    doses: 3
+    self_damage: 10
+  recipes:
+    - skill: herblore
+      level: 74
+      xp: 1.5
+      materials:
+        - item_name: Ranging potion(3)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 4
+      output_quantity: 1
+  passive_effects:
+    - name: Locked ranged boost
+      description: "Boosts Ranged by 4 + 10% of the player's Ranged level for 5 minutes, with no natural decline"
+    - name: Self damage
+      description: "Each dose deals 10 damage; requires at least 11 Hitpoints to drink"
+  related_items:
+    - item_name: Ranging potion(3)
+      slug: ranging-potion-3
+      relationship: component
+      description: "Base ranging potion combined with crystal dust to brew the divine variant"
+    - item_name: Crystal dust
+      slug: crystal-dust
+      relationship: component
+      description: "4 dust per dose, the divine ingredient required by the recipe"
+    - item_name: Divine ranging potion(4)
+      slug: divine-ranging-potion-4
+      relationship: variant
+      description: "Four-dose version of the same potion"
+    - item_name: Divine bastion potion(3)
+      slug: divine-bastion-potion-3
+      relationship: alternative
+      description: "Hybrid divine ranged potion bundling defence and ranged boosts"
+  about: "Divine ranging potion(3) is a 3-dose Herblore potion brewed at 74 Herblore by combining a ranging potion(3) with 4 crystal dust for 1.5 xp per dose. Each dose locks the player's Ranged boost at 4 + 10% of base level for five minutes with no natural decline, in exchange for 10 self-damage on drink, making it a staple at Vorkath, Cox, ToB, and PvP."
+  market_strategy:
+    notes:
+      - "Bound to crystal dust supply, which depends on crystal shards from Prifddinas content"
+      - "Mainstay PvM/PvP demand keeps volume healthy versus standard ranging potions"
+      - "Margin tracks the Prifddinas crystal grind, watch crystal dust spikes"
+  trading_tips:
+    - "Buy ahead of league/raid events when ranged DPS demand spikes"
+    - "Pair flips with crystal dust supply trends rather than ranging potion price alone"
+  history:
+    - date: "2019-07-25"
+      description: "Released alongside the divine potions update that reworked combat potions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-strength-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-strength-potion-3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine super strength potion(3) | OSRS Price Data
-description: "Divine super strength potion(3): 3 doses of divine super strength potion.. High alch: 102 GP, GE limit: 2,000."
+description: "Divine super strength potion(3) is a 3-dose Herblore potion brewed at 97 Herblore that boosts Strength by 5 + 15% and locks the level for 5 minutes. High alch: 102 GP, GE limit: 2,000."
 osrs:
   id: 23712
   name: Divine super strength potion(3)
@@ -12,12 +12,86 @@ osrs:
   lowalch: 68
   highalch: 102
   limit: 2000
-  about: "Divine super strength potion(3) is a members-only item in Old School RuneScape. High alchemy value: 102 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2018-08-30"
+    update: "Divine Potions"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    doses: 3
+    effect: "Boosts Strength by 5 + 15% of base level and locks the stat for 5 minutes."
+    effects:
+      - stat: strength
+        boost_type: percent_plus_flat
+        boost_formula: "5 + floor(level * 15%)"
+        duration: 300
+        description: "Boosts Strength by 5 + 15% of the base level and prevents the boost from draining for 5 minutes."
+  recipes:
+    - skill: herblore
+      level: 97
+      xp: 200
+      materials:
+        - item_name: Super strength(3)
+          quantity: 1
+        - item_name: Crystal dust
+          quantity: 1
+      output_quantity: 1
+      notes: "Combine a 3-dose super strength potion with crystal dust at 97 Herblore."
+  related_items:
+    - item_name: Divine super strength potion(4)
+      slug: divine-super-strength-potion-4
+      relationship: variant
+      description: "Full 4-dose variant - most commonly brewed and traded"
+    - item_name: Divine super strength potion(2)
+      slug: divine-super-strength-potion-2
+      relationship: variant
+      description: "2-dose variant"
+    - item_name: Divine super strength potion(1)
+      slug: divine-super-strength-potion-1
+      relationship: variant
+      description: "1-dose variant"
+    - item_name: Super strength(3)
+      slug: super-strength-3
+      relationship: component
+      description: "Base super strength potion combined with crystal dust to brew the divine variant"
+    - item_name: Crystal dust
+      slug: crystal-dust
+      relationship: component
+      description: "Ground from a crystal shard - the upgrade reagent for divine potions"
+  about: "Divine super strength potion(3) is a 3-dose members-only Herblore potion brewed at 97 Herblore by combining a 3-dose super strength potion with crystal dust, granting 200 Herblore XP per brew. Each dose boosts Strength by 5 + 15% of the player's base level and locks the boost from draining for 5 minutes, making divine potions the meta choice for tick-precise PvM where a single drained level can swing a damage tier or break a one-tick kill threshold."
+  market_strategy:
+    notes:
+      - "Demand is dominated by high-end PvM bracket: ToB, ToA expert, Inferno, and DPS-locked bossing setups"
+      - "Mid-dose stock typically sits in decant arbitrage territory; 4-dose holds the cleanest margin"
+      - "Supply ties directly to crystal shard generation rate via Prif and Gauntlet"
+      - "High alch of 102 gp is meaningless; never alch divine potions"
+  trading_tips:
+    - "Decant into 4-dose when the (3) premium spreads above decant fees"
+    - "Watch crystal shard price as the upstream cost driver; shards move on Prif content updates"
+    - "Stockpile ahead of major PvM releases, leagues, and DMM tournaments"
+  history:
+    - date: "2018-08-30"
+      description: "Released with the Divine Potions update that introduced the crystal-dust upgrade chain for super combat-tier potions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-2h-sword.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon 2h sword | OSRS Price Data
-description: "Dragon 2h sword is a members weapon slot item with +93 melee strength requiring 60 Attack. High alch: 132,000 GP, GE limit: 8."
+description: "Dragon 2h sword is a 60 Attack two-handed dragon weapon with +92 slash, +93 strength, and the multi-target Powerstab spec. High alch: 132,000 GP, GE limit: 8."
 osrs:
   id: 7158
   name: Dragon 2h sword
@@ -12,10 +12,35 @@ osrs:
   lowalch: 88000
   highalch: 132000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
+    weapon_type: 2h_sword
     two_handed: true
     attack_speed: 7
+    weight: 3.628
+    requirements:
+      attack: 60
     attack_bonus:
       stab: -4
       slash: 92
@@ -33,79 +58,78 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      attack: 60
-    weight: 3.628
   special_attack:
     name: Powerstab
     energy: 60
-    description: Hits all targets within 1 tile in multi-combat areas. Maximum 14 NPCs or 3 players per use.
+    description: "Hits all targets within a 1-tile radius in multi-combat areas, up to a maximum of 14 NPCs or 3 players per activation. No effect in single-combat zones."
   drop_table:
     sources:
       - source: Kalphite Queen
         combat_level: 333
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/128
+        rarity: rare
+        drop_rate: 1/256
         members_only: true
       - source: Chaos Elemental
         combat_level: 305
         quantity: "1"
         rarity: uncommon
+        drop_rate: 2/128
+        members_only: true
+      - source: Scorpia
+        combat_level: 225
+        quantity: "1"
+        rarity: rare
         drop_rate: 1/128
+        members_only: true
+      - source: Callisto
+        combat_level: 470
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/256
+        members_only: true
+      - source: "Vet'ion"
+        combat_level: 454
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/256
+        members_only: true
+      - source: Venenatis
+        combat_level: 464
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/256
         members_only: true
   related_items:
     - item_id: 1377
       item_name: Dragon battleaxe
       slug: dragon-battleaxe
       relationship: alternative
-      description: One-handed dragon strength weapon
+      description: One-handed dragon strength weapon with a 100% Strength-boost spec
     - item_id: 1249
       item_name: Dragon spear
       slug: dragon-spear
       relationship: alternative
-      description: Two-handed with stun spec
-  about: |-
-    | Attack | Value |
-    |--------|-------|
-    | Slash | +92 |
-    | Crush | +80 |
-
-    | Other | Value |
-    |-------|-------|
-    | Strength | +93 |
-
-    Requirements: 60 Attack | Speed: 7 tick (4.2s) | Two-handed
-
-    The highest Strength bonus (+93) and Slash attack (+92) of any dragon weapon, but extremely slow at 7-tick speed.
-
-    Cost: 60% special attack energy
-
-    In multi-combat areas, hits all targets within a 1-tile radius:
-    - Maximum 14 NPCs or 3 players per use
-    - No benefit in single-combat areas
-    - Area-of-effect damage makes it unique among dragon weapons
-
-    The Powerstab spec excels in:
-    - Nightmare Zone — hit multiple bosses simultaneously
-    - Catacombs of Kourend — multi-target training
-    - Multi-combat Slayer — clear clusters of monsters
-    - PvP multi-combat — hit up to 3 players at once
-
-    | Weapon | Speed | Slash | Str | Spec |
-    |--------|-------|-------|-----|------|
-    | Dragon 2h sword | 7 tick | +92 | +93 | AoE (60%) |
-    | Dragon scimitar | 4 tick | +67 | +66 | Def drain (55%) |
-    | Dragon battleaxe | 6 tick | +70 | +85 | Str boost (100%) |
-
-    Highest raw stats but the slowest speed makes it impractical for standard training. Best used for spec switching in multi-combat.
+      description: Two-handed dragon weapon with the Shove stun spec
+    - item_id: 4587
+      item_name: Dragon scimitar
+      slug: dragon-scimitar
+      relationship: alternative
+      description: Fastest one-handed dragon weapon, the standard 60 Attack training scimitar
+  about: "Dragon 2h sword is a two-handed dragon weapon requiring 60 Attack, dropped by Kalphite Queen, Chaos Elemental, Scorpia and the Wilderness bosses. Its slow 7-tick speed makes it impractical for standard training, but its Powerstab special attack hits every target within one tile in multi-combat, making it a niche AoE spec weapon for NMZ, Catacombs of Kourend, multi-target Slayer, and PvP team fights."
   market_strategy:
     notes:
-      - Kalphite Queen and Wilderness bosses are primary sources
-      - PvP demand for multi-spec
-      - Price sits near alch value
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Boss-drop only - no Smithing supply; price floor sits near the 132k high-alch value"
+      - "Kalphite Queen and Wilderness boss clears are the main supply faucets"
+      - "PvP and NMZ multi-spec demand keep volume alive despite the niche role"
+      - "GE buy limit of 8 per 4 hours caps merchant flips"
+  trading_tips:
+    - "Watch Wilderness boss rework news - drop-rate or hotspot changes move supply hard"
+    - "Stockpile before PvP tournaments and DMM seasons for multi-combat spec demand"
+    - "Cross-check against Dragon claws / Dragon warhammer demand to gauge boss-drop sentiment"
+  history:
+    - date: "2006-02-20"
+      description: "Released as the two-handed entry in the dragon weapon line with the Powerstab AoE special attack."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-halberd.mdx
@@ -12,93 +12,106 @@ osrs:
   lowalch: 100000
   highalch: 150000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2004-09-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 4.535
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: 2h
-    type: halberd
-    attack_style: melee
+    weapon_type: polearm
     attack_speed: 7
     attack_range: 2
+    weight: 4.535
     requirements:
       attack: 60
       strength: 30
-      quest: Regicide
-    stats:
-      attack_stab: 70
-      attack_slash: 95
-      attack_magic: -4
-      strength: 89
-    special_attack:
-      name: Sweep
-      energy: 30
-      effect: +10% damage, hits large monsters twice, multi-target
+    attack_bonus:
+      stab: 70
+      slash: 95
+      crush: 0
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 89
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  quest_requirements:
+    - quest_name: Regicide
+      required: true
+  special_attack:
+    name: Sweep
+    energy: 30
+    description: "+10% damage, hits large monsters (2x2+) twice, and cleaves up to 10 NPCs or 3 players in multi-combat."
+  shops:
+    - shop_name: "Quartermaster's Stores"
+      location: Tyras Camp
+      price: 325000
+      currency: coins
+      members_only: true
   drop_table:
     sources:
-      - source: Tyras Camp shop
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: 325K gp
-        members_only: true
       - source: Zulrah
-        source_id: 2044
         combat_level: 725
         quantity: "1"
-        rarity: 1/1,024
-        members_only: true
+        rarity: 1/1024
+        notes: "Magic/range form drop table item."
       - source: The Gauntlet
-        source_id: 0
         combat_level: 0
         quantity: "1"
         rarity: Rare
-        members_only: true
+        notes: "Reward chest from The Gauntlet."
   related_items:
     - item_id: 23987
       item_name: Crystal halberd
       slug: crystal-halberd
       relationship: upgrade
-      description: Upgrade
+      description: "Direct power-up halberd unlocked via Song of the Elves."
     - item_id: 4151
       item_name: Abyssal whip
       slug: abyssal-whip
       relationship: alternative
-      description: Main weapon
+      description: "Mainhand slash weapon used outside spec windows."
     - item_id: 22978
       item_name: Scythe of vitur
       slug: scythe-of-vitur
       relationship: upgrade
-      description: BiS alternative
-  about: |-
-    | Offense | Value |
-    |---------|-------|
-    | Stab | +70 |
-    | Slash | +95 |
-    | Magic | -4 |
-    | Strength | +89 |
-
-    | Defence | Value |
-    |---------|-------|
-    | All | +0 |
-
-    Requirements: 60 Attack, 30 Strength, Regicide
-
-    Sweep (30% energy):
-    - +10% damage
-    - Second hit on large monsters (2x2+)
-    - Hits up to 10 NPCs / 3 players in multi
-
-    Popular for:
-    - CoX (Tekton)
-    - Large monster specs
-    - Multi-target situations
-
-    Budget alternative to Crystal halberd.
+      description: "BiS large-monster two-hander."
+  about: "Dragon halberd is a members two-handed polearm with a 2-tile reach and 7-tick attack speed, requiring 60 Attack, 30 Strength and Regicide to wield. Its Sweep special attack deals +10% damage and hits large monsters twice, making it a budget alternative to the Crystal halberd at CoX Tekton and on multi-target Slayer tasks."
   market_strategy:
     notes:
-      - Regicide required
-      - Great spec weapon
-      - Upgrade to crystal halberd
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Regicide quest unlock gates supply; price is propped up by spec-weapon demand."
+      - "Crystal halberd upgrade pulls top-end players off the dragon halberd market."
+      - "Daily Tyras Camp shop restock at 325k caps GE upside."
+  trading_tips:
+    - "Use shop arbitrage from Tyras Camp when GE pricing spikes."
+    - "Demand follows raid metas that favour Tekton spec rotations."
+  history:
+    - date: "2004-09-20"
+      description: "Released alongside other halberds in the Halberd update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-keel-parts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon keel parts | OSRS Price Data
-description: "Dragon keel parts: Parts for creating a dragon keel for a boat.. High alch: 22,500 GP, GE limit: 100."
+description: "Dragon keel parts: Parts for creating a dragon keel for a boat. High alch: 22,500 GP, GE limit: 100."
 osrs:
   id: 32017
   name: Dragon keel parts
@@ -12,9 +12,81 @@ osrs:
   lowalch: 15000
   highalch: 22500
   limit: 100
-  about: "Dragon keel parts is a members-only item in Old School RuneScape. High alchemy value: 22,500 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2024-09-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Vorkath
+        combat_level: 732
+        quantity: "1"
+        rarity: 1/3000
+        notes: "Drop table item used in Eastern boatbuilding contracts."
+      - source: Calvar'ion
+        combat_level: 590
+        quantity: "1"
+        rarity: 1/2400
+        notes: "Wilderness boss reward shared with Vet'ion."
+  recipes:
+    - skill: crafting
+      level: 78
+      xp: 0
+      materials:
+        - item_id: 32017
+          item_name: Dragon keel parts
+          quantity: 1
+      output:
+        item_id: 32014
+        item_name: Dragon keel
+        output_quantity: 1
+      tools: []
+      facility: Boatbuilding workbench
+      members: true
+      notes: "Used as a Boatbuilding contract material toward a Dragon keel."
+  related_items:
+    - item_id: 32014
+      item_name: Dragon keel
+      slug: dragon-keel
+      relationship: upgrade
+      description: "Assembled keel built from these parts."
+    - item_id: 32016
+      item_name: Dragon mast parts
+      slug: dragon-mast-parts
+      relationship: alternative
+      description: "Sister Boatbuilding component piece."
+    - item_id: 32018
+      item_name: Dragon hull parts
+      slug: dragon-hull-parts
+      relationship: alternative
+      description: "Sister Boatbuilding component piece."
+  about: "Dragon keel parts are a Boatbuilding tradeable used to construct a Dragon keel, obtained as a rare drop from Vorkath and Wilderness bosses, with a 100 buy limit and a 22,500 high alch value."
+  market_strategy:
+    notes:
+      - "Boatbuilding contract demand sets the floor for dragon parts."
+      - "Vorkath and Wilderness boss supply keeps daily volume tight."
+      - "Limit 100 per 4 hours throttles large-scale flipping."
+  trading_tips:
+    - "Stock parts during Boatbuilding meta updates and contract pushes."
+    - "Compare keel parts vs hull/mast spread to balance supplier rotations."
+  history:
+    - date: "2024-09-04"
+      description: "Released with the Boatbuilding skill expansion as a Dragon-tier component."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-lump.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-lump.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon metal lump | OSRS Price Data
-description: "Dragon metal lump: A badly damaged lump of dragon metal.. High alch: 90,000 GP, GE limit: 50."
+description: "Dragon metal lump is a rune dragon drop combined with shards and slices to forge dragon platebody pieces. High alch: 90,000 GP, GE limit: 50."
 osrs:
   id: 22103
   name: Dragon metal lump
@@ -12,9 +12,91 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 50
-  about: "Dragon metal lump is a members-only item in Old School RuneScape. High alchemy value: 90,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: smithing-component
+    tier: high
+  drop_table:
+    primary_source: Rune dragon
+    best_drop_rate: 1/5,000
+    sources:
+      - source: Rune dragon
+        combat_level: 380
+        quantity: "1"
+        rarity: very-rare
+        drop_rate: 1/5,000
+        members_only: true
+  recipes:
+    - skill: smithing
+      level: 90
+      xp: 2000
+      materials:
+        - item_name: Dragon chainbody
+          quantity: 1
+        - item_name: Dragon metal shard
+          quantity: 1
+        - item_name: Dragon metal lump
+          quantity: 1
+      product: Dragon platebody
+      product_id: 21892
+      output_quantity: 1
+      facility: Anvil
+      quest_required: Dragon Slayer II
+      members_only: true
+  related_items:
+    - item_id: 22105
+      item_name: Dragon metal shard
+      slug: dragon-metal-shard
+      relationship: component
+      description: Second high-tier rune dragon drop paired with the lump.
+    - item_id: 22107
+      item_name: Dragon metal slice
+      slug: dragon-metal-slice
+      relationship: component
+      description: Related rune dragon drop used in dragon platebody crafting flow.
+    - item_id: 3140
+      item_name: Dragon chainbody
+      slug: dragon-chainbody
+      relationship: component
+      description: Base body upgraded with shard + lump into the dragon platebody.
+    - item_id: 21892
+      item_name: Dragon platebody
+      slug: dragon-platebody
+      relationship: product
+      description: End product of the 90 Smithing dragon body upgrade.
+  about: |-
+    The dragon metal lump is one of two Rune dragon-only drops required to craft the Dragon platebody,
+    the other being the dragon metal shard. With a 1/5,000 drop rate from one of the strongest dragons
+    in the game, the lump's price is anchored by raw rune dragon supply versus dragon platebody demand
+    from melee endgame DPS upgrades.
+  market_strategy:
+    title: Rune Dragon Supply Squeeze
+    notes:
+      - Supply is locked to active rune dragon killers; price is sensitive to slayer task assignments
+      - Dragon Slayer II + 90 Smithing requirement caps demand-side competition
+      - Pairs cleanly with dragon metal shard — track both before committing capital
+      - Buy limit of 50 means large investors can comfortably accumulate over multiple cycles
+  trading_tips:
+    - Watch the dragon platebody / chainbody spread to predict lump direction
+    - Bid hard during prolonged slayer droughts when supply dries up
+    - Avoid overbuying near double-XP weekends; smithing demand spikes are short-lived
+  history:
+    - date: "2018-01-04"
+      description: Released with Dragon Slayer II as one of the rune dragon platebody components.
+  properties:
+    release_date: "2018-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 2.721
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-slice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-slice.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon metal slice | OSRS Price Data
-description: "Dragon metal slice: A badly damaged slice of dragon metal.. High alch: 60,000 GP, GE limit: 50."
+description: "Dragon metal slice is a rare adamant dragon drop combined with a dragon metal shard and dragon sq shield to smith the dragon kiteshield. High alch: 60,000 GP, GE limit: 50."
 osrs:
   id: 22100
   name: Dragon metal slice
@@ -12,12 +12,83 @@ osrs:
   lowalch: 40000
   highalch: 60000
   limit: 50
-  about: "Dragon metal slice is a members-only item in Old School RuneScape. High alchemy value: 60,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    update: "Dragon Slayer II"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.721
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 75
+      xp: 1000
+      materials:
+        - item_name: Dragon metal slice
+          quantity: 1
+        - item_name: Dragon metal shard
+          quantity: 1
+        - item_name: Dragon sq shield
+          quantity: 1
+      tools:
+        - Blast furnace
+      output_quantity: 1
+      product: Dragon kiteshield
+      notes: "Forged at the Blast Furnace after completion of Dragon Slayer II."
+  drops:
+    - source: Adamant dragon
+      combat_level: 338
+      quantity: 1
+      rarity: 1/5000
+      notes: "Exclusive drop; only adamant dragons drop the slice."
+  related_items:
+    - item_name: Dragon metal shard
+      slug: dragon-metal-shard
+      relationship: component
+      description: "Companion rare drop from rune dragons; pairs with the slice in the kiteshield recipe."
+    - item_name: Dragon sq shield
+      slug: dragon-sq-shield
+      relationship: component
+      description: "Base shield consumed in the dragon kiteshield Smithing recipe."
+    - item_name: Dragon kiteshield
+      slug: dragon-kiteshield
+      relationship: product
+      description: "Final tier-75 melee shield crafted from the slice + shard + sq shield combo."
+    - item_name: Adamant dragon
+      slug: adamant-dragon
+      relationship: alternative
+      description: "Only NPC that drops the slice."
+  about: "Dragon metal slice is a rare 1/5000 drop from adamant dragons added with Dragon Slayer II, used together with a Dragon metal shard (from rune dragons) and a Dragon sq shield to smith the Dragon kiteshield at 75 Smithing for 1,000 XP at the Blast Furnace. It is one of the gating components for the dragon kiteshield grind and pairs visually with the shard as two halves of a square shield in the drop animation."
+  market_strategy:
+    notes:
+      - "Supply gated by adamant dragon farm pace and the 1/5000 drop rate"
+      - "Demand tied to dragon kiteshield ironman / pure account upgrade cycles"
+      - "Buy limit of 50 per 4 hours keeps spreads wide on each GE flip"
+      - "Price floor anchored by dragon kiteshield resale less shard + sq shield cost"
+  trading_tips:
+    - "Pair slice + shard buy orders to lock in kiteshield assembly margin"
+    - "Watch Dragon Slayer II quest spikes during free-to-play retention pushes"
+    - "Avoid heavy slice longs when Smithing methods get reworked - kiteshield demand softens"
+  history:
+    - date: "2018-01-04"
+      description: "Released with Dragon Slayer II as part of the dragon kiteshield Smithing recipe."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-bolt-tips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonstone bolt tips | OSRS Price Data
-description: "Dragonstone bolt tips: Dragonstone bolt tips.. High alch: 400 GP, GE limit: 11,000."
+description: "Dragonstone bolt tips: Dragonstone bolt tips. High alch: 400 GP, GE limit: 11,000."
 osrs:
   id: 9193
   name: Dragonstone bolt tips
@@ -12,11 +12,24 @@ osrs:
   lowalch: 266
   highalch: 400
   limit: 11000
-  item:
-    type: ammunition_component
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragonstone
+    tier: high
+  properties:
+    release_date: "2006-07-31"
     tradeable: true
     stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
     weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: fletching
       level: 71
@@ -24,40 +37,55 @@ osrs:
       materials:
         - item_name: Dragonstone
           quantity: 1
-      product: Dragonstone bolt tips
-      product_quantity: 12
+      tools:
+        - Chisel
+      output_quantity: 12
+  drop_table:
+    sources:
+      - source: Zulrah
+        quantity: "12-40"
+        rarity: Common
+      - source: Vorkath
+        quantity: "12-40"
+        rarity: Common
+      - source: Alchemical Hydra
+        quantity: "4-12"
+        rarity: Uncommon
+      - source: Revenant dragon
+        quantity: "1-3"
+        rarity: Uncommon
+      - source: Vyrewatch
+        quantity: "1"
+        rarity: Rare
   related_items:
-    - item_id: 9341
-      item_name: Dragonstone bolts
+    - item_name: Dragonstone
+      slug: dragonstone
+      relationship: component
+      description: "Cut gem chiselled into 12 bolt tips at 71 Fletching"
+    - item_name: Dragonstone bolts
       slug: dragonstone-bolts
       relationship: product
-      description: Created item
-    - item_id: 9244
-      item_name: Dragonstone bolts (e)
+      description: "Tips attached to runite bolts at 71 Fletching"
+    - item_name: Dragonstone dragon bolts
+      slug: dragonstone-dragon-bolts
+      relationship: product
+      description: "Tips attached to dragon bolts at 84 Fletching"
+    - item_name: Dragonstone bolts (e)
       slug: dragonstone-bolts-e
       relationship: alternative
-      description: Enchanted version
-    - item_id: 21948
-      item_name: Dragonstone dragon bolts
-      slug: dragonstone-dragon-bolts
-      relationship: alternative
-      description: Dragon variant
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Ammunition Component |
-    | Tradeable | Yes |
-    | Stackable | Yes |
-    | Weight | 0 kg |
-
-    | Bolt Created | Materials | Fletching |
-    |--------------|-----------|-----------|
-    | Dragonstone bolts | Runite bolts + Dragonstone bolt tips | 71 |
-    | Dragonstone dragon bolts | Dragon bolts + Dragonstone bolt tips | 84 |
-
-    Can be enchanted after attachment.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Magic-enchanted Dragon's Breath proc version of the finished bolts"
+  about: "Dragonstone bolt tips are Fletching components produced by chiselling a cut dragonstone into 12 tips at 71 Fletching for 8.2 xp. Attached to runite bolts at 71 Fletching or dragon bolts at 84 Fletching, they form the base ammo for dragonstone bolts (e), which carry the Dragon's Breath proc that ignores 100% of dragonfire resistance bonuses on enchanted hits."
+  market_strategy:
+    notes:
+      - "Margin scales with the dragonstone gem spread, watch Karambwan trips and Zulrah supply"
+      - "End-product demand is dragonstone bolts (e) at Zulrah and PvP, not raw tips"
+      - "Stable utility item, modest holds work as the dragonstone price drifts"
+  trading_tips:
+    - "Buy tips when dragonstone supply spikes from PvM drops, sell into bolt-crafters"
+    - "Compare tip GE price to (dragonstone / 12) plus 8.2 xp value before flipping"
+  history:
+    - date: "2006-07-31"
+      description: "Released with the dragonstone bolt content for Fletching."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-ring.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragonstone ring | OSRS Price Data
-description: "Dragonstone ring is a members ring slot item. High alch: 10,575 GP, GE limit: 10,000."
+description: "Dragonstone ring is a members Crafting-made ring; enchanted with Lvl-5 Enchant into the Ring of wealth. High alch: 10,575 GP, GE limit: 10,000."
 osrs:
   id: 1645
   name: Dragonstone ring
@@ -12,60 +12,124 @@ osrs:
   lowalch: 7050
   highalch: 10575
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragonstone
+    tier: high
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.006
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ring
-    requirements:
-      crafting: 55
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 55
       xp: 100
-      inputs:
-        - item_id: 1615
-          item_name: Dragonstone
+      materials:
+        - item_name: Gold bar
+          item_id: 2357
           quantity: 1
-        - item_id: 2357
-          item_name: Gold bar
+        - item_name: Dragonstone
+          item_id: 1615
           quantity: 1
+        - item_name: Ring mould
+          quantity: 1
+      tools:
+        - Furnace
       output_quantity: 1
+    - skill: magic
+      level: 68
+      xp: 78
+      materials:
+        - item_name: Dragonstone ring
+          item_id: 1645
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Earth rune
+          quantity: 15
+        - item_name: Water rune
+          quantity: 15
+      product: Ring of wealth
+      product_id: 2572
+      output_quantity: 1
+      notes: "Lvl-5 Enchant converts the ring into the Ring of wealth, unlocking rare-drop-table boosts and teleport charges."
   related_items:
     - item_id: 1643
       item_name: Diamond ring
       slug: diamond-ring
       relationship: downgrade
-      description: Previous tier ring
+      description: "Previous-tier Crafting ring made from a diamond."
     - item_id: 6575
       item_name: Onyx ring
       slug: onyx-ring
       relationship: upgrade
-      description: Next tier ring
+      description: "Next-tier Crafting ring made from an onyx."
     - item_id: 2572
       item_name: Ring of wealth
       slug: ring-of-wealth
       relationship: upgrade
-      description: Enchanted version (improves RDT)
-  about: |-
-    Crafting (Level 55): Dragonstone + Gold bar at a furnace (100 XP)
-
-    > *"A dragonstone ring."*
-
-    Lvl-5 Enchant (68 Magic): 1 cosmic rune + 15 earth runes + 15 water runes (78 XP)
-
-    The Ring of wealth improves the Rare Drop Table (RDT):
-    - Removes empty slots from the RDT, effectively increasing the chance of receiving a valuable drop
-    - Provides 5 charges of teleportation (Miscellania, Grand Exchange, Falador Park)
-    - Shows a notification when a RDT drop is received
-    - Can be imbued at the Nightmare Zone for double effect in the Wilderness
-
-    The ring of wealth is one of the most widely used rings for general PvM, particularly for players without better ring options.
+      description: "Enchanted version that improves the Rare Drop Table."
+    - item_id: 1615
+      item_name: Dragonstone
+      slug: dragonstone
+      relationship: component
+      description: "Cut gem required for the Crafting recipe."
+    - item_id: 2357
+      item_name: Gold bar
+      slug: gold-bar
+      relationship: component
+      description: "Smelted base used with a ring mould at the furnace."
+  about: "Dragonstone ring is a members Crafting ring made at 55 Crafting from a gold bar, a dragonstone, and a ring mould at any furnace for 100 Crafting XP. Unenchanted it offers zero combat bonuses, so its value comes from Lvl-5 Enchant (68 Magic, 78 Magic XP - 1 cosmic, 15 earth, 15 water runes) which converts it into the Ring of wealth, a high-traffic PvM ring that boosts the Rare Drop Table and carries five teleport charges."
   market_strategy:
     notes:
-      - Ring of wealth is rechargeable (not destroyed on use)
-      - Dragonstone cost drives the ring price
-      - Enchanting is usually profitable
-      - High demand — used by many players for general PvM
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Dragonstone + gold bar input cost sets the price floor"
+      - "Lvl-5 Enchant arbitrage feeds the Ring of wealth market"
+      - "GE buy limit of 10,000 supports bulk merching"
+      - "Demand is enchanter-driven - not worn directly at scale"
+  trading_tips:
+    - "Cross-check Dragonstone ring vs Ring of wealth + cosmic/earth/water rune costs to spot enchant arbitrage"
+    - "Watch Slayer/PvM meta shifts that raise Ring of wealth demand"
+    - "Steady, stable item - best used as a flip leg rather than a hold"
+  history:
+    - date: "2002-02-27"
+      description: "Released with the original gem ring expansion in early RuneScape."
+    - date: "2007-04-30"
+      description: "Received an updated equipped sprite."
+    - date: "2018-12-13"
+      description: "Sprite rotated to better distinguish from enchanted variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dual-sai.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dual-sai.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dual sai | OSRS Price Data
-description: "Dual sai: A pair of aggressive Sai.. High alch: 3,600 GP, GE limit: 8."
+description: "Dual sai is a members hard clue reward; a stab two-handed weapon with +14 melee strength. High alch: 3,600 GP, GE limit: 8."
 osrs:
   id: 23206
   name: Dual sai
@@ -12,9 +12,94 @@ osrs:
   lowalch: 2400
   highalch: 3600
   limit: 8
-  about: "Dual sai is a members-only item in Old School RuneScape. High alchemy value: 3,600 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: weapon
+    tier: mid
+  equipment:
+    slot: 2h
+    weapon_type: 2h-sword
+    attack_speed: 5
+    weight: 1.36
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 11
+      slash: 8
+      crush: -4
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 14
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  drop_table:
+    primary_source: Reward casket (hard)
+    best_drop_rate: 1/1,625
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/1,625
+        members_only: true
+  related_items:
+    - item_id: 23200
+      item_name: Bowl wig
+      slug: bowl-wig
+      relationship: alternative
+      description: Other cosmetic hard clue reward from the same drop pool.
+    - item_id: 23203
+      item_name: Afro
+      slug: afro
+      relationship: alternative
+      description: Hard clue cosmetic released alongside the dual sai.
+  about: |-
+    The dual sai is a two-handed stab weapon obtained from hard Treasure Trail reward caskets. While the
+    base stats trail dedicated stab options like the abyssal dagger, the dual sai's +14 melee strength
+    bonus and unique stab-style attack make it a collectible flex piece more than a meta DPS choice.
+  market_strategy:
+    title: Hard Clue Supply
+    notes:
+      - Supply scales with the hard clue scroll meta; popular farming methods inflate listings
+      - Cosmetic appeal and small buy limit (8) keep retail prices above pure stat value
+      - Track hard clue Wiki pages and content patches for unlock rate changes
+      - Hold during sustained clue droughts; flip aggressively during double-cast events
+  trading_tips:
+    - Compare to abyssal dagger when pricing — collectors are the main demand driver
+    - Buy out crashes after major drop-rate buffs to the hard clue table
+    - Avoid stockpiling deep; the 8 buy limit slows clearing on lows
+  history:
+    - date: "2019-04-11"
+      description: Added as a hard Treasure Trail reward in the 2019 clue scroll expansion.
+  properties:
+    release_date: "2019-04-11"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 1.36
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/echo-pearl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/echo-pearl.mdx
@@ -1,6 +1,6 @@
 ---
 title: Echo pearl | OSRS Price Data
-description: "Echo pearl: A glowing pearl, as you stare into it you can hear sounds of the ocean.. High alch: 4,800 GP."
+description: "Echo pearl is a rare orca/dolphin drop required to craft the fathom pearl Sailing facility. High alch: 4,800 GP."
 osrs:
   id: 31946
   name: Echo pearl
@@ -11,52 +11,92 @@ osrs:
   value: 8000
   lowalch: 3200
   highalch: 4800
-  limit: null
-  item_type: material
-  tradeable: true
-  weight: 1
-  high_alch: 4800
-  low_alch: 3200
+  limit:
+  material:
+    type: crafting-component
+    tier: mid-high
   drop_table:
     primary_source: Orca
-    best_drop_rate: 1/65.5
+    best_drop_rate: 1/35
     sources:
       - source: Orca
+        combat_level: 205
         quantity: "1"
         rarity: uncommon
-        drop_rate: 1/65.5
+        drop_rate: 1/70
         members_only: true
       - source: Dolphin
+        combat_level: 22
         quantity: "1"
         rarity: rare
-        drop_rate: 1/927
+        drop_rate: 1/1,200
         members_only: true
-  obtaining:
-    source: Orca, Dolphin
-    location: Sea creatures while Sailing
-    requirements: Sailing skill access
+  recipes:
+    - skill: construction
+      level: 83
+      xp: 2307
+      materials:
+        - item_name: Rosewood plank
+          quantity: 10
+        - item_name: Dragon nails
+          quantity: 40
+        - item_name: Dragon metal sheet
+          quantity: 2
+        - item_name: Echo pearl
+          quantity: 1
+      product: Fathom pearl
+      product_id: 32229
+      output_quantity: 1
+      facility: Boat upgrade hotspot
+      members_only: true
   related_items:
     - item_id: 32229
       item_name: Fathom pearl
       slug: fathom-pearl
       relationship: product
-      description: Used to craft the Fathom pearl facility
+      description: High-level Sailing boat facility crafted from the echo pearl.
+    - item_name: Rosewood plank
+      slug: rosewood-plank
+      relationship: component
+      description: Bulk plank component paired with the echo pearl in the recipe.
+    - item_name: Dragon metal sheet
+      slug: dragon-metal-sheet
+      relationship: component
+      description: High-tier smithing component required for the fathom pearl.
   about: |-
-    "A glowing pearl, as you stare into it you can hear sounds of the ocean."
-
-    The Echo pearl is a crafting material primarily used in Sailing and Construction to create the Fathom pearl facility.
-
-    Crafting Uses:
-    - Required component for Fathom pearl (requires 91 Sailing, 83 Construction)
-    - Combined with Rosewood planks, Dragon nails, and Dragon metal sheets
+    The echo pearl is a Sailing-era drop pulled from orcas and dolphins out on the open ocean. It feeds
+    a single recipe — the fathom pearl boat upgrade — which gates progression for high-level Construction
+    + Sailing pairings. Orcas drop the pearl roughly 17× more often than dolphins, so dedicated farmers
+    target the higher-combat creature.
   market_strategy:
+    title: Sailing Drop Economy
     notes:
-      - Orcas provide much better drop rate than dolphins
-      - Required for Fathom pearl - high-level trawling upgrade
-      - Price fluctuates based on Sailing skill demand
-      - Consider farming orcas for more efficient acquisition
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Supply is locked to active orca and dolphin hunters; spikes follow Sailing content drops
+      - Demand is single-recipe; fathom pearl saturation will eventually soften the floor
+      - No buy limit — bulk movers can flood listings quickly during gluts
+      - Track the rosewood plank and dragon metal sheet markets to anticipate recipe demand
+  trading_tips:
+    - Buy aggressively when Sailing content is featured in seasonal events
+    - Watch fathom pearl demand patterns; this is a single-use recipe component
+    - Avoid hoarding once fathom pearl owners saturate the market
+  history:
+    - date: "2025-11-19"
+      description: Added with the Sailing skill release as a high-level boat upgrade component.
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eldritch-orb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eldritch-orb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Eldritch orb | OSRS Price Data
-description: "Eldritch orb: An ancient magical orb, corrupted by darkness.. High alch: 2,400,000 GP, GE limit: 8."
+description: "Eldritch orb is a Nightmare-only drop combined with the Nightmare staff to forge the prayer-sustain Eldritch nightmare staff. High alch: 2,400,000 GP, GE limit: 8."
 osrs:
   id: 24517
   name: Eldritch orb
@@ -12,62 +12,95 @@ osrs:
   lowalch: 1600000
   highalch: 2400000
   limit: 8
-  item:
-    type: upgrade material
-    tradeable: true
-    weight: 0.1
-  obtaining:
-    - source: The Nightmare
-      drop_rate: 1/960 to 1/548.7
-    - source: Phosani's Nightmare
-      drop_rate: 1/1,600
+  material:
+    type: upgrade-component
+    tier: high
+  drop_table:
+    primary_source: The Nightmare
+    best_drop_rate: 1/548.7
+    sources:
+      - source: The Nightmare
+        combat_level: 814
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/960 to 1/548.7
+        members_only: true
+      - source: Phosani's Nightmare
+        combat_level: 1024
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/1,600
+        members_only: true
   recipes:
-    - skill: crafting
+    - skill: magic
       level: 1
+      xp: 0
       materials:
-        - item_id: 24517
-          item_name: Eldritch orb
-          quantity: 1
         - item_id: 24422
           item_name: Nightmare staff
           quantity: 1
+        - item_id: 24517
+          item_name: Eldritch orb
+          quantity: 1
       product: Eldritch nightmare staff
       product_id: 24505
-  effect:
-    description: Special attack drains prayer from target and restores user's prayer
-    notes: Useful for prayer-based content
+      output_quantity: 1
+      members_only: true
   related_items:
     - item_id: 24422
       item_name: Nightmare staff
       slug: nightmare-staff
       relationship: component
-      description: Base weapon for upgrade
+      description: Base weapon upgraded with the eldritch orb.
     - item_id: 24505
       item_name: Eldritch nightmare staff
       slug: eldritch-nightmare-staff
       relationship: product
-      description: Created prayer sustain weapon
+      description: Prayer-sustain magic staff created from the orb upgrade.
+    - item_id: 24511
+      item_name: Harmonised orb
+      slug: harmonised-orb
+      relationship: alternative
+      description: Alternative orb that produces the Harmonised nightmare staff.
+    - item_id: 24514
+      item_name: Volatile orb
+      slug: volatile-orb
+      relationship: alternative
+      description: Alternative orb that produces the Volatile nightmare staff.
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Upgrade Material |
-    | Tradeable | Yes |
-    | Weight | 0.1 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Eldritch nightmare staff | Nightmare staff + Eldritch orb |
-
-    Special attack drains prayer from target and restores user's prayer.
-
-    Useful for prayer-based content.
+    The eldritch orb is one of three orb drops from The Nightmare and Phosani's Nightmare. Combined with
+    the Nightmare staff it forges the Eldritch nightmare staff, whose special attack drains an enemy's
+    prayer and restores the wielder's own. It is the niche prayer-sustain pick of the three orbs and
+    commands a high price thanks to drop rarity and constrained buy limit.
   market_strategy:
+    title: Boss Drop Investment
     notes:
-      - Farm Nightmare/Phosani's
-      - Prayer sustain weapon
-      - Niche uses
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Supply is gated by Nightmare and Phosani's Nightmare uniques tables
+      - High alch value (2.4M) provides a soft floor against extreme dips
+      - Buy limit of 8 favours sustained holders over volume flippers
+      - Track Magic spec-weapon meta and prayer-drain content for demand signals
+  trading_tips:
+    - Watch all three nightmare orbs together — supply shifts move them in lockstep
+    - Enter on confirmed PvM meta shifts that reward prayer drain
+    - Avoid revenge-buys after sharp pumps; thin order book amplifies whipsaws
+  history:
+    - date: "2020-02-06"
+      description: Released with The Nightmare of Ashihama as one of three boss orb drops.
+  properties:
+    release_date: "2020-02-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-skirt-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-skirt-white.mdx
@@ -1,20 +1,93 @@
 ---
 title: Elven skirt (white) | OSRS Price Data
-description: "Elven skirt (white): Clothing from the elven city of Prifddinas.. High alch: 3,000 GP."
+description: "Elven skirt (white) is a cosmetic Prifddinas leg piece sold by Lliann's Wares after Song of the Elves. High alch: 3,000 GP."
 osrs:
   id: 24018
   name: Elven skirt (white)
   slug: elven-skirt-white
   examine: Clothing from the elven city of Prifddinas.
-  members: false
+  members: true
   icon: Elven skirt (white).png
   value: 5000
   lowalch: 2000
   highalch: 3000
-  limit: null
-  about: "Elven skirt (white) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: elven cloth
+    tier: mid
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  obtaining:
+    methods:
+      - source: Lliann's Wares (Prifddinas)
+        price: 5000
+        requirements:
+          quest: Song of the Elves
+        description: "Purchased from Lliann's Wares in Prifddinas for 5,000 coins; 100 stock, 5-hour restock."
+  related_items:
+    - item_name: Elven top (white)
+      slug: elven-top-white
+      relationship: set-piece
+      description: "Matching white elven body piece sold at Lliann's Wares."
+    - item_name: Elven dress (white)
+      slug: elven-dress-white
+      relationship: alternative
+      description: "Full-length white elven robe variant."
+    - item_name: Lliann's Wares
+      slug: lliann-s-wares
+      relationship: alternative
+      description: "Prifddinas clothing shop carrying the elven cosmetic line."
+  about: "Elven skirt (white) is a cosmetic leg piece from the Prifddinas Lliann's Wares clothing line, released 25 July 2019 with Song of the Elves. It is purely cosmetic with zero combat bonuses and is bought for 5,000 gp after completing Song of the Elves. Part of the broader white elven outfit collection."
+  market_strategy:
+    notes:
+      - "Shop buy price of 5,000 gp sets the production floor"
+      - "Pure cosmetic demand from fashionscape collectors"
+      - "Buy limit of 4 per 4 hours keeps merch flows thin"
+      - "Restock cadence at Lliann's Wares is the main supply throttle"
+  trading_tips:
+    - "Compare GE price vs 5,000 gp Lliann's Wares restock to flip after Song of the Elves bursts"
+    - "Stockpile during low-volume weeks before fashionscape events"
+    - "Pair flips with matching elven top variants for set-piece buyers"
+  history:
+    - date: "2019-07-25"
+      description: "Released alongside the Prifddinas city opening in the Song of the Elves update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-white.mdx
@@ -1,6 +1,6 @@
 ---
 title: Elven top (white) | OSRS Price Data
-description: "Elven top (white): Clothing from the elven city of Prifddinas.. High alch: 3,000 GP."
+description: "Elven top (white) is a free-to-play Prifddinas cosmetic body item with zero combat bonuses. High alch: 3,000 GP."
 osrs:
   id: 24015
   name: Elven top (white)
@@ -11,10 +11,84 @@ osrs:
   value: 5000
   lowalch: 2000
   highalch: 3000
-  limit: null
-  about: "Elven top (white) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2019-07-25"
+    update: "Song of the Elves"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: cosmetic
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: Lliann's Wares
+      location: Prifddinas
+      price: 5000
+      currency: Coins
+      stock: 100
+  related_items:
+    - item_name: Elven top (yellow)
+      slug: elven-top-yellow
+      relationship: variant
+      description: "Yellow color variant from the same Prifddinas tailor."
+    - item_name: Elven skirt (white)
+      slug: elven-skirt-white
+      relationship: variant
+      description: "Matching white skirt for the same outfit."
+    - item_name: Elven vest (white)
+      slug: elven-vest-white
+      relationship: variant
+      description: "Matching white vest in the elven outfit."
+  about: "Elven top (white) is a purely cosmetic body-slot outfit piece bought from Lliann's Wares in Prifddinas for 5,000 coins. It was added with the Song of the Elves update and, despite being sold in a members-only city, is flagged as free-to-play so the garment can be traded and equipped on F2P worlds."
+  market_strategy:
+    notes:
+      - "Cosmetic demand from completionists and roleplayers, no combat use."
+      - "Shop stock of 100 every 5 hours keeps a hard ceiling on prices."
+      - "High alch of 3,000 gp is a soft floor below the GE spread."
+      - "F2P-flagged listing widens the buyer pool versus other Prifddinas items."
+  trading_tips:
+    - "Run shop pulls when GE price drifts well above the 5,000 gp restock cost."
+    - "Track matching skirt and vest pricing for full-set flips."
+    - "Volume is thin - prefer limit-orders over market buys."
+  history:
+    - date: "2019-07-25"
+      description: "Released with the Song of the Elves quest update and the reopening of Prifddinas."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/emerald-bolts-e.mdx
@@ -1,6 +1,6 @@
 ---
 title: Emerald bolts (e) | OSRS Price Data
-description: "Emerald bolts (e) is a members ammo slot item with +85 ranged strength requiring 1 Ranged. High alch: 35 GP, GE limit: 11,000."
+description: "Emerald bolts (e) are enchanted Emerald-tipped Mithril bolts with a 55% Magical Poison proc dealing 5 venom damage. High alch: 35 GP, GE limit: 11,000."
 osrs:
   id: 9241
   name: Emerald bolts (e)
@@ -12,46 +12,104 @@ osrs:
   lowalch: 23
   highalch: 35
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
-    other_bonus:
-      ranged_strength: 85
+    weapon_type: crossbow
+    attack_speed: 6
+    weight: 0
     requirements:
       ranged: 1
-    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 85
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: magic
+      level: 27
+      xp: 37
+      materials:
+        - item_name: Emerald bolts
+          quantity: 10
+        - item_name: Air rune
+          quantity: 3
+        - item_name: Nature rune
+          quantity: 1
+        - item_name: Cosmic rune
+          quantity: 1
+      tools: []
+      product: Emerald bolts (e)
+      output_quantity: 10
+  passive_effects:
+    - name: Magical Poison
+      description: "55% proc chance (54% vs players, 65% with Kandarin Hard Diary) applies poison dealing 5 damage that ticks down over time; 6 damage with Zaryte crossbow. Highest enchanted-bolt proc rate in the game."
   related_items:
     - item_id: 9240
+      item_name: Emerald bolts
+      slug: emerald-bolts
+      relationship: component
+      description: Unenchanted base bolt fletched from Mithril bolts plus Emerald bolt tips
+    - item_id: 9239
       item_name: Sapphire bolts (e)
       slug: sapphire-bolts-e
       relationship: downgrade
-      description: Previous tier enchanted bolt
-  about: |-
-    | Other | Value |
-    |-------|-------|
-    | Ranged Strength | +85 |
-
-    Proc chance: 54% (59.4% with Kandarin hard diary)
-
-    On activation, applies 5 poison damage to the target through a cloud of poisonous gas. This is by far the highest proc rate of any enchanted bolt — over 10x more frequent than most others.
-
-    At 54-59% activation rate, emerald bolts (e) are the most reliable way to poison targets with crossbow bolts:
-    - First hit has >50% chance to poison
-    - 5 poison damage ticks down over time (5→4→3→2→1)
-    - Poison continues even after switching weapons
-    - Works in both PvP and PvM
-
-    | Method | Poison Dmg | Reliability |
-    |--------|-----------|-------------|
-    | Emerald bolts (e) | 5 | 54% per hit |
-    | Dragon dagger (p++) | 10 | On hit only |
-    | Toxic blowpipe | Venom (6+) | 25% per hit |
+      description: Previous-tier enchanted bolt with the Clear Mind effect
+    - item_id: 9243
+      item_name: Ruby bolts (e)
+      slug: ruby-bolts-e
+      relationship: upgrade
+      description: Next-tier enchanted bolt with the Blood Forfeit effect
+    - item_id: 21947
+      item_name: Emerald dragon bolts (e)
+      slug: emerald-dragon-bolts-e
+      relationship: variant
+      description: Dragon-tipped enchanted variant fired only from a Dragon hunter crossbow or above
+  about: "Emerald bolts (e) are enchanted Emerald-tipped Mithril crossbow bolts created by casting Enchant Crossbow Bolt (Emerald) at 27 Magic. Their Magical Poison effect procs roughly 55% of hits, making them the most reliable poison-application tool in OSRS and a staple in low-level PKing and against Corporeal Beast's dark energy core."
   market_strategy:
     notes:
-      - Highest proc rate of any enchanted bolt
-      - Popular for consistent poison application
-      - Cheap to enchant at 27 Magic
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Highest proc rate of any enchanted bolt - over 10x more frequent than most others"
+      - "Cheap to enchant at 27 Magic with a small rune cost"
+      - "Demand from PKers, NMZ AFKers, and Corporeal Beast core killers"
+      - "Supply tied to Mithril bolt fletcher output and Emerald bolt tip drops/cuts"
+  trading_tips:
+    - "Cross-check Emerald bolts + nature/cosmic rune spot prices to detect enchantment arbitrage windows"
+    - "Stockpile during PvP tournament weekends and DMM seasons"
+    - "Hard Kandarin Diary completion bumps proc rate to 65% - watch for diary-update demand spikes"
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside the Fletching Crossbows update introducing gem-tipped bolts and enchanted variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-imp-head.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ensouled-imp-head.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ensouled imp head | OSRS Price Data
-description: "Ensouled imp head: The creature's soul is still in here.. High alch: 93 GP, GE limit: 3,000."
+description: "Ensouled imp head: The creature's soul is still in here. High alch: 93 GP, GE limit: 3,000."
 osrs:
   id: 13454
   name: Ensouled imp head
@@ -12,51 +12,80 @@ osrs:
   lowalch: 62
   highalch: 93
   limit: 3000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
   material:
-    type: ensouled_head
-    tier: basic
-  prayer:
-    xp_reanimate: 286
-    magic_level: 3
-    spell: Basic Reanimation
+    type: ensouled-head
+    tier: low
+  properties:
+    release_date: "2016-01-07"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Imp
         source_id: 708
         combat_level: 8
         quantity: "1"
-        rarity: uncommon
+        rarity: "1/25"
         members_only: true
+  passive_effects:
+    - name: Basic Reanimation
+      description: "Cast on the head at the Dark Altar to reanimate an Imp Ensouled Shade that grants 286 Prayer XP when killed."
+      trigger: while_worn
+      affected_skill: prayer
+      boost_value: 286
   related_items:
     - item_id: 13448
       item_name: Ensouled goblin head
       slug: ensouled-goblin-head
       relationship: downgrade
-      description: Lower XP (130)
+      description: "Lower XP (130 Prayer XP) ensouled head."
     - item_id: 13463
       item_name: Ensouled bear head
       slug: ensouled-bear-head
       relationship: upgrade
-      description: Higher XP (480)
+      description: "Adept-tier ensouled head (480 Prayer XP)."
     - item_id: 13502
       item_name: Ensouled demon head
       slug: ensouled-demon-head
       relationship: upgrade
-      description: Much higher XP (1,170)
-  about: |-
-    1. Cast Basic Reanimation spell on the head
-    2. Kill the reanimated creature
-    3. Receive Prayer XP
+      description: "Master-tier ensouled head (1,170 Prayer XP)."
+    - item_id: 559
+      item_name: Body rune
+      slug: body-rune
+      relationship: component
+      description: "Four body runes required to cast Basic Reanimation."
+    - item_id: 561
+      item_name: Nature rune
+      slug: nature-rune
+      relationship: component
+      description: "Two nature runes required to cast Basic Reanimation."
+  about: "Ensouled imp head is the basic-tier reagent in the Arceuus Reanimation spell chain, dropped by Imps. Casting Basic Reanimation on the head at the Dark Altar (or within ~15 tiles where it dropped) requires 16 Magic plus 4 body runes and 2 nature runes, granting 32 Magic XP. The reanimated Imp Ensouled Shade is a low-level NPC that drops 286 Prayer XP when killed, making it an entry-level alternative to bone burying for early Prayer training."
   market_strategy:
     notes:
-      - Early game Prayer option
-      - More XP than goblin heads
-      - Cheap but low demand
-      - Budget Prayer training
-      - Not commonly traded
-      - Better heads give more XP/gp
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Entry-level Prayer XP option for low Magic accounts."
+      - "More XP per cast than goblin heads but well below adept and master heads."
+      - "Niche demand; budget Ironman setups and very-early-game Prayer flippers."
+      - "Buy limit of 3,000 per 4 hours dwarfs typical trading volume."
+  trading_tips:
+    - "Stockpile when Imp slayer tasks dump supply; resell into Leagues / DMM Prayer rush events."
+    - "Pair purchases with body + nature rune batches to lock in cast cost."
+    - "Avoid heavy positions; XP/gp is dominated by higher-tier ensouled heads."
+  history:
+    - date: "2016-01-07"
+      description: "Ensouled imp head added with the Zeah: Great Kourend release and the Arceuus Reanimation spell line."
+    - date: "2022-03-30"
+      description: "Ensouled heads can now drop inside instanced areas."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/equa-leaves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/equa-leaves.mdx
@@ -1,6 +1,6 @@
 ---
 title: Equa leaves | OSRS Price Data
-description: "Equa leaves: Small sweet smelling leaves.. High alch: 1 GP, GE limit: 13,000."
+description: "Equa leaves are a members Gnome Cooking ingredient sold at Grand Tree groceries and used in nearly every gnome dish and cocktail. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 2128
   name: Equa leaves
@@ -12,9 +12,69 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Equa leaves is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: ingredient
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.014
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  food:
+    heals: 1
+    bites: 1
+  shops:
+    - shop_name: "Funch's Fine Groceries"
+      location: Grand Tree
+      price: 2
+      currency: Coins
+      stock: 20
+    - shop_name: "Grand Tree Groceries"
+      location: Grand Tree
+      price: 2
+      currency: Coins
+      stock: 20
+  related_items:
+    - item_id: 2150
+      item_name: Gianne dough
+      slug: gianne-dough
+      relationship: alternative
+      description: "Companion Gnome Cooking ingredient used across the same recipe family."
+    - item_id: 2130
+      item_name: Pot of cream
+      slug: pot-of-cream
+      relationship: alternative
+      description: "Frequent partner ingredient in Blurberry cocktails alongside equa leaves."
+    - item_id: 2092
+      item_name: Lime chunks
+      slug: lime-chunks
+      relationship: alternative
+      description: "Tropical Gnome Cooking ingredient that often pairs with equa leaves in cocktails."
+  about: "Equa leaves are a members-only Gnome Cooking ingredient harvested southeast of Rantz in Feldip Hills or bought from Funch's Fine Groceries and the Grand Tree Groceries above ground. They appear in nearly every gnome dish and cocktail (Blurberry Special, Short Green Guy, gnomebatta crunchies, etc.) and can be eaten raw for a 1 Hitpoint heal."
+  market_strategy:
+    notes:
+      - "Restocked at 2 gp from two Grand Tree shops, capping reasonable GE offers near that floor."
+      - "Heavy buy limit (13,000) suits bulk Gnome Cooking suppliers but caps merchant inventory."
+      - "Alch value of 1 gp makes it useless as an alching target."
+      - "Demand spikes whenever a Gnome Restaurant or Cooking guide shifts the meta toward gnome dishes."
+  trading_tips:
+    - "Buy out the Funch's Fine Groceries and Grand Tree Groceries stacks for fast-flip margin when GE bids spike."
+    - "Stockpile before patch days that adjust Cooking XP routes - gnome food is a common content lever."
+  history:
+    - date: "2002-12-12"
+      description: "Released alongside Gnome Cooking and the Tree Gnome Stronghold groceries."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extended super antifire mix(1) | OSRS Price Data
-description: "Extended super antifire mix(1): One dose of fishy extended super anti-firebreath potion.. High alch: 96 GP, GE limit: 2,000."
+description: "Extended super antifire mix(1) is a 1-dose Barbarian Herblore mix granting 6 minutes of full dragonfire protection plus a small Hitpoints heal. High alch: 96 GP, GE limit: 2,000."
 osrs:
   id: 22224
   name: Extended super antifire mix(1)
@@ -12,12 +12,85 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 2000
-  about: "Extended super antifire mix(1) is a members-only item in Old School RuneScape. High alchemy value: 96 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: high
+  properties:
+    release_date: "2018-01-25"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Grants 6 minutes of complete immunity to dragonfire and Wyvern icy breath."
+        duration: 360
+      - description: "Restores 6 Hitpoints per dose on top of the antifire effect (Barbarian mix bonus)."
+        duration: 0
+    requirements:
+      quest: "Dragon Slayer I"
+  recipes:
+    - skill: herblore
+      level: 99
+      xp: 78
+      materials:
+        - item_name: Extended super antifire(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      notes: "Combine caviar with an Extended super antifire(2) to make Extended super antifire mix(2); decant for the (1) dose. Requires 99 Herblore and completion of Barbarian Herblore training."
+  related_items:
+    - item_id: 22222
+      item_name: Extended super antifire mix(2)
+      slug: extended-super-antifire-mix-2
+      relationship: variant
+      description: "2-dose Barbarian mix variant produced directly by the recipe."
+    - item_id: 22209
+      item_name: Extended super antifire(4)
+      slug: extended-super-antifire-4
+      relationship: alternative
+      description: "Full 4-dose extended super antifire potion without the Barbarian heal bonus."
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: "Barbarian Herblore secondary that converts the potion into a mix."
+    - item_name: Lava scale shard
+      slug: lava-scale-shard
+      relationship: component
+      description: "Secondary used earlier in the extended super antifire chain."
+  about: "Extended super antifire mix(1) is the 1-dose Barbarian Herblore variant of extended super antifire, providing 6 minutes of complete dragonfire and icy breath immunity plus a 6 Hitpoints heal per dose. It is made at 99 Herblore by combining caviar with an Extended super antifire(2) (after Barbarian Herblore training and Dragon Slayer I), then decanting to the 1-dose form, and is mainly used as a single-sip inventory filler for Vorkath, Galvek, the Wilderness Wyrm and other dragonfire-heavy PvM where the extra heal pays for inventory pressure."
+  market_strategy:
+    notes:
+      - "Supply gated behind 99 Herblore + Barbarian training + Dragon Slayer I, capping crafters"
+      - "Demand tracks Vorkath/Wyrm meta and Wilderness dragonfire training popularity"
+      - "Decant arbitrage versus (2) is the cleanest flip; (1) doses are usually discounted"
+      - "Buy limit 2,000 per 4 hours keeps it a small-volume flip"
+  trading_tips:
+    - "Decant (2) into (1) only when single-dose discount inverts - check both prices before each batch"
+    - "Stockpile ahead of bounty / Wilderness rework updates that push more players onto dragonfire content"
+    - "Track caviar price as the upstream secondary - cheap caviar widens craft margin"
+  history:
+    - date: "2018-01-25"
+      description: "Released alongside extended super antifire potions and the Barbarian Herblore mix variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/feather.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/feather.mdx
@@ -1,6 +1,6 @@
 ---
 title: Feather | OSRS Price Data
-description: "Feather: Used for fly fishing.. High alch: 1 GP, GE limit: 30,000."
+description: "Feather is a stackable F2P material used in Fletching, Fishing, and Herblore. High alch: 1 GP, GE limit: 30,000."
 osrs:
   id: 314
   name: Feather
@@ -12,17 +12,26 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 30000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
   material:
     type: crafting
-    tier: basic
-  fletching:
-    uses:
-      - Arrow shafts → Headless arrows
-      - Dart tips → Darts
-  fishing:
-    skill: fishing
-    level: 20
-    tool: Fly fishing rod
+    tier: mid
+  properties:
+    release_date: "2001-06-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   recipes:
     - skill: fletching
       level: 1
@@ -35,66 +44,74 @@ osrs:
           item_id: 314
           quantity: 15
       product: Headless arrow
-      product_id: 53
-      product_quantity: 15
+      output_quantity: 15
+  shops:
+    - shop_name: Gerrant's Fishy Business
+      location: Port Sarim
+      price: 2
+      currency: Coins
+      stock: 1000
+    - shop_name: Fernahei's Fishing Hut
+      location: Shilo Village
+      price: 2
+      currency: Coins
+      stock: 1000
+    - shop_name: Fishing Guild shop
+      location: Fishing Guild
+      price: 2
+      currency: Coins
+      stock: 1000
+  drop_table:
+    sources:
+      - source: Chicken
+        rarity: common
+        members_only: false
+      - source: Bird house trap
+        rarity: common
+        members_only: true
+      - source: Aviansie
+        rarity: common
+        members_only: true
+      - source: Kree'arra
+        rarity: common
+        members_only: true
   related_items:
     - item_id: 52
       item_name: Arrow shaft
       slug: arrow-shaft
       relationship: component
-      description: Combined with feathers
+      description: "Combined with a feather to make a headless arrow at level 1 Fletching."
     - item_id: 53
       item_name: Headless arrow
       slug: headless-arrow
       relationship: product
-      description: Product
+      description: "Direct product of the feather + arrow shaft recipe."
     - item_id: 309
       item_name: Fly fishing rod
       slug: fly-fishing-rod
       relationship: alternative
-      description: Uses feathers
+      description: "Tool that consumes feathers as bait for trout and salmon."
     - item_id: 335
       item_name: Raw trout
       slug: raw-trout
       relationship: alternative
-      description: Caught with feathers
-  about: |-
-    Feathers are used in multiple skills:
-
-    Fletching:
-    - Arrow shaft + Feather = Headless arrow
-    - 10 feathers per 10 arrow shafts
-
-    Fishing:
-    - Fly fishing for Raw trout and Raw salmon
-    - Barbarian fishing
-
-    Herblore:
-    - Some potion recipes require feathers
+      description: "Common fly fishing catch that uses feathers as bait."
+  about: "Feather is a stackable basic material used across Fletching (headless arrows, darts, bolts), Fishing (fly fishing rod bait for trout and salmon, barbarian rod bait), and a handful of Herblore recipes. F2P players gather them by killing chickens or buying from fishing shops, while members can farm bird house traps and Aviansie drops for bulk supply."
   market_strategy:
-    title: |-
-      - Fletching training
-      - Fly fishing
-      - Arrow production chains
-    steps:
-      - order: 1
-        action: Buy Arrow shaft + Feathers
-      - order: 2
-        action: Fletch into Headless arrow
-      - order: 3
-        action: Sell to arrow makers
     notes:
-      - Chicken killing (common bot activity)
-      - Shop purchases (limited stock)
-      - Fishing drops
-      - Fletching training
-      - Fly fishing
-      - Arrow production chains
-      - "Buy limit: 13,000 per 4 hours"
-      - Very stable price, high volume
-      - Cheap but essential item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Extremely high volume - among the largest daily GE turnovers."
+      - "GE buy limit of 30,000 per 4 hours (raised from 13,000 in September 2020)."
+      - "Price floor near 1 gp high alch keeps downside limited."
+      - "Supply driven by chicken farms and Aviansie bots more than skiller output."
+  trading_tips:
+    - "Tiny per-unit margins - only worth flipping in the tens of thousands of units."
+    - "Watch Fletching xp events for short demand spikes on arrow chains."
+    - "Aviansie bot waves cause periodic short-term oversupply dips."
+  history:
+    - date: "2001-06-11"
+      description: "Released as part of the original Fletching and Fishing material set."
+    - date: "2020-09"
+      description: "Grand Exchange buy limit raised from 13,000 to 30,000 per 4 hours."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fine-cloth.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fine-cloth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fine cloth | OSRS Price Data
-description: "Fine cloth: Amazingly untouched by time.. High alch: 300 GP, GE limit: 11,000."
+description: "Fine cloth is a Shades of Mort'ton chest reward used to craft splitbark armour pieces. High alch: 300 GP, GE limit: 11,000."
 osrs:
   id: 3470
   name: Fine cloth
@@ -12,9 +12,121 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 11000
-  about: "Fine cloth is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: crafting-component
+    tier: mid
+  drop_table:
+    primary_source: Shades of Mort'ton chests
+    sources:
+      - source: Steel chest (Shades of Mort'ton)
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Black chest (Shades of Mort'ton)
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Silver chest (Shades of Mort'ton)
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+      - source: Gold chest (Shades of Mort'ton)
+        quantity: "1"
+        rarity: uncommon
+        members_only: true
+  recipes:
+    - skill: crafting
+      level: 40
+      xp: 25
+      materials:
+        - item_name: Bark
+          quantity: 1
+        - item_name: Fine cloth
+          quantity: 4
+      product: Splitbark body
+      product_id: 3835
+      output_quantity: 1
+      facility: Loom
+      members_only: true
+    - skill: crafting
+      level: 40
+      xp: 22
+      materials:
+        - item_name: Bark
+          quantity: 1
+        - item_name: Fine cloth
+          quantity: 3
+      product: Splitbark legs
+      product_id: 3837
+      output_quantity: 1
+      facility: Loom
+      members_only: true
+    - skill: crafting
+      level: 40
+      xp: 16
+      materials:
+        - item_name: Bark
+          quantity: 1
+        - item_name: Fine cloth
+          quantity: 2
+      product: Splitbark helm
+      product_id: 3839
+      output_quantity: 1
+      facility: Loom
+      members_only: true
+  related_items:
+    - item_id: 3833
+      item_name: Bark
+      slug: bark
+      relationship: component
+      description: Paired material with fine cloth for splitbark armour crafting.
+    - item_id: 3835
+      item_name: Splitbark body
+      slug: splitbark-body
+      relationship: product
+      description: Largest fine cloth consumer (4 cloths per body).
+    - item_id: 3837
+      item_name: Splitbark legs
+      slug: splitbark-legs
+      relationship: product
+      description: 3 cloths per legs piece.
+    - item_name: Thread
+      slug: thread
+      relationship: alternative
+      description: Optional secondary crafting material used alongside cloth.
+  about: |-
+    Fine cloth drops exclusively from Shades of Mort'ton chests above the bronze tier, and forms the
+    main fabric input for the splitbark armour set (11 cloths for a full kit). Demand is anchored by
+    new players completing Lunar Diplomacy prerequisites and clue-stash splitbark requirements.
+  market_strategy:
+    title: Shade Chest Supply
+    notes:
+      - Supply tracks active Shades of Mort'ton minigame populations
+      - Demand is steady from clue stash splitbark requirements
+      - 11,000 GE buy limit means flippers can move large clips without saturation worry
+      - Watch silver/gold chest droprate buffs which sharply increase supply
+  trading_tips:
+    - Bulk-buy during seasonal events that boost Shades minigame popularity
+    - Use clue scroll meta as a demand signal — every splitbark stash needs cloth
+    - Don't hoard during double-XP weekends when crafters dump excess inventory
+  history:
+    - date: "2004-10-18"
+      description: Introduced with the Shades of Mort'ton minigame.
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.453
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-mix-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fishing mix(1) | OSRS Price Data
-description: "Fishing mix(1): One dose of fishy Fishing potion.. High alch: 60 GP, GE limit: 2,000."
+description: "Fishing mix(1) is a Barbarian Herblore Fishing potion variant that boosts Fishing by 3 and restores 6 Hitpoints per dose, brewed at 53 Herblore. High alch: 60 GP, GE limit: 2,000."
 osrs:
   id: 11479
   name: Fishing mix(1)
@@ -12,9 +12,83 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 2000
-  about: "Fishing mix(1) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.045
+    options:
+      - Drink
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  effects:
+    - skill: Fishing
+      boost: 3
+      type: visible
+    - description: Restores 6 Hitpoints on drink.
+  recipes:
+    - skill: herblore
+      level: 53
+      xp: 38
+      materials:
+        - item_name: Fishing potion(2)
+          item_id: 3047
+          quantity: 1
+        - item_name: Caviar
+          item_id: 7588
+          quantity: 1
+      product: Fishing mix(1)
+      output_quantity: 1
+      facility: Barbarian Herblore (mix bowl)
+      members_only: true
+  related_items:
+    - item_id: 11478
+      item_name: Fishing mix(2)
+      slug: fishing-mix-2
+      relationship: alternative
+      description: Two-dose variant of the same Barbarian potion.
+    - item_id: 3047
+      item_name: Fishing potion(2)
+      slug: fishing-potion-2
+      relationship: component
+      description: Base Fishing potion combined with caviar to make the mix.
+    - item_id: 7588
+      item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Barbarian Herblore ingredient added to a 2-dose Fishing potion.
+    - item_id: 3049
+      item_name: Fishing potion(1)
+      slug: fishing-potion-1
+      relationship: alternative
+      description: Standard one-dose Fishing potion without the hitpoint heal.
+  about: "Fishing mix(1) is a one-dose Barbarian Herblore variant of the Fishing potion, unlocked after the Alvis subquest of Barbarian Training. Mixing a Fishing potion(2) with caviar at 53 Herblore yields the 2-dose mix; a single dose boosts Fishing by 3 levels and heals 6 Hitpoints, making it a niche utility during long fishing trips and Tempoross/Wintertodt runs."
+  market_strategy:
+    notes:
+      - "Demand is thin - only Barbarian-trained members brewing or stocking the heal-on-drink combo bother with it."
+      - "GE buy limit of 2,000 per 4 hours is rarely the binding constraint."
+      - "High alch of 60 gp is well below GE price - not an alch target."
+      - "Supply depends on Fishing potion(2) plus caviar availability; both follow Sturgeon fishing rates."
+  trading_tips:
+    - "Cross-check Fishing potion(2) plus Caviar combined price to spot brewer arbitrage."
+    - "Watch caviar supply during Barbarian Training updates - it moves the mix price most."
+    - "Niche flip - prefer holding doses for personal Fishing trips over speculative resale."
+  history:
+    - date: "2007-07-03"
+      description: "Released with the Barbarian Training update that added Barbarian Herblore mixes."
+    - date: "2016-04-15"
+      description: "Half-full potions made convertible into bank placeholders."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-brown-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fremennik-brown-cloak.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fremennik brown cloak | OSRS Price Data
-description: "Fremennik brown cloak: The latest fashion in Rellekka.. High alch: 150 GP, GE limit: 150."
+description: "Fremennik brown cloak: The latest fashion in Rellekka. High alch: 150 GP, GE limit: 150."
 osrs:
   id: 3761
   name: Fremennik brown cloak
@@ -12,9 +12,88 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Fremennik brown cloak is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-11-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weapon_type:
+    weight: 0.453
+    requirements:
+      none: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Yrsa's Accoutrements"
+      location: Rellekka
+      price: 325
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Fremennik cloak
+      slug: fremennik-cloak
+      relationship: variant
+      description: "Standard Fremennik cloak colour variant."
+    - item_name: Fremennik black cloak
+      slug: fremennik-black-cloak
+      relationship: variant
+      description: "Black colour variant from the same Yrsa's stock line."
+    - item_name: Fremennik blue cloak
+      slug: fremennik-blue-cloak
+      relationship: variant
+      description: "Blue colour variant."
+    - item_name: Fremennik gold cloak
+      slug: fremennik-gold-cloak
+      relationship: variant
+      description: "Gold colour variant."
+  about: "The Fremennik brown cloak is a members-only cape sold by Yrsa's Accoutrements in Rellekka after completing The Fremennik Trials quest. It is one of eleven colour variants of the Fremennik cloak line, offering minor defensive bonuses and a small fashionscape role for early-game Fremennik aesthetics."
+  market_strategy:
+    notes:
+      - "Cosmetic cape with low alch headroom; profits come from shop-flip arbitrage off the 325 gp restock price."
+      - "Demand is steady but thin since each variant draws only a fraction of Fremennik fashionscape buyers."
+      - "Bulk buying from Yrsa's restocks scales poorly with the 1-minute restock cadence."
+      - "Quest gate on The Fremennik Trials keeps supply naturally limited."
+  trading_tips:
+    - "Restock-flip from Yrsa's at 325 gp when GE bid sits well above shop price."
+    - "Stack purchases across the 11 cloak colours to spread the fashionscape demand risk."
+    - "Watch for Fremennik area updates that drive incidental cape sales."
+  history:
+    - date: "2004-11-02"
+      description: "Released with The Fremennik Trials quest as one of the Yrsa's Accoutrements cloak colours."
+    - date: "2014-12-10"
+      description: "Renamed from Fremennik cloak to Fremennik brown cloak as part of the Trading Post update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-chainbody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Gilded chainbody | OSRS Price Data
-description: "Gilded chainbody: A series of connected metal rings plated in gold.. High alch: 30,000 GP, GE limit: 70."
+description: "Gilded chainbody: A series of connected metal rings plated in gold. High alch: 30,000 GP, GE limit: 70."
 osrs:
   id: 20149
   name: Gilded chainbody
@@ -12,9 +12,102 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 70
-  about: "Gilded chainbody is a free-to-play item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: gilded armour
+    tier: high
+  properties:
+    release_date: "2017-12-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.072
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weapon_type: unarmed
+    attack_speed: 4
+    weight: 9.072
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: -10
+    defence_bonus:
+      stab: 63
+      slash: 65
+      crush: 56
+      magic: -3
+      ranged: 64
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails
+        quantity: "1"
+        rarity: 1/35750
+      - source: Elite Treasure Trails
+        quantity: "1"
+        rarity: 1/32257.5
+      - source: Master Treasure Trails
+        quantity: "1"
+        rarity: 1/149776
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+      - elite
+      - master
+  related_items:
+    - item_id: 3481
+      item_name: Gilded platebody
+      slug: gilded-platebody
+      relationship: alternative
+      description: Platebody alternative with the same combat profile as rune
+    - item_id: 1103
+      item_name: Rune chainbody
+      slug: rune-chainbody
+      relationship: variant
+      description: Standard rune chainbody with identical stats
+    - item_id: 3486
+      item_name: Gilded full helm
+      slug: gilded-full-helm
+      relationship: set-piece
+      description: Matching gilded head slot
+    - item_id: 3483
+      item_name: Gilded platelegs
+      slug: gilded-platelegs
+      relationship: set-piece
+      description: Matching gilded legs slot
+  about: "Gilded chainbody is a cosmetic free-to-play body slot armour with stats identical to a rune chainbody. It is a rare reward from hard, elite, and master Treasure Trails clue scrolls and shares the high-prestige gilded look favoured for fashionscape."
+  market_strategy:
+    notes:
+      - "Pure cosmetic premium over rune chainbody pricing"
+      - "Buy limit of 70 keeps the market thin and price-sensitive"
+      - "F2P accessibility broadens the buyer base"
+  trading_tips:
+    - Compare against rune chainbody as a price-to-prestige benchmark
+    - Stockpile during clue droughts ahead of broadcast-worthy clue events
+  history:
+    - date: "2017-12-14"
+      description: "Added to the game as a rare hard/elite/master clue reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/golden-statuette.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/golden-statuette.mdx
@@ -1,6 +1,6 @@
 ---
 title: Golden statuette | OSRS Price Data
-description: "Golden statuette: A small golden statuette.. High alch: 18 GP, GE limit: 13,000."
+description: "Golden statuette is a Pyramid Plunder artefact sold to Simon Templeton for 1,250 GP and used in stacks of six to recharge the Pharaoh's sceptre. High alch: 18 GP, GE limit: 13,000."
 osrs:
   id: 9034
   name: Golden statuette
@@ -12,12 +12,77 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 13000
-  about: "Golden statuette is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: artefact
+    tier: mid
+  properties:
+    release_date: "2006-07-17"
+    update: "Pyramid Plunder"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drops:
+    - source: Pyramid Plunder
+      activity: "Sophanem Pyramid Plunder minigame"
+      requirements: "81+ Thieving for high-level rooms"
+      notes: "Found in upper-room urns and chests during the Pyramid Plunder Thieving activity."
+  related_items:
+    - item_name: Pharaoh's sceptre
+      slug: pharaohs-sceptre
+      relationship: alternative
+      description: "Used six at a time to recharge the Pharaoh's sceptre teleport pool."
+    - item_name: Stone seal
+      slug: stone-seal
+      relationship: alternative
+      description: "Other Pyramid Plunder artefact sold to Simon Templeton."
+    - item_name: Pottery scarab
+      slug: pottery-scarab
+      relationship: alternative
+      description: "Other Pyramid Plunder artefact sold to Simon Templeton."
+    - item_name: Pottery statuette
+      slug: pottery-statuette
+      relationship: alternative
+      description: "Other Pyramid Plunder artefact sold to Simon Templeton."
+    - item_name: Stone statuette
+      slug: stone-statuette
+      relationship: alternative
+      description: "Other Pyramid Plunder artefact sold to Simon Templeton."
+  teleport:
+    destinations:
+      - name: Simon Templeton's shop
+        location: Agility Pyramid (Northern Desert)
+        method: "Trade-in NPC for Pyramid Plunder loot; sells each golden statuette for 1,250 coins."
+  about: "Golden statuette is a Pyramid Plunder loot artefact pulled from upper-room urns inside the Sophanem Pyramid Plunder minigame and one of the headline payouts for high-level Thieving sessions. It can be sold to Simon Templeton at the Agility Pyramid for 1,250 coins each and stacks of six can also be used to recharge the Pharaoh's sceptre teleport pool, making it a dual cash-and-utility drop for desert Thieving accounts."
+  market_strategy:
+    notes:
+      - "Simon Templeton's 1,250 gp offer is the firm price floor; GE rarely strays much above"
+      - "Supply driven by Pyramid Plunder XP/h metas - more thievers, more statuettes"
+      - "Pharaoh's sceptre rechargers create steady, low-margin demand"
+      - "Buy limit of 13,000 per 4 hours makes it a low-margin bulk flip"
+  trading_tips:
+    - "Treat 1,250 gp as the hard floor - never overpay above NPC value unless sceptre demand spikes"
+    - "Bulk-flip during Thieving double-XP weekends when supply floods the GE"
+    - "Spread orders across the day to avoid getting stuck at floor pricing"
+  history:
+    - date: "2006-07-17"
+      description: "Released with the Pyramid Plunder minigame in Sophanem."
+    - date: "2015-02-26"
+      description: "Made tradeable on the Grand Exchange."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-cadantine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grimy-cadantine.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grimy cadantine | OSRS Price Data
-description: "Grimy cadantine: It needs cleaning.. High alch: 13 GP, GE limit: 11,000."
+description: "Grimy cadantine: It needs cleaning. High alch: 13 GP, GE limit: 11,000."
 osrs:
   id: 215
   name: Grimy cadantine
@@ -12,18 +12,36 @@ osrs:
   lowalch: 8
   highalch: 13
   limit: 11000
-  herb:
-    type: grimy
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: herb
     tier: high
-  herblore:
-    cleaning_level: 65
-    cleaning_xp: 12.5
-    clean_id: 265
-    clean_name: Cadantine
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Clean
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    skill: herblore
+    level: 65
+    xp: 12.5
+    effects:
+      - description: "Cleans into Cadantine, the secondary herb for Super defence potions."
   farming:
-    level: 67
-    seed_id: 5301
+    farming_level: 67
     seed_name: Cadantine seed
+    seed_id: 5301
+    patch_type: herb
   drop_table:
     sources:
       - source: Nechryael
@@ -38,6 +56,32 @@ osrs:
         quantity: "1"
         rarity: common
         members_only: true
+  recipes:
+    - skill: herblore
+      level: 65
+      xp: 12.5
+      materials:
+        - item_name: Grimy cadantine
+          item_id: 215
+          quantity: 1
+      product: Cadantine
+      product_id: 265
+      output_quantity: 1
+      members_only: true
+    - skill: herblore
+      level: 66
+      xp: 150
+      materials:
+        - item_name: Cadantine potion (unf)
+          item_id: 107
+          quantity: 1
+        - item_name: White berries
+          item_id: 239
+          quantity: 1
+      product: Super defence(3)
+      product_id: 163
+      output_quantity: 1
+      members_only: true
   related_items:
     - item_id: 265
       item_name: Cadantine
@@ -59,21 +103,18 @@ osrs:
       slug: cadantine-seed
       relationship: component
       description: Farming seed
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Grimy Herb |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-    | Herblore Level | 65 (to clean) |
-
-    Clean to produce cadantine for Herblore.
-
-    Cadantine used for:
-    - Super defence
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  about: "Grimy cadantine is the uncleaned form of Cadantine, requiring level 65 Herblore to clean for 12.5 XP. Cleaned Cadantine is the secondary used in Super defence potions, making this a steady Slayer-task drop with reliable demand from Herblore trainers."
+  market_strategy:
+    notes:
+      - "Steady Slayer drop supply from Nechryael and Gargoyles"
+      - "Super defence demand keeps a consistent buyer base"
+      - "Farming at level 67 alternative supply with seed loop"
+  trading_tips:
+    - Compare grimy vs clean cadantine to spot cleaning profit windows
+    - Bulk during Slayer events that flood mid-tier herb supply
+  history:
+    - date: "2002-02-27"
+      description: "Released alongside the Herblore skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-cloak.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-cloak.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix cloak | OSRS Price Data
-description: "Guthix cloak is a members cape slot item. High alch: 1,200 GP, GE limit: 8."
+description: "Guthix cloak is the cape piece of the Guthix vestment set requiring 40 Prayer, giving +3 prayer bonus. High alch: 1,200 GP, GE limit: 8."
 osrs:
   id: 10448
   name: Guthix cloak
@@ -12,27 +12,107 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: mid
+  properties:
+    release_date: "2007-08-06"
+    update: "Treasure Trail Tweaks"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: cape
+    weight: 0.453
     requirements:
       prayer: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 3
+  passive_effects:
+    - name: Guthixian alignment
+      description: "Counts as a Guthixian item in the God Wars Dungeon, letting the wearer bypass the Guthix faction door without being attacked by Guthixian followers."
+      trigger: while_worn
+  drop_table:
+    sources:
+      - source: Hard clue scroll casket
+        quantity: "1"
+        rarity: Rare
+        notes: "Reward casket from a Hard Treasure Trail."
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 10462
-      item_name: Guthix robe top
+    - item_name: Guthix robe top
       slug: guthix-robe-top
       relationship: set-piece
-      description: Guthix vestment body
-  about: |-
-    > *"A Guthix cloak."*
-
-    The Guthix cloak is the cape piece of the Guthix vestment set. It provides a +3 Prayer bonus and requires 40 Prayer to equip. Counts as a Guthixian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Body slot piece of the Guthix vestment set"
+    - item_name: Guthix robe legs
+      slug: guthix-robe-legs
+      relationship: set-piece
+      description: "Legs slot piece of the Guthix vestment set"
+    - item_name: Guthix mitre
+      slug: guthix-mitre
+      relationship: set-piece
+      description: "Head slot piece of the Guthix vestment set"
+    - item_name: Guthix stole
+      slug: guthix-stole
+      relationship: set-piece
+      description: "Neck slot piece of the Guthix vestment set"
+    - item_name: Saradomin cloak
+      slug: saradomin-cloak
+      relationship: variant
+      description: "Saradomin vestment cape variant with identical stats"
+    - item_name: Zamorak cloak
+      slug: zamorak-cloak
+      relationship: variant
+      description: "Zamorak vestment cape variant with identical stats"
+  about: "Guthix cloak is the cape piece of the Guthix vestment set, rewarded from Hard Treasure Trails. It requires 40 Prayer to wear, grants +3 prayer bonus, and counts as a Guthixian item in the God Wars Dungeon - letting the wearer bypass the Guthix faction door without aggro from Guthixian followers. The cloak is functionally identical to the other god vestment cloaks at the same prayer bonus tier."
+  market_strategy:
+    notes:
+      - "Hard clue casket exclusive; supply tied to clue completion rate"
+      - "Buy limit 8 per 4 hours throttles bulk flipping"
+      - "Demand is split across all three god vestment cloak variants"
+      - "Used by GWD setups for door bypass and by ironmen for prayer cape upgrades"
+  trading_tips:
+    - "Compare Guthix, Saradomin, and Zamorak cloak prices and list the cheapest one"
+    - "Stockpile ahead of Hard clue events when supply temporarily inflates"
+  history:
+    - date: "2007-08-06"
+      description: "Released with the Treasure Trail Tweaks god vestment set expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-dragonhide-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix dragonhide set | OSRS Price Data
-description: "Guthix dragonhide set: A set containing a Guthix dragonhide coif, body, chaps and vambraces.. High alch: 5,400 GP, GE limit: 8."
+description: "Guthix dragonhide set bundles the coif, body, chaps, and vambraces into a single Grand Exchange item. High alch: 5,400 GP, GE limit: 8."
 osrs:
   id: 13165
   name: Guthix dragonhide set
@@ -12,9 +12,103 @@ osrs:
   lowalch: 3600
   highalch: 5400
   limit: 8
-  about: "Guthix dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 5,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour-set
+    tier: mid
+  shops:
+    - shop_name: Grand Exchange Sets
+      location: Grand Exchange
+      price: 0
+      stock: 0
+      currency: coins
+      requirements: Use a Grand Exchange clerk's 'Sets' right-click option
+      members_only: true
+  recipes:
+    - skill: magic
+      level: 1
+      materials:
+        - item_id: 10380
+          item_name: Guthix coif
+          quantity: 1
+        - item_id: 10378
+          item_name: Guthix dragonhide body
+          quantity: 1
+        - item_id: 10376
+          item_name: Guthix chaps
+          quantity: 1
+        - item_id: 10374
+          item_name: Guthix bracers
+          quantity: 1
+      product: Guthix dragonhide set
+      product_id: 13165
+      output_quantity: 1
+      facility: Grand Exchange clerk (Sets)
+      members_only: true
+  related_items:
+    - item_id: 10380
+      item_name: Guthix coif
+      slug: guthix-coif
+      relationship: set-piece
+      description: Head slot piece of the Guthix dragonhide set.
+    - item_id: 10378
+      item_name: Guthix dragonhide body
+      slug: guthix-dragonhide-body
+      relationship: set-piece
+      description: Body slot piece of the Guthix dragonhide set.
+    - item_id: 10376
+      item_name: Guthix chaps
+      slug: guthix-chaps
+      relationship: set-piece
+      description: Legs slot piece of the Guthix dragonhide set.
+    - item_id: 10374
+      item_name: Guthix bracers
+      slug: guthix-bracers
+      relationship: set-piece
+      description: Hands slot piece of the Guthix dragonhide set.
+    - item_id: 13167
+      item_name: Saradomin dragonhide set
+      slug: saradomin-dragonhide-set
+      relationship: alternative
+      description: God dragonhide alternative for Saradomin worshippers.
+    - item_id: 13163
+      item_name: Zamorak dragonhide set
+      slug: zamorak-dragonhide-set
+      relationship: alternative
+      description: God dragonhide alternative for Zamorak worshippers.
+  about: |-
+    The Guthix dragonhide set is a Grand Exchange convenience bundle of the four equipable Guthix
+    dragonhide pieces — coif, body, chaps, and bracers. It exists purely to streamline trading: players
+    swap a full equipped set for a single tradeable item, and vice-versa, via the clerk's Sets menu.
+    Shield and boots are not included in the bundle.
+  market_strategy:
+    title: Set Arbitrage
+    notes:
+      - Compare set price to the sum of all four piece prices for arb opportunities
+      - Set premiums widen during god-themed events and trim demand spikes
+      - 8 buy limit per four hours caps individual exposure
+      - Cosmetic demand from Castle Wars and PvP loadouts drives long-term floor
+  trading_tips:
+    - Always cross-check the sum-of-parts before flipping the bundle
+    - Convert via the GE clerk when piece prices spike unevenly
+    - Watch all three god d'hide sets together; collectors often hold them as a trio
+  history:
+    - date: "2015-03-19"
+      description: Released alongside the Grand Exchange Sets tab update.
+  properties:
+    release_date: "2015-03-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.05
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-rest-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-rest-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix rest(1) | OSRS Price Data
-description: "Guthix rest(1): A cup of Guthix Rest.. High alch: 30 GP, GE limit: 2,000."
+description: "Guthix rest(1) is a single-dose Herblore tea restoring 5 HP and 5% run energy. High alch: 30 GP, GE limit: 2,000."
 osrs:
   id: 4423
   name: Guthix rest(1)
@@ -12,9 +12,74 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 2000
-  about: "Guthix rest(1) is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: low
+  properties:
+    release_date: "2005-02-28"
+    update: "One Small Favour"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: herblore
+      level: 18
+      xp: 0
+      materials:
+        - item_name: Cup of hot water
+          quantity: 1
+        - item_name: Guam leaf
+          quantity: 2
+        - item_name: Harralander
+          quantity: 1
+        - item_name: Marrentill
+          quantity: 1
+      product: Guthix rest(4)
+      output_quantity: 1
+  related_items:
+    - item_name: Guthix rest(2)
+      slug: guthix-rest-2
+      relationship: variant
+      description: "Two-dose Guthix rest tea."
+    - item_name: Guthix rest(3)
+      slug: guthix-rest-3
+      relationship: variant
+      description: "Three-dose Guthix rest tea."
+    - item_name: Guthix rest(4)
+      slug: guthix-rest-4
+      relationship: variant
+      description: "Four-dose Guthix rest tea brewed from the base recipe."
+    - item_name: Cup of tea
+      slug: cup-of-tea
+      relationship: alternative
+      description: "Generic tea drink without Herblore effects."
+  about: "Guthix rest(1) is the final dose of a Herblore-brewed cup of tea introduced with the One Small Favour quest update. Each dose heals 5 Hitpoints, restores 5% run energy, and reduces venom to poison or shaves 1 damage off active poison, making it a niche utility consumable for low-cost run management and venom mitigation."
+  market_strategy:
+    notes:
+      - "Niche demand - mainly used by players running tea utility setups or doing diary tasks."
+      - "GE buy limit of 2,000 per 4 hours is generous for this low volume item."
+      - "High alch of 30 gp far below GE price - not an alch target."
+      - "Supply driven entirely by player Herblore brewing at level 18+."
+  trading_tips:
+    - "Cross-check four-dose Guthix rest pricing against the single-dose stack to spot decant arbitrage."
+    - "Single doses are often dumped after sip-down, creating short-term GE oversupply."
+    - "Watch Herblore training events for spikes in the underlying herb costs."
+  history:
+    - date: "2005-02-28"
+      description: "Released with the One Small Favour quest, alongside the rest of the Guthix rest dose chain."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ham-hood.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ham-hood.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ham hood | OSRS Price Data
-description: "Ham hood is a members head slot item. High alch: 45 GP, GE limit: 15."
+description: "Ham hood is a members head slot piece of the H.A.M. robes set used to cut eject odds in the H.A.M. Hideout. High alch: 45 GP, GE limit: 15."
 osrs:
   id: 4302
   name: Ham hood
@@ -12,41 +12,110 @@ osrs:
   lowalch: 30
   highalch: 45
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: true
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
+    weapon_type:
+    weight: 0.453
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 2
+      magic: 0
+      ranged: 1
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: H.A.M. disguise
+      description: "Counts toward the H.A.M. robes set; wearing more pieces reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing."
+  set_effect:
+    name: H.A.M. robes
+    pieces:
+      - Ham hood
+      - Ham shirt
+      - Ham robe
+      - Ham cloak
+      - Ham gloves
+      - Ham boots
+      - Ham logo
+    description: "Each additional piece worn lowers the eject chance from the H.A.M. Hideout; only affects ejection, not pickpocket success rates."
+  drop_table:
+    sources:
+      - source: H.A.M. Member (pickpocket, Thieving 20+)
+        quantity: "1"
+        rarity: Common
+      - source: H.A.M. Guard
+        quantity: "1"
+        rarity: Uncommon
   related_items:
     - item_id: 4298
       item_name: Ham shirt
       slug: ham-shirt
       relationship: set-piece
-      description: H.A.M. body piece
+      description: "Body piece of the H.A.M. robes set."
     - item_id: 4300
       item_name: Ham robe
       slug: ham-robe
       relationship: set-piece
-      description: H.A.M. legs piece
+      description: "Legs piece of the H.A.M. robes set."
     - item_id: 4304
       item_name: Ham cloak
       slug: ham-cloak
       relationship: set-piece
-      description: H.A.M. cape piece
+      description: "Cape piece of the H.A.M. robes set."
     - item_id: 4308
       item_name: Ham gloves
       slug: ham-gloves
       relationship: set-piece
-      description: H.A.M. hands piece
+      description: "Hands piece of the H.A.M. robes set."
     - item_id: 4310
       item_name: Ham boots
       slug: ham-boots
       relationship: set-piece
-      description: H.A.M. feet piece
-  about: |-
-    > *"Light-weight head protection and eye shield."*
-
-    The ham hood is part of the H.A.M. (Humans Against Monsters) robes set. Wearing more pieces of the set reduces the chance of being ejected from the H.A.M. Hideout when caught pickpocketing, though it does not improve pickpocket success rates. Required for the Death to the Dorgeshuun quest.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Feet piece of the H.A.M. robes set."
+  about: "Ham hood is the head slot piece of the H.A.M. (Humans Against Monsters) robes set, required during the Death to the Dorgeshuun quest. It is obtained by pickpocketing H.A.M. members (level 20 Thieving) or dropped by H.A.M. Guards. Wearing more pieces of the set lowers the chance of being ejected from the H.A.M. Hideout when caught, but it does not improve pickpocket success rates."
+  market_strategy:
+    notes:
+      - "Tiny 15-per-4-hour buy limit caps any merchant play."
+      - "Player demand is almost entirely Death to the Dorgeshuun questers and H.A.M. pickpocketing trainers."
+      - "Supply is steady because every H.A.M. member/guard drops or hands one out via thieving."
+      - "High alch of 45 gp is irrelevant against modern GE pricing."
+  trading_tips:
+    - "Buy from the GE on quest weekends or when a fresh H.A.M. Thieving guide bumps the meta."
+    - "Bulk picks from H.A.M. pickpocketing supply the cheapest restock for ironmen building the full set."
+  history:
+    - date: "2005-02-22"
+      description: "Released alongside the H.A.M. Hideout and the H.A.M. robes drop tables."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/hemp-yarn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/hemp-yarn.mdx
@@ -1,6 +1,6 @@
 ---
 title: Hemp yarn | OSRS Price Data
-description: "Hemp yarn: Spun from hemp.. High alch: 21 GP, GE limit: 13,000."
+description: "Hemp yarn is spun on a spinning wheel and feeds canvas weaving and Sailing trawling net recipes. High alch: 21 GP, GE limit: 13,000."
 osrs:
   id: 31466
   name: Hemp yarn
@@ -12,9 +12,99 @@ osrs:
   lowalch: 14
   highalch: 21
   limit: 13000
-  about: "Hemp yarn is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: crafting-component
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 39
+      xp: 60
+      materials:
+        - item_name: Hemp
+          quantity: 1
+      tools:
+        - Spinning wheel
+      product: Hemp yarn
+      product_id: 31466
+      output_quantity: 1
+      ticks: 3
+      members_only: true
+    - skill: crafting
+      level: 75
+      materials:
+        - item_name: Hemp yarn
+          quantity: 2
+      tools:
+        - Loom
+      product: Bolt of canvas
+      output_quantity: 1
+      members_only: true
+    - skill: sailing
+      level: 76
+      materials:
+        - item_name: Hemp yarn
+          quantity: 6
+        - item_name: Camphor plank
+          quantity: 4
+        - item_name: Rope
+          quantity: 1
+        - item_name: Adamantite bar
+          quantity: 4
+        - item_name: Cupronickel bar
+          quantity: 2
+        - item_name: Ray barb
+          quantity: 4
+      product: Hemp trawling net
+      output_quantity: 1
+      facility: Sailing workbench
+      members_only: true
+  related_items:
+    - item_name: Hemp
+      slug: hemp
+      relationship: component
+      description: Raw input spun on a spinning wheel into yarn.
+    - item_name: Bolt of canvas
+      slug: bolt-of-canvas
+      relationship: product
+      description: Higher-tier weaving product made from two hemp yarn.
+    - item_name: Hemp trawling net
+      slug: hemp-trawling-net
+      relationship: product
+      description: Sailing-era trawling net using bulk hemp yarn.
+  about: |-
+    Hemp yarn is the Sailing-era spinning-wheel product, produced at Crafting 39 from raw hemp. It
+    feeds two parallel pipelines: bulk canvas weaving (2 yarn per bolt) and a high-level Sailing
+    trawling-net recipe. The 13,000 GE buy limit and shared input with canvas bolts make it a
+    reliable mid-tier flip target.
+  market_strategy:
+    title: Yarn Pipeline
+    notes:
+      - Margin per spin is razor-thin; volume matters more than per-craft profit
+      - Demand follows Sailing trawling-net popularity and canvas bolt construction projects
+      - Watch raw hemp price; ingredient spikes squeeze the yarn margin to zero
+      - 13,000 GE buy limit gives bulk flippers room to operate
+  trading_tips:
+    - Bulk-buy raw hemp when crafters dump stock between updates
+    - List yarn just below instant-buy to clear pre-spike inventory
+    - Track bolt of canvas prices as a leading indicator
+  history:
+    - date: "2025-11-19"
+      description: Released with the Sailing skill launch and the spinning-wheel hemp recipe.
+  properties:
+    release_date: "2025-11-19"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    weight: 0.025
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/insect-repellent.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/insect-repellent.mdx
@@ -1,6 +1,6 @@
 ---
 title: Insect repellent | OSRS Price Data
-description: "Insect repellent: Drives away all known 6 legged creatures.. High alch: 1 GP, GE limit: 15."
+description: "Insect repellent is a members quest item used on beehives in Catherby/Seers' and on mosquitoes at Tai Bwo Wannai. High alch: 1 GP, GE limit: 15."
 osrs:
   id: 28
   name: Insect repellent
@@ -12,18 +12,49 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: consumable
+    tier: low
+  properties:
+    release_date: "2002-02-27"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.028
+    options:
+      - Use
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   related_items:
     - item_id: 30
       item_name: Bucket of wax
       slug: bucket-of-wax
+      relationship: product
+      description: "Obtained by using insect repellent on a beehive near Catherby."
+    - item_id: 1925
+      item_name: Bucket
+      slug: bucket
       relationship: component
-      description: Made by using repellent on beehive
-  about: |-
-    > _"Drives away all known 6 legged creatures."_
-
-    Insect repellent is a members-only quest item used in Merlin's Crystal and Troll Romance. Applied to beehives near Catherby to safely collect a bucket of wax. Also reduces combat stats of mosquitoes during Tai Bwo Wannai Cleanup.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Empty bucket required to collect the wax from a sprayed hive."
+  about: "Insect repellent is a members-only quest item required for Merlin's Crystal and Troll Romance. It is applied to beehives near Catherby and Seers' Village to safely harvest a bucket of wax, and used on mosquitoes during Tai Bwo Wannai Cleanup to suppress their attacks for six seconds."
+  market_strategy:
+    notes:
+      - "Quest-gated demand only - bought once per quester for Merlin's Crystal / Troll Romance."
+      - "GE buy limit of 15 per 4 hours keeps it a thin, low-volume listing."
+      - "High alch of 1 gp makes alching irrelevant."
+  trading_tips:
+    - "Stock 1-2 from the Apothecary or GE before starting Merlin's Crystal to avoid stalling on bucket-of-wax steps."
+    - "Bulk-buying offers minimal upside; the BTC chain is supply-light and demand-thin."
+  history:
+    - date: "2002-02-27"
+      description: "Released alongside the Merlin's Crystal quest as the beehive wax-collection consumable."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-battleaxe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-battleaxe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron battleaxe | OSRS Price Data
-description: "Iron battleaxe is a F2P weapon slot item requiring 1 Attack. High alch: 109 GP, GE limit: 125."
+description: "Iron battleaxe is a F2P two-handed melee weapon requiring 1 Attack. High alch: 109 GP, GE limit: 125."
 osrs:
   id: 1363
   name: Iron battleaxe
@@ -12,9 +12,35 @@ osrs:
   lowalch: 72
   highalch: 109
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    update: "RuneScape Classic launch"
+    quest_item: false
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    weight: 2.721
+    destroy: "Drop"
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    examine_options:
+      - Examine
+    alchable: true
   equipment:
     slot: weapon
     type: battleaxe
+    attack_style: slash
+    attack_speed: 6
+    attack_range: 1
     tradeable: true
     weight: 2.721
     requirements:
@@ -30,10 +56,48 @@ osrs:
       defence_crush: 0
       defence_magic: 0
       defence_ranged: 0
-      strength: 13
+      melee_strength: 13
       ranged_strength: 0
       magic_damage: 0
-      prayer: 0
+      prayer_bonus: 0
+  recipes:
+    - skill: smithing
+      level: 35
+      xp: 50
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_id: 2351
+          item_name: Iron bar
+          quantity: 3
+      output:
+        item_id: 1363
+        item_name: Iron battleaxe
+        output_quantity: 1
+      members: false
+      notes: "Smithed from 3 iron bars at any anvil"
+  shops:
+    - shop_name: Brian's Battleaxe Bazaar
+      location: Port Sarim
+      price: 182
+      sell_price: 109
+      stock: 3
+      restock_time: 100
+      currency: coins
+      notes: "Stocks iron battleaxes by default"
+  drop_table:
+    sources:
+      - source: Hobgoblin
+        combat_level: 28
+        quantity: "1"
+        rarity: Uncommon
+        notes: "Drops iron battleaxes in F2P areas"
+      - source: Reward casket (easy)
+        combat_level: 0
+        quantity: "1"
+        rarity: Uncommon
+        notes: "Rolled from easy clue scroll rewards"
   related_items:
     - item_id: 1365
       item_name: Steel battleaxe
@@ -44,9 +108,29 @@ osrs:
       item_name: Iron sword
       slug: iron-sword
       relationship: alternative
-      description: Better accuracy alternative
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Better stab accuracy alternative
+    - item_id: 1323
+      item_name: Iron scimitar
+      slug: iron-scimitar
+      relationship: alternative
+      description: Faster one-handed slash alternative
+    - item_id: 1361
+      item_name: Bronze battleaxe
+      slug: bronze-battleaxe
+      relationship: downgrade
+      description: Lower tier battleaxe
+  market_strategy:
+    notes:
+      - "Low tier weapon with thin GE volume"
+      - "Smithing 3 iron bars rarely profitable vs GE"
+      - "Demand primarily from low-level Slayer and ironmen"
+      - "Reasonable bulk alch fodder for new mages"
+  history:
+    - date: "2001-01-04"
+      description: "Released with RuneScape Classic launch"
+    - date: "2004-05-05"
+      description: "Graphical update applied with RuneScape 2 transition"
+  about: "The iron battleaxe is a free-to-play two-handed slash weapon usable at 1 Attack. Smithed from 3 iron bars at level 35 Smithing or bought from Brian's Battleaxe Bazaar in Port Sarim, it provides a budget melee option for early-game Attack and Strength training."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger-p-5686.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dagger-p-5686.mdx
@@ -1,20 +1,119 @@
 ---
 title: Iron dagger(p++) | OSRS Price Data
-description: "Iron dagger(p++): Short but pointy.. High alch: 21 GP, GE limit: 125."
+description: "Iron dagger(p++) is an iron dagger coated in weapon poison++, applying stronger poison ticks on hit. High alch: 21 GP, GE limit: 125."
 osrs:
   id: 5686
   name: Iron dagger(p++)
   slug: iron-dagger-p
-  examine: Short but pointy.
+  examine: The blade is covered with poison.
   members: true
   icon: Iron dagger(p++).png
   value: 35
   lowalch: 14
   highalch: 21
   limit: 125
-  about: "Iron dagger(p++) is a members-only item in Old School RuneScape. High alchemy value: 21 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: weapon
+    tier: low
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    weight: 0.4
+    requirements:
+      attack: 1
+    attack_bonus:
+      stab: 5
+      slash: 3
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Weapon poison++
+      description: Hits have a chance to apply weapon poison++, ticking 6 damage that decays over time.
+      trigger: on_hit
+      affected_skill: attack
+  recipes:
+    - skill: herblore
+      level: 82
+      materials:
+        - item_id: 1203
+          item_name: Iron dagger
+          quantity: 1
+        - item_name: Weapon poison++
+          quantity: 1
+      product: Iron dagger(p++)
+      product_id: 5686
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 1203
+      item_name: Iron dagger
+      slug: iron-dagger
+      relationship: variant
+      description: Unpoisoned base dagger.
+    - item_id: 1219
+      item_name: Iron dagger(p)
+      slug: iron-dagger-p-1219
+      relationship: variant
+      description: Standard weapon poison variant.
+    - item_id: 5684
+      item_name: Iron dagger(p+)
+      slug: iron-dagger-p-5684
+      relationship: variant
+      description: Weapon poison(+) variant; ticks 5 damage on hit.
+  about: |-
+    The iron dagger(p++) is the strongest poison-coated iron dagger, made by applying weapon poison++
+    to a base iron dagger. The poison itself is the main draw — at 82 Herblore the (p++) coating is a
+    drop-in upgrade for low-tier melee training or budget PvP needles, ticking heavy poison damage on
+    successful hits.
+  market_strategy:
+    title: Poison Tier Spread
+    notes:
+      - Tracks the iron dagger price plus the weapon poison++ supply
+      - Demand is thin; mainly low-level PvP enthusiasts and quest-poison stockists
+      - 125 GE buy limit caps bulk flips, but volume is too low for arb at scale
+      - Watch weapon poison++ Herblore guides for occasional content-driven spikes
+  trading_tips:
+    - Compare to (p+) variant before buying; spread is often pennies
+    - Hold during quest releases that require poisoned daggers
+    - Avoid deep stockpiles — listings clear slowly outside event spikes
+  history:
+    - date: "2001-01-04"
+      description: Iron dagger base item released.
+    - date: "2002-02-27"
+      description: Poison variants introduced with the Weapon Poison update.
+    - date: "2006-08-22"
+      description: Poison naming convention updated to current (p/p+/p++) format.
+  properties:
+    release_date: "2006-08-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    weight: 0.4
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+    quest_item: false
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-gold-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-gold-trimmed-set-sk.mdx
@@ -1,20 +1,91 @@
 ---
 title: Iron gold-trimmed set (sk) | OSRS Price Data
-description: "Iron gold-trimmed set (sk): A set containing a full helm, platebody, skirt and kiteshield.. High alch: 540 GP, GE limit: 8."
+description: "Iron gold-trimmed set (sk) is a F2P Grand Exchange set bundling iron full helm (g), platebody (g), skirt (g) and kiteshield (g). High alch: 540 GP, GE limit: 8."
 osrs:
   id: 12982
   name: Iron gold-trimmed set (sk)
   slug: iron-gold-trimmed-set-sk
-  examine: A set containing a full helm, platebody, skirt and kiteshield.
+  examine: "A set containing a full helm, platebody, skirt and kiteshield."
   members: false
   icon: Iron gold-trimmed set (sk).png
   value: 900
   lowalch: 360
   highalch: 540
   limit: 8
-  about: "Iron gold-trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 540 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2007-11-15"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6.0
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  set_bonus:
+    set_name: "Iron gold-trimmed armour set (skirt)"
+    pieces_required: 4
+    description: "Grand Exchange convenience bundle that exchanges into one each of Iron full helm (g), Iron platebody (g), Iron plateskirt (g), and Iron kiteshield (g)."
+    pieces:
+      - 2782
+      - 2778
+      - 2780
+      - 2776
+  related_items:
+    - item_id: 12980
+      item_name: Iron gold-trimmed set (lg)
+      slug: iron-gold-trimmed-set-lg
+      relationship: variant
+      description: "Legs variant of the iron gold-trimmed armour set."
+    - item_id: 2782
+      item_name: Iron full helm (g)
+      slug: iron-full-helm-g
+      relationship: component
+      description: "Component piece in the set."
+    - item_id: 2778
+      item_name: Iron platebody (g)
+      slug: iron-platebody-g
+      relationship: component
+      description: "Component piece in the set."
+    - item_id: 2780
+      item_name: Iron plateskirt (g)
+      slug: iron-plateskirt-g
+      relationship: component
+      description: "Component piece in the set."
+    - item_id: 2776
+      item_name: Iron kiteshield (g)
+      slug: iron-kiteshield-g
+      relationship: component
+      description: "Component piece in the set."
+    - item_id: 12978
+      item_name: Iron trimmed set (sk)
+      slug: iron-trimmed-set-sk
+      relationship: variant
+      description: "Standard (white) trimmed variant of the iron armour set."
+  about: "Iron gold-trimmed set (sk) is a Free-to-Play Grand Exchange armour bundle that packages an Iron full helm (g), Iron platebody (g), Iron plateskirt (g) and Iron kiteshield (g) into a single tradeable item. It exists to speed up bulk transfers between players for the gold-trimmed clue-reward iron armour cosmetic. Exchanging the set at any Grand Exchange clerk converts it into the individual pieces."
+  market_strategy:
+    notes:
+      - "Arbitrage between set price and the sum of its 4 gold-trimmed components."
+      - "Low GE buy limit (8) caps daily flip volume."
+      - "Supply ties to Easy Treasure Trail clue completions that drop the trimmed pieces."
+      - "F2P-tradeable, so liquidity is consistent on flipping worlds."
+  trading_tips:
+    - "Buy the set when sum of pieces exceeds the set price, exchange at a clerk, and resell components."
+    - "Track Easy clue scroll completion rates and trimmed iron piece supply trends."
+    - "Cosmetic value dominates over combat utility; price is fashionscape-driven."
+  history:
+    - date: "2007-11-15"
+      description: "Released with the Grand Exchange armour set update that introduced trimmed and gold-trimmed iron set bundles."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife-p-5662.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-knife-p-5662.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron knife(p++) | OSRS Price Data
-description: "Iron knife(p++): A finely balanced throwing knife.. High alch: 1 GP, GE limit: 7,000."
+description: "Iron knife(p++) is a thrown iron knife coated with weapon poison++, dealing 6-damage venom ticks on hit. High alch: 0 GP, GE limit: 7,000."
 osrs:
   id: 5662
   name: Iron knife(p++)
@@ -12,9 +12,99 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
-  about: "Iron knife(p++) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: thrown
+    attack_speed: 3
+    weight: 0
+    requirements:
+      ranged: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 5
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 4
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: none
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Iron knife
+          quantity: 5
+        - item_name: Weapon poison(++)
+          quantity: 1
+      tools: []
+      product: Iron knife(p++)
+      output_quantity: 5
+  passive_effects:
+    - name: Weapon poison++
+      description: "Has a chance on hit to apply poison dealing up to 6 damage that ticks down over time; the strongest tier of weapon poison applied to thrown knives."
+  related_items:
+    - item_id: 863
+      item_name: Iron knife
+      slug: iron-knife
+      relationship: component
+      description: Unpoisoned base knife dipped in Weapon poison(++) to make the (p++) variant
+    - item_id: 5660
+      item_name: Iron knife(p)
+      slug: iron-knife-p
+      relationship: variant
+      description: Lower-tier poisoned variant using basic Weapon poison
+    - item_id: 5661
+      item_name: Iron knife(p+)
+      slug: iron-knife-p-plus
+      relationship: variant
+      description: Mid-tier poisoned variant using Weapon poison(+)
+    - item_name: Weapon poison(++)
+      slug: weapon-poison-pp
+      relationship: component
+      description: Top-tier poison vial brewed at 82 Herblore and applied to make (p++) thrown weapons
+  about: "Iron knife (p++) is the top-poison variant of the iron throwing knife, created by applying Weapon poison(++) to 5 Iron knives at once; identical combat stats to the base knife (+5 ranged attack, +4 ranged strength, 3-tick attack speed) with a chance on hit to inflict 6-damage poison, used in low-level PKing and pure builds."
+  market_strategy:
+    notes:
+      - "Niche PvP/pure-build ammo - demand spikes around DMM seasons and tournament weekends"
+      - "Not alchable - pure utility item, no NPC value floor"
+      - "Supply tied to Iron knife smithing throughput and Weapon poison(++) brewers"
+      - "GE buy limit of 7,000 per 4 hours easily covers PKer restocks"
+  trading_tips:
+    - "Cross-check Iron knife + Weapon poison(++) spot prices to detect poisoning arbitrage windows"
+    - "Stockpile before DMM/PvP world events for spec-knife demand"
+    - "Watch Herblore meta changes - cheaper Weapon poison(++) compresses margins on every (p++) variant"
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming update that introduced the (p++) poison tier across thrown and melee weapons."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-platelegs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Iron platelegs | OSRS Price Data
-description: "Iron platelegs: These look pretty heavy.. High alch: 168 GP, GE limit: 125."
+description: "Iron platelegs are F2P legs slot armour requiring 1 Defence, smithed from 3 iron bars at 31 Smithing for 75 xp. High alch: 168 GP, GE limit: 125."
 osrs:
   id: 1067
   name: Iron platelegs
@@ -12,24 +12,106 @@ osrs:
   lowalch: 112
   highalch: 168
   limit: 125
-  item_id: 1067
-  item_type: armor
-  slot: legs
-  type: platelegs
-  tradeable: true
-  weight: 9.071
-  requirements:
-    defence: 0
-  stats:
-    stab_defence: 11
-    slash_defence: 10
-    crush_defence: 10
-    ranged_defence: 10
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: iron
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    update: "RuneScape launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 9.071
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weight: 9.071
+    requirements:
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: -7
+    defence_bonus:
+      stab: 11
+      slash: 10
+      crush: 10
+      magic: -4
+      ranged: 10
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 31
+      xp: 75
+      materials:
+        - item_name: Iron bar
+          item_id: 2351
+          quantity: 3
+      facility: Anvil
+      product: Iron platelegs
+      product_id: 1067
+      output_quantity: 1
+  shops:
+    - shop_name: Horvik's Armour Shop
+      location: Varrock
+      stock: 1
+      price: 280
+    - shop_name: Louie's Armoured Legs Bazaar
+      location: Al Kharid
+      stock: 10
+      price: 280
   related_items:
-    - slug: steel-platelegs
-    - slug: iron-platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1115
+      item_name: Iron platebody
+      slug: iron-platebody
+      relationship: set-piece
+      description: "Matching iron-tier body slot armour."
+    - item_id: 1153
+      item_name: Iron full helm
+      slug: iron-full-helm
+      relationship: set-piece
+      description: "Matching iron-tier head slot armour."
+    - item_id: 1081
+      item_name: Iron plateskirt
+      slug: iron-plateskirt
+      relationship: alternative
+      description: "Identical-stat skirt variant of iron platelegs."
+    - item_id: 1069
+      item_name: Steel platelegs
+      slug: steel-platelegs
+      relationship: upgrade
+      description: "Next-tier metal platelegs with stronger defensive bonuses."
+  about: "Iron platelegs are entry-tier F2P legs slot armour smithed at 31 Smithing from three iron bars for 75 Smithing XP, requiring only 1 Defence to wear. They are the iron-tier metal legs in the smithing progression chain, primarily used by very low-level F2P melee accounts and Smithing trainers who consume bars for XP and dump the output to alch or NPC shops."
+  market_strategy:
+    notes:
+      - "Supply floods in from Smithing trainers - GE price often hugs high alch value."
+      - "GE buy limit of 125 per 4 hours caps any single flip cycle."
+      - "High alch of 168 gp can exceed GE price during glut windows - viable nature-rune alch fodder."
+      - "Demand is thin - F2P training accounts and occasional clue stash builds."
+  trading_tips:
+    - "Watch the GE vs high alch spread; alch when GE undercuts the 168 gp ceiling."
+    - "Cross-reference iron bar prices to detect smithing arbitrage glut signals."
+    - "Low-volatility item - treat as alch fodder, not a directional flip."
+  history:
+    - date: "2001-01-04"
+      description: "Available since RuneScape's launch as a core smithable F2P armour piece."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jade-dragon-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jade-dragon-bolts-e.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jade dragon bolts (e) | OSRS Price Data
-description: "Jade dragon bolts (e) is a members ammo slot item with +122 ranged strength. High alch: 378 GP, GE limit: 11,000."
+description: "Jade dragon bolts (e) are enchanted dragon-tier crossbow bolts with +122 ranged strength and a 6% Earth's Fury knockdown stun. High alch: 378 GP, GE limit: 11,000."
 osrs:
   id: 21934
   name: Jade dragon bolts (e)
@@ -12,59 +12,100 @@ osrs:
   lowalch: 252
   highalch: 378
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragon
+    tier: high
+  properties:
+    release_date: "2018-01-04"
+    update: "Dragon Slayer II"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: ammo
+    weight: 0
+    requirements: {}
     attack_bonus:
       stab: 0
       slash: 0
       crush: 0
       magic: 0
       ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
       ranged_strength: 122
+      magic_damage: 0
       prayer: 0
-    requirements: {}
+  passive_effects:
+    - name: "Earth's Fury"
+      description: "6% chance per hit (boosted to 6.6% with Hard Kandarin Diary) to knock the target to the ground and stun them for 8 game ticks (4.8 seconds). The roll is contested against the target's Agility level, so high-Agility opponents may resist."
   recipes:
     - skill: magic
       level: 14
       xp: 19
-      inputs:
+      materials:
         - item_name: Jade dragon bolts
+          item_id: 21932
           quantity: 10
+        - item_name: Cosmic rune
+          item_id: 564
+          quantity: 1
+        - item_name: Earth rune
+          item_id: 557
+          quantity: 2
+      facility: Enchant Crossbow Bolt (Jade)
+      product: Jade dragon bolts (e)
+      product_id: 21934
       output_quantity: 10
   related_items:
+    - item_id: 21932
+      item_name: Jade dragon bolts
+      slug: jade-dragon-bolts
+      relationship: component
+      description: "Unenchanted dragon bolt base required for Enchant Crossbow Bolt (Jade)."
     - item_id: 9237
       item_name: Jade bolts (e)
       slug: jade-bolts-e
       relationship: downgrade
-      description: Regular crossbow version
-  about: |-
-    > *"Enchanted Dragon crossbow bolts, tipped with jade."*
-
-    Jade dragon bolts (e) carry the Earth's Fury enchantment. On activation, there is a 6% chance to knock the target to the ground for 8 ticks (4.8 seconds), temporarily stunning them. However, agile opponents may resist the knockdown effect. This makes jade bolts a crowd-control option, though the low activation rate limits reliability.
-
-    Enchant Crossbow Bolt (Jade) requires Magic level 14 and grants 19 XP per cast. Each cast enchants 10 bolts at a time.
-
-    | Component | Quantity |
-    |-----------|----------|
-    | Jade dragon bolts | 10 |
-    | Cosmic rune | 1 |
-    | Earth rune | 2 |
-
-    | Stat | Dragon (e) | Regular (e) |
-    |------|-----------|-------------|
-    | Ranged Str | +122 | +31 |
-    | Base bolt | Dragon crossbow bolt | Blurite bolt |
-
-    The dragon bolt base provides significantly higher ranged strength while retaining the same knockdown enchantment.
+      description: "Blurite-tier counterpart with the same Earth's Fury proc but only +31 ranged strength."
+    - item_id: 21902
+      item_name: Dragon crossbow
+      slug: dragon-crossbow
+      relationship: alternative
+      description: "Highest-tier crossbow capable of firing dragon bolts to maximise ranged strength scaling."
+  about: "Jade dragon bolts (e) are dragon-tier crossbow bolts enchanted via the standard-spellbook Enchant Crossbow Bolt (Jade) spell at 14 Magic for 19 XP per 10-bolt cast. They carry the Earth's Fury proc - a 6% chance to stun the target for 4.8 seconds - and combine that crowd-control with a strong +122 ranged strength bonus, making them a stun-utility option for Slayer trash, multi-target PvM, and PvP setups where the knockdown lockout matters more than DPS optimisation."
   market_strategy:
     notes:
-      - Stun effect lasts 4.8 seconds when triggered
-      - Only 6% activation rate
-      - Many opponents resist the knockdown
-      - Low enchant requirement (Magic 14)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply is fletch-side - dragon bolts plus jade tips plus the enchant cycle."
+      - "GE buy limit of 11,000 per 4 hours supports steady mid-volume flipping."
+      - "High alch of 378 gp may exceed GE price during glut windows - alch when spread positive."
+      - "Demand is niche; players typically pick diamond/onyx/ruby dragon bolts (e) over jade for DPS."
+  trading_tips:
+    - "Cross-reference Jade dragon bolts unenchanted plus rune costs to spot enchant arbitrage."
+    - "Watch PvP meta and stun-utility content (e.g. Wilderness bosses) that may bump demand."
+    - "Compare against ruby/diamond/onyx (e) - substitution risk caps upside."
+  history:
+    - date: "2018-01-04"
+      description: "Released as part of Dragon Slayer II, which unlocked dragon crossbow ammunition crafting."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-chemicals.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jar-of-chemicals.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jar of chemicals | OSRS Price Data
-description: "Jar of chemicals: Looks unstable.. High alch: 1 GP, GE limit: 4."
+description: "Jar of chemicals is a members rare boss jar from Alchemical Hydra. High alch: 1 GP, GE limit: 4."
 osrs:
   id: 23064
   name: Jar of chemicals
@@ -12,9 +12,82 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
-  about: "Jar of chemicals is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: jar
+    tier: high
+  properties:
+    release_date: "2019-01-31"
+    update: "Karuulm Slayer Dungeon"
+    quest_item: false
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    weight: 0.5
+    destroy: "Drop"
+    options:
+      - Drop
+      - Use
+    examine_options:
+      - Examine
+    alchable: true
+  drop_table:
+    sources:
+      - source: Alchemical Hydra
+        source_id: 8615
+        combat_level: 426
+        quantity: "1"
+        rarity: 1/2000
+        notes: "Rare drop only available on Hydra Slayer tasks"
+  recipes:
+    - skill: construction
+      level: 5
+      xp: 0
+      tools:
+        - Hammer
+        - Saw
+      materials:
+        - item_id: 23064
+          item_name: Jar of chemicals
+          quantity: 1
+        - item_id: 23074
+          item_name: Hydra (pet)
+          quantity: 1
+      output:
+        item_name: Jar of chemicals (display)
+        output_quantity: 1
+      members: true
+      notes: "Used with the Hydra pet to display it on a Treasure Room jar mount"
+  related_items:
+    - item_name: Alchemical Hydra
+      slug: alchemical-hydra
+      relationship: alternative
+      description: Boss that drops the jar of chemicals
+    - item_id: 23074
+      item_name: Hydra
+      slug: hydra
+      relationship: alternative
+      description: Boss pet rolled from the same boss
+    - item_name: Jar of sand
+      slug: jar-of-sand
+      relationship: variant
+      description: Kalphite Queen boss jar variant
+    - item_name: Jar of darkness
+      slug: jar-of-darkness
+      relationship: variant
+      description: Skotizo boss jar variant
+  market_strategy:
+    notes:
+      - "Rare 1/2000 Hydra unique; thin supply"
+      - "Collector demand from completionist accounts"
+      - "Required for Hydra pet jar display in Treasure Room"
+      - "Speculate around Hydra slayer task updates"
+  history:
+    - date: "2019-01-31"
+      description: "Released with the Karuulm Slayer Dungeon and Alchemical Hydra"
+  about: "Jar of chemicals is a rare drop from the Alchemical Hydra in the Karuulm Slayer Dungeon. It can be combined with a Hydra pet to mount the pet on a jar display inside a POH Treasure Room."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karambwan-vessel-baited.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karambwan-vessel-baited.mdx
@@ -1,6 +1,6 @@
 ---
 title: Karambwan vessel (baited) | OSRS Price Data
-description: "Karambwan vessel (baited): This Karambwan Vessel is loaded with Karambwanji.. High alch: 24 GP, GE limit: 15."
+description: "Karambwan vessel (baited): This Karambwan Vessel is loaded with Karambwanji. High alch: 24 GP, GE limit: 15."
 osrs:
   id: 3159
   name: Karambwan vessel (baited)
@@ -12,9 +12,66 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15
-  about: "Karambwan vessel (baited) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2004-09-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.0
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      materials:
+        - item_name: Karambwan vessel
+          item_id: 3157
+          quantity: 1
+        - item_name: Raw karambwanji
+          item_id: 3150
+          quantity: 1
+      product: Karambwan vessel (baited)
+      product_id: 3159
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 3157
+      item_name: Karambwan vessel
+      slug: karambwan-vessel
+      relationship: component
+      description: Empty vessel before baiting
+    - item_id: 3150
+      item_name: Raw karambwanji
+      slug: raw-karambwanji
+      relationship: component
+      description: Bait used to load the vessel
+    - item_id: 3142
+      item_name: Raw karambwan
+      slug: raw-karambwan
+      relationship: product
+      description: Caught with the baited vessel at Karamja's karambwan spot
+  about: "Karambwan vessel (baited) is a fishing tool used to catch raw karambwan at the eastern coast of Karamja. It is created by combining an empty Karambwan vessel with raw karambwanji and is consumed on catch, returning to an empty vessel."
+  market_strategy:
+    notes:
+      - "Niche fishing tool with most supply made by players locally"
+      - "Buy limit of 15 keeps GE turnover tiny"
+      - "Most players bait their own vessels rather than buy off the GE"
+  trading_tips:
+    - Cheaper to bait vessels yourself with raw karambwanji
+    - Useful as a backup during long karambwan fishing trips
+  history:
+    - date: "2004-09-14"
+      description: "Added with the Tai Bwo Wannai Trio quest alongside Karambwan fishing."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leathertop.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/karil-s-leathertop.mdx
@@ -12,84 +12,90 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: barrows-leather
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 6.803
+    degradeable: true
+    options:
+      - Wear
+      - Check
+      - Drop
+    worn_options:
+      - Remove
+      - Check
+    alchable: true
+    destroy: "If you drop this item it will break. Are you sure you want to drop it?"
   equipment:
     slot: body
-    type: barrows
-    set: Karil
-    tradeable: true
-    degradeable: true
-    weight: 6.8
     requirements:
       defence: 70
       ranged: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -15
-      attack_ranged: 30
-      defence_stab: 47
-      defence_slash: 42
-      defence_crush: 50
-      defence_magic: 65
-      defence_ranged: 57
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -15
+      ranged: 30
+    defence_bonus:
+      stab: 47
+      slash: 42
+      crush: 50
+      magic: 65
+      ranged: 57
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
   set_effect:
     name: Tainted Shot
     pieces_required: 4
-    description: 25% chance to lower opponent's Agility by 20%
-    amulet_of_damned: 25% chance to hit twice (second hit at 50% damage)
+    description: "25% chance per Karil's crossbow hit to lower opponent's Agility by 20%; with Amulet of the Damned, 25% chance for a second hit at 50% damage"
+  drop_table:
+    sources:
+      - source: Karil the Tainted
+        quantity: "1"
+        rarity: "1/392 per Barrows reward roll"
   related_items:
-    - item_id: 4732
-      item_name: Karil's coif
+    - item_name: Karil's coif
       slug: karils-coif
       relationship: set-piece
-      description: Head slot set piece
-    - item_id: 4738
-      item_name: Karil's leatherskirt
+      description: "Head slot set piece"
+    - item_name: Karil's leatherskirt
       slug: karils-leatherskirt
       relationship: set-piece
-      description: Legs slot set piece
-    - item_id: 4734
-      item_name: Karil's crossbow
+      description: "Legs slot set piece"
+    - item_name: Karil's crossbow
       slug: karils-crossbow
       relationship: set-piece
-      description: Weapon set piece
-    - item_id: 11828
-      item_name: Armadyl chestplate
+      description: "Weapon set piece"
+    - item_name: Armadyl chestplate
       slug: armadyl-chestplate
       relationship: upgrade
-      description: Upgrade path
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Ranged attack | +30 |
-    | Stab defence | +47 |
-    | Slash defence | +42 |
-    | Crush defence | +50 |
-    | Magic defence | +65 |
-    | Ranged defence | +57 |
-    | Magic attack | -15 |
-
-    Tainted Shot:
-    When wearing full Karil's (coif, leathertop, leatherskirt, crossbow):
-    - 25% chance to lower opponent's Agility by 20%
-
-    With Amulet of the Damned:
-    - 25% chance to hit twice (second hit at 50% damage)
-
-    Best For:
-    - Budget ranged body before Armadyl
-    - High magic defence situations
-    - Barrows set bonus scenarios
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Non-degrading ranged body upgrade path"
+  about: "Karil's leathertop is the body slot piece of Karil's set, dropped from Karil the Tainted at the Barrows minigame. It gives +30 ranged attack and very high magic defence at 70 Defence/70 Ranged, but degrades over 15 hours of combat through 100/75/50/25/0 stages, repairable for 90,000 gp at Bob in Lumbridge or cheaper at a POH armour stand with Smithing."
+  market_strategy:
+    notes:
+      - "Barrows drop rate of ~1/392 supplies the GE; price tracks brother-killing volume"
+      - "Magic-defence niche keeps demand steady for Cox prep and budget ranged bodies"
+      - "Repair burn caps profit on long PvM trips, factor when comparing to Armadyl"
+  trading_tips:
+    - "Buy ahead of Barrows xp events and competitive league pushes"
+    - "Stack a couple of charged spares when repair gold is short on ironman alts"
+  history:
+    - date: "2005-05-09"
+      description: "Released as part of the Barrows minigame update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kyatt-legs.mdx
@@ -12,9 +12,99 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
-  about: "Kyatt legs is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: fur
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.226
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weapon_type:
+    weight: 0.226
+    requirements:
+      hunter: 52
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 6
+      slash: 9
+      crush: 9
+      magic: 0
+      ranged: 6
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: crafting
+      level: 57
+      xp: 90
+      facility: Fancy Clothes Store, Varrock
+      materials:
+        - item_name: Kyatt fur
+          quantity: 2
+        - item_name: Coins
+          quantity: 1100
+      tools: []
+      output_quantity: 1
+      members_only: true
+      notes: "Bring kyatt fur and coins to the Fancy Clothes Store tailor in Varrock to have the legs stitched."
+  related_items:
+    - item_id: 10037
+      item_name: Kyatt top
+      slug: kyatt-top
+      relationship: set-piece
+      description: Polar Hunter outfit body piece
+    - item_id: 10033
+      item_name: Kyatt hat
+      slug: kyatt-hat
+      relationship: set-piece
+      description: Polar Hunter outfit hat
+    - item_id: 10041
+      item_name: Larupia legs
+      slug: larupia-legs
+      relationship: alternative
+      description: Jungle Hunter equivalent legs
+    - item_id: 10073
+      item_name: Graahk legs
+      slug: graahk-legs
+      relationship: alternative
+      description: Desert Hunter equivalent legs
+  about: "Kyatt legs are the polar-region Hunter camouflage leg slot piece crafted at 57 Crafting from two kyatt furs at the Fancy Clothes Store. Worn together with the kyatt top and hat as the polar Hunter outfit, the trio reduces detection by polar Hunter creatures and is required for sabre-toothed kyatt hunts."
+  market_strategy:
+    notes:
+      - "Supply depends on hunters crafting from raw kyatt fur"
+      - "Demand spikes when Hunter task content or Polar Hunter promos roll out"
+      - "Buy limit of 150 every 4 hours keeps margins moderate"
+      - "Outfit set is a stepping stone to Larupia, Graahk and Spotted cape upgrades"
+  trading_tips:
+    - "Track kyatt fur pricing as the material floor"
+    - "Pair flips with kyatt top and hat for full set arbitrage"
+    - "Stock around new Hunter quests or Twisted League content"
+  history:
+    - date: "2006-11-21"
+      description: "Released with the Hunter skill update as part of the polar camouflage outfit."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/light-infinity-colour-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/light-infinity-colour-kit.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Light infinity colour kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ornament-kit
+    tier: high
+  treasure_trail:
+    tier: elite
+    drop_rate: 1/1275
+    source: Reward casket (elite)
+  related_items:
+    - item_id: 12526
+      item_name: Dark infinity colour kit
+      slug: dark-infinity-colour-kit
+      relationship: alternative
+      description: Alternative recolour kit
+    - item_id: 6918
+      item_name: Infinity hat
+      slug: infinity-hat
+      relationship: component
+      description: Recolour target
+    - item_id: 6916
+      item_name: Infinity top
+      slug: infinity-top
+      relationship: component
+      description: Recolour target
+    - item_id: 6924
+      item_name: Infinity bottoms
+      slug: infinity-bottoms
+      relationship: component
+      description: Recolour target
+  about: |-
+    Light infinity colour kit is an elite Treasure Trails cosmetic reward that recolours three infinity robe pieces — the hat, top, and bottoms. Boots and gloves are not affected. Once applied, the recoloured pieces become untradeable, but the kit can be detached at any time to recover both the recolour kit and the original item.
+
+    | Property | Value |
+    |----------|-------|
+    | Slot | Cosmetic kit |
+    | Tradeable | Yes |
+    | Stackable | No |
+    | Weight | 0.5 kg |
+
+    | Targets | Result |
+    |---------|--------|
+    | Infinity hat | Light recolour |
+    | Infinity top | Light recolour |
+    | Infinity bottoms | Light recolour |
+  market_strategy:
+    notes:
+      - Pure cosmetic — value driven by fashionscape demand
+      - Elite clue exclusive (1/1275 from elite caskets)
+      - Buy limit of 4 per 4 hours throttles flips
+      - Dark infinity colour kit is the only direct cosmetic alternative
+      - Detachable, so recolour does not destroy the kit
+  trading_tips:
+    - Watch elite clue completion rates for supply spikes
+    - Cosmetic kits tend to swing on community fashion trends
+    - Low limit means bulk flipping requires multiple accounts
+  history:
+    - date: "2014-06-12"
+      description: Released with the Treasure Trail Expansion.
+    - date: "2018-01-25"
+      description: Received a graphical update alongside new ornament kit releases.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/loar-remains.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/loar-remains.mdx
@@ -1,6 +1,6 @@
 ---
 title: Loar remains | OSRS Price Data
-description: "Loar remains: The remains of a deadly shade.. High alch: 1 GP, GE limit: 7,500."
+description: "Loar remains are the lowest-tier shade remains used at Shades of Mort'ton funeral pyres for Firemaking and Prayer XP. High alch: 0 GP, GE limit: 7,500."
 osrs:
   id: 3396
   name: Loar remains
@@ -12,9 +12,59 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7500
-  about: "Loar remains is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: shade-remains
+    tier: low
+  properties:
+    release_date: "2004-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.36
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  passive_effects:
+    - name: Shades of Mort'ton pyre fuel
+      description: "Burned on a funeral pyre with pyre logs and a tinderbox during the Shades of Mort'ton minigame; cremation grants Firemaking and Prayer XP plus a 79% chance at a bronze shade key (red/brown/crimson) or a 21% chance at 200-300 coins. Morytania Diary boosts apply."
+  related_items:
+    - item_name: Pyre logs
+      slug: pyre-logs
+      relationship: component
+      description: Base pyre logs ignited with the remains for 50 Firemaking / 25 Prayer XP
+    - item_name: Bronze shade key
+      slug: bronze-shade-key
+      relationship: product
+      description: Primary reward roll from cremating Loar remains
+    - item_name: Phrin remains
+      slug: phrin-remains
+      relationship: upgrade
+      description: Next-tier shade remains dropped by Phrin Shades
+    - item_name: Riyl remains
+      slug: riyl-remains
+      relationship: upgrade
+      description: Higher-tier shade remains used at Mort'ton funeral pyres
+  about: "Loar remains are the lowest-tier shade remains dropped by Loar Shades around Mort'ton and burnt on funeral pyres during the Shades of Mort'ton minigame for Firemaking and Prayer experience, with each cremation rolling a bronze shade key or a small coin reward."
+  market_strategy:
+    notes:
+      - "Demand tied to Shades of Mort'ton minigame popularity and bronze key chasing"
+      - "Always-drop from a single, low-level monster keeps the supply elastic"
+      - "GE buy limit of 7,500 per 4 hours supports bulk pyre runs"
+      - "Not alchable - pure utility item, no NPC value floor"
+  trading_tips:
+    - "Stockpile before Firemaking double XP weekends when pyre throughput peaks"
+    - "Watch bronze key/loot table updates - reward shifts move the whole shade remains market"
+    - "Morytania Diary completions raise reward quality, lifting steady minigame demand"
+  history:
+    - date: "2004-10-18"
+      description: "Released with the Shades of Mort'ton minigame as the entry-tier shade remains."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lumbridge-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lumbridge-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lumbridge teleport (tablet) | OSRS Price Data
-description: "Lumbridge teleport (tablet): A teleport to Lumbridge.. High alch: 1 GP, GE limit: 10,000."
+description: "Lumbridge teleport (tablet) is a stackable standard-spellbook Magic tablet teleporting the user to Lumbridge Castle courtyard, crafted at 31 Magic on a lectern. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 8008
   name: Lumbridge teleport (tablet)
@@ -12,9 +12,89 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Lumbridge teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2006-05-31"
+    update: "POH eagle lectern teleport tablets"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Break
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  teleport:
+    type: tablet
+    spellbook: standard
+    destinations:
+      - name: Lumbridge
+        location: Lumbridge Castle courtyard
+    charges: 1
+    magic_level: 31
+    magic_xp: 41
+    runes:
+      - "1 Law rune"
+      - "3 Air rune"
+      - "1 Earth rune"
+  recipes:
+    - skill: magic
+      level: 31
+      xp: 41
+      materials:
+        - item_name: Soft clay
+          item_id: 1761
+          quantity: 1
+        - item_name: Law rune
+          item_id: 563
+          quantity: 1
+        - item_name: Air rune
+          item_id: 556
+          quantity: 3
+        - item_name: Earth rune
+          item_id: 557
+          quantity: 1
+      facility: Eagle lectern (player-owned house)
+      product: Lumbridge teleport (tablet)
+      product_id: 8008
+      output_quantity: 1
+  related_items:
+    - item_id: 8007
+      item_name: Varrock teleport (tablet)
+      slug: varrock-teleport-tablet
+      relationship: alternative
+      description: "Lower-level standard spellbook teleport tablet to Varrock."
+    - item_id: 8009
+      item_name: Falador teleport (tablet)
+      slug: falador-teleport-tablet
+      relationship: alternative
+      description: "Another standard spellbook teleport tablet."
+    - item_id: 8010
+      item_name: Camelot teleport (tablet)
+      slug: camelot-teleport-tablet
+      relationship: alternative
+      description: "Higher-level standard spellbook teleport tablet."
+  about: "Lumbridge teleport (tablet) is a stackable Magic tablet that instantly teleports the user to the Lumbridge Castle courtyard regardless of their own Magic level. Tablets are crafted on a player-owned house eagle lectern at 31 Magic from one soft clay, one law rune, three air runes, and one earth rune for 41 Magic XP each, and are widely used as a death-respawn point or quick capital-region hop."
+  market_strategy:
+    notes:
+      - "High daily volume - the lowest barrier of the city tablet trio."
+      - "Crafting profit floats with law rune and soft clay prices."
+      - "Buy limit of 10,000 per 4 hours allows true bulk flipping."
+      - "High alch of 1 gp - alching is impossible; the tablet is consumed not melted."
+  trading_tips:
+    - "Watch law rune and soft clay supply pressure to time tablet crafts."
+    - "Demand spikes near Inferno/Fight Cave death-pile recovery and clue meta shifts."
+    - "Stable margins; volume-flip rather than spread-flip."
+  history:
+    - date: "2006-05-31"
+      description: "Released alongside the eagle lectern POH teleport tablet system."
+    - date: "2007-12-10"
+      description: "Tablet examine text reworked to standardise teleport descriptions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-cape-rack-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-cape-rack-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Magic cape rack (flatpack) | OSRS Price Data
-description: "Magic cape rack (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Magic cape rack (flatpack): a pre-built Construction flatpack for a top-tier costume room cape rack. High alch: 6 GP, GE limit: 500."
 osrs:
   id: 9848
   name: Magic cape rack (flatpack)
@@ -12,9 +12,78 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Magic cape rack (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: wood
+    tier: high
+  properties:
+    release_date: "2007-05-22"
+    update: "Player-Owned Houses (Costume Room)"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  construction:
+    construction_level: 80
+    xp: 1000
+    materials:
+      - item_name: Magic logs
+        quantity: "4"
+      - item_name: Gold leaf
+        quantity: "2"
+    hotspot: Cape rack space
+    room: Costume Room
+    tools:
+      - Hammer
+      - Saw
+    notes: "Built at a Wooden workbench in a player-owned house workshop; stores all rare and skill capes."
+  recipes:
+    - skill: construction
+      level: 80
+      xp: 1000
+      materials:
+        - item_name: Magic logs
+          quantity: 4
+        - item_name: Gold leaf
+          quantity: 2
+      output_quantity: 1
+      notes: "Assembled at a Wooden workbench."
+  related_items:
+    - item_name: Magic logs
+      slug: magic-logs
+      relationship: component
+      description: Primary material consumed during assembly.
+    - item_name: Gold leaf
+      slug: gold-leaf
+      relationship: component
+      description: Decorative material applied to finish the rack.
+    - item_name: Yew cape rack (flatpack)
+      slug: yew-cape-rack-flatpack
+      relationship: alternative
+      description: Lower-tier cape rack flatpack.
+  about: |-
+    Magic cape rack (flatpack) is a pre-built version of the top-tier Costume Room cape rack, assembled at a player-owned house Wooden workbench from 4 magic logs and 2 gold leaves. It requires 80 Construction to build and grants 1,000 Construction experience.
+
+    Once placed, the magic cape rack stores all rare and skill capes for retrieval, occupying a Costume Room cape rack hotspot.
+  market_strategy:
+    notes:
+      - "Used by Construction trainers as a high-XP-per-action option."
+      - "Demand spikes during Construction bonus events."
+      - "Margins driven by magic log and gold leaf prices."
+  trading_tips:
+    - "Buy magic logs and gold leaves at GE lows before building flatpacks for resale."
+    - "GE limit 500 supports bulk flipping during Construction events."
+  history:
+    - date: "2007-05-22"
+      description: "Released alongside the Costume Room update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/magic-potion-2.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Magic potion(2) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: mid
+  properties:
+    release_date: "2004-09-07"
+    update: "Situation in the Sands"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.025
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    doses: 2
+    effects:
+      - description: "Temporarily raises Magic level by 4 for casting purposes; does not lift equipment Magic requirements."
+        skill: magic
+        boost: 4
+        duration: 60
+  recipes:
+    - skill: herblore
+      level: 76
+      xp: 172.5
+      materials:
+        - item_name: Lantadyme potion (unf)
+          quantity: 1
+        - item_name: Potato cactus
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      members_only: true
+      notes: "The full recipe produces a 3-dose magic potion; the 2-dose form is the partially drunk remainder."
+  related_items:
+    - item_id: 3040
+      item_name: Magic potion(4)
+      slug: magic-potion-4
+      relationship: variant
+      description: Full 4-dose form of the potion
+    - item_id: 3042
+      item_name: Magic potion(3)
+      slug: magic-potion-3
+      relationship: variant
+      description: 3-dose form of the potion
+    - item_id: 3046
+      item_name: Magic potion(1)
+      slug: magic-potion-1
+      relationship: variant
+      description: 1-dose form of the potion
+    - item_id: 22449
+      item_name: Battlemage potion(4)
+      slug: battlemage-potion-4
+      relationship: upgrade
+      description: Combo magic and defence potion replacement
+  about: "Magic potion(2) is the 2-dose form of the magic potion line that temporarily boosts Magic by 4 levels for casting spells slightly above the player's base Magic level. Created by Herblorists at level 76 from lantadyme potion (unf) and potato cactus; the 2-dose form is the partially drunk remainder of a 3-dose brew."
+  market_strategy:
+    notes:
+      - "Decanted from 4-dose potions, so 2-dose price tracks 4-dose closely"
+      - "Buy limit of 2,000 per 4 hours keeps flips moderate"
+      - "Demand spikes around boss raids needing high-tier autocast spells"
+      - "Supply depends on Herblore training drops and decanting services"
+  trading_tips:
+    - "Compare per-dose price against 4-dose for decant arbitrage"
+    - "Stock when lantadyme prices dip during Farming herb runs"
+    - "Avoid high alching; 120 gp return is below typical GE pricing"
+  history:
+    - date: "2004-09-07"
+      description: "Released alongside the Magic potion line with the Situation in the Sands update."
+    - date: "2004-10-26"
+      description: "An Empty option was added to magic potion vials."
+    - date: "2015-10-08"
+      description: "Magic potion recoloured to distinguish from Ranging potions."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-wardrobe-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mahogany wardrobe (flatpack) | OSRS Price Data
-description: "Mahogany wardrobe (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Mahogany wardrobe (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8620
   name: Mahogany wardrobe (flatpack)
@@ -12,9 +12,75 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Mahogany wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: flatpack
+    tier: high
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.0
+    options:
+      - Build
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 75
+      xp: 420
+      materials:
+        - item_name: Mahogany plank
+          item_id: 8782
+          quantity: 3
+      facility: Workbench (player-owned house workshop)
+      product: Mahogany wardrobe (flatpack)
+      product_id: 8620
+      output_quantity: 1
+  construction:
+    construction_level: 75
+    construction_xp: 420
+    room: Bedroom
+    hotspot: Wardrobe
+    flatpack: true
+  related_items:
+    - item_id: 8782
+      item_name: Mahogany plank
+      slug: mahogany-plank
+      relationship: component
+      description: "Material (x3) for the flatpack."
+    - item_id: 8618
+      item_name: Teak wardrobe (flatpack)
+      slug: teak-wardrobe-flatpack
+      relationship: downgrade
+      description: "Lower tier wardrobe flatpack."
+    - item_id: 8622
+      item_name: Gilded wardrobe (flatpack)
+      slug: gilded-wardrobe-flatpack
+      relationship: upgrade
+      description: "Higher tier wardrobe flatpack."
+  about: "Mahogany wardrobe (flatpack) is a Construction 75 workbench product crafted from 3 mahogany planks for the Bedroom wardrobe hotspot in the player-owned house. Each build awards 420 Construction XP and is a common Ironman supply route for filling out a POH bedroom without hauling planks to the build hotspot directly."
+  market_strategy:
+    notes:
+      - "Construction 75 + 3 mahogany planks per flatpack."
+      - "420 XP per build; useful for Ironman Bedroom routes and incidental Construction XP."
+      - "GE buy limit 500 per 4 hours, more than enough for typical use."
+      - "High alch only 6 gp, alching is unprofitable."
+  trading_tips:
+    - "Watch mahogany plank price; flatpack value tracks raw plank cost closely."
+    - "Bulk-buy for Bedroom loadouts on Ironman accounts that want to skip plank-hauling."
+    - "Margins are thin; avoid heavy positions, treat as supply-line item."
+  history:
+    - date: "2006-05-31"
+      description: "Mahogany wardrobe flatpack added with the Construction skill release."
+    - date: "2014-12-10"
+      description: "Renamed from Mahogany 'drobe to Mahogany wardrobe with the Trading Post rename pass."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/malediction-ward.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/malediction-ward.mdx
@@ -1,6 +1,6 @@
 ---
 title: Malediction ward | OSRS Price Data
-description: "Malediction ward is a members shield slot item requiring 60 Defence. High alch: 27,000 GP, GE limit: 8."
+description: "Malediction ward is a 60 Defence magic shield with +12 magic attack and +2% magic damage built from three Wilderness boss shards. High alch: 27,000 GP, GE limit: 8."
 osrs:
   id: 11924
   name: Malediction ward
@@ -12,28 +12,59 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: shield
+    tier: high
+  properties:
+    release_date: "2014-03-13"
+    update: "Wilderness Bosses"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: magic_shield
+    weapon_type: magic_shield
+    weight: 3.628
     requirements:
       defence: 60
-    stats:
-      attack_magic: 12
+    attack_bonus:
+      stab: -8
+      slash: -8
+      crush: -8
+      magic: 12
+      ranged: -8
+    defence_bonus:
+      stab: 50
+      slash: 52
+      crush: 48
+      magic: 15
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
       magic_damage: 2
-      defence_stab: 50
-      defence_slash: 52
-      defence_crush: 48
-      defence_magic: 15
+      prayer: 0
   drop_table:
     sources:
       - source: Volcanic Forge
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: N/A
+        location: North-east Wilderness
+        rarity: assembly
         members_only: true
   recipes:
-    - skill: N/A
+    - skill: none
       level: 0
       xp: 0
       materials:
@@ -47,61 +78,52 @@ osrs:
           item_name: Malediction shard 3
           quantity: 1
       product: Malediction ward
-      product_id: 11924
-      facility: Volcanic Forge
-      members_only: true
+      output_quantity: 1
   related_items:
     - item_id: 11926
       item_name: Odium ward
       slug: odium-ward
       relationship: alternative
-      description: Ranged version
+      description: "Ranged counterpart shield from the same Wilderness boss shard system."
     - item_id: 12825
       item_name: Arcane spirit shield
       slug: arcane-spirit-shield
       relationship: upgrade
-      description: BiS magic shield
+      description: "Best-in-slot magic shield with stronger offence and prayer bonus."
     - item_id: 6889
       item_name: Mage's book
       slug: mages-book
       relationship: alternative
-      description: Alternative
-  about: |-
-    Combine 3 shards at Volcanic Forge (NE Wilderness):
-
-    | Shard | Source |
-    |-------|--------|
-    | Malediction shard 1 | Chaos Fanatic |
-    | Malediction shard 2 | Crazy Archaeologist |
-    | Malediction shard 3 | Scorpia |
-
-    | Offense | Value |
-    |---------|-------|
-    | Magic attack | +12 |
-    | Magic damage | +2% |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +50 |
-    | Slash | +52 |
-    | Crush | +48 |
-    | Magic | +15 |
-
-    Requirements: 60 Defence
-
-    Budget magic shield for:
-    - Magic combat
-    - Slayer tasks
-    - Mid-game content
-
-    Only shield with +2% magic damage.
+      description: "Off-hand magic alternative with higher magic attack and no Defence requirement."
+    - item_id: 11931
+      item_name: Malediction shard 1
+      slug: malediction-shard-1
+      relationship: component
+      description: "Chaos Fanatic drop, first of three combine shards."
+    - item_id: 11932
+      item_name: Malediction shard 2
+      slug: malediction-shard-2
+      relationship: component
+      description: "Crazy Archaeologist drop, second of three combine shards."
+    - item_id: 11933
+      item_name: Malediction shard 3
+      slug: malediction-shard-3
+      relationship: component
+      description: "Scorpia drop, third of three combine shards."
+  about: "Malediction ward is the magic-leaning shield half of the Wilderness boss shard system, assembled by combining Malediction shard 1, 2, and 3 at the Volcanic Forge in the north-east Wilderness. With a +12 magic attack, +2% magic damage, and dragon-square-tier melee defence, it is the only off-hand magic option that offers a damage multiplier without the price tag of a spirit shield, making it the standard mid-budget shield for Slayer mages and mid-game magic content."
   market_strategy:
     notes:
-      - Wilderness bosses for shards
-      - Magic damage bonus is unique
-      - Budget option before arcane
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand peaks with Wilderness boss hunting and Slayer magic tasks."
+      - "GE buy limit of 8 keeps merchanting thin and sensitive to wars."
+      - "Shard supply is risk-gated by Wilderness PKers, dampening output."
+      - "High alch of 27,000 gp is far below GE - not an alch target."
+  trading_tips:
+    - "Sum shard prices vs assembled ward to detect combine arbitrage windows."
+    - "Track Wilderness PvP activity - quieter weeks lift shard supply."
+    - "Spirit shield meta shifts (Arcane buffs/nerfs) move ward demand sharply."
+  history:
+    - date: "2014-03-13"
+      description: "Released with the Wilderness Bosses update alongside its Odium ward counterpart."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/malicious-ashes.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/malicious-ashes.mdx
@@ -11,10 +11,10 @@ osrs:
   value: 1
   lowalch: 1
   highalch: 1
-  limit: null
+  limit:
   material:
     type: ashes
-    tier: medium
+    tier: mid
   prayer:
     xp_scatter: 65
     xp_demonic_offering: 195
@@ -52,16 +52,35 @@ osrs:
       slug: fiendish-ashes
       relationship: downgrade
       description: Lowest XP (10 base)
+  about: |-
+    Malicious ashes are a mid-tier demonic ashes dropped by black demons and Nechryael. They sit between vile ashes (25 XP) and abyssal ashes (85 XP) on the Prayer scatter ladder, granting 65 Prayer XP per scatter or 195 XP via the Demonic Offering spell on a desecrated altar.
+
+    | Source | Combat | Drop |
+    |--------|--------|------|
+    | Black demon | 172 | Always |
+    | Nechryael | 115 | Always |
+
+    | Prayer Use | XP |
+    |------------|------|
+    | Scatter | 65 |
+    | Demonic Offering | 195 |
   market_strategy:
     notes:
-      - Common from black demon tasks
-      - Nechryael barraging popular
-      - Steady supply and demand
-      - Good middle-ground ashes
+      - Common from black demon Slayer tasks
+      - Nechryael barraging keeps supply steady
+      - Steady supply and demand balance
+      - Mid-tier ashes — useful filler for Prayer training
       - Popular Slayer task drops
-      - Compare to bone GP/XP ratios
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Compare GP/XP against superior bones
+  trading_tips:
+    - Best price spikes after demon-task multiplier bonuses
+    - Bulk buy during Slayer events for arbitrage
+    - Compare scatter GP/XP versus dragon bones daily
+  history:
+    - date: "2021-04-21"
+      description: Released with the Forsaken Tower update as the mid-tier demonic ashes.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-red-kilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-red-kilt.mdx
@@ -1,6 +1,6 @@
 ---
 title: Menaphite red kilt | OSRS Price Data
-description: "Menaphite red kilt: Look at those nobbily knees.. High alch: 12 GP, GE limit: 150."
+description: "Menaphite red kilt is a members cosmetic legs piece from the Rogue Trader miniquest; delays desert heat onset by 12 seconds when worn. High alch: 12 GP, GE limit: 150."
 osrs:
   id: 6406
   name: Menaphite red kilt
@@ -12,9 +12,92 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 150
-  about: "Menaphite red kilt is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2005-08-15"
+    update: "Rogue Trader"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weight: 0.005
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Desert heat protection
+      description: "Delays the onset of desert heat damage by 20 ticks (12 seconds) while worn."
+  related_items:
+    - item_id: 6402
+      item_name: Menaphite red hat
+      slug: menaphite-red-hat
+      relationship: alternative
+      description: Matching head slot piece for the red Menaphite outfit.
+    - item_id: 6404
+      item_name: Menaphite red robe
+      slug: menaphite-red-robe
+      relationship: alternative
+      description: Matching body slot piece for the red Menaphite outfit.
+    - item_id: 6408
+      item_name: Menaphite purple kilt
+      slug: menaphite-purple-kilt
+      relationship: variant
+      description: Purple colour variant from the same Rogue Trader reward set.
+  shop:
+    - location: Pollnivneach
+      npc: Ali Morrisane
+      shop_name: Rogue Trader reward
+      base_price: Three dyes (any colour) traded to Siamun
+  about: "Menaphite red kilt is a members-only cosmetic legs piece earned by completing the Rogue Trader miniquest in Pollnivneach. Players hand three dyes of any colour to Siamun, then trade with Ali Morrisane to receive the kilt. Originally a pure-cosmetic item, it received a desert heat protection bonus on 22 March 2023 that delays heat damage onset by 12 seconds while worn, making it useful for early desert exploration before Akhthanakos's blessing or a waterskin loadout."
+  market_strategy:
+    notes:
+      - "Demand is mostly fashionscape - some uplift after 2023 from new desert-heat players."
+      - "GE buy limit of 150 per 4 hours caps merchant volume."
+      - "High alch of 12 gp is below GE price - never an alch target."
+      - "Supply is driven by Rogue Trader completions, mostly ironmen and collection log hunters."
+  trading_tips:
+    - "Watch Menaphos / desert content updates - heat protection demand spikes briefly."
+    - "Compare with the purple variant - red is generally the more popular colour."
+    - "Low-volume cosmetic - prefer single-set flips over bulk holdings."
+  history:
+    - date: "2005-08-15"
+      description: "Released with the Rogue Trader miniquest update."
+    - date: "2014-12-10"
+      description: "Renamed from 'Menap action kilt' to 'Menaphite red kilt'."
+    - date: "2023-03-22"
+      description: "Added desert heat protection of 20 ticks (12 seconds) while worn."
+    - date: "2024-10-23"
+      description: "Model recoloured to its originally intended colours after config fixes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-remedy-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-remedy-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Menaphite remedy(1) | OSRS Price Data
-description: "Menaphite remedy(1): 1 dose of Menaphite remedy.. High alch: 66 GP."
+description: "Menaphite remedy(1) is the 1-dose stat renewal potion restoring 6 + 16 percent combat stats every 15 seconds for 5 minutes and countering Saradomin brew drain. High alch: 66 GP."
 osrs:
   id: 27211
   name: Menaphite remedy(1)
@@ -11,21 +11,37 @@ osrs:
   value: 110
   lowalch: 44
   highalch: 66
-  limit: null
-  item:
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
     type: potion
+    tier: high
+  properties:
+    release_date: "2022-08-24"
+    update: "Tombs of Amascut"
     tradeable: true
-    doses: 4
-  effect:
-    boost:
-      - skill: combat stats
-        amount: 6 + 16%
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.035
+    options:
+      - Drink
+      - Empty
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  potion:
+    effects:
+      - description: "Restores 6 + 16 percent of combat stats (Attack, Strength, Defence, Magic, Ranged) every 15 seconds for 5 minutes."
         duration: 300
-        interval: 15
-    special:
-      - Negates Saradomin brew stat drain
-      - Removes divine potion effects
-      - Stats decrease at normal rates
+      - description: "Negates Saradomin brew stat drain, allowing stacked brew sips without combat stat loss."
+        duration: 300
+      - description: "Removes divine potion lock-in, letting boosted stats decay normally instead of resetting to base."
+        duration: 0
   recipes:
     - skill: herblore
       level: 88
@@ -38,50 +54,55 @@ osrs:
           item_name: Lily of the sands
           quantity: 1
       product: Menaphite remedy(4)
-      product_id: 27211
+      product_id: 27205
+      output_quantity: 1
+      notes: "Produces a 4-dose; decant at GE for (1) doses."
   related_items:
+    - item_id: 27205
+      item_name: Menaphite remedy(4)
+      slug: menaphite-remedy-4
+      relationship: variant
+      description: "Full 4-dose variant - most efficient inventory form."
+    - item_id: 27207
+      item_name: Menaphite remedy(3)
+      slug: menaphite-remedy-3
+      relationship: variant
+      description: "3-dose variant for partial decants."
+    - item_id: 27209
+      item_name: Menaphite remedy(2)
+      slug: menaphite-remedy-2
+      relationship: variant
+      description: "2-dose variant for mid-tier flips."
     - item_id: 27226
       item_name: Lily of the sands
       slug: lily-of-the-sands
       relationship: component
-      description: Herblore ingredient from ToA
+      description: "ToA-exclusive Herblore ingredient gating supply."
     - item_id: 6685
       item_name: Saradomin brew(4)
-      slug: saradomin-brew
+      slug: saradomin-brew-4
       relationship: alternative
-      description: Pairs well - negates stat drain
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Potion |
-    | Tradeable | Yes |
-    | Stackable | No |
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore | 88 (boostable) |
-    | XP | 200 |
-
-    Ingredients:
-    - Dwarf weed potion (unf)
-    - Lily of the sands
-
-    Stat Renewal: Restores 6 + 16% of combat stats (excluding prayer) every 15 seconds for 5 minutes.
-
-    Special Properties:
-    - Negates Saradomin brew stat drain
-    - Removes divine potion effects
-    - Stats decrease at normal rates
+      description: "Pairs in inventory - remedy negates brew's combat-stat drain."
+  about: "Menaphite remedy(1) is the 1-dose form of the Tombs of Amascut stat renewal potion, brewed at 88 Herblore by combining a dwarf weed potion (unf) with a Lily of the Sands for 200 XP. It restores 6 + 16 percent of all combat stats every 15 seconds for 5 minutes, counters Saradomin brew stat drain in extended bossing, and overrides divine potion lock-in so boosts decay normally. The single-dose form is mostly the residue of GE decant arbitrage."
   market_strategy:
     notes:
-      - Made with ToA ingredient
-      - Useful for extended fights
-      - Counters brew drain
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Decant arbitrage candidate - (4) splits into 4x (1) at GE decanters."
+      - "Demand follows ToA, CoX, and brew-stack-heavy boss meta."
+      - "Supply is gated by Lily of the Sands drop rates inside ToA."
+      - "No GE limit on this dose - flips scale freely with capital."
+  trading_tips:
+    - "Watch (4) vs (1) spread - decant when the 4x price exceeds (4)."
+    - "Track ToA team-size meta - solo runners burn more remedies per hour."
+    - "Stockpile ahead of new Herblore content that consumes Lily of the Sands."
+  history:
+    - date: "2022-08-24"
+      description: "Released with Tombs of Amascut as the headline Herblore reward."
+    - date: "2025-04-30"
+      description: "Lily of the Sands now correctly draws from the reagent pouch during creation."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mind-bomb-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mind-bomb-m4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mind bomb(m4) | OSRS Price Data
-description: "Mind bomb(m4): This keg contains 4 pints of mature Wizards Mind Bomb.. High alch: 1 GP, GE limit: 2,000."
+description: "Mind bomb(m4) is a full 4-pint keg of mature Wizard's Mind Bomb brewed at 34 Cooking; +3 Magic boost with combat-stat drain. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5881
   name: Mind bomb(m4)
@@ -12,9 +12,103 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Mind bomb(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: ale keg
+    tier: low
+  properties:
+    release_date: "2005-07-11"
+    update: "Farming"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.028
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 34
+      xp: 0
+      materials:
+        - item_name: Bucket of water
+          quantity: 2
+        - item_name: Barley malt
+          quantity: 2
+        - item_name: Yanillian hops
+          quantity: 4
+        - item_name: Ale yeast
+          quantity: 1
+        - item_name: Calquat keg
+          quantity: 2
+      tools:
+        - Brewery vat (Keldagrim or Phasmatys)
+      output_quantity: 2
+      notes: "Brew 8 pints of mature Wizard's Mind Bomb, then fit them into 2 calquat kegs to yield two m4 kegs."
+  potion:
+    effects:
+      - description: "Boosts Magic by 2 + 2% of base level (3 at level 99)"
+        duration: 0
+      - description: "Drains Attack by 4 levels"
+        duration: 0
+      - description: "Drains Defence, Ranged, Strength, and Prayer by 3 levels each"
+        duration: 0
+      - description: "Restores 1 Hitpoint per pint"
+        duration: 0
+  related_items:
+    - item_id: 5875
+      item_name: Mind bomb(m1)
+      slug: mind-bomb-m1
+      relationship: variant
+      description: "Keg variant containing 1 pint of mature Wizard's Mind Bomb."
+    - item_id: 5877
+      item_name: Mind bomb(m2)
+      slug: mind-bomb-m2
+      relationship: variant
+      description: "Keg variant containing 2 pints of mature Wizard's Mind Bomb."
+    - item_id: 5879
+      item_name: Mind bomb(m3)
+      slug: mind-bomb-m3
+      relationship: variant
+      description: "Keg variant containing 3 pints of mature Wizard's Mind Bomb."
+    - item_name: Mature Wizard's Mind Bomb
+      slug: mature-wizards-mind-bomb
+      relationship: alternative
+      description: "Glass-pint variant of the same brewed drink."
+    - item_name: Calquat keg
+      slug: calquat-keg
+      relationship: component
+      description: "Empty keg used to package brewed pints into m1-m4 variants."
+  about: "Mind bomb(m4) is a full 4-pint keg of mature Wizard's Mind Bomb, brewed at 34 Cooking at Keldagrim or Port Phasmatys breweries (2 buckets of water, 2 barley malt, 4 yanillian hops, 1 ale yeast, 2 calquat kegs - 8 pints yields 2 m4 kegs). Each pint grants a +3 Magic boost (at 99) plus a 1 HP heal, at the cost of small Attack/Defence/Ranged/Strength/Prayer drains - a niche pre-Saradomin-brew Magic booster."
+  passive_effects:
+    - name: Magic boost
+      description: "Each pint temporarily raises Magic by 2 + 2% of the base level, useful for boost-locked content like the Mage Arena."
+    - name: Combat-stat drain
+      description: "Drains Attack by 4 and Defence, Ranged, Strength, and Prayer by 3 levels each per pint, limiting use to pure-mage strategies."
+  market_strategy:
+    notes:
+      - "Supply is fully player-brewed at Keldagrim/Phasmatys breweries"
+      - "Buy limit of 2,000 keeps merch volume modest"
+      - "Niche Magic-boost demand from Mage Arena and Wilderness mages"
+      - "Untradeable once partially drunk - keg integrity matters for resale"
+  trading_tips:
+    - "Compare m4 keg price to 4x Mature Wizard's Mind Bomb glass pints to spot brewer arbitrage"
+    - "Demand spikes around Mage Arena training cycles and boost-locked Wilderness content"
+    - "Brew during Cooking double XP weeks to flood supply"
+  history:
+    - date: "2005-07-11"
+      description: "Released with the Farming and Brewing rework that introduced calquat kegs and the mature ale variants."
+    - date: "2005-10-04"
+      description: "Renamed from Mind bomb(n) variants to the current Mind bomb(mn) naming."
+    - date: "2015-02-26"
+      description: "Partially-drunk variants made untradeable to clean up the Grand Exchange listings."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mint-cake.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mint-cake.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mint cake | OSRS Price Data
-description: "Mint cake: It looks very minty.. High alch: 150 GP, GE limit: 10,000."
+description: "Mint cake is a Gnome Restaurant reward that restores 50% run energy in a single bite. High alch: 150 GP, GE limit: 10,000."
 osrs:
   id: 9475
   name: Mint cake
@@ -12,9 +12,72 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 10000
-  about: "Mint cake is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2006-08-07"
+    update: "Gnome Cuisine"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Brambickle
+        location: Gnome Restaurant
+        rarity: 23/512
+        members_only: true
+      - source: Wingstone
+        location: Gnome Restaurant
+        rarity: 23/512
+        members_only: true
+      - source: Penwie
+        location: Gnome Restaurant
+        rarity: 23/512
+        members_only: true
+      - source: Longramble
+        location: The Path of Glouphrie quest
+        rarity: one-off
+        members_only: true
+  related_items:
+    - item_name: Energy potion
+      slug: energy-potion
+      relationship: alternative
+      description: "Herblore-brewed potion that restores 10% run energy per dose."
+    - item_name: Stamina potion
+      slug: stamina-potion
+      relationship: alternative
+      description: "Premium energy restorer that also halves drain rate for two minutes."
+    - item_name: Strange fruit
+      slug: strange-fruit
+      relationship: alternative
+      description: "Cheaper energy snack that restores a smaller percentage of run energy."
+  about: "Mint cake is a Gnome Restaurant minigame reward that restores 50% run energy in a single click - the highest per-bite energy restoration of any item in OSRS. It is randomly tipped by the gnome customers Brambickle, Wingstone, and Penwie at a 23/512 rate, and a single one-off cake is also handed out by Longramble during The Path of Glouphrie."
+  market_strategy:
+    notes:
+      - "Demand driven by long-walk PvM and Slayer setups that want one-tile energy spikes."
+      - "Supply is bottlenecked behind Gnome Restaurant grinders and runs thin."
+      - "GE buy limit of 10,000 per 4 hours rarely binds at current volume."
+      - "High alch of 150 gp is far below GE - never an alch target."
+  trading_tips:
+    - "Watch GE price against stamina potion equivalents for substitution flips."
+    - "Stockpile around new Wilderness or sailing content drops that punish run energy."
+    - "Thin supply means single PvM streamers can move price - track meta swings."
+  history:
+    - date: "2006-08-07"
+      description: "Released with the Gnome Cuisine update and added to the Gnome Restaurant reward pool."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-trimmed-set-sk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril trimmed set (sk) | OSRS Price Data
-description: "Mithril trimmed set (sk): A set containing a full helm, platebody, skirt and kiteshield.. High alch: 3,000 GP, GE limit: 8."
+description: "Mithril trimmed set (sk) is the F2P Grand Exchange Sets bundle containing a Mithril full helm (t), platebody (t), plateskirt (t) and kiteshield (t). High alch: 3,000 GP, GE limit: 8."
 osrs:
   id: 13006
   name: Mithril trimmed set (sk)
@@ -12,9 +12,60 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 8
-  about: "Mithril trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: mithril
+    tier: mid
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 6
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Mithril full helm (t)
+      slug: mithril-full-helm-t
+      relationship: component
+      description: Trimmed Mithril full helm bundled into the set
+    - item_name: Mithril platebody (t)
+      slug: mithril-platebody-t
+      relationship: component
+      description: Trimmed Mithril platebody bundled into the set
+    - item_name: Mithril plateskirt (t)
+      slug: mithril-plateskirt-t
+      relationship: component
+      description: Trimmed Mithril plateskirt bundled into the set
+    - item_name: Mithril kiteshield (t)
+      slug: mithril-kiteshield-t
+      relationship: component
+      description: Trimmed Mithril kiteshield bundled into the set
+    - item_name: Mithril trimmed set (lg)
+      slug: mithril-trimmed-set-lg
+      relationship: variant
+      description: Platelegs variant of the trimmed mithril armour set
+  about: "Mithril trimmed set (sk) is a free-to-play Grand Exchange Sets bundle that packages a Mithril full helm (t), platebody (t), plateskirt (t), and kiteshield (t) into a single tradeable item via the Grand Exchange clerk's Sets interface, used to save bank space when storing the trimmed Mithril armour kit."
+  market_strategy:
+    notes:
+      - "Pure bank-space convenience item - value tracks the sum of its four trimmed Mithril components"
+      - "GE buy limit of 8 per 4 hours caps merchant flips"
+      - "F2P-tradeable, so demand survives membership lapses"
+      - "Trimmed Mithril pieces are cosmetic-only and historically rarer than standard Mithril"
+  trading_tips:
+    - "Watch component spot prices versus set price to spot arbitrage from assembling or breaking the set"
+    - "Demand spikes during F2P fashionscape events and treasure trail meta shifts"
+    - "Low daily volume - lean on small consistent margins, not big swings"
+  history:
+    - date: "2015-02-26"
+      description: "Released as part of the Grand Exchange Sets expansion that added bank-space-saving armour bundles."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mixed-hide-armour-set.mdx
@@ -11,10 +11,56 @@ osrs:
   value: 145000
   lowalch: 58000
   highalch: 87000
-  limit: null
-  about: "Mixed hide armour set is a members-only item in Old School RuneScape. High alchemy value: 87,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: armour-set
+    tier: mid-high
+  properties:
+    release_date: "2024-04-24"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Mixed hide top
+      slug: mixed-hide-top
+      relationship: set-piece
+      description: Body slot piece in the mixed hide armour set
+    - item_name: Mixed hide legs
+      slug: mixed-hide-legs
+      relationship: set-piece
+      description: Legs slot piece in the mixed hide armour set
+    - item_name: Mixed hide boots
+      slug: mixed-hide-boots
+      relationship: set-piece
+      description: Feet slot piece in the mixed hide armour set
+    - item_name: Mixed hide cape
+      slug: mixed-hide-cape
+      relationship: set-piece
+      description: Cape slot piece in the mixed hide armour set
+  about: "Mixed hide armour set is a Grand Exchange convenience bundle of the four mixed hide armour pieces (top, legs, boots, cape). Players combine the pieces into the set at a Grand Exchange clerk via the Sets interface, primarily to list all four parts in a single trade; only the unpacked components are equippable."
+  market_strategy:
+    notes:
+      - "Bundle premium hinges on full-component supply at the GE"
+      - "Convenience item for sellers; not equippable directly"
+      - "Tracks the combined price of all four mixed hide pieces"
+  trading_tips:
+    - Compare set price vs. sum of components to flip the cheaper side
+    - Component shortages widen the bundle premium
+  history:
+    - date: "2024-04-24"
+      description: "Added to the game alongside the Mixed hide armour pieces."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-top-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-top-t.mdx
@@ -1,6 +1,6 @@
 ---
 title: Monk's robe top (t) | OSRS Price Data
-description: "Monk's robe top (t) is a F2P body slot item. High alch: 300 GP, GE limit: 4."
+description: "Monk's robe top (t) is a F2P trimmed beginner clue cosmetic body piece granting +6 Prayer with no level requirements. High alch: 300 GP, GE limit: 4."
 osrs:
   id: 23303
   name: Monk's robe top (t)
@@ -12,28 +12,87 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2019-04-11"
+    update: "Treasure Trails Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
+    weapon_type:
+    weight: 0.907
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
     other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
       prayer: 6
+  passive_effects:
+    - name: Saradomin-aligned cosmetic
+      description: "Counts as a Saradomin item in the God Wars Dungeon and grants a +6 prayer bonus with zero stat requirements."
+  drop_table:
+    sources:
+      - source: Reward casket (beginner)
+        quantity: "1"
+        rarity: 1/360
   related_items:
     - item_id: 23306
       item_name: Monk's robe (t)
       slug: monks-robe-t
       relationship: set-piece
-      description: Matching trimmed monk's robe legs
+      description: "Matching trimmed monk's robe legs."
+    - item_id: 542
+      item_name: Monk's robe top
+      slug: monks-robe-top
+      relationship: variant
+      description: "Untrimmed base version of the monk's robe top."
     - item_id: 20199
       item_name: Monk's robe top (g)
       slug: monks-robe-top-g
       relationship: variant
-      description: Gold-trimmed variant
-  about: |-
-    > *"A\"holy\" robe top, now with a \"fashionable\" trim."*
-
-    The monk's robe top (t) is a trimmed cosmetic variant of the monk's robe top. Provides +6 Prayer bonus with no requirements. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Gold-trimmed beginner clue cosmetic variant."
+  about: "Monk's robe top (t) is the trimmed cosmetic variant of the monk's robe top, added with the 2019 Treasure Trails expansion. It is exclusively obtained from beginner reward caskets at roughly 1/360 and grants a +6 prayer bonus with no level requirements, identical in stats to the plain monk's robe top. It is Saradomin-aligned for God Wars Dungeon access and can be stored in costume room treasure chests."
+  market_strategy:
+    notes:
+      - "Buy limit of 4 per 4 hours keeps it a thin, fashionscape-driven listing."
+      - "Supply tied directly to beginner clue completion volume; spikes after clue-friendly events."
+      - "Prayer-bonus utility is fully covered by the untrimmed top, so demand is mostly cosmetic."
+      - "High alch 300 gp is far below GE price - alching is not a strategy."
+  trading_tips:
+    - "Stack listings into long-running offers; the tiny buy limit prevents fast flips."
+    - "Watch beginner clue meta shifts (drop boosts, scroll changes) before adjusting bid stacks."
+  history:
+    - date: "2019-04-11"
+      description: "Released as part of the Treasure Trails Expansion as a beginner reward casket cosmetic."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/moon-lite.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/moon-lite.mdx
@@ -1,6 +1,6 @@
 ---
 title: Moon-lite | OSRS Price Data
-description: "Moon-lite: A popular spirit all across Varlamore.. High alch: 9 GP."
+description: "Moon-lite is a members Varlamore drink purchased at taverns. High alch: 9 GP."
 osrs:
   id: 29418
   name: Moon-lite
@@ -11,10 +11,58 @@ osrs:
   value: 15
   lowalch: 6
   highalch: 9
-  limit: null
-  about: "Moon-lite is a members-only item in Old School RuneScape. High alchemy value: 9 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: drink
+    tier: low
+  properties:
+    release_date: "2024-02-21"
+    update: "Varlamore: The Final Dawn"
+    quest_item: false
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    weight: 0.45
+    destroy: "Drop"
+    options:
+      - Drink
+      - Drop
+    examine_options:
+      - Examine
+    alchable: true
+  obtaining:
+    - method: Purchase
+      source: Varlamore taverns
+      location: Civitas illa Fortis
+      currency: coins
+      cost: 15
+      notes: "Bought from publicans at Varlamore inns and taverns"
+  related_items:
+    - item_name: Sunset slugger
+      slug: sunset-slugger
+      relationship: alternative
+      description: Another Varlamore tavern drink
+    - item_name: Beer
+      slug: beer
+      relationship: alternative
+      description: Classic Gielinor tavern drink
+    - item_name: Wizard's mind bomb
+      slug: wizards-mind-bomb
+      relationship: alternative
+      description: Magic boost cocktail alternative
+  market_strategy:
+    notes:
+      - "Untradeable cosmetic drink, no GE liquidity"
+      - "Only obtained directly from Varlamore taverns"
+      - "Collectors of Varlamore flavour items keep light demand"
+      - "Not worth alching at scale; value tied to tavern roleplay"
+  history:
+    - date: "2024-02-21"
+      description: "Released with Varlamore: The Final Dawn"
+  about: "Moon-lite is a Varlamore-themed alcoholic beverage purchased from taverns across Civitas illa Fortis. Drinking it slightly drains stats and provides cosmetic flavour for players exploring the Varlamore content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/musketeer-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/musketeer-hat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Musketeer hat | OSRS Price Data
-description: "Musketeer hat: Engarde!. High alch: 2,100 GP, GE limit: 4."
+description: "Musketeer hat is the head slot piece of the Musketeer cosmetic outfit, a rare reward from elite Treasure Trails with no combat bonuses. High alch: 2,100 GP, GE limit: 4."
 osrs:
   id: 12351
   name: Musketeer hat
@@ -12,9 +12,81 @@ osrs:
   lowalch: 1400
   highalch: 2100
   limit: 4
-  about: "Musketeer hat is a members-only item in Old School RuneScape. High alchemy value: 2,100 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2014-06-12"
+    update: "Treasure Trail Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weight: 0.005
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (elite)
+        quantity: "1"
+        rarity: "1/1,275"
+  treasure_trail:
+    tier: elite
+    is_reward: true
+    reward_tiers:
+      - elite
+  related_items:
+    - item_id: 12353
+      item_name: Musketeer tabard
+      slug: musketeer-tabard
+      relationship: set-piece
+      description: "Body slot piece of the Musketeer cosmetic outfit."
+    - item_id: 12355
+      item_name: Musketeer pants
+      slug: musketeer-pants
+      relationship: set-piece
+      description: "Legs slot piece of the Musketeer cosmetic outfit."
+  about: "Musketeer hat is a cosmetic head slot item released with the Treasure Trail Expansion. It is a rare 1/1,275 drop from elite reward caskets, has zero combat bonuses, and exists purely for the Musketeer outfit collection - players typically store the full set inside the costume room treasure chest of a player-owned house."
+  market_strategy:
+    notes:
+      - "Supply trickles in only from active elite clue completions - low and steady."
+      - "GE buy limit of 4 per 4 hours forces collectors to drip-feed orders."
+      - "High alch of 2,100 gp is a fraction of GE price - never alch."
+      - "Demand is driven by costume-room set completionists, not gameplay utility."
+  trading_tips:
+    - "Watch for elite clue meta shifts (Vorkath, Demonic Gorillas) that bump casket throughput."
+    - "Cross-reference Musketeer tabard and pants prices - all three move together as a set."
+    - "Buy limit of 4 makes serious accumulation slow; treat as a long-hold cosmetic flip."
+  history:
+    - date: "2014-06-12"
+      description: "Added as part of the Treasure Trail Expansion update, distributed via elite reward caskets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-air-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-air-staff.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic air staff | OSRS Price Data
-description: "Mystic air staff is a members weapon slot item requiring 40 Attack. High alch: 25,500 GP, GE limit: 18,000."
+description: "Mystic air staff is a members elemental staff requiring 40 Attack and 40 Magic; supplies unlimited air runes and supports air-spell autocast. High alch: 25,500 GP, GE limit: 18,000."
 osrs:
   id: 1405
   name: Mystic air staff
@@ -12,61 +12,106 @@ osrs:
   lowalch: 17000
   highalch: 25500
   limit: 18000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: mystic
+    tier: mid
+  properties:
+    release_date: "2002-03-25"
+    update: "Latest RuneScape News (25 March 2002)"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: staff
-    tradeable: true
+    weapon_type: staff
     weight: 2.267
+    attack_speed: 5
     requirements:
       attack: 40
       magic: 40
-    stats:
-      attack_stab: 7
-      attack_slash: -1
-      attack_crush: 28
-      attack_magic: 14
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 35
+    attack_bonus:
+      stab: 10
+      slash: -1
+      crush: 40
+      magic: 14
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 14
+      ranged: 0
+    other_bonus:
+      melee_strength: 50
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
+  passive_effects:
+    - name: Unlimited air runes
+      description: "Supplies an unlimited source of air runes for spellcasting while equipped."
+    - name: Air spell autocast
+      description: "Supports standard spellbook autocast for air-element spells, including a defensive autocast option."
+  drop_table:
+    sources:
+      - source: Chaos Elemental
+        members_only: true
+      - source: Dust devil
+        members_only: true
+      - source: Venenatis
+        members_only: true
+      - source: Thermonuclear smoke devil
+        members_only: true
+      - source: Corporeal Beast
+        members_only: true
+      - source: Abyssal Sire
+        members_only: true
+      - source: Greater nechryael
+        members_only: true
   related_items:
     - item_id: 1397
       item_name: Air battlestaff
       slug: air-battlestaff
       relationship: component
-      description: Base item for upgrade
+      description: Base battlestaff upgraded by a Magic Guild instructor to create the mystic version.
     - item_id: 1403
       item_name: Mystic water staff
       slug: mystic-water-staff
       relationship: alternative
-      description: Water variant
+      description: Water-element mystic staff with matching stats.
     - item_id: 1381
       item_name: Staff of air
       slug: staff-of-air
       relationship: downgrade
-      description: Lower tier staff
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +7 |
-    | Slash | -1 |
-    | Crush | +28 |
-    | Magic | +14 |
-    | Strength | +35 |
-
-    Attack Speed: 5-tick (3.0s)
-
-    Unlimited air runes when equipped.
-
-    Supports autocast for air spells.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Lower-tier basic air staff with no level requirement.
+  about: "The Mystic air staff is a members-only elemental staff in OSRS requiring 40 Attack and 40 Magic. It is upgraded from an Air battlestaff by a Magic Guild instructor for 40,000 coins and supplies an unlimited number of air runes plus standard-spellbook air-spell autocast. With +14 magic attack and defence and +40 crush, it is the cheapest training-grade air autocaster and a popular slayer/teleport utility staff."
+  market_strategy:
+    notes:
+      - "Demand is dominated by mid-level mages, slayers, and ironmen wanting an unlimited air-rune source."
+      - "GE buy limit of 18,000 per 4 hours leaves plenty of room for flips and bulk training stock."
+      - "High alch of 25,500 gp typically clears GE price - viable as a nature-rune alch target when discounted."
+      - "Supply is fed by Magic Guild upgrades plus drops from Chaos Elemental, Dust devils, and Abyssal Sire."
+  trading_tips:
+    - "Cross-check Air battlestaff price plus 40k upgrade fee to gauge production margin."
+    - "Magic-rebalance patches historically move mystic staff prices - watch update notes."
+    - "Stable mid-tier item - prefer steady flips over speculative holds."
+  history:
+    - date: "2002-03-25"
+      description: "Released in the original RuneScape mystic staff line alongside the water, earth, and fire variants."
+    - date: "2021-09-22"
+      description: "Magic attack and defence bonuses of mystic staves raised from +10 to +14."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-dusk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-hat-dusk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic hat (dusk) | OSRS Price Data
-description: "Mystic hat (dusk): A dusky magical hat.. High alch: 9,000 GP, GE limit: 70."
+description: "Mystic hat (dusk): A dusky magical hat. High alch: 9,000 GP, GE limit: 70."
 osrs:
   id: 23047
   name: Mystic hat (dusk)
@@ -12,9 +12,100 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 70
-  about: "Mystic hat (dusk) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: enchanted-cloth
+    tier: high
+  properties:
+    release_date: "2018-04-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weapon_type: unarmed
+    attack_speed: 4
+    weight: 0.453
+    requirements:
+      magic: 40
+      defence: 20
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 4
+      ranged: 0
+    other_bonus:
+      strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Master Treasure Trails reward casket
+        quantity: "1"
+        rarity: 1/14336
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_id: 3385
+      item_name: Mystic hat
+      slug: mystic-hat
+      relationship: variant
+      description: Standard blue colour variant with identical bonuses
+    - item_id: 4099
+      item_name: Mystic hat (dark)
+      slug: mystic-hat-dark
+      relationship: variant
+      description: Dark colour variant
+    - item_id: 4109
+      item_name: Mystic hat (light)
+      slug: mystic-hat-light
+      relationship: variant
+      description: Light colour variant
+    - item_id: 23051
+      item_name: Mystic robe top (dusk)
+      slug: mystic-robe-top-dusk
+      relationship: set-piece
+      description: Body piece of the dusk mystic robes set
+    - item_id: 23055
+      item_name: Mystic robe bottom (dusk)
+      slug: mystic-robe-bottom-dusk
+      relationship: set-piece
+      description: Legs piece of the dusk mystic robes set
+  about: "Mystic hat (dusk) is a master clue scroll cosmetic recolour of the standard mystic hat with identical bonuses (+4 magic attack and defence). Released with the Treasure Trails master tier update, it shares the mystic 40 Magic / 20 Defence requirement and serves as a fashionscape collectible piece."
+  market_strategy:
+    notes:
+      - "Pure cosmetic recolour with identical stats to base mystic hat"
+      - "Drop-only supply from master clues keeps stock thin"
+      - "Buy limit of 70 supports occasional bulk flips"
+  trading_tips:
+    - Compare against the standard mystic hat for mispriced cosmetic premium
+    - Watch master clue completion rate trends for supply pulses
+  history:
+    - date: "2018-04-12"
+      description: "Released with the master tier Treasure Trails expansion as a cosmetic recolour."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-set-dark.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-set-dark.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mystic set (dark) | OSRS Price Data
-description: "Mystic set (dark): A set containing dark mystic hat, robe top and bottom, gloves and boots.. High alch: 141,000 GP, GE limit: 70."
+description: "Mystic set (dark) is a Grand Exchange bundle containing the full dark mystic Magic armour kit. High alch: 141,000 GP, GE limit: 70."
 osrs:
   id: 23116
   name: Mystic set (dark)
@@ -12,9 +12,70 @@ osrs:
   lowalch: 94000
   highalch: 141000
   limit: 70
-  about: "Mystic set (dark) is a members-only item in Old School RuneScape. High alchemy value: 141,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: mystic
+    tier: high
+  properties:
+    release_date: "2019-03-14"
+    update: "Grand Exchange Sets"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.05
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_name: Dark mystic hat
+      slug: dark-mystic-hat
+      relationship: set-piece
+      description: "Head slot piece of the dark mystic set."
+    - item_name: Dark mystic robe top
+      slug: dark-mystic-robe-top
+      relationship: set-piece
+      description: "Body slot piece of the dark mystic set."
+    - item_name: Dark mystic robe bottom
+      slug: dark-mystic-robe-bottom
+      relationship: set-piece
+      description: "Leg slot piece of the dark mystic set."
+    - item_name: Dark mystic gloves
+      slug: dark-mystic-gloves
+      relationship: set-piece
+      description: "Hand slot piece of the dark mystic set."
+    - item_name: Dark mystic boots
+      slug: dark-mystic-boots
+      relationship: set-piece
+      description: "Foot slot piece of the dark mystic set."
+    - item_name: Mystic set (light)
+      slug: mystic-set-light
+      relationship: alternative
+      description: "Light recolour variant of the same mystic robe bundle."
+    - item_name: Mystic set (blue)
+      slug: mystic-set-blue
+      relationship: alternative
+      description: "Standard blue variant of the mystic robe bundle."
+  about: "Mystic set (dark) is a Grand Exchange bundle containing dark mystic hat, robe top, robe bottom, gloves, and boots - the full dark recolour of the high-Magic Mystic robe set. Exchanging the set at any Grand Exchange clerk returns the five component pieces, giving raid mages and PvM mages a single tradeable wrapper for the +45 Magic attack / +45 Magic defence kit."
+  market_strategy:
+    notes:
+      - "Flip vs sum of dark mystic components for armour bundle arbitrage"
+      - "Buy limit of 70 per 4 hours throttles bulk merching"
+      - "Demand mostly from cosmetic mages and dark-set collectors"
+      - "Exchange the set to split when individual component prices run hot"
+  trading_tips:
+    - "Compare set GE price to (hat + top + bottom + gloves + boots) and arbitrage the spread"
+    - "Boot and hat tend to lead price moves - track those when sizing flips"
+    - "Light and blue mystic set variants share component supply via the underlying Mystic set quest reward base"
+  history:
+    - date: "2019-03-14"
+      description: "Added with the Grand Exchange armour set expansion covering Mystic recolours."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nihil-horn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nihil-horn.mdx
@@ -1,6 +1,6 @@
 ---
 title: Nihil horn | OSRS Price Data
-description: "Nihil horn: The horn of a proud nihil.. High alch: 1,200,000 GP."
+description: "Nihil horn is a members unique drop from Nex used to craft the Zaryte crossbow. High alch: 1,200,000 GP."
 osrs:
   id: 26372
   name: Nihil horn
@@ -11,60 +11,86 @@ osrs:
   value: 2000000
   lowalch: 800000
   highalch: 1200000
-  limit: null
-  item:
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
     type: upgrade material
+    tier: high
+  properties:
+    release_date: "2022-01-19"
+    update: "Nex - The Mage of Saradomin"
+    quest_item: false
     tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
     weight: 0.006
-  obtaining:
-    - source: Nex
-      drop_rate: 1/258
+    destroy: "Drop"
+    options:
+      - Drop
+    examine_options:
+      - Examine
+    alchable: true
+  drop_table:
+    sources:
+      - source: Nex
+        source_id: 11278
+        combat_level: 1001
+        quantity: "1"
+        rarity: 1/258
+        notes: "Unique drop split among the team based on damage contribution"
   recipes:
-    - materials:
-        - item_id: 26372
-          item_name: Nihil horn
-          quantity: 1
+    - skill: none
+      level: 0
+      xp: 0
+      materials:
         - item_id: 11785
           item_name: Armadyl crossbow
+          quantity: 1
+        - item_id: 26372
+          item_name: Nihil horn
           quantity: 1
         - item_id: 26231
           item_name: Nihil shard
           quantity: 250
-      product: Zaryte crossbow
-      product_id: 26374
+      output:
+        item_id: 26374
+        item_name: Zaryte crossbow
+        output_quantity: 1
+      members: true
+      notes: "Combine at Nex's altar to upgrade Armadyl crossbow into Zaryte crossbow"
   related_items:
     - item_id: 11785
       item_name: Armadyl crossbow
       slug: armadyl-crossbow
       relationship: component
-      description: Base weapon for upgrade
+      description: Base crossbow consumed by the Zaryte crossbow upgrade
     - item_id: 26374
       item_name: Zaryte crossbow
       slug: zaryte-crossbow
       relationship: product
-      description: BiS crossbow created
+      description: BiS general-purpose crossbow produced by the upgrade
     - item_id: 26231
       item_name: Nihil shard
       slug: nihil-shard
       relationship: component
-      description: Required crafting material
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Type | Upgrade Material |
-    | Tradeable | Yes |
-    | Weight | 0.006 kg |
-
-    | Item Created | Materials |
-    |--------------|-----------|
-    | Zaryte crossbow | Armadyl crossbow + Nihil horn + 250 Nihil shards |
+      description: 250 shards required alongside the nihil horn
+    - item_id: 26382
+      item_name: Ancient hilt
+      slug: ancient-hilt
+      relationship: alternative
+      description: Another Nex unique drop tier
   market_strategy:
     notes:
-      - Nex exclusive drop
-      - Creates BiS crossbow
-      - High value unique
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Nex unique with thin supply; price tracks Zaryte crossbow demand"
+      - "Consumed permanently on Zaryte upgrade, creating a steady sink"
+      - "Single-supply choke: only Nex drops them"
+      - "Speculate around metas that buff bolt-DPS BiS"
+  history:
+    - date: "2022-01-19"
+      description: "Released with the Nex boss update"
+  about: "The nihil horn is a members rare drop from Nex used as the central component for upgrading the Armadyl crossbow into the Zaryte crossbow. Combined with 250 nihil shards and an Armadyl crossbow at Nex's altar, it produces the best-in-slot general crossbow."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nihil-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nihil-shard.mdx
@@ -12,29 +12,40 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 30000
-  item:
-    type: crafting material
-    tradeable: true
-    stackable: true
-    weight: 0
-  obtaining:
-    - source: Nex
-      drop_rate: 5/82 - 8/209
-      quantity: 80-95
-    - source: Spiritual mage (Zaros)
-      drop_rate: 1/128
-      quantity: 5-9
-    - source: Spiritual ranger (Zaros)
-      drop_rate: 1/128
-      quantity: 2-7
-    - source: Spiritual warrior (Zaros)
-      drop_rate: 1/128
-      quantity: 2-5
-    - source: Blood Reaver
-      drop_rate: 1/128
-      quantity: 2-7
+  material:
+    type: crafting-material
+    tier: high
+  drop_table:
+    sources:
+      - source: Nex
+        quantity: "80-95"
+        rarity: common
+        drop_rate: 5/82
+        members_only: true
+      - source: Spiritual mage (Zaros)
+        quantity: "5-9"
+        rarity: uncommon
+        drop_rate: 1/128
+        members_only: true
+      - source: Spiritual ranger (Zaros)
+        quantity: "2-7"
+        rarity: uncommon
+        drop_rate: 1/128
+        members_only: true
+      - source: Spiritual warrior (Zaros)
+        quantity: "2-5"
+        rarity: uncommon
+        drop_rate: 1/128
+        members_only: true
+      - source: Blood Reaver
+        quantity: "2-7"
+        rarity: uncommon
+        drop_rate: 1/128
+        members_only: true
   recipes:
-    - product: Zaryte crossbow
+    - skill: smithing
+      level: 1
+      xp: 0
       materials:
         - item_name: Nihil shard
           quantity: 250
@@ -42,18 +53,24 @@ osrs:
           quantity: 1
         - item_name: Nihil horn
           quantity: 1
-    - product: Nihil dust
+      product: Zaryte crossbow
+      output_quantity: 1
+    - skill: herblore
+      level: 1
+      xp: 0
       materials:
         - item_name: Nihil shard
           quantity: 1
         - item_name: Pestle and mortar
           quantity: 1
-      notes: Use for Ancient brew (85 Herblore)
+      product: Nihil dust
+      output_quantity: 1
+      notes: Nihil dust is a secondary for the Ancient brew (85 Herblore).
   related_items:
     - item_id: 26372
       item_name: Nihil horn
       slug: nihil-horn
-      relationship: alternative
+      relationship: component
       description: Crafting partner for Zaryte crossbow
     - item_id: 26374
       item_name: Zaryte crossbow
@@ -63,12 +80,14 @@ osrs:
     - item_id: 26346
       item_name: Ancient brew
       slug: ancient-brew
-      relationship: alternative
-      description: Herblore use
+      relationship: product
+      description: Herblore use via Nihil dust
   about: |-
+    Nihil shards are dropped by Nex and the Ancient Prison Zarosian spiritual creatures. They are the bulk component of the Zaryte crossbow recipe (250 shards + Armadyl crossbow + Nihil horn) and can be ground into Nihil dust for Ancient brew potions (85 Herblore).
+
     | Property | Value |
     |----------|-------|
-    | Type | Crafting Material |
+    | Type | Crafting material |
     | Tradeable | Yes |
     | Stackable | Yes |
     | Weight | 0 kg |
@@ -78,8 +97,22 @@ osrs:
     | Zaryte crossbow | 250 shards + ACB + Nihil horn |
     | Nihil dust | 1 shard (pestle and mortar) |
     | Ancient brew | Nihil dust + Dwarf weed potion (85 Herblore) |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - Demand driven by Zaryte crossbow assembly (250 per craft)
+      - Steady consumption from Ancient brew herblorists
+      - Nex farming caps daily supply
+      - Buy limit of 30,000 supports bulk flips
+      - Watch Nex DPS-meta shifts for supply shocks
+  trading_tips:
+    - Track Zaryte crossbow GE volume for demand pressure
+    - Watch Nex team formation events for short-term supply spikes
+    - Ancient brew price moves independently — compare GP/XP daily
+  history:
+    - date: "2022-02-23"
+      description: Released with the Nex update as a drop from the Ancient Prison boss.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-blackjack-o.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-blackjack-o.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oak blackjack(o) | OSRS Price Data
-description: "Oak blackjack(o): An offensive blackjack.. High alch: 240 GP, GE limit: 125."
+description: "Oak blackjack(o) is the offensive oak blackjack variant requiring 10 Attack and 10 Thieving, used to knockout NPCs for pickpocketing. High alch: 240 GP, GE limit: 125."
 osrs:
   id: 6408
   name: Oak blackjack(o)
@@ -12,12 +12,94 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 125
-  about: "Oak blackjack(o) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: oak
+    tier: low
+  properties:
+    release_date: "2005-08-15"
+    update: "Rogue Trader"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.814
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: blackjack
+    weight: 1.814
+    attack_speed: 4
+    requirements:
+      attack: 10
+      thieving: 10
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 6406
+      item_name: Oak blackjack
+      slug: oak-blackjack
+      relationship: variant
+      description: "Standard oak blackjack with balanced offence/defence bonuses."
+    - item_id: 6410
+      item_name: Oak blackjack(d)
+      slug: oak-blackjack-d
+      relationship: variant
+      description: "Defensive oak blackjack variant - higher defence bonus, lower attack."
+    - item_id: 6412
+      item_name: Willow blackjack(o)
+      slug: willow-blackjack-o
+      relationship: upgrade
+      description: "Next-tier offensive blackjack with stronger knockout rates."
+    - item_id: 6416
+      item_name: Maple blackjack(o)
+      slug: maple-blackjack-o
+      relationship: upgrade
+      description: "Top-tier offensive blackjack for high-Thieving pickpocketing."
+  about: "Oak blackjack(o) is the offensive variant of the oak blackjack, sold by Ali's Discount Wares in Al Kharid after completing the Rogue Trader minigame. Requiring 10 Attack and 10 Thieving to wield, it favors knockout success over block-up resistance and is used in Pollnivneach to lure-and-knockout villagers, bandits, and Menaphite Thugs for repeatable Thieving XP. Mostly a stepping stone between the base oak blackjack and the willow tier."
+  market_strategy:
+    notes:
+      - "Demand is structurally tied to Pollnivneach Thieving training population."
+      - "GE buy limit of 125 per 4 hours keeps daily flips small."
+      - "Supply comes via Ali's Discount Wares at 400 gp - hard price ceiling for arbitrage."
+      - "High alch of 240 gp is below GE - never alch."
+  trading_tips:
+    - "Watch Thieving XP buff news; oak blackjack(o) sees demand spikes when Pollnivneach knockout meta returns."
+    - "Cheap NPC source caps profit potential - flip volume not margin."
+    - "Avoid if Maple blackjack is on cooldown nerf threads."
+  history:
+    - date: "2005-08-15"
+      description: "Released alongside the Rogue Trader minigame and Pollnivneach Thieving content."
+    - date: "2006-08-22"
+      description: "Renamed from 'Oak blackjack(a)' to 'Oak blackjack(o)' for consistency with offensive/defensive suffixes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oak-drawers-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oak-drawers-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oak drawers (flatpack) | OSRS Price Data
-description: "Oak drawers (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Oak drawers (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8612
   name: Oak drawers (flatpack)
@@ -12,9 +12,80 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Oak drawers (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  construction:
+    construction_level: 20
+    xp: 360
+    materials:
+      - item_id: 8778
+        item_name: Oak plank
+        quantity: "6"
+    hotspot: Drawers space
+    room: Bedroom
+    tools:
+      - Hammer
+      - Saw
+    notes: Built at a Wooden workbench in a player-owned house workshop.
+  recipes:
+    - skill: construction
+      level: 20
+      xp: 360
+      materials:
+        - item_id: 8778
+          item_name: Oak plank
+          quantity: 6
+      output:
+        item_id: 8612
+        item_name: Oak drawers (flatpack)
+        output_quantity: 1
+      members: true
+      notes: "Assembled at a Wooden workbench from 6 oak planks."
+  related_items:
+    - item_id: 8778
+      item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: "Base material used for assembly."
+    - item_id: 8606
+      item_name: Drawers (flatpack)
+      slug: drawers-flatpack
+      relationship: downgrade
+      description: "Cheaper regular-plank variant for lower Construction levels."
+    - item_id: 8636
+      item_name: Teak drawers (flatpack)
+      slug: teak-drawers-flatpack
+      relationship: upgrade
+      description: "Higher-tier teak variant with more Construction XP."
+  about: "Oak drawers (flatpack) is a Construction flatpack assembled at a Wooden workbench from 6 oak planks at 20 Construction for 360 XP, used to place a drawers hotspot in a player-owned house Bedroom."
+  market_strategy:
+    notes:
+      - "Cheap mid-low Construction XP feedstock."
+      - "Niche demand from Bedroom finishing in PoH builds."
+      - "Daily volume is modest with a 500 buy limit."
+  trading_tips:
+    - "Compare 6 oak plank GE cost vs flatpack price for assembly margin."
+    - "Bulk-stock when oak plank supply spikes for arbitrage."
+  history:
+    - date: "2006-05-31"
+      description: "Released with the Construction skill update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-shards.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oathplate-shards.mdx
@@ -1,6 +1,6 @@
 ---
 title: Oathplate shards | OSRS Price Data
-description: "Oathplate shards: A strange metal from a distant realm. It has long since lost its luster.. High alch: 600 GP."
+description: "Oathplate shards are a stackable Yama drop refined with crushed infernal shale into infernal blend at 83 Smithing, used to craft Oathplate armour. High alch: 600 GP."
 osrs:
   id: 30765
   name: Oathplate shards
@@ -11,13 +11,79 @@ osrs:
   value: 1000
   lowalch: 400
   highalch: 600
-  limit: null
-  about: "Oathplate shards is a members-only item in Old School RuneScape. High alchemy value: 600 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: oathplate
+    tier: high
+  properties:
+    release_date: "2025-05-14"
+    update: "Yama, the Master of Pacts"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 83
+      xp: 0
+      materials:
+        - item_id: 30765
+          item_name: Oathplate shards
+          quantity: 5
+        - item_name: Crushed infernal shale
+          quantity: 28
+      product: Infernal blend
+      output_quantity: 1
+      notes: "Each batch refines 5 shards + 28 crushed infernal shale into 1 infernal blend; ~450 shards needed per Oathplate piece."
+  related_items:
+    - item_name: Infernal blend
+      slug: infernal-blend
+      relationship: product
+      description: "Smithed intermediate combining shards with crushed infernal shale."
+    - item_name: Crushed infernal shale
+      slug: crushed-infernal-shale
+      relationship: component
+      description: "Stack of crushed infernal shale required to refine each batch of shards."
+    - item_name: Oathplate helm
+      slug: oathplate-helm
+      relationship: product
+      description: "Endgame helm crafted from refined Oathplate components."
+    - item_name: Oathplate chest
+      slug: oathplate-chest
+      relationship: product
+      description: "Endgame torso crafted from refined Oathplate components."
+    - item_name: Oathplate legs
+      slug: oathplate-legs
+      relationship: product
+      description: "Endgame legs crafted from refined Oathplate components."
+  about: "Oathplate shards are the smelted metal currency dropped by Yama, the Master of Pacts, and pulled from Forgotten lockboxes and Yama Contract rewards. They refine at 83 Smithing into infernal blend (5 shards + 28 crushed infernal shale per batch), with roughly 450 shards needed per Oathplate armour piece. As the gating resource for the post-2025 Oathplate armour set, shards sit at the centre of late-game prayer-bonus melee gear demand."
+  market_strategy:
+    notes:
+      - "Supply ties directly to Yama kill rate and Yama Contract completion (45 shards guaranteed per contract)."
+      - "Demand is gated by 83 Smithing + Oathplate armour grind cycle - 450 shards per piece is structural."
+      - "Stackable + tradeable + no GE limit - moves in massive blocks, watch order book depth."
+      - "Forgotten lockbox stack drops (11-14) provide background drip supply."
+  trading_tips:
+    - "Watch Yama kill threads after balance changes; nerfs to Yama loot table spike shard price hard."
+    - "Cross-track crushed infernal shale - shards alone are useless without shale supply."
+    - "Pre-position before any Oathplate set-bonus buff announcement."
+  history:
+    - date: "2025-05-14"
+      description: "Released with Yama, the Master of Pacts as the Oathplate armour upgrade material."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/polished-buttons.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/polished-buttons.mdx
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Polished buttons is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: quest-item
+    tier: low
+  properties:
+    release_date: "2006-08-21"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0.453
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: H.A.M. Members chest
+        quantity: "1"
+        rarity: 1/24
+        members_only: true
+      - source: H.A.M. Guard
+        combat_level: 22
+        quantity: "1"
+        rarity: 1/200
+        members_only: true
+  related_items:
+    - item_id: 4298
+      item_name: H.A.M. shirt
+      slug: ham-shirt
+      relationship: alternative
+      description: H.A.M. pickpocket loot used in the same quest
+    - item_id: 762
+      item_name: Damp cloth
+      slug: damp-cloth
+      relationship: component
+      description: Used together to clean the H.A.M. statuette in Death to the Dorgeshuun
+  about: "Polished buttons are shiny ornamental buttons obtained by searching the chest in the H.A.M. dungeon during Death to the Dorgeshuun. They are part of the quest sequence used to fashion a fake statuette and trick the H.A.M. council, though they can also drop from pickpocketed H.A.M. members and chest searches in later activities."
+  market_strategy:
+    notes:
+      - "Quest-bound item with negligible alch value"
+      - "Demand is almost entirely from active Death to the Dorgeshuun questers"
+      - "Buy limit of 15 keeps any flips niche"
+      - "Drop sources are abundant relative to demand once the quest is finished"
+  trading_tips:
+    - "Stock during fresh account waves chasing Death to the Dorgeshuun"
+    - "Avoid alching; 1 gp return is below nature rune cost"
+    - "Pair with damp cloth listings to catch full-quest shoppers"
+  history:
+    - date: "2005-10-31"
+      description: "Released alongside the Death to the Dorgeshuun quest as a key quest item."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pot.mdx
@@ -14,10 +14,7 @@ osrs:
   limit: 13000
   material:
     type: pottery
-    tier: fired
-  crafting:
-    level: 1
-    xp: 6.3
+    tier: low
   recipes:
     - skill: crafting
       level: 1
@@ -28,8 +25,25 @@ osrs:
           quantity: 1
       product: Pot
       product_id: 1931
-      product_quantity: 1
+      output_quantity: 1
       facility: Pottery oven
+  shops:
+    - shop_name: "Toothy's Pickaxes"
+      location: Lumbridge
+      price: 1
+      stock: 50000
+      restock_seconds: 0.6
+    - shop_name: Little Shop of Horace
+      location: Draynor Village
+      price: 1
+      stock: 30
+      restock_seconds: 60
+    - shop_name: Port Phasmatys General Store
+      location: Port Phasmatys
+      price: 1
+      stock: 100
+      restock_seconds: 60
+      members_only: true
   related_items:
     - item_id: 1787
       item_name: Unfired pot
@@ -47,6 +61,8 @@ osrs:
       relationship: product
       description: Filled version
   about: |-
+    The pot is one of the oldest items in RuneScape, used as a generic container for flour, vinegar, weeds, and many other substances. It is free-to-play, weighs almost nothing, and can be crafted from soft clay at any pottery oven from level 1 Crafting (6.3 XP).
+
     | Method | Level | Materials |
     |--------|-------|-----------|
     | Pottery oven | 1 | 1 Unfired pot |
@@ -57,17 +73,24 @@ osrs:
     | Mill grain | Pot of flour |
     | Cooking | Various recipes |
     | Storage | Hold items |
+
+    At Crafting level 13 and above, pottery is guaranteed to succeed. Pots also spawn freely on counters and tables across Gielinor, including the ground-floor kitchen in Lumbridge Castle.
   market_strategy:
     notes:
-      - Flour grinding
-      - Cooking skill
-      - F2P crafting
-      - Basic pottery item
-      - Used for flour
-      - F2P accessible
-      - Low value item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Sold at 1 gp from multiple general stores
+      - Used in cooking and bonemeal recipes
+      - F2P accessible — crafting from soft clay
+      - Buy limit of 13,000 supports bulk skilling
+      - Margin flips are negligible — value comes from convenience
+  trading_tips:
+    - Buy from Toothy's Pickaxes (50k stock) for bulk skilling supply
+    - GE price tends to track 15 gp; arbitrage versus 1 gp shops is steady
+    - Useful for completing low-level cooking and crafting tasks
+  history:
+    - date: "2001-01-04"
+      description: One of the original RuneScape items released at beta launch.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-w-m-crun.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-w-m-crun.mdx
@@ -1,6 +1,6 @@
 ---
 title: Premade w'm crun' | OSRS Price Data
-description: "Premade w'm crun': Some Premade Worm Crunchies.. High alch: 51 GP, GE limit: 6,000."
+description: "Premade w'm crun': Some Premade Worm Crunchies. High alch: 51 GP, GE limit: 6,000."
 osrs:
   id: 2237
   name: Premade w'm crun'
@@ -12,9 +12,59 @@ osrs:
   lowalch: 34
   highalch: 51
   limit: 6000
-  about: "Premade w'm crun' is a members-only item in Old School RuneScape. High alchemy value: 51 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: gnome-food
+    tier: low
+  properties:
+    release_date: "2002-12-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.25
+    options:
+      - Eat
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  consumable:
+    heals: 8
+    action: Eat
+  shops:
+    - shop_name: "Gianne's Restaurant"
+      location: "Grand Tree, Tree Gnome Stronghold"
+      price: 85
+      currency: Coins
+      stock: 10
+  related_items:
+    - item_name: Worm crunchies
+      slug: worm-crunchies
+      relationship: alternative
+      description: "Player-crafted version usable in the Gnome Restaurant minigame"
+    - item_name: Premade choc crunch
+      slug: premade-choc-crunch
+      relationship: alternative
+      description: "Sibling premade gnome crunchy with different flavour"
+    - item_name: Premade veg ball
+      slug: premade-veg-ball
+      relationship: alternative
+      description: "Another premade gnome food sold by the same waiter"
+  about: "Premade worm crunchies are a members-only gnome food sold by the gnome waiter at Gianne's Restaurant in the Grand Tree. Each one heals 8 hitpoints when eaten, sits at a base value of 85 gp, and is purchased rather than cooked. Unlike player-crafted worm crunchies, the premade version cannot be used in the Gnome Restaurant minigame."
+  market_strategy:
+    notes:
+      - "Shop floor stock at 85 gp anchors the price near base value"
+      - "Healing efficiency is poor versus modern food, so demand stays niche"
+      - "Useful mostly for gnome cooking turn-ins and ironman gnome cuisine progression"
+  trading_tips:
+    - "Restock-flip when the shop respawns and GE bid lifts above 85 gp"
+    - "Avoid bulk holds, daily volume is thin and price barely moves"
+  history:
+    - date: "2002-12-12"
+      description: "Added with the Tree Gnome Stronghold and gnome cooking content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-sweets.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-sweets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Purple sweets | OSRS Price Data
-description: "Purple sweets: Remember to brush after eating!. High alch: 9 GP, GE limit: 10,000."
+description: "Purple sweets are a stackable Treasure Trails reward food that restores 1-3 HP and 10% run energy per dose. High alch: 9 GP, GE limit: 10,000."
 osrs:
   id: 10476
   name: Purple sweets
@@ -12,12 +12,70 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 10000
-  about: "Purple sweets is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  consumable:
+    heals: 3
+    effects:
+      - description: "Restores 1 to 3 Hitpoints per sweet eaten."
+        duration: 0
+      - description: "Restores 10% run energy per sweet eaten."
+        duration: 0
+  related_items:
+    - item_id: 20546
+      item_name: Reward casket (easy)
+      slug: reward-casket-easy
+      relationship: alternative
+      description: "Easy clue casket - drops purple sweets in stacks of 4-20."
+    - item_id: 20545
+      item_name: Reward casket (medium)
+      slug: reward-casket-medium
+      relationship: alternative
+      description: "Medium clue casket - drops purple sweets in larger stacks."
+    - item_id: 20544
+      item_name: Reward casket (hard)
+      slug: reward-casket-hard
+      relationship: alternative
+      description: "Hard clue casket - higher stack sizes for tick-eating supply."
+  about: "Purple sweets are the only stackable food item in OSRS, obtained exclusively from Treasure Trails reward caskets across every difficulty. They restore 1-3 HP and 10% run energy per dose, making them prized for tick-eating at bosses (Inferno, Vorkath, NMZ) where conventional food cycles too slowly, and as a cheap run-energy top-up during long agility or farm runs."
+  market_strategy:
+    notes:
+      - "Demand is structurally elevated by Inferno/Colosseum tick-eaters and high-level PvM run-energy management."
+      - "Supply is bottlenecked by clue completion rates across all five difficulties."
+      - "GE buy limit of 10,000 per 4 hours is high - flip volume is rarely the constraint."
+      - "Price moves with Leagues lulls (more clue grinders) and Inferno meta shifts."
+  trading_tips:
+    - "Stockpile ahead of new Inferno-class content launches."
+    - "Watch Leagues/DMM cycle - off-season clue grinding inflates supply, summer events deflate."
+    - "Pair with super energy potions to read run-energy meta directly."
+  history:
+    - date: "2006-12-05"
+      description: "Released as a Treasure Trails reward in the Treasure Trails, spiders and sheep update."
+    - date: "2015-07-02"
+      description: "Temple Trekking feeding no longer consumes entire stacks - one sweet per feed action."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/quetzal-feed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/quetzal-feed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quetzal feed | OSRS Price Data
-description: "Quetzal feed: A sack of quetzal feed.. High alch: 30 GP, GE limit: 100."
+description: "Quetzal feed: A sack of quetzal feed. High alch: 30 GP, GE limit: 100."
 osrs:
   id: 29307
   name: Quetzal feed
@@ -12,9 +12,66 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 100
-  about: "Quetzal feed is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: consumable
+    tier: low
+  properties:
+    release_date: "2024-08-14"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 1
+      xp: 0
+      materials:
+        - item_name: Sun-kissed wheat
+          quantity: 1
+        - item_name: Sunfire splinters
+          quantity: 50
+      output_quantity: 1
+      notes: "Made at a hopper using sun-kissed wheat and sunfire splinters in Civitas illa Fortis."
+  shops:
+    - shop_name: "Quetzal Trader"
+      location: Civitas illa Fortis
+      price: 50
+      currency: coins
+      notes: "Sold by Felipe and other quetzal traders in Varlamore."
+  related_items:
+    - item_name: Quetzal whistle
+      slug: quetzal-whistle
+      relationship: component
+      description: Used to summon and ride quetzals that consume the feed.
+    - item_name: Renewed quetzal whistle
+      slug: renewed-quetzal-whistle
+      relationship: upgrade
+      description: Upgraded whistle with additional teleport destinations.
+  about: |-
+    Quetzal feed is a stack of seeds used to summon and fly quetzals around Varlamore. Players hand a feed sack to a quetzal trader or use it on their quetzal whistle to refresh travel charges.
+
+    Each feed grants a short-term boost to quetzal flight stamina, supporting fast travel between Civitas illa Fortis, Kourend, and the southern Varlamore biomes.
+  market_strategy:
+    notes:
+      - "Steady demand from Varlamore traversal and Hunter routes."
+      - "Buy-limit 100 keeps margins narrow but supply consistent."
+      - "Stack supply when new Varlamore content drops."
+  trading_tips:
+    - "Buy from quetzal traders in bulk when prices spike."
+    - "Watch for promo events tied to Varlamore expansions."
+  history:
+    - date: "2024-08-14"
+      description: "Introduced with the Varlamore: The Final Dawn update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-death-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-death-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raging echoes death scroll | OSRS Price Data
-description: "Raging echoes death scroll: A scroll which unlocks the Raging Echoes death and respawn animation.. High alch: 15,000 GP."
+description: "Raging echoes death scroll unlocks the Raging Echoes League death and respawn animation override, purchased from the Leagues V reward shop for 2,000 points. High alch: 15,000 GP."
 osrs:
   id: 30455
   name: Raging echoes death scroll
@@ -11,10 +11,62 @@ osrs:
   value: 25000
   lowalch: 10000
   highalch: 15000
-  limit: null
-  about: "Raging echoes death scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2025-01-15"
+    update: "Leagues V: Raging Echoes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Read
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: "Death animation override"
+      description: "Reading the scroll unlocks the Raging Echoes League death and respawn animation as a cosmetic override on the player's account, persistent across deaths."
+  related_items:
+    - item_id: 30453
+      item_name: Raging echoes home teleport scroll
+      slug: raging-echoes-home-teleport-scroll
+      relationship: alternative
+      description: "Companion Leagues V cosmetic override for the standard home teleport animation."
+    - item_id: 30459
+      item_name: Raging echoes nexus scroll
+      slug: raging-echoes-nexus-scroll
+      relationship: alternative
+      description: "Leagues V POH nexus teleport animation override sold from the same reward shop."
+    - item_id: 30457
+      item_name: Raging echoes spirit tree scroll
+      slug: raging-echoes-spirit-tree-scroll
+      relationship: alternative
+      description: "Leagues V spirit tree teleport animation override sold from the same reward shop."
+    - item_id: 30461
+      item_name: Raging echoes portal scroll
+      slug: raging-echoes-portal-scroll
+      relationship: alternative
+      description: "Leagues V POH portal teleport animation override sold from the same reward shop."
+  about: "Raging echoes death scroll is a Leagues V: Raging Echoes reward unlocked by reading a one-time consumable scroll purchased from the league reward shop for 2,000 League Points. The cosmetic override permanently replaces the standard death and respawn animation with the Raging Echoes themed sequence on the player's account."
+  market_strategy:
+    notes:
+      - "Supply is finite - only Leagues V participants who spent 2,000 LP could initially obtain the scroll."
+      - "Read-and-bind mechanic means most in-circulation copies sit with collectors, not flippers."
+      - "No GE buy limit makes whales the marginal buyer; thin daily volume."
+      - "High alch of 15,000 gp sits massively below GE price - never alch this scroll."
+  trading_tips:
+    - "Watch for league anniversary or rerun teasers that bump cosmetic-override demand."
+    - "Cross-reference the four sibling Raging Echoes teleport scrolls - collectors typically buy the full set."
+    - "Hold rather than flip - thin order book makes round-trip taxes punishing."
+  history:
+    - date: "2025-01-15"
+      description: "Released as part of Leagues V: Raging Echoes, added to the league reward shop for 2,000 League Points."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-portal-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raging-echoes-portal-scroll.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raging echoes portal scroll | OSRS Price Data
-description: "Raging echoes portal scroll is a members-only OSRS item. High alch: 15,000 GP."
+description: "Raging echoes portal scroll is a members POH decoration from Leagues V. High alch: 15,000 GP."
 osrs:
   id: 30461
   name: Raging echoes portal scroll
@@ -11,10 +11,62 @@ osrs:
   value: 25000
   lowalch: 10000
   highalch: 15000
-  limit: null
-  about: "Raging echoes portal scroll is a members-only item in Old School RuneScape. High alchemy value: 15,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: scroll
+    tier: mid
+  properties:
+    release_date: "2024-11-15"
+    update: "Leagues V: Raging Echoes"
+    quest_item: false
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    weight: 0.01
+    destroy: "Drop"
+    options:
+      - Read
+      - Drop
+    examine_options:
+      - Examine
+    alchable: true
+  obtaining:
+    - method: League rewards shop
+      source: Leagues V Rewards Shop
+      location: Leagues V hub
+      currency: League Points
+      cost: 1500
+      notes: "Purchased from the League Rewards shop during Leagues V"
+  related_items:
+    - item_name: Raging echoes banner
+      slug: raging-echoes-banner
+      relationship: set-piece
+      description: Companion cosmetic from the Leagues V reward set
+    - item_name: Raging echoes curtains
+      slug: raging-echoes-curtains
+      relationship: set-piece
+      description: POH curtain cosmetic from Leagues V
+    - item_name: Raging echoes cane
+      slug: raging-echoes-cane
+      relationship: set-piece
+      description: Companion cosmetic walking cane
+    - item_name: Raging echoes nexus scroll
+      slug: raging-echoes-nexus-scroll
+      relationship: alternative
+      description: POH nexus decoration counterpart
+  market_strategy:
+    notes:
+      - "Cosmetic-only POH decoration; collector demand only"
+      - "Supply locked to Leagues V participants who claimed rewards"
+      - "Long-term value rises after league rewards stop minting"
+      - "Trade volume thin; expect spread between bid and ask"
+  history:
+    - date: "2024-11-15"
+      description: "Released with Leagues V: Raging Echoes rewards shop"
+  about: "The raging echoes portal scroll is a members-only Player Owned House decoration unlocked through the Leagues V: Raging Echoes Rewards Shop. Used on a POH portal, it reskins the portal in Leagues V style."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bass.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-bass.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw bass | OSRS Price Data
-description: "Raw bass: I should try cooking this.. High alch: 24 GP, GE limit: 15,000."
+description: "Raw bass: a members fish caught at 46 Fishing with a big net or harpoon. High alch: 24 GP, GE limit: 15,000."
 osrs:
   id: 363
   name: Raw bass
@@ -12,18 +12,70 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: fish
+    tier: mid
+  properties:
+    release_date: "2002-04-11"
+    update: "Member Skills"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.5
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fishing
+      level: 46
+      xp: 100
+      materials: []
+      output_quantity: 1
+      notes: "Caught with a big net or harpoon at Catherby, the Fishing Guild and Shilo Village."
+    - skill: cooking
+      level: 43
+      xp: 130
+      materials:
+        - item_name: Raw bass
+          quantity: 1
+      output_quantity: 1
+      notes: "Cook on a fire or range to produce Bass (heals 13 hitpoints)."
   related_items:
     - item_id: 365
       item_name: Bass
       slug: bass
       relationship: product
-      description: Cooked version
+      description: Cooked version, heals 13 hitpoints.
+    - item_name: Burnt bass
+      slug: burnt-bass
+      relationship: alternative
+      description: Failed cook attempt below ~50 Cooking.
+    - item_name: Big fishing net
+      slug: big-fishing-net
+      relationship: component
+      description: Tool used to catch raw bass alongside harpoons.
   about: |-
-    > _"I should try cooking this."_
+    Raw bass is a members-only fish caught with a big net or harpoon at 46 Fishing, granting 100 Fishing experience per catch. The fish is most commonly netted at Catherby, Shilo Village and inside the Fishing Guild.
 
-    Raw bass can be cooked at 43 Cooking. The highest-tier fish commonly caught with a big fishing net.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Cooked on a fire or range at 43 Cooking, raw bass produces bass that heals 13 hitpoints, making it a stepping stone between lobsters and sharks for mid-level food choices.
+  market_strategy:
+    notes:
+      - "Steady supply from Fishing Guild big-net trips."
+      - "Cooked bass demand is light; price moves with food meta shifts."
+      - "Good high-alch fodder when nature rune costs are low."
+  trading_tips:
+    - "Watch for Cooking events when raw bass is targeted for XP gains."
+    - "Compare with raw lobster and raw swordfish before committing to bulk supply."
+  history:
+    - date: "2002-04-11"
+      description: "Bass introduced with the Catherby Fishing update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-yak-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-yak-meat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Raw yak meat | OSRS Price Data
-description: "Raw yak meat: I need to cook this.. High alch: 1 GP, GE limit: 11,000."
+description: "Raw yak meat is dropped from yaks on Neitiznot and is cooked into yak-hide armour upkeep food. High alch: 1 GP, GE limit: 11,000."
 osrs:
   id: 10816
   name: Raw yak meat
@@ -12,12 +12,76 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
-  about: "Raw yak meat is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: meat
+    tier: low
+  properties:
+    release_date: "2007-02-06"
+    update: "The Fremennik Isles"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.4
+    options:
+      - Cook
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  food:
+    heals: 0
+    bites: 1
+  recipes:
+    - skill: cooking
+      level: 30
+      xp: 102
+      materials:
+        - item_name: Raw yak meat
+          quantity: 1
+      tools:
+        - Fire
+      output_quantity: 1
+      notes: "Cooks into yak meat or burnt meat; burn rate stops at level 41."
+  drop_table:
+    sources:
+      - source: Yak
+        combat_level: 22
+        quantity: "1"
+        rarity: Always
+        notes: "100% drop from yaks on Neitiznot and the Mountain Camp."
+  related_items:
+    - item_name: Yak meat
+      slug: yak-meat
+      relationship: product
+      description: "Cooked version restored when cooked at 30 Cooking"
+    - item_name: Yak-hide
+      slug: yak-hide
+      relationship: alternative
+      description: "Other resource yielded from yaks, used in Fremennik isles armour"
+    - item_name: Burnt meat
+      slug: burnt-meat
+      relationship: alternative
+      description: "Failed cook output when below the burn-stop level"
+  about: "Raw yak meat is a members-only raw food dropped 100% from yaks on Neitiznot and at the Mountain Camp. It cooks into yak meat at 30 Cooking for 102 xp, with burns stopping at 41 Cooking, and is occasionally used as a cheap mid-level Cooking xp source thanks to its high drop rate and stack potential."
+  market_strategy:
+    notes:
+      - "GE limit 11,000 per 4 hours supports bulk Cooking xp flips"
+      - "Supply driven by yak-hide farmers banking the meat as a by-product"
+      - "Margins are tiny in absolute gp, but stack throughput is high"
+  trading_tips:
+    - "Buy bulk when yak-hide trends; meat supply spikes alongside hide farming"
+    - "List cooked yak meat above raw price to capture the cooking xp premium"
+  history:
+    - date: "2007-02-06"
+      description: "Released with The Fremennik Isles quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-crab-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-crab-meat.mdx
@@ -11,10 +11,65 @@ osrs:
   value: 100
   lowalch: 40
   highalch: 60
-  limit: null
-  about: "Red crab meat is a members-only item in Old School RuneScape. High alchemy value: 60 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  material:
+    type: food
+    tier: mid
+  food:
+    heals: 8
+    cooking_level: 21
+    cooking_xp: 85
+    stop_burn_fire: 56
+    stop_burn_range: 51
+  recipes:
+    - skill: cooking
+      level: 21
+      xp: 85
+      materials:
+        - item_name: Raw red crab meat
+          quantity: 1
+      product: Red crab meat
+      output_quantity: 1
+      facility: Fire or cooking range
+  related_items:
+    - item_id: 31687
+      item_name: Raw red crab meat
+      slug: raw-red-crab-meat
+      relationship: component
+      description: Uncooked ingredient
+    - item_id: 31685
+      item_name: Red crab
+      slug: red-crab
+      relationship: component
+      description: Source NPC harvested via Sailing
+  about: |-
+    Red crab meat is the cooked product of raw red crab meat. It heals 8 Hitpoints per dose and grants 85 Cooking XP. Burn rate drops off completely at level 56 on a fire and 51 on a cooking range, with Hosidius bonuses lowering the threshold further.
+
+    | Property | Value |
+    |----------|-------|
+    | Heals | 8 HP |
+    | Cooking level | 21 |
+    | Cooking XP | 85 |
+    | Stop-burn (fire) | 56 |
+    | Stop-burn (range) | 51 |
+
+    Introduced as part of the Sailing skill update, red crab meat sits in the mid-tier seafood band — a step above shrimp and trout but below shark/anglerfish for serious combat content.
+  market_strategy:
+    notes:
+      - Sailing-era release — fresh supply curve
+      - Mid-tier cooking XP at level 21 (85 XP)
+      - Untradeable buy limit (null GE limit field)
+      - Often consumed for early Sailing/Cooking grinds
+      - Watch Hosidius bonus interactions for XP/hour optimization
+  trading_tips:
+    - Track raw red crab meat costs to gauge cook-flip margins
+    - Hosidius house bonuses cut burn rate further
+    - Useful filler food for mid-level Slayer tasks
+  history:
+    - date: "2025-11-19"
+      description: Introduced with the Sailing skill update.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-vambraces.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-d-hide-vambraces.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red d'hide vambraces | OSRS Price Data
-description: "Red d'hide vambraces is a members hands slot item. High alch: 2,160 GP, GE limit: 70."
+description: "Red d'hide vambraces is a members-only ranged hands slot armour requiring 60 Ranged, crafted at 73 Crafting from 1 Red dragon leather. High alch: 2,160 GP, GE limit: 70."
 osrs:
   id: 2489
   name: Red d'hide vambraces
@@ -12,19 +12,50 @@ osrs:
   lowalch: 1440
   highalch: 2160
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragonhide
+    tier: mid
+  properties:
+    release_date: "2004-03-29"
+    update: "RuneScape 2 launch"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.283
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
-    type: ranged_armour
-    ranged_requirement: 60
-    defence_requirement: 40
-  attack_bonuses:
-    ranged: 10
-  defence_bonuses:
-    ranged: 9
-    magic: 6
-  crafting:
-    level: 73
-    xp: 78
+    weight: 0.283
+    requirements:
+      ranged: 60
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -10
+      ranged: 10
+    defence_bonus:
+      stab: 3
+      slash: 4
+      crush: 4
+      magic: 6
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   recipes:
     - skill: crafting
       level: 73
@@ -37,67 +68,68 @@ osrs:
           item_id: 1734
           quantity: 1
       product: Red d'hide vambraces
-      product_id: 2489
-      product_quantity: 1
-      facility: Needle and thread
-      members_only: true
+      output_quantity: 1
+  drop_table:
+    sources:
+      - source: Dust devil
+        rarity: "2/128"
+        members_only: true
+      - source: Dagannoth Supreme
+        rarity: "7/128"
+        members_only: true
+      - source: Lizardman shaman
+        rarity: "10/500"
+        members_only: true
+      - source: Brutal red dragon
+        rarity: "1/128"
+        members_only: true
   related_items:
     - item_id: 1749
       item_name: Red dragonhide
       slug: red-dragonhide
       relationship: component
-      description: Raw material
+      description: Raw hide tanned into Red dragon leather before crafting.
     - item_id: 2507
       item_name: Red dragon leather
       slug: red-dragon-leather
       relationship: component
-      description: Tanned hide
+      description: Tanned leather used as the direct crafting material.
     - item_id: 2501
       item_name: Red d'hide body
       slug: red-dhide-body
       relationship: alternative
-      description: Matching body
+      description: Matching dragonhide body for the red set.
     - item_id: 2495
       item_name: Red d'hide chaps
       slug: red-dhide-chaps
       relationship: alternative
-      description: Matching legs
+      description: Matching dragonhide legs for the red set.
     - item_id: 2487
       item_name: Blue d'hide vambraces
       slug: blue-dhide-vambraces
-      relationship: alternative
-      description: Lower tier vambraces
+      relationship: downgrade
+      description: Previous-tier vambraces requiring 50 Ranged.
     - item_id: 2491
       item_name: Black d'hide vambraces
       slug: black-dhide-vambraces
-      relationship: alternative
-      description: Higher tier vambraces
-  about: |-
-    | Method | Level | Materials |
-    |--------|-------|-----------|
-    | Crafting | 73 | 1 Red dragon leather |
-    | XP | 78 | - |
-
-    | Stat | Value |
-    |------|-------|
-    | Ranged requirement | 60 |
-    | Defence requirement | 40 |
-    | Ranged attack | +10 |
-    | Ranged defence | +9 |
-    | Magic defence | +6 |
+      relationship: upgrade
+      description: Next-tier vambraces requiring 70 Ranged.
+  about: "Red d'hide vambraces are the third-tier dragonhide vambraces in OSRS, requiring 60 Ranged to wear and 73 Crafting to make from a Red dragon leather plus thread for 78 Crafting XP. They sit between blue and black d'hide vambraces in the standard dragonhide progression, offering +10 ranged attack and balanced defensive bonuses, and are a staple Crafting training target for members."
   market_strategy:
     notes:
-      - Third dragonhide glove tier
-      - Members only
-      - Popular crafting item
-      - Crafting training (78 XP)
-      - High-level ranged armor
-      - Budget gear
-      - 1 leather per vambraces
-      - Fast crafting method
-      - Lowest level in red set
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand comes from mid-level rangers, ironmen scaling Crafting, and clue-step gear loadouts."
+      - "GE buy limit of 70 per 4 hours caps merchant volume."
+      - "High alch return of 2,160 gp typically sits below GE price - not a profitable alch target."
+      - "Supply is driven by Red dragon leather crafters plus drops from Dust devils, Dagannoth Supreme, and Lizardman shamans."
+  trading_tips:
+    - "Cross-check Red dragon leather + Thread spot prices to detect crafter arbitrage windows."
+    - "Watch dragonhide leather price swings - vambraces follow leather supply tightly."
+    - "Low-volatility flip - stable margin item, rarely a profit driver."
+  history:
+    - date: "2004-03-29"
+      description: "Released alongside the dragonhide armour line at the launch of RuneScape 2."
+    - date: "2021-09-22"
+      description: "Defence bonuses adjusted as part of the ranged armour rebalance (stab 5 to 3, crush 6 to 4)."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-dragonhide-set.mdx
@@ -12,9 +12,66 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 70
-  about: "Red dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragonhide
+    tier: mid
+  properties:
+    release_date: "2015-02-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 11
+    options:
+      - Exchange
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  related_items:
+    - item_id: 2501
+      item_name: Red dragonhide body
+      slug: red-dragonhide-body
+      relationship: set-piece
+      description: Body armour piece included in the set
+    - item_id: 2497
+      item_name: Red dragonhide chaps
+      slug: red-dragonhide-chaps
+      relationship: set-piece
+      description: Leg armour piece included in the set
+    - item_id: 2487
+      item_name: Red dragonhide vambraces
+      slug: red-dragonhide-vambraces
+      relationship: set-piece
+      description: Hand piece included in the set
+    - item_id: 12873
+      item_name: Black dragonhide set
+      slug: black-dragonhide-set
+      relationship: upgrade
+      description: Higher tier dragonhide set
+    - item_id: 12867
+      item_name: Blue dragonhide set
+      slug: blue-dragonhide-set
+      relationship: downgrade
+      description: Lower tier dragonhide set
+  about: "Red dragonhide set bundles a red dragonhide body, chaps and vambraces into one Grand Exchange Sets package for convenient bank storage and faster trading. The set is exchanged for the individual pieces at the Grand Exchange clerk and is identical in stats to the components combined."
+  market_strategy:
+    notes:
+      - "Convenience premium over individual dragonhide pieces"
+      - "Useful for bank space savings when training Ranged"
+      - "Exchange via the Grand Exchange Sets interface"
+      - "Popular for low-level Ranged gear transfers between accounts"
+  trading_tips:
+    - "Compare set price to combined component price for arbitrage"
+    - "Buy when red dragonhide drops from green dragon hunts spike"
+    - "Sell into Slayer or Ranged training events for premium pricing"
+  history:
+    - date: "2015-02-26"
+      description: "Red dragonhide set added to the Grand Exchange Sets interface."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-partyhat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-partyhat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red partyhat | OSRS Price Data
-description: "Red partyhat: A nice hat from a cracker.. High alch: 1 GP, GE limit: 5."
+description: "Red partyhat is one of the original 2001 Christmas cracker rare hat slot items in OSRS. High alch: 1 GP, GE limit: 5."
 osrs:
   id: 1038
   name: Red partyhat
@@ -12,9 +12,92 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 5
-  about: "Red partyhat is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rare
+    tier: high
+  properties:
+    release_date: "2001-12-25"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: false
+    members: false
+    quest_item: false
+    weight: 0
+    alchable: false
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weight: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 1040
+      item_name: Yellow partyhat
+      slug: yellow-partyhat
+      relationship: variant
+      description: Yellow colour variant of the original partyhat set
+    - item_id: 1042
+      item_name: Blue partyhat
+      slug: blue-partyhat
+      relationship: variant
+      description: Blue colour variant of the original partyhat set
+    - item_id: 1044
+      item_name: Green partyhat
+      slug: green-partyhat
+      relationship: variant
+      description: Green colour variant of the original partyhat set
+    - item_id: 1046
+      item_name: Purple partyhat
+      slug: purple-partyhat
+      relationship: variant
+      description: Purple colour variant of the original partyhat set
+    - item_id: 1048
+      item_name: White partyhat
+      slug: white-partyhat
+      relationship: variant
+      description: White colour variant of the original partyhat set
+  market_strategy:
+    title: Investment Notes
+    notes:
+      - "Original 2001 holiday rare with a fixed, ever-shrinking supply"
+      - "Long-term wealth store; treated as a GP cap workaround"
+      - "Price track follows total GP-in-game inflation, not utility"
+      - "Buy limit only 5 per 4 hours — buyouts often go through PvP world trades"
+      - "Confirm trade history and ban states before completing high-value swaps"
+  trading_tips:
+    - Use the Grand Exchange offer history page to confirm fair price discovery
+    - Never high-alch; partyhats are not alchable and burning one loses billions
+    - Watch for fake-out spikes around major economy updates (Sailing, leagues)
+    - Trade through the GE rather than direct PvP world drops to avoid scams
+  about: Red partyhat is one of the original 2001 Christmas cracker rare hats and one of the most valuable items in Old School RuneScape. It occupies the head slot, has zero combat stats, and is a pure cosmetic and wealth-storage item with an ever-shrinking supply.
+  history:
+    - date: "2001-12-25"
+      description: "Released as a holiday drop inside Christmas crackers during the 2001 Christmas event."
+    - date: "2007-12-10"
+      description: "Trade restrictions briefly affected partyhat liquidity ahead of the Grand Exchange rollout in 2007."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/roast-beast-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/roast-beast-meat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Roast beast meat | OSRS Price Data
-description: "Roast beast meat: A delicious looking slab of roast beast.. High alch: 15 GP, GE limit: 6,000."
+description: "Roast beast meat is a members 21 Cooking food cooked from skewered beast on a fire, healing 8 Hitpoints. High alch: 15 GP, GE limit: 6,000."
 osrs:
   id: 9988
   name: Roast beast meat
@@ -12,9 +12,72 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 6000
-  about: "Roast beast meat is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: meat
+    tier: low
+  properties:
+    release_date: "2006-11-21"
+    update: "Hunter skill release"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 2.0
+    options:
+      - Eat
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  food:
+    heals: 8
+    bites: 1
+  recipes:
+    - skill: cooking
+      level: 21
+      xp: 82.5
+      materials:
+        - item_name: Skewered beast
+          item_id: 9992
+          quantity: 1
+      tools:
+        - Fire
+      product: Roast beast meat
+      product_id: 9988
+      output_quantity: 1
+  related_items:
+    - item_id: 9992
+      item_name: Skewered beast
+      slug: skewered-beast
+      relationship: component
+      description: "Raw beast meat threaded on an iron spit, ready to roast over a fire."
+    - item_id: 9986
+      item_name: Raw beast meat
+      slug: raw-beast-meat
+      relationship: component
+      description: "Raw drop from various Hunter creatures; combined with an iron spit before cooking."
+    - item_id: 9990
+      item_name: Burnt beast meat
+      slug: burnt-beast-meat
+      relationship: alternative
+      description: "Failure outcome when cooking the skewered beast at low levels."
+  about: "Roast beast meat is a members food cooked from a skewered beast over any fire at 21 Cooking for 82.5 XP. It restores 8 Hitpoints per bite and is most commonly produced as a by-product of Hunter rumours and survival training. Cooking fails at low levels produce burnt beast meat; success rate reaches 100% at 99 Cooking."
+  market_strategy:
+    notes:
+      - "Demand is thin - mostly Hunter rumour completers and survivalists, not mainline PvM food."
+      - "Buy limit of 6,000 per 4 hours allows for bulk plays when Hunter rumours surge."
+      - "High alch 15 gp keeps the alch floor effectively below market value."
+      - "Supply tracks raw beast meat / skewered beast availability from Hunter content."
+  trading_tips:
+    - "Bulk-buy on patch days that boost Hunter XP - rumour spam dumps raw beast meat onto the GE."
+    - "Use as cheap throw-away food for low-effort Hunter trips before pivoting to higher-heal options."
+  history:
+    - date: "2006-11-21"
+      description: "Released alongside the Hunter skill as a campfire-roasted food option."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-shard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-shard.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rock-shell shard | OSRS Price Data
-description: "Rock-shell shard: A curved piece of rock-shell.. High alch: 36 GP, GE limit: 11,000."
+description: "Rock-shell shard is a Dagannoth-drop crafting component combined by Skulgrimen with dagannoth hide to make rock-shell platebodies. High alch: 36 GP, GE limit: 11,000."
 osrs:
   id: 6159
   name: Rock-shell shard
@@ -12,9 +12,76 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Rock-shell shard is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rock-shell
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Giant Rock Crab
+        combat_level: 137
+        quantity: "1"
+        rarity: uncommon
+        drop_rate: 2/128
+        members_only: true
+      - source: King Sand Crab
+        combat_level: 107
+        quantity: "1"
+        rarity: uncommon
+        drop_rate: 2/128
+        members_only: true
+      - source: Dagannoth
+        combat_level: 74
+        quantity: "1"
+        rarity: rare
+        drop_rate: 1/128
+        members_only: true
+  related_items:
+    - item_name: Rock-shell plate
+      slug: rock-shell-plate
+      relationship: product
+      description: Forged by Skulgrimen on the Fremennik Isles from 3 dagannoth hides, 1 rock-shell shard, and 10,000 coins
+    - item_name: Rock-shell chunk
+      slug: rock-shell-chunk
+      relationship: alternative
+      description: Heavier dagannoth drop used to craft rock-shell helms
+    - item_name: Rock-shell splinter
+      slug: rock-shell-splinter
+      relationship: alternative
+      description: Smaller dagannoth drop used to craft rock-shell legs
+    - item_name: Dagannoth hide
+      slug: dagannoth-hide
+      relationship: component
+      description: Soft-tier dagannoth drop combined with rock-shell shards at Skulgrimen
+  about: "Rock-shell shard is a Fremennik Isles crafting component dropped by dagannoth and crab variants, combined with dagannoth hide at Skulgrimen after The Fremennik Isles quest to forge rock-shell platebodies; before completing The Fremennik Trials it can also be exchanged with Askeladden for cooked tuna."
+  market_strategy:
+    notes:
+      - "Demand tied to rock-shell armour crafters and low-Defence pures kitting out free attack bonuses"
+      - "Supply faucets are Dagannoth and crab-tier monsters - shifts with Slayer task popularity"
+      - "GE buy limit of 11,000 per 4 hours easily covers crafter runs"
+      - "High alch of 36 gp is well below price - not viable as an alch target"
+  trading_tips:
+    - "Watch Slayer task rotations for Dagannoth/crab spikes that flood supply"
+    - "Cross-check against Dagannoth hide spot prices to gauge crafter margin"
+    - "Rock-shell armour stays niche - stick to small, consistent flips"
+  history:
+    - date: "2005-08-01"
+      description: "Released with The Fremennik Isles quest expanding the dagannoth-themed armour line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rosemary.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rosemary.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rosemary | OSRS Price Data
-description: "Rosemary: Some rosemary.. High alch: 1 GP, GE limit: 600."
+description: "Rosemary: Some rosemary. High alch: 1 GP, GE limit: 600."
 osrs:
   id: 6014
   name: Rosemary
@@ -12,9 +12,50 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 600
-  about: "Rosemary is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: herb
+    tier: low
+  properties:
+    release_date: "2003-09-02"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  farming:
+    farming_level: 11
+    seed_name: Rosemary seed
+    seed_id: 5096
+    patch_type: flower
+  related_items:
+    - item_name: Rosemary seed
+      slug: rosemary-seed
+      relationship: component
+      description: Seed planted in a flower patch to grow rosemary
+    - item_name: Flax
+      slug: flax
+      relationship: alternative
+      description: Often grown via flower patch protection chains
+  about: "Rosemary is a flower grown from a Rosemary seed at level 11 Farming. It is primarily used as a flower patch crop and as a Master Farmer pickpocket reward, with minimal direct utility outside of farming routines."
+  market_strategy:
+    notes:
+      - "Cheap, low-volume item with narrow trade window"
+      - "Buy limit of 600 keeps the GE market small"
+      - "Supply driven by Master Farmer pickpocketing and incidental farming"
+  trading_tips:
+    - Generally not worth flipping due to tight margins
+    - Useful as an Ironman intermediate while training Farming
+  history:
+    - date: "2003-09-02"
+      description: "Added to the game alongside the Farming skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolt-tips.mdx
@@ -12,11 +12,9 @@ osrs:
   lowalch: 26
   highalch: 40
   limit: 11000
-  item:
-    type: ammunition_component
-    tradeable: true
-    stackable: true
-    weight: 0
+  material:
+    type: ammunition-component
+    tier: mid-high
   recipes:
     - skill: fletching
       level: 63
@@ -25,7 +23,7 @@ osrs:
         - item_name: Ruby
           quantity: 1
       product: Ruby bolt tips
-      product_quantity: 12
+      output_quantity: 12
   related_items:
     - item_id: 9339
       item_name: Ruby bolts
@@ -35,7 +33,7 @@ osrs:
     - item_id: 9242
       item_name: Ruby bolts (e)
       slug: ruby-bolts-e
-      relationship: alternative
+      relationship: upgrade
       description: Enchanted version
     - item_id: 21944
       item_name: Ruby dragon bolts
@@ -43,9 +41,11 @@ osrs:
       relationship: alternative
       description: Dragon variant
   about: |-
+    Ruby bolt tips are crafted by cutting a ruby at Fletching level 63 (6.3 XP, 12 tips per gem). Attaching them to adamant bolts at the same level creates ruby bolts, which can be enchanted into the popular Enchant Crossbow Bolt (Ruby) ammunition with the Blood Forfeit effect.
+
     | Property | Value |
     |----------|-------|
-    | Type | Ammunition Component |
+    | Type | Ammunition component |
     | Tradeable | Yes |
     | Stackable | Yes |
     | Weight | 0 kg |
@@ -55,9 +55,23 @@ osrs:
     | Ruby bolts | Adamant bolts + Ruby bolt tips | 63 |
     | Ruby dragon bolts | Dragon bolts + Ruby bolt tips | 84 |
 
-    Can be enchanted after attachment.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Can be enchanted after attachment for the iconic Blood Forfeit special effect.
+  market_strategy:
+    notes:
+      - Driven by ruby bolt (e) demand for boss content
+      - 12 tips per gem keeps margin tight versus raw rubies
+      - Buy limit 11,000 supports bulk fletcher flips
+      - Dragon bolt variant adds upstream demand at level 84
+      - Compare to enchanted bolt GE prices daily
+  trading_tips:
+    - Watch Ruby bolts (e) demand for short-term price moves
+    - Bulk-fletch from rubies when GE margin exceeds 12 gp per gem
+    - Pair with adamant bolts cost-tracking for full assembly margins
+  history:
+    - date: "2005-09-26"
+      description: Released with the introduction of crossbow gems and bolts.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rum-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rum-blue.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rum (blue) | OSRS Price Data
-description: "Rum (blue): Alcohol in the loosest sense of the word.. High alch: 120 GP."
+description: "Rum (blue) is a Trouble Brewing minigame drink bought from Honest Jimmy for 20 pieces of eight; drinking it teleports the player back outside the minigame lobby. High alch: 120 GP."
 osrs:
   id: 8941
   name: Rum (blue)
@@ -11,10 +11,57 @@ osrs:
   value: 200
   lowalch: 80
   highalch: 120
-  limit: null
-  about: "Rum (blue) is a members-only item in Old School RuneScape. High alchemy value: 120 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: minigame-reward
+    tier: low
+  properties:
+    release_date: "2006-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.003
+    options:
+      - Drink
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  passive_effects:
+    - name: Trouble Brewing teleport
+      description: "Drinking knocks the player out and teleports them outside the Trouble Brewing lobby on Mos Le'Harmless; cannot be drunk above 20 Wilderness."
+  related_items:
+    - item_name: Rum (red)
+      slug: rum-red
+      relationship: variant
+      description: Red-team variant of the Trouble Brewing rum, mechanically identical
+    - item_name: Pieces of eight
+      slug: pieces-of-eight
+      relationship: component
+      description: Minigame currency spent at Honest Jimmy to buy Rum (blue) at 20 each
+    - item_name: Karamjan rum
+      slug: karamjan-rum
+      relationship: alternative
+      description: Pirate's Treasure quest rum from Karamja, unrelated to Trouble Brewing
+  about: "Rum (blue) is a tradeable drink sold by Honest Jimmy at the Trouble Brewing minigame on Mos Le'Harmless for 20 pieces of eight; drinking it knocks the player out and acts as a single-use teleport back to the minigame lobby, blocked above 20 Wilderness."
+  market_strategy:
+    notes:
+      - "Niche teleport-utility item - demand tied to active Trouble Brewing minigame players"
+      - "Bought directly from Honest Jimmy for 20 pieces of eight - GE flips compete with shop supply"
+      - "No GE buy limit listed - thin daily volume still throttles bulk trades"
+      - "High alch of 120 gp sits below GE price - not viable as an alch target"
+  trading_tips:
+    - "Watch any Trouble Brewing rework news - the minigame's been mostly dormant since release"
+    - "Cross-check Rum (red) spot price to spot team-color arbitrage"
+    - "Trade small quantities - low daily volume punishes large undercuts"
+  history:
+    - date: "2006-07-04"
+      description: "Released with the Trouble Brewing minigame on Mos Le'Harmless as a team-colored teleport rum."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrowtips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrowtips.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune arrowtips | OSRS Price Data
-description: "Rune arrowtips: I can make some arrows with these.. High alch: 120 GP, GE limit: 10,000."
+description: "Rune arrowtips: I can make some arrows with these. High alch: 120 GP, GE limit: 10,000."
 osrs:
   id: 44
   name: Rune arrowtips
@@ -12,18 +12,105 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 90
+      xp: 75
+      materials:
+        - item_name: Runite bar
+          item_id: 2363
+          quantity: 1
+      tools:
+        - Hammer
+      facility: Anvil
+      product: Rune arrowtips
+      product_id: 44
+      output_quantity: 15
+      notes: "Smith 1 runite bar at an anvil for 15 rune arrowtips."
+    - skill: fletching
+      level: 75
+      xp: 187.5
+      materials:
+        - item_name: Headless arrow
+          item_id: 53
+          quantity: 15
+        - item_name: Rune arrowtips
+          item_id: 44
+          quantity: 15
+      product: Rune arrow
+      product_id: 892
+      output_quantity: 15
+      notes: "Attach 15 rune arrowtips to 15 headless arrows for 15 rune arrows."
+  shops:
+    - shop_name: "Hickton's Archery Emporium"
+      location: Catherby
+      price: 200
+      currency: Coins
+      stock: 100
+    - shop_name: "Void Knight Archery Store"
+      location: Void Knights' Outpost
+      price: 200
+      currency: Coins
+      stock: 5
+    - shop_name: "Dargaud's Bow and Arrows"
+      location: Ranging Guild
+      price: 200
+      currency: Coins
+      stock: 150
   related_items:
     - item_id: 43
       item_name: Adamant arrowtips
       slug: adamant-arrowtips
-      relationship: variant
-      description: Lower tier arrowtips
-  about: |-
-    > _"I can make some arrows with these."_
-
-    Rune arrowtips are members-only Fletching supplies. Attach to headless arrows at 75 Fletching to create rune arrows. The highest tier of standard arrowtips.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: downgrade
+      description: "Lower-tier arrowtips made from adamant bars at 75 Smithing."
+    - item_id: 892
+      item_name: Rune arrow
+      slug: rune-arrow
+      relationship: product
+      description: "Fletched rune arrow produced from these tips."
+    - item_id: 53
+      item_name: Headless arrow
+      slug: headless-arrow
+      relationship: component
+      description: "Base shaft combined with rune arrowtips to fletch rune arrows."
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: "Smithed into 15 rune arrowtips per bar at 90 Smithing."
+  about: "Rune arrowtips are members-only Fletching supplies made by smithing one runite bar into 15 tips at 90 Smithing. They are attached to headless arrows at 75 Fletching to produce rune arrows, the highest tier of standard arrowtips and the headline output of high-Smithing/Fletching bottlenecks."
+  market_strategy:
+    notes:
+      - "Demand floor set by 75 Fletching rune arrow production routes."
+      - "Supply ties directly to runite bar price; thin Smithing-90 player count keeps spreads alive."
+      - "Buy limit of 10,000 per 4 hours scales well for bulk fletchers."
+      - "Niche shops at Catherby, Void Knights' Outpost, and the Ranging Guild restock at 200 gp each."
+  trading_tips:
+    - "Track runite bar price; arrowtip price tends to lead bar moves by a few hours."
+    - "Bulk-buy on weekend dumps when rune arrow demand softens, then flip into weekday raid prep."
+    - "Pair runite bar buys with hammer/anvil routes for ironman-grade Smithing XP rates."
+  history:
+    - date: "2002-03-25"
+      description: "Rune arrowtips released with the broader rune Fletching/Smithing arrow rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-cannonball.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-cannonball.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune cannonball | OSRS Price Data
-description: "Rune cannonball: Ammo suited for a boat's cannon.. High alch: 840 GP, GE limit: 11,000."
+description: "Rune cannonball is a stackable rune-tier cannon round smithed at 90 Smithing for the boat cannon line. High alch: 840 GP, GE limit: 11,000."
 osrs:
   id: 31914
   name: Rune cannonball
@@ -12,12 +12,75 @@ osrs:
   lowalch: 560
   highalch: 840
   limit: 11000
-  about: "Rune cannonball is a members-only item in Old School RuneScape. High alchemy value: 840 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 90
+      xp: 50.8
+      materials:
+        - item_name: Runite bar
+          quantity: 1
+      tools:
+        - Ammo mould
+      output_quantity: 4
+      notes: "Use a runite bar on a furnace with an ammo mould in the inventory. A double ammo mould doubles input/output per action."
+  related_items:
+    - item_id: 2
+      item_name: Cannonball
+      slug: cannonball
+      relationship: variant
+      description: "Steel-tier boat / Dwarf multicannon round."
+    - item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: "Bar smelted into rune cannonballs."
+    - item_name: Ammo mould
+      slug: ammo-mould
+      relationship: component
+      description: "Standard mould used to smith cannonballs of any tier."
+    - item_name: Double ammo mould
+      slug: double-ammo-mould
+      relationship: component
+      description: "Upgraded mould that produces twice the cannonballs per bar."
+  about: "Rune cannonball is the rune-tier boat cannon round introduced with the Sailing skill, smithed from runite bars at 90 Smithing for 50.8 XP per bar (4 balls per bar, 8 with the double ammo mould). It carries a +201 ranged strength bonus inside the rune-tier boat cannon line and is also dropped by frost dragons, great white sharks, aquanites and various Sailing salvage tables, making it both a high-end Smithing money-maker and a sink for Sailing combat content."
+  market_strategy:
+    notes:
+      - "Margin tracks runite bar cost vs. rune cannonball GE price - flip the ratio, not the absolute"
+      - "Sailing combat consumption is the primary demand driver; spikes follow Sailing PvM updates"
+      - "GE buy limit of 11,000 lets bulk smithers and Sailors move size each 4 hours"
+      - "Volume from Smithing bots and Frost dragon farmers caps upside in steady metas"
+  trading_tips:
+    - "Pair limit-buy orders on runite bars with limit-sell on cannonballs to lock arbitrage spread"
+    - "Watch Sailing patch notes for accuracy/strength changes - any tweak retags the meta supply curve"
+    - "Stockpile ahead of double-XP weekends when Smithing throughput peaks"
+  history:
+    - date: "2025-11-19"
+      description: "Released with the Sailing skill as the rune-tier boat cannon ammunition."
+    - date: "2026-03-18"
+      description: "Ranged Strength bonus rebalanced from +113 to +201."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune dagger | OSRS Price Data
-description: "Rune dagger: A powerful dagger.. High alch: 4,800 GP, GE limit: 70."
+description: "Rune dagger is a F2P rune-tier stab dagger forged at 85 Smithing from a runite bar. High alch: 4,800 GP, GE limit: 70."
 osrs:
   id: 1213
   name: Rune dagger
@@ -12,33 +12,105 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 70
-  item_id: 1213
-  item_type: equipment
-  slot: weapon
-  type: dagger
-  tradeable: true
-  weight: 0.453
-  requirements:
-    attack: 40
-  stats:
-    stab_attack: 25
-    slash_attack: 12
-    crush_attack: -4
-    magic_attack: 1
-    magic_defence: 1
-    melee_strength: 24
-  attack_speed: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: mid
+  properties:
+    release_date: "2001-08-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    attack_range: 1
+    weight: 0.453
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 25
+      slash: 12
+      crush: -4
+      magic: 1
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 1
+      ranged: 0
+    other_bonus:
+      melee_strength: 24
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 85
+      xp: 75
+      materials:
+        - item_name: Runite bar
+          item_id: 2363
+          quantity: 1
+      tools:
+        - Hammer
+        - Anvil
+      product: Rune dagger
+      product_id: 1213
+      output_quantity: 1
   related_items:
-    - slug: rune-scimitar
-    - slug: dragon-dagger
-    - slug: rune-sword
-    - slug: runite-bar
-  about: |-
-    *A powerful dagger.*
-
-    The rune dagger is fast (4 tick) but has significantly lower strength (+24) and accuracy (+25 stab) compared to the Rune scimitar. The small +1 magic attack bonus is unique among rune melee weapons. In F2P, the Rune sword is a better stab weapon with the same speed but higher bonuses. The Dragon dagger is the direct members upgrade with a powerful special attack.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: "Smithed on any anvil at 85 Smithing for the rune dagger."
+    - item_id: 1333
+      item_name: Rune scimitar
+      slug: rune-scimitar
+      relationship: alternative
+      description: "Slash-focused rune weapon with higher accuracy and strength bonuses."
+    - item_id: 1289
+      item_name: Rune sword
+      slug: rune-sword
+      relationship: alternative
+      description: "F2P stab alternative with the same speed but better bonuses."
+    - item_id: 1215
+      item_name: Dragon dagger
+      slug: dragon-dagger
+      relationship: upgrade
+      description: "Members upgrade with a powerful special attack."
+    - item_id: 5680
+      item_name: Rune dagger(p)
+      slug: rune-dagger-p
+      relationship: variant
+      description: "Poisoned variant for a small DPS uplift in PvM/PvP."
+  about: "Rune dagger is the rune-tier stab dagger in OSRS, requiring 40 Attack to wield and 85 Smithing to forge from a single runite bar for 75 Smithing XP. It is fast (4-tick) with +25 stab and +24 strength, plus a unique +1 magic attack bonus that no other rune melee weapon offers. It ranks third among daggers behind the dragon and abyssal variants and is generally outclassed by the rune scimitar for general training; the F2P rune sword is the better stab option."
+  market_strategy:
+    notes:
+      - "Cheapest rune-tier stab weapon; demand is mostly mid-game F2P stab setups and ironman supply."
+      - "85 Smithing is a high gate, so supply leans on monster drops and bulk smithers."
+      - "GE buy limit 70 per 4 hours keeps it a low-volume flip."
+      - "High alch 4,800 gp regularly sits above GE price, making it a viable nature-rune alch target when stock is cheap."
+  trading_tips:
+    - "Watch the rune dagger vs nature rune spread - it occasionally beats steel platebodies for F2P alch gp/hr."
+    - "Stack offers across multiple buy-limit windows; the small limit blocks instant arbitrage."
+  history:
+    - date: "2001-08-13"
+      description: "Released with the original rune metal weapon set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-halberd.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-halberd.mdx
@@ -12,9 +12,87 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 70
-  about: "Rune halberd is a members-only item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: high
+  equipment:
+    slot: 2h
+    attack_bonus:
+      stab: 48
+      slash: 67
+      crush: 0
+      magic: -4
+      ranged: 0
+    defence_bonus:
+      stab: -1
+      slash: 4
+      crush: 5
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 68
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    requirements:
+      attack: 40
+      strength: 20
+    weight: 3.175
+    attack_speed: 7
+    attack_range: 2
+  shops:
+    - shop_name: Quartermaster's Stores
+      location: Tyras Camp
+      price: 83200
+      stock: 2
+      restock_seconds: 60
+      members_only: true
+  related_items:
+    - item_id: 3200
+      item_name: Adamant halberd
+      slug: adamant-halberd
+      relationship: downgrade
+      description: Lower-tier halberd
+    - item_id: 3204
+      item_name: Dragon halberd
+      slug: dragon-halberd
+      relationship: upgrade
+      description: Higher-tier halberd
+    - item_id: 1305
+      item_name: Rune longsword
+      slug: rune-longsword
+      relationship: alternative
+      description: Single-handed melee alternative
+  about: |-
+    The rune halberd is a two-handed reach weapon obtained from the Tyras Camp Quartermaster's Stores (Regicide quest required) for 83,200 coins. It attacks at two tiles, making halberds unique among melee weapons for safespotting.
+
+    | Stat | Value |
+    |------|-------|
+    | Stab | +48 |
+    | Slash | +67 |
+    | Strength | +68 |
+    | Attack speed | 7 ticks (4.2s) |
+    | Attack range | 2 tiles |
+
+    Requirements: 40 Attack, 20 Strength. Three attack styles: Controlled stab (shared XP), Aggressive slash (Strength), and Defensive stab (Defence).
+
+    The two-tile range is the defining feature — it allows melee safespotting through obstacles and against ranged-immune monsters that would otherwise be unreachable with a sword or scimitar.
+  market_strategy:
+    notes:
+      - Locked behind Regicide quest completion
+      - Tyras shop stock supports a hard supply floor at 83,200 gp
+      - Unique safespotting niche keeps PvM demand alive
+      - Buy limit of 70 throttles flips
+      - High alch barely covers shop purchase
+  trading_tips:
+    - Margin flips run thin versus shop price; track GE vs 83,200 gp shop
+    - Rune halberd alch is 38,400 — never profitable to high alch fresh
+    - Dragon halberd is the standard upgrade path at 70 Attack
+  history:
+    - date: "2004-09-20"
+      description: Released with the Regicide quest and Tyras Camp.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-keel-parts.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune keel parts | OSRS Price Data
-description: "Rune keel parts: Parts for creating a runite keel for a boat.. High alch: 12,000 GP, GE limit: 100."
+description: "Rune keel parts are a Sailing component smithed from 5 runite bars at 86 Smithing post-Pandemonium, combined into Large rune keel parts. High alch: 12,000 GP, GE limit: 100."
 osrs:
   id: 32014
   name: Rune keel parts
@@ -12,12 +12,73 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 100
-  about: "Rune keel parts is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: high
+  properties:
+    release_date: "2025-11-19"
+    update: "Sailing"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 4
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: smithing
+      level: 86
+      xp: 375
+      materials:
+        - item_id: 2363
+          item_name: Runite bar
+          quantity: 5
+      tools:
+        - Hammer
+      product: Rune keel parts
+      product_id: 32014
+      output_quantity: 1
+      notes: "Requires Pandemonium quest completion. Smithed at an anvil."
+  related_items:
+    - item_id: 32015
+      item_name: Large rune keel parts
+      slug: large-rune-keel-parts
+      relationship: product
+      description: "Combined keel section smithed from 5x Rune keel parts."
+    - item_name: Rune keel
+      slug: rune-keel
+      relationship: product
+      description: "Final boat keel assembled from 10x Rune keel parts + 5x Cupronickel bars."
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: "Smithing input - 5 bars per Rune keel part."
+  about: "Rune keel parts are a Smithing-crafted boat-keel component released with the Sailing skill, smithed from 5 runite bars per part at 86 Smithing for 375 XP after completing Pandemonium. Five Rune keel parts combine into Large rune keel parts, with the full Rune keel requiring 10 parts plus 5 cupronickel bars. They sit on the standard rune-bar supply chain, so price tracks runite ore farm output and bar smithing meta."
+  market_strategy:
+    notes:
+      - "Per-part recipe is currently -6,219 gp after GE tax - producers are loss-making at spot, expect upward drift."
+      - "GE buy limit of 100 per 4 hours throttles serious flips."
+      - "Supply gated by 86 Smithing + Pandemonium completion - genuine bottleneck."
+      - "Demand follows Sailing progression curve and large-keel construction throughput."
+  trading_tips:
+    - "Track runite bar spread - keel-part profitability flips with bar dips."
+    - "Stockpile during Sailing skill release lulls when crafters pause."
+    - "Cross-check Large rune keel parts spot - if (large) > 5x (parts) + GE tax, smith and combine."
+  history:
+    - date: "2025-11-19"
+      description: "Released alongside the Sailing skill as the runite-tier keel-construction Smithing intermediate."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h4.mdx
@@ -5,16 +5,102 @@ osrs:
   id: 7354
   name: Rune shield (h4)
   slug: rune-shield-h4
-  examine: A shield with a heraldic design
+  examine: A shield with a heraldic design.
   members: false
   icon: Rune shield (h4).png
   value: 54400
   lowalch: 21760
   highalch: 32640
   limit: 70
-  about: "Rune shield (h4) is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2006-02-20"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 44
+      slash: 48
+      crush: 46
+      magic: -1
+      ranged: 46
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Reward casket (hard)
+        quantity: "1"
+        rarity: Rare
+        notes: "Heraldic shield reward from hard clue scroll caskets."
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 1201
+      item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: alternative
+      description: "Standard rune kiteshield with identical combat bonuses."
+    - item_id: 7336
+      item_name: Rune shield (h1)
+      slug: rune-shield-h1
+      relationship: variant
+      description: "Alternate heraldic colour scheme from the same hard clue pool."
+    - item_id: 7348
+      item_name: Rune shield (h3)
+      slug: rune-shield-h3
+      relationship: variant
+      description: "Alternate heraldic colour scheme from the same hard clue pool."
+    - item_id: 7360
+      item_name: Rune shield (h5)
+      slug: rune-shield-h5
+      relationship: variant
+      description: "Alternate heraldic colour scheme from the same hard clue pool."
+  about: "Rune shield (h4) is a free-to-play heraldic variant of the rune kiteshield with identical combat stats, obtainable only as a hard treasure trail reward and traded for cosmetic value above the base kiteshield."
+  market_strategy:
+    notes:
+      - "Hard clue supply keeps prices above the equivalent rune kiteshield."
+      - "F2P availability since 2006 means demand spans both game modes."
+      - "Daily volume is modest; large flips require patience."
+  trading_tips:
+    - "Compare h1/h2/h3/h4/h5 spread to flip the cheapest pattern first."
+    - "Stock for fashionscape pushes and clue scroll content launches."
+  history:
+    - date: "2006-02-20"
+      description: "Released as a hard treasure trail reward."
+    - date: "2006-05-31"
+      description: "Renamed from \"Rune kiteshield(h)\" to \"Rune shield(h4)\"."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-sq-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-sq-shield.mdx
@@ -12,30 +12,98 @@ osrs:
   lowalch: 15360
   highalch: 23040
   limit: 70
-  item_id: 1185
-  item_type: armor
-  slot: shield
-  type: sq_shield
-  tradeable: true
-  weight: 3.628
-  requirements:
-    defence: 40
-  stats:
-    stab_defence: 38
-    slash_defence: 40
-    crush_defence: 36
-    ranged_defence: 38
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: mid-high
+  properties:
+    release_date: "2001-08-13"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type:
+    weight: 3.628
+    requirements:
+      defence: 40
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 38
+      slash: 40
+      crush: 36
+      magic: -1
+      ranged: 38
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 96
+      xp: 150
+      materials:
+        - item_name: Runite bar
+          quantity: 2
+      tools:
+        - Hammer
+        - Anvil
+      output_quantity: 1
   related_items:
-    - slug: rune-kiteshield
-    - slug: rune-defender
-    - slug: dragon-sq-shield
-    - slug: runite-bar
-  about: |-
-    *A medium square shield.*
-
-    The rune sq shield has lower defensive bonuses than the Rune kiteshield across all categories (e.g. +40 slash vs +48 slash on the kiteshield), but is lighter at 3.628 kg vs 5.443 kg. In F2P, the kiteshield is strictly better for tanking. Members should aim for a Rune defender or higher for the offensive bonuses. The Dragon sq shield is the direct upgrade.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_id: 1201
+      item_name: Rune kiteshield
+      slug: rune-kiteshield
+      relationship: upgrade
+      description: Larger rune shield with stronger defence
+    - item_id: 1187
+      item_name: Dragon sq shield
+      slug: dragon-sq-shield
+      relationship: upgrade
+      description: Higher tier square shield
+    - item_id: 8850
+      item_name: Rune defender
+      slug: rune-defender
+      relationship: alternative
+      description: Members defender with offensive bonuses
+    - item_id: 2363
+      item_name: Runite bar
+      slug: runite-bar
+      relationship: component
+      description: Smithing material used to forge the shield
+  about: "Rune sq shield is the rune-tier medium square shield smithed from 2 runite bars at 96 Smithing, requiring 40 Defence to wield. Defensive stats are slightly below the Rune kiteshield across the board (e.g. +40 slash vs +48), but it weighs less at 3.628 kg vs 5.443 kg. Available in free-to-play; members usually skip it in favour of the Rune defender for offensive bonuses, while the Dragon sq shield is the direct upgrade."
+  market_strategy:
+    notes:
+      - "Supply driven by Smithing trainers at 96 levels"
+      - "Steady F2P demand from low-budget tanks hitting 40 Defence"
+      - "Buy limit of 70 supports moderate flipping volume"
+      - "Outclassed by kiteshield and Rune defender, capping ceiling demand"
+  trading_tips:
+    - "Track runite bar pricing; two bars set the production floor"
+    - "Buy after Smithing XP rebalance announcements when supply spikes"
+    - "Sell to F2P bond events when new accounts gear up"
+  history:
+    - date: "2001-08-13"
+      description: "Released alongside the rune armour line in Free-to-play."
+    - date: "2015-07-09"
+      description: "Defence requirement clarified as 40 in the wiki refresh."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/samurai-gloves.mdx
@@ -1,6 +1,6 @@
 ---
 title: Samurai gloves | OSRS Price Data
-description: "Samurai gloves: Armoured gloves of the Samurai.. High alch: 1,920 GP, GE limit: 70."
+description: "Samurai gloves are members hand slot armour from the Colosseum's samurai set, rewarded for using sunfire fanatic kits. High alch: 1,920 GP, GE limit: 70."
 osrs:
   id: 20041
   name: Samurai gloves
@@ -12,9 +12,81 @@ osrs:
   lowalch: 1280
   highalch: 1920
   limit: 70
-  about: "Samurai gloves is a members-only item in Old School RuneScape. High alchemy value: 1,920 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2018-08-30"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    destroy: "Drop"
+  equipment:
+    slot: hands
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 20029
+      item_name: Samurai helmet
+      slug: samurai-helmet
+      relationship: set-piece
+      description: Head slot of the samurai cosmetic set
+    - item_id: 20035
+      item_name: Samurai shirt
+      slug: samurai-shirt
+      relationship: set-piece
+      description: Body slot of the samurai cosmetic set
+    - item_id: 20038
+      item_name: Samurai greaves
+      slug: samurai-greaves
+      relationship: set-piece
+      description: Legs slot of the samurai cosmetic set
+    - item_id: 20032
+      item_name: Samurai boots
+      slug: samurai-boots
+      relationship: set-piece
+      description: Feet slot of the samurai cosmetic set
+  market_strategy:
+    notes:
+      - "Pure cosmetic — no combat stats, fashionscape demand only"
+      - "Supply gated by Last Man Standing samurai kit conversions"
+      - "Buy limit 70 per 4 hours; thin order books on the GE"
+      - "High alch margin only meaningful with bulk LMS unlocks"
+  trading_tips:
+    - Bundle the full samurai set for collectors instead of trickling pieces
+    - Track price spikes during fashionscape events and LMS double-points weekends
+    - Avoid alching new buys; market value typically beats nature-rune profit
+  about: Samurai gloves are a hand slot cosmetic piece of the samurai set, released as a Last Man Standing reward and tradeable on the Grand Exchange. They have no combat stats.
+  history:
+    - date: "2018-08-30"
+      description: "Released alongside the samurai cosmetic set as a Last Man Standing reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-bolts.mdx
@@ -12,9 +12,107 @@ osrs:
   lowalch: 14
   highalch: 22
   limit: 11000
-  about: "Sapphire bolts is a members-only item in Old School RuneScape. High alchemy value: 22 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: low
+  equipment:
+    slot: ammo
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 83
+      magic_damage: 0
+      prayer: 0
+    weight: 0
+  recipes:
+    - skill: fletching
+      level: 56
+      xp: 4.7
+      materials:
+        - item_name: Mithril bolts
+          quantity: 10
+        - item_name: Sapphire bolt tips
+          quantity: 10
+      product: Sapphire bolts
+      output_quantity: 10
+    - skill: magic
+      level: 7
+      xp: 17.5
+      materials:
+        - item_name: Sapphire bolts
+          quantity: 10
+        - item_name: Cosmic rune
+          quantity: 1
+        - item_name: Mind rune
+          quantity: 1
+        - item_name: Water rune
+          quantity: 1
+      product: Sapphire bolts (e)
+      output_quantity: 10
+      notes: Enchant Crossbow Bolt (Sapphire) spell.
+  related_items:
+    - item_id: 9189
+      item_name: Sapphire bolt tips
+      slug: sapphire-bolt-tips
+      relationship: component
+      description: Gem tip required for fletching
+    - item_id: 9145
+      item_name: Mithril bolts
+      slug: mithril-bolts
+      relationship: component
+      description: Base bolt receiving the tip
+    - item_id: 9240
+      item_name: Sapphire bolts (e)
+      slug: sapphire-bolts-e
+      relationship: upgrade
+      description: Enchanted Sapphire bolts
+    - item_id: 21932
+      item_name: Sapphire dragon bolts
+      slug: sapphire-dragon-bolts
+      relationship: alternative
+      description: Dragon variant
+  about: |-
+    Sapphire bolts are a low-tier enchantable crossbow ammunition. Fletch at level 56 from 10 mithril bolts + 10 sapphire bolt tips (4.7 XP per 10), then enchant via Enchant Crossbow Bolt (Sapphire) at level 7 Magic to unlock the Clear Mind effect, which has a 5% chance to drain the target's prayer.
+
+    | Property | Value |
+    |----------|-------|
+    | Slot | Ammo |
+    | Ranged strength | +83 |
+    | Weight | 0 kg |
+
+    | Recipe | Level | XP |
+    |--------|-------|-----|
+    | Fletch (10) | 56 Fletching | 4.7 |
+    | Enchant (10) | 7 Magic | 17.5 |
+
+    Enchanted variants are popular for PK builds that benefit from prayer drain pressure.
+  market_strategy:
+    notes:
+      - Demand driven by Enchant Crossbow Bolt (Sapphire) supply
+      - Low GE buy limit pressure (11,000 per 4h)
+      - Fletching margin runs ~160 gp per 10 bolts
+      - Mid-tier Magic enchanters drive bulk flips
+      - PK supply demand fluctuates with PvP events
+  trading_tips:
+    - Sapphire bolt tip price drives margin
+    - Watch (e) variant demand for PK season swings
+    - Sapphire bolt fletching is profitable at 56 Fletching
+  history:
+    - date: "2006-07-31"
+      description: Released with the Crossbow expansion.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/security-book.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/security-book.mdx
@@ -1,6 +1,6 @@
 ---
 title: Security book | OSRS Price Data
-description: "Security book: WARNING: Contains information which could make your account secure!. High alch: 1 GP, GE limit: 15."
+description: "Security book: a book containing tips for keeping your OSRS account safe. High alch: 1 GP, GE limit: 15."
 osrs:
   id: 9003
   name: Security book
@@ -12,9 +12,58 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Security book is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: book
+    tier: low
+  properties:
+    release_date: "2007-06-26"
+    update: "Account Security"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Read
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Diango's Toy Store"
+      location: Draynor Village
+      price: 1
+      currency: coins
+      notes: "Reclaimable from Diango if lost."
+  related_items:
+    - item_name: Stronghold of Security helm
+      slug: fremennik-helm
+      relationship: alternative
+      description: Reward from completing the Stronghold of Security alongside the security book.
+    - item_name: Fancy boots
+      slug: fancy-boots
+      relationship: alternative
+      description: Alternative reward path from the Stronghold of Security.
+  about: |-
+    The Security book is handed out to players who complete the Stronghold of Security, summarising Jagex's official advice on account security: authenticators, strong passwords, anti-phishing tips, and reporting suspicious activity.
+
+    It is a tradeable, free-to-play item with no combat use. Lost copies can be reclaimed from Diango in Draynor Village.
+  market_strategy:
+    notes:
+      - "Limited market depth due to 15 buy-limit."
+      - "Demand is purely cosmetic and from collection-log hunters."
+      - "Held cheap by Diango reclaim fallback."
+  trading_tips:
+    - "Reclaim from Diango if you lose the original copy."
+    - "Treat as a low-effort collection log tick when running F2P content."
+  history:
+    - date: "2007-06-26"
+      description: "Released alongside the Stronghold of Security update."
+    - date: "2013-02-22"
+      description: "OSRS launch carried the security book forward unchanged."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/seed-dibber.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/seed-dibber.mdx
@@ -1,6 +1,6 @@
 ---
 title: Seed dibber | OSRS Price Data
-description: "Seed dibber: Use this to plant seeds with.. High alch: 3 GP, GE limit: 40."
+description: "Seed dibber: Use this to plant seeds with. High alch: 3 GP, GE limit: 40."
 osrs:
   id: 5343
   name: Seed dibber
@@ -12,9 +12,65 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 40
-  about: "Seed dibber is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: farming-tool
+    tier: low
+  properties:
+    release_date: "2005-06-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.002
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Head Farmer Jones's Farming Shop"
+      location: "Farming Guild"
+      price: 6
+      currency: Coins
+      stock: 5
+    - shop_name: "Olivia's Tool Store"
+      location: "Draynor Village"
+      price: 6
+      currency: Coins
+      stock: 5
+    - shop_name: "Heskel's Farming Shop"
+      location: "Falador"
+      price: 6
+      currency: Coins
+      stock: 5
+  related_items:
+    - item_name: Rake
+      slug: rake
+      relationship: alternative
+      description: "Companion farming tool for clearing weeds before planting"
+    - item_name: Spade
+      slug: spade
+      relationship: alternative
+      description: "Companion farming tool for digging up crops"
+    - item_name: Watering can
+      slug: watering-can
+      relationship: alternative
+      description: "Companion farming tool used to water flower and allotment seeds"
+  about: "The seed dibber is a baseline members-only Farming tool used to plant seeds in allotments, flower patches, and most herb patches across Gielinor. It costs 6 gp from farming shops, weighs effectively nothing, and stores in tool leprechauns near patches; completing the Barbarian Training Farming subquest removes the need to carry one entirely."
+  market_strategy:
+    notes:
+      - "Shop stock at 6 gp keeps GE price pinned near vendor value"
+      - "Demand is one-per-account at most, so flip upside is negligible"
+      - "Bulk buying is gated by the 40-per-4-hour GE limit"
+  trading_tips:
+    - "Skip GE flips, simply restock from Olivia or Head Farmer Jones"
+    - "Useful as a cheap stocking line for ironman alts setting up Farming runs"
+  history:
+    - date: "2005-06-06"
+      description: "Released with the Farming skill in the 2005 farming update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/serpentine-helm-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/serpentine-helm-uncharged.mdx
@@ -1,6 +1,6 @@
 ---
 title: Serpentine helm (uncharged) | OSRS Price Data
-description: "Serpentine helm (uncharged) is a members head slot item requiring 75 Defence. High alch: 66,000 GP, GE limit: 8."
+description: "Serpentine helm (uncharged) is the tradeable, uncharged form of the venom-immune serpentine helm, requiring 75 Defence and Zulrah's scales to activate. High alch: 66,000 GP, GE limit: 8."
 osrs:
   id: 12929
   name: Serpentine helm (uncharged)
@@ -12,95 +12,118 @@ osrs:
   lowalch: 44000
   highalch: 66000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: serpentine
+    tier: high
+  properties:
+    release_date: "2015-01-08"
+    update: "Zulrah"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.9
+    options:
+      - Charge
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: helm
-    attack_style: melee
+    weapon_type: helm
+    weight: 0.9
     requirements:
       defence: 75
-    stats:
-      defence_stab: 52
-      defence_slash: 55
-      defence_crush: 58
-      defence_ranged: 50
-      strength: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 52
+      slash: 55
+      crush: 58
       magic: -5
-      ranged: -5
+      ranged: 50
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+    notes: "Uncharged form cannot actually be equipped; defence stats listed reflect the charged serpentine helm and apply once activated with Zulrah's scales."
   charging:
     material_id: 12934
     material_name: Zulrah's scales
     max_charges: 11000
-    duration: 16.5 hours of combat
+    rate: "1 scale per 10 minutes of combat"
+    duration: "16.5 hours of combat at full charge"
+    notes: "Helm becomes equipable only while it has scales loaded. Uncharging is irreversible and refunds 20,000 scales when the helm is dismantled."
   passive_effects:
     - name: Venom Immunity
-      description: Immune to venom and poison
+      description: "Grants immunity to venom and poison while equipped in charged form."
     - name: Melee Venom
-      description: 16.7% chance to envenom on melee hit
+      description: "1/6 (16.7%) chance to envenom non-poisoned weapons on melee hits; ~50% with poisoned weapons; 100% with the toxic blowpipe and toxic staff of the dead. Does not work against players."
+  recipes:
+    - skill: crafting
+      level: 52
+      xp: 120
+      materials:
+        - item_name: Serpentine visage
+          quantity: 1
+      tools:
+        - Chisel
+      output_quantity: 1
+      notes: "Use a chisel on a Serpentine visage to craft the uncharged helm."
   related_items:
-    - item_id: 12934
-      item_name: Zulrah's scales
-      slug: zulrahs-scales
-      relationship: component
-      description: Charges
     - item_id: 12927
       item_name: Serpentine visage
       slug: serpentine-visage
       relationship: component
-      description: From Zulrah
+      description: "Rare Zulrah drop chiselled into the uncharged helm at 52 Crafting."
+    - item_id: 12934
+      item_name: Zulrah's scales
+      slug: zulrahs-scales
+      relationship: component
+      description: "Charges the helm; 11,000 scales for a full 16.5-hour charge."
+    - item_id: 12931
+      item_name: Magma helm (uncharged)
+      slug: magma-helm-uncharged
+      relationship: variant
+      description: "Cosmetic recolour via magma mutagen."
+    - item_id: 13197
+      item_name: Tanzanite helm (uncharged)
+      slug: tanzanite-helm-uncharged
+      relationship: variant
+      description: "Cosmetic recolour via tanzanite mutagen."
     - item_id: 12924
       item_name: Toxic blowpipe
       slug: toxic-blowpipe
       relationship: alternative
-      description: Also uses scales
-  about: |-
-    Use chisel on Serpentine visage.
-
-    | Requirement | Value |
-    |-------------|-------|
-    | Crafting | 52 |
-    | XP | 120 |
-
-    | Defence | Value |
-    |---------|-------|
-    | Stab | +52 |
-    | Slash | +55 |
-    | Crush | +58 |
-    | Ranged | +50 |
-
-    | Offense | Value |
-    |---------|-------|
-    | Strength | +5 |
-    | Magic | -5 |
-    | Ranged | -5 |
-
-    Requirements: 75 Defence
-
-    Venom Immunity:
-    - Immune to venom and poison
-
-    Melee Venom:
-    - 16.7% chance to envenom on melee hit
-
-    - 11,000 scales for full charge
-    - 16.5 hours of combat
-    - ~2.4M per full charge
-
-    BiS for:
-    - Zulrah (venom immunity)
-    - Any venom content
-    - AFK melee training
-
-    Only helm with venom immunity.
+      description: "Other Zulrah-themed gear that also consumes Zulrah's scales."
+  about: "Serpentine helm (uncharged) is the tradeable form of the only venom-immune helm in OSRS, crafted at 52 Crafting from a serpentine visage and chisel for 120 Crafting XP. It must be charged with Zulrah's scales (11,000 for a full 16.5 hours of combat) before it can be equipped; once active it grants permanent venom and poison immunity while worn, plus a 1/6 chance to envenom enemies on melee hits - making it BiS for Zulrah, any venom-heavy content, and a popular AFK melee training helm."
   market_strategy:
     notes:
-      - Scales from Zulrah
-      - Recolors available
-      - High upkeep cost
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply pegged to serpentine visage drops from Zulrah; demand spikes follow toxic blowpipe and Zulrah meta cycles"
+      - "Buy limit of 8 per 4 hours keeps the uncharged form thinly traded and price-sensitive"
+      - "Scale upkeep (~118k/hour) is the real cost driver - track Zulrah's scales GE for downstream pricing"
+      - "Recolour mutagens (magma/tanzanite) divert supply into cosmetic variants when fashionscape demand spikes"
+  trading_tips:
+    - "Watch Zulrah drop rate or table reworks - any change directly resets visage supply"
+    - "Pair uncharged serpentine helm orders with Zulrah's scales to dollar-cost the full-charge cost"
+    - "Toxic blowpipe demand drains scales; rising blowpipe prices typically pull helm prices with them"
+  history:
+    - date: "2015-01-08"
+      description: "Released with the Zulrah update as the first venom-immune headgear."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-alchemist.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-alchemist.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of the alchemist | OSRS Price Data
-description: "Sigil of the alchemist: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP, GE limit: 10."
+description: "Sigil of the alchemist is a Deadman Mode sigil drop that, once attuned, lets the wearer batch-process herbs and potions in a single click. High alch: 6,000 GP, GE limit: 10."
 osrs:
   id: 26027
   name: Sigil of the alchemist
@@ -12,9 +12,67 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of the alchemist is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: sigil
+    tier: high
+  properties:
+    release_date: "2021-08-25"
+    update: "Deadman: Reborn"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Attune
+      - Drop
+    alchable: true
+    destroy: "Drop"
+    seasonal: true
+  passive_effects:
+    - name: Batch herblore processing
+      description: "Once attuned, allows the player to clean herbs or craft potions in a single batched action instead of one at a time."
+    - name: Attuned, untradeable
+      description: "After attunement the sigil becomes character-bound and must be un-attuned before destruction."
+  drop_table:
+    sources:
+      - source: Deadman Mode rare drop table
+        rarity: very rare
+        members_only: true
+  related_items:
+    - item_id: 26025
+      item_name: Sigil of the menacing mage
+      slug: sigil-of-the-menacing-mage
+      relationship: alternative
+      description: Deadman sigil that boosts magic combat utility.
+    - item_id: 26019
+      item_name: Sigil of the smith
+      slug: sigil-of-the-smith
+      relationship: alternative
+      description: Deadman sigil that batches Smithing operations.
+    - item_id: 26033
+      item_name: Sigil of the formidable fighter
+      slug: sigil-of-the-formidable-fighter
+      relationship: alternative
+      description: Deadman sigil that boosts melee combat utility.
+  about: "Sigil of the alchemist is a Deadman Mode reward sigil released with the Deadman: Reborn season on 25 August 2021. The un-attuned version drops from most monsters via the Deadman rare drop table and is tradeable; once activated through the Attune option it becomes character-bound and unlocks single-click batch herbal processing - cleaning grimy herbs or making potions in one batched action. The sigil exists only inside Deadman Mode seasons and is unobtainable in the main game outside event windows."
+  market_strategy:
+    notes:
+      - "Demand spikes inside each Deadman season as alchers race to clear potion inventories."
+      - "GE buy limit of 10 per 4 hours severely throttles flips."
+      - "High alch of 6,000 gp is below GE price - not an alch target."
+      - "Supply is seasonal - the un-attuned sigil only enters circulation during active Deadman events."
+  trading_tips:
+    - "Trade only during active Deadman seasons - off-season liquidity is effectively zero."
+    - "Watch sigil rebalances - prior seasons have moved Alchemist value sharply when the herblore meta shifted."
+    - "Track other batch sigils as comparables - Smith and Tools sigils move with similar demand drivers."
+  history:
+    - date: "2021-08-25"
+      description: "Released with the Deadman: Reborn season as part of the new sigil reward family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-craftsman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-craftsman.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of the craftsman | OSRS Price Data
-description: "Sigil of the craftsman: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP, GE limit: 10."
+description: "Sigil of the craftsman is a Sanguine Sands-tier passive sigil that lets Smithing produce extra bars and items while attuned. High alch: 6,000 GP, GE limit: 10."
 osrs:
   id: 26036
   name: Sigil of the craftsman
@@ -12,9 +12,65 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of the craftsman is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: sigil
+    tier: high
+  properties:
+    release_date: "2022-03-30"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Attune
+      - Drop
+    destroy: "Once attuned the sigil's power becomes part of you."
+  drop_table:
+    sources:
+      - source: Tombs of Amascut chest reward
+        combat_level: 0
+        quantity: "1"
+        rarity: very-rare
+        notes: "Rolled from the unique table after a Tombs of Amascut raid completion"
+  passive_effects:
+    - name: Craftsman
+      description: "Grants a chance for extra output bars when smelting and extra items when smithing while the sigil is attuned."
+      trigger: while_worn
+      affected_skill: smithing
+      chance: 0.1
+  related_items:
+    - item_name: Sigil of the gunslinger
+      slug: sigil-of-the-gunslinger
+      relationship: variant
+      description: Ranged-DPS sigil from the Hueycoatl reward table
+    - item_name: Sigil of devotion
+      slug: sigil-of-devotion
+      relationship: alternative
+      description: Prayer-focused sigil from the same reward pool
+    - item_name: Sigil of the formidable fighter
+      slug: sigil-of-the-formidable-fighter
+      relationship: alternative
+      description: Melee combat sigil rolled on the same Tombs of Amascut table
+  market_strategy:
+    notes:
+      - "Buy limit only 10 per 4 hours — extreme thin liquidity"
+      - "Drop rate gated by Tombs of Amascut completions per hour"
+      - "Demand from Smithing XP racers stacking craftsman procs"
+      - "Attuning consumes the sigil; resale only viable on the unattuned item"
+      - "High alch barely above cost — never alch a tradeable copy"
+  trading_tips:
+    - Verify untradeable vs tradeable state before listing; attuned sigils cannot be sold
+    - Stack craftsman sigils across alts to maximise Smithing XP/hr
+    - Watch for spikes during Smithing rework patches and Blast Furnace bonus weekends
+  about: Sigil of the craftsman is a tradeable Tombs of Amascut sigil that, once attuned, gives a chance for extra output when smelting bars and smithing items, accelerating Smithing XP/hr.
+  history:
+    - date: "2022-03-30"
+      description: "Sigil pool introduced as a chase reward layer for Tombs of Amascut raid scaling."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-forager.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-forager.mdx
@@ -12,9 +12,60 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
-  about: "Sigil of the forager is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: high
+  passive_effects:
+    - name: Forager (Armageddon/Reborn)
+      description: Doubles harvested resources from Mining, Fishing, Woodcutting, and Farming. Does not stack with Sigil of Enhanced Harvest.
+    - name: Forager (Apocalypse)
+      description: Triples harvested resources from Mining, Fishing, Woodcutting, and Farming during the Apocalypse Deadman event.
+  drop_table:
+    sources:
+      - source: Deadman Mode drop table
+        quantity: "1"
+        rarity: rare
+        members_only: true
+  related_items:
+    - item_id: 26100
+      item_name: Sigil of enhanced harvest
+      slug: sigil-of-enhanced-harvest
+      relationship: alternative
+      description: Conflicting skilling sigil — does not stack
+    - item_id: 26104
+      item_name: Sigil of the menacing mage
+      slug: sigil-of-the-menacing-mage
+      relationship: alternative
+      description: Combat-focused Deadman sigil
+  about: |-
+    The sigil of the forager is a Deadman Mode-exclusive power sigil that doubles (or triples in Apocalypse) the resources gained from Mining, Fishing, Woodcutting, and Farming actions. The un-attuned version is dropped across the Deadman drop table; once attuned, it cannot be traded.
+
+    | Effect | Event |
+    |--------|-------|
+    | 2x resources | Armageddon / Reborn |
+    | 3x resources | Apocalypse |
+
+    Does not stack with the Sigil of Enhanced Harvest — pick one or the other for the skilling slot.
+
+    Only obtainable while a Deadman Mode event is live; not available in the standard live game.
+  market_strategy:
+    notes:
+      - Deadman-event-only — supply tied to active events
+      - Buy limit 8 per 4 hours throttles speculative flips
+      - Off-event prices collapse on the main game
+      - Watch Deadman event windows for re-issuance
+      - Powerful skilling boost during live events
+  trading_tips:
+    - Only buy/sell during active Deadman events
+    - Compare against Sigil of Enhanced Harvest pricing
+    - Track event countdown announcements for entry windows
+  history:
+    - date: "2021-08-25"
+      description: Released for Deadman Reborn.
+    - date: "2023-08-23"
+      description: Received a graphical update.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-gunslinger.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-gunslinger.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of the gunslinger | OSRS Price Data
-description: "Sigil of the gunslinger: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP."
+description: "Sigil of the gunslinger is a Leagues-style passive sigil dropped at Hueycoatl that boosts ranged weapon attack speed. High alch: 6,000 GP."
 osrs:
   id: 29676
   name: Sigil of the gunslinger
@@ -11,10 +11,66 @@ osrs:
   value: 10000
   lowalch: 4000
   highalch: 6000
-  limit: null
-  about: "Sigil of the gunslinger is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: sigil
+    tier: high
+  properties:
+    release_date: "2024-09-25"
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Attune
+      - Drop
+    destroy: "Once attuned the sigil's power becomes part of you."
+  drop_table:
+    sources:
+      - source: The Hueycoatl
+        combat_level: 695
+        quantity: "1"
+        rarity: rare
+        drop_rate: "1/300"
+        notes: "Rolled on the unique table after a successful Hueycoatl kill"
+  passive_effects:
+    - name: Gunslinger
+      description: "Reduces the attack speed of two-handed ranged weapons by 1 tick (faster shots) while attuned."
+      trigger: while_worn
+      affected_skill: ranged
+      boost_formula: "attack_speed - 1 tick"
+  related_items:
+    - item_name: Sigil of the craftsman
+      slug: sigil-of-the-craftsman
+      relationship: variant
+      description: Another sigil that boosts a non-combat workflow
+    - item_name: Sigil of slaughter
+      slug: sigil-of-slaughter
+      relationship: alternative
+      description: Melee-focused passive sigil from the same Hueycoatl drop table
+    - item_name: Sigil of the smith
+      slug: sigil-of-the-smith
+      relationship: alternative
+      description: Smithing-focused sigil from a comparable boss drop pool
+  market_strategy:
+    notes:
+      - "Untradeable; value is purely utility for ranged DPS attuning"
+      - "Hueycoatl is the only drop source — supply gated by boss popularity"
+      - "Best-in-slot QoL for ranged 2h DPS races (Bowfa, tbow, Zaryte cbow)"
+      - "High alch only meaningful if you intentionally vendor an attuned sigil"
+  trading_tips:
+    - Attuning consumes the sigil permanently — confirm DPS gain before binding
+    - Use a sigil swap setup with the slaughter sigil to cover melee + ranged
+    - Verify Hueycoatl encounter mechanics before grinding for repeat sigils
+  about: Sigil of the gunslinger is a Hueycoatl-exclusive passive sigil that, once attuned, reduces the attack speed of two-handed ranged weapons by one tick. The sigil is untradeable and consumed on attunement.
+  history:
+    - date: "2024-09-25"
+      description: "Released as part of The Hueycoatl boss launch and Varlamore: The Final Dawn content drop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/silver-bolts-unf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Silver bolts (unf) | OSRS Price Data
-description: "Silver bolts (unf): Unfeathered silver crossbow bolts.. High alch: 1 GP, GE limit: 13,000."
+description: "Silver bolts (unf) are unfeathered silver crossbow bolts cast at 21 Crafting from a Silver bar and fletched into Silver bolts with feathers. High alch: 0 GP, GE limit: 13,000."
 osrs:
   id: 9382
   name: Silver bolts (unf)
@@ -12,9 +12,68 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Silver bolts (unf) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: silver
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 21
+      xp: 50
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+      tools:
+        - Bolt mould
+        - Furnace
+      product: Silver bolts (unf)
+      output_quantity: 10
+  related_items:
+    - item_name: Silver bar
+      slug: silver-bar
+      relationship: component
+      description: Smelted at the furnace and cast through a bolt mould to produce 10 unfeathered silver bolts
+    - item_name: Feather
+      slug: feather
+      relationship: component
+      description: Added at 43 Fletching to finish Silver bolts (unf) into Silver bolts
+    - item_name: Silver bolts
+      slug: silver-bolts
+      relationship: product
+      description: Finished crossbow bolt fletched from Silver bolts (unf) and feathers
+    - item_name: Steel bolts (unf)
+      slug: steel-bolts-unf
+      relationship: upgrade
+      description: Next-tier unfeathered bolt cast from a Steel bar
+  about: "Silver bolts (unf) are unfeathered silver crossbow bolt blanks cast from a Silver bar at 21 Crafting using a bolt mould at a furnace, producing 10 bolts for 50 Crafting XP; players later add feathers at 43 Fletching to finish them into Silver bolts used in Vampyre Slayer or against pyrefiend-style enemies."
+  market_strategy:
+    notes:
+      - "Not alchable - pure crafting/fletching intermediate, no NPC value floor"
+      - "Niche demand - the finished Silver bolts are mostly used against Vampyres in Theatre of Blood"
+      - "GE buy limit of 13,000 per 4 hours easily covers fletcher restocks"
+      - "Supply ties to Silver bar prices and bolt mould throughput"
+  trading_tips:
+    - "Track Silver bar spot price - feathering margin sets the GE floor"
+    - "Demand spikes around Vampyric Slayer task/Theatre of Blood meta shifts"
+    - "Low-volume item - lean on small consistent margins, not big swings"
+  history:
+    - date: "2006-07-31"
+      description: "Released alongside the Fletching Crossbows update introducing castable metal bolt blanks."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skeletal-top.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 18000
   highalch: 27000
   limit: 70
+  material:
+    type: hybrid-armour
+    tier: mid-high
   equipment:
     slot: body
     attack_bonus:
@@ -60,6 +63,8 @@ osrs:
       relationship: alternative
       description: Slightly superior alternative
   about: |-
+    The skeletal top is a hybrid melee/magic body piece dropped by Dagannoth Prime at a 1/128 rate. It is part of the Fremennik skeletal set and requires 40 Defence and 40 Magic to wear.
+
     | Attack | Value |
     |--------|-------|
     | Magic | +8 |
@@ -91,8 +96,17 @@ osrs:
       - Dagannoth Prime drop (passive from DK farming)
       - Splitbark body is generally preferred for stats
       - Low trade volume — niche item
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Costume Room storage drives ironman/collector demand
+      - GE buy limit 70 supports flips of small batches
+  trading_tips:
+    - Track DK farming team metas for short-term supply
+    - Cosmetic/set collectors keep a price floor
+    - Compare against splitbark body daily for upgrade arbitrage
+  history:
+    - date: "2005-07-04"
+      description: Released with the Royal Trouble quest and Waterbirth Island rework.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/soiled-page.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/soiled-page.mdx
@@ -12,9 +12,67 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 11000
-  about: "Soiled page is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: page
+    tier: mid-high
+  properties:
+    release_date: "2024-09-25"
+    update: "Hueycoatl"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.005
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: runecraft
+      level: 50
+      xp: 0
+      facility: Book of Earthen Might
+      materials:
+        - item_name: Desiccated page
+          quantity: 1
+      output_quantity: 1
+      notes: "Convert a desiccated page into a soiled page at the Book of Earthen Might facility."
+  drop_table:
+    sources:
+      - source: The Hueycoatl
+        combat_level: 642
+        quantity: "4-80"
+        rarity: "1/13.6"
+        notes: "Primary drop from The Hueycoatl boss in Varlamore."
+  related_items:
+    - item_name: Tome of earth
+      slug: tome-of-earth
+      relationship: product
+      description: Each soiled page adds 20 charges to the Tome of Earth.
+    - item_name: Desiccated page
+      slug: desiccated-page
+      relationship: component
+      description: Crafted into a soiled page at the Book of Earthen Might.
+  about: |-
+    Soiled page is a charge consumable for the Tome of Earth, used by mages who want a 10% damage and accuracy boost on earth spells. Each page adds 20 charges to the tome, and the pages themselves are produced by converting desiccated pages at the Book of Earthen Might with level 50 Runecraft.
+
+    The primary source of soiled pages is The Hueycoatl, a Varlamore boss released in September 2024 that drops 4-80 pages at roughly 1 in 13.6 kills.
+  market_strategy:
+    notes:
+      - "Bulk supply tied to Hueycoatl kill volume; price softens when the boss is meta."
+      - "Demand from mages charging Tome of Earth for raids and Slayer; steady consumable flow."
+      - "Avoid alching — high alch returns only 120 gp vs GE price."
+  trading_tips:
+    - "Stock up during Hueycoatl boss-of-the-week events when supply spikes."
+    - "Flip in 1k+ lots; 11k buy limit per 4 hours gives meaningful inventory turnover."
+    - "Watch for new earth-spell content that drives Tome of Earth demand."
+  history:
+    - date: "2024-09-25"
+      description: "Released as a drop from The Hueycoatl during the Varlamore update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/soulreaper-axe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/soulreaper-axe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Soulreaper axe | OSRS Price Data
-description: "Soulreaper axe is a members weapon slot item requiring 80 Attack. High alch: 144,000 GP."
+description: "Soulreaper axe is the BiS two-handed melee weapon requiring 80 Attack and Strength, assembled from the four Desert Treasure II boss components. High alch: 144,000 GP."
 osrs:
   id: 28338
   name: Soulreaper axe
@@ -11,36 +11,61 @@ osrs:
   value: 240000
   lowalch: 96000
   highalch: 144000
-  limit: null
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: soulreaper
+    tier: mid
+  properties:
+    release_date: "2023-07-26"
+    update: "Desert Treasure II - The Fallen Empire"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.825
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: two-handed axe
-    tradeable: true
+    weapon_type: two-handed axe
     weight: 2.825
+    attack_speed: 5
     requirements:
       attack: 80
       strength: 80
-    stats:
-      attack_stab: 28
-      attack_slash: 134
-      attack_crush: 66
-      attack_magic: 0
-      attack_ranged: 0
-      defence_stab: 0
-      defence_slash: 0
-      defence_crush: 0
-      defence_magic: 0
-      defence_ranged: 0
-      strength: 121
+    attack_bonus:
+      stab: 28
+      slash: 134
+      crush: 66
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 121
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  passive_effect:
-    name: Soul Stacks
-    description: Each attack builds a stack (max 5). +6% strength per stack, up to +30% at 5 stacks. Take 8 damage per attack while building.
+  passive_effects:
+    - name: Soul Stacks
+      description: "Each attack builds a Soul Stack (max 5), granting +6 percent Strength per stack up to +30 percent at 5 stacks. Player takes 8 typeless damage per attack while stacks build, capping at 8 HP remaining."
   special_attack:
     name: Behead
-    effect: Consumes stacks for accuracy/damage boost and healing
+    cost: 0
+    effect: "Consumes all Soul Stacks for an accuracy and damage boost scaled by stacks consumed, healing the wielder for damage dealt. Does not use special attack energy."
   recipes:
     - skill: magic
       level: 75
@@ -63,52 +88,52 @@ osrs:
           quantity: 2000
       product: Soulreaper axe
       product_id: 28338
+      output_quantity: 1
+      notes: "Magic level of 75 cannot be boosted. Combined at the lectern in the Ancient Vault."
   related_items:
     - item_id: 28319
       item_name: Executioner's axe head
       slug: executioners-axe-head
       relationship: component
-      description: Component from Vardorvis
+      description: "Unique drop from Vardorvis - the axe body."
     - item_id: 28325
       item_name: Leviathan's lure
       slug: leviathans-lure
       relationship: component
-      description: Component from Leviathan
+      description: "Unique drop from The Leviathan."
+    - item_id: 28323
+      item_name: Siren's staff
+      slug: sirens-staff
+      relationship: component
+      description: "Unique drop from The Whisperer."
+    - item_id: 28321
+      item_name: Eye of the duke
+      slug: eye-of-the-duke
+      relationship: component
+      description: "Unique drop from Duke Sucellus."
     - item_id: 22325
       item_name: Scythe of vitur
       slug: scythe-of-vitur
       relationship: alternative
-      description: Alternative BiS melee weapon
-  about: |-
-    | Offence | Bonus |
-    |---------|-------|
-    | Stab | +28 |
-    | Slash | +134 |
-    | Crush | +66 |
-    | Strength | +121 |
-
-    Soul Stacks: Each attack builds a stack (max 5).
-
-    | Stacks | Strength Bonus |
-    |--------|----------------|
-    | 1 | +6% |
-    | 5 | +30% |
-
-    Damage: Take 8 damage per attack while building stacks.
-
-    Behead: Consumes stacks for accuracy/damage boost and healing.
-
-    Used for:
-    - Maximum melee DPS
-    - Bossing with healing
-    - Strength training
-
-    Highest DPS melee weapon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Theatre of Blood BiS slash weapon - higher DPS without self-damage."
+  about: "Soulreaper axe is the post-Desert Treasure II two-handed BiS crush/slash weapon, requiring 80 Attack and Strength to wield and 75 Magic (unboostable) to assemble at the Ancient Vault lectern. Its Soul Stacks mechanic trades self-damage for a stacking Strength bonus up to +30 percent, and the free Behead special heals the user. It excels at single-target bossing where the player can mitigate or out-heal the self-damage tax."
+  market_strategy:
+    notes:
+      - "Price is the sum of four DT2 unique drops plus 2,000 blood runes - fundamentals follow boss kills per hour."
+      - "Not GE-limited (limit null), so high-roll buyers can move size."
+      - "Demand swings hard on new high-tier PvM releases that favor crush/slash."
+      - "High alch of 144,000 gp is far below cost - never alch."
+  trading_tips:
+    - "Track component price spread: arbitrage when sum-of-parts diverges from assembled axe."
+    - "Buy Executioner's axe head and Eye of the duke dips - those bosses are the bottleneck."
+    - "Pre-position before announced PvM updates - history shows 30 percent plus swings on meta shifts."
+  history:
+    - date: "2023-07-26"
+      description: "Released with Desert Treasure II - The Fallen Empire as the four-boss combine reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-air.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-air.mdx
@@ -1,6 +1,6 @@
 ---
 title: Staff of air | OSRS Price Data
-description: "Staff of air: A Magical staff.. High alch: 900 GP, GE limit: 125."
+description: "Staff of air is a F2P elemental staff with +10 magic attack and unlimited air runes when wielded. High alch: 900 GP, GE limit: 125."
 osrs:
   id: 1381
   name: Staff of air
@@ -12,25 +12,102 @@ osrs:
   lowalch: 600
   highalch: 900
   limit: 125
-  item_id: 1381
-  item_type: equipment
-  slot: weapon
-  type: staff
-  tradeable: true
-  weight: 2.267
-  requirements:
-    magic: 0
-  stats:
-    magic_attack: 10
-    magic_defence: 10
-  effect:
-    description: Provides unlimited air runes when equipped.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: staff
+    tier: mid
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: staff
+    weight: 2.267
+    attack_speed: 5
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: -1
+      crush: 7
+      magic: 10
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 10
+      ranged: 0
+    other_bonus:
+      melee_strength: 3
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Unlimited air runes
+      description: "Provides unlimited air runes for spellcasting while wielded."
+  shops:
+    - shop_name: Zaff's Superior Staffs!
+      location: Varrock
+      price: 1500
+      currency: Coins
+      stock: 5
+  drop_table:
+    sources:
+      - source: Beginner Treasure Trails reward casket
+        rarity: clue
+        members_only: false
+      - source: Easy Treasure Trails reward casket
+        rarity: clue
+        members_only: false
   related_items:
-    - slug: air-battlestaff
-    - slug: mystic-air-staff
-  about: Provides unlimited air runes when equipped.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Air battlestaff
+      slug: air-battlestaff
+      relationship: upgrade
+      description: "Next-tier air staff with stronger combat bonuses."
+    - item_name: Mystic air staff
+      slug: mystic-air-staff
+      relationship: upgrade
+      description: "Mystic-tier upgrade requiring 40 Magic and 40 Attack."
+    - item_name: Staff of water
+      slug: staff-of-water
+      relationship: alternative
+      description: "Same tier elemental staff providing unlimited water runes."
+    - item_name: Staff of earth
+      slug: staff-of-earth
+      relationship: alternative
+      description: "Same tier elemental staff providing unlimited earth runes."
+    - item_name: Staff of fire
+      slug: staff-of-fire
+      relationship: alternative
+      description: "Same tier elemental staff providing unlimited fire runes."
+  about: "Staff of air is the most basic elemental staff in OSRS, providing an unlimited supply of air runes when wielded. Sold by Zaff's Superior Staffs! in Varrock for 1,500 coins, it is also a common reward from beginner and easy clue caskets. The staff is the entry-level weapon for any low-level mage casting air spells like Wind Strike on the standard spellbook."
+  market_strategy:
+    notes:
+      - "Steady F2P demand from new mages and ironmen ramping Magic."
+      - "Shop restock at 1,500 gp caps the GE ceiling."
+      - "GE buy limit of 125 per 4 hours is generous for flipping."
+      - "High alch of 900 gp sits near the GE price - watch alch margins."
+  trading_tips:
+    - "Run Varrock shop loops when GE price drifts well above 1,500 gp."
+    - "Cross-check air battlestaff pricing to detect early-mage upgrade arbitrage."
+    - "Pair flipping with rune-saving builds during low-tier Magic xp events."
+  history:
+    - date: "2001-01-04"
+      description: "Released as part of the original RuneScape Magic skill toolkit."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-light.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-light.mdx
@@ -12,12 +12,36 @@ osrs:
   lowalch: 400002
   highalch: 600003
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: composite-staff
+    tier: high
+  properties:
+    release_date: "2018-02-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Wield
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
     weapon_type: staff
-    weight: 1.5
     attack_speed: 4
     attack_range: 1
+    weight: 1.5
+    requirements:
+      attack: 75
+      magic: 75
     attack_bonus:
       stab: 55
       slash: 70
@@ -35,74 +59,56 @@ osrs:
       ranged_strength: 0
       magic_damage: 15
       prayer: 0
-    requirements:
-      attack: 75
-      magic: 75
-  special_attack:
-    name: Power of Death
-    energy: 100
-    description: Halves all melee damage taken for one minute
-    damage_reduction: 0.5
-    duration: 60
-  drop_table:
-    primary_source: Created item
-    best_drop_rate: N/A
-    sources:
-      - source: Combine Staff of the dead + Saradomin's light
-        source_id: 0
-        combat_level: 0
-        quantity: "1"
-        rarity: created
-        drop_rate: N/A
-        members_only: true
+  recipes:
+    - skill: combination
+      level: 0
+      xp: 0
+      materials:
+        - item_name: Staff of the dead
+          quantity: 1
+        - item_name: Saradomin's light
+          quantity: 1
+      output_quantity: 1
+  special_attacks:
+    - name: Power of Death
+      energy: 100
+      description: "Halves all melee damage taken for one minute"
+  passive_effects:
+    - name: Saradomin Strike autocast
+      description: "Autocasts Saradomin Strike instead of Flames of Zamorak"
+    - name: 1/7 rune save
+      description: "1/7 chance to negate rune cost on standard spell casts"
+    - name: GWD dual faction
+      description: "Counts as both a Saradomin and Zamorak item in the God Wars Dungeon"
   related_items:
-    - item_id: 11791
-      item_name: Staff of the dead
+    - item_name: Staff of the dead
       slug: staff-of-the-dead
       relationship: component
-      description: Required base staff
-    - item_id: 13256
-      item_name: Saradomin's light
+      description: "Base staff required for the combination"
+    - item_name: Saradomin's light
       slug: saradomins-light
       relationship: component
-      description: Required upgrade material
-    - item_id: 22647
-      item_name: Staff of balance
+      description: "Upgrade item attached to the Staff of the dead"
+    - item_name: Staff of balance
       slug: staff-of-balance
       relationship: variant
-      description: Guthix variant of the staff
-    - item_id: 12002
-      item_name: Occult necklace
+      description: "Guthix-aligned variant produced from a Guthixian icon"
+    - item_name: Occult necklace
       slug: occult-necklace
       relationship: alternative
-      description: Stacks magic damage bonus
-  about: |-
-    Identical to Staff of the dead:
-    - +17 Magic attack
-    - +15% Magic damage
-    - 1/7 chance to negate rune cost
-
-    Autocasts:
-    - Saradomin Strike
-    - All standard spells
-    - Crumble Undead
-
-    Special attack - Power of Death:
-    - 100% special energy
-    - Halves melee damage for 60 seconds
-    - Stacks with Protect from Melee
-
-    GWD protection:
-    - Counts as Saradomin item
-    - Also counts as Zamorak item
+      description: "Pairs with the staff for stacking magic damage"
+  about: "Staff of light is a top-tier members staff produced by combining a Staff of the dead with Saradomin's light. It carries +17 magic attack, +15% magic damage, +72 melee strength, autocasts Saradomin Strike, retains the 1/7 rune-save passive, and counts as both Saradomin and Zamorak in the God Wars Dungeon. Its Power of Death special attack halves incoming melee damage for one minute, making it a premier defensive PvM utility staff."
   market_strategy:
     notes:
-      - Cosmetic upgrade from Staff of the dead
-      - Same stats, different appearance
-      - Popular for fashionscape
-      - Useful for GWD protection
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Component cost of Staff of the dead plus Saradomin's light anchors GE price closely"
+      - "Cosmetic-plus-utility premium over Staff of the dead is paid for GWD dual factioning"
+      - "Volume is low because combination is irreversible, so flips need patient bids"
+  trading_tips:
+    - "Watch Saradomin's light supply spikes from GWD trips before bidding"
+    - "Avoid bulk holds, GE limit of 8 caps any blow-out flip"
+  history:
+    - date: "2018-02-08"
+      description: "Released alongside the rework of God Wars Dungeon items and Saradomin's light."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-the-dead.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff-of-the-dead.mdx
@@ -12,76 +12,103 @@ osrs:
   lowalch: 400002
   highalch: 600003
   limit: 8
-  equipment:
-    slot: weapon
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
     type: staff
-    attack_style: magic
+    tier: high
+  properties:
+    release_date: "2011-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1.5
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: 2h
+    weapon_type: staff
     attack_speed: 4
+    attack_range: 1
+    weight: 1.5
     requirements:
-      magic: 75
       attack: 75
-    stats:
-      attack_magic: 17
-      attack_stab: 55
-      attack_slash: 70
-      strength: 72
-      magic_damage_percent: 15
+      magic: 75
+    attack_bonus:
+      stab: 55
+      slash: 70
+      crush: 0
+      magic: 17
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 3
+      magic: 17
+      ranged: 0
+    other_bonus:
+      melee_strength: 72
+      ranged_strength: 0
+      magic_damage: 15
+      prayer: 0
   special_attack:
     name: Power of Death
-    energy: 100
-    effect: Halves melee damage received for 1 minute
-  drop_sources:
-    - name: K'ril Tsutsaroth
-      combat_level: 650
-      drop_rate: 1/508
-      members_only: true
+    energy_cost: 100
+    description: "Halves all melee damage taken for one minute; stacks with Protect from Melee."
+  drop_table:
+    sources:
+      - source: "K'ril Tsutsaroth"
+        combat_level: 650
+        quantity: "1"
+        rarity: 1/508
+        members_only: true
   related_items:
     - item_id: 12902
       item_name: Toxic staff of the dead
       slug: toxic-staff-of-the-dead
       relationship: upgrade
-      description: Venomed version
+      description: Venom-infused upgrade with Magic damage boost
+    - item_id: 22296
+      item_name: Staff of light
+      slug: staff-of-light
+      relationship: variant
+      description: Cosmetic upgrade using Saradomin's light
+    - item_id: 24144
+      item_name: Staff of balance
+      slug: staff-of-balance
+      relationship: variant
+      description: Guthixian icon variant from Song of the Elves
     - item_id: 21006
       item_name: Kodai wand
       slug: kodai-wand
       relationship: alternative
-      description: Higher magic attack
-    - item_id: 24423
-      item_name: Harmonised nightmare staff
-      slug: harmonised-nightmare-staff
-      relationship: alternative
-      description: Best magic DPS
-  about: |-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +17 |
-    | Magic damage | +15% |
-    | Stab attack | +55 |
-    | Slash attack | +70 |
-    | Strength bonus | +72 |
-    | Requirements | 75 Magic, 75 Attack |
-
-    Power of Death (100% energy):
-    - Halves melee damage received
-    - Lasts 1 minute
-    - Great for tanking
-
-    PvM:
-    - Hybrid magic/melee staff
-    - Good for Slayer
-    - Budget magic option
-
-    PvP:
-    - Melee defence spec
-    - Tribrid setups
-    - Staff bash damage
+      description: Higher tier magic weapon with stronger Magic attack
+  about: "Staff of the dead is a tier 75 staff dropped by K'ril Tsutsaroth in the God Wars Dungeon, granting +17 Magic attack, +15% Magic damage and a 1/7 chance to negate rune costs while equipped. Its Power of Death special attack halves incoming melee damage for one minute, making it a strong tribrid weapon for PvM and PvP setups; it is also the base component for the Staff of light, Staff of balance and Toxic staff of the dead upgrades."
   market_strategy:
     notes:
-      - K'ril drop drives supply
-      - Component for toxic version
-      - Budget magic weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply driven entirely by K'ril Tsutsaroth GWD drops"
+      - "Buy limit of 8 every 4 hours throttles flips"
+      - "Component requirement for toxic, light and balance variants creates sticky demand"
+      - "Power of Death spec keeps PvP tribrid demand consistent"
+  trading_tips:
+    - "Track Bandos and Zamorak team scaling changes that shift K'ril attendance"
+    - "Buy ahead of new Saradomin or Guthix variant content for upgrade arbitrage"
+    - "Hold through DMM tournaments when tribrid weapons spike"
+  history:
+    - date: "2011-05-31"
+      description: "Released as a Zamorak Boss drop from K'ril Tsutsaroth in the God Wars Dungeon."
+    - date: "2013-02-22"
+      description: "Returned to Old School RuneScape at launch as part of the God Wars Dungeon content."
+    - date: "2017-01-05"
+      description: "Used as the base for the Toxic staff of the dead with the Zulrah update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/staff.mdx
@@ -1,6 +1,6 @@
 ---
 title: Staff | OSRS Price Data
-description: "Staff: It's a slightly magical stick.. High alch: 9 GP, GE limit: 125."
+description: "Staff is a F2P weapon slot item requiring 1 Magic. High alch: 9 GP, GE limit: 125."
 osrs:
   id: 1379
   name: Staff
@@ -12,9 +12,126 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 125
-  about: "Staff is a free-to-play item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2001-01-04"
+    update: "RuneScape Classic launch"
+    quest_item: false
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    weight: 2.267
+    destroy: "Drop"
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    examine_options:
+      - Examine
+    alchable: true
+  equipment:
+    slot: weapon
+    type: staff
+    attack_style: crush
+    attack_speed: 5
+    attack_range: 1
+    tradeable: true
+    weight: 2.267
+    requirements:
+      magic: 1
+    stats:
+      attack_stab: 0
+      attack_slash: 0
+      attack_crush: 7
+      attack_magic: 10
+      attack_ranged: 0
+      defence_stab: 0
+      defence_slash: 0
+      defence_crush: 0
+      defence_magic: 10
+      defence_ranged: 0
+      melee_strength: 9
+      ranged_strength: 0
+      magic_damage: 0
+      prayer_bonus: 0
+  shops:
+    - shop_name: Zaff's Superior Staffs
+      location: Varrock
+      price: 15
+      sell_price: 9
+      stock: 5
+      restock_time: 100
+      currency: coins
+      notes: "Stocks plain staves for casual mages"
+    - shop_name: Lowe's Archery Emporium
+      location: Varrock
+      price: 15
+      sell_price: 9
+      stock: 0
+      restock_time: 100
+      currency: coins
+      notes: "Buys staves when player-sold"
+  drop_table:
+    sources:
+      - source: Dark wizard (level 7)
+        combat_level: 7
+        quantity: "1"
+        rarity: Common
+        notes: "Frequently drops basic staves"
+      - source: Dark wizard (level 20)
+        combat_level: 20
+        quantity: "1"
+        rarity: Common
+        notes: "Common drop"
+      - source: Wizard (level 9)
+        combat_level: 9
+        quantity: "1"
+        rarity: Common
+        notes: "Drops plain staves"
+  related_items:
+    - item_id: 1381
+      item_name: Staff of air
+      slug: staff-of-air
+      relationship: upgrade
+      description: Provides unlimited air runes
+    - item_id: 1383
+      item_name: Staff of water
+      slug: staff-of-water
+      relationship: upgrade
+      description: Provides unlimited water runes
+    - item_id: 1385
+      item_name: Staff of earth
+      slug: staff-of-earth
+      relationship: upgrade
+      description: Provides unlimited earth runes
+    - item_id: 1387
+      item_name: Staff of fire
+      slug: staff-of-fire
+      relationship: upgrade
+      description: Provides unlimited fire runes
+    - item_id: 1389
+      item_name: Magic staff
+      slug: magic-staff
+      relationship: alternative
+      description: Magic-tier staff with stronger bonuses
+  market_strategy:
+    notes:
+      - "Lowest tier staff, almost zero demand at GE"
+      - "Bulk supply from Dark wizard drops"
+      - "Use as cheap throwaway training weapon"
+      - "Not worth high alching given low value"
+  history:
+    - date: "2001-01-04"
+      description: "Released with RuneScape Classic launch"
+    - date: "2004-05-05"
+      description: "Graphical update applied with RuneScape 2 transition"
+  about: "The staff is the entry-level magic weapon in Old School RuneScape, a one-handed crush staff with a small magic attack bonus. Available to free-to-play players and commonly stocked by Zaff's Superior Staffs in Varrock, it serves as the cheapest baseline magic weapon, frequently dropped by dark wizards."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts-unf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel bolts (unf) | OSRS Price Data
-description: "Steel bolts (unf): Unfeathered steel crossbow bolts.. High alch: 1 GP, GE limit: 13,000."
+description: "Steel bolts (unf) is a members Fletching intermediate for steel bolts. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 9378
   name: Steel bolts (unf)
@@ -12,9 +12,95 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  about: "Steel bolts (unf) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: mid
+  properties:
+    release_date: "2006-07-04"
+    update: "Bolt-tipping update"
+    quest_item: false
+    tradeable: true
+    equipable: false
+    stackable: true
+    noteable: true
+    weight: 0.04
+    destroy: "Drop"
+    options:
+      - Drop
+    examine_options:
+      - Examine
+    alchable: true
+  recipes:
+    - skill: smithing
+      level: 33
+      xp: 37.5
+      tools:
+        - Hammer
+        - Anvil
+      materials:
+        - item_id: 2353
+          item_name: Steel bar
+          quantity: 1
+      output:
+        item_id: 9378
+        item_name: Steel bolts (unf)
+        output_quantity: 10
+      members: true
+      notes: "One steel bar produces 10 unfinished steel bolts"
+    - skill: fletching
+      level: 39
+      xp: 35
+      materials:
+        - item_id: 9378
+          item_name: Steel bolts (unf)
+          quantity: 10
+        - item_id: 314
+          item_name: Feather
+          quantity: 10
+      output:
+        item_id: 9141
+        item_name: Steel bolts
+        output_quantity: 10
+      members: true
+      notes: "Attach feathers to finish steel bolts"
+  related_items:
+    - item_id: 9141
+      item_name: Steel bolts
+      slug: steel-bolts
+      relationship: product
+      description: Finished bolts after fletching with feathers
+    - item_id: 2353
+      item_name: Steel bar
+      slug: steel-bar
+      relationship: component
+      description: Source material for smithing steel bolts (unf)
+    - item_id: 314
+      item_name: Feather
+      slug: feather
+      relationship: component
+      description: Required to fletch into finished steel bolts
+    - item_id: 9376
+      item_name: Iron bolts (unf)
+      slug: iron-bolts-unf
+      relationship: downgrade
+      description: Lower tier unfinished bolt
+    - item_id: 9380
+      item_name: Mithril bolts (unf)
+      slug: mithril-bolts-unf
+      relationship: upgrade
+      description: Higher tier unfinished bolt
+  market_strategy:
+    notes:
+      - "Smithing/Fletching intermediate; demand from bolt fletchers"
+      - "Floor-priced supply; profitability depends on feather and steel bar margins"
+      - "Bulk-buy by ranged armament fletchers leveling Fletching"
+      - "Not worth alching; alch value equals 1 gp"
+  history:
+    - date: "2006-07-04"
+      description: "Added with the unfinished bolt tipping rework"
+  about: "Steel bolts (unf) are unfinished steel crossbow bolts produced by smithing a steel bar at level 33 Smithing. Members can attach feathers at 39 Fletching to convert them into finished steel bolts."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dagger-p-5672.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dagger-p-5672.mdx
@@ -1,10 +1,10 @@
 ---
 title: Steel dagger(p+) | OSRS Price Data
-description: "Steel dagger(p+): The blade has been poisoned.. High alch: 75 GP, GE limit: 125."
+description: "Steel dagger(p+) is the extra-strong-poisoned variant of the steel dagger, applying P+ poison on hit. High alch: 75 GP, GE limit: 125."
 osrs:
   id: 5672
   name: Steel dagger(p+)
-  slug: steel-dagger-p
+  slug: steel-dagger-p-5672
   examine: The blade has been poisoned.
   members: true
   icon: Steel dagger(p+).png
@@ -12,12 +12,101 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 125
-  about: "Steel dagger(p+) is a members-only item in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2004-08-23"
+    update: "Poisoned Weapons"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: dagger
+    attack_speed: 4
+    attack_range: 1
+    weight: 0.453
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 8
+      slash: 7
+      crush: -2
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 7
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Extra-strong poison
+      description: "Successful hits have a chance to inflict extra-strong poison (P+), dealing 6 damage initially and decaying over time."
+      trigger: on_hit
+  recipes:
+    - skill: herblore
+      level: 73
+      xp: 0
+      materials:
+        - item_name: Steel dagger
+          quantity: 1
+        - item_name: Weapon poison(+)
+          quantity: 1
+      output_quantity: 1
+      notes: "Apply weapon poison(+) to an unpoisoned steel dagger at 73 Herblore."
+  related_items:
+    - item_name: Steel dagger
+      slug: steel-dagger
+      relationship: variant
+      description: "Unpoisoned steel dagger with identical stats"
+    - item_name: Steel dagger(p)
+      slug: steel-dagger-p
+      relationship: variant
+      description: "Standard poisoned variant using weapon poison"
+    - item_name: Mithril dagger(p+)
+      slug: mithril-dagger-p-5677
+      relationship: upgrade
+      description: "Higher-tier mithril dagger with extra-strong poison"
+    - item_name: Iron dagger(p+)
+      slug: iron-dagger-p-5670
+      relationship: downgrade
+      description: "Lower-tier iron dagger with extra-strong poison"
+  about: "Steel dagger(p+) is the extra-strong-poisoned variant of the steel dagger, created by applying weapon poison(+) at 73 Herblore. It requires 5 Attack and carries the same combat stats as the base dagger but has a chance to inflict P+ poison on successful hits, useful for early Slayer tasks and low-level PvP where stacked poison ticks add meaningful damage."
+  market_strategy:
+    notes:
+      - "Niche budget poisoned weapon; volume sits in lower-tier daggers"
+      - "Bound to weapon poison(+) market and herb supply"
+      - "Limit 125 per 4 hours throttles bulk flipping"
+  trading_tips:
+    - "Craft from steel dagger + weapon poison(+) when crafted spread beats GE bid"
+    - "Compare (p), (p+), (p++) variants; the cheapest tier per poison damage usually wins"
+  history:
+    - date: "2004-08-23"
+      description: "Released with the Poisoned Weapons update introducing weapon poison(+) variants."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-hasta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-hasta.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel hasta | OSRS Price Data
-description: "Steel hasta: A steel-tipped, one-handed hasta.. High alch: 195 GP, GE limit: 125."
+description: "Steel hasta is a members one-handed steel-tipped hasta forged via Barbarian Smithing at level 35. High alch: 195 GP, GE limit: 125."
 osrs:
   id: 11371
   name: Steel hasta
@@ -12,9 +12,101 @@ osrs:
   lowalch: 130
   highalch: 195
   limit: 125
-  about: "Steel hasta is a members-only item in Old School RuneScape. High alchemy value: 195 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: steel
+    tier: low
+  properties:
+    release_date: "2007-07-03"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: spear
+    attack_speed: 4
+    attack_range: 1
+    weight: 2.267
+    requirements:
+      attack: 5
+    attack_bonus:
+      stab: 12
+      slash: 12
+      crush: 12
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: -3
+      slash: -3
+      crush: -3
+      magic: 0
+      ranged: -3
+    other_bonus:
+      melee_strength: 12
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 35
+      xp: 75
+      materials:
+        - item_name: Steel spear
+          item_id: 1539
+          quantity: 1
+      tools:
+        - Barbarian anvil
+        - Hammer
+      facility: Otto's Grotto barbarian anvil
+      product: Steel hasta
+      product_id: 11371
+      output_quantity: 1
+  related_items:
+    - item_id: 1539
+      item_name: Steel spear
+      slug: steel-spear
+      relationship: component
+      description: "Steel spear forged into a hasta on the Barbarian anvil."
+    - item_id: 11367
+      item_name: Iron hasta
+      slug: iron-hasta
+      relationship: downgrade
+      description: "Lower-tier hasta with weaker bonuses."
+    - item_id: 11375
+      item_name: Mithril hasta
+      slug: mithril-hasta
+      relationship: upgrade
+      description: "Next-tier hasta with stronger combat bonuses."
+    - item_id: 11373
+      item_name: Steel hasta(p)
+      slug: steel-hasta-p
+      relationship: variant
+      description: "Poisoned version of the steel hasta for slight DPS uplift."
+  about: "Steel hasta is a one-handed steel-tipped spear made through Barbarian Smithing at the Otto's Grotto anvil from a steel spear (75 Smithing XP, level 35 Smithing required, Tai Bwo Wannai Trio plus the Barbarian Training miniquest unlock). Unlike full spears it can be wielded with a shield, making it a popular F2P-style stab option for early Slayer and dragon tasks once paired with a kiteshield."
+  market_strategy:
+    notes:
+      - "Hasta supply is gated by Barbarian Smithing unlocks, keeping the active fletcher pool small."
+      - "GE buy limit of 125 per 4 hours suits low-volume flips, not bulk arbitrage."
+      - "High alch 195 gp sits below GE price - alching is not a profitable use."
+      - "Demand is steady but light, driven by mid-level shield-stab setups and Tai Bwo Wannai questers."
+  trading_tips:
+    - "Cross-check the steel spear price; whenever the spread covers the 75 XP smelt, Barbarian Smithing flips become viable."
+    - "Stock spikes briefly after Barbarian Training rebalances or new Slayer routes that favour stab+shield."
+  history:
+    - date: "2007-07-03"
+      description: "Released with the Barbarian Smithing expansion of the Barbarian Training miniquest, adding shield-friendly hasta variants for every metal tier."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-plateskirt-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-plateskirt-g.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel plateskirt (g) | OSRS Price Data
-description: "Steel plateskirt (g) is a F2P legs slot item requiring 5 Defence. High alch: 600 GP, GE limit: 125."
+description: "Steel plateskirt (g) is a gold-trimmed F2P easy-clue legs cosmetic with steel plateskirt stats. High alch: 600 GP, GE limit: 125."
 osrs:
   id: 20175
   name: Steel plateskirt (g)
@@ -12,22 +12,86 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: steel
+    tier: mid
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trails refresh"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 8.164
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: legs
+    weapon_type: armour
+    weight: 8.164
     requirements:
       defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 17
+      slash: 16
+      crush: 15
+      magic: -4
+      ranged: 16
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Easy Treasure Trails reward casket
+        rarity: clue
+        members_only: false
   related_items:
     - item_id: 20190
       item_name: Steel plateskirt (t)
       slug: steel-plateskirt-t
       relationship: variant
-      description: Trimmed variant
-  about: |-
-    > *"Steel plateskirt with gold trim."*
-
-    The steel plateskirt (g) is a gold-trimmed cosmetic variant of the steel plateskirt. Requiring 5 Defence. Clue scroll exclusive.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Trimmed (silver) variant from the same easy-clue table."
+    - item_name: Steel plateskirt
+      slug: steel-plateskirt
+      relationship: alternative
+      description: "Standard untrimmed steel plateskirt with identical combat stats."
+    - item_name: Steel platebody (g)
+      slug: steel-platebody-g
+      relationship: variant
+      description: "Matching gold-trim torso piece in the steel (g) set."
+  about: "Steel plateskirt (g) is the gold-trimmed cosmetic variant of the steel plateskirt, dropped exclusively from easy-tier Treasure Trail reward caskets. It matches the standard plateskirt's stats - a 5 Defence requirement and steel-tier defensive bonuses - and exists purely as showpiece flair for F2P clue chasers and gold-trim set collectors."
+  market_strategy:
+    notes:
+      - "Easy-clue exclusive supply keeps the price wobbling with clue activity."
+      - "GE buy limit of 125 per 4 hours gives merchanters real room to flip."
+      - "High alch of 600 gp sits well below GE - no alch profit."
+      - "Steel-tier defence floor caps appeal beyond cosmetics."
+  trading_tips:
+    - "Track easy-clue caskets opening trends - dry weeks lift gold-trim prices."
+    - "Compare set sum vs piece sum for full steel (g) outfit flips."
+    - "Stat parity with plain steel plateskirt makes it a roleplay/cosmetic-only buy."
+  history:
+    - date: "2016-07-06"
+      description: "Added to easy Treasure Trail reward tables in the 2016 clue rework."
+    - date: "2021-04-21"
+      description: "Ranged defence bonus reduced from -7 to -11 alongside other base-tier armour rebalances."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-sq-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-sq-shield.mdx
@@ -1,6 +1,6 @@
 ---
 title: Steel sq shield | OSRS Price Data
-description: "Steel sq shield: A medium square shield.. High alch: 360 GP, GE limit: 125."
+description: "Steel sq shield: A medium square shield. High alch: 360 GP, GE limit: 125."
 osrs:
   id: 1177
   name: Steel sq shield
@@ -12,25 +12,103 @@ osrs:
   lowalch: 240
   highalch: 360
   limit: 125
-  item_id: 1177
-  item_type: armor
-  slot: shield
-  type: square_shield
-  tradeable: true
-  weight: 3.628
-  requirements:
-    defence: 5
-  stats:
-    stab_defence: 12
-    slash_defence: 13
-    crush_defence: 11
-    magic_defence: 0
-    ranged_defence: 12
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: steel
+    tier: mid
+  properties:
+    release_date: "2001-01-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 3.628
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: shield
+    weapon_type:
+    weight: 3.628
+    requirements:
+      defence: 5
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: 0
+    defence_bonus:
+      stab: 12
+      slash: 13
+      crush: 11
+      magic: 0
+      ranged: 12
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 38
+      xp: 75
+      materials:
+        - item_name: Steel bar
+          item_id: 2353
+          quantity: 2
+      tools:
+        - Hammer
+      facility: Anvil
+      product: Steel sq shield
+      product_id: 1177
+      output_quantity: 1
+      notes: "Smith 2 steel bars at an anvil with a hammer."
+  shops:
+    - shop_name: "Cassie's Shield Shop"
+      location: Falador
+      price: 600
+      currency: Coins
+      stock: 5
+    - shop_name: "Quality Armour Shop"
+      location: Keldagrim
+      price: 600
+      currency: Coins
+      stock: 0
   related_items:
-    - slug: black-sq-shield
-    - slug: steel-kiteshield
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Black sq shield
+      slug: black-sq-shield
+      relationship: downgrade
+      description: "Lower-tier square shield."
+    - item_name: Mithril sq shield
+      slug: mithril-sq-shield
+      relationship: upgrade
+      description: "Higher-tier square shield."
+    - item_name: Steel kiteshield
+      slug: steel-kiteshield
+      relationship: variant
+      description: "Same tier but kiteshield form factor with stronger stats."
+  about: "Steel sq shield is a free-to-play melee shield requiring 5 Defence to wear. It is smithed from 2 steel bars at 38 Smithing for 75 XP, and sold by Cassie's Shield Shop in Falador. While its stats are below the kiteshield of the same tier, it remains a common low-level F2P training shield and a steady Smithing-XP supply line."
+  market_strategy:
+    notes:
+      - "Entry-level F2P shield; demand from new accounts and Defence trainers."
+      - "Smithing supply is steady; shop-flip arbitrage off Cassie's 600 gp price is the main angle."
+      - "Buy limit 125 per 4 hours caps daily flip volume."
+      - "High alch 360 gp leaves modest headroom for nature rune alch routes."
+  trading_tips:
+    - "Buy near alch value to cap downside on flips."
+    - "Compare to steel kiteshield price; kite stats dominate, so sq shield is fashionscape-only above price parity."
+    - "Track steel bar pricing for Smithing supply-side moves."
+  history:
+    - date: "2001-01-04"
+      description: "Released as part of the early F2P melee armour rollout."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/stretched-hide.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/stretched-hide.mdx
@@ -12,9 +12,57 @@ osrs:
   lowalch: 24
   highalch: 36
   limit: 11000
-  about: "Stretched hide is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: hide
+    tier: mid
+  properties:
+    release_date: "2005-08-01"
+    update: "Waterbirth Island"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3.175
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Dagannoth (Waterbirth Dungeon, level 88 ranged)
+        combat_level: 88
+        quantity: "1"
+        rarity: "2/128"
+        notes: "Dropped by the ranged variant of dagannoths in the Waterbirth Dungeon."
+  related_items:
+    - item_name: Spined chaps
+      slug: spined-chaps
+      relationship: product
+      description: Crafted by Sigli the Huntsman using stretched hide and dagannoth hides.
+    - item_name: Dagannoth hide
+      slug: dagannoth-hide
+      relationship: component
+      description: Required alongside stretched hide for spined chaps.
+  about: |-
+    Stretched hide is a Fremennik-themed hide dropped by the level 88 ranged dagannoths in the Waterbirth Dungeon. Players bring one stretched hide, two regular dagannoth hides, and 7,500 coins to Sigli the Huntsman in Rellekka to craft spined chaps after completing The Fremennik Trials.
+
+    Pre-quest, the hide can also be traded to Askeladden for cooked tuna; post-quest, the trade upgrades to cooked lobster. The item itself is not gated by the quest and can be banked beforehand.
+  market_strategy:
+    notes:
+      - "Supply tied to Waterbirth dagannoth Slayer/AFK kills; modest steady drops."
+      - "Demand limited to spined chaps crafters and quest completionists."
+      - "Volume too thin for aggressive flipping; prefer flat-buy at GE price."
+  trading_tips:
+    - "Buy when Waterbirth slayer tasks are popular and supply dips."
+    - "Stack with dagannoth hides for full spined-chaps crafting kits."
+    - "Sell to ironmen progressing to The Fremennik Isles content."
+  history:
+    - date: "2005-08-01"
+      description: "Released as part of the Waterbirth Island update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-fanatic-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sunfire fanatic helm | OSRS Price Data
-description: "Sunfire fanatic helm is a members head slot item requiring 40 Defence. High alch: 225,000 GP."
+description: "Sunfire fanatic helm is a members prayer-bonus head slot helm dropped from the Fortis Colosseum, requiring 60 Prayer and 40 Defence. High alch: 225,000 GP."
 osrs:
   id: 28933
   name: Sunfire fanatic helm
@@ -11,12 +11,36 @@ osrs:
   value: 375000
   lowalch: 150000
   highalch: 225000
-  limit: null
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: sunfire
+    tier: high
+  properties:
+    release_date: "2024-03-20"
+    update: "Varlamore: The Final Dawn"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: melee_prayer
-    tradeable: true
+    weapon_type:
     weight: 2.267
+    requirements:
+      prayer: 60
+      defence: 40
     attack_bonus:
       stab: 0
       slash: 0
@@ -34,83 +58,50 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 6
-    requirements:
-      prayer: 60
-      defence: 40
+  passive_effects:
+    - name: Best-in-slot prayer head
+      description: "Provides the highest +6 prayer bonus available in the head slot while keeping melee-grade defensive stats."
   set_effect:
     name: Sunfire Fanatic
     pieces:
       - Sunfire fanatic helm
       - Sunfire fanatic cuirass
       - Sunfire fanatic chausses
-    description: Best-in-slot prayer bonus armor set
+    description: "Full set delivers a combined +24 prayer bonus, the highest stackable prayer total for a melee-style outfit."
   drop_table:
-    primary_source: Fortis Colosseum
-    best_drop_rate: 1/24.47
     sources:
-      - source: Fortis Colosseum
+      - source: Fortis Colosseum (reward chest)
         quantity: "1"
-        rarity: uncommon
-        drop_rate: 1/24.47 (full completion)
-        members_only: true
-  market:
-    buy_limit: 8
-    price_estimate: 1216061
+        rarity: 1/24.47
   related_items:
     - item_id: 28936
       item_name: Sunfire fanatic cuirass
       slug: sunfire-fanatic-cuirass
       relationship: set-piece
-      description: Body piece
+      description: "Body piece of the Sunfire fanatic set (+10 prayer)."
     - item_id: 28939
       item_name: Sunfire fanatic chausses
       slug: sunfire-fanatic-chausses
       relationship: set-piece
-      description: Leg piece
-  about: |-
-    ### Defensive Bonuses
-    | Defence Type | Bonus |
-    |--------------|-------|
-    | Stab | +30 |
-    | Slash | +32 |
-    | Crush | +27 |
-    | Magic | -1 |
-    | Ranged | +30 |
-
-    ### Other Bonuses
-    | Stat | Bonus |
-    |------|-------|
-    | Magic Attack | -6 |
-    | Ranged Attack | -3 |
-    | Prayer | +6 |
-
-    The Sunfire Fanatic set provides the best-in-slot prayer bonus when worn together:
-
-    Full Set Pieces:
-    - Sunfire fanatic helm (+6 Prayer)
-    - Sunfire fanatic cuirass (+10 Prayer)
-    - Sunfire fanatic chausses (+8 Prayer)
-
-    Total Set Prayer Bonus: +24
-
-    This makes the complete set invaluable for extended boss fights and activities where prayer drain is a concern.
-
-    Best uses for the Sunfire fanatic helm:
-
-    - Prayer-heavy bossing: Reduces prayer potion consumption
-    - Inferno: Excellent for prayer preservation
-    - Fight Caves: Extends trip duration
-    - GWD trips: Longer stays with fewer supplies
-    - Slayer: Extended prayer-protected tasks
+      description: "Leg piece of the Sunfire fanatic set (+8 prayer)."
+    - item_id: 9472
+      item_name: Proselyte sallet
+      slug: proselyte-sallet
+      relationship: downgrade
+      description: "Cheaper prayer-bonus helm for budget setups."
+  about: "Sunfire fanatic helm is the head slot piece of the Sunfire fanatic armour set introduced with Varlamore: The Final Dawn. It is dropped from the Fortis Colosseum reward chest at roughly 1/24.47 per full completion (waves 4-12) and requires 60 Prayer and 40 Defence to wear. The helm delivers the highest +6 prayer bonus in the head slot while retaining melee-grade defensive stats, making it core gear for prayer-heavy PvM such as the Inferno, Fight Caves, GWD trips and prolonged Slayer tasks."
   market_strategy:
     notes:
-      - Most affordable piece of the set
-      - Good entry point for Colosseum gear
-      - Price stable due to consistent demand
-      - Consider buying full set for maximum benefit
-      - Compare to Proselyte for cost-efficiency
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheapest of the three Sunfire fanatic pieces, the helm is the usual entry point into the set."
+      - "Demand is steady from Colosseum/Inferno/GWD prep buyers; price tracks the broader prayer-bonus meta."
+      - "No GE buy limit; restocking is supply-side bound by Colosseum completions."
+      - "High alch 225,000 gp sits well under GE price, so alching is not viable."
+  trading_tips:
+    - "Watch Fortis Colosseum content patches and prayer-bonus meta shifts - drop-rate or BIS changes move the price the fastest."
+    - "Cross-reference cuirass and chausses prices; full-set buyers create temporary demand spikes after big PvM updates."
+  history:
+    - date: "2024-03-20"
+      description: "Released as part of Varlamore: The Final Dawn alongside the Fortis Colosseum and the rest of the Sunfire fanatic set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/swords-and-emblem.mdx
@@ -1,20 +1,87 @@
 ---
 title: Swords and emblem | OSRS Price Data
-description: "Swords and emblem: Sadly, the blades are only decorative."
+description: "Swords and emblem is a decorative Grid Master event reward worn in the weapon slot. High alch: 60,000 GP."
 osrs:
   id: 31193
   name: Swords and emblem
   slug: swords-and-emblem
-  examine: Sadly, the blades are only decorative
+  examine: Sadly, the blades are only decorative.
   members: true
   icon: Swords and emblem.png
   value: 100000
-  lowalch: null
-  highalch: null
-  limit: null
-  about: Swords and emblem is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  lowalch: 40000
+  highalch: 60000
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: mid
+  properties:
+    release_date: "2025-10-15"
+    update: "Grid Master event"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.3
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: cosmetic
+    weight: 0.3
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  drop_table:
+    sources:
+      - source: Events Reward Shop
+        location: Varrock Square
+        cost: 1100 event points
+        rarity: shop
+        members_only: true
+  related_items:
+    - item_name: Grid master tabard
+      slug: grid-master-tabard
+      relationship: variant
+      description: "Matching tabard from the same Grid Master event reward shop."
+  about: "Swords and emblem is a decorative weapon-slot cosmetic sold by the Events Reward Shop in Varrock Square during the 2025 Grid Master community event. It carries no combat bonuses, exists purely as showpiece flair, and can be stored in the costume room armour case alongside its matching grid master tabard color variants."
+  market_strategy:
+    notes:
+      - "Pure cosmetic - demand driven by collectors and event nostalgia, not utility."
+      - "No GE buy limit reported, so flips are uncapped but volume is thin."
+      - "High alch of 60,000 gp keeps a floor under the GE price."
+      - "Supply only grows when event shop points are spent, then permanently shrinks."
+  trading_tips:
+    - "Watch alt-event hype cycles - cosmetic prices spike around announcements."
+    - "Compare against grid master tabard pricing for set arbitrage."
+    - "High-alch floor protects downside if you flip into a dip."
+  history:
+    - date: "2025-10-15"
+      description: "Released to the Events Reward Shop during the Grid Master community event."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-fancy-dress-box-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-fancy-dress-box-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teak fancy dress box (flatpack) | OSRS Price Data
-description: "Teak fancy dress box (flatpack): Teak fancy dress box.. High alch: 6 GP, GE limit: 500."
+description: "Teak fancy dress box (flatpack) is a members Construction 62 workbench product crafted from 2 teak planks for the Costume Room. High alch: 6 GP, GE limit: 500."
 osrs:
   id: 9866
   name: Teak fancy dress box (flatpack)
@@ -12,9 +12,76 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Teak fancy dress box (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: flatpack
+    tier: low
+  properties:
+    release_date: "2006-10-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.0
+    options:
+      - Build
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: construction
+      level: 62
+      xp: 180
+      materials:
+        - item_name: Teak plank
+          item_id: 8780
+          quantity: 2
+      tools:
+        - Hammer
+        - Saw
+      facility: Workbench (player-owned house workshop)
+      product: Teak fancy dress box (flatpack)
+      product_id: 9866
+      output_quantity: 1
+  construction:
+    construction_level: 62
+    construction_xp: 180
+    room: Costume Room
+    hotspot: Fancy Dress Box
+    flatpack: true
+  related_items:
+    - item_id: 8780
+      item_name: Teak plank
+      slug: teak-plank
+      relationship: component
+      description: "Material (x2) used at the workbench to build the flatpack."
+    - item_id: 9864
+      item_name: Oak fancy dress box (flatpack)
+      slug: oak-fancy-dress-box-flatpack
+      relationship: downgrade
+      description: "Lower-tier oak version of the same Costume Room hotspot."
+    - item_id: 9868
+      item_name: Mahogany fancy dress box (flatpack)
+      slug: mahogany-fancy-dress-box-flatpack
+      relationship: upgrade
+      description: "Higher-tier mahogany version with more storage in the Costume Room."
+  about: "Teak fancy dress box (flatpack) is a player-made Construction flatpack crafted at a player-owned house workbench from 2 teak planks at level 62 Construction for 180 XP. It is used to upgrade the Fancy Dress Box hotspot in the Costume Room, expanding the slots available for stored cosmetic outfits."
+  market_strategy:
+    notes:
+      - "Niche flatpack with thin demand; only sells to ironman-tier Costume Room finishers."
+      - "Buy limit of 500 supports light bulk plays but cannot move much volume."
+      - "High alch 6 gp makes alching pointless."
+      - "Supply tracks teak-plank prices; any plank price shift translates 1:1 into flatpack margin."
+  trading_tips:
+    - "Flip only when teak plank is below the GE price minus tax - otherwise the build is a net loss."
+    - "Stock ahead of double-construction events when Costume Room demand briefly spikes."
+  history:
+    - date: "2006-10-18"
+      description: "Released alongside the Construction Costume Room and the Fancy Dress Box hotspot."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teal-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teal-boots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teal boots | OSRS Price Data
-description: "Teal boots: Very stylish!. High alch: 300 GP, GE limit: 150."
+description: "Teal boots are F2P cosmetic foot slot fashion sold by Thessalia in Varrock. High alch: 300 GP, GE limit: 150."
 osrs:
   id: 2924
   name: Teal boots
@@ -12,12 +12,83 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Teal boots is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2002-07-29"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: feet
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Thessalia's Fine Clothes"
+      location: Varrock
+      price: 500
+      currency: Coins
+      stock: 0
+  related_items:
+    - item_name: Pink boots
+      slug: pink-boots
+      relationship: variant
+      description: "Pink colour variant from Thessalia's clothes shop"
+    - item_name: Turquoise boots
+      slug: turquoise-boots
+      relationship: variant
+      description: "Turquoise colour variant of the same fashion line"
+    - item_name: Cream boots
+      slug: cream-boots
+      relationship: variant
+      description: "Cream colour variant of the same fashion line"
+  about: "Teal boots are free-to-play cosmetic foot slot boots sold by Thessalia's Fine Clothes in Varrock as part of her recolour fashion line. They give no combat bonuses and exist purely for fashionscape and the costume room."
+  market_strategy:
+    notes:
+      - "Pure cosmetic; value floats on fashionscape demand only"
+      - "Thessalia restock at 500 gp caps the upside hard"
+      - "All Thessalia colour variants compete for the same buyer pool"
+  trading_tips:
+    - "Restock-flip from Thessalia when GE bid clears the 500 gp wall"
+    - "Compare against pink/turquoise/cream variants and list the cheapest one"
+  history:
+    - date: "2002-07-29"
+      description: "Released as part of Thessalia's coloured boots fashion line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-11-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-11-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-11 cape | OSRS Price Data
-description: "Team-11 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-11 cape is a F2P cape slot cosmetic. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4335
   name: Team-11 cape
@@ -12,9 +12,81 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-11 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2004-09-13"
+    update: "Team Capes update"
+    quest_item: false
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    weight: 0.4
+    destroy: "Drop"
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    examine_options:
+      - Examine
+    alchable: true
+  equipment:
+    slot: cape
+    type: cape
+    tradeable: true
+    weight: 0.4
+    requirements: {}
+    stats:
+      attack_stab: 0
+      attack_slash: 0
+      attack_crush: 0
+      attack_magic: 0
+      attack_ranged: 0
+      defence_stab: 0
+      defence_slash: 0
+      defence_crush: 0
+      defence_magic: 0
+      defence_ranged: 0
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer_bonus: 0
+  shops:
+    - shop_name: Cape rack (POH)
+      location: Player Owned House
+      price: 50
+      sell_price: 30
+      stock: 0
+      currency: coins
+      notes: "Cape rack in costume room stores team capes"
+  related_items:
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Lowest numbered team cape variant
+    - item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: variant
+      description: Highest numbered team cape variant
+    - item_name: Team cape zero
+      slug: team-cape-zero
+      relationship: alternative
+      description: Star-pattern team cape unlocked via Castle Wars
+  market_strategy:
+    notes:
+      - "Pure cosmetic cape with no combat stats"
+      - "Demand driven by Castle Wars teams and clue scroll cosmetics"
+      - "Floor-priced; flips razor-thin"
+      - "Alch margin minimal; not worth nature rune cost"
+  history:
+    - date: "2004-09-13"
+      description: "Released with the team cape update for clan-style PK games"
+  about: "The team-11 cape is one of 50 numbered cosmetic capes available from team cape shops, used to identify allies in friendly PvP and team-based minigames such as Castle Wars. It has no combat stats and is free-to-play."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-28-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-28-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-28 cape | OSRS Price Data
-description: "Team-28 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-28 cape is a free-to-play cosmetic team cape sold by Edmond's Wilderness Cape Shop for 50 gp, paired wearers show as blue minimap dots. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4369
   name: Team-28 cape
@@ -12,9 +12,84 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-28 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2005-02-22"
+    update: "Team capes"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: "Team minimap colour"
+      description: "Players wearing matching team capes appear as blue dots on each other's minimaps instead of white, and attack options shift to right-click based on level advantage - useful for clan PvP coordination."
+  shops:
+    - shop_name: Edmond's Wilderness Cape Shop
+      location: South of the Lava Maze, Wilderness
+      stock: 0
+      price: 50
+  related_items:
+    - item_id: 4329
+      item_name: Team-8 cape
+      slug: team-8-cape
+      relationship: alternative
+      description: "Another team cape variant from Edmond's shop."
+    - item_id: 4349
+      item_name: Team-18 cape
+      slug: team-18-cape
+      relationship: alternative
+      description: "Another team cape variant from Edmond's shop."
+    - item_id: 4389
+      item_name: Team-38 cape
+      slug: team-38-cape
+      relationship: alternative
+      description: "Another team cape variant from Edmond's shop."
+  about: "Team-28 cape is one of fifty numbered cosmetic team capes sold by Edmond at the Wilderness Cape Shop for 50 gp. Wearing matching capes turns paired players into blue minimap dots and gates left-click attack into a right-click confirm based on combat-level difference, which is the system's PvP value over plain capes."
+  market_strategy:
+    notes:
+      - "Supply is shop-bound at 50 gp - GE arbitrage above shop price is the entire flip."
+      - "GE buy limit of 150 per 4 hours supports light bulk flipping."
+      - "High alch of 30 gp is below shop cost - alching is unprofitable."
+      - "Demand is sporadic, driven by clan PvP events or nostalgia buyers."
+  trading_tips:
+    - "Watch wilderness/PvP event cycles that push clan demand for matched capes."
+    - "Cross-reference other team cape numbers - thin spreads exist between rarer numbers."
+    - "Low-margin flip; treat as collection-completion volume play, not active merchanting."
+  history:
+    - date: "2005-02-22"
+      description: "Released as part of the team capes update; sold from Edmond's Wilderness Cape Shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-43-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-43-cape.mdx
@@ -12,9 +12,86 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-43 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-02-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "William's Wilderness Cape Shop"
+      location: Lava Dragon Isle
+      price: 50
+      currency: Coins
+      stock: 100
+  related_items:
+    - item_name: Team-42 cape
+      slug: team-42-cape
+      relationship: variant
+      description: Adjacent numbered team cape variant
+    - item_name: Team-44 cape
+      slug: team-44-cape
+      relationship: variant
+      description: Adjacent numbered team cape variant
+    - item_name: Team-1 cape
+      slug: team-1-cape
+      relationship: variant
+      description: Lowest numbered team cape in the line
+    - item_name: Team-50 cape
+      slug: team-50-cape
+      relationship: variant
+      description: Highest numbered team cape in the line
+  about: "Team-43 cape is one of fifty numbered team capes used to flag allies during multi-combat encounters. Matching capes hide the attack option and show wearers as allies on the minimap; mismatched capes leave attack on left-click. Sold by William on Lava Dragon Isle in the Wilderness."
+  market_strategy:
+    notes:
+      - "Shop-bought from William for 50 gp keeps the GE floor flat"
+      - "Demand spikes during clan wars and team-based PvP tournaments"
+      - "Low alch ceiling keeps profit margins thin"
+      - "Buy limit of 150 every 4 hours supports light bulk flips"
+  trading_tips:
+    - "Pair flips with adjacent numbered team capes when one is in vogue"
+    - "Stock up before scheduled PvP events that favour team coordination"
+    - "Avoid high alching; the 30 gp return is below GE pricing"
+  history:
+    - date: "2005-02-22"
+      description: "Released as part of the team cape numbering system."
+    - date: "2013-05-23"
+      description: "Made available to free-to-play players."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-cape-i.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-cape-i.mdx
@@ -12,21 +12,85 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2016-07-06"
+    update: "Treasure Trails Expansion"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: cape
+    weight: 0.453
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 2
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: easy
+    is_reward: true
+    reward_tiers:
+      - easy
+  drop_table:
+    sources:
+      - source: Reward casket (easy)
+        combat_level: 0
+        quantity: "1"
+        rarity: "1/5616"
+        notes: "Rare cosmetic cape reward from easy clue caskets."
   related_items:
     - item_id: 20211
       item_name: Team cape zero
       slug: team-cape-zero
       relationship: variant
-      description: Team cape zero variant
+      description: Alternate Team cape clue reward variant.
   about: |-
     > *"Ooohhh look at the dirty colours..."*
 
-    Team cape i is a cosmetic cape from easy treasure trails. A rare variant that cannot be bought from NPC team cape sellers. No stats or requirements.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Team cape i is a rare cosmetic cape rolled from easy clue scroll reward caskets at roughly 1 in 5,616. It cannot be purchased from NPC team cape shopkeepers and is one of the only F2P team capes available to free players.
+
+    The cape grants minor defensive bonuses (+1 slash, +1 crush, +2 ranged defence) but no attack or other bonuses, making it primarily a fashionscape and collection piece.
+  market_strategy:
+    notes:
+      - "Tiny GE buy limit (4) caps flipping volume; treat as a rare collection piece."
+      - "Supply driven entirely by easy clue completions; demand from collectors and fashionscape."
+      - "Price moves on streamer attention and clue scroll meta shifts."
+  trading_tips:
+    - "Stock 1-2 units when GE price dips below alch; rare clue items rarely stay cheap."
+    - "List for sale during DMM/Leagues hype when ironmen and mains chase rare cosmetics."
+    - "Watch the easy clue reward pool — new additions can dilute team cape i demand."
+  history:
+    - date: "2016-07-06"
+      description: "Added to easy clue scroll reward tables during the Treasure Trails expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toadflax.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toadflax.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toadflax | OSRS Price Data
-description: "Toadflax: A useful herb.. High alch: 28 GP, GE limit: 13,000."
+description: "Toadflax is a clean Herblore herb used in Agility potion, Antidote+, and Saradomin brew recipes. High alch: 28 GP, GE limit: 13,000."
 osrs:
   id: 2998
   name: Toadflax
@@ -12,9 +12,26 @@ osrs:
   lowalch: 19
   highalch: 28
   limit: 13000
-  herb:
-    type: clean
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: clean herb
     tier: mid
+  properties:
+    release_date: "2004-07-27"
+    update: "Agility, Potions and Parties!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
   herblore:
     cleaning_level: 30
     cleaning_xp: 8
@@ -26,87 +43,110 @@ osrs:
     seed_name: Toadflax seed
   recipes:
     - skill: herblore
+      level: 30
+      xp: 8
+      materials:
+        - item_name: Grimy toadflax
+          item_id: 3049
+          quantity: 1
+      product: Toadflax
+      product_id: 2998
+      output_quantity: 1
+      notes: "Clean grimy toadflax for 8 Herblore XP."
+    - skill: herblore
       level: 34
-      xp: 80
+      xp: 0
       materials:
         - item_name: Toadflax
           item_id: 2998
+          quantity: 1
+        - item_name: Vial of water
+          quantity: 1
+      product: Toadflax potion (unf)
+      output_quantity: 1
+      notes: "Make the unfinished toadflax potion base used by all downstream brews."
+    - skill: herblore
+      level: 34
+      xp: 80
+      materials:
+        - item_name: Toadflax potion (unf)
           quantity: 1
         - item_name: Toad's legs
           item_id: 2152
           quantity: 1
       product: Agility potion(3)
       product_id: 3034
-      product_quantity: 1
-      members_only: true
+      output_quantity: 1
     - skill: herblore
       level: 68
       xp: 155
       materials:
-        - item_name: Toadflax
-          item_id: 2998
+        - item_name: Toadflax potion (unf)
           quantity: 1
         - item_name: Yew roots
           item_id: 6049
           quantity: 1
       product: Antidote+(3)
       product_id: 5945
-      product_quantity: 1
-      members_only: true
+      output_quantity: 1
     - skill: herblore
       level: 81
       xp: 180
       materials:
-        - item_name: Toadflax
-          item_id: 2998
+        - item_name: Toadflax potion (unf)
           quantity: 1
         - item_name: Crushed nest
           item_id: 6693
           quantity: 1
       product: Saradomin brew(3)
       product_id: 6687
-      product_quantity: 1
-      members_only: true
+      output_quantity: 1
   related_items:
     - item_id: 3049
       item_name: Grimy toadflax
       slug: grimy-toadflax
       relationship: component
-      description: Uncleaned version
+      description: "Uncleaned grimy version cleaned at 30 Herblore."
     - item_id: 5296
       item_name: Toadflax seed
       slug: toadflax-seed
       relationship: component
-      description: For farming
+      description: "Seed planted in an allotment-tier herb patch at 38 Farming."
     - item_id: 6693
       item_name: Crushed nest
       slug: crushed-nest
       relationship: component
-      description: Sara brew secondary
+      description: "Secondary used to brew Saradomin brew."
     - item_id: 6685
       item_name: Saradomin brew(4)
       slug: saradomin-brew-4
       relationship: product
-      description: Final product
-  about: |-
-    | Potion | Secondary | Herblore Level | XP |
-    |--------|-----------|----------------|-----|
-    | Agility potion | Toad's legs | 34 | 80 |
-    | Antidote+ | Yew roots | 68 | 155 |
-    | Saradomin brew | Crushed nest | 81 | 180 |
+      description: "Top-tier Herblore product made from toadflax."
+    - item_id: 2152
+      item_name: Toad's legs
+      slug: toads-legs
+      relationship: component
+      description: "Secondary used to brew Agility potion."
+    - item_id: 6049
+      item_name: Yew roots
+      slug: yew-roots
+      relationship: component
+      description: "Secondary used to brew Antidote+."
+  about: "Toadflax is a clean mid-tier Herblore herb (released 27 July 2004 with the Agility update) used to make Agility potion (34 Herblore, +Toad's legs), Antidote+ (68 Herblore, +Yew roots), and Saradomin brew (81 Herblore, +Crushed nest). Grown at 38 Farming from a toadflax seed and cleaned from grimy toadflax at 30 Herblore for 8 xp, it sits at the centre of the high-XP brew pipeline favoured by raiders and PvMers."
   market_strategy:
-    profit_formulas:
-      - Brew price - Toadflax - Crushed nest - Vial = Profit
     notes:
-      - Buy Grimy toadflax → Clean → Sell clean
-      - Small margin, high volume
-      - Toadflax + Crushed nest → Saradomin brew
-      - High demand from raiders
-      - "Calculate:"
-      - Toadflax seed (38 Farming)
-      - Profitable herb to farm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Saradomin brew demand from raiders drives most volume"
+      - "Buy limit of 13,000 supports bulk cleaning flips"
+      - "Grimy -> clean cleaning is a steady small-margin grind"
+      - "Toadflax + Crushed nest profit ties directly to raid activity"
+      - "Toadflax seed (38 Farming) keeps farm-run supply healthy"
+  trading_tips:
+    - "Compare Saradomin brew(4) price to (Toadflax + Crushed nest + Vial) for brew arbitrage"
+    - "Watch Grimy toadflax spreads after Slayer xp events for clean-and-resell flips"
+    - "Stockpile before raid leagues / Theatre of Blood updates"
+  history:
+    - date: "2004-07-27"
+      description: "Released with the Agility, Potions and Parties! update alongside Agility potion and the wider herb expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-amulet-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/topaz-amulet-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Topaz amulet (u) | OSRS Price Data
-description: "Topaz amulet (u): It needs a string so I can wear it.. High alch: 765 GP, GE limit: 10,000."
+description: "Topaz amulet (u) is the unstrung red topaz amulet crafted at level 45 Crafting for 80 xp, strung with wool to make a Topaz amulet. High alch: 765 GP, GE limit: 10,000."
 osrs:
   id: 21105
   name: Topaz amulet (u)
@@ -12,9 +12,78 @@ osrs:
   lowalch: 510
   highalch: 765
   limit: 10000
-  about: "Topaz amulet (u) is a members-only item in Old School RuneScape. High alchemy value: 765 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: gold
+    tier: mid
+  properties:
+    release_date: "2017-02-02"
+    update: "Jewellery rework"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.004
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: crafting
+      level: 45
+      xp: 80
+      materials:
+        - item_name: Gold bar
+          item_id: 2357
+          quantity: 1
+        - item_name: Red topaz
+          item_id: 1639
+          quantity: 1
+        - item_name: Amulet mould
+          item_id: 1595
+          quantity: 1
+      facility: Furnace
+      product: Topaz amulet (u)
+      product_id: 21105
+      output_quantity: 1
+  related_items:
+    - item_id: 1639
+      item_name: Red topaz
+      slug: red-topaz
+      relationship: component
+      description: "Cut red topaz gem used to craft the unstrung amulet."
+    - item_id: 1673
+      item_name: Topaz amulet
+      slug: topaz-amulet
+      relationship: upgrade
+      description: "Strung wearable amulet made by adding a ball of wool."
+    - item_id: 1725
+      item_name: Burning amulet
+      slug: burning-amulet
+      relationship: upgrade
+      description: "Enchanted topaz amulet that teleports near lava sources; created via Lvl-3 Enchant at 49 Magic."
+    - item_id: 1675
+      item_name: Topaz necklace
+      slug: topaz-necklace
+      relationship: alternative
+      description: "Necklace-slot counterpart crafted from the same red topaz and silver."
+  about: "Topaz amulet (u) is the unstrung red topaz amulet, crafted at 45 Crafting at a furnace from a gold bar, red topaz, and an amulet mould for 80 Crafting XP. The unstrung amulet is non-wearable until combined with a ball of wool to produce the standard Topaz amulet, which can then be enchanted at 49 Magic into a Burning amulet for lava-area teleports."
+  market_strategy:
+    notes:
+      - "Supply is entirely Crafting-side - gold bar plus red topaz cost is the floor."
+      - "GE buy limit of 10,000 per 4 hours supports bulk crafter flips."
+      - "High alch of 765 gp sits near or below GE price - alching is rarely profitable."
+      - "Demand spikes follow Burning amulet usage in lava-area Slayer or Wilderness content."
+  trading_tips:
+    - "Cross-check red topaz and gold bar prices - the spread tells you crafter break-even."
+    - "Watch for Burning amulet demand bursts to drive intermediate Topaz amulet (u) supply pressure."
+    - "Stable, high-volume jewellery item - good practice flip with thin margins."
+  history:
+    - date: "2017-02-02"
+      description: "Added with the jewellery rework that introduced the topaz amulet line alongside other crafted gem amulets."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Torag's helm | OSRS Price Data
-description: "Torag's helm is a members head slot item requiring 70 Defence. High alch: 61,800 GP, GE limit: 15."
+description: "Torag's helm is the helm piece of Torag's Barrows set requiring 70 Defence. High alch: 61,800 GP, GE limit: 15."
 osrs:
   id: 4745
   name: Torag's helm
@@ -12,87 +12,102 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: barrows
+    tier: high
+  properties:
+    release_date: "2005-05-09"
+    update: "Barrows"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.7
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: head
-    type: barrows
-    set: Torag
-    tradeable: true
-    degradeable: true
     weight: 2.7
     requirements:
       defence: 70
-    stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
-      attack_magic: -6
-      attack_ranged: 0
-      defence_stab: 55
-      defence_slash: 58
-      defence_crush: 54
-      defence_magic: -1
-      defence_ranged: 62
-      strength: 0
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: 0
+    defence_bonus:
+      stab: 55
+      slash: 58
+      crush: 54
+      magic: -1
+      ranged: 62
+    other_bonus:
+      melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-  set_effect:
-    name: Corruption
-    pieces_required: 4
-    description: 25% chance to lower opponent's run energy by 20%
-    amulet_of_damned: Defence is increased by 1% for every 1 HP missing
+  passive_effects:
+    - name: Corruption set effect
+      description: "While wearing the full Torag's set (helm, platebody, platelegs, hammers), each successful melee hit on the opponent has a 25% chance to drain 20% of their run energy."
+      trigger: on_hit
+    - name: Amulet of the damned synergy
+      description: "While the full set is equipped with Amulet of the damned, defence is increased by 1% for every 1 HP the player is missing."
+      trigger: while_worn
+  drop_table:
+    sources:
+      - source: Barrows reward chest
+        quantity: "1"
+        rarity: 1/2530
+        notes: "Rolled from Torag the Corrupted's coffin in the Barrows minigame."
   related_items:
-    - item_id: 4749
-      item_name: Torag's platebody
-      slug: torags-platebody
+    - item_name: Torag's platebody
+      slug: torag-s-platebody
       relationship: set-piece
-      description: Body slot set piece
-    - item_id: 4751
-      item_name: Torag's platelegs
-      slug: torags-platelegs
+      description: "Body slot piece of the Torag's Barrows set"
+    - item_name: Torag's platelegs
+      slug: torag-s-platelegs
       relationship: set-piece
-      description: Legs slot set piece
-    - item_id: 4747
-      item_name: Torag's hammers
-      slug: torags-hammers
+      description: "Legs slot piece of the Torag's Barrows set"
+    - item_name: Torag's hammers
+      slug: torag-s-hammers
       relationship: set-piece
-      description: Weapon set piece
-  about: |-
-    | Bonus | Value |
-    |-------|-------|
-    | Stab defence | +55 |
-    | Slash defence | +58 |
-    | Crush defence | +54 |
-    | Magic defence | -1 |
-    | Ranged defence | +62 |
-    | Magic attack | -6 |
-
-    Corruption:
-    When wearing full Torag's (helm, platebody, platelegs, hammers):
-    - 25% chance to lower opponent's run energy by 20%
-    - Generally considered weakest Barrows effect
-
-    With Amulet of the Damned:
-    - Defence is increased by 1% for every 1 HP missing
-
-    Best For:
-    - Budget tank helm
-    - Identical stats to Guthan's helm
-    - Cheaper alternative for defence
-
-    Note: Set effect rarely used; pieces often worn standalone for stats.
-
-    - 15 hours of combat use
-    - Repair at Bob in Lumbridge or POH armor stand
+      description: "Two-handed crush weapon piece of the Torag's Barrows set"
+    - item_name: Guthan's helm
+      slug: guthan-s-helm
+      relationship: alternative
+      description: "Guthan's Barrows helm with identical defensive stats"
+    - item_name: Verac's helm
+      slug: verac-s-helm
+      relationship: alternative
+      description: "Verac's Barrows helm with prayer bonus instead of higher defence"
+  about: "Torag's helm is the head piece of Torag the Corrupted's Barrows set, requiring 70 Defence to wear. It degrades with combat use, lasting roughly 15 hours of combat before fully broken, and shares its defensive profile with Guthan's helm. The Corruption set effect is widely considered the weakest Barrows brother bonus, so the helm is typically worn standalone as a budget tank head slot rather than for the four-piece effect."
   market_strategy:
     notes:
-      - Cheapest Barrows helm
-      - Used for stats, not set effect
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Cheapest Barrows helm on the GE, anchored by weak set effect demand"
+      - "Identical stat profile to Guthan's helm at much lower price"
+      - "Repair cost at Bob in Lumbridge or POH armour stand caps the practical floor"
+      - "Limit 15 per 4 hours throttles bulk flipping"
+  trading_tips:
+    - "Compare Torag's helm vs Guthan's helm price gap; arbitrage when spread widens"
+    - "Buy fully-charged copies and avoid degraded variants on the GE"
+    - "Restock during Barrows event weekends when supply floods the market"
+  history:
+    - date: "2005-05-09"
+      description: "Released with the Barrows minigame."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toxic-staff-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toxic-staff-uncharged.mdx
@@ -12,27 +12,62 @@ osrs:
   lowalch: 400002
   highalch: 600003
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: toxic
+    tier: high
+  properties:
+    release_date: "2015-01-08"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: weapon
-    type: staff
-    attack_style: magic
+    weapon_type: staff
     attack_speed: 4
+    attack_range: 1
+    weight: 2.267
     requirements:
-      magic: 75
       attack: 75
-    stats:
-      attack_magic: 25
-      attack_stab: 55
-      attack_slash: 70
-      strength: 72
-      magic_damage_percent: 15
-    degradeable: true
-  effect:
-    venom_infliction: 25
+      magic: 75
+    attack_bonus:
+      stab: 55
+      slash: 70
+      crush: 0
+      magic: 25
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 3
+      crush: 1
+      magic: 15
+      ranged: 0
+    other_bonus:
+      melee_strength: 72
+      ranged_strength: 0
+      magic_damage: 15
+      prayer: 0
   special_attack:
     name: Power of Death
     energy: 100
-    effect: Halves melee damage received for 1 minute
+    description: "Halves melee damage received for 1 minute."
+  passive_effects:
+    - name: Venom Infliction
+      description: "25% chance to inflict venom on magic and melee attacks."
+    - name: Magic Defence
+      description: "Provides notable magic defence in melee distance fights."
   charging:
     material_id: 12934
     material_name: Zulrah's scales
@@ -42,68 +77,53 @@ osrs:
       level: 59
       xp: 0
       materials:
-        - item_name: Staff of the dead
-          item_id: 11791
+        - item_id: 11791
+          item_name: Staff of the dead
           quantity: 1
-        - item_name: Magic fang
-          item_id: 12932
+        - item_id: 12932
+          item_name: Magic fang
           quantity: 1
-      product: Toxic staff of the dead
-      product_id: 12902
-      product_quantity: 1
+      output:
+        item_id: 12902
+        item_name: Toxic staff (uncharged)
+        output_quantity: 1
+      tools: []
       facility: None
-      members_only: true
+      members: true
+      notes: "Attach Magic fang to Staff of the dead at 59 Crafting."
   related_items:
     - item_id: 11791
       item_name: Staff of the dead
       slug: staff-of-the-dead
       relationship: component
-      description: Base staff
+      description: "Base staff used in the combination."
     - item_id: 12932
       item_name: Magic fang
       slug: magic-fang
       relationship: component
-      description: From Zulrah
+      description: "Zulrah drop attached to grant venom procs."
+    - item_id: 12904
+      item_name: Toxic staff of the dead
+      slug: toxic-staff-of-the-dead
+      relationship: upgrade
+      description: "Charged variant once Zulrah's scales are loaded."
     - item_id: 21006
       item_name: Kodai wand
       slug: kodai-wand
       relationship: alternative
-      description: Higher magic attack
-  about: |-
-    Attach Magic fang to Staff of the dead (59 Crafting).
-
-    | Component | Source | Price |
-    |-----------|--------|-------|
-    | Staff of the dead | K'ril Tsutsaroth | ~8M gp |
-    | Magic fang | Zulrah | ~3M gp |
-
-    | Stat | Value |
-    |------|-------|
-    | Magic attack | +25 |
-    | Magic damage | +15% |
-    | Stab attack | +55 |
-    | Slash attack | +70 |
-    | Strength bonus | +72 |
-    | Requirements | 75 Magic, 75 Attack |
-
-    Venom Infliction:
-    - 25% chance to inflict venom
-    - Works on magic and melee attacks
-
-    Power of Death (100% energy):
-    - Halves melee damage received
-    - Lasts 1 minute
-
-    | Resource | Amount |
-    |----------|--------|
-    | Zulrah's scales | 11,000 |
+      description: "Higher magic attack one-handed alternative."
+  about: "Toxic staff (uncharged) is the unfueled member staff produced by combining a Staff of the dead with a Magic fang at 59 Crafting, ready to be charged with Zulrah's scales into the Toxic staff of the dead for venom procs and +15% magic damage."
   market_strategy:
     notes:
-      - Higher magic bonus than base
-      - Venom is useful for Slayer
-      - Degrades over time
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Price tracks Staff of the dead + Magic fang component spread."
+      - "Buy limit of 8 per 4 hours throttles bulk flipping."
+      - "Demand pulses with Zulrah meta and venom Slayer tasks."
+  trading_tips:
+    - "Watch Staff of the dead and Magic fang prices for combination arbitrage."
+    - "Bulk-stock uncharged variant ahead of charged Toxic SOTD price spikes."
+  history:
+    - date: "2015-01-08"
+      description: "Released as part of the Zulrah update; combination craft with Magic fang and Staff of the dead."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-blowpipe-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-blowpipe-ornament-kit.mdx
@@ -11,10 +11,54 @@ osrs:
   value: 5000
   lowalch: 2000
   highalch: 3000
-  limit: null
-  about: "Trailblazer reloaded blowpipe ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: high
+  properties:
+    release_date: "2023-11-15"
+    update: "Leagues IV: Trailblazer Reloaded"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Use
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  related_items:
+    - item_name: Toxic blowpipe
+      slug: toxic-blowpipe
+      relationship: component
+      description: Base weapon the ornament kit is applied to.
+    - item_name: Blazing blowpipe
+      slug: blazing-blowpipe
+      relationship: product
+      description: Result of applying the ornament kit to an uncharged Toxic blowpipe.
+  about: |-
+    Trailblazer reloaded blowpipe ornament kit is a cosmetic upgrade earned from the Leagues IV: Trailblazer Reloaded reward shop for 6,000 League Points. When applied to an uncharged Toxic blowpipe, it transforms the weapon into a Blazing blowpipe, swapping the green-and-purple palette for the fiery Leagues IV theme.
+
+    The kit is fully reversible — players can revert the Blazing blowpipe back into the original Toxic blowpipe and the ornament kit at any time, preserving long-term flexibility for fashionscape and resale.
+  market_strategy:
+    notes:
+      - "Supply fixed at Leagues IV completion volume; price floor grows over time."
+      - "No GE buy limit listed — large flips are possible but volume is thin."
+      - "Demand spikes around new Leagues seasons and PvM streamer attention."
+  trading_tips:
+    - "Reversible ornament kit retains optionality — buyers pay for the swap-back guarantee."
+    - "List during high-value PvM meta when Toxic blowpipe demand rises."
+    - "Track Leagues-themed cosmetic prices as a basket; they move together."
+  history:
+    - date: "2023-11-15"
+      description: "Added to the game during Leagues IV: Trailblazer Reloaded."
+    - date: "2023-11-29"
+      description: "Made obtainable from the Leagues Reward Shop for 6,000 League Points."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-trousers-t3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-trousers-t3.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer trousers (t3) | OSRS Price Data
-description: "Trailblazer trousers (t3): The trousers of a trailblazer relic hunter.. High alch: 90,000 GP, GE limit: 5."
+description: "Trailblazer trousers (t3): The trousers of a trailblazer relic hunter. High alch: 90,000 GP, GE limit: 5."
 osrs:
   id: 25007
   name: Trailblazer trousers (t3)
@@ -12,9 +12,82 @@ osrs:
   lowalch: 60000
   highalch: 90000
   limit: 5
-  about: "Trailblazer trousers (t3) is a members-only item in Old School RuneScape. High alchemy value: 90,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic-cloth
+    tier: high
+  properties:
+    release_date: "2021-01-06"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Leagues Reward Shop"
+      location: "League Hall"
+      price: 15000
+      currency: League Points
+      stock: 1
+  related_items:
+    - item_name: Trailblazer hood (t3)
+      slug: trailblazer-hood-t3
+      relationship: set-piece
+      description: "Tier 3 hood from the trailblazer relic hunter outfit"
+    - item_name: Trailblazer top (t3)
+      slug: trailblazer-top-t3
+      relationship: set-piece
+      description: "Tier 3 top from the trailblazer relic hunter outfit"
+    - item_name: Trailblazer boots (t3)
+      slug: trailblazer-boots-t3
+      relationship: set-piece
+      description: "Tier 3 boots from the trailblazer relic hunter outfit"
+    - item_name: Trailblazer cane
+      slug: trailblazer-cane
+      relationship: alternative
+      description: "Companion cosmetic shown with the outfit on the League hall stand"
+  about: "Trailblazer trousers (t3) are the tier 3 legs of the cosmetic Trailblazer relic hunter outfit, originally purchased from the Leagues Reward Shop for 15,000 League points during the Trailblazer Reloaded league. The piece grants zero combat bonuses, is tradeable on the Grand Exchange, and stores in a costume room armour case alongside the rest of the outfit."
+  market_strategy:
+    notes:
+      - "Pure cosmetic item, demand is fashionscape and outfit completion only"
+      - "Limited supply because new copies require a future league event"
+      - "GE limit of 5 keeps any flash-flip ceiling modest"
+  trading_tips:
+    - "Buy during cosmetic flips after popular fashionscape streams"
+    - "Stock matching set pieces together to lift total resale margin"
+  history:
+    - date: "2021-01-06"
+      description: "Released as a Trailblazer League tier 3 reward outfit piece."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-fortuity-active.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trinket-of-fortuity-active.mdx
@@ -1,20 +1,66 @@
 ---
 title: Trinket of fortuity (active) | OSRS Price Data
-description: Trinket of fortuity (active) is a members-only OSRS item.
+description: "Trinket of fortuity (active) is a Wilderness boss luck modifier that boosts rare drop chances while skulling teleports."
 osrs:
   id: 33050
   name: Trinket of fortuity (active)
   slug: trinket-of-fortuity-active
-  examine: A magic rock! This one increases the chance of obtaining rare items. Teleportation will behave as if you were skulled.
+  examine: "A magic rock! This one increases the chance of obtaining rare items. Teleportation will behave as if you were skulled."
   members: true
   icon: Trinket of fortuity.png
   value: 0
-  lowalch: null
-  highalch: null
-  limit: null
-  about: Trinket of fortuity (active) is a members-only item in Old School RuneScape.
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  lowalch: 0
+  highalch: 0
+  limit: 0
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: trinket
+    tier: high
+  properties:
+    release_date: "2023-12-13"
+    update: "Wilderness Boss Rework"
+    tradeable: false
+    equipable: false
+    stackable: false
+    noteable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Deactivate
+      - Drop
+    alchable: false
+    destroy: "Drop"
+  passive_effects:
+    - name: Wilderness boss luck boost
+      description: "While active, increases the chance of receiving unique drops from Callisto, Venenatis and Vet'ion (and their Calvarion/Spindel/Artio variants)."
+    - name: Skulling teleport penalty
+      description: "Teleports while the trinket is active act as if the player is skulled, so all items will be lost on death."
+  related_items:
+    - item_name: Trinket of fortuity
+      slug: trinket-of-fortuity
+      relationship: variant
+      description: Inactive form of the trinket before activation.
+    - item_name: Trinket of vengeance
+      slug: trinket-of-vengeance
+      relationship: alternative
+      description: PvP-focused alternative trinket from the same loot pool.
+  about: |-
+    Trinket of fortuity (active) is the activated form of the Trinket of fortuity, dropped from the resurrected Wilderness bosses. While active, it raises the chance of receiving the unique drops from Callisto, Venenatis, Vet'ion and their lesser variants.
+
+    Activating the trinket also imposes a skull-style teleport penalty: every teleport while it is active behaves as if the player were skulled, so any item left unprotected will drop on death.
+  market_strategy:
+    notes:
+      - "Untradeable; no Grand Exchange market."
+      - "Value is measured in Wilderness boss KC efficiency, not GE price."
+      - "Active state cannot be reset without deactivation; weigh skull risk vs. uplift."
+  trading_tips:
+    - "Activate only after committing to a focused Wilderness boss session."
+    - "Pair with non-teleport escape routes to mitigate the skulled teleport penalty."
+  history:
+    - date: "2023-12-13"
+      description: "Released alongside the Wilderness Boss Rework."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trousers-brown.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trousers-brown.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trousers (brown) | OSRS Price Data
-description: "Trousers (brown): A pair of long dwarven trousers... long for dwarves, of course.. High alch: 330 GP, GE limit: 150."
+description: "Trousers (brown): A pair of long dwarven trousers, long for dwarves, of course. High alch: 330 GP, GE limit: 150."
 osrs:
   id: 5036
   name: Trousers (brown)
@@ -12,9 +12,78 @@ osrs:
   lowalch: 220
   highalch: 330
   limit: 150
-  about: "Trousers (brown) is a members-only item in Old School RuneScape. High alchemy value: 330 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-08-22"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weight: 0.453
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Thessalia's Fine Clothes"
+      location: Varrock
+      price: 650
+      currency: coins
+      stock: 0
+      members_only: false
+  related_items:
+    - item_id: 5034
+      item_name: Shirt (brown)
+      slug: shirt-brown
+      relationship: set-piece
+      description: "Matching brown shirt for the dwarven outfit."
+    - item_id: 5038
+      item_name: Trousers (red)
+      slug: trousers-red
+      relationship: variant
+      description: "Alternate colour variant of the dwarven trousers."
+  about: "Trousers (brown) is a members cosmetic legwear sold by Thessalia's Fine Clothes in Varrock as part of the dwarven outfit set, offering no combat stats and existing purely for fashionscape."
+  market_strategy:
+    notes:
+      - "Pure cosmetic with zero combat bonus; demand is fashionscape-only."
+      - "Thessalia restocks keep the GE ceiling near shop price."
+      - "Limit 150 per 4 hours throttles bulk arbitrage."
+  trading_tips:
+    - "Stock during fashionscape competitions and outfit hype cycles."
+    - "Compare brown vs red variant for cheapest stock to bulk-flip."
+  history:
+    - date: "2005-08-22"
+      description: "Added to Thessalia's Fine Clothes wardrobe expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-botanical-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-botanical-pie.mdx
@@ -1,6 +1,6 @@
 ---
 title: Uncooked botanical pie | OSRS Price Data
-description: "Uncooked botanical pie: This would be much tastier cooked.. High alch: 9 GP, GE limit: 13,000."
+description: "Uncooked botanical pie: This would be much tastier cooked. High alch: 9 GP, GE limit: 13,000."
 osrs:
   id: 19656
   name: Uncooked botanical pie
@@ -12,9 +12,79 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 13000
-  about: "Uncooked botanical pie is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: mid
+  properties:
+    release_date: "2016-05-26"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.499
+    options:
+      - Use
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 52
+      xp: 12
+      materials:
+        - item_name: Pie shell
+          item_id: 2315
+          quantity: 1
+        - item_name: Golovanova fruit top
+          item_id: 19656
+          quantity: 1
+      product: Uncooked botanical pie
+      product_id: 19656
+      output_quantity: 1
+      members_only: true
+    - skill: cooking
+      level: 52
+      xp: 180
+      materials:
+        - item_name: Uncooked botanical pie
+          item_id: 19656
+          quantity: 1
+      product: Botanical pie
+      product_id: 19662
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 19662
+      item_name: Botanical pie
+      slug: botanical-pie
+      relationship: product
+      description: Cooked form that boosts Herblore by 4 levels
+    - item_id: 2315
+      item_name: Pie shell
+      slug: pie-shell
+      relationship: component
+      description: Base shell used to build the pie
+    - item_id: 2347
+      item_name: Pie dish
+      slug: pie-dish
+      relationship: component
+      description: Returned after the cooked pie is eaten
+  about: "Uncooked botanical pie is the raw stage of botanical pie, made by adding a golovanova fruit top to a pie shell at level 52 Cooking. It must be cooked on a range to become a botanical pie, which heals 14 Hitpoints and grants a temporary +4 Herblore boost."
+  market_strategy:
+    notes:
+      - "Demand tracks cooked botanical pie price for Herblore boost flips"
+      - "Cheap intermediate sold mainly by Herblore boosters"
+      - "GE buy limit of 13,000 supports bulk Ironman cooking"
+  trading_tips:
+    - Spread the price gap between raw and cooked pies for Cooking XP arbitrage
+    - Bulk supply spikes around Herblore content updates
+  history:
+    - date: "2016-05-26"
+      description: "Released alongside Botanical pie with Monkey Madness II."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-meat-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncooked-meat-pie.mdx
@@ -12,9 +12,79 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 13000
-  about: "Uncooked meat pie is a free-to-play item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: low
+  properties:
+    release_date: "2001-03-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.5
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: cooking
+      level: 20
+      xp: 0
+      tools: []
+      materials:
+        - item_name: Pie shell
+          quantity: 1
+        - item_name: Cooked meat
+          quantity: 1
+      output_quantity: 1
+      notes: "Use cooked meat (or cooked chicken) on a pie shell to assemble; no XP awarded for assembly."
+    - skill: cooking
+      level: 20
+      xp: 110
+      tools:
+        - Range
+      materials:
+        - item_name: Uncooked meat pie
+          quantity: 1
+      output_quantity: 1
+      notes: "Cook on any range to produce a Meat pie; risk of burning into Burnt pie."
+  related_items:
+    - item_name: Meat pie
+      slug: meat-pie
+      relationship: product
+      description: Cooked result that heals 6 hitpoints per half.
+    - item_name: Pie shell
+      slug: pie-shell
+      relationship: component
+      description: Base pastry shell required for the recipe.
+    - item_name: Cooked meat
+      slug: cooked-meat
+      relationship: component
+      description: Filling for the uncooked pie.
+    - item_name: Burnt pie
+      slug: burnt-pie
+      relationship: alternative
+      description: Failure result when cooking the uncooked meat pie.
+  about: |-
+    Uncooked meat pie is the raw form of the meat pie food item, assembled by combining a pie shell with cooked meat or cooked chicken. It is cooked on any range at level 20 Cooking for 110 experience, producing a meat pie or — on a failed attempt — a burnt pie.
+
+    The pie itself is a beginner-friendly food that heals 6 hitpoints per half once cooked. The uncooked version is mostly used as a Cooking training input, with negligible GE flipping volume due to its low price.
+  market_strategy:
+    notes:
+      - "Cheap Cooking training input; price tracks pie shell + cooked meat sum."
+      - "Buy limit is 13,000 per 4 hours but daily volume is small."
+      - "Margins thin — focus on bulk Cooking XP/hr rather than flipping."
+  trading_tips:
+    - "Compare GE price to assembled cost; arbitrage rarely pays off below 20 gp gap."
+    - "Stock up during Cooking XP weekends when raw food prices spike."
+    - "Sell directly to ironmen training Cooking around level 20-30."
+  history:
+    - date: "2001-03-17"
+      description: "Released alongside the original Cooking skill content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-sapphire.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncut-sapphire.mdx
@@ -1,6 +1,6 @@
 ---
 title: Uncut sapphire | OSRS Price Data
-description: "Uncut sapphire: This would be worth more cut.. High alch: 15 GP, GE limit: 10,000."
+description: "Uncut sapphire is the base form of a sapphire gem; cut with a chisel at 20 Crafting for 50 XP to produce a Sapphire. High alch: 15 GP, GE limit: 10,000."
 osrs:
   id: 1623
   name: Uncut sapphire
@@ -12,19 +12,41 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
   material:
     type: gem
     tier: low
-  crafting:
-    cutting_level: 20
-    cutting_xp: 50
-    uncut: true
+  properties:
+    release_date: "2001-03-17"
+    update: "RuneScape Classic - gem mining"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    weight: 0.003
+    options:
+      - Drop
+    alchable: true
+    destroy: "Drop"
   drop_table:
     sources:
       - source: Gem rocks
-        source_id: 0
-        quantity: "1"
+        rarity: "1/29 (with Charged dragonstone amulet)"
+        members_only: true
+      - source: Rare drop table
         rarity: common
+      - source: TzHaar-Xil
+        members_only: true
+      - source: TzHaar-Ket
+        members_only: true
+      - source: Waterfiend
+        members_only: true
+      - source: Gem stall (Thieving 75)
+        members_only: true
+      - source: Wall safe (Thieving 50)
         members_only: true
   recipes:
     - skill: crafting
@@ -34,9 +56,11 @@ osrs:
         - item_name: Uncut sapphire
           item_id: 1623
           quantity: 1
+        - item_name: Chisel
+          item_id: 1755
+          quantity: 1
       product: Sapphire
-      product_id: 1607
-      product_quantity: 1
+      output_quantity: 1
     - skill: fletching
       level: 56
       xp: 4
@@ -44,58 +68,54 @@ osrs:
         - item_name: Sapphire
           item_id: 1607
           quantity: 1
+        - item_name: Chisel
+          item_id: 1755
+          quantity: 1
       product: Sapphire bolt tips
-      product_id: 9189
-      product_quantity: 12
+      output_quantity: 12
       members_only: true
   related_items:
-    - item_id: 1621
-      item_name: Uncut emerald
-      slug: uncut-emerald
-      relationship: alternative
-      description: Higher tier gem
     - item_id: 1607
       item_name: Sapphire
       slug: sapphire
       relationship: product
-      description: Cut version
-    - item_id: 2550
-      item_name: Ring of recoil
-      slug: ring-of-recoil
-      relationship: product
-      description: Combat use
-    - item_id: 3853
-      item_name: Games necklace
-      slug: games-necklace
-      relationship: product
-      description: Teleportation
+      description: Cut sapphire used for jewellery and bolt tips.
     - item_id: 1755
       item_name: Chisel
       slug: chisel
       relationship: component
-      description: For cutting
-  about: |-
-    | Item | Enchantment | Effect |
-    |------|-------------|--------|
-    | Sapphire ring | Ring of recoil | Reflect 10% damage |
-    | Sapphire necklace | Games necklace | Minigame teleports |
-    | Sapphire amulet | Amulet of magic | +10 Magic |
-    | Sapphire bolts | Sapphire bolts (e) | Mana drain |
+      description: Required tool to cut the gem.
+    - item_id: 1621
+      item_name: Uncut emerald
+      slug: uncut-emerald
+      relationship: upgrade
+      description: Next-tier uncut gem at 27 Crafting.
+    - item_id: 2550
+      item_name: Ring of recoil
+      slug: ring-of-recoil
+      relationship: product
+      description: Sapphire-derived combat utility ring.
+    - item_id: 3853
+      item_name: Games necklace
+      slug: games-necklace
+      relationship: product
+      description: Sapphire-derived teleport jewellery.
+  about: "Uncut sapphire is the lowest-tier coloured gem in OSRS, available in both free-to-play and members areas. It is cut with a chisel at 20 Crafting for 50 XP to produce a Sapphire, the base gem used for sapphire jewellery (ring of recoil, games necklace, amulet of magic) and members-only sapphire bolt tips. Drop sources include gem rocks, the rare drop table, TzHaar creatures, Waterfiends, gem stalls, and wall safes - making it one of the highest-volume Crafting training feedstocks in the game."
   market_strategy:
     notes:
-      - Most common uncut gem
-      - Buy uncut → Cut → Sell
-      - Good for Crafting training
-      - Games necklace (teleports)
-      - Ring of recoil (PvM)
-      - Crafting training
-      - Sapphire bolt tips
-      - Cheapest gem to process
-      - High volume trading
-      - Ring of recoil always needed
-      - Games necklace for minigames
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Demand comes from Crafting trainers, fletchers cutting bolt tips, and jewellery producers."
+      - "GE buy limit of 10,000 per 4 hours supports heavy bulk movement."
+      - "High alch return of 15 gp is below GE price - never an alch target."
+      - "Supply is fed by gem rock miners, TzHaar drops, and the rare drop table - very deep liquidity."
+  trading_tips:
+    - "Watch the uncut-vs-cut sapphire spread - tight margins mean bulk buys pay off."
+    - "Track gem-rock mining update notes - changes to rates move uncut supply quickly."
+    - "Pair with sapphire bolt tips arbitrage for fletcher resale loops."
+  history:
+    - date: "2001-03-17"
+      description: "Released as part of the original RuneScape Classic gem-cutting and jewellery chain."
+    - date: "2007-08-06"
+      description: "Graphical update to the gem inventory icon."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-symbol.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unholy-symbol.mdx
@@ -12,59 +12,119 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: amulet
+    tier: low
+  properties:
+    release_date: "2003-03-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: neck
-    type: symbol
-    prayer_bonus: 8
+    weight: 0.007
     requirements:
       prayer: 31
-  crafting:
-    skill: crafting
-    level: 31
-    xp: 50
-    materials:
-      - item_name: Unstrung symbol (Zamorak)
-        item_id: 1720
-        quantity: "1"
-      - item_name: Ball of wool
-        item_id: 1759
-        quantity: "1"
+    attack_bonus:
+      stab: 2
+      slash: 2
+      crush: 2
+      magic: 2
+      ranged: 2
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 8
+  recipes:
+    - skill: crafting
+      level: 16
+      xp: 50
+      tools:
+        - Furnace
+        - Unholy mould
+      materials:
+        - item_name: Silver bar
+          quantity: 1
+      output_quantity: 1
+      notes: "Cast silver bar at a furnace with the unholy mould to create an unstrung symbol (Zamorak)."
+    - skill: crafting
+      level: 16
+      xp: 4
+      tools: []
+      materials:
+        - item_name: Unstrung symbol (Zamorak)
+          quantity: 1
+        - item_name: Ball of wool
+          quantity: 1
+      output_quantity: 1
+      notes: "Use ball of wool on the unstrung symbol to make an unpowered unholy symbol."
+    - skill: prayer
+      level: 50
+      xp: 0
+      tools:
+        - Unholy book
+      materials:
+        - item_name: Unpowered unholy symbol
+          quantity: 1
+      output_quantity: 1
+      notes: "Use the unholy book (or book of balance) to bless the symbol into the equippable Unholy symbol."
   related_items:
     - item_id: 1718
       item_name: Holy symbol
       slug: holy-symbol
       relationship: alternative
-      description: Saradomin counterpart (+8 Prayer)
+      description: Saradomin counterpart with the same +8 Prayer bonus.
     - item_id: 1704
       item_name: Amulet of glory
       slug: amulet-of-glory
       relationship: alternative
-      description: Better combat stats, no prayer bonus
+      description: Stronger combat amulet without the Prayer bonus.
     - item_id: 19492
       item_name: Amulet of the damned
       slug: amulet-of-the-damned
       relationship: upgrade
-      description: For Barrows sets
+      description: Barrows-set upgrade amulet with set bonus effects.
+    - item_name: Unstrung symbol (Zamorak)
+      slug: unstrung-symbol-zamorak
+      relationship: component
+      description: Mould-cast intermediate before stringing.
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Neck |
-    | Prayer Bonus | +8 |
-    | Prayer Req | 31 |
+    Unholy symbol is the Zamorakian counterpart to the holy symbol, providing the same +8 Prayer bonus but with offensive bonuses (+2 across all attack styles) instead of defensive ones. It occupies the neck slot, weighs 0.007 kg and requires 31 Prayer to equip.
 
-    - Prayer bonus for protection prayers
-    - Zamorak-themed gear
-    - Budget prayer gear option
+    Players craft the symbol in three steps: cast a silver bar with the unholy mould at a furnace (16 Crafting, 50 XP), string the unstrung symbol with a ball of wool (4 XP), then bless the unpowered symbol with an unholy book or book of balance after reaching 50 Prayer. The blessing step requires the player to have completed appropriate book-of-balance content; budget prayer trainers usually go with the holy symbol instead.
   market_strategy:
     notes:
-      - Lower demand than holy symbol
-      - Zamorak aesthetic appeal
-      - Limited practical use
-      - Less popular than holy symbol
-      - Very low trading volume
-      - Crafting usually cheaper
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Lower demand than holy symbol — most prayer gear users pick Saradomin."
+      - "Zamorak aesthetic and PvP gear setups drive niche demand."
+      - "Very low trading volume; crafting from silver bar is usually cheaper than GE."
+      - "Buy limit 125 per 4 hours makes meaningful flipping slow."
+  trading_tips:
+    - "Compare GE price to silver bar + ball of wool + blessing cost before buying."
+    - "Stock for Zamorak-themed PvP loadouts and fashionscape buyers."
+    - "Avoid during major prayer rework discussions — sentiment moves price."
+  history:
+    - date: "2003-03-17"
+      description: "Released alongside the original Prayer/Crafting content for Zamorak followers."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/urt-salt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/urt-salt.mdx
@@ -12,9 +12,78 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Urt salt is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: salt
+    tier: low
+  properties:
+    release_date: "2018-09-06"
+    tradeable: true
+    stackable: true
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  skilling_sources:
+    - skill: mining
+      level: 72
+      xp: 17
+      location: Salt mine beneath Weiss
+      method: "Mine green salt rocks in the Weiss salt mine after completing Making Friends with My Arm"
+      members_only: true
+  recipes:
+    - skill: magic
+      level: 82
+      xp: 32
+      facility: Weiss fire pit
+      materials:
+        - item_name: Urt salt
+          quantity: 3
+        - item_name: Te salt
+          quantity: 1
+        - item_name: Basalt
+          quantity: 1
+      output_quantity: 1
+      product: Stony basalt
+      members_only: true
+      notes: "Combined with Te salt and basalt at a Weiss fire pit to produce stony basalt for Lunar teleports."
+  related_items:
+    - item_id: 22593
+      item_name: Te salt
+      slug: te-salt
+      relationship: alternative
+      description: Red Weiss salt mined alongside urt salt
+    - item_id: 22595
+      item_name: Efh salt
+      slug: efh-salt
+      relationship: alternative
+      description: Blue Weiss salt mined alongside urt salt
+    - item_id: 22591
+      item_name: Basalt
+      slug: basalt
+      relationship: component
+      description: Combined with salts to make icy and stony basalt
+  about: "Urt salt is a green mineable salt obtained from the Weiss salt mine after Making Friends with My Arm. Combined with other Weiss salts and basalt at fire pits to produce stony basalt for Lunar teleport spells and used in Portal Nexus room attunements. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  market_strategy:
+    notes:
+      - "Supply tied to dedicated Weiss salt miners with 72 Mining"
+      - "Construction Portal Nexus rooms consume salts in bulk"
+      - "Demand spikes when Lunar teleport optimisations trend"
+      - "Buy limit of 10,000 supports large bulk flips"
+  trading_tips:
+    - "Pair flips with Te and Efh salts since the trio is bought together"
+    - "Stock up before Construction-themed Twisted League events"
+    - "Avoid high alching; the 6 gp return rarely covers nature rune cost"
+  history:
+    - date: "2018-09-06"
+      description: "Released alongside the Making Friends with My Arm quest and the Weiss Salt Mine."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/vesta-s-chainbody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/vesta-s-chainbody.mdx
@@ -1,6 +1,6 @@
 ---
 title: Vesta's chainbody | OSRS Price Data
-description: "Vesta's chainbody: A powerful chainbody.. High alch: 300,000 GP, GE limit: 10."
+description: "Vesta's chainbody: A powerful chainbody. High alch: 300,000 GP, GE limit: 10."
 osrs:
   id: 22616
   name: Vesta's chainbody
@@ -12,9 +12,86 @@ osrs:
   lowalch: 200000
   highalch: 300000
   limit: 10
-  about: "Vesta's chainbody is a members-only item in Old School RuneScape. High alchemy value: 300,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: high
+  properties:
+    release_date: "2023-05-24"
+    update: "Bounty Hunter Rework"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 10.886
+    options:
+      - Uncharge
+      - Drop
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weight: 10.886
+    requirements:
+      defence: 78
+    attack_bonus:
+      stab: 1
+      slash: 1
+      crush: 10
+      magic: -30
+      ranged: -10
+    defence_bonus:
+      stab: 117
+      slash: 115
+      crush: 110
+      magic: -10
+      ranged: 130
+    other_bonus:
+      melee_strength: 4
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+  related_items:
+    - item_name: Vesta's plateskirt
+      slug: vesta-s-plateskirt
+      relationship: set-piece
+      description: Leg armour half of the Vesta's PvP set.
+    - item_name: Vesta's longsword
+      slug: vesta-s-longsword
+      relationship: set-piece
+      description: Iconic stab weapon associated with the Vesta's set.
+    - item_name: Vesta's spear
+      slug: vesta-s-spear
+      relationship: set-piece
+      description: Polearm option that completes the Vesta's wargear.
+    - item_name: Corrupted vesta's chainbody
+      slug: corrupted-vesta-s-chainbody
+      relationship: variant
+      description: Corrupted version with the same role in Bounty Hunter combat.
+  about: |-
+    Vesta's chainbody is a high-end body piece purchased from the Bounty Hunter Store for 500 Bounty Hunter points, with an additional 5,000,000 coin activation fee. It requires 78 Defence to equip and offers some of the strongest melee defensive bonuses in the chest slot.
+
+    Wearable only inside PvP arenas, Castle Wars, Clan Wars, Soul Wars, the TzHaar Fight Pit and POH combat rings. The chainbody is untradeable, non-alchable and degrades with use before requiring re-charging.
+
+    Requirements: 78 Defence | Slot: Body | Weight: 10.886 kg
+  market_strategy:
+    notes:
+      - "Untradeable - no Grand Exchange market; cost is in BH points and activation fees."
+      - "Set bonus restricted to allowed PvP arenas."
+      - "5,000,000 coin activation fee resets each fresh purchase."
+  trading_tips:
+    - "Budget BH points across the full Vesta's set before committing to a single piece."
+    - "If only Castle Wars / Soul Wars usage is planned, weigh against Bandos / Torva chest pieces."
+  history:
+    - date: "2023-06-14"
+      description: "Set bonuses adjusted post-release."
+    - date: "2023-05-24"
+      description: "Released as part of the revamped Bounty Hunter Store."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-hat-blue.mdx
@@ -12,9 +12,93 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 150
-  about: "Villager hat (blue) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    update: "Tai Bwo Wannai Clean-Up"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: head
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Gabooty's Tai Bwo Wannai Cooperative"
+      location: Tai Bwo Wannai
+      price: 240
+      sell_price: 120
+      stock: 5
+      restock_time: 100
+      currency: Trading sticks
+      notes: "Costs 240 trading sticks (reduced to 200 with Karamja gloves 1 or better)."
+  related_items:
+    - item_name: Villager hat (brown)
+      slug: villager-hat-brown
+      relationship: variant
+      description: Brown colour variant from the Tai Bwo Wannai villager set.
+    - item_name: Villager hat (yellow)
+      slug: villager-hat-yellow
+      relationship: variant
+      description: Yellow colour variant of the villager hat.
+    - item_name: Villager hat (pink)
+      slug: villager-hat-pink
+      relationship: variant
+      description: Pink colour variant of the villager hat.
+    - item_name: Villager robe (blue)
+      slug: villager-robe-blue
+      relationship: set-piece
+      description: Matching blue robe to complete the villager outfit.
+  about: |-
+    > *"A brightly coloured hat prized by the Tai Bwo Wannai peoples."*
+
+    Villager hat (blue) is a cosmetic head slot item from the Tai Bwo Wannai villager outfit, available in four colour variants (brown, blue, yellow, pink). It is purchased from Gabooty's Tai Bwo Wannai Cooperative for 240 trading sticks, dropping to 200 if a Karamja gloves 1 or better is worn.
+
+    The hat is purely cosmetic — it occupies the head slot with no combat bonuses and is most often used as a fashionscape piece or stored in a player-owned house magic wardrobe.
+  market_strategy:
+    notes:
+      - "GE price floats around ~4k coins; supply driven by trading-stick farmers."
+      - "Buy limit 150 / 4 hours is plenty for collectors but thin for flipping."
+      - "Demand from fashionscape buyers and Tai Bwo Wannai completionists."
+  trading_tips:
+    - "Earn trading sticks via Tai Bwo Wannai Cleanup and resell for steady profit."
+    - "Stack the full villager outfit for buyers who want the look in one trade."
+    - "Watch fashionscape trend streams — niche cosmetic prices move on hype."
+  history:
+    - date: "2005-08-09"
+      description: "Added with the Tai Bwo Wannai Clean-Up minigame and villager outfit set."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/villager-robe-yellow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/villager-robe-yellow.mdx
@@ -1,6 +1,6 @@
 ---
 title: Villager robe (yellow) | OSRS Price Data
-description: "Villager robe (yellow): A brightly coloured robe prized by the Tai Bwo Wannai peoples.. High alch: 150 GP, GE limit: 150."
+description: "Villager robe (yellow) is a members-only cosmetic legs piece bought at Gabooty's Tai Bwo Wannai Cooperative for 300 trading sticks (250 with Karamja gloves). High alch: 150 GP, GE limit: 150."
 osrs:
   id: 6363
   name: Villager robe (yellow)
@@ -12,9 +12,96 @@ osrs:
   lowalch: 100
   highalch: 150
   limit: 150
-  about: "Villager robe (yellow) is a members-only item in Old School RuneScape. High alchemy value: 150 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cosmetic
+    tier: low
+  properties:
+    release_date: "2005-08-09"
+    update: "Tai Bwo Wannai Clean-Up"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: legs
+    weight: 2
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shop:
+    - location: Tai Bwo Wannai
+      npc: Gabooty
+      shop_name: Gabooty's Tai Bwo Wannai Cooperative
+      base_price: 300 trading sticks
+      discounted_price: 250 trading sticks (Karamja gloves 1 or better)
+      stock: 50
+      restock_seconds: 60
+  related_items:
+    - item_id: 6357
+      item_name: Villager hat (yellow)
+      slug: villager-hat-yellow
+      relationship: alternative
+      description: Matching head slot piece for the yellow villager outfit.
+    - item_id: 6379
+      item_name: Villager top (yellow)
+      slug: villager-top-yellow
+      relationship: alternative
+      description: Matching body slot piece for the yellow villager outfit.
+    - item_id: 6395
+      item_name: Villager armband (yellow)
+      slug: villager-armband-yellow
+      relationship: alternative
+      description: Matching hands slot piece for the yellow villager outfit.
+    - item_id: 6371
+      item_name: Villager sandals (yellow)
+      slug: villager-sandals-yellow
+      relationship: alternative
+      description: Matching feet slot piece for the yellow villager outfit.
+    - item_id: 6361
+      item_name: Villager robe (blue)
+      slug: villager-robe-blue
+      relationship: variant
+      description: Blue colour variant of the same cosmetic robe.
+  about: "Villager robe (yellow) is the yellow-dyed legs slot piece of the Tai Bwo Wannai villager outfit, released with the Tai Bwo Wannai Clean-Up update on 9 August 2005. It is bought from Gabooty's Tai Bwo Wannai Cooperative for 300 trading sticks (or 250 with Karamja gloves 1 or better) and provides no combat bonuses. The robe is mainly used for cosmetic loadouts, Karamja roleplay sets, and fashionscape collection."
+  market_strategy:
+    notes:
+      - "Demand is largely cosmetic - fashionscape collectors and Karamja-themed loadout buyers."
+      - "GE buy limit of 150 per 4 hours keeps merchant volume capped."
+      - "High alch of 150 gp is below GE price - not an alch target."
+      - "Supply is a constant trickle from Gabooty's stock of 50 with 60-second restock."
+  trading_tips:
+    - "Trading-sticks-to-gp conversion sets the production floor - check sticks pricing before bulk buying."
+    - "Watch villager outfit demand spikes around quest reward streams or Karamja events."
+    - "Low-volume cosmetic - prefer single-set flips over bulk holdings."
+  history:
+    - date: "2005-08-09"
+      description: "Released with the Tai Bwo Wannai Clean-Up update alongside the full villager outfit."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/water-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/water-battlestaff.mdx
@@ -1,6 +1,6 @@
 ---
 title: Water battlestaff | OSRS Price Data
-description: "Water battlestaff: It's a slightly magical stick.. High alch: 9,300 GP, GE limit: 18,000."
+description: "Water battlestaff is a members one-handed battlestaff requiring 30 Attack and 30 Magic that supplies unlimited water runes when wielded. High alch: 9,300 GP, GE limit: 18,000."
 osrs:
   id: 1395
   name: Water battlestaff
@@ -12,34 +12,109 @@ osrs:
   lowalch: 6200
   highalch: 9300
   limit: 18000
-  item_id: 1395
-  item_type: equipment
-  slot: weapon
-  type: battlestaff
-  attack_speed: 5
-  tradeable: true
-  weight: 2.267
-  requirements:
-    attack: 30
-    magic: 30
-  stats:
-    magic_attack: 12
-    crush_attack: 7
-    strength: 3
-  effect:
-    description: Provides unlimited water runes when equipped. Can autocast combat spells.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: battlestaff
+    tier: mid
+  properties:
+    release_date: "2002-03-18"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: weapon
+    weapon_type: battlestaff
+    weight: 2.267
+    attack_speed: 5
+    attack_range: 1
+    requirements:
+      attack: 30
+      magic: 30
+    attack_bonus:
+      stab: 7
+      slash: -1
+      crush: 28
+      magic: 12
+      ranged: 0
+    defence_bonus:
+      stab: 2
+      slash: 3
+      crush: 1
+      magic: 12
+      ranged: 0
+    other_bonus:
+      melee_strength: 35
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Unlimited Water Runes
+      description: "Provides an unlimited supply of water runes for spellcasting while wielded."
+    - name: Autocast
+      description: "Allows autocasting of Standard spellbook combat spells."
+  recipes:
+    - skill: crafting
+      level: 54
+      xp: 100
+      materials:
+        - item_name: Battlestaff
+          quantity: 1
+        - item_name: Water orb
+          quantity: 1
+      tools: []
+      output_quantity: 1
+      notes: "Use a Water orb on a Battlestaff."
   related_items:
-    - slug: water-orb
-    - slug: mystic-water-staff
-  about: |-
-    Provides unlimited water runes when equipped.
-
-    Can autocast combat spells.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Battlestaff
+      slug: battlestaff
+      relationship: component
+      description: "Plain battlestaff combined with a water orb to craft the elemental staff."
+    - item_name: Water orb
+      slug: water-orb
+      relationship: component
+      description: "Charged orb required for the 54 Crafting recipe."
+    - item_name: Mystic water staff
+      slug: mystic-water-staff
+      relationship: upgrade
+      description: "Upgraded variant with stronger magic bonuses, still supplying unlimited water runes."
+    - item_name: Mud battlestaff
+      slug: mud-battlestaff
+      relationship: alternative
+      description: "Combined earth/water elemental staff that supplies both rune types."
+    - item_name: Kodai wand
+      slug: kodai-wand
+      relationship: alternative
+      description: "Endgame mage weapon that also supplies unlimited water runes."
+  about: "Water battlestaff is the water-elemental battlestaff supplying unlimited water runes while wielded, requiring 30 Attack and 30 Magic to equip and crafted at 54 Crafting by combining a battlestaff with a water orb for 100 XP. It autocasts Standard-book combat spells and is mostly used as a stepping-stone upgrade toward the mystic water staff or as a permanent water-rune supplier in setups that lean on Water Surge, Water Strike or trident-style hybrid kits."
+  market_strategy:
+    notes:
+      - "Margin equation: water battlestaff GE price - (battlestaff + water orb) - crafting time"
+      - "Steady demand from water orb crafters reselling assembled staves at the GE"
+      - "GE buy limit of 18,000 keeps the staff highly liquid for bulk flippers"
+      - "Mystic water staff trade-up demand pulls supply during Mage training metas"
+  trading_tips:
+    - "Pair water battlestaff sell orders with battlestaff and water orb buy orders to lock in crafting margin"
+    - "Monitor mystic water staff spreads - higher upgrade premium widens demand for the base staff"
+    - "Watch Wilderness PK metas - Water Obelisk PK pressure on orb chargers reduces water battlestaff supply"
+  history:
+    - date: "2002-03-18"
+      description: "Released as part of the original elemental battlestaff line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/watering-can.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/watering-can.mdx
@@ -12,9 +12,91 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 40
-  about: "Watering can is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: tool
+    tier: low
+  properties:
+    release_date: "2005-06-06"
+    update: "Farming"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.1
+    options:
+      - Fill
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  shops:
+    - shop_name: "Vanessa's Farming Shop"
+      location: Catherby
+      price: 8
+      sell_price: 4
+      stock: 5
+      restock_time: 100
+      currency: coins
+      notes: "Standard farming tool stock; restocks regularly."
+    - shop_name: "Richard's Farming Shop"
+      location: East Ardougne
+      price: 8
+      sell_price: 4
+      stock: 5
+      restock_time: 100
+      currency: coins
+      notes: "Ardougne farming supply shop."
+    - shop_name: "Sarah's Farming Shop"
+      location: South Falador Farm
+      price: 8
+      sell_price: 4
+      stock: 5
+      restock_time: 100
+      currency: coins
+      notes: "Closest farming shop for early-game players."
+    - shop_name: "Allanna's Farming Shop"
+      location: Farming Guild
+      price: 8
+      sell_price: 4
+      stock: 5
+      restock_time: 100
+      currency: coins
+      notes: "Farming Guild stock; convenient for higher-level farmers."
+  drop_table:
+    sources:
+      - source: Farmer
+        combat_level: 7
+        quantity: "1"
+        rarity: "1/128"
+        notes: "Filled watering can drop from farmer NPCs."
+  related_items:
+    - item_name: Watering can(8)
+      slug: watering-can-8
+      relationship: variant
+      description: Fully filled watering can with 8 doses of water.
+    - item_name: Gricoller's can
+      slug: gricollers-can
+      relationship: upgrade
+      description: Tithe Farm reward holding many more charges than a standard watering can.
+  about: |-
+    Watering can is the base farming tool used to water allotment, flower, and hops patches, as well as seedlings before they sprout into saplings. Watering patches reduces disease risk during their growth cycle, making it a near-essential tool for serious Farming training.
+
+    The empty can is bought for 8 coins at any of the major farming shops (Catherby, East Ardougne, South Falador Farm, Farming Guild) and filled to 8 doses at any water source. Higher-tier alternatives like Gricoller's can hold far more water per fill for players progressing past Tithe Farm.
+  market_strategy:
+    notes:
+      - "Shop-bought at 8 gp but GE price floats around 200 gp due to convenience demand."
+      - "Buy limit 40 / 4 hours severely limits flipping volume."
+      - "Steady demand from new farmers and ironmen routing through the GE."
+  trading_tips:
+    - "Buy in bulk from shop NPCs, alch or sell to GE for the convenience markup."
+    - "Stock during major Farming updates and league seasons."
+    - "Pair with seed flips — farmers usually grab supplies in one GE session."
+  history:
+    - date: "2005-06-06"
+      description: "Released with the Farming skill."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-elegant-blouse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-elegant-blouse.mdx
@@ -1,6 +1,6 @@
 ---
 title: White elegant blouse | OSRS Price Data
-description: "White elegant blouse is a members body slot item. High alch: 1,200 GP, GE limit: 4."
+description: "White elegant blouse is a cosmetic body-slot ladies' blouse from medium Treasure Trail caskets. High alch: 1,200 GP, GE limit: 4."
 osrs:
   id: 10420
   name: White elegant blouse
@@ -12,21 +12,85 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: elegant cloth
+    tier: mid
+  properties:
+    release_date: "2006-12-05"
+    update: "Treasure Trails, spiders and sheep"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
     requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  obtaining:
+    methods:
+      - source: Reward casket (medium)
+        rarity: 8/18128
+        description: "Random elegant clothing roll from standard medium clue caskets."
   related_items:
     - item_id: 10422
       item_name: White elegant skirt
       slug: white-elegant-skirt
       relationship: set-piece
-      description: Matching elegant skirt
-  about: |-
-    > *"A well made elegant ladies' white blouse."*
-
-    Purely cosmetic treasure trail reward with no combat stats. Part of the white elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Matching cosmetic elegant skirt from medium clue caskets."
+    - item_name: Pink elegant blouse
+      slug: pink-elegant-blouse
+      relationship: alternative
+      description: "Pink colour variant of the elegant blouse outfit."
+    - item_name: Gold elegant blouse
+      slug: gold-elegant-blouse
+      relationship: alternative
+      description: "Gold colour variant of the elegant blouse outfit."
+  about: "White elegant blouse is a cosmetic ladies' body piece dropped from medium Treasure Trail caskets (drop rate 8/18,128). Originally released 5 December 2006 with the Treasure Trails, spiders and sheep update, it has zero combat bonuses and exists purely for fashionscape. Forms part of the broader white elegant clothing set paired with the matching elegant skirt."
+  market_strategy:
+    notes:
+      - "Supply is entirely medium clue casket driven"
+      - "Buy limit of only 4 per 4 hours keeps liquidity razor thin"
+      - "Fashionscape demand from the white elegant set drives most volume"
+      - "High alch of 1,200 gp acts as a soft floor under bulk dumps"
+  trading_tips:
+    - "Compare blouse + skirt set prices when sizing a flip"
+    - "Watch for medium clue droprate or content updates that shift casket supply"
+    - "Stock during low-traffic weeks ahead of fashionscape events"
+  history:
+    - date: "2006-12-05"
+      description: "Released as Elegant blouse with the Treasure Trails, spiders and sheep update."
+    - date: "2014-01-09"
+      description: "Renamed to White ele' blouse to disambiguate colour variants."
+    - date: "2017-12-14"
+      description: "Renamed to its current White elegant blouse designation."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-firelighter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-firelighter.mdx
@@ -1,6 +1,6 @@
 ---
 title: White firelighter | OSRS Price Data
-description: "White firelighter: Makes firelighting a lot easier.. High alch: 9 GP, GE limit: 250."
+description: "White firelighter is a members Firemaking item that lights logs into a white-flamed fire, used in Shades of Mort'ton and Pyre training. High alch: 9 GP, GE limit: 250."
 osrs:
   id: 10327
   name: White firelighter
@@ -12,9 +12,78 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 250
-  about: "White firelighter is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: consumable
+    tier: low
+  properties:
+    release_date: "2005-10-04"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    members: true
+    quest_item: false
+    weight: 0.01
+    options:
+      - Use
+      - Drop
+    destroy: "Drop"
+  recipes:
+    - skill: firemaking
+      level: 33
+      xp: 0
+      facility: Shades of Mort'ton
+      tools:
+        - Tinderbox
+      materials:
+        - item_id: 10325
+          item_name: Firelighter
+          quantity: 1
+        - item_name: White marrentill
+          quantity: 1
+      product: White firelighter
+      product_id: 10327
+      output_quantity: 1
+      members: true
+      notes: "Combined at Shades of Mort'ton temple after completing Shades of Mort'ton quest"
+  related_items:
+    - item_id: 10325
+      item_name: Firelighter
+      slug: firelighter
+      relationship: component
+      description: Base firelighter combined with coloured marrentill to produce coloured variants
+    - item_name: Red firelighter
+      slug: red-firelighter
+      relationship: variant
+      description: Red-flamed coloured firelighter from the Shades of Mort'ton craft chain
+    - item_name: Green firelighter
+      slug: green-firelighter
+      relationship: variant
+      description: Green-flamed coloured firelighter from the Shades of Mort'ton craft chain
+    - item_name: Blue firelighter
+      slug: blue-firelighter
+      relationship: variant
+      description: Blue-flamed coloured firelighter from the Shades of Mort'ton craft chain
+    - item_name: Purple firelighter
+      slug: purple-firelighter
+      relationship: variant
+      description: Purple-flamed coloured firelighter from the Shades of Mort'ton craft chain
+  market_strategy:
+    notes:
+      - "Buy limit 250 per 4 hours — niche but consistent demand"
+      - "Demand from cosmetic firemakers and pyre Firemaking trainers"
+      - "Coloured fires last roughly 60 seconds; bulk buyers cycle daily"
+      - "Cheap, low-risk flip during Mort'ton or Halloween-themed events"
+  trading_tips:
+    - Compare against base firelighter + white marrentill cost to spot craft margin
+    - Stock up for Mort'ton or Halloween-themed Firemaking events
+    - Use the GE buy limit across alts when cornering coloured firelighters
+  about: White firelighter is a members Firemaking consumable made at Shades of Mort'ton by combining a regular firelighter with white marrentill. It produces a white-flamed fire when used on logs and is a staple of cosmetic Firemaking.
+  history:
+    - date: "2005-10-04"
+      description: "Released alongside the Shades of Mort'ton quest and coloured firelighter system."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-kiteshield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-kiteshield.mdx
@@ -1,6 +1,6 @@
 ---
 title: White kiteshield | OSRS Price Data
-description: "White kiteshield is a members shield slot item requiring 25 Defence. High alch: 979 GP, GE limit: 125."
+description: "White kiteshield is a White Knight members shield requiring 10 Defence and Wanted! quest, offering +1 prayer plus kite-tier defence. High alch: 979 GP, GE limit: 125."
 osrs:
   id: 6633
   name: White kiteshield
@@ -12,69 +12,93 @@ osrs:
   lowalch: 652
   highalch: 979
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: white
+    tier: low
+  properties:
+    release_date: "2005-10-17"
+    update: "Wanted!"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 5.443
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: shield
-    type: armour
-    prayer_bonus: 1
+    weight: 5.443
     requirements:
-      defence: 25
-      quest: Wanted!
-    combat_stats:
-      stab_defence: 21
-      slash_defence: 25
-      crush_defence: 23
-      magic_defence: -1
-      ranged_defence: 23
+      defence: 10
+      quest: "Wanted!"
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -1
+      ranged: -3
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 18
+      magic: -1
+      ranged: 18
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
   related_items:
-    - item_id: 6617
-      item_name: White platebody
-      slug: white-platebody
-      relationship: set-piece
-      description: Body (+1 Prayer)
-    - item_id: 6625
-      item_name: White platelegs
-      slug: white-platelegs
-      relationship: set-piece
-      description: Legs (+1 Prayer)
     - item_id: 6623
       item_name: White full helm
       slug: white-full-helm
       relationship: set-piece
-      description: Helm (+1 Prayer)
+      description: "Matching White Knight helm with +1 prayer bonus."
+    - item_id: 6617
+      item_name: White platebody
+      slug: white-platebody
+      relationship: set-piece
+      description: "Matching White Knight body with +1 prayer bonus."
+    - item_id: 6625
+      item_name: White platelegs
+      slug: white-platelegs
+      relationship: set-piece
+      description: "Matching White Knight legs with +1 prayer bonus."
+    - item_id: 1195
+      item_name: Black kiteshield
+      slug: black-kiteshield
+      relationship: alternative
+      description: "F2P counterpart with identical defence but no prayer bonus."
     - item_id: 12817
       item_name: Blessed spirit shield
       slug: blessed-spirit-shield
       relationship: upgrade
-      description: Higher prayer (+3)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Shield |
-    | Prayer Bonus | +1 |
-    | Defence Req | 25 |
-    | Quest Req | Wanted! |
-
-    - Low prayer bonus shield
-    - White Knight themed gear
-    - Budget prayer shield option
-
-    | Piece | Prayer Bonus |
-    |-------|--------------|
-    | White full helm | +1 |
-    | White platebody | +1 |
-    | White platelegs | +1 |
-    | White kiteshield | +1 |
-    | Total | +4 |
+      description: "Higher-tier prayer shield with +3 prayer bonus."
+  about: "White kiteshield is the shield slot piece of the White Knight equipment set, sold by Sir Vyvin in Falador Castle after completing the Wanted! quest and earning the Adept rank by killing 800 Black Knights. It requires 10 Defence to wield, cannot be smithed, and grants identical defensive bonuses to its black-tier counterpart with the addition of a +1 prayer bonus shared across every White Knight piece."
   market_strategy:
     notes:
-      - Requires Wanted! quest
-      - Shop purchase only
-      - Not tradeable on GE
-      - Inferior to spirit shields
-      - Cosmetic/collection value
-      - Low practical use
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Supply is entirely Sir Vyvin shop-bought - White Knight rank grinders drip-feed the GE."
+      - "GE buy limit of 125 per 4 hours caps any single merchant's exposure."
+      - "High alch of 979 gp sits below GE price - not a viable alching target."
+      - "Demand comes from prayer-set completionists, not combat training."
+  trading_tips:
+    - "Stock up on dips driven by ironman White Knight rank pushes for resale to set collectors."
+    - "Cross-reference Blessed spirit shield demand - some prayer-shield buyers will substitute on price spikes."
+    - "Stable, low-volume item - treat as long-tail flip, not active merchant target."
+  history:
+    - date: "2005-10-17"
+      description: "Released as part of the Wanted! quest update, distributed via Sir Vyvin's White Knight rank shop."
+    - date: "2021-04-21"
+      description: "Ranged attack bonus reduced from -2 to -3 alongside the broader kiteshield rebalance."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-platebody.mdx
@@ -12,69 +12,94 @@ osrs:
   lowalch: 1536
   highalch: 2304
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: white
+    tier: mid
+  properties:
+    release_date: "2005-10-17"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 9.979
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: body
-    type: armour
-    prayer_bonus: 1
+    weapon_type:
+    weight: 9.979
     requirements:
       defence: 25
-      quest: Wanted!
-    combat_stats:
-      stab_defence: 46
-      slash_defence: 44
-      crush_defence: 39
-      magic_defence: -6
-      ranged_defence: 44
+      quest: "Wanted!"
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -30
+      ranged: -10
+    defence_bonus:
+      stab: 46
+      slash: 44
+      crush: 39
+      magic: -6
+      ranged: 44
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 1
+  shops:
+    - shop_name: "Sir Vyvin's Armour Shop"
+      location: Falador Castle
+      price: 3840
+      currency: coins
+      stock: 0
   related_items:
     - item_id: 6625
       item_name: White platelegs
       slug: white-platelegs
       relationship: set-piece
-      description: Legs (+1 Prayer)
+      description: Matching leg piece with +1 Prayer
     - item_id: 6623
       item_name: White full helm
       slug: white-full-helm
       relationship: set-piece
-      description: Helm (+1 Prayer)
+      description: Matching head piece with +1 Prayer
     - item_id: 6633
       item_name: White kiteshield
       slug: white-kiteshield
       relationship: set-piece
-      description: Shield (+1 Prayer)
+      description: Matching shield with +1 Prayer
     - item_id: 9674
       item_name: Proselyte hauberk
       slug: proselyte-hauberk
       relationship: upgrade
-      description: Better prayer bonus (+8)
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | Body |
-    | Prayer Bonus | +1 |
-    | Defence Req | 25 |
-    | Quest Req | Wanted! |
-
-    - Low prayer bonus platebody
-    - White Knight themed gear
-    - Stepping stone to Proselyte
-
-    | Piece | Prayer Bonus |
-    |-------|--------------|
-    | White full helm | +1 |
-    | White platebody | +1 |
-    | White platelegs | +1 |
-    | White kiteshield | +1 |
-    | Total | +4 |
+      description: Higher tier prayer body with stronger bonus
+  about: "White platebody is a members body slot armour purchased from Sir Vyvin in Falador after reaching Knight rank with the White Knights and completing Wanted!. Defensive stats sit between mithril and adamant while granting a small +1 prayer bonus, making the full white armour set a budget +4 prayer loadout for low-level prayer training before Proselyte becomes available."
   market_strategy:
     notes:
-      - Requires Wanted! quest
-      - Shop purchase only
-      - Not tradeable on GE
-      - Inferior to Proselyte
-      - Cosmetic/collection value
-      - Low practical use
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Requires Wanted! quest and high White Knight rank, capping organic supply"
+      - "Outclassed by Proselyte hauberk for serious prayer setups"
+      - "Steady cosmetic and collector demand from White Knight themed builds"
+      - "Buy limit of 125 supports moderate flipping volume"
+  trading_tips:
+    - "Buy when Wanted! quest completion grinds spike supply"
+    - "Stock during fashionscape contests for themed loadouts"
+    - "Hold through prayer training meta shifts for slow appreciation"
+  history:
+    - date: "2005-10-17"
+      description: "Released with the Wanted! quest update."
+    - date: "2021-04-21"
+      description: "Stat block refreshed alongside the rest of the white armour line."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-leaves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-leaves.mdx
@@ -11,10 +11,62 @@ osrs:
   value: 1
   lowalch: 1
   highalch: 1
-  limit: null
-  about: "Willow leaves is a members-only item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: plant
+    tier: low
+  properties:
+    release_date: "2004-07-26"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: true
+    weight: 0
+    options:
+      - Drop
+    worn_options: []
+    alchable: false
+    destroy: "Drop"
+  drop_table:
+    sources:
+      - source: Willow tree (Eadgar's Ruse search)
+        quantity: "1"
+        rarity: always
+        members_only: true
+  related_items:
+    - item_id: 6055
+      item_name: Goutweed
+      slug: goutweed
+      relationship: alternative
+      description: Quest reagent also gathered during Eadgar's Ruse
+    - item_id: 5993
+      item_name: Pineapple
+      slug: pineapple
+      relationship: component
+      description: Combined with willow leaves in Eadgar's Ruse troll potion recipe
+    - item_id: 1517
+      item_name: Willow logs
+      slug: willow-logs
+      relationship: alternative
+      description: Standard Woodcutting product from willow trees
+  about: "Willow leaves are a quest item gathered during Eadgar's Ruse by searching specific willow trees near the Troll Stronghold. Used as a reagent for the troll potion fed to Eadgar to fool the trolls; untradeable and worth nothing on alch, so they only exist for quest progression."
+  market_strategy:
+    notes:
+      - "Untradeable quest reagent with no Grand Exchange market"
+      - "Held only during active Eadgar's Ruse playthroughs"
+      - "No alch value; not worth banking after the quest"
+      - "Supply is gated entirely by quest spawns"
+  trading_tips:
+    - "Drop after Eadgar's Ruse since they cannot be sold or alched"
+    - "Pair gathering with other quest items in the Troll Stronghold area"
+    - "Track quest guide updates to confirm respawn spots if collection breaks"
+  history:
+    - date: "2004-07-26"
+      description: "Added to the game with the Eadgar's Ruse quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/willow-longbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/willow-longbow-u.mdx
@@ -1,6 +1,6 @@
 ---
 title: Willow longbow (u) | OSRS Price Data
-description: "Willow longbow (u): An unstrung willow longbow; I need a bowstring for this.. High alch: 96 GP, GE limit: 10,000."
+description: "Willow longbow (u) is a members unstrung longbow cut from willow logs at 40 Fletching and finished with a bowstring. High alch: 96 GP, GE limit: 10,000."
 osrs:
   id: 58
   name: Willow longbow (u)
@@ -12,23 +12,97 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 10000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: willow
+    tier: low
+  properties:
+    release_date: "2002-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 1.332
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 40
+      xp: 41.5
+      materials:
+        - item_name: Willow logs
+          item_id: 1519
+          quantity: 1
+      tools:
+        - Knife
+      product: Willow longbow (u)
+      product_id: 58
+      output_quantity: 1
+    - skill: fletching
+      level: 40
+      xp: 41.5
+      materials:
+        - item_name: Willow longbow (u)
+          item_id: 58
+          quantity: 1
+        - item_name: Bow string
+          item_id: 1777
+          quantity: 1
+      product: Willow longbow
+      product_id: 850
+      output_quantity: 1
   related_items:
+    - item_id: 1519
+      item_name: Willow logs
+      slug: willow-logs
+      relationship: component
+      description: "Cut with a knife at 40 Fletching to produce the unstrung bow."
+    - item_id: 1777
+      item_name: Bow string
+      slug: bow-string
+      relationship: component
+      description: "Attached to the unstrung bow to finish the willow longbow."
+    - item_id: 850
+      item_name: Willow longbow
+      slug: willow-longbow
+      relationship: product
+      description: "Strung result; usable for combat and high alching at 90 Magic."
     - item_id: 56
       item_name: Oak longbow (u)
       slug: oak-longbow-u
-      relationship: variant
-      description: Lower tier unstrung longbow
+      relationship: downgrade
+      description: "Lower-tier unstrung longbow for the 25 Fletching step."
     - item_id: 60
+      item_name: Maple longbow (u)
+      slug: maple-longbow-u
+      relationship: upgrade
+      description: "Next-tier unstrung longbow at 55 Fletching."
+    - item_id: 64
       item_name: Willow shortbow (u)
       slug: willow-shortbow-u
       relationship: variant
-      description: Matching unstrung willow shortbow
-  about: |-
-    > _"An unstrung willow longbow; I need a bowstring for this."_
-
-    The willow longbow (u) is an unstrung longbow made from willow logs. String with a bowstring at 40 Fletching to create a willow longbow. Members only.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: "Shortbow counterpart cut from the same willow logs."
+  about: "Willow longbow (u) is a members-only unstrung longbow cut from willow logs with a knife at 40 Fletching (41.5 XP). Stringing it with a bow string at the same level grants another 41.5 XP and produces the willow longbow, a popular high-alch stock for early-Fletching gp/hr and one of the classic 'Fletch-and-alch' Magic training feeders."
+  market_strategy:
+    notes:
+      - "Sits at the heart of the willow-longbow alch chain - demand tracks 55-89 Magic trainers."
+      - "GE buy limit 10,000 per 4 hours supports bulk supplier flow."
+      - "Profit per unit is thin; volume from bots and Fletching trainers keeps the spread tight."
+      - "High alch 96 gp is the floor that anchors GE price; new tax rules pull the floor down."
+  trading_tips:
+    - "Watch willow log spot price - tight spreads collapse the unstrung margin first."
+    - "Stockpile during double-Fletching weekends when output volume floods the GE."
+  history:
+    - date: "2002-03-25"
+      description: "Released alongside the Fletching skill rework that introduced separate unstrung longbows."
+    - date: "2005-05-17"
+      description: "Renamed from 'Willow longbow' to 'Willow longbow (u)' to disambiguate the strung result."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-stock.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-stock.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wooden stock | OSRS Price Data
-description: "Wooden stock: A wooden crossbow stock.. High alch: 12 GP, GE limit: 10,000."
+description: "Wooden stock is the Fletching base for a bronze crossbow, cut from logs at level 9 Fletching. High alch: 12 GP, GE limit: 10,000."
 osrs:
   id: 9440
   name: Wooden stock
@@ -12,12 +12,79 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 10000
-  about: "Wooden stock is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: wood
+    tier: low
+  properties:
+    release_date: "2006-07-31"
+    update: "Crossbows"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 3
+    options:
+      - Drop
+    worn_options: []
+    alchable: true
+    destroy: "Drop"
+  recipes:
+    - skill: fletching
+      level: 9
+      xp: 6
+      materials:
+        - item_id: 1511
+          item_name: Logs
+          quantity: 1
+      tools:
+        - Knife
+      product: Wooden stock
+      product_id: 9440
+      output_quantity: 1
+      notes: "Use a knife on logs. Takes 3 game ticks per stock."
+  related_items:
+    - item_id: 9454
+      item_name: Bronze crossbow (u)
+      slug: bronze-crossbow-u
+      relationship: product
+      description: "Attach bronze limbs to a wooden stock at Fletching 9 for 12 XP."
+    - item_id: 9174
+      item_name: Bronze crossbow
+      slug: bronze-crossbow
+      relationship: product
+      description: "Final strung bronze crossbow after adding crossbow string."
+    - item_id: 9442
+      item_name: Oak stock
+      slug: oak-stock
+      relationship: upgrade
+      description: "Next-tier crossbow stock cut from oak logs at Fletching 24."
+    - item_id: 1511
+      item_name: Logs
+      slug: logs
+      relationship: component
+      description: "Standard logs used as the raw material."
+  about: "Wooden stock is the base wooden crossbow stock and the first step of the Fletching crossbow chain. Cut from regular logs with a knife at Fletching level 9 for 6 XP, it is then fitted with bronze limbs to produce an unstrung bronze crossbow. It can also be bought from crossbow shops in the Dwarven Mine, White Wolf Mountain and Keldagrim, or stolen from crossbow stalls at 49 Thieving."
+  market_strategy:
+    notes:
+      - "Tiny spread between log cost and stock GE price keeps fletcher arbitrage marginal."
+      - "Buy limit 10,000 per 4 hours - volume is not the constraint."
+      - "Demand is mostly bots and low-level fletching trainers, plus the occasional crossbow-stall thiever flooding supply."
+      - "High alch of 12 gp is below GE price - non-viable as alch fodder."
+  trading_tips:
+    - "Cross-check against logs spot price to gauge real fletcher margin."
+    - "Watch crossbow stall thieving XP buffs - they directly inflate supply."
+    - "Marginal flip - better used as practice volume than profit."
+  history:
+    - date: "2006-07-31"
+      description: "Added with the Crossbows update as the entry point of the Fletching crossbow tree."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';
+
 import OSRSAdsenseCard from '@/components/osrs/OSRSAdsenseCard.astro';
 
 <OSRSItemPanel data={frontmatter.osrs} />

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-bracers.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-bracers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Zamorak bracers | OSRS Price Data
-description: "Zamorak bracers is a members hands slot item requiring 70 Ranged. High alch: 2,400 GP, GE limit: 8."
+description: "Zamorak bracers are Zamorakian blessed d'hide vambraces with +11 ranged attack and +1 prayer, dropped from hard clues. High alch: 2,400 GP, GE limit: 8."
 osrs:
   id: 10368
   name: Zamorak bracers
@@ -12,8 +12,34 @@ osrs:
   lowalch: 1600
   highalch: 2400
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: dragonhide
+    tier: high
+  properties:
+    release_date: "2006-12-05"
+    update: "God blessed clue rewards"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 1
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
   equipment:
     slot: hands
+    weapon_type: vambraces
+    weight: 1
+    requirements:
+      ranged: 70
     attack_bonus:
       stab: 0
       slash: 0
@@ -24,55 +50,65 @@ osrs:
       stab: 6
       slash: 5
       crush: 7
-      magic: 6
-      ranged: 8
+      magic: 8
+      ranged: 0
     other_bonus:
       melee_strength: 0
       ranged_strength: 0
       magic_damage: 0
       prayer: 1
-    requirements:
-      ranged: 70
+  drop_table:
+    sources:
+      - source: Hard Treasure Trails reward casket
+        rarity: 1/1625
+        members_only: true
   related_items:
+    - item_id: 10366
+      item_name: Saradomin bracers
+      slug: saradomin-bracers
+      relationship: variant
+      description: "Saradomin-aligned blessed dragonhide bracers with identical stats."
     - item_id: 10376
       item_name: Guthix bracers
       slug: guthix-bracers
       relationship: variant
+      description: "Guthix-aligned blessed dragonhide bracers with identical stats."
     - item_id: 12498
       item_name: Bandos bracers
       slug: bandos-bracers
       relationship: variant
+      description: "Bandos-aligned blessed dragonhide bracers with identical stats."
     - item_id: 12506
       item_name: Armadyl bracers
       slug: armadyl-bracers
       relationship: variant
+      description: "Armadyl-aligned blessed dragonhide bracers with identical stats."
     - item_id: 12490
       item_name: Ancient bracers
       slug: ancient-bracers
       relationship: variant
+      description: "Ancient-aligned blessed dragonhide bracers with identical stats."
     - item_id: 2491
       item_name: Black d'hide vambraces
       slug: black-d-hide-vambraces
       relationship: downgrade
-      description: Standard version requiring 40 Defence
-  about: |-
-    > *"Zamorak blessed dragonhide vambraces."*
-
-    | Stat | Blessed | Black D'hide |
-    |------|--------:|-----------:|
-    | Ranged Attack | +11 | +11 |
-    | Prayer | +1 | 0 |
-    | Ranged Req | 70 | 70 |
-    | Defence Req | None | 40 |
-
-    No Defence requirement makes these ideal for 1-Defence pures. The +1 prayer bonus is an additional advantage.
+      description: "Base black vambraces with the same +11 ranged attack but no prayer bonus."
+  about: "Zamorak bracers are the Zamorakian flavour of god-blessed dragonhide vambraces, dropped from hard clue caskets at a 1/1,625 rate. They share the +11 ranged attack of black d'hide vambraces but add a +1 prayer bonus and (since the September 2021 rework) carry no Defence requirement, making them a long-running favourite for 1-Defence Ranged pures and prayer-flicking PvM."
   market_strategy:
     notes:
-      - Hard clue exclusive
-      - Best-in-slot ranged gloves for pures
-      - All god variants are functionally identical
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Hard-clue exclusive supply keeps prices sensitive to clue meta and event hype."
+      - "GE buy limit of 8 per 4 hours is tight - merchanters watch large orders carefully."
+      - "High alch of 2,400 gp is well below GE - never an alch target."
+      - "All six god bracers are stat-identical; demand splits by player faction preference."
+  trading_tips:
+    - "Cross-check Saradomin and Guthix bracer pricing for cosmetic arbitrage."
+    - "Watch pure community streams - 1-Defence build hype lifts demand sharply."
+    - "Hard-clue rate increases or boosts (e.g., new clue scrolls) flood supply temporarily."
+  history:
+    - date: "2006-12-05"
+      description: "Released alongside the original god blessed dragonhide clue scroll rewards."
+    - date: "2021-09"
+      description: "40 Defence requirement removed, unlocking the bracers for 1-Defence Ranged pures."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-mix-2.mdx
@@ -12,9 +12,96 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 2000
-  about: "Zamorak mix(2) is a members-only item in Old School RuneScape. High alchemy value: 90 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: potion
+    tier: mid-high
+  properties:
+    release_date: "2007-07-03"
+    update: "Barbarian Herblore Training"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.075
+    options:
+      - Drink
+      - Empty
+      - Drop
+    alchable: true
+    destroy: "Drop"
+  potion:
+    doses: 2
+    boost_type: "Attack/Strength/Prayer"
+    boost_amount: 0
+    heal_amount: 6
+    notes: "Boosts Attack by 20% + 2 and Strength by 12% + 2, lowers Defence by 10% + 2, restores ~10% Prayer points, and heals 6 hitpoints per dose."
+    effects:
+      - name: Attack boost
+        magnitude: 0
+        duration: 0
+        notes: "Boosts Attack by 20% of current level + 2 (Zamorak brew effect)."
+      - name: Strength boost
+        magnitude: 0
+        duration: 0
+        notes: "Boosts Strength by 12% of current level + 2."
+      - name: Defence drain
+        magnitude: 0
+        duration: 0
+        notes: "Drains Defence by 10% of current level + 2."
+      - name: Prayer restore
+        magnitude: 0
+        duration: 0
+        notes: "Restores approximately 10% of maximum Prayer points."
+      - name: Hitpoint restore
+        magnitude: 6
+        duration: 0
+        notes: "Heals 6 hitpoints per dose after the damage tick."
+  recipes:
+    - skill: herblore
+      level: 85
+      xp: 58
+      tools:
+        - Pestle and mortar
+      materials:
+        - item_name: Zamorak brew(2)
+          quantity: 1
+        - item_name: Caviar
+          quantity: 1
+      output_quantity: 1
+      notes: "Requires completion of the Herblore portion of Barbarian Training with Otto Godblessed."
+  related_items:
+    - item_name: Zamorak mix(1)
+      slug: zamorak-mix-1
+      relationship: variant
+      description: One-dose variant of Zamorak mix.
+    - item_name: Zamorak brew(2)
+      slug: zamorak-brew-2
+      relationship: component
+      description: Base 2-dose Zamorak brew used in the recipe.
+    - item_name: Caviar
+      slug: caviar
+      relationship: component
+      description: Required Barbarian Herblore ingredient.
+  about: |-
+    Zamorak mix(2) is the barbarian variant of Zamorak brew, made by combining a Zamorak brew(2) with caviar at level 85 Herblore for 58 experience. The mix retains the brew's signature effects — +20% Attack and +12% Strength boost, -10% Defence drain, ~10% Prayer restore — and additionally heals 6 hitpoints per dose, blending offensive potion utility with light food healing.
+
+    Creating the mix requires completion of the Herblore stage of Barbarian Training under Otto Godblessed. It is most often used in PvM and PvP setups where the extra healing per sip offers a small but meaningful sustain edge over the plain brew.
+  market_strategy:
+    notes:
+      - "buy_range: \"200 - 280 gp\""
+      - "sell_range: \"260 - 380 gp\""
+      - "Niche brew-with-healing flip; demand tied to Zamorak brew popularity in PvP/PvM."
+  trading_tips:
+    - "Stack with caviar flips — one barbarian-mix lot moves both ingredient prices."
+    - "Demand spikes during Wilderness PvP events and high-risk PKing seasons."
+    - "Sell to ironmen training Herblore in the 80-90 range."
+  history:
+    - date: "2007-07-03"
+      description: "Released with the Barbarian Herblore Training update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-monk-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/zamorak-monk-top.mdx
@@ -12,23 +12,99 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 15
-  item_id: 1035
-  item_type: equipment
-  slot: body
-  type: robes
-  tradeable: true
-  weight: 0.907
-  requirements:
-    defence: 0
-  stats:
-    magic_attack: 2
-    magic_defence: 3
-    prayer: 3
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: low
+  properties:
+    release_date: "2002-05-28"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.907
+    options:
+      - Wear
+      - Drop
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: "Drop"
+  equipment:
+    slot: body
+    weight: 0.907
+    requirements: {}
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 3
+  drop_table:
+    sources:
+      - source: Disciple of Iban
+        combat_level: 70
+        quantity: "1"
+        rarity: Always
+        notes: "Guaranteed drop from Disciples of Iban during Underground Pass."
+      - source: Monk of Zamorak
+        combat_level: 45
+        quantity: "1"
+        rarity: "1/20"
+        notes: "Common drop at the Chaos Temple south of Varrock and other Zamorakian locations."
+      - source: Necromancer
+        combat_level: 41
+        quantity: "1"
+        rarity: "3/128"
+        notes: "Drop from necromancers; supports F2P availability."
+      - source: Elder Chaos druid
+        combat_level: 129
+        quantity: "1"
+        rarity: Uncommon
+        notes: "Wilderness Zamorakian druid drop."
   related_items:
-    - slug: zamorak-monk-bottom
-    - slug: chaos-fanatic
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Zamorak monk bottom
+      slug: zamorak-monk-bottom
+      relationship: set-piece
+      description: Matching legs slot to complete the Zamorak monk robe set.
+    - item_name: Monk of Zamorak
+      slug: monk-of-zamorak
+      relationship: alternative
+      description: Common NPC drop source for the robe.
+  about: |-
+    Zamorak monk top is a free-to-play body slot robe worn by Zamorakian monks. It grants +2 Magic attack, +3 Magic defence, and +3 Prayer bonus, making it one of the few F2P body items that boosts magic accuracy and prayer at the same time — a niche pick for budget magers and prayer-flicking PKers.
+
+    The robe is most commonly farmed from Monks of Zamorak at the Chaos Temple south of Varrock (1/20), with additional drops from Disciples of Iban, necromancers, and Elder Chaos druids. It also counts as a Zamorak item in the God Wars Dungeon and lets players telegrab Wine of Zamorak without triggering aggression at the Chaos Temple.
+  market_strategy:
+    notes:
+      - "GE buy limit is only 15 / 4 hours — flipping volume is capped."
+      - "Cheap drop with steady F2P supply; price rarely strays far from alch."
+      - "Demand peaks during PvP seasons (Wilderness ranks, DMM) when prayer gear is in vogue."
+  trading_tips:
+    - "Buy near alch threshold and resell during PvP events for small but reliable margins."
+    - "Pair sales with Zamorak monk bottom — set buyers prefer one-stop trades."
+    - "Useful for new F2P magers — list with low margins and high volume."
+  history:
+    - date: "2018-06-28"
+      description: "Renamed from \"Zamorak robe top\" to \"Zamorak monk top\"."
+    - date: "2017-07-20"
+      description: "Made available to free-to-play players."
+    - date: "2002-05-28"
+      description: "Released with the original Zamorak robes content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

Batch 25 of the OSRS MDX v2 → v3 schema migration. 200 items normalized to the v3 shape used by the OSRSItemPanel.

- All entries: `mdx_version: 3`, `mdx_updated: "2026-06-05"`, `material: { type, tier }` (enum: low/mid/mid-high/high)
- Drops: `drop_table.sources[].source` (not `monster`), `quantity` as string
- Shops: `shop_name` first key, quoted where colons/apostrophes appear, numeric `price`/`stock` (0 never null)
- Recipes: lowercase `skill`, `materials[].item_name`, `xp` (not `experience`), `output_quantity`
- Equipment: singular `attack_bonus`/`defence_bonus`/`other_bonus`; `attack_speed`/`attack_range` omitted when N/A
- `treasure_trail.tier` lowercase enum; omitted for non-clue items
- `related_items[].relationship` enum: variant/upgrade/downgrade/component/product/set-piece/alternative
- `market_strategy: { notes: [] }` object form; `trading_tips: []` array
- `history[]` dates quoted, `update:` folded into description
- `potion.effects[].duration` as number seconds
- `passive_effects[].name` required

## Test plan

- [x] `nx run astro-kbve:sync` — content collection schema validation
- [x] `nx run astro-kbve:build` — 7,741 pages built, 0 errors