### PR TITLE
fix(kube): cryptothrone fleet drops hostPort (portPolicy: None)

### DIFF
--- a/apps/kube/agones/cryptothrone/manifests/namespace.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/namespace.yaml
@@ -1,10 +1,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-    name: nexus-defense
+    name: cryptothrone
     labels:
-        app.kubernetes.io/part-of: nexus-defense
-        # Cilium hubble/observability tagging — keeps the netflow board grouped.
+        app.kubernetes.io/part-of: cryptothrone
         kbve.com/stack: agones
         pod-security.kubernetes.io/enforce: privileged
         pod-security.kubernetes.io/audit: privileged


### PR DESCRIPTION
## Summary
Gameserver pods were dying at admission:

`pods ... forbidden: violates PodSecurity "baseline:latest": hostPort`

First cut of this PR went privileged-PSA like arc-runners — but cryptothrone's traffic path makes that unnecessary: clients only ever reach the server through the **Cilium gateway** (`game.cryptothrone.com` listener → HTTPRoute → `cryptothrone-game` ClusterIP Service → pod :7979). Nothing dials the node directly, so Agones' default `Dynamic` hostPort allocation is dead weight.

- `portPolicy: None` on the fleet's ws port — no hostPort, pod stays **baseline**-compatible, namespace stays unprivileged (it also hosts the website deployment, so not loosening PSA there is a real win)
- namespace manifest added with observability labels only
- Validated against live admission with a server-side dry-run (Agones 1.56, PortPolicyNone beta/default-on)

nexus-defense left untouched — its fleet can adopt the same pattern when nd work resumes.

With this + the now-issued `cryptothrone-game-tls` cert, the 525→503 chain on `wss://game.cryptothrone.com/ws` should close.