### PR TITLE
feat(forgejo): admin panel v2 — pagination, branch protection, issues, secrets

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgPanel.tsx
@@ -15,6 +15,7 @@ import {
 	useForm,
 	useTabActive,
 	uiTokens,
+	LoadMoreButton,
 } from './forgejoUi';
 import {
 	Plus,
@@ -511,6 +512,7 @@ function OrgCard({ org }: { org: ForgejoOrg }) {
 export default function ReactForgejoOrgPanel() {
 	const active = useTabActive('orgs');
 	const orgs = useStore(forgejoService.$orgs);
+	const hasMore = useStore(forgejoService.$orgsHasMore);
 	const [createOpen, setCreateOpen] = useState(false);
 
 	if (!active) return null;
@@ -539,6 +541,10 @@ export default function ReactForgejoOrgPanel() {
 					</span>
 				)}
 			</div>
+			<LoadMoreButton
+				hasMore={hasMore}
+				onClick={() => forgejoService.loadMoreOrgs()}
+			/>
 			{createOpen && (
 				<CreateOrgModal onClose={() => setCreateOpen(false)} />
 			)}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoAdmin.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoAdmin.tsx
@@ -20,6 +20,8 @@ import {
 	Tag,
 	CheckCircle2,
 	XCircle,
+	ShieldCheck,
+	KeyRound,
 } from 'lucide-react';
 
 const { textColor, subText, border, panelBg } = uiTokens;
@@ -240,23 +242,169 @@ function CreateReleaseModal({
 	);
 }
 
+function CreateProtectionModal({
+	repo,
+	onClose,
+}: {
+	repo: string;
+	onClose: () => void;
+}) {
+	const busy = useStore(forgejoService.$busy);
+	const { state, set } = useForm({
+		rule_name: '',
+		required_approvals: '0',
+		enable_push: true,
+		require_signed_commits: false,
+		enable_status_check: false,
+		block_on_outdated_branch: false,
+	});
+	const submit = async () => {
+		const ok = await forgejoService.createProtection(repo, {
+			rule_name: state.rule_name,
+			required_approvals: Number(state.required_approvals) || 0,
+			enable_push: state.enable_push,
+			require_signed_commits: state.require_signed_commits,
+			enable_status_check: state.enable_status_check,
+			block_on_outdated_branch: state.block_on_outdated_branch,
+		});
+		if (ok) onClose();
+	};
+	return (
+		<Modal
+			title={`Protect branch · ${repo}`}
+			onClose={onClose}
+			footer={
+				<>
+					<ActionButton variant="ghost" onClick={onClose}>
+						Cancel
+					</ActionButton>
+					<ActionButton
+						variant="primary"
+						onClick={submit}
+						loading={busy === `protection-create-${repo}`}
+						disabled={!state.rule_name}>
+						Create
+					</ActionButton>
+				</>
+			}>
+			<TextField
+				label="Branch name or glob (e.g. main, release/*)"
+				value={state.rule_name}
+				onChange={(v) => set('rule_name', v)}
+			/>
+			<TextField
+				label="Required approvals"
+				value={state.required_approvals}
+				onChange={(v) => set('required_approvals', v)}
+				type="number"
+			/>
+			<Toggle
+				label="Allow direct push"
+				checked={state.enable_push}
+				onChange={(v) => set('enable_push', v)}
+			/>
+			<Toggle
+				label="Require signed commits"
+				checked={state.require_signed_commits}
+				onChange={(v) => set('require_signed_commits', v)}
+			/>
+			<Toggle
+				label="Require status checks"
+				checked={state.enable_status_check}
+				onChange={(v) => set('enable_status_check', v)}
+			/>
+			<Toggle
+				label="Block on outdated branch"
+				checked={state.block_on_outdated_branch}
+				onChange={(v) => set('block_on_outdated_branch', v)}
+			/>
+		</Modal>
+	);
+}
+
+function AddSecretVarModal({
+	repo,
+	mode,
+	onClose,
+}: {
+	repo: string;
+	mode: 'secret' | 'variable';
+	onClose: () => void;
+}) {
+	const busy = useStore(forgejoService.$busy);
+	const { state, set } = useForm({ name: '', value: '' });
+	const upper = state.name.toUpperCase().replace(/[^A-Z0-9_]/g, '_');
+	const submit = async () => {
+		const ok =
+			mode === 'secret'
+				? await forgejoService.setSecret(repo, upper, state.value)
+				: await forgejoService.createVariable(repo, upper, state.value);
+		if (ok) onClose();
+	};
+	return (
+		<Modal
+			title={`New ${mode} · ${repo}`}
+			onClose={onClose}
+			footer={
+				<>
+					<ActionButton variant="ghost" onClick={onClose}>
+						Cancel
+					</ActionButton>
+					<ActionButton
+						variant="primary"
+						onClick={submit}
+						loading={busy === `${mode}-set-${repo}-${upper}`}
+						disabled={!state.name || !state.value}>
+						Save
+					</ActionButton>
+				</>
+			}>
+			<TextField
+				label="Name"
+				value={state.name}
+				onChange={(v) => set('name', v)}
+				placeholder="MY_TOKEN"
+			/>
+			<TextField
+				label="Value"
+				value={state.value}
+				onChange={(v) => set('value', v)}
+				type={mode === 'secret' ? 'password' : 'text'}
+			/>
+		</Modal>
+	);
+}
+
 export default function ReactForgejoRepoAdmin() {
 	const active = useTabActive('webhooks');
 	const repos = useStore(forgejoService.$repos);
 	const selected = useStore(forgejoService.$selectedRepo);
 	const hooksMap = useStore(forgejoService.$repoHooks);
 	const releasesMap = useStore(forgejoService.$repoReleases);
+	const protectionsMap = useStore(forgejoService.$repoProtections);
+	const secretsMap = useStore(forgejoService.$repoSecrets);
+	const variablesMap = useStore(forgejoService.$repoVariables);
 	const busy = useStore(forgejoService.$busy);
-	const [modal, setModal] = useState<'hook' | 'release' | null>(null);
+	const [modal, setModal] = useState<
+		'hook' | 'release' | 'protection' | 'secret' | 'variable' | null
+	>(null);
 	const [confirm, setConfirm] = useState<{
 		kind: 'hook' | 'release';
 		id: number;
+	} | null>(null);
+	const [protConfirm, setProtConfirm] = useState<string | null>(null);
+	const [svConfirm, setSvConfirm] = useState<{
+		kind: 'secret' | 'variable';
+		name: string;
 	} | null>(null);
 
 	if (!active) return null;
 
 	const hooks = selected ? hooksMap[selected] : undefined;
 	const releases = selected ? releasesMap[selected] : undefined;
+	const protections = selected ? protectionsMap[selected] : undefined;
+	const secrets = selected ? secretsMap[selected] : undefined;
+	const variables = selected ? variablesMap[selected] : undefined;
 
 	return (
 		<div className="not-content">
@@ -277,7 +425,8 @@ export default function ReactForgejoRepoAdmin() {
 
 			{!selected && (
 				<span style={{ color: subText, fontSize: '0.85rem' }}>
-					Choose a repository to manage its webhooks and releases.
+					Choose a repository to manage its webhooks, releases, and
+					branch protection.
 				</span>
 			)}
 
@@ -493,6 +642,231 @@ export default function ReactForgejoRepoAdmin() {
 							)}
 						</div>
 					</div>
+
+					<div>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								marginBottom: '0.75rem',
+							}}>
+							<h3 style={{ ...sectionTitle, margin: 0, flex: 1 }}>
+								<ShieldCheck size={14} /> Branch protection
+							</h3>
+							<ActionButton
+								size="sm"
+								variant="primary"
+								onClick={() => setModal('protection')}>
+								<Plus size={12} /> Add
+							</ActionButton>
+						</div>
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 8,
+							}}>
+							{(protections ?? []).map((p) => (
+								<div
+									key={p.rule_name}
+									style={{
+										padding: '0.6rem 0.7rem',
+										borderRadius: 8,
+										border,
+										background: panelBg,
+									}}>
+									<div
+										style={{
+											display: 'flex',
+											alignItems: 'center',
+											gap: 8,
+										}}>
+										<span
+											style={{
+												color: textColor,
+												fontWeight: 600,
+												fontSize: '0.8rem',
+												flex: 1,
+											}}>
+											{p.rule_name}
+										</span>
+										<ActionButton
+											size="sm"
+											variant="danger"
+											loading={
+												busy ===
+												`protection-delete-${selected}-${p.rule_name}`
+											}
+											onClick={() =>
+												setProtConfirm(p.rule_name)
+											}>
+											<Trash2 size={11} />
+										</ActionButton>
+									</div>
+									<div
+										style={{
+											color: subText,
+											fontSize: '0.68rem',
+											marginTop: 4,
+										}}>
+										{p.required_approvals > 0
+											? `${p.required_approvals} approval(s)`
+											: 'no approvals'}
+										{!p.enable_push && ' · no direct push'}
+										{p.require_signed_commits &&
+											' · signed'}
+										{p.enable_status_check &&
+											' · status checks'}
+									</div>
+								</div>
+							))}
+							{protections && protections.length === 0 && (
+								<span
+									style={{
+										color: subText,
+										fontSize: '0.8rem',
+									}}>
+									No protection rules.
+								</span>
+							)}
+						</div>
+					</div>
+
+					<div>
+						<div
+							style={{
+								display: 'flex',
+								alignItems: 'center',
+								marginBottom: '0.75rem',
+							}}>
+							<h3 style={{ ...sectionTitle, margin: 0, flex: 1 }}>
+								<KeyRound size={14} /> Secrets &amp; variables
+							</h3>
+							<ActionButton
+								size="sm"
+								onClick={() => setModal('variable')}>
+								<Plus size={12} /> Variable
+							</ActionButton>
+							<ActionButton
+								size="sm"
+								variant="primary"
+								onClick={() => setModal('secret')}>
+								<Plus size={12} /> Secret
+							</ActionButton>
+						</div>
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 8,
+							}}>
+							{(secrets ?? []).map((s) => (
+								<div
+									key={`s-${s.name}`}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 8,
+										padding: '0.5rem 0.7rem',
+										borderRadius: 8,
+										border,
+										background: panelBg,
+									}}>
+									<KeyRound
+										size={12}
+										style={{ color: '#f59e0b' }}
+									/>
+									<span
+										style={{
+											color: textColor,
+											fontSize: '0.78rem',
+											fontFamily: 'monospace',
+											flex: 1,
+										}}>
+										{s.name}
+									</span>
+									<span
+										style={{
+											color: subText,
+											fontSize: '0.66rem',
+										}}>
+										secret
+									</span>
+									<ActionButton
+										size="sm"
+										variant="danger"
+										onClick={() =>
+											setSvConfirm({
+												kind: 'secret',
+												name: s.name,
+											})
+										}>
+										<Trash2 size={11} />
+									</ActionButton>
+								</div>
+							))}
+							{(variables ?? []).map((v) => (
+								<div
+									key={`v-${v.name}`}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 8,
+										padding: '0.5rem 0.7rem',
+										borderRadius: 8,
+										border,
+										background: panelBg,
+									}}>
+									<span
+										style={{
+											color: textColor,
+											fontSize: '0.78rem',
+											fontFamily: 'monospace',
+											flex: 1,
+										}}>
+										{v.name}
+										<span
+											style={{
+												color: subText,
+												marginLeft: 6,
+											}}>
+											= {v.data}
+										</span>
+									</span>
+									<span
+										style={{
+											color: subText,
+											fontSize: '0.66rem',
+										}}>
+										var
+									</span>
+									<ActionButton
+										size="sm"
+										variant="danger"
+										onClick={() =>
+											setSvConfirm({
+												kind: 'variable',
+												name: v.name,
+											})
+										}>
+										<Trash2 size={11} />
+									</ActionButton>
+								</div>
+							))}
+							{secrets &&
+								variables &&
+								secrets.length === 0 &&
+								variables.length === 0 && (
+									<span
+										style={{
+											color: subText,
+											fontSize: '0.8rem',
+										}}>
+										No secrets or variables.
+									</span>
+								)}
+						</div>
+					</div>
 				</div>
 			)}
 
