### PR TITLE
feat(chuck): un-park chuckrpg-beta — Agones fleet + tenant deploy

### DIFF
--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/application.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/application.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: agones-rows-chuckrpg-beta
+    namespace: argocd
+    labels:
+        app.kubernetes.io/part-of: rows
+        app.kubernetes.io/instance: chuckrpg-beta
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/kbve/kbve
+        targetRevision: main
+        path: apps/kube/agones/rows-tenants/chuckrpg-beta/manifests
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: arc-runners
+    ignoreDifferences:
+        - group: agones.dev
+          kind: Fleet
+          jsonPointers:
+              - /spec/replicas
+    syncPolicy:
+        automated:
+            prune: true
+        syncOptions:
+            - CreateNamespace=false
+            - ServerSideApply=true
+            - RespectIgnoreDifferences=true

--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet-autoscaler.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet-autoscaler.yaml
@@ -1,0 +1,21 @@
+apiVersion: autoscaling.agones.dev/v1
+kind: FleetAutoscaler
+metadata:
+    name: ows-chuckrpg-beta-autoscaler
+    namespace: arc-runners
+    labels:
+        app: ows-gameserver
+        app.kubernetes.io/part-of: ows
+        app.kubernetes.io/instance: chuckrpg-beta
+spec:
+    fleetName: ows-chuckrpg-beta
+    policy:
+        type: Buffer
+        buffer:
+            bufferSize: 2
+            minReplicas: 0
+            maxReplicas: 10
+    sync:
+        type: FixedInterval
+        fixedInterval:
+            seconds: 30

--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
@@ -1,0 +1,113 @@
+apiVersion: agones.dev/v1
+kind: Fleet
+metadata:
+    name: ows-chuckrpg-beta
+    namespace: arc-runners
+    labels:
+        app: ows-gameserver
+        app.kubernetes.io/part-of: ows
+        app.kubernetes.io/instance: chuckrpg-beta
+spec:
+    replicas: 0
+    scheduling: Packed
+    strategy:
+        type: RollingUpdate
+        rollingUpdate:
+            maxSurge: 25%
+            maxUnavailable: 25%
+    template:
+        metadata:
+            labels:
+                app: ows-gameserver
+                app.kubernetes.io/part-of: ows
+                app.kubernetes.io/instance: chuckrpg-beta
+        spec:
+            ports:
+                - name: game
+                  portPolicy: Dynamic
+                  containerPort: 7777
+                  protocol: UDP
+            health:
+                initialDelaySeconds: 30
+                periodSeconds: 15
+                failureThreshold: 5
+            template:
+                spec:
+                    securityContext:
+                        runAsNonRoot: true
+                        runAsUser: 1000
+                        runAsGroup: 1000
+                        fsGroup: 1000
+                    containers:
+                        - name: ue5-server
+                          image: ubuntu:24.04
+                          command:
+                              - /bin/bash
+                              - -c
+                              - |
+                                  SERVER_DIR=$(find /server -maxdepth 2 -name "LinuxServer" -type d | sort -V | tail -1)
+                                  if [ -z "${SERVER_DIR}" ]; then
+                                    echo "ERROR: LinuxServer directory not found on PVC"
+                                    ls -la /server/ 2>/dev/null
+                                    exit 1
+                                  fi
+                                  SERVER_BIN=$(find "${SERVER_DIR}" -maxdepth 1 -name "*Server.sh" | head -1)
+                                  if [ -z "${SERVER_BIN}" ]; then
+                                    SERVER_BIN="${SERVER_DIR}/ChuckServer.sh"
+                                  fi
+                                  if [ ! -f "${SERVER_BIN}" ]; then
+                                    echo "ERROR: Server binary not found at ${SERVER_BIN}"
+                                    ls -la "${SERVER_DIR}/" 2>/dev/null
+                                    exit 1
+                                  fi
+                                  echo "Starting UE5 dedicated server from ${SERVER_BIN}"
+                                  exec "${SERVER_BIN}" \
+                                    -server \
+                                    -log \
+                                    -nosteam \
+                                    -unattended \
+                                    -port=${GAME_PORT:-7777} \
+                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    ${OWS_EXTRA_ARGS:-}
+                          env:
+                              - name: GAME_PORT
+                                value: '7777'
+                              - name: OWS_API_PATH
+                                value: http://rows.rows-chuckrpg-beta.svc.cluster.local:4322/
+                              - name: OWS_INSTANCE_MANAGEMENT_PATH
+                                value: http://rows.rows-chuckrpg-beta.svc.cluster.local:4322/
+                              - name: OWS_CHARACTER_PERSISTENCE_PATH
+                                value: http://rows.rows-chuckrpg-beta.svc.cluster.local:4322/
+                              - name: OWS_GLOBAL_DATA_PATH
+                                value: http://rows.rows-chuckrpg-beta.svc.cluster.local:4322/
+                              - name: OWS_API_CUSTOMER_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: ows-gameserver-secrets-chuckrpg-beta
+                                        key: customer-guid
+                              - name: OWS_ENCRYPTION_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: ows-gameserver-secrets-chuckrpg-beta
+                                        key: encryption-key
+                              - name: OWS_SERVICE_KEY
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: ows-service-key-chuckrpg-beta
+                                        key: service-key
+                                        optional: true
+                          resources:
+                              requests:
+                                  memory: 2Gi
+                                  cpu: '1'
+                              limits:
+                                  memory: 4Gi
+                                  cpu: '2'
+                          volumeMounts:
+                              - name: server-binary
+                                mountPath: /server
+                                subPath: chuckServerBeta
+                    volumes:
+                        - name: server-binary
+                          persistentVolumeClaim:
+                              claimName: ows-server-build

