### PR TITLE
fix(auth): allow cryptothrone.com OAuth redirects in GoTrue

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -45,7 +45,7 @@ spec:
                       - name: GOTRUE_SITE_URL
                         value: 'https://kbve.com'
                       - name: GOTRUE_URI_ALLOW_LIST
-                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://chat.kbve.com/**,https://supabase.kbve.com/**,https://forgejo.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,https://chuckrpg.com/**,https://*.chuckrpg.com/**,https://api.chuckrpg.com/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**,http://127.0.0.1:**,kbve://**'
+                        value: 'https://kbve.com/**,https://*.kbve.com/**,https://chat.kbve.com/**,https://supabase.kbve.com/**,https://forgejo.kbve.com/**,https://api.kbve.com/**,https://discord.sh/**,https://*.discord.sh/**,https://rentearth.com/**,https://*.rentearth.com/**,https://herbmail.com/**,https://*.herbmail.com/**,https://meme.sh/**,https://*.meme.sh/**,https://chuckrpg.com/**,https://*.chuckrpg.com/**,https://api.chuckrpg.com/**,https://cryptothrone.com/**,https://*.cryptothrone.com/**,http://localhost:4321/**,http://localhost:**,http://localhost:3000/*,http://127.0.0.1:3000/*,http://127.0.0.1:3000/**,http://127.0.0.1:**,kbve://**'
                       - name: GOTRUE_DISABLE_SIGNUP
                         value: 'false'
 


### PR DESCRIPTION
## Summary
- `cryptothrone.com` was missing from `GOTRUE_URI_ALLOW_LIST` (chuckrpg et al are present) — verified live: `kubectl get deploy supabase-auth -n kilobase` shows the same list, and the authorize state JWT falls back to `site_url: kbve.com`
- Effect: OAuth from https://cryptothrone.com/game/play/ completes at GitHub/Discord, but GoTrue rejects the `redirect_to` and strands the session on kbve.com — the game gate never sees it
- Adds `https://cryptothrone.com/**` + `https://*.cryptothrone.com/**`

ArgoCD `auth` app tracks main — lands on cluster after the next dev→main release; env change rolls the supabase-auth pods automatically.