### PR TITLE
fix(ci): Linux client cooked Shipping + beta = cooked Shipping release

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -722,6 +722,7 @@ jobs:
                       "$RUNUAT" BuildCookRun \
                         -project=/project/'"${UPROJECT_NAME}"' \
                         -targetplatform=Linux \
+                        -clientconfig=Shipping \
                         -cook -allmaps -build -stage -pak -archive \
                         -archivedirectory=/output \
                         -unattended -utf8output -NoP4

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -35,11 +35,12 @@ external_publish:
 
 ## Overview
 
-Chuck RPG UE5 standalone game client. The playable build (distinct from the
-[Unreal Chuck](/project/unreal-chuck) dedicated server) is compiled from the
-external game repo [`KBVE/chuck`](https://github.com/kbve/chuck) (default branch,
+Chuck RPG UE5 standalone game client — the **cooked, non-editor Shipping** release
+(`-clientconfig=Shipping`, `-cook -pak`) of the `main` branch. Compiled from the external
+game repo [`KBVE/chuck`](https://github.com/kbve/chuck) (default branch = `main`,
 `.uproject` under `engine.project_path`, Content pulled from the chuck Forgejo LFS
-endpoint) and shipped to itch.io under `kbve/chuckrpg`.
+endpoint) and shipped to itch.io under `kbve/chuckrpg`. The editor/Development counterpart
+is [Unreal Chuck Dev](/project/unreal-chuck-dev).
 
 ## Pipeline
 


### PR DESCRIPTION
## Fix
The Win64 client builds `-clientconfig=Shipping`, but the Linux `BuildCookRun` omitted `-clientconfig` → defaulted to **Development**. So the cooked client wasn't a true Shipping release on Linux. Added `-clientconfig=Shipping` to match Win64 — both platforms now produce the cooked, non-editor Shipping client.

`unreal-chuck-beta.mdx`: clarified it's the **cooked Shipping** release of `main` (vs the editor/Development `unreal-chuck-dev`). Prose-only (no manifest change).

## Why beta needs nothing more right now
beta = `main` = the repo's **default branch**, which CI already clones. So beta needs none of the dev-only machinery.

## Deferred (the dev/beta server split — tracked for follow-up)
- **Per-env `server_target` + `server_config`** read from the manifest entry (one shared build.toml can't hold two configs) → `chuckServerDev` (Development) vs `chuckServerBeta` (Shipping). `*.Target.cs` live in the monorepo shell `apps/chuckrpg/unreal-chuck/Source` since the server build uses the shell.
- **`external_repo_ref` branch param** — only needed for `dev` (non-default branch); plumb through ci-main → ci-unreal → ci-unreal-build `git clone --branch`.
- **Server build source** currently = monorepo shell; to build the dev server from the `dev` branch it must clone the external repo at the ref (touches the working chuck server path).
- Earlier fleet `subPath` fix (#12201) already scopes each fleet to its target dir.

Beta is the immediate, non-breaking win; the dev split is the larger follow-up once the `dev` branch + targets are ready.