### PR TITLE
fix(agones): server PVC subPath so fleets find LinuxServer (+ dev/beta build-out plan)

### DIFF
--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
@@ -106,6 +106,7 @@ spec:
                           volumeMounts:
                               - name: server-binary
                                 mountPath: /server
+                                subPath: chuckServerDev
                     volumes:
                         - name: server-binary
                           persistentVolumeClaim:

--- a/apps/kube/agones/rows/manifests/fleet.yaml
+++ b/apps/kube/agones/rows/manifests/fleet.yaml
@@ -128,6 +128,7 @@ spec:
                           volumeMounts:
                               - name: server-binary
                                 mountPath: /server
+                                subPath: chuckServer
                     volumes:
                         - name: server-binary
                           persistentVolumeClaim:


### PR DESCRIPTION
## Verified bug fix (this PR)
The build archives to `/ows-server/<server_target>/<ver>/LinuxServer`; the fleet mounts the PVC **root** at `/server` and runs `find /server -maxdepth 2 -name LinuxServer` — but LinuxServer is at **depth 3**, so it's never found. `ows-hubworld`'s server-find has been silently broken.

Fix: mount the PVC with `subPath: <server_target>` at `/server` → `/server` becomes the target dir, `<ver>/LinuxServer` is depth 2 (matches the existing find), and each fleet only sees its own target.
- ows-hubworld → subPath `chuckServer`
- chuckrpg-dev → subPath `chuckServerDev`

## Remaining dev/beta build-out (follow-up, gated on the Target.cs below)
Goal: chuck-**dev** builds the `dev` branch (Development, `chuckServerDev`) → dev fleet; chuck-**beta** builds `main` (Shipping, `chuckServerBeta`) → beta fleet. Branch sets the source; separate server_target keeps the PVC artifacts apart.

Needs:
1. **Target.cs in KBVE/chuck (dev + main)** — `chuckServerDev.Target.cs` + `chuckServerBeta.Target.cs` (both Type=Server). **Gate** — `-target=chuckServerDev` fails until these exist.
2. **engine.external_repo_ref** schema field (proto → zod → content.config.ts) + manifest.
3. **CI branch plumbing** — ci-main dispatch + ci-unreal.yml + ci-unreal-build.yml `git clone --branch <ref>` for BOTH the client clone (external_repo_url) and the server clone (build.toml.repo).
4. **Per-env config** — apps/chuckrpg/chuck-dev/ + chuck-beta/ (build.toml: server_target + server_config + repo; own version.toml); point dev/beta MDX source_path/version_toml/shell_path + external_repo_ref there.
5. dev/beta MDX finalize + manifest regen.

Confirmed: KBVE/chuck has `dev` + `main` branches; project has only chuck/chuckServer/chuckEditor targets today (hence #1).