### PR TITLE
feat(ci): per-game unreal build config in MDX registry (de-hardcode)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.194",
+			"version": "1.0.195",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.10",
+			"version": "0.1.11",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -120,7 +120,7 @@
 		{
 			"key": "cryptothrone_server",
 			"app_name": "cryptothrone-server",
-			"version": "0.0.2",
+			"version": "0.0.3",
 			"version_toml": "apps/agones/cryptothrone/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
 			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",
@@ -1082,7 +1082,12 @@
 					"Win64",
 					"Linux"
 				],
-				"external_repo_url": "https://github.com/kbve/chuck"
+				"external_repo_url": "https://github.com/kbve/chuck",
+				"client_config": "Shipping",
+				"maps": [
+					"/Game/Menus/L_MainMenu",
+					"/Game/Map/L_ChuckWorld"
+				]
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"version": "0.3.19",
@@ -1104,7 +1109,16 @@
 					"Win64",
 					"Linux"
 				],
-				"external_repo_url": "https://github.com/kbve/chuck"
+				"external_repo_url": "https://github.com/kbve/chuck",
+				"external_repo_ref": "dev",
+				"server_target": "chuckServerDev",
+				"server_config": "Development",
+				"client_config": "Development",
+				"maps": [
+					"/Game/Menus/L_MainMenu",
+					"/Game/Map/L_ChuckWorld"
+				],
+				"game_mode": "/Script/Chuck.ChuckGameMode"
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
@@ -1115,7 +1129,7 @@
 			"external_publish": {
 				"itch_user": "kbve",
 				"itch_game": "chuckrpg",
-				"itch_channel": "demo"
+				"itch_channel": "dev"
 			}
 		},
 		{

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -526,6 +526,12 @@ jobs:
                     dotnet=$(echo "$entry" | jq -r '.engine.dotnet_enabled // false')
                     lic=$(echo "$entry" | jq -r '.engine.license_method // empty')
                     ext_repo=$(echo "$entry" | jq -r '.engine.external_repo_url // empty')
+                    ext_ref=$(echo "$entry" | jq -r '.engine.external_repo_ref // empty')
+                    srv_target=$(echo "$entry" | jq -r '.engine.server_target // empty')
+                    srv_config=$(echo "$entry" | jq -r '.engine.server_config // empty')
+                    cli_config=$(echo "$entry" | jq -r '.engine.client_config // empty')
+                    game_mode=$(echo "$entry" | jq -r '.engine.game_mode // empty')
+                    maps=$(echo "$entry" | jq -c '.engine.maps // []')
                     itch_user=$(echo "$entry" | jq -r '.external_publish.itch_user // empty')
                     itch_game=$(echo "$entry" | jq -r '.external_publish.itch_game // empty')
                     deploy_itch="false"
@@ -561,6 +567,12 @@ jobs:
                     [ "$features" != "[]" ] && extra="$extra --field features=${features}"
                     [ -n "$lic" ] && extra="$extra --field license_method=${lic}"
                     [ -n "$ext_repo" ] && extra="$extra --field external_repo_url=${ext_repo}"
+                    [ -n "$ext_ref" ] && extra="$extra --field external_repo_ref=${ext_ref}"
+                    [ -n "$srv_target" ] && extra="$extra --field server_target=${srv_target}"
+                    [ -n "$srv_config" ] && extra="$extra --field server_config=${srv_config}"
+                    [ -n "$cli_config" ] && extra="$extra --field client_config=${cli_config}"
+                    [ -n "$game_mode" ] && extra="$extra --field game_mode=${game_mode}"
+                    [ "$maps" != "[]" ] && extra="$extra --field maps=${maps}"
                     [ "$dotnet" = "true" ] && extra="$extra --field dotnet_enabled=true"
                     extra="$extra --field deploy_to_itch=${deploy_itch}"
                     [ -n "$itch_user" ] && extra="$extra --field itch_user=${itch_user}"

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -44,6 +44,36 @@ on:
                 required: false
                 type: string
                 default: ''
+            external_repo_ref:
+                description: '[game] Branch/ref of external_repo_url (empty = default branch)'
+                required: false
+                type: string
+                default: ''
+            server_target:
+                description: '[game] UE server target (overrides build.toml)'
+                required: false
+                type: string
+                default: ''
+            server_config:
+                description: '[game] UE -serverconfig (overrides build.toml)'
+                required: false
+                type: string
+                default: ''
+            client_config:
+                description: '[game] UE -clientconfig (default Shipping)'
+                required: false
+                type: string
+                default: ''
+            game_mode:
+                description: '[game] Server launch game mode (fleet metadata)'
+                required: false
+                type: string
+                default: ''
+            maps:
+                description: '[game] JSON array of maps to cook (empty = -allmaps)'
+                required: false
+                type: string
+                default: ''
             version_source:
                 description: '[game] Path to version source (mdx)'
                 required: false
@@ -267,6 +297,11 @@ jobs:
                   SERVER_TARGET=$(get_val "server_target")
                   UE_IMAGE_TAG=$(get_val "ue_image_tag")
                   SERVER_CONFIG=$(get_val "server_config")
+
+                  # Manifest entry (MDX engine.*) wins over build.toml so per-game config
+                  # lives in the registry and the workflow stays game-agnostic.
+                  [ -n "${{ inputs.server_target }}" ] && SERVER_TARGET="${{ inputs.server_target }}"
+                  [ -n "${{ inputs.server_config }}" ] && SERVER_CONFIG="${{ inputs.server_config }}"
 
                   UE_IMAGE_TAG="${UE_IMAGE_TAG:-dev-5.7.4}"
                   SERVER_CONFIG="${SERVER_CONFIG:-Development}"
@@ -638,10 +673,11 @@ jobs:
                   SLUG="${SLUG#git@github.com:}"
                   SLUG="${SLUG%.git}"
                   SUBDIR="${{ inputs.project_path }}"
-                  echo "::notice::Cloning external game repo ${SLUG} (default branch), subdir '${SUBDIR}'"
+                  REF="${{ inputs.external_repo_ref }}"
+                  echo "::notice::Cloning external game repo ${SLUG} (${REF:-default branch}), subdir '${SUBDIR}'"
                   rm -rf /tmp/game-clone /tmp/game-project
 
-                  GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 \
+                  GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 ${REF:+--branch "${REF}"} \
                     "https://x-access-token:${GH_TOKEN}@github.com/${SLUG}.git" /tmp/game-clone
 
                   cd /tmp/game-clone
@@ -703,7 +739,14 @@ jobs:
                     exit 1
                   fi
                   UPROJECT_NAME=$(basename "${UPROJECT_FILE}")
-                  echo "::notice::Building ${UPROJECT_NAME} (Linux client)"
+                  CLIENT_CONFIG='${{ inputs.client_config }}'; CLIENT_CONFIG="${CLIENT_CONFIG:-Shipping}"
+                  MAPS_JSON='${{ inputs.maps }}'
+                  if [ -n "${MAPS_JSON}" ] && [ "${MAPS_JSON}" != "[]" ]; then
+                    MAP_ARG="-map=$(echo "${MAPS_JSON}" | jq -r 'join("+")')"
+                  else
+                    MAP_ARG="-allmaps"
+                  fi
+                  echo "::notice::Building ${UPROJECT_NAME} (Linux client, ${CLIENT_CONFIG}, ${MAP_ARG})"
 
                   docker run --rm \
                     -v /tmp/game-project:/project \
@@ -722,8 +765,8 @@ jobs:
                       "$RUNUAT" BuildCookRun \
                         -project=/project/'"${UPROJECT_NAME}"' \
                         -targetplatform=Linux \
-                        -clientconfig=Shipping \
-                        -cook -allmaps -build -stage -pak -archive \
+                        -clientconfig='"${CLIENT_CONFIG}"' \
+                        -cook '"${MAP_ARG}"' -build -stage -pak -archive \
                         -archivedirectory=/output \
                         -unattended -utf8output -NoP4
                     '
@@ -825,12 +868,18 @@ jobs:
                   $slug = '${{ inputs.external_repo_url }}'
                   $slug = $slug -replace '^https://github.com/', '' -replace '^git@github.com:', '' -replace '\.git$', ''
                   $subdir = '${{ inputs.project_path }}'
+                  $ref = '${{ inputs.external_repo_ref }}'
                   $clone = 'C:\game-clone'
                   if (Test-Path $clone) { Remove-Item -Recurse -Force $clone -ErrorAction SilentlyContinue }
-                  Write-Host "::notice::Cloning external game repo $slug (default branch), subdir '$subdir'"
+                  $refLabel = if ($ref) { $ref } else { 'default branch' }
+                  Write-Host "::notice::Cloning external game repo $slug ($refLabel), subdir '$subdir'"
 
                   $env:GIT_LFS_SKIP_SMUDGE = '1'
-                  git clone --depth 1 "https://x-access-token:$token@github.com/$slug.git" $clone
+                  if ($ref) {
+                    git clone --depth 1 --branch $ref "https://x-access-token:$token@github.com/$slug.git" $clone
+                  } else {
+                    git clone --depth 1 "https://x-access-token:$token@github.com/$slug.git" $clone
+                  }
                   if ($LASTEXITCODE -ne 0) { Write-Host "::error::clone failed"; exit $LASTEXITCODE }
                   Remove-Item Env:\GIT_LFS_SKIP_SMUDGE
 
@@ -869,12 +918,19 @@ jobs:
                   if (-not $uproject) { Write-Host "::error::No .uproject found in $projRoot"; exit 1 }
                   $out = "C:\ue5-game-output"
                   New-Item -ItemType Directory -Force -Path $out | Out-Null
-                  Write-Host "::notice::Building $($uproject.FullName) (Win64 client)"
+                  $clientConfig = if ('${{ inputs.client_config }}') { '${{ inputs.client_config }}' } else { 'Shipping' }
+                  $mapsJson = '${{ inputs.maps }}'
+                  if ($mapsJson -and $mapsJson -ne '[]') {
+                      $mapArg = '-map=' + (($mapsJson | ConvertFrom-Json) -join '+')
+                  } else {
+                      $mapArg = '-allmaps'
+                  }
+                  Write-Host "::notice::Building $($uproject.FullName) (Win64 client, $clientConfig, $mapArg)"
                   & '${{ steps.engine.outputs.runuat }}' BuildCookRun `
                       -project="$($uproject.FullName)" `
                       -targetplatform=Win64 `
-                      -clientconfig=Shipping `
-                      -cook -map=/Game/Menus/L_MainMenu+/Game/Map/L_ChuckWorld `
+                      -clientconfig=$clientConfig `
+                      -cook $mapArg `
                       -build -stage -pak -archive `
                       -archivedirectory="$out" `
                       -nodebuginfo `

--- a/.github/workflows/ci-unreal.yml
+++ b/.github/workflows/ci-unreal.yml
@@ -47,6 +47,36 @@ on:
                 required: false
                 type: string
                 default: ''
+            external_repo_ref:
+                description: '[game] Branch/ref of external_repo_url'
+                required: false
+                type: string
+                default: ''
+            server_target:
+                description: '[game] UE server target'
+                required: false
+                type: string
+                default: ''
+            server_config:
+                description: '[game] UE -serverconfig'
+                required: false
+                type: string
+                default: ''
+            client_config:
+                description: '[game] UE -clientconfig'
+                required: false
+                type: string
+                default: ''
+            game_mode:
+                description: '[game] Server launch game mode'
+                required: false
+                type: string
+                default: ''
+            maps:
+                description: '[game] JSON array of maps to cook'
+                required: false
+                type: string
+                default: ''
             license_method:
                 description: '[game] License method (manifest passthrough)'
                 required: false
@@ -144,6 +174,12 @@ jobs:
             engine_version: ${{ inputs.engine_version }}
             build_targets: ${{ inputs.build_targets }}
             external_repo_url: ${{ inputs.external_repo_url }}
+            external_repo_ref: ${{ inputs.external_repo_ref }}
+            server_target: ${{ inputs.server_target }}
+            server_config: ${{ inputs.server_config }}
+            client_config: ${{ inputs.client_config }}
+            game_mode: ${{ inputs.game_mode }}
+            maps: ${{ inputs.maps }}
             version_source: ${{ inputs.version_source }}
             version_toml: ${{ inputs.version_toml }}
             manifest_version: ${{ inputs.manifest_version }}

--- a/apps/chuckrpg/unreal-chuck/Source/chuckServerDev.Target.cs
+++ b/apps/chuckrpg/unreal-chuck/Source/chuckServerDev.Target.cs
@@ -1,0 +1,15 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class chuckServerDevTarget : TargetRules
+{
+	public chuckServerDevTarget(TargetInfo Target) : base(Target)
+	{
+		Type = TargetType.Server;
+		DefaultBuildSettings = BuildSettingsVersion.V6;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_7;
+		ExtraModuleNames.Add("chuck");
+	}
+}

--- a/apps/kbve/astro-kbve/src/content.config.ts
+++ b/apps/kbve/astro-kbve/src/content.config.ts
@@ -127,6 +127,16 @@ const ProjectSchemaWithEngine = ICiProjectSchema.extend({
 			test_args: z.array(z.string().max(256)).max(50).optional(),
 			features: z.array(z.string().min(1).max(64)).max(50).optional(),
 			external_repo_url: z.string().url().max(512).optional(),
+			external_repo_ref: z.string().min(1).max(128).optional(),
+			server_target: z.string().min(1).max(128).optional(),
+			server_config: z
+				.enum(['Development', 'Shipping', 'Test', 'DebugGame', 'Debug'])
+				.optional(),
+			client_config: z
+				.enum(['Development', 'Shipping', 'Test', 'DebugGame', 'Debug'])
+				.optional(),
+			maps: z.array(z.string().min(1).max(128)).max(50).optional(),
+			game_mode: z.string().min(1).max(256).optional(),
 		})
 		.optional(),
 	external_publish: ExternalPublishInline,

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -28,6 +28,10 @@ engine:
     build_targets:
         - Win64
         - Linux
+    client_config: Shipping
+    maps:
+        - /Game/Menus/L_MainMenu
+        - /Game/Map/L_ChuckWorld
 external_publish:
     itch_user: kbve
     itch_game: chuckrpg

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-dev.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-dev.mdx
@@ -28,10 +28,18 @@ engine:
     build_targets:
         - Win64
         - Linux
+    external_repo_ref: dev
+    client_config: Development
+    server_target: chuckServerDev
+    server_config: Development
+    game_mode: /Script/Chuck.ChuckGameMode
+    maps:
+        - /Game/Menus/L_MainMenu
+        - /Game/Map/L_ChuckWorld
 external_publish:
     itch_user: kbve
     itch_game: chuckrpg
-    itch_channel: demo
+    itch_channel: dev
 shell_path: apps/chuckrpg/unreal-chuck
 ---
 

--- a/packages/data/proto/kbve/ci_registry.proto
+++ b/packages/data/proto/kbve/ci_registry.proto
@@ -84,6 +84,25 @@ message GameEngineConfig {
   // (e.g. Azure DevOps repo for a private Unity project that ships
   // public artifacts).
   optional string external_repo_url = 8;
+
+  // Branch / ref of external_repo_url to clone. Empty = repo default branch.
+  optional string external_repo_ref = 9;
+
+  // UE Server target name (e.g. chuckServerDev, chuckServerBeta). Drives -target and
+  // the PVC artifact dir /ows-server/<server_target>/<version>. Empty = build.toml.
+  optional string server_target = 10;
+
+  // UE dedicated-server build config: Development | Shipping | Test | DebugGame | Debug.
+  optional string server_config = 11;
+
+  // UE game-client build config: Development | Shipping | Test | DebugGame | Debug.
+  optional string client_config = 12;
+
+  // Maps to cook. Empty = -allmaps.
+  repeated string maps = 13;
+
+  // Server launch game mode (e.g. /Script/Chuck.ChuckGameMode) for the Agones fleet.
+  optional string game_mode = 14;
 }
 
 // One Steam application entry for [`ExternalPublish`]. Demos, the main


### PR DESCRIPTION
Moves per-game UE build config out of the workflow into each registry entry's `engine` block, so `ci-unreal-build.yml` stays game-agnostic — chuck dev/beta + future games (rentearth) configure themselves via MDX.

## Schema (proto + content.config.ts)
New `engine` fields: `external_repo_ref`, `server_target`, `server_config`, `client_config`, `maps`, `game_mode`.

## Wiring (data flows entry → build)
ci-main extracts + `--field` → ci-unreal inputs/passthrough → ci-unreal-build:
- parse job: `server_target`/`server_config` from the entry (build.toml fallback)
- Linux + Win64 client: `client_config` + `maps` — **removed the hardcoded `-clientconfig=Shipping` and the baked-in `-map=/Game/Menus/L_MainMenu+/Game/Map/L_ChuckWorld`** (Win64 was chuck-specific)
- both external clones: `git clone --branch ${external_repo_ref}` (empty = default branch)

## chuckServerDev.Target.cs
Added to the shell `Source` (the server build uses the monorepo shell, not the external repo), so dev's `server_target: chuckServerDev` resolves.

## MDX populated
- **beta**: `client_config: Shipping` + the two chuck maps (preserves Win64; now also applied on Linux instead of `-allmaps`)
- **dev**: `external_repo_ref: dev`, `chuckServerDev`, `Development`, maps, `game_mode`, itch channel `dev`

Manifest regenerated; astro build + sync clean; all 3 workflows parse.

## Behavior-change to note
Win64 chuck client previously cooked only the 2 maps; Linux cooked `-allmaps`. Now both honor the entry's `maps` (the 2 maps) — consistent, but Linux cooks fewer maps than before. If `-allmaps` is wanted for an entry, omit `maps`.

## Deferred
- server `-allmaps` left as default (omit `maps` = all)
- fleet `-GameMode` de-hardcode (runtime/k8s, consumes `game_mode`) — separate follow-up
- dev server build still uses the monorepo shell; building it from the `dev` branch (external clone) is the larger server-source change.