### PR TITLE
fix(kube): cryptothrone game-server runtime prereqs (agones SA namespaces + wss listener)

### DIFF
--- a/apps/kube/agones/values.yaml
+++ b/apps/kube/agones/values.yaml
@@ -62,6 +62,8 @@ gameservers:
         - ows
         - arc-runners
         - factorio
+        - cryptothrone
+        - nexus-defense
 
     # Port range for game server host ports.
     # Capped at 7900 to avoid MetalLB speaker memberlist port (7946).

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -97,6 +97,20 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-cryptothrone-game
+          protocol: HTTPS
+          port: 443
+          hostname: game.cryptothrone.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: cryptothrone-game-tls
+                    namespace: cryptothrone
+          allowedRoutes:
+              namespaces:
+                  from: All
         - name: https-chuckrpg
           protocol: HTTPS
           port: 443


### PR DESCRIPTION
## Summary
Fleet registered via #12211 but pods error at creation, and wss:// has nowhere to terminate:

1. **agones-sdk SA missing**: Agones provisions the `agones-sdk` serviceaccount only for namespaces in `gameservers.namespaces` (helm values). `cryptothrone` was missing → `pods ... forbidden: serviceaccount "agones-sdk" not found` on every gameserver. Also adds `nexus-defense` — the nd-server fleet is Degraded with the same signature.
2. **No TLS listener for game.cryptothrone.com**: kbve-gateway had no listener for the hostname, so the HTTPRoute fell through to the :80 listener — `wss://game.cryptothrone.com/ws` could never terminate. Adds `https-cryptothrone-game` using the existing `cryptothrone-game-tls` Certificate (own cert per listener — avoids the SAN/listener filter-chain dup gotcha).

DNS A/CNAME for game.cryptothrone.com is being added separately (out of repo).