### PR TITLE
feat(kube): register agones-cryptothrone in the root app-of-apps

### DIFF
--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -61,6 +61,7 @@ resources:
     - agones/rows-tenants/chuckrpg-dev/application.yaml
     - agones/mc/application.yaml
     - agones/nd-server/application.yaml
+    - agones/cryptothrone/application.yaml
     - agones/factorio/application.yaml
     - chuckrpg/application.yaml
     # RareIcon — bullet-hell roguelite website + API


### PR DESCRIPTION
## Summary
- `apps/kube/agones/cryptothrone/application.yaml` exists but was never added to the kube-root kustomization, so ArgoCD never created the app — no fleet, no game servers, while `cryptothrone-server:0.0.3` sits published with nothing running it
- One-line add next to the other agones entries; kube-root (tracks main) creates the `agones-cryptothrone` app on the next sync, which then owns the fleet with auto-sync/prune/selfHeal

Lands on cluster after the next dev→main release.