### PR TITLE
feat(chuck): beta builds the dedicated server (chuckServerBeta, Shipping)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -1083,13 +1083,17 @@
 					"Linux"
 				],
 				"external_repo_url": "https://github.com/kbve/chuck",
+				"server_target": "chuckServerBeta",
+				"server_config": "Shipping",
 				"client_config": "Shipping",
 				"maps": [
 					"/Game/Menus/L_MainMenu",
 					"/Game/Map/L_ChuckWorld"
-				]
+				],
+				"game_mode": "/Script/Chuck.ChuckGameMode"
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
+			"shell_path": "apps/chuckrpg/unreal-chuck",
 			"version": "0.3.19",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",

--- a/apps/chuckrpg/unreal-chuck/Source/chuckServerBeta.Target.cs
+++ b/apps/chuckrpg/unreal-chuck/Source/chuckServerBeta.Target.cs
@@ -1,0 +1,15 @@
+// Copyright Epic Games, Inc. All Rights Reserved.
+
+using UnrealBuildTool;
+using System.Collections.Generic;
+
+public class chuckServerBetaTarget : TargetRules
+{
+	public chuckServerBetaTarget(TargetInfo Target) : base(Target)
+	{
+		Type = TargetType.Server;
+		DefaultBuildSettings = BuildSettingsVersion.V6;
+		IncludeOrderVersion = EngineIncludeOrderVersion.Unreal5_7;
+		ExtraModuleNames.Add("chuck");
+	}
+}

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -29,12 +29,16 @@ engine:
         - Win64
         - Linux
     client_config: Shipping
+    server_target: chuckServerBeta
+    server_config: Shipping
+    game_mode: /Script/Chuck.ChuckGameMode
     maps:
         - /Game/Menus/L_MainMenu
         - /Game/Map/L_ChuckWorld
 external_publish:
     itch_user: kbve
     itch_game: chuckrpg
+shell_path: apps/chuckrpg/unreal-chuck
 ---
 
 ## Overview
@@ -62,6 +66,12 @@ version gate / `version_toml` tracker still lives in this monorepo.
 - `Linux` — `BuildCookRun` in the cached Epic UE Docker image on `arc-runner-ue`
 
 Mac is stubbed until the `macos-builder` VM is provisioned.
+
+Plus the bundled Linux **dedicated server** (`shell_path` → `task: server`): the
+`chuckServerBeta` target (`server_config: Shipping`) is cooked from the monorepo shell
+and archived to the OWS PVC at `/ows-server/chuckServerBeta/<version>`, where the
+chuckrpg-beta Agones fleet reads it (`subPath: chuckServerBeta`). Same version gate as the
+client (1:1).
 
 ## Distribution
 


### PR DESCRIPTION
Phase 1 of getting chuckrpg-beta going: build the **server** off main, not just the client.

beta was client-only. Now:
- **chuckServerBeta.Target.cs** in the shell Source (Server target).
- **unreal-chuck-beta**: `shell_path` (triggers `task: server`) + `server_target: chuckServerBeta`, `server_config: Shipping`, `game_mode`.

So beta = Win64/Linux **client** (cooked Shipping, main) + Linux **dedicated server** (`chuckServerBeta`, Shipping) → `/ows-server/chuckServerBeta/<version>`.

Thanks to the per-game registry config (#12219), this needed **zero workflow edits** — beta just declares its server target/config in MDX. Build + manifest sync clean.

## Next (phase 2 — deploy)
chuckrpg-beta Agones fleet (`subPath: chuckServerBeta`) + un-park the chuckrpg-beta rows tenant (app-of-apps + gateway) so Agones+rows allocate the beta server image.