--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/gameserver-secrets.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/gameserver-secrets.yaml
@@ -1,0 +1,74 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: rows-chuckrpg-beta-gs-reader
+    namespace: rows-chuckrpg-beta
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['rows-customer-guid', 'rows-encryption-key']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: agones-read-rows-chuckrpg-beta
+    namespace: rows-chuckrpg-beta
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: rows-chuckrpg-beta-gs-reader
+subjects:
+    - kind: ServiceAccount
+      name: agones-rows-chuckrpg-beta-secrets
+      namespace: arc-runners
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: agones-rows-chuckrpg-beta-secrets
+    namespace: arc-runners
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: rows-chuckrpg-beta-gs-store
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rows-chuckrpg-beta
+            auth:
+                serviceAccount:
+                    name: agones-rows-chuckrpg-beta-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-gameserver-secrets-chuckrpg-beta
+    namespace: arc-runners
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: rows-chuckrpg-beta-gs-store
+        kind: SecretStore
+    target:
+        name: ows-gameserver-secrets-chuckrpg-beta
+        creationPolicy: Owner
+    data:
+        - secretKey: customer-guid
+          remoteRef:
+              key: rows-customer-guid
+              property: customer-guid
+        - secretKey: encryption-key
+          remoteRef:
+              key: rows-encryption-key
+              property: encryption-key

--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/service-key-external-secret.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/service-key-external-secret.yaml
@@ -1,0 +1,64 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: supabase-service-key-reader-for-chuckrpg-beta
+    namespace: kilobase
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      resourceNames: ['supabase-service-key']
+      verbs: ['get', 'list', 'watch']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: agones-read-svckey-chuckrpg-beta
+    namespace: kilobase
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: supabase-service-key-reader-for-chuckrpg-beta
+subjects:
+    - kind: ServiceAccount
+      name: agones-rows-chuckrpg-beta-secrets
+      namespace: arc-runners
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: kilobase-svckey-store-chuckrpg-beta
+    namespace: arc-runners
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: agones-rows-chuckrpg-beta-secrets
+                    namespace: arc-runners
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: ows-service-key-chuckrpg-beta
+    namespace: arc-runners
+spec:
+    refreshInterval: 15m
+    secretStoreRef:
+        name: kilobase-svckey-store-chuckrpg-beta
+        kind: SecretStore
+    target:
+        name: ows-service-key-chuckrpg-beta
+        creationPolicy: Owner
+    data:
+        - secretKey: service-key
+          remoteRef:
+              key: supabase-service-key
+              property: key

--- a/apps/kube/kbve/manifest/kbve-gateway.yaml
+++ b/apps/kube/kbve/manifest/kbve-gateway.yaml
@@ -143,6 +143,20 @@ spec:
           allowedRoutes:
               namespaces:
                   from: All
+        - name: https-rows-chuckrpg-beta
+          protocol: HTTPS
+          port: 443
+          hostname: api-beta.chuckrpg.com
+          tls:
+              mode: Terminate
+              certificateRefs:
+                  - kind: Secret
+                    group: ''
+                    name: rows-chuckrpg-beta-api-tls
+                    namespace: rows-chuckrpg-beta
+          allowedRoutes:
+              namespaces:
+                  from: All
         - name: https-cityvote
           protocol: HTTPS
           port: 443

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -56,9 +56,11 @@ resources:
     - n8n/application.yaml
     - rabbitmq/application.yaml
     - rows/tenants/overlays/chuckrpg-dev/application.yaml
+    - rows/tenants/overlays/chuckrpg-beta/application.yaml
     - agones/application.yaml
     - agones/rows/application.yaml
     - agones/rows-tenants/chuckrpg-dev/application.yaml
+    - agones/rows-tenants/chuckrpg-beta/application.yaml
     - agones/mc/application.yaml
     - agones/nd-server/application.yaml
     - agones/cryptothrone/application.yaml


### PR DESCRIPTION
Phase 2 of beta — deploys the server #12225 builds.

- **apps/kube/agones/rows-tenants/chuckrpg-beta/**: Fleet `ows-chuckrpg-beta` + autoscaler reading the PVC via `subPath: chuckServerBeta`; gameserver + service-key ExternalSecrets from the `rows-chuckrpg-beta` namespace; `OWS_API_PATH` → the beta rows service. Mirrors the chuckrpg-dev fleet.
- **app-of-apps**: re-register the `chuckrpg-beta` rows tenant + the beta Agones app (both parked during the diminish).
- **gateway**: restore the `api-beta.chuckrpg.com` listener.

Validated: YAML + app-of-apps kustomize build (both beta apps emit).

## Timing
ArgoCD tracks **main**, so this is inert on dev — the live beta tenant + fleet deploy only at the dev→main release. Fleet stays at **0 replicas** until a `chuckServerBeta` build lands on the PVC (#12225 + an `unreal-chuck-beta` version bump at release).

## Release checklist (chuck batch → main)
1. #12225 (beta server build config) + this (deploy) on dev ✓
2. Bump `unreal-chuck-beta` MDX `version:` so the release triggers the build
3. dev→main release → ci-main builds chuckServerBeta + ArgoCD deploys the beta tenant/fleet
4. Provision the `rows-chuckrpg-beta` secrets (kubeseal guid) + DNS for api-beta.chuckrpg.com