### PR TITLE
feat(cryptothrone): connection overlay, persistent nav + auth badge, online roster

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
@@ -12,10 +12,8 @@ test.describe('game page layout', () => {
 		await expect(page.locator('.game-fullscreen')).toBeAttached();
 	});
 
-	test('Starlight header is hidden while the game is active', async ({
-		page,
-	}) => {
-		await expect(page.locator('header').first()).toBeHidden();
+	test('nav bar stays visible while the game is active', async ({ page }) => {
+		await expect(page.locator('header').first()).toBeVisible();
 	});
 
 	test('body scroll is locked on the game page', async ({ page }) => {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactAuthBadge.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/auth/ReactAuthBadge.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from 'react';
+import { useSession } from '@kbve/astro';
+import { authBridge, initSupa } from '@/lib/supa';
+
+export default function ReactAuthBadge() {
+	const session = useSession();
+	const [open, setOpen] = useState(false);
+	const menuRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		initSupa().catch(() => {});
+	}, []);
+
+	useEffect(() => {
+		if (!open) return;
+		const close = (e: MouseEvent) => {
+			if (!menuRef.current?.contains(e.target as Node)) setOpen(false);
+		};
+		document.addEventListener('pointerdown', close);
+		return () => document.removeEventListener('pointerdown', close);
+	}, [open]);
+
+	if (!session.ready) {
+		return (
+			<span
+				className="h-7 w-7 animate-pulse rounded-full bg-white/10"
+				aria-hidden="true"
+			/>
+		);
+	}
+
+	if (!session.authenticated) {
+		return (
+			<a
+				href="/game/play/"
+				className="rounded-full border border-amber-400/40 px-3 py-1 text-[0.7rem] font-semibold uppercase tracking-widest text-amber-300 no-underline transition hover:border-amber-300 hover:text-amber-200">
+				Sign in
+			</a>
+		);
+	}
+
+	const display = session.username || session.name || 'adventurer';
+	const initial = display.charAt(0).toUpperCase();
+
+	return (
+		<div ref={menuRef} className="relative">
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				aria-haspopup="menu"
+				aria-expanded={open}
+				className="flex items-center gap-2 rounded-full border border-white/10 bg-white/5 py-1 pl-1 pr-3 transition hover:border-amber-400/40">
+				{session.avatar ? (
+					<img
+						src={session.avatar}
+						alt=""
+						className="h-6 w-6 rounded-full object-cover"
+					/>
+				) : (
+					<span className="flex h-6 w-6 items-center justify-center rounded-full bg-amber-500/80 text-xs font-bold text-black">
+						{initial}
+					</span>
+				)}
+				<span className="max-w-[8rem] truncate text-xs font-semibold text-stone-200">
+					{display}
+				</span>
+			</button>
+			{open && (
+				<div
+					role="menu"
+					className="absolute right-0 top-full z-50 mt-2 w-44 overflow-hidden rounded-xl border border-white/10 bg-black/90 shadow-xl shadow-black/50 backdrop-blur-xl">
+					{session.username && (
+						<a
+							role="menuitem"
+							href={`https://kbve.com/@${session.username}`}
+							target="_blank"
+							rel="noopener"
+							className="block px-4 py-2.5 text-xs text-stone-300 no-underline transition hover:bg-white/5 hover:text-amber-200">
+							View profile
+						</a>
+					)}
+					<a
+						role="menuitem"
+						href="/game/play/"
+						className="block px-4 py-2.5 text-xs text-stone-300 no-underline transition hover:bg-white/5 hover:text-amber-200">
+						Enter the game
+					</a>
+					<button
+						role="menuitem"
+						type="button"
+						onClick={async () => {
+							setOpen(false);
+							try {
+								await authBridge.signOut();
+							} finally {
+								window.location.reload();
+							}
+						}}
+						className="block w-full px-4 py-2.5 text-left text-xs text-red-300 transition hover:bg-red-500/10 hover:text-red-200">
+						Sign out
+					</button>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -14,6 +14,7 @@ import { ActionMenu } from './ui/ActionMenu';
 import { DialogueModal } from './ui/DialogueModal';
 import { DiceRollModal } from './ui/DiceRollModal';
 import { ChatBar } from './ui/ChatBar';
+import { ConnectionOverlay } from './ui/ConnectionOverlay';
 
 /**
  * Isolated Phaser canvas — never re-renders when game store changes.
@@ -91,6 +92,7 @@ function GameUI({ username }: { username?: string }) {
 			<CharacterDialog />
 			<NotificationToast />
 			<ChatBar />
+			<ConnectionOverlay />
 		</>
 	);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -61,6 +61,8 @@ export class CloudCityScene extends Scene {
 	private myHp = -1;
 	private myMaxHp = -1;
 	private nearbyHostiles = 0;
+	private slowTimer = 0;
+	private netReady = false;
 	private laserUnsubs: (() => void)[] = [];
 
 	constructor() {
@@ -117,7 +119,13 @@ export class CloudCityScene extends Scene {
 			kbveUsername: cfg.username,
 		});
 		this.client = client;
+		client.on('open', () => {
+			laserEvents.emit('net:status', { status: 'connected' });
+		});
 		client.on('welcome', (w) => {
+			this.netReady = true;
+			window.clearTimeout(this.slowTimer);
+			laserEvents.emit('net:status', { status: 'ready' });
 			this.mySlot = w.your_slot;
 			this.registry.clear();
 			for (const entry of w.registry ?? []) {
@@ -169,15 +177,36 @@ export class CloudCityScene extends Scene {
 			});
 		});
 		client.on('reject', (reason) => {
-			laserEvents.emit('char:event', {
-				message: `Server rejected the connection: ${reason}`,
+			window.clearTimeout(this.slowTimer);
+			laserEvents.emit('net:status', {
+				status: 'rejected',
+				detail: `The server turned you away: ${reason}`,
+			});
+		});
+		client.on('error', () => {
+			if (this.netReady) return;
+			window.clearTimeout(this.slowTimer);
+			laserEvents.emit('net:status', {
+				status: 'error',
+				detail: 'Could not reach the game server. Check your connection and try again.',
 			});
 		});
 		client.on('close', () => {
-			laserEvents.emit('char:event', {
-				message: 'Disconnected from the world.',
+			window.clearTimeout(this.slowTimer);
+			laserEvents.emit('net:status', {
+				status: 'disconnected',
+				detail: this.netReady
+					? 'You were disconnected from the world.'
+					: 'The game server closed the connection before the world loaded.',
 			});
+			this.netReady = false;
 		});
+		laserEvents.emit('net:status', { status: 'connecting' });
+		this.slowTimer = window.setTimeout(() => {
+			if (!this.netReady) {
+				laserEvents.emit('net:status', { status: 'slow' });
+			}
+		}, 8000);
 		client.connect();
 
 		this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) =>
@@ -200,6 +229,7 @@ export class CloudCityScene extends Scene {
 		);
 
 		this.events.once('shutdown', () => {
+			window.clearTimeout(this.slowTimer);
 			this.laserUnsubs.forEach((off) => off());
 			this.laserUnsubs = [];
 			this.client?.close();

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -63,6 +63,7 @@ export class CloudCityScene extends Scene {
 	private nearbyHostiles = 0;
 	private slowTimer = 0;
 	private netReady = false;
+	private rosterKey = '';
 	private laserUnsubs: (() => void)[] = [];
 
 	constructor() {
@@ -372,6 +373,18 @@ export class CloudCityScene extends Scene {
 
 		this.checkRanges();
 		this.checkHostileProximity();
+		this.syncRoster(snap);
+	}
+
+	private syncRoster(snap: Snapshot) {
+		const players = snap.players
+			.filter((p) => p.connected)
+			.map((p) => ({ slot: p.slot, username: p.kbve_username }))
+			.sort((a, b) => a.slot - b.slot);
+		const key = players.map((p) => `${p.slot}:${p.username}`).join('|');
+		if (key === this.rosterKey) return;
+		this.rosterKey = key;
+		laserEvents.emit('players:sync', { players });
 	}
 
 	private checkHostileProximity() {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.test.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.test.ts
@@ -147,3 +147,17 @@ describe('gameReducer', () => {
 		expect(s).toBe(start);
 	});
 });
+
+describe('SET_CONNECTION', () => {
+	it('replaces the connection state', () => {
+		const next = gameReducer(initialGameState, {
+			type: 'SET_CONNECTION',
+			payload: { status: 'rejected', detail: 'match full' },
+		});
+		expect(next.connection).toEqual({
+			status: 'rejected',
+			detail: 'match full',
+		});
+		expect(initialGameState.connection.status).toBe('connecting');
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
@@ -23,12 +23,18 @@ export interface ConnectionState {
 	detail?: string;
 }
 
+export interface OnlinePlayer {
+	slot: number;
+	username: string;
+}
+
 export interface GameState {
 	player: {
 		stats: PlayerStats;
 		inventory: PlayerInventory;
 	};
 	connection: ConnectionState;
+	players: OnlinePlayer[];
 	settings: {
 		isStatsCollapsed: boolean;
 		isSettingsCollapsed: boolean;
@@ -68,7 +74,8 @@ export type GameAction =
 			payload: { diceValues: number[]; totalRoll: number };
 	  }
 	| { type: 'SET_MODAL'; payload: ModalState | null }
-	| { type: 'SET_CONNECTION'; payload: ConnectionState };
+	| { type: 'SET_CONNECTION'; payload: ConnectionState }
+	| { type: 'SET_PLAYERS'; payload: OnlinePlayer[] };
 
 const DEFAULT_EQUIPMENT: Record<EquipmentSlot, string | null> = {
 	head: null,
@@ -83,6 +90,7 @@ const DEFAULT_EQUIPMENT: Record<EquipmentSlot, string | null> = {
 
 export const initialGameState: GameState = {
 	connection: { status: 'connecting' },
+	players: [],
 	player: {
 		stats: {
 			hp: 100,
@@ -245,6 +253,9 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 
 		case 'SET_CONNECTION':
 			return { ...state, connection: action.payload };
+
+		case 'SET_PLAYERS':
+			return { ...state, players: action.payload };
 
 		case 'SET_MODAL':
 			return { ...state, activeModal: action.payload };

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
@@ -9,11 +9,26 @@ import type {
 	EquipmentSlot,
 } from '../types';
 
+export type ConnectionStatus =
+	| 'connecting'
+	| 'connected'
+	| 'slow'
+	| 'ready'
+	| 'rejected'
+	| 'error'
+	| 'disconnected';
+
+export interface ConnectionState {
+	status: ConnectionStatus;
+	detail?: string;
+}
+
 export interface GameState {
 	player: {
 		stats: PlayerStats;
 		inventory: PlayerInventory;
 	};
+	connection: ConnectionState;
 	settings: {
 		isStatsCollapsed: boolean;
 		isSettingsCollapsed: boolean;
@@ -52,7 +67,8 @@ export type GameAction =
 			type: 'UPDATE_DICE_VALUES';
 			payload: { diceValues: number[]; totalRoll: number };
 	  }
-	| { type: 'SET_MODAL'; payload: ModalState | null };
+	| { type: 'SET_MODAL'; payload: ModalState | null }
+	| { type: 'SET_CONNECTION'; payload: ConnectionState };
 
 const DEFAULT_EQUIPMENT: Record<EquipmentSlot, string | null> = {
 	head: null,
@@ -66,6 +82,7 @@ const DEFAULT_EQUIPMENT: Record<EquipmentSlot, string | null> = {
 };
 
 export const initialGameState: GameState = {
+	connection: { status: 'connecting' },
 	player: {
 		stats: {
 			hp: 100,
@@ -225,6 +242,9 @@ export function gameReducer(state: GameState, action: GameAction): GameState {
 					phase: 'result',
 				},
 			};
+
+		case 'SET_CONNECTION':
+			return { ...state, connection: action.payload };
 
 		case 'SET_MODAL':
 			return { ...state, activeModal: action.payload };

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
@@ -27,6 +27,15 @@ export function useEventBridge(dispatch: Dispatch<GameAction>) {
 		);
 
 		unsubs.push(
+			laserEvents.on('players:sync', (data) => {
+				const payload = data as {
+					players: { slot: number; username: string }[];
+				};
+				dispatch({ type: 'SET_PLAYERS', payload: payload.players });
+			}),
+		);
+
+		unsubs.push(
 			laserEvents.on('char:event', (data: CharacterEventData) => {
 				dispatch({
 					type: 'SET_MODAL',

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
@@ -10,6 +10,23 @@ export function useEventBridge(dispatch: Dispatch<GameAction>) {
 		const unsubs: (() => void)[] = [];
 
 		unsubs.push(
+			laserEvents.on('net:status', (data) => {
+				const conn = data as {
+					status:
+						| 'connecting'
+						| 'connected'
+						| 'slow'
+						| 'ready'
+						| 'rejected'
+						| 'error'
+						| 'disconnected';
+					detail?: string;
+				};
+				dispatch({ type: 'SET_CONNECTION', payload: conn });
+			}),
+		);
+
+		unsubs.push(
 			laserEvents.on('char:event', (data: CharacterEventData) => {
 				dispatch({
 					type: 'SET_MODAL',

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
@@ -18,6 +18,22 @@ export function ChatBar() {
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key !== 'Enter') return;
+			const active = document.activeElement;
+			if (
+				active instanceof HTMLInputElement ||
+				active instanceof HTMLTextAreaElement
+			)
+				return;
+			e.preventDefault();
+			inputRef.current?.focus();
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, []);
+
+	useEffect(() => {
 		return laserEvents.on('chat:message', (data) => {
 			const msg = data as { from: string; text: string };
 			setLines((prev) =>
@@ -60,7 +76,7 @@ export function ChatBar() {
 					maxLength={MAX_INPUT}
 					onChange={(e) => setDraft(e.target.value)}
 					onKeyDown={(e) => e.stopPropagation()}
-					placeholder="Say something…"
+					placeholder="Press Enter to chat…"
 					aria-label="Chat message"
 					className="w-full rounded border border-white/20 bg-black/60 px-2 py-1 text-xs text-white placeholder-gray-400 outline-none backdrop-blur-sm focus:border-cyan-400"
 				/>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
@@ -1,0 +1,66 @@
+import { useGameSelector } from '../store/GameStoreContext';
+
+export function ConnectionOverlay() {
+	const connection = useGameSelector((s) => s.connection);
+
+	if (connection.status === 'ready') return null;
+
+	const isPending =
+		connection.status === 'connecting' ||
+		connection.status === 'connected' ||
+		connection.status === 'slow';
+
+	return (
+		<div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-[2px]">
+			<div className="pointer-events-auto w-full max-w-xs rounded-2xl border border-amber-200/10 bg-black/70 p-6 text-center shadow-2xl shadow-black/60 backdrop-blur-xl">
+				{isPending ? (
+					<>
+						<span
+							className="mx-auto mb-4 block h-8 w-8 animate-spin rounded-full border-2 border-amber-400/20 border-t-amber-400"
+							aria-hidden="true"
+						/>
+						<p className="text-sm font-semibold text-amber-200">
+							Linking to Cloud City…
+						</p>
+						<p className="mt-2 text-xs text-stone-400">
+							{connection.status === 'slow'
+								? 'This is taking longer than usual. The realm may be waking up — hang tight.'
+								: 'Establishing a secure connection to the game server.'}
+						</p>
+					</>
+				) : (
+					<>
+						<svg
+							className="mx-auto mb-4 h-8 w-8 text-red-400"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="1.75"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							aria-hidden="true">
+							<path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.7 3.86a2 2 0 0 0-3.4 0z" />
+							<line x1="12" y1="9" x2="12" y2="13" />
+							<line x1="12" y1="17" x2="12.01" y2="17" />
+						</svg>
+						<p className="text-sm font-semibold text-red-300">
+							{connection.status === 'rejected'
+								? 'Connection rejected'
+								: 'Connection lost'}
+						</p>
+						<p className="mt-2 text-xs text-stone-400">
+							{connection.detail ??
+								'The link to the game server failed. The world may be offline or unreachable.'}
+						</p>
+						<button
+							type="button"
+							onClick={() => window.location.reload()}
+							className="mt-4 w-full rounded-lg bg-amber-500/90 px-4 py-2 text-sm font-semibold text-black transition hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/70">
+							Retry connection
+						</button>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/OnlinePlayers.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/OnlinePlayers.tsx
@@ -1,0 +1,41 @@
+import { useGameSelector } from '../store/GameStoreContext';
+
+export function OnlinePlayers() {
+	const players = useGameSelector((s) => s.players);
+	const me = useGameSelector((s) => s.player.stats.username);
+
+	return (
+		<div className="mb-4">
+			<h2 className="text-lg font-semibold mb-2">
+				Online
+				<span className="ml-2 rounded-full bg-emerald-500/20 px-2 py-0.5 text-xs font-semibold text-emerald-300">
+					{players.length}
+				</span>
+			</h2>
+			{players.length === 0 ? (
+				<p className="text-sm text-gray-500">Nobody in the realm.</p>
+			) : (
+				<ul className="space-y-1">
+					{players.map((p) => (
+						<li
+							key={p.slot}
+							className="flex items-center gap-2 text-sm">
+							<span
+								className="h-1.5 w-1.5 rounded-full bg-emerald-400"
+								aria-hidden="true"
+							/>
+							<span className="truncate">
+								{p.username}
+								{p.username === me && (
+									<span className="ml-1 text-xs text-gray-500">
+										(you)
+									</span>
+								)}
+							</span>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
@@ -2,6 +2,7 @@ import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 import { StatsSection } from './StatsSection';
 import { ToggleButton } from './ToggleButton';
 import { InventoryGrid } from './InventoryGrid';
+import { OnlinePlayers } from './OnlinePlayers';
 import { getItemById } from '../data/items';
 
 export function StickySidebar() {
@@ -70,6 +71,8 @@ export function StickySidebar() {
 						{player.stats.username || 'Guest'}
 					</p>
 				</div>
+
+				<OnlinePlayers />
 
 				<div className="mb-4">
 					<h2 className="text-lg font-semibold mb-2">Inventory</h2>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/starlight/Header.astro
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/starlight/Header.astro
@@ -6,6 +6,7 @@ import SiteTitle from 'virtual:starlight/components/SiteTitle';
 import SocialIcons from 'virtual:starlight/components/SocialIcons';
 import ThemeSelect from 'virtual:starlight/components/ThemeSelect';
 import LanguageSelect from 'virtual:starlight/components/LanguageSelect';
+import ReactAuthBadge from '../auth/ReactAuthBadge';
 
 const shouldRenderSearch =
 	config.pagefind ||
@@ -40,6 +41,7 @@ const shouldRenderSearch =
 		</div>
 		<ThemeSelect />
 		<LanguageSelect />
+		<ReactAuthBadge client:only="react" />
 	</div>
 </div>
 

--- a/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
+++ b/apps/cryptothrone/astro-cryptothrone/src/styles/global.css
@@ -51,9 +51,8 @@ body:has(.game-fullscreen) {
 	overflow: hidden;
 }
 
-/* Strip every Starlight chrome element so the overlay is truly full-bleed */
-body:has(.game-fullscreen) header,
-body:has(.game-fullscreen) .ct-header,
+/* Strip Starlight chrome below the header so the game gets the rest of
+   the viewport — the nav bar stays for orientation + the auth badge */
 body:has(.game-fullscreen) .sidebar,
 body:has(.game-fullscreen) .right-sidebar,
 body:has(.game-fullscreen) starlight-menu-button,
@@ -62,17 +61,16 @@ body:has(.game-fullscreen) .ct-footer {
 	display: none;
 }
 
-/* Drop the reserved nav-height gap once the header is gone */
 body:has(.game-fullscreen) .page,
 body:has(.game-fullscreen) .main-frame {
 	padding-top: 0 !important;
 }
 
-/* Full-viewport game overlay — sits above all Starlight chrome */
+/* Game overlay fills the viewport below the nav bar */
 .game-fullscreen {
 	position: fixed;
-	inset: 0;
-	z-index: 9999;
+	inset: var(--sl-nav-height, 3.5rem) 0 0 0;
+	z-index: 40;
 	background: var(--ct-bg-deep);
 	display: flex;
 	align-items: center;
@@ -85,7 +83,7 @@ body:has(.game-fullscreen) .main-frame {
 	width: 100%;
 	height: 100%;
 	max-width: 100vw;
-	max-height: 100vh;
+	max-height: calc(100vh - var(--sl-nav-height, 3.5rem));
 	object-fit: contain;
 }
 


### PR DESCRIPTION
## Summary
Two batches in one PR.

### WebSocket connection status overlay
The game canvas previously failed silently when `wss://game.cryptothrone.com/ws` was unreachable.
- New `connection` slice in the game store, fed by `net:status` laser events from the GameClient lifecycle
- **Connecting**: glass card + spinner; flips to a 'taking longer than usual' warning after 8s without a Welcome
- **Failed**: warning card for reject (server reason), socket error, and close-before-Welcome — each with a Retry button; clears on Welcome
- Disconnect after a live session reads 'You were disconnected from the world'

### Persistent nav bar + auth badge
- The game overlay now sits **below the Starlight nav** (`inset: var(--sl-nav-height) 0 0 0`, z-index under the header) — sidebars/footer still stripped; header e2e flipped to assert visibility
- New **ReactAuthBadge** in the header right-group: session-aware (via `useSession`) avatar-or-initial + username chip, dropdown with View profile (kbve.com/@user), Enter the game, Sign out; amber Sign-in pill when logged out; skeleton while auth boots

### HUD sweep
- **Online roster**: sidebar section listing connected players (snapshot roster, edge-triggered `players:sync`), count badge, '(you)' marker
- **Chat hotkey**: Enter focuses the chat input when no field is active; placeholder updated

Screenshot-verified: overlay pending/failed states, nav + badge in-game.

## Testing
- astro-cryptothrone: 29/29 vitest, site builds
- e2e preview: 57 passed / 0 failed (updated header + gate assertions)