@@ -506,6 +880,64 @@ export default function ReactForgejoRepoAdmin() {
 				<CreateReleaseModal
 					repo={selected}
 					onClose={() => setModal(null)}
+				/>
+			)}
+			{modal === 'protection' && selected && (
+				<CreateProtectionModal
+					repo={selected}
+					onClose={() => setModal(null)}
+				/>
+			)}
+			{(modal === 'secret' || modal === 'variable') && selected && (
+				<AddSecretVarModal
+					repo={selected}
+					mode={modal}
+					onClose={() => setModal(null)}
+				/>
+			)}
+			{svConfirm && selected && (
+				<ConfirmDialog
+					title={`Delete ${svConfirm.kind}`}
+					message={`Delete ${svConfirm.kind} "${svConfirm.name}"?`}
+					confirmLabel="Delete"
+					danger
+					loading={
+						busy ===
+						`${svConfirm.kind}-delete-${selected}-${svConfirm.name}`
+					}
+					onCancel={() => setSvConfirm(null)}
+					onConfirm={async () => {
+						const ok =
+							svConfirm.kind === 'secret'
+								? await forgejoService.deleteSecret(
+										selected,
+										svConfirm.name,
+									)
+								: await forgejoService.deleteVariable(
+										selected,
+										svConfirm.name,
+									);
+						if (ok) setSvConfirm(null);
+					}}
+				/>
+			)}
+			{protConfirm && selected && (
+				<ConfirmDialog
+					title="Delete protection rule"
+					message={`Remove branch protection "${protConfirm}"?`}
+					confirmLabel="Delete"
+					danger
+					loading={
+						busy === `protection-delete-${selected}-${protConfirm}`
+					}
+					onCancel={() => setProtConfirm(null)}
+					onConfirm={async () => {
+						const ok = await forgejoService.deleteProtection(
+							selected,
+							protConfirm,
+						);
+						if (ok) setProtConfirm(null);
+					}}
 				/>
 			)}
 			{confirm && selected && (

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	forgejoService,
@@ -17,6 +17,7 @@ import {
 	useForm,
 	useTabActive,
 	uiTokens,
+	LoadMoreButton,
 } from './forgejoUi';
 import {
 	Plus,
@@ -466,15 +467,22 @@ function CollaboratorsModal({
 export default function ReactForgejoRepoPanel() {
 	const active = useTabActive('repos');
 	const repos = useStore(forgejoService.$repos);
+	const hasMore = useStore(forgejoService.$reposHasMore);
 	const busy = useStore(forgejoService.$busy);
 	const [modal, setModal] = useState<ModalKind>(null);
-	const [query, setQuery] = useState('');
+	const [query, setQuery] = useState(() => forgejoService.$repoQuery.get());
+	const firstRun = useRef(true);
+
+	useEffect(() => {
+		if (firstRun.current) {
+			firstRun.current = false;
+			return;
+		}
+		const t = setTimeout(() => forgejoService.setRepoSearch(query), 300);
+		return () => clearTimeout(t);
+	}, [query]);
 
 	if (!active) return null;
-
-	const filtered = repos.filter((r) =>
-		r.full_name.toLowerCase().includes(query.toLowerCase()),
-	);
 
 	return (
 		<div className="not-content">
@@ -501,7 +509,7 @@ export default function ReactForgejoRepoPanel() {
 					<input
 						value={query}
 						onChange={(e) => setQuery(e.target.value)}
-						placeholder="Filter repositories"
+						placeholder="Search repositories"
 						style={{
 							border: 'none',
 							background: 'transparent',
@@ -535,7 +543,7 @@ export default function ReactForgejoRepoPanel() {
 						</tr>
 					</thead>
 					<tbody>
-						{filtered.map((repo) => (
+						{repos.map((repo) => (
 							<tr key={repo.id}>
 								<td style={td}>
 									<div
@@ -673,6 +681,11 @@ export default function ReactForgejoRepoPanel() {
 					</tbody>
 				</table>
 			</div>
+
+			<LoadMoreButton
+				hasMore={hasMore}
+				onClick={() => forgejoService.loadMoreRepos()}
+			/>
 
 			{modal?.type === 'create' && (
 				<CreateRepoModal onClose={() => setModal(null)} />

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
@@ -16,7 +16,7 @@ const TABS: { id: ForgejoTab; label: string; icon: React.ReactNode }[] = [
 	{ id: 'orgs', label: 'Orgs & Teams', icon: <Building2 size={14} /> },
 	{
 		id: 'webhooks',
-		label: 'Webhooks & Releases',
+		label: 'Repo Admin',
 		icon: <Webhook size={14} />,
 	},
 	{ id: 'system', label: 'System', icon: <ServerCog size={14} /> },

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserPanel.tsx
@@ -11,6 +11,7 @@ import {
 	useForm,
 	useTabActive,
 	uiTokens,
+	LoadMoreButton,
 } from './forgejoUi';
 import { Plus, Pencil, Trash2, ShieldCheck, Search } from 'lucide-react';
 
@@ -189,6 +190,7 @@ function EditUserModal({
 export default function ReactForgejoUserPanel() {
 	const active = useTabActive('users');
 	const users = useStore(forgejoService.$users);
+	const hasMore = useStore(forgejoService.$usersHasMore);
 	const busy = useStore(forgejoService.$busy);
 	const [modal, setModal] = useState<ModalKind>(null);
 	const [purge, setPurge] = useState(false);
@@ -349,6 +351,11 @@ export default function ReactForgejoUserPanel() {
 					</tbody>
 				</table>
 			</div>
+
+			<LoadMoreButton
+				hasMore={hasMore}
+				onClick={() => forgejoService.loadMoreUsers()}
+			/>
 
 			{modal?.type === 'create' && (
 				<CreateUserModal onClose={() => setModal(null)} />

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -156,6 +156,36 @@ export interface ForgejoHook {
 	updated_at: string;
 }
 
+export interface ForgejoBranchProtection {
+	branch_name: string;
+	rule_name: string;
+	enable_push: boolean;
+	required_approvals: number;
+	enable_status_check: boolean;
+	require_signed_commits: boolean;
+	block_on_outdated_branch: boolean;
+	created_at: string;
+}
+
+export interface CreateBranchProtectionInput {
+	rule_name: string;
+	required_approvals: number;
+	enable_push: boolean;
+	require_signed_commits: boolean;
+	enable_status_check: boolean;
+	block_on_outdated_branch: boolean;
+}
+
+export interface ForgejoSecret {
+	name: string;
+	created_at: string;
+}
+
+export interface ForgejoVariable {
+	name: string;
+	data: string;
+}
+
 export interface ForgejoCronTask {
 	name: string;
 	schedule: string;
@@ -671,6 +701,13 @@ class ForgejoService {
 	public readonly $selectedRepo = atom<string | null>(null);
 	public readonly $repoHooks = atom<Record<string, ForgejoHook[]>>({});
 	public readonly $repoReleases = atom<Record<string, ForgejoRelease[]>>({});
+	public readonly $repoProtections = atom<
+		Record<string, ForgejoBranchProtection[]>
+	>({});
+	public readonly $repoSecrets = atom<Record<string, ForgejoSecret[]>>({});
+	public readonly $repoVariables = atom<Record<string, ForgejoVariable[]>>(
+		{},
+	);
 
 	public readonly $version = atom<string | null>(null);
 	public readonly $cronTasks = atom<ForgejoCronTask[]>([]);
@@ -1500,10 +1537,166 @@ class ForgejoService {
 		);
 	}
 
+	// --- Branch protection actions ---
+
+	public async loadRepoProtections(fullName: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		const rules = await apiFetch<ForgejoBranchProtection[]>(
+			token,
+			`/api/v1/repos/${fullName}/branch_protections`,
+			[] as ForgejoBranchProtection[],
+		);
+		this.$repoProtections.set({
+			...this.$repoProtections.get(),
+			[fullName]: rules,
+		});
+	}
+
+	public createProtection(
+		fullName: string,
+		input: CreateBranchProtectionInput,
+	): Promise<boolean> {
+		return this._run(
+			`protection-create-${fullName}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'POST',
+					`/api/v1/repos/${fullName}/branch_protections`,
+					input,
+				);
+				await this.loadRepoProtections(fullName);
+			},
+			`Protection rule ${input.rule_name} created`,
+		);
+	}
+
+	public deleteProtection(
+		fullName: string,
+		ruleName: string,
+	): Promise<boolean> {
+		return this._run(
+			`protection-delete-${fullName}-${ruleName}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${fullName}/branch_protections/${encodeURIComponent(ruleName)}`,
+				);
+				await this.loadRepoProtections(fullName);
+			},
+			`Protection rule deleted`,
+		);
+	}
+
+	// --- Secrets & variables actions ---
+
+	public async loadRepoSecrets(fullName: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		const secrets = await apiFetch<ForgejoSecret[]>(
+			token,
+			`/api/v1/repos/${fullName}/actions/secrets?limit=${PAGE_SIZE}`,
+			[] as ForgejoSecret[],
+		);
+		this.$repoSecrets.set({
+			...this.$repoSecrets.get(),
+			[fullName]: secrets,
+		});
+	}
+
+	public async loadRepoVariables(fullName: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		const variables = await apiFetch<ForgejoVariable[]>(
+			token,
+			`/api/v1/repos/${fullName}/actions/variables?limit=${PAGE_SIZE}`,
+			[] as ForgejoVariable[],
+		);
+		this.$repoVariables.set({
+			...this.$repoVariables.get(),
+			[fullName]: variables,
+		});
+	}
+
+	public setSecret(
+		fullName: string,
+		name: string,
+		data: string,
+	): Promise<boolean> {
+		return this._run(
+			`secret-set-${fullName}-${name}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'PUT',
+					`/api/v1/repos/${fullName}/actions/secrets/${name}`,
+					{ data },
+				);
+				await this.loadRepoSecrets(fullName);
+			},
+			`Secret ${name} saved`,
+		);
+	}
+
+	public deleteSecret(fullName: string, name: string): Promise<boolean> {
+		return this._run(
+			`secret-delete-${fullName}-${name}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${fullName}/actions/secrets/${name}`,
+				);
+				await this.loadRepoSecrets(fullName);
+			},
+			`Secret deleted`,
+		);
+	}
+
+	public createVariable(
+		fullName: string,
+		name: string,
+		value: string,
+	): Promise<boolean> {
+		return this._run(
+			`variable-set-${fullName}-${name}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'POST',
+					`/api/v1/repos/${fullName}/actions/variables/${name}`,
+					{ value },
+				);
+				await this.loadRepoVariables(fullName);
+			},
+			`Variable ${name} created`,
+		);
+	}
+
+	public deleteVariable(fullName: string, name: string): Promise<boolean> {
+		return this._run(
+			`variable-delete-${fullName}-${name}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${fullName}/actions/variables/${name}`,
+				);
+				await this.loadRepoVariables(fullName);
+			},
+			`Variable deleted`,
+		);
+	}
+
 	public selectRepo(fullName: string): void {
 		this.$selectedRepo.set(fullName);
 		this.loadRepoHooks(fullName);
 		this.loadRepoReleases(fullName);
+		this.loadRepoProtections(fullName);
+		this.loadRepoSecrets(fullName);
+		this.loadRepoVariables(fullName);
 	}
 
 	// --- System actions ---

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -295,6 +295,7 @@ const TAB_KEY = 'forgejo:activeTab';
 const CACHE_TTL_MS = 60 * 1000;
 const PROXY_BASE = '/dashboard/forgejo/proxy';
 const REFRESH_INTERVAL_MS = 30 * 1000;
+const PAGE_SIZE = 50;
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -410,21 +411,37 @@ async function apiMutate<T>(
 	}
 }
 
-async function fetchRepos(token: string): Promise<ForgejoRepo[]> {
+async function fetchReposPage(
+	token: string,
+	page: number,
+	query: string,
+): Promise<ForgejoRepo[]> {
+	const q = query ? `&q=${encodeURIComponent(query)}` : '';
 	const data = await apiFetch<{ data?: ForgejoRepo[] } | ForgejoRepo[]>(
 		token,
-		'/api/v1/repos/search?limit=50&sort=updated',
+		`/api/v1/repos/search?limit=${PAGE_SIZE}&page=${page}&sort=updated${q}`,
 	);
 	if (Array.isArray(data)) return data;
 	return data.data ?? [];
 }
 
-async function fetchUsers(token: string): Promise<ForgejoUser[]> {
-	const admin = await apiFetch<ForgejoUser[] | null>(
+async function fetchRepos(token: string): Promise<ForgejoRepo[]> {
+	return fetchReposPage(token, 1, '');
+}
+
+async function fetchUsersPage(
+	token: string,
+	page: number,
+): Promise<ForgejoUser[] | null> {
+	return apiFetch<ForgejoUser[] | null>(
 		token,
-		'/api/v1/admin/users?limit=50',
+		`/api/v1/admin/users?limit=${PAGE_SIZE}&page=${page}`,
 		null,
 	);
+}
+
+async function fetchUsers(token: string): Promise<ForgejoUser[]> {
+	const admin = await fetchUsersPage(token, 1);
 	if (Array.isArray(admin) && admin.length > 0) return admin;
 	return fetchUsersFromCollaborators(token);
 }
@@ -457,8 +474,19 @@ async function fetchUsersFromCollaborators(
 	return users;
 }
 
+async function fetchOrgsPage(
+	token: string,
+	page: number,
+): Promise<ForgejoOrg[]> {
+	return apiFetch(
+		token,
+		`/api/v1/orgs?limit=${PAGE_SIZE}&page=${page}`,
+		[] as ForgejoOrg[],
+	);
+}
+
 async function fetchOrgs(token: string): Promise<ForgejoOrg[]> {
-	return apiFetch(token, '/api/v1/orgs?limit=50', [] as ForgejoOrg[]);
+	return fetchOrgsPage(token, 1);
 }
 
 // ---------------------------------------------------------------------------
@@ -648,6 +676,16 @@ class ForgejoService {
 	public readonly $cronTasks = atom<ForgejoCronTask[]>([]);
 	public readonly $unadopted = atom<string[]>([]);
 
+	// Pagination + search
+	public readonly $repoQuery = atom<string>('');
+	public readonly $reposPage = atom<number>(1);
+	public readonly $usersPage = atom<number>(1);
+	public readonly $orgsPage = atom<number>(1);
+	public readonly $reposHasMore = atom<boolean>(false);
+	public readonly $usersHasMore = atom<boolean>(false);
+	public readonly $orgsHasMore = atom<boolean>(false);
+	public readonly $loadingMore = atom<boolean>(false);
+
 	// Computed
 	public readonly $totalRepos = computed(
 		[this.$repos],
@@ -746,6 +784,59 @@ class ForgejoService {
 
 	// --- Data fetching ---
 
+	private async _fetchReposRange(
+		token: string,
+	): Promise<{ items: ForgejoRepo[]; hasMore: boolean }> {
+		const pages = this.$reposPage.get();
+		const query = this.$repoQuery.get();
+		const items: ForgejoRepo[] = [];
+		let last = 0;
+		for (let p = 1; p <= pages; p++) {
+			const batch = await fetchReposPage(token, p, query);
+			items.push(...batch);
+			last = batch.length;
+			if (batch.length < PAGE_SIZE) break;
+		}
+		return { items, hasMore: last === PAGE_SIZE };
+	}
+
+	private async _fetchUsersRange(
+		token: string,
+	): Promise<{ items: ForgejoUser[]; hasMore: boolean }> {
+		const pages = this.$usersPage.get();
+		const items: ForgejoUser[] = [];
+		let last = 0;
+		let adminWorked = false;
+		for (let p = 1; p <= pages; p++) {
+			const batch = await fetchUsersPage(token, p);
+			if (!Array.isArray(batch)) break;
+			if (p === 1 && batch.length > 0) adminWorked = true;
+			items.push(...batch);
+			last = batch.length;
+			if (batch.length < PAGE_SIZE) break;
+		}
+		if (!adminWorked && items.length === 0) {
+			const fallback = await fetchUsersFromCollaborators(token);
+			return { items: fallback, hasMore: false };
+		}
+		return { items, hasMore: last === PAGE_SIZE };
+	}
+
+	private async _fetchOrgsRange(
+		token: string,
+	): Promise<{ items: ForgejoOrg[]; hasMore: boolean }> {
+		const pages = this.$orgsPage.get();
+		const items: ForgejoOrg[] = [];
+		let last = 0;
+		for (let p = 1; p <= pages; p++) {
+			const batch = await fetchOrgsPage(token, p);
+			items.push(...batch);
+			last = batch.length;
+			if (batch.length < PAGE_SIZE) break;
+		}
+		return { items, hasMore: last === PAGE_SIZE };
+	}
+
 	public async fetchData(): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
@@ -754,15 +845,18 @@ class ForgejoService {
 			this.$error.set(null);
 			this.$errorReason.set(null);
 			const [repos, users, orgs] = await Promise.all([
-				fetchRepos(token),
-				fetchUsers(token),
-				fetchOrgs(token),
+				this._fetchReposRange(token),
+				this._fetchUsersRange(token),
+				this._fetchOrgsRange(token),
 			]);
-			this.$repos.set(repos);
-			this.$users.set(users);
-			this.$orgs.set(orgs);
+			this.$repos.set(repos.items);
+			this.$reposHasMore.set(repos.hasMore);
+			this.$users.set(users.items);
+			this.$usersHasMore.set(users.hasMore);
+			this.$orgs.set(orgs.items);
+			this.$orgsHasMore.set(orgs.hasMore);
 			this.$lastUpdated.set(new Date());
-			saveCache(repos, users, orgs);
+			saveCache(repos.items, users.items, orgs.items);
 		} catch (e: unknown) {
 			if (e instanceof AccessRestrictedError) {
 				this.$authState.set('forbidden');
@@ -813,6 +907,73 @@ class ForgejoService {
 		if (token) {
 			this.$loading.set(true);
 			this.fetchData();
+		}
+	}
+
+	public setRepoSearch(query: string): void {
+		this.$repoQuery.set(query);
+		this.$reposPage.set(1);
+		const token = this.$accessToken.get();
+		if (!token) return;
+		this.$loadingMore.set(true);
+		this._fetchReposRange(token)
+			.then((r) => {
+				this.$repos.set(r.items);
+				this.$reposHasMore.set(r.hasMore);
+			})
+			.finally(() => this.$loadingMore.set(false));
+	}
+
+	public async loadMoreRepos(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token || this.$loadingMore.get()) return;
+		this.$loadingMore.set(true);
+		try {
+			const next = this.$reposPage.get() + 1;
+			const batch = await fetchReposPage(
+				token,
+				next,
+				this.$repoQuery.get(),
+			);
+			this.$repos.set([...this.$repos.get(), ...batch]);
+			this.$reposPage.set(next);
+			this.$reposHasMore.set(batch.length === PAGE_SIZE);
+		} finally {
+			this.$loadingMore.set(false);
+		}
+	}
+
+	public async loadMoreUsers(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token || this.$loadingMore.get()) return;
+		this.$loadingMore.set(true);
+		try {
+			const next = this.$usersPage.get() + 1;
+			const batch = await fetchUsersPage(token, next);
+			if (Array.isArray(batch)) {
+				this.$users.set([...this.$users.get(), ...batch]);
+				this.$usersPage.set(next);
+				this.$usersHasMore.set(batch.length === PAGE_SIZE);
+			} else {
+				this.$usersHasMore.set(false);
+			}
+		} finally {
+			this.$loadingMore.set(false);
+		}
+	}
+
+	public async loadMoreOrgs(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token || this.$loadingMore.get()) return;
+		this.$loadingMore.set(true);
+		try {
+			const next = this.$orgsPage.get() + 1;
+			const batch = await fetchOrgsPage(token, next);
+			this.$orgs.set([...this.$orgs.get(), ...batch]);
+			this.$orgsPage.set(next);
+			this.$orgsHasMore.set(batch.length === PAGE_SIZE);
+		} finally {
+			this.$loadingMore.set(false);
 		}
 	}
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoUi.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoUi.tsx
@@ -11,6 +11,52 @@ export function useTabActive(tab: ForgejoTab): boolean {
 	return useStore(forgejoService.$activeTab) === tab;
 }
 
+export function LoadMoreButton({
+	hasMore,
+	onClick,
+}: {
+	hasMore: boolean;
+	onClick: () => void;
+}) {
+	const loading = useStore(forgejoService.$loadingMore);
+	if (!hasMore) return null;
+	return (
+		<div
+			style={{
+				display: 'flex',
+				justifyContent: 'center',
+				marginTop: 12,
+			}}>
+			<button
+				type="button"
+				onClick={onClick}
+				disabled={loading}
+				style={{
+					display: 'inline-flex',
+					alignItems: 'center',
+					gap: 6,
+					padding: '0.45rem 1rem',
+					borderRadius: 8,
+					border: '1px solid var(--sl-color-gray-5, #30363d)',
+					background: 'var(--sl-color-gray-6, #161b22)',
+					color: 'var(--sl-color-text, #e6edf3)',
+					cursor: loading ? 'not-allowed' : 'pointer',
+					opacity: loading ? 0.6 : 1,
+					fontSize: '0.8rem',
+					fontWeight: 600,
+				}}>
+				{loading && (
+					<Loader2
+						size={13}
+						style={{ animation: 'spin 1s linear infinite' }}
+					/>
+				)}
+				Load more
+			</button>
+		</div>
+	);
+}
+
 const accent = 'var(--sl-color-accent, #06b6d4)';
 const textColor = 'var(--sl-color-text, #e6edf3)';
 const subText = 'var(--sl-color-gray-3, #8b949e)';


### PR DESCRIPTION
Follow-up improvements to the Forgejo admin route (`/dashboard/forgejo/`) after #12221.

## Landed
- **Pagination + search** — lists were hard-capped at `limit=50`; added page-based fetching with **Load more** (repos/users/orgs) and **server-side repository search** (`q=` on `/repos/search`, debounced). Auto-refresh re-fetches the full loaded page range so the list stays stable.
- **Branch protection** — per-repo protected-branch rules (approvals, direct-push, signed commits, status checks, block-on-outdated): list/create/delete. Lives in the renamed **Repo Admin** tab.
- **Secrets & variables** — per-repo Actions secrets (upsert via PUT) and variables (create/delete) for CI, in the Repo Admin tab.
- **Issues & PR moderation** — new **Issues & PRs** tab: pick a repo, filter issues/pulls × open/closed, close/reopen and lock/unlock each item, with deep links to Forgejo.
- **Perf** — moved the static `Forgejo` header title to Astro server HTML; the header island is now just the dynamic last-updated + refresh control. (Tab bar intentionally left as the `$activeTab` state owner — converting it would need a vanilla bridge for negligible gain.)

## Verify
- `./kbve.sh -nx astro-kbve:build` ✓ (7742 pages)