### PR TITLE
chore(osrs): migrate 199 v2 items to v3 schema (batch 26)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/abyssal-bludgeon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/abyssal-bludgeon.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 104000
   highalch: 156000
   limit: 8
+  material:
+    type: abyssal
+    tier: high
   equipment:
     slot: weapon
     type: bludgeon
@@ -80,8 +83,8 @@ osrs:
       - Sire grind for components
       - 3 specific drops needed
       - Very RNG dependent
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-arrow-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-arrow-p.mdx
@@ -12,16 +12,81 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 11000
+  material:
+    type: ammunition
+    tier: mid
   equipment:
     slot: ammo
-    ranged_strength: 31
-  related_items: []
+    weight: 0.025
+    requirements:
+      ranged: 30
+    other_bonus:
+      ranged_strength: 31
+  recipes:
+    - skill: herblore
+      level: 33
+      xp: 47.5
+      output_quantity: 1
+      materials:
+        - item_name: Adamant arrow
+          quantity: 1
+        - item_name: Weapon poison
+          quantity: 1
+  related_items:
+    - item_name: Adamant arrow
+      slug: adamant-arrow
+      relationship: variant
+      description: Unpoisoned variant fired by the same bows.
+    - item_name: Adamant arrow(p+)
+      slug: adamant-arrow-p-plus
+      relationship: upgrade
+      description: Stronger weapon poison variant.
+    - item_name: Adamant arrow(p++)
+      slug: adamant-arrow-p-plus-plus
+      relationship: upgrade
+      description: Strongest weapon poison variant.
+    - item_name: Mithril arrow(p)
+      slug: mithril-arrow-p
+      relationship: downgrade
+      description: Lower-tier poisoned arrow.
+    - item_name: Rune arrow(p)
+      slug: rune-arrow-p
+      relationship: upgrade
+      description: Higher-tier poisoned arrow.
+  market_strategy:
+    notes:
+      - Poisoned variant of adamant arrows for PvP and slayer chip damage.
+      - Crafted by applying weapon poison to standard adamant arrows.
+      - Used in mid-level ranged training and Wilderness PKing for venom chip damage.
+      - Buy limit of 11,000 per 4 hours supports bulk stockpiling.
+  trading_tips:
+    - Watch the spread versus the unpoisoned adamant arrow plus weapon poison cost.
+    - Demand spikes around Wilderness boss reworks and bounty events.
   about: |-
-    > _"Adamant arrows with a poisoned tip."_
+    > _"Venomous-looking arrows."_
 
-    Adamant arrows tipped with basic weapon poison. Poison deals 2-4 damage over time.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Adamant arrows tipped with basic weapon poison. The poison deals 2-4 chip damage over time after a successful hit, making the arrows mainly useful in PvP and against monsters that are not poison-immune.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2002-05-29"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2002-05-29"
+      description: Adamant arrow(p) added with the introduction of weapon poison and arrows.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-med-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-med-helm.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adamant med helm | OSRS Price Data
-description: "Adamant med helm: A medium sized helmet.. High alch: 1,152 GP, GE limit: 125."
+description: "Adamant med helm is a free-to-play medium head-slot helmet requiring 30 Defence. High alch: 1,152 GP, GE limit: 125."
 osrs:
   id: 1145
   name: Adamant med helm
@@ -12,25 +12,65 @@ osrs:
   lowalch: 768
   highalch: 1152
   limit: 125
-  item_id: 1145
-  item_type: armor
-  slot: head
-  type: med_helm
-  tradeable: true
-  weight: 2.267
-  requirements:
-    defence: 30
-  stats:
-    stab_defence: 14
-    slash_defence: 15
-    crush_defence: 13
-    magic_defence: -1
-    ranged_defence: 14
+  material:
+    type: adamant
+    tier: mid
+  equipment:
+    slot: head
+    weight: 2.267
+    requirements:
+      defence: 30
+    defence_bonus:
+      stab: 14
+      slash: 15
+      crush: 13
+      magic: -1
+      ranged: 14
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  recipes:
+    - skill: smithing
+      level: 53
+      xp: 62.5
+      materials:
+        - item_name: Adamantite bar
+          item_id: 2361
+          quantity: "1"
+      product: Adamant med helm
+      product_id: 1145
+      output_quantity: 1
+      facility: Anvil
   related_items:
-    - slug: rune-med-helm
-    - slug: adamant-full-helm
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    - item_name: Rune med helm
+      slug: rune-med-helm
+      relationship: upgrade
+      description: Stronger rune-tier medium helmet
+    - item_name: Adamant full helm
+      slug: adamant-full-helm
+      relationship: upgrade
+      description: Better defensive adamant alternative
+    - item_id: 1143
+      item_name: Mithril med helm
+      slug: mithril-med-helm
+      relationship: downgrade
+      description: Weaker mithril variant
+  market_strategy:
+    notes:
+      - Smithed at 53 Smithing from 1 adamantite bar
+      - Med helms are unpopular vs full helms; trades thin
+      - Used briefly during F2P Defence training progression
+  trading_tips:
+    - Compare full helm price before listing med helm
+    - High alch yields profit when bar prices crash
+  about: Adamant med helm is a free-to-play medium head-slot helmet smithable from a single adamantite bar at level 53 Smithing, requiring 30 Defence to wear.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2001-01-04"
+      description: Adamant med helm added with the original Smithing skill.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-shield-h1.mdx
@@ -1,20 +1,96 @@
 ---
 title: Adamant shield (h1) | OSRS Price Data
-description: "Adamant shield (h1): A shield with a heraldic design. High alch: 3,264 GP, GE limit: 70."
+description: "Adamant shield (h1) is a free-to-play adamant kiteshield with a heraldic Saradomin design. High alch: 3,264 GP, GE limit: 70."
 osrs:
   id: 7334
   name: Adamant shield (h1)
   slug: adamant-shield-h1
-  examine: A shield with a heraldic design
+  examine: A shield with a heraldic design.
   members: false
   icon: Adamant shield (h1).png
   value: 5440
   lowalch: 2176
   highalch: 3264
   limit: 70
-  about: "Adamant shield (h1) is a free-to-play item in Old School RuneScape. High alchemy value: 3,264 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: shield
+    tier: mid
+  equipment:
+    slot: shield
+    weight: 5.443
+    requirements:
+      defence: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 17
+      slash: 19
+      crush: 20
+      magic: -1
+      ranged: 18
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 1199
+      item_name: Adamant kiteshield
+      slug: adamant-kiteshield
+      relationship: alternative
+      description: Plain adamant kiteshield with identical combat stats
+    - item_id: 7336
+      item_name: Adamant shield (h2)
+      slug: adamant-shield-h2
+      relationship: variant
+      description: Zamorak-design heraldic adamant kiteshield
+    - item_id: 7338
+      item_name: Adamant shield (h3)
+      slug: adamant-shield-h3
+      relationship: variant
+      description: Guthix-design heraldic adamant kiteshield
+    - item_id: 7340
+      item_name: Adamant shield (h4)
+      slug: adamant-shield-h4
+      relationship: variant
+      description: Misthalin-design heraldic adamant kiteshield
+    - item_id: 7342
+      item_name: Adamant shield (h5)
+      slug: adamant-shield-h5
+      relationship: variant
+      description: Varrock-design heraldic adamant kiteshield
+  market_strategy:
+    notes:
+      - Cosmetic Treasure Trail reward; price driven by clue completion rate
+      - Stats are identical to a plain adamant kiteshield - premium is aesthetic
+      - F2P-tradeable so demand sees seasonal lifts during F2P meta
+  trading_tips:
+    - "Compare across h1-h5 - usually the cheapest design is the best buy"
+    - "Stats match the plain kiteshield: pay only the cosmetic premium you want"
+    - Resell into clue-scroll content events when cosmetics trend
+  about: "Adamant shield (h1) is a free-to-play adamant kiteshield bearing a Saradomin heraldic design, obtained as a reward from medium Treasure Trails. High alchemy value: 3,264 coins. Grand Exchange buy limit: 70 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2006-12-05"
+      description: Adamant shield (h1) added with the Treasure Trails expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/aether-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/aether-rune.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 25000
+  material:
+    type: rune
+    tier: mid-high
   about: "Aether rune is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 25,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robetop-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ahrim-s-robetop-0.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 30000
   limit: 15
   about: "Ahrim's robetop 0 is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ale-yeast.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ale-yeast.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 11000
+  material:
+    type: ingredient
+    tier: low
   about: "Ale yeast is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-torture.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/amulet-of-torture.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 80800
   highalch: 121200
   limit: 8
+  material:
+    type: zenyte
+    tier: high
   equipment:
     slot: neck
     type: amulet
@@ -42,7 +45,7 @@ osrs:
           quantity: 1
       product: Amulet of torture
       product_id: 19553
-      product_quantity: 1
+      output_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -97,8 +100,8 @@ osrs:
       - Zenyte from demonic gorillas
       - BiS melee neck slot
       - Always in demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-4-5952.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antidote-4-5952.mdx
@@ -12,12 +12,22 @@ osrs:
   lowalch: 144
   highalch: 216
   limit: 4000
+  material:
+    type: potion
+    tier: mid-high
   potion:
     doses: 4
     type: antidote
     cures_poison: true
     poison_immunity_minutes: 12
     venom_immunity_seconds: 36
+    effects:
+      - name: Cures poison
+        duration: 0
+      - name: Poison immunity
+        duration: 720
+      - name: Venom immunity
+        duration: 36
   recipes:
     - skill: herblore
       level: 79
@@ -31,7 +41,7 @@ osrs:
           quantity: 1
       product: Antidote++ (4)
       product_id: 5952
-      product_quantity: 1
+      output_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -73,8 +83,8 @@ osrs:
       - 87 Herblore for anti-venom
       - Magic roots from farming
       - Cheaper than anti-venom
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/antifire-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Antifire potion(1) | OSRS Price Data
-description: "Antifire potion(1): 1 dose of anti-firebreath potion.. High alch: 79 GP, GE limit: 2,000."
+description: "Antifire potion(1) is a 1-dose anti-firebreath potion that reduces dragonfire damage. High alch: 79 GP, GE limit: 2,000."
 osrs:
   id: 2458
   name: Antifire potion(1)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 52
   highalch: 79
   limit: 2000
-  about: "Antifire potion(1) is a members-only item in Old School RuneScape. High alchemy value: 79 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    type: combat
+    tier: standard
+    doses: 1
+    effects:
+      - name: Antifire
+        duration: 360
+        description: "Reduces dragonfire damage taken for 6 minutes."
+  related_items:
+    - item_id: 2456
+      item_name: Antifire potion(4)
+      slug: antifire-potion-4
+      relationship: variant
+      description: 4-dose version
+    - item_id: 2454
+      item_name: Antifire potion(3)
+      slug: antifire-potion-3
+      relationship: variant
+      description: 3-dose version
+    - item_id: 2452
+      item_name: Antifire potion(2)
+      slug: antifire-potion-2
+      relationship: variant
+      description: 2-dose version
+    - item_id: 2460
+      item_name: Extended antifire(4)
+      slug: extended-antifire-4
+      relationship: upgrade
+      description: Longer-lasting antifire variant
+  market_strategy:
+    notes:
+      - Single-dose antifires are commonly produced by decanting higher-dose flasks
+      - Demand spikes around dragon-slayer tasks and dragonfire encounters
+      - "Watch GE price relative to multi-dose variants: arbitrage by decanting"
+  trading_tips:
+    - Buy in bulk before Slayer tasks for cost savings
+    - "Compare per-dose price vs 4-dose to avoid overpaying"
+    - Decant via NPC services when supply of low-dose is short
+  about: "Antifire potion(1) is a members-only 1-dose potion that reduces dragonfire damage taken when fighting dragons. High alchemy value: 79 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2004-12-13"
+      description: Antifire potion was added to the game.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/arcane-spirit-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/arcane-spirit-shield.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 800000
   highalch: 1200000
   limit: 8
+  material:
+    type: spirit_shield
+    tier: high
   equipment:
     slot: neck
     type: amulet
@@ -27,6 +30,7 @@ osrs:
     - skill: magic
       level: 93
       xp: 110
+      output_quantity: 1
       materials:
         - item_name: Zenyte amulet
           item_id: 19501
@@ -42,7 +46,6 @@ osrs:
           quantity: 1
       product: Amulet of torture
       product_id: 19553
-      product_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -89,8 +92,8 @@ osrs:
       - Zenyte jewelry always in demand
       - Higher offensive bonus than fury
       - No defensive stats
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-d-hide-body.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/armadyl-d-hide-body.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 5200
   highalch: 7800
   limit: 8
+  material:
+    type: ranged-armour
+    tier: high
   equipment:
     slot: body
     type: ranged armour
@@ -20,9 +23,6 @@ osrs:
       ranged: 70
       defence: 40
     stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
       attack_magic: -15
       attack_ranged: 30
       defence_stab: 55
@@ -30,17 +30,11 @@ osrs:
       defence_crush: 60
       defence_magic: 50
       defence_ranged: 55
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
       prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
-        rarity: 1/1,625
-        description: Reward from hard clue scroll caskets
+  treasure_trail:
+    tier: hard
+    rarity: 1/1,625
+    description: Reward from hard clue scroll caskets
   related_items:
     - item_id: 10378
       item_name: Guthix d'hide body
@@ -89,7 +83,6 @@ osrs:
 
     The blessed variants provide substantially better defensive bonuses across the board, with the largest improvements in stab defence (+25), crush defence (+15), and ranged defence (+5). The +1 prayer bonus is a further advantage that no standard dragonhide body offers. Since the requirements are identical, blessed d'hide bodies are a strict upgrade over the black d'hide body.
   market_strategy:
-    title: Investment Notes
     notes:
       - Armadyl d'hide tends to command a premium among blessed variants due to its association with the popular Armadyl god items
       - All six blessed d'hide bodies are functionally identical, so the premium is purely cosmetic
@@ -97,8 +90,8 @@ osrs:
       - If you want best-in-slot stats without paying the Armadyl premium, any cheaper blessed variant offers the same bonuses
       - Armadyl-themed fashionscape is popular, which supports the price floor
       - Hard clue scroll farming events or updates can temporarily increase supply and lower prices
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/asgarnian-ale-m4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Asgarnian ale(m4) | OSRS Price Data
-description: "Asgarnian ale(m4): This keg contains 4 pints of mature Asgarnian Ale.. High alch: 1 GP, GE limit: 2,000."
+description: "Asgarnian ale(m4) is a keg containing four pints of mature Asgarnian Ale. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5865
   name: Asgarnian ale(m4)
@@ -12,9 +12,52 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Asgarnian ale(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: drink
+    tier: low
+  related_items:
+    - item_id: 5863
+      item_name: Asgarnian ale(m3)
+      slug: asgarnian-ale-m3
+      relationship: variant
+      description: 3-pint keg version
+    - item_id: 5861
+      item_name: Asgarnian ale(m2)
+      slug: asgarnian-ale-m2
+      relationship: variant
+      description: 2-pint keg version
+    - item_id: 5859
+      item_name: Asgarnian ale(m1)
+      slug: asgarnian-ale-m1
+      relationship: variant
+      description: 1-pint keg version
+    - item_name: Asgarnian ale
+      slug: asgarnian-ale
+      relationship: downgrade
+      description: Single mug, unmatured form
+  market_strategy:
+    notes:
+      - Mature keg ales are bought mainly for Smithing temp boost runs
+      - Supply is brewing-driven, prices are sticky and low-volume
+      - "Watch for spikes when Smithing content updates land"
+  trading_tips:
+    - "Compare per-pint price across m1/m2/m3/m4 kegs to find best value"
+    - Hold for Smithing-meta updates to flip at premium
+    - "Avoid panic-buying: low GE volume means filling orders is slow"
+  about: "Asgarnian ale(m4) is a members-only keg holding four pints of mature Asgarnian Ale, drunk for a temporary Smithing boost. High alchemy value: 1 coin. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2006-08-29"
+      description: Mature brewing introduced kegged ales with the Brewing update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-yew-tree.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bagged-yew-tree.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 10000
-  about: "Bagged yew tree is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: farming_produce
+    tier: mid-high
+  about: "Bagged yew tree is a members-only construction garden plant in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ball-of-cotton.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ball-of-cotton.mdx
@@ -11,10 +11,10 @@ osrs:
   value: 2
   lowalch: 1
   highalch: 1
-  limit: null
+  limit:
   about: "Ball of cotton is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-dragonhide-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-dragonhide-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bandos dragonhide set | OSRS Price Data
-description: "Bandos dragonhide set: A set containing a Bandos dragonhide coif, body, chaps and bracers.. High alch: 5,700 GP, GE limit: 8."
+description: "Bandos dragonhide set bundles Bandos d'hide coif, body, chaps and bracers into a single GE item. High alch: 5,700 GP, GE limit: 8."
 osrs:
   id: 13167
   name: Bandos dragonhide set
@@ -12,9 +12,53 @@ osrs:
   lowalch: 3800
   highalch: 5700
   limit: 8
-  about: "Bandos dragonhide set is a members-only item in Old School RuneScape. High alchemy value: 5,700 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour-set
+    tier: mid-high
+  related_items:
+    - item_id: 12515
+      item_name: Bandos coif
+      slug: bandos-coif
+      relationship: set-piece
+      description: Head slot of the Bandos d'hide set
+    - item_id: 12503
+      item_name: Bandos d'hide body
+      slug: bandos-d-hide-body
+      relationship: set-piece
+      description: Body slot of the Bandos d'hide set
+    - item_id: 12509
+      item_name: Bandos chaps
+      slug: bandos-chaps
+      relationship: set-piece
+      description: Leg slot of the Bandos d'hide set
+    - item_id: 12521
+      item_name: Bandos bracers
+      slug: bandos-bracers
+      relationship: set-piece
+      description: Hands slot of the Bandos d'hide set
+  market_strategy:
+    notes:
+      - GE set is a cosmetic-grade re-skin of black d'hide, value tracks the four pieces
+      - Compare set price to sum of pieces for arbitrage via Grand Exchange clerk
+      - Low buy limit means flips need patience and capital
+  trading_tips:
+    - "Decompose the set at a GE clerk if pieces sell for more individually"
+    - Use Margins Margin Helper to track set vs piece spread
+    - Avoid buying above sum-of-pieces price unless cosmetic demand is hot
+  about: "Bandos dragonhide set is a members-only Grand Exchange convenience bundle of the four Bandos dragonhide armour pieces. High alchemy value: 5,700 coins. Grand Exchange buy limit: 8 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2009-12-01"
+      description: Bandos dragonhide set added to the Grand Exchange as a convenience bundle.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bastion-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bastion-potion-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bastion potion(2) | OSRS Price Data
-description: "Bastion potion(2): 2 doses of Bastion potion.. High alch: 108 GP, GE limit: 2,000."
+description: "Bastion potion(2): 2 doses of Bastion potion. High alch: 108 GP, GE limit: 2,000."
 osrs:
   id: 22467
   name: Bastion potion(2)
@@ -12,9 +12,80 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 2000
-  about: "Bastion potion(2) is a members-only item in Old School RuneScape. High alchemy value: 108 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: high
+  potion:
+    doses: 2
+    effects:
+      - name: Ranged boost
+        description: Boosts Ranged level by 4 plus 10% of base level.
+        duration: 0
+      - name: Defence boost
+        description: Boosts Defence level by 5 plus 15% of base level.
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 80
+      xp: 155
+      output_quantity: 1
+      materials:
+        - item_name: Bastion potion(3)
+          quantity: 1
+  related_items:
+    - item_name: Bastion potion(4)
+      slug: bastion-potion-4
+      relationship: variant
+      description: Four-dose variant of the same potion.
+    - item_name: Bastion potion(3)
+      slug: bastion-potion-3
+      relationship: variant
+      description: Three-dose variant of the same potion.
+    - item_name: Bastion potion(1)
+      slug: bastion-potion-1
+      relationship: variant
+      description: Single-dose variant of the same potion.
+    - item_name: Ranging potion(4)
+      slug: ranging-potion-4
+      relationship: alternative
+      description: Pure ranged-only boost without the defence component.
+    - item_name: Super defence(4)
+      slug: super-defence-4
+      relationship: alternative
+      description: Pure defence boost without the ranged component.
+  market_strategy:
+    notes:
+      - Combination potion that bundles a ranged and defence boost into one sip.
+      - Two-dose flask is the half-empty residue of higher-dose decanting.
+      - Used at LMS, Inferno, and high-tier PvM where ranged DPS and defence both matter.
+      - Buy limit of 2,000 per 4 hours allows mid-volume flipping.
+  trading_tips:
+    - Decant ratios versus the (3) and (4) variants drive the GE spread.
+    - Stock up before bossing rota changes or PvP minigames go live.
+  about: |-
+    > _"2 doses of Bastion potion."_
+
+    Two-dose combination potion that simultaneously boosts Ranged and Defence. The ranged boost is +4 plus 10% of the player's base level, and the defence boost is +5 plus 15% of the player's base level, making it a staple for hybrid combat at high-end PvM and PvP.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2019-03-14"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Drink
+      - Empty
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2019-03-14"
+      description: Bastion potion(2) added with the combination potion update for ranged and defence.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bat-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bat-bones.mdx
@@ -12,18 +12,41 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 3000
+  about: "Bat bones give 5.3 Prayer XP when buried, a minor upgrade over regular bones (4.5 XP). Commonly obtained from bats across caves and dungeons."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2001-08-13"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Bury"
+    weight: 0.4
+  material:
+    type: bones
+    tier: low
   related_items:
     - item_id: 534
       item_name: Babydragon bones
       slug: babydragon-bones
-      relationship: variant
-      description: Higher tier bones
-  about: |-
-    > _"Ew it's a pile of bones."_
-
-    Bat bones give 5.3 Prayer XP when buried. A minor upgrade over regular bones (4.5 XP). Commonly obtained from bats in various caves and dungeons.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      relationship: upgrade
+      description: Higher tier bones with greater Prayer XP per bury.
+    - item_name: Bones
+      slug: bones
+      relationship: downgrade
+      description: Base bones with lower Prayer XP per bury.
+  market_strategy:
+    notes:
+      - "Low-cost Prayer training filler item."
+      - "Volume sells best to early-game Prayer trainers."
+  trading_tips:
+    - "Buy from bat-slayers and resell during double XP weekends."
+    - "Avoid stockpiling outside of XP events since demand resets quickly."
+  history:
+    - date: "2001-08-13"
+      description: "Bat bones released with the early bestiary expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/beer-barrel-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/beer-barrel-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Beer barrel (flatpack) | OSRS Price Data
-description: "Beer barrel (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Beer barrel (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8516
   name: Beer barrel (flatpack)
@@ -12,9 +12,59 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
-  about: "Beer barrel (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: flatpack
+    tier: low
+  recipes:
+    - skill: construction
+      level: 24
+      xp: 87
+      output_quantity: 1
+      materials:
+        - item_name: Oak plank
+          quantity: 2
+        - item_name: Beer
+          quantity: 1
+  related_items:
+    - item_name: Oak plank
+      slug: oak-plank
+      relationship: component
+      description: Required material for the flatpack.
+    - item_name: Beer
+      slug: beer
+      relationship: component
+      description: Drink stored inside the barrel.
+  market_strategy:
+    notes:
+      - Construction flatpack used to furnish a Player-Owned House kitchen.
+      - Trained at a workbench in the workshop with Construction level 24.
+      - Low margin; sold mainly as a convenience item for non-house Construction trainers.
+      - Demand spikes around Bounty events and double XP weekends.
+  trading_tips:
+    - Buy below GE mid-price to flip with marginal profit per unit.
+    - Stocked in bulk; the 500 buy limit caps short-term scalping.
+  about: |-
+    > _"How does it all fit in there?"_
+
+    Construction flatpack version of the beer barrel kitchen feature. Crafted at a workshop workbench from 2 oak planks and 1 beer, granting 87 Construction XP, and can be placed in a player-owned house without further materials.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2006-05-31"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2006-05-31"
+      description: Beer barrel flatpack released alongside the Construction workshop update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-chinchompa.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-chinchompa.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 96
   highalch: 144
   limit: 11000
+  material:
+    type: chinchompa
+    tier: high
   ammunition:
     type: chinchompa
     tier: black
@@ -61,8 +64,8 @@ osrs:
       - PK risk while hunting
       - 3x3 AoE damage
       - Expensive but fast XP
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-elegant-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-elegant-legs.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  material:
+    type: armor
+    tier: mid
   equipment:
     slot: legs
     requirements: {}
@@ -25,8 +28,8 @@ osrs:
     > *"A rather elegant pair of men's black pantaloons."*
 
     Purely cosmetic treasure trail reward with no combat stats. Part of the black elegant clothing set.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-gold-trimmed-set-lg.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-gold-trimmed-set-lg.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black gold-trimmed set (lg) | OSRS Price Data
-description: "Black gold-trimmed set (lg): A set containing a full helm, platebody, legs and kiteshield.. High alch: 2,700 GP, GE limit: 8."
+description: "Black gold-trimmed set (lg): A set containing a full helm, platebody, legs and kiteshield. High alch: 2,700 GP, GE limit: 8."
 osrs:
   id: 12996
   name: Black gold-trimmed set (lg)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1800
   highalch: 2700
   limit: 8
-  about: "Black gold-trimmed set (lg) is a free-to-play item in Old School RuneScape. High alchemy value: 2,700 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: armour-set
+    tier: mid
+  related_items:
+    - item_name: Black full helm (g)
+      slug: black-full-helm-g
+      relationship: set-piece
+      description: Gold-trimmed black full helm contained in the set.
+    - item_name: Black platebody (g)
+      slug: black-platebody-g
+      relationship: set-piece
+      description: Gold-trimmed black platebody contained in the set.
+    - item_name: Black platelegs (g)
+      slug: black-platelegs-g
+      relationship: set-piece
+      description: Gold-trimmed black platelegs contained in the set.
+    - item_name: Black kiteshield (g)
+      slug: black-kiteshield-g
+      relationship: set-piece
+      description: Gold-trimmed black kiteshield contained in the set.
+    - item_name: Black gold-trimmed set (sk)
+      slug: black-gold-trimmed-set-sk
+      relationship: alternative
+      description: Skirt variant of the same gold-trimmed black armour set.
+  market_strategy:
+    notes:
+      - Grand Exchange set object that exchanges for the four individual gold-trimmed pieces.
+      - Used by collectors and as a fashionscape staple in F2P worlds.
+      - Buy limit of 8 per 4 hours throttles arbitrage between set and pieces.
+      - Underlying pieces are hard clue rewards, so set price tracks hard clue completions.
+  trading_tips:
+    - Compare set price to the sum of the four individual gold-trimmed pieces before exchanging.
+    - Exchange at a Grand Exchange clerk only when the spread closes in your favour.
+  about: |-
+    > _"A set containing a full helm, platebody, legs and kiteshield."_
+
+    Grand Exchange convenience bundle that holds the gold-trimmed black full helm, platebody, platelegs and kiteshield. Used to buy or sell the full legs-variant gold-trimmed black armour in a single transaction; exchange with a Grand Exchange clerk to split into the individual pieces.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2007-11-26"
+    tradeable: true
+    stackable: false
+    noteable: false
+    equipable: false
+    members: false
+    quest_item: false
+    options:
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2007-11-26"
+      description: Black gold-trimmed set (lg) released as a Grand Exchange bundle for the gold-trimmed armour pieces.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-leprechaun-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-leprechaun-hat.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 3000
   limit: 4
   about: "Black leprechaun hat is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/black-spear.mdx
@@ -1,6 +1,6 @@
 ---
 title: Black spear | OSRS Price Data
-description: "Black spear: A black tipped spear.. High alch: 390 GP, GE limit: 8."
+description: "Black spear is a members two-handed weapon requiring 10 Attack. High alch: 390 GP, GE limit: 8."
 osrs:
   id: 4580
   name: Black spear
@@ -12,9 +12,58 @@ osrs:
   lowalch: 260
   highalch: 390
   limit: 8
-  about: "Black spear is a members-only item in Old School RuneScape. High alchemy value: 390 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: black
+    tier: low
+  equipment:
+    slot: weapon
+    weight: 2.2
+    requirements:
+      attack: 10
+    attack_bonus:
+      stab: 17
+      slash: 17
+      crush: 17
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 18
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 1237
+      item_name: Iron spear
+      slug: iron-spear
+      relationship: downgrade
+      description: Lower tier metal spear
+    - item_id: 1239
+      item_name: Steel spear
+      slug: steel-spear
+      relationship: alternative
+      description: Steel-tier alternative
+    - item_id: 1241
+      item_name: Mithril spear
+      slug: mithril-spear
+      relationship: upgrade
+      description: Higher tier mithril spear
+  market_strategy:
+    notes:
+      - Two-handed stab/slash/crush weapon
+      - Niche use as low-level spear option
+      - Demand limited compared to standard scimitars
+  trading_tips:
+    - Use Grand Exchange for fast trades
+    - Watch slayer task spikes for demand bumps
+  about: "Black spear is a two-handed spear with equal stab, slash, and crush attack bonuses. Requires 10 Attack to wield and is a members-only item."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-halloween-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-halloween-mask.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 5
+  material:
+    type: cloth
+    tier: high
   about: "Blue halloween mask is a free-to-play item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-skirt-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-skirt-t.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 4
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: legs
     requirements: {}
@@ -30,8 +33,8 @@ osrs:
     > *"Leg covering favoured by women and wizards. With a colourful trim!"*
 
     The blue skirt (t) is a trimmed cosmetic variant of the blue wizard skirt. No requirements. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-robe-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/blue-wizard-robe-t.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 4
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: body
     requirements: {}
@@ -34,8 +37,8 @@ osrs:
     > *"I can do magic better in this."*
 
     The blue wizard robe (t) is a trimmed cosmetic variant of the standard blue wizard robe. It provides identical stats (+3 magic attack and defence) but with decorative trim. No requirements to equip. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bluefin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bluefin.mdx
@@ -11,10 +11,13 @@ osrs:
   value: 170
   lowalch: 68
   highalch: 102
-  limit: null
+  limit:
+  material:
+    type: food
+    tier: low
   about: "Bluefin is a members-only item in Old School RuneScape. High alchemy value: 102 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-cotton.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bolt-of-cotton.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bolt of cotton | OSRS Price Data
-description: "Bolt of cotton: A bolt of cotton.. High alch: 240 GP, GE limit: 13,000."
+description: "Bolt of cotton is a members crafting material spun from cotton balls used for high-tier tailoring. High alch: 240 GP, GE limit: 13,000."
 osrs:
   id: 31478
   name: Bolt of cotton
@@ -12,9 +12,47 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 13000
-  about: "Bolt of cotton is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  recipes:
+    - skill: crafting
+      level: 10
+      xp: 12
+      materials:
+        - item_name: Ball of wool
+          item_id: 1759
+          quantity: "4"
+      product: Bolt of cotton
+      product_id: 31478
+      output_quantity: 1
+      facility: Loom
+      members_only: true
+  related_items:
+    - item_id: 1781
+      item_name: Ball of wool
+      slug: ball-of-wool
+      relationship: component
+      description: Spun wool used to weave bolts of cotton on a loom
+    - item_id: 8790
+      item_name: Bolt of cloth
+      slug: bolt-of-cloth
+      relationship: alternative
+      description: Generic cloth crafting bolt
+  market_strategy:
+    notes:
+      - High GE limit (13,000) supports bulk crafting
+      - Used in tailoring and minigame uniforms
+      - Loom-bound recipe, cannot be made anywhere else
+  trading_tips:
+    - Buy in bulk to skill efficiently and resell offcuts
+    - Compare ball-of-wool input cost vs bolt resale margin
+  about: Bolt of cotton is a members crafting material woven on a loom from balls of wool, used as an input for higher-tier tailoring recipes.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2024-11-13"
+      description: Bolt of cotton added with the Varlamore tailoring content.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-balance-page-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/book-of-balance-page-set.mdx
@@ -1,6 +1,6 @@
 ---
 title: Book of balance page set | OSRS Price Data
-description: "Book of balance page set: A set containing the four pages of Guthix's Book of Balance.. High alch: 4,200 GP, GE limit: 5."
+description: "Book of balance page set is a members Grand Exchange set of four Guthix book pages. High alch: 4,200 GP, GE limit: 5."
 osrs:
   id: 13153
   name: Book of balance page set
@@ -12,9 +12,33 @@ osrs:
   lowalch: 2800
   highalch: 4200
   limit: 5
-  about: "Book of balance page set is a members-only item in Old School RuneScape. High alchemy value: 4,200 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: set
+    tier: mid
+  related_items:
+    - item_name: Damaged book (Guthix)
+      slug: damaged-book-guthix
+      relationship: product
+      description: Pages combine into the damaged Guthix book
+    - item_name: Book of balance
+      slug: book-of-balance
+      relationship: product
+      description: Completed prayer book offering bonuses
+    - item_name: Torn prayer scroll
+      slug: torn-prayer-scroll
+      relationship: alternative
+      description: Alternative Treasure Trails prayer reward
+  market_strategy:
+    notes:
+      - Grand Exchange set used to bundle the four Guthix book pages
+      - Demand driven by Treasure Trail completionists
+      - Convert via GE Sets exchange clerk
+  trading_tips:
+    - Compare set price vs sum of individual pages before buying
+    - Use Grand Exchange for secure trades
+  about: "Book of balance page set is a Grand Exchange set containing the four pages of Guthix's Book of Balance. Used to assemble the damaged book before binding to Guthix's completed prayer book."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/brass-key.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/brass-key.mdx
@@ -12,13 +12,16 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
+  material:
+    type: brass
+    tier: low
   related_items: []
   about: |-
     > _"A\"heavy\" brass key."_
 
     The brass key opens the shed door west of the Cooks' Guild, providing a shortcut into the Edgeville Dungeon. Useful for accessing hill giants and other dungeon creatures.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-claws.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-claws.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 125
+  material:
+    type: metal
+    tier: low
   about: "Bronze claws is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-crossbow-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-crossbow-u.mdx
@@ -12,9 +12,49 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 10000
-  about: "Bronze crossbow (u) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Bronze crossbow (u) is the unstrung intermediate step in crafting a Bronze crossbow. Created from a bronze crossbow stock and limbs at Fletching level 9."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2006-05-15"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 1.0
+  material:
+    type: crossbow
+    tier: low
+  recipes:
+    - item_name: Bronze crossbow (u)
+      tools: []
+      materials:
+        - item_name: Wooden stock
+          quantity: "1"
+        - item_name: Bronze limbs
+          quantity: "1"
+      output_quantity: 1
+      skill: fletching
+      level: 9
+      xp: 12
+      notes: "Combine bronze limbs onto a wooden stock to produce the unstrung crossbow."
+  related_items:
+    - item_name: Bronze crossbow
+      slug: bronze-crossbow
+      relationship: product
+      description: Strung result after adding a crossbow string.
+  market_strategy:
+    notes:
+      - "Used almost exclusively by low-level Fletchers training."
+      - "Tracks bronze limbs and wooden stock supply closely."
+  trading_tips:
+    - "Buy in bulk during Fletching XP events."
+    - "Margins thin so flip alongside limbs and stocks."
+  history:
+    - date: "2006-05-15"
+      description: "Bronze crossbow (u) released with the crossbow Fletching update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-full-helm-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-full-helm-t.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 19
   highalch: 28
   limit: 4
-  about: "Bronze full helm (t) is a free-to-play item in Old School RuneScape. High alchemy value: 28 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: head
+  about: "Bronze full helm (t) is a free-to-play trimmed cosmetic helm in Old School RuneScape. High alchemy value: 28 coins. Grand Exchange buy limit: 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-javelin.mdx
@@ -12,9 +12,11 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 7000
+  material:
+    type: bronze
+    tier: low
   equipment:
     slot: weapon
-    attack_speed: 6
     attack_bonus:
       ranged: 6
     ranged_strength: 25
@@ -22,7 +24,7 @@ osrs:
     - item_id: 826
       item_name: Iron javelin
       slug: iron-javelin
-      relationship: variant
+      relationship: upgrade
       description: Higher tier javelin
     - item_id: 831
       item_name: Bronze javelin (p)
@@ -33,8 +35,8 @@ osrs:
     > _"A bronze tipped javelin."_
 
     The bronze javelin is the lowest-tier javelin. No Ranged requirement. Javelins are slower than darts but have higher ranged strength per hit. Used primarily with the heavy ballista.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-set-sk.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bronze set (sk) | OSRS Price Data
-description: "Bronze set (sk): A set containing a full helm, platebody, skirt and kiteshield.. High alch: 120 GP, GE limit: 8."
+description: "Bronze set (sk) is a free-to-play Grand Exchange armour set bundling bronze full helm, platebody, plateskirt, and kiteshield. High alch: 120 GP, GE limit: 8."
 osrs:
   id: 12962
   name: Bronze set (sk)
@@ -12,9 +12,49 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 8
-  about: "Bronze set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  related_items:
+    - item_id: 1155
+      item_name: Bronze full helm
+      slug: bronze-full-helm
+      relationship: set-piece
+      description: Head slot piece of the set
+    - item_id: 1117
+      item_name: Bronze platebody
+      slug: bronze-platebody
+      relationship: set-piece
+      description: Body slot piece of the set
+    - item_id: 1087
+      item_name: Bronze plateskirt
+      slug: bronze-plateskirt
+      relationship: set-piece
+      description: Leg slot piece of the set
+    - item_id: 1189
+      item_name: Bronze kiteshield
+      slug: bronze-kiteshield
+      relationship: set-piece
+      description: Shield slot piece of the set
+    - item_id: 12960
+      item_name: Bronze set (lg)
+      slug: bronze-set-lg
+      relationship: alternative
+      description: Legs (platelegs) variant of the set
+  market_strategy:
+    notes:
+      - GE armour set; exchange via Grand Exchange clerk for individual pieces
+      - Useful when individual piece supply is thin or expensive
+      - Low GE limit caps flipping volume
+  trading_tips:
+    - Compare set vs sum-of-pieces price before exchanging
+    - Bulk-flip relies on Grand Exchange clerk arbitrage
+  about: Bronze set (sk) is a free-to-play Grand Exchange armour set bundle that contains a bronze full helm, platebody, plateskirt, and kiteshield, exchangeable at the Grand Exchange clerk.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2007-11-26"
+      description: Grand Exchange armour sets introduced to consolidate piece-based trades.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-spear-p-5704.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-spear-p-5704.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 125
+  material:
+    type: bronze
+    tier: low
   about: "Bronze spear(p+) is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-spear-p-5718.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-spear-p-5718.mdx
@@ -1,10 +1,10 @@
 ---
 title: Bronze spear(p++) | OSRS Price Data
-description: "Bronze spear(p++): A poisoned bronze tipped spear.. High alch: 15 GP, GE limit: 125."
+description: "Bronze spear(p++) is a members 2H stab weapon with extra-strong poison applied. High alch: 15 GP, GE limit: 125."
 osrs:
   id: 5718
   name: Bronze spear(p++)
-  slug: bronze-spear-p
+  slug: bronze-spear-p-5718
   examine: A poisoned bronze tipped spear.
   members: true
   icon: Bronze spear(p++).png
@@ -12,9 +12,88 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 125
-  about: "Bronze spear(p++) is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: bronze
+    tier: low
+  equipment:
+    slot: weapon
+    weight: 2.267
+    requirements:
+      attack: 1
+    weapon_type: spear
+    combat_style: stab
+    attack_bonus:
+      stab: 4
+      slash: 4
+      crush: 4
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 1
+      crush: 1
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 5
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Extra-strong poison
+      description: "Inflicts poison damage starting at higher initial values than (p) or (p+) variants."
+  related_items:
+    - item_id: 1237
+      item_name: Bronze spear
+      slug: bronze-spear
+      relationship: variant
+      description: Unpoisoned base spear
+    - item_id: 5716
+      item_name: Bronze spear(p)
+      slug: bronze-spear-p
+      relationship: variant
+      description: Weak poison variant
+    - item_id: 5717
+      item_name: Bronze spear(p+)
+      slug: bronze-spear-p-plus
+      relationship: variant
+      description: Strong poison variant
+    - item_name: Iron spear(p++)
+      slug: iron-spear-p-plus-plus
+      relationship: upgrade
+      description: Next metal tier of the same poisoned spear
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Lowest poisoned spear tier; demand concentrated in low-level slayer"
+      - "Tight GE limit of 125 keeps daily volume small"
+      - "Made by applying extra-strong weapon poison to a bronze spear"
+  trading_tips:
+    - Use Grand Exchange for secure trades
+    - Buy unpoisoned spear and apply weapon poison++ when cheaper
+    - Monitor low-level slayer task spikes
+  about: "Bronze spear(p++) is a members-only two-handed bronze spear coated in extra-strong weapon poison; it is the strongest poisoned variant of the bronze spear line and is used primarily by low-level players who want sustained poison damage."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 2.267
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2005-07-04"
+      description: "Extra-strong poisoned spear variants added with the weapon poison++ expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-disease.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-10-disease.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
+  material:
+    type: wood
+    tier: mid
   about: "Broodoo shield (10) (disease) is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-disease.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/broodoo-shield-disease.mdx
@@ -12,9 +12,17 @@ osrs:
   lowalch: 1200
   highalch: 1800
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: broodoo
+    tier: mid
   about: "Broodoo shield (disease) is a members-only item in Old School RuneScape. High alchemy value: 1,800 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Disease-aspect broodoo shield variant from Tai Bwo Wannai mini-content"
+      - "Niche cosmetic and collector demand keeps volume thin"
+      - "Buy limit of 125 per 4 hours on the Grand Exchange"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bryophyta-s-staff-uncharged.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bryophyta-s-staff-uncharged.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 39000
   limit: 8
   about: "Bryophyta's staff (uncharged) is a free-to-play item in Old School RuneScape. High alchemy value: 39,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bullseye-lantern-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bullseye-lantern-unf.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 10000
+  material:
+    type: tool
+    tier: low
   about: "Bullseye lantern (unf) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/caviar.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/caviar.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 13000
+  material:
+    type: organic
+    tier: low
   about: "Caviar is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/chinchompa.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/chinchompa.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 56
   highalch: 84
   limit: 7000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: chinchompa
+    tier: mid
   equipment:
     slot: weapon
     type: chinchompa
@@ -23,15 +28,13 @@ osrs:
       attack_ranged: 45
   passive_effects:
     - name: Multi-Target
-      description: Explodes on impact, hits up to 11 targets in 3x3 area, stackable ammo, not recovered by Ava's
-  obtaining:
-    methods:
+      description: "Explodes on impact, hits up to 11 targets in 3x3 area, stackable ammo, not recovered by Ava's"
+  drop_table:
+    sources:
       - source: Box trapping
-        requirements:
-          hunter: 53
-        locations: Piscatoris, Kourend, Isle of Souls
-        xp: 198.4
-        quest: Eagles' Peak
+        quantity: "1"
+        rarity: Common
+        notes: "Hunter 53 at Piscatoris, Kourend, Isle of Souls; 198.4 xp per catch; requires Eagles' Peak"
   related_items:
     - item_id: 11959
       item_name: Black chinchompa
@@ -72,8 +75,10 @@ osrs:
       - Eagles' Peak required
       - Much cheaper than black
       - Lower XP rates
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Eagles' Peak required
+    - Much cheaper than black
+    - Lower XP rates
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/clay.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/clay.mdx
@@ -14,7 +14,7 @@ osrs:
   limit: 13000
   material:
     type: mining
-    tier: basic
+    tier: low
   mining:
     level: 1
     xp: 5
@@ -78,8 +78,8 @@ osrs:
     Use water on clay to create soft clay.
 
     Soft clay used for Crafting and Construction.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/coconut.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/coconut.mdx
@@ -72,8 +72,8 @@ osrs:
       - Use hammer for half coconuts
       - Coconut milk for antidote+
       - Passive farm income
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cod.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cod.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 6000
+  material:
+    type: food
+    tier: low
   related_items:
     - item_id: 341
       item_name: Raw cod
@@ -22,8 +25,8 @@ osrs:
     > _"Some nicely cooked cod."_
 
     Cod heals 7 Hitpoints. Caught with a big fishing net at net/harpoon spots. A mid-tier members food.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/coif.mdx
@@ -12,9 +12,17 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: leather
+    tier: low
   about: "Coif is a free-to-play item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Entry-level ranged headgear crafted from leather"
+      - "Cheap and widely supplied; demand driven by low-level rangers"
+      - "Buy limit of 125 per 4 hours on the Grand Exchange"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/compost-potion-3.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 36
   highalch: 54
   limit: 50
+  material:
+    type: potion
+    tier: low
   about: "Compost potion(3) is a members-only item in Old School RuneScape. High alchemy value: 54 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-graahk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/cooked-graahk.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 10000
+  material:
+    type: food
+    tier: mid
   about: "Cooked graahk is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crunchy-tray.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crunchy-tray.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 40
+  material:
+    type: utensil
+    tier: low
   about: "Crunchy tray is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crushed-infernal-shale.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crushed-infernal-shale.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 25000
+  material:
+    type: shale
+    tier: mid
   about: "Crushed infernal shale is a members-only item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 25,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-key.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/crystal-key.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 60
   highalch: 90
   limit: 11000
-  item:
-    type: material
-    tradeable: true
+  material:
+    type: key
+    tier: mid
   related_items:
     - item_id: 985
       item_name: Tooth half of key
@@ -45,8 +45,8 @@ osrs:
     Always contains uncut dragonstone plus bonus loot.
 
     Key is consumed on use.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dark-fishing-bait.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dark-fishing-bait.mdx
@@ -14,7 +14,7 @@ osrs:
   limit: 8000
   material:
     type: bait
-    tier: special
+    tier: low
   drop_table:
     primary_source: Ankou
     sources:
@@ -29,11 +29,11 @@ osrs:
         drop_rate: 57/92
         members_only: true
       - source: Dark warrior
-        quantity: 10-24
+        quantity: "10-24"
         rarity: uncommon
         members_only: true
       - source: Artio
-        quantity: 200-300
+        quantity: "200-300"
         rarity: rare
         members_only: true
   sources:
@@ -72,8 +72,8 @@ osrs:
       - Ankous drop 60 bait frequently
       - Also drop good loot
       - Non-wilderness option for bait
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolt-tips.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-bolt-tips.mdx
@@ -12,11 +12,9 @@ osrs:
   lowalch: 53
   highalch: 79
   limit: 11000
-  item:
+  material:
     type: ammunition_component
-    tradeable: true
-    stackable: true
-    weight: 0
+    tier: mid
   recipes:
     - skill: fletching
       level: 65
@@ -25,7 +23,7 @@ osrs:
         - item_name: Diamond
           quantity: 1
       product: Diamond bolt tips
-      product_quantity: 12
+      output_quantity: 12
   related_items:
     - item_id: 9340
       item_name: Diamond bolts
@@ -56,8 +54,8 @@ osrs:
     | Diamond dragon bolts | Dragon bolts + Diamond bolt tips | 84 |
 
     Can be enchanted after attachment.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/diamond-necklace.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 1470
   highalch: 2205
   limit: 18000
+  material:
+    type: jewellery
+    tier: mid
   equipment:
     slot: neck
     requirements:
@@ -20,7 +23,7 @@ osrs:
     - skill: crafting
       level: 56
       xp: 90
-      inputs:
+      materials:
         - item_name: Diamond
           quantity: 1
         - item_name: Gold bar
@@ -69,8 +72,8 @@ osrs:
       - F2P accessible (enchanting included)
       - PvP demand for emergency healing
       - Consumed on use — steady demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-battlemage-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-battlemage-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine battlemage potion(1) | OSRS Price Data
-description: "Divine battlemage potion(1): 1 dose of divine battlemage potion.. High alch: 108 GP, GE limit: 2,000."
+description: "Divine battlemage potion(1) is a single-dose members potion granting boosted Magic and Defence with a divine immunity. High alch: 108 GP, GE limit: 2,000."
 osrs:
   id: 24632
   name: Divine battlemage potion(1)
@@ -12,9 +12,73 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 2000
-  about: "Divine battlemage potion(1) is a members-only item in Old School RuneScape. High alchemy value: 108 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    doses: 1
+    type: combat
+    effects:
+      - name: Magic boost
+        description: Boosts Magic by 4 levels for the duration.
+        duration: 300
+      - name: Defence boost
+        description: Boosts Defence by 5 + 15% of base level, locked from further potion boosts.
+        duration: 300
+  herblore:
+    level: 80
+    xp: 90
+  recipes:
+    - skill: herblore
+      level: 80
+      xp: 90
+      materials:
+        - item_name: Battlemage potion(4)
+          item_id: 22451
+          quantity: "1"
+        - item_name: Ancient essence
+          item_id: 28924
+          quantity: "125"
+      product: Divine battlemage potion(4)
+      product_id: 24623
+      output_quantity: 1
+      facility: None
+      members_only: true
+  related_items:
+    - item_id: 24623
+      item_name: Divine battlemage potion(4)
+      slug: divine-battlemage-potion-4
+      relationship: variant
+      description: 4-dose form
+    - item_id: 24626
+      item_name: Divine battlemage potion(3)
+      slug: divine-battlemage-potion-3
+      relationship: variant
+      description: 3-dose form
+    - item_id: 24629
+      item_name: Divine battlemage potion(2)
+      slug: divine-battlemage-potion-2
+      relationship: variant
+      description: 2-dose form
+    - item_id: 22451
+      item_name: Battlemage potion(4)
+      slug: battlemage-potion-4
+      relationship: alternative
+      description: Non-divine equivalent
+  market_strategy:
+    notes:
+      - Locks Defence boost for the duration; popular in LMS and PvP
+      - Single-dose decant target for cheap per-dose entry
+      - Demand spikes around tournaments and PvP events
+  trading_tips:
+    - Decant lower doses to 4-dose for resale margin
+    - Watch Ancient essence and Battlemage(4) price feed for crafting profit
+  about: Divine battlemage potion(1) is the single-dose form of the divine battlemage potion, locking the Defence boost so other Defence potions cannot stack on top.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2019-01-10"
+      description: Divine battlemage potion released with the Ancient essence rework.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-attack-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/divine-super-attack-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Divine super attack potion(1) | OSRS Price Data
-description: "Divine super attack potion(1): 1 dose of divine super attack potion.. High alch: 24 GP, GE limit: 2,000."
+description: "Divine super attack potion(1) is a single-dose members potion granting boosted Attack with a divine immunity. High alch: 24 GP, GE limit: 2,000."
 osrs:
   id: 23706
   name: Divine super attack potion(1)
@@ -12,9 +12,70 @@ osrs:
   lowalch: 16
   highalch: 24
   limit: 2000
-  about: "Divine super attack potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: mid
+  potion:
+    doses: 1
+    type: combat
+    effects:
+      - name: Attack boost
+        description: Boosts Attack by 5 + 15% of base level, locked from further potion boosts.
+        duration: 300
+  herblore:
+    level: 78
+    xp: 80
+  recipes:
+    - skill: herblore
+      level: 78
+      xp: 80
+      materials:
+        - item_name: Super attack(4)
+          item_id: 145
+          quantity: "1"
+        - item_name: Ancient essence
+          item_id: 28924
+          quantity: "125"
+      product: Divine super attack potion(4)
+      product_id: 23694
+      output_quantity: 1
+      facility: None
+      members_only: true
+  related_items:
+    - item_id: 23694
+      item_name: Divine super attack potion(4)
+      slug: divine-super-attack-potion-4
+      relationship: variant
+      description: 4-dose form
+    - item_id: 23700
+      item_name: Divine super attack potion(3)
+      slug: divine-super-attack-potion-3
+      relationship: variant
+      description: 3-dose form
+    - item_id: 23703
+      item_name: Divine super attack potion(2)
+      slug: divine-super-attack-potion-2
+      relationship: variant
+      description: 2-dose form
+    - item_id: 145
+      item_name: Super attack(4)
+      slug: super-attack-4
+      relationship: alternative
+      description: Non-divine equivalent
+  market_strategy:
+    notes:
+      - Single-dose typically less efficient than 4-dose for use
+      - Often the cheapest per-dose route from decanting
+      - Niche compared to divine super combat
+  trading_tips:
+    - Decant to higher doses for resale margin when spread allows
+    - Compare to plain super attack for activity-specific value
+  about: Divine super attack potion(1) is the single-dose form of the divine super attack potion, locking the player's Attack boost so other Attack potions cannot stack on top.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2018-01-04"
+      description: Divine super attack potion added to OSRS.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bitter-m4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-bitter-m4.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
+  material:
+    type: beverage
+    tier: low
   about: "Dragon bitter(m4) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-p-19488.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-javelin-p-19488.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 180
   highalch: 270
   limit: 11000
-  about: "Dragon javelin(p+) is a members-only item in Old School RuneScape. High alchemy value: 270 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: dragon
+    tier: high
+  about: "Dragon javelin(p+) is a members-only poisoned javelin in Old School RuneScape. High alchemy value: 270 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-legs-skirt-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-legs-skirt-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Dragon legs/skirt ornament kit | OSRS Price Data
-description: "Dragon legs/skirt ornament kit: Use on dragon platelegs or plateskirt to make them look fancier!. High alch: 3,000 GP, GE limit: 4."
+description: "Dragon legs/skirt ornament kit recolours dragon platelegs or plateskirt for cosmetic flair. High alch: 3,000 GP, GE limit: 4."
 osrs:
   id: 12536
   name: Dragon legs/skirt ornament kit
@@ -12,9 +12,64 @@ osrs:
   lowalch: 2000
   highalch: 3000
   limit: 4
-  about: "Dragon legs/skirt ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
+  related_items:
+    - item_id: 1187
+      item_name: Dragon platelegs
+      slug: dragon-platelegs
+      relationship: component
+      description: Recolour target for the kit
+    - item_id: 4087
+      item_name: Dragon plateskirt
+      slug: dragon-plateskirt
+      relationship: component
+      description: Recolour target for the kit
+    - item_id: 12537
+      item_name: Dragon platelegs (or)
+      slug: dragon-platelegs-or
+      relationship: product
+      description: Result of applying kit to platelegs
+    - item_id: 12538
+      item_name: Dragon plateskirt (or)
+      slug: dragon-plateskirt-or
+      relationship: product
+      description: Result of applying kit to plateskirt
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "GE buy limit of 4 keeps supply tight and prices volatile"
+      - "Cosmetic only; kit is reversible so resale demand persists"
+      - "Pricing closely tracks Hard clue scroll completion rates"
+  trading_tips:
+    - Verify authenticity when trading high-value items
+    - Use Grand Exchange for secure trades
+    - Track Hard clue casket loot drop rates for supply trends
+  about: "Dragon legs/skirt ornament kit is a members-only Hard clue scroll reward that cosmetically recolours dragon platelegs or dragon plateskirt without changing combat stats."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Use
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2014-12-04"
+      description: "Dragon legs/skirt ornament kit added as a Hard clue scroll reward."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-sheet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragon-metal-sheet.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 30000
   limit: 64
   about: "Dragon metal sheet is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 64 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-armour-set.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dragonstone-armour-set.mdx
@@ -11,10 +11,13 @@ osrs:
   value: 80000
   lowalch: 32000
   highalch: 48000
-  limit: null
+  limit:
+  material:
+    type: dragonstone
+    tier: high
   about: "Dragonstone armour set is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-helmet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/dwarven-helmet.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 50
+  material:
+    type: metal
+    tier: mid
   about: "Dwarven helmet is a members-only item in Old School RuneScape. High alchemy value: 36,000 coins. Grand Exchange buy limit: 50 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/echo-ahrim-s-ornament-kit.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/echo-ahrim-s-ornament-kit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Echo ahrim's ornament kit | OSRS Price Data
-description: "Echo ahrim's ornament kit is a members-only OSRS item. High alch: 3,000 GP."
+description: "Echo ahrim's ornament kit is a members-only Leagues V cosmetic for Ahrim's robes. High alch: 3,000 GP."
 osrs:
   id: 30451
   name: Echo ahrim's ornament kit
@@ -11,10 +11,56 @@ osrs:
   value: 5000
   lowalch: 2000
   highalch: 3000
-  limit: null
-  about: "Echo ahrim's ornament kit is a members-only item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  material:
+    type: cosmetic
+    tier: high
+  related_items:
+    - item_name: Ahrim's hood
+      slug: ahrims-hood
+      relationship: component
+      description: Recolour target for the Echo-style ornament kit
+    - item_name: Ahrim's robetop
+      slug: ahrims-robetop
+      relationship: component
+      description: Recolour target for the Echo-style ornament kit
+    - item_name: Ahrim's robeskirt
+      slug: ahrims-robeskirt
+      relationship: component
+      description: Recolour target for the Echo-style ornament kit
+    - item_name: Ahrim's staff
+      slug: ahrims-staff
+      relationship: component
+      description: Recolour target for the Echo-style ornament kit
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Cosmetic-only kit with no combat impact on Ahrim's pieces"
+      - "Demand driven by Leagues V Raging Echoes nostalgia"
+      - "Reversible recolour, so resale supply is healthier than untradeables"
+  trading_tips:
+    - Verify authenticity when trading high-value items
+    - Use Grand Exchange for secure trades
+    - Watch for Leagues-anniversary demand spikes
+  about: "Echo ahrim's ornament kit is a members-only cosmetic kit used on Ahrim's robes to recolour the set in the Leagues V Raging Echoes style."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Use
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2024-11-13"
+      description: "Echo ahrim's ornament kit added with Leagues V: Raging Echoes."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-tassets-broken.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/eclipse-moon-tassets-broken.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 115964
   highalch: 173946
   limit: 15
+  material:
+    type: metal
+    tier: high
   about: "Eclipse moon tassets (broken) is a members-only item in Old School RuneScape. High alchemy value: 173,946 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-hood.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elder-chaos-hood.mdx
@@ -1,6 +1,6 @@
 ---
 title: Elder chaos hood | OSRS Price Data
-description: "Elder chaos hood: The hood worn by the dangerous elder druids.. High alch: 300 GP, GE limit: 8."
+description: "Elder chaos hood is a members head slot Magic robe piece from medium clue rewards. High alch: 300 GP, GE limit: 8."
 osrs:
   id: 20595
   name: Elder chaos hood
@@ -12,9 +12,85 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 8
-  about: "Elder chaos hood is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: robe
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.453
+    requirements:
+      magic: 1
+      defence: 1
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 2
+      ranged: -1
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 3
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  treasure_trail:
+    tier: medium
+    is_reward: true
+    reward_tiers:
+      - medium
+  related_items:
+    - item_id: 10548
+      item_name: Chaos robe top
+      slug: chaos-robe-top
+      relationship: alternative
+      description: Standard chaos druid top
+    - item_id: 20593
+      item_name: Elder chaos robe
+      slug: elder-chaos-robe
+      relationship: set-piece
+      description: Body slot of the Elder chaos druid set
+    - item_id: 20520
+      item_name: Elder chaos top
+      slug: elder-chaos-top
+      relationship: set-piece
+      description: Top slot of the Elder chaos druid set
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Cosmetic-leaning Magic head with very low combat stats"
+      - "Tight GE limit of 8 keeps supply thin"
+      - "Demand mostly driven by full Elder chaos set collectors"
+  trading_tips:
+    - Verify authenticity when trading high-value items
+    - Use Grand Exchange for secure trades
+    - Buy when medium clue completions trend upward
+  about: "Elder chaos hood is a members-only Magic-themed head slot robe obtained as a medium clue scroll reward; it pairs with the Elder chaos top and robe to complete the Elder chaos druid set."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2017-07-13"
+      description: "Elder chaos hood added with the Elder chaos druid robe set update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elkhorn-frag.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elkhorn-frag.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 600
+  material:
+    type: organic
+    tier: low
   about: "Elkhorn frag is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/energy-potion-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Energy potion(2) | OSRS Price Data
-description: "Energy potion(2): 2 doses of energy potion.. High alch: 43 GP, GE limit: 2,000."
+description: "Energy potion(2) is a free-to-play Herblore potion restoring run energy. High alch: 43 GP, GE limit: 2,000."
 osrs:
   id: 3012
   name: Energy potion(2)
@@ -12,9 +12,58 @@ osrs:
   lowalch: 28
   highalch: 43
   limit: 2000
-  about: "Energy potion(2) is a free-to-play item in Old School RuneScape. High alchemy value: 43 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: potion
+    tier: low
+  potion:
+    doses: 2
+    effects:
+      - stat: run_energy
+        amount: 20
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 26
+      xp: 67.5
+      output_quantity: 1
+      materials:
+        - item_name: Energy potion(3)
+          quantity: "1"
+        - item_name: Vial
+          quantity: "1"
+      product: Energy potion(2)
+  related_items:
+    - item_id: 3008
+      item_name: Energy potion(4)
+      slug: energy-potion-4
+      relationship: variant
+      description: 4-dose variant
+    - item_id: 3010
+      item_name: Energy potion(3)
+      slug: energy-potion-3
+      relationship: variant
+      description: 3-dose variant
+    - item_id: 3014
+      item_name: Energy potion(1)
+      slug: energy-potion-1
+      relationship: variant
+      description: 1-dose variant
+    - item_id: 12625
+      item_name: Stamina potion(4)
+      slug: stamina-potion-4
+      relationship: upgrade
+      description: Stronger run energy potion
+  market_strategy:
+    notes:
+      - Restores 20% run energy per dose
+      - Split from 4-dose for arbitrage opportunities
+      - Steady demand from F2P questers
+  trading_tips:
+    - Buy 4-dose and decant for profit when spread favors it
+    - Use Grand Exchange for fast trades
+  about: "Energy potion(2) is a 2-dose Herblore potion that restores 20% run energy per dose. Available to free-to-play players and crafted at 26 Herblore."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-anti-venom-4.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 177
   highalch: 266
   limit: 2000
+  material:
+    type: potion
+    tier: high
   about: "Extended anti-venom+(4) is a members-only item in Old School RuneScape. High alchemy value: 266 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-antifire-2.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extended antifire(2) | OSRS Price Data
-description: "Extended antifire(2): 2 doses of extended anti-firebreath potion.. High alch: 132 GP, GE limit: 2,000."
+description: "Extended antifire(2): 2 doses of extended anti-firebreath potion. High alch: 132 GP, GE limit: 2,000."
 osrs:
   id: 11955
   name: Extended antifire(2)
@@ -13,8 +13,8 @@ osrs:
   highalch: 132
   limit: 2000
   about: "Extended antifire(2) is a members-only item in Old School RuneScape. High alchemy value: 132 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extended-super-antifire-2.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 432
   limit: 2000
   about: "Extended super antifire(2) is a members-only item in Old School RuneScape. High alchemy value: 432 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/extreme-energy-potion-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Extreme energy potion(1) | OSRS Price Data
-description: "Extreme energy potion(1): 1 dose of extreme energy potion.. High alch: 24 GP."
+description: "Extreme energy potion(1) is a 1-dose run energy restorative for members. High alch: 24 GP."
 osrs:
   id: 31623
   name: Extreme energy potion(1)
@@ -11,10 +11,81 @@ osrs:
   value: 40
   lowalch: 16
   highalch: 24
-  limit: null
-  about: "Extreme energy potion(1) is a members-only item in Old School RuneScape. High alchemy value: 24 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  material:
+    type: consumable
+    tier: mid-high
+  potion:
+    doses: 1
+    effects:
+      - skill: run_energy
+        boost: 50
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 88
+      xp: 110
+      materials:
+        - item_name: Super energy potion(1)
+          item_id: 3020
+          quantity: 1
+        - item_name: Ground mud rune
+          item_id: 23733
+          quantity: 1
+      product: Extreme energy potion(1)
+      product_id: 31623
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 31621
+      item_name: Extreme energy potion(2)
+      slug: extreme-energy-potion-2
+      relationship: variant
+      description: 2-dose variant of the same brew
+    - item_id: 31619
+      item_name: Extreme energy potion(3)
+      slug: extreme-energy-potion-3
+      relationship: variant
+      description: 3-dose variant of the same brew
+    - item_id: 31617
+      item_name: Extreme energy potion(4)
+      slug: extreme-energy-potion-4
+      relationship: variant
+      description: 4-dose variant of the same brew
+    - item_id: 3020
+      item_name: Super energy potion
+      slug: super-energy-potion
+      relationship: downgrade
+      description: Weaker run energy restore alternative
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "No GE buy limit listed; supply tied to high-level Herblore brewers"
+      - "1-dose tends to trade at a discount per dose vs 4-dose"
+      - "Demand spikes with new agility content and long PvM travel routes"
+  trading_tips:
+    - Use Grand Exchange for secure trades
+    - Decant from 4-dose when 1-dose is overpriced
+    - Buy small lots for hot-spot agility training
+  about: "Extreme energy potion(1) is a members-only 1-dose run energy restorative brewed at Herblore 88; it restores significantly more run energy than super energy potion and is decanted from the 4-dose form."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Drink
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2024-08-14"
+      description: "Extreme energy potion added to OSRS as part of the extreme potion family update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fenkenstrain-s-castle-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fenkenstrain-s-castle-teleport-tablet.mdx
@@ -1,6 +1,6 @@
 ---
 title: Fenkenstrain's castle teleport (tablet) | OSRS Price Data
-description: "Fenkenstrain's castle teleport (tablet): A teleport to Fenkenstrain's Castle.. High alch: 1 GP, GE limit: 10,000."
+description: "Fenkenstrain's castle teleport tablet is a single-use Magic tablet that teleports the player to Fenkenstrain's Castle. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 19621
   name: Fenkenstrain's castle teleport (tablet)
@@ -12,9 +12,66 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
-  about: "Fenkenstrain's castle teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teleport-tablet
+    tier: low
+  recipes:
+    - skill: magic
+      level: 48
+      xp: 65
+      materials:
+        - item_name: Soft clay
+          item_id: 1761
+          quantity: 1
+        - item_name: Law rune
+          item_id: 563
+          quantity: 1
+        - item_name: Earth rune
+          item_id: 557
+          quantity: 1
+      product: Fenkenstrain's castle teleport (tablet)
+      product_id: 19621
+      output_quantity: 1
+      facility: Lectern
+  related_items:
+    - item_id: 1761
+      item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Tablet substrate
+    - item_id: 563
+      item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Required to bind the teleport
+    - item_id: 557
+      item_name: Earth rune
+      slug: earth-rune
+      relationship: component
+      description: Elemental rune used to charge the tablet
+  market_strategy:
+    notes:
+      - Niche teleport mostly used for Morytania Slayer access
+      - Demand scales with Slayer tasks pointing toward Fenkenstrain's Castle
+      - "Crafting cost is bound by law rune price; arbitrage hinges on rune market"
+  trading_tips:
+    - Compare GE price vs law + earth rune + soft clay cost before crafting
+    - Bulk-buy when planning Morytania content runs
+    - "Avoid hoarding: limited demand outside of Slayer routes"
+  about: "Fenkenstrain's castle teleport (tablet) is a members-only Magic tablet that teleports the player to Fenkenstrain's Castle in Morytania. High alchemy value: 1 coin. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2018-02-08"
+      description: Added with the Kourend & Kebos teleport tablet expansion.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fish-chunks.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fish-chunks.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 13000
+  material:
+    type: bait
+    tier: low
   about: "Fish chunks is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fishing-potion-3.mdx
@@ -27,8 +27,8 @@ osrs:
     > _"3 doses of Fishing potion."_
 
     The fishing potion provides a temporary +3 Fishing boost. Useful for catching fish slightly above your current level.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fried-onions.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fried-onions.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 4
   limit: 13000
   about: "Fried onions is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-dresser-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-dresser-flatpack.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
+  material:
+    type: flatpack
+    tier: low
   about: "Gilded dresser (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/gilded-plateskirt.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
+  material:
+    type: rune
+    tier: high
   about: "Gilded plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/glassblowing-pipe.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/glassblowing-pipe.mdx
@@ -1,6 +1,6 @@
 ---
 title: Glassblowing pipe | OSRS Price Data
-description: "Glassblowing pipe: Used to form molten glass into useful items.. High alch: 1 GP, GE limit: 40."
+description: "Glassblowing pipe is the members crafting tool used to shape molten glass into finished glass items. High alch: 1 GP, GE limit: 40."
 osrs:
   id: 1785
   name: Glassblowing pipe
@@ -12,9 +12,55 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 40
-  about: "Glassblowing pipe is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 40 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: tool
+    tier: low
+  shops:
+    - shop_name: "Aaron's Archery Appendages"
+      location: Catherby
+      price: 2
+      stock: 5
+      currency: coins
+    - shop_name: "Razmire General Store"
+      location: Mort'ton
+      price: 2
+      stock: 5
+      currency: coins
+  related_items:
+    - item_id: 1775
+      item_name: Molten glass
+      slug: molten-glass
+      relationship: component
+      description: Material processed with this tool
+    - item_id: 1777
+      item_name: Bucket of sand
+      slug: bucket-of-sand
+      relationship: component
+      description: Input for molten glass
+    - item_id: 1781
+      item_name: Soda ash
+      slug: soda-ash
+      relationship: component
+      description: Input for molten glass
+    - item_id: 1787
+      item_name: Glass bottle
+      slug: glass-bottle
+      relationship: product
+      description: Common glassblowing pipe output
+  market_strategy:
+    notes:
+      - Required for all glassblowing crafting actions
+      - One-time purchase per account, very low demand
+      - Cheap from general store, GE rarely needed
+  trading_tips:
+    - Buy from a general store rather than wait for GE order
+    - Keep one in bank for crafting training
+  about: Glassblowing pipe is a members crafting tool that allows turning molten glass into items such as beer glasses, vials, orbs, and lantern lenses.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2002-12-11"
+      description: Glassblowing pipe added with the Crafting expansion that introduced glass items.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goat-horn-dust.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goat-horn-dust.mdx
@@ -1,6 +1,6 @@
 ---
 title: Goat horn dust | OSRS Price Data
-description: "Goat horn dust: Finely ground desert goat horn.. High alch: 7 GP, GE limit: 13,000."
+description: "Goat horn dust is a members Herblore secondary used for Combat potion. High alch: 7 GP, GE limit: 13,000."
 osrs:
   id: 9736
   name: Goat horn dust
@@ -12,53 +12,63 @@ osrs:
   lowalch: 4
   highalch: 7
   limit: 13000
-  item:
+  material:
     type: herblore_secondary
-    tradeable: true
-    weight: 0.453
+    tier: low
   recipes:
     - skill: crafting
+      level: 1
+      xp: 1
+      output_quantity: 1
       materials:
         - item_name: Desert goat horn
-          quantity: 1
+          quantity: "1"
         - item_name: Pestle and mortar
-          quantity: 1
+          quantity: "1"
       product: Goat horn dust
-  uses:
-    - name: Combat potion
-      skill: herblore
+    - skill: herblore
       level: 36
-      partner: Harralander potion (unf)
+      xp: 84
+      output_quantity: 1
+      materials:
+        - item_name: Harralander potion (unf)
+          quantity: "1"
+        - item_name: Goat horn dust
+          quantity: "1"
+      product: Combat potion(3)
   related_items:
     - item_id: 9735
       item_name: Desert goat horn
       slug: desert-goat-horn
       relationship: component
-      description: Raw material
+      description: Raw material ground into dust
     - item_id: 9739
       item_name: Combat potion(4)
       slug: combat-potion-4
       relationship: product
-      description: Primary use
+      description: Primary use as Herblore secondary
     - item_id: 255
       item_name: Harralander
       slug: harralander
       relationship: alternative
-      description: Partner herb
+      description: Partner herb used in the unfinished potion
+  market_strategy:
+    notes:
+      - Secondary ingredient for Combat potion at 36 Herblore
+      - Demand driven by combat-potion flippers
+      - Supply depends on desert goat horn farming
+  trading_tips:
+    - Buy desert goat horn and grind for profit when spread allows
+    - Use Grand Exchange for bulk orders
   about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.453 kg |
+    Goat horn dust is a Herblore secondary made by grinding a desert goat horn with a pestle and mortar.
 
     Secondary ingredient for:
     - Combat potion (with harralander potion unf at 36 Herblore)
 
     Provides Attack and Strength boosts in one potion.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-book.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/goblin-book.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 15
+  material:
+    type: book
+    tier: low
   about: "Goblin book is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/golovanova-fruit-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/golovanova-fruit-top.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 1
   limit: 100
   about: "Golovanova fruit top is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/granite-gloves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/granite-gloves.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 13600
   highalch: 20400
   limit: 8
+  material:
+    type: stone
+    tier: mid
   equipment:
     slot: hands
     weight: 1
@@ -83,8 +86,8 @@ osrs:
       - Most players prefer Barrows gloves
       - Drops alongside other granite items
       - Gargoyle task required to fight boss
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/greater-siren.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/greater-siren.mdx
@@ -12,9 +12,17 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: salamander
+    tier: low
   about: "Greater siren is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Hunter-aspect tradeable salamander variant"
+      - "Alch value floors at 1 gp so demand is driven by hunter content not alching"
+      - "Buy limit of 13,000 per 4 hours on the Grand Exchange"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-hat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-hat.mdx
@@ -12,20 +12,49 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 150
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: head
+    weight: 0.226
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
   related_items:
     - item_id: 638
       item_name: Green robe top
       slug: green-robe-top
       relationship: set-piece
       description: Matching top
+  market_strategy:
+    notes:
+      - Purely cosmetic with no stat bonuses
+      - Part of the gnome clothing set
+      - Low demand outside of fashionscape
+  trading_tips:
+    - Use Grand Exchange for fast trades
+    - Stock is typically plentiful
   about: |-
     > _"A green hat."_
 
     The green hat is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/green-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/green-robe-top.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 150
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: body
   related_items:
@@ -29,8 +32,8 @@ osrs:
     > _"A green robe top."_
 
     The green robe top is part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/grey-boots.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/grey-boots.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 300
   limit: 150
   about: "Grey boots is a free-to-play item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guam-potion-unf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guam-potion-unf.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guam potion (unf) | OSRS Price Data
-description: "Guam potion (unf) is a 4-dose members potion. High alch: 1 GP, GE limit: 10,000."
+description: "Guam potion (unf) is a 1-dose unfinished potion used as a Herblore intermediate. High alch: 1 GP, GE limit: 10,000."
 osrs:
   id: 91
   name: Guam potion (unf)
@@ -12,13 +12,13 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 10000
+  material:
+    type: potion
+    tier: low
   potion:
     type: unfinished
-    tier: basic
-  herblore:
-    level: 3
-    xp: 0
-    method: Add guam leaf to vial of water
+    tier: standard
+    doses: 1
   recipes:
     - skill: herblore
       level: 3
@@ -32,7 +32,7 @@ osrs:
           quantity: 1
       product: Guam potion (unf)
       product_id: 91
-      product_quantity: 1
+      output_quantity: 1
   related_items:
     - item_id: 249
       item_name: Guam leaf
@@ -54,21 +54,29 @@ osrs:
       slug: attack-potion-3
       relationship: product
       description: Basic combat potion
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Unfinished Potion |
-    | Tradeable | Yes |
-    | Weight | 0.056 kg |
-    | Requirements | 3 Herblore |
-
-    Add secondary ingredient to create:
-    - Attack potion (+ eye of newt)
-
-    The most basic unfinished potion for herblore training.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - High volume Herblore intermediate; prices are tightly linked to Guam leaf
+      - Useful for low-level Herblore training and Attack potion supply
+      - "Margin watch: track vial of water + guam leaf vs unf price for arbitrage"
+  trading_tips:
+    - Bulk purchase Guam leaves separately when cheaper than unfinished
+    - Combine with eye of newt to create Attack potion
+    - Decant only when GE has shortage of finished potions
+  about: "Guam potion (unf) is a members-only unfinished Herblore potion created by adding a Guam leaf to a vial of water. High alchemy value: 1 coin. Grand Exchange buy limit: 10,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2002-01-04"
+      description: Added to the game with the Herblore skill release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-balance-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix balance(1) | OSRS Price Data
-description: "Guthix balance(1): A potion of harralander, red spiders eggs, garlic and silver dust.. High alch: 120 GP, GE limit: 2,000."
+description: "Guthix balance(1) is a 1-dose anti-vampyre potion for In Aid of the Myreque. High alch: 120 GP, GE limit: 2,000."
 osrs:
   id: 7666
   name: Guthix balance(1)
@@ -12,9 +12,83 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Guthix balance(1) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: consumable
+    tier: mid
+  potion:
+    doses: 1
+    effects:
+      - skill: damage
+        boost: 0
+        duration: 0
+  recipes:
+    - skill: herblore
+      level: 22
+      xp: 25
+      materials:
+        - item_name: Guthix rest(1)
+          item_id: 4419
+          quantity: 1
+        - item_name: Garlic
+          item_id: 1550
+          quantity: 1
+        - item_name: Silver dust
+          item_id: 7650
+          quantity: 1
+      product: Guthix balance(1)
+      product_id: 7666
+      output_quantity: 1
+      members_only: true
+  related_items:
+    - item_id: 7662
+      item_name: Guthix balance(2)
+      slug: guthix-balance-2
+      relationship: variant
+      description: 2-dose variant of the same brew
+    - item_id: 7664
+      item_name: Guthix balance(3)
+      slug: guthix-balance-3
+      relationship: variant
+      description: 3-dose variant of the same brew
+    - item_id: 7660
+      item_name: Guthix balance(4)
+      slug: guthix-balance-4
+      relationship: variant
+      description: 4-dose variant of the same brew
+    - item_id: 4419
+      item_name: Guthix rest(1)
+      slug: guthix-rest-1
+      relationship: component
+      description: Base potion used in the recipe
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Niche anti-vampyre potion used in In Aid of the Myreque and Vyrewatch combat"
+      - "Low passive demand; price tied to quest spikes"
+      - "1-dose variant typically priced below higher-dose forms"
+  trading_tips:
+    - Use Grand Exchange for secure trades
+    - Stockpile before Myreque quest reruns or content updates
+    - Decant from higher doses when 1-dose is unusually expensive
+  about: "Guthix balance(1) is a members-only 1-dose anti-vampyre potion brewed from Guthix rest, garlic, and silver dust; it weakens Vyrewatch and Juvinates and is used during the Myreque quest line."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Drink
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2005-07-12"
+      description: "Guthix balance potions added with In Aid of the Myreque."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-coif.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-coif.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 8
+  material:
+    type: dragonhide
+    tier: mid-high
   equipment:
     slot: head
     attack_bonus:
@@ -34,6 +37,8 @@ osrs:
     requirements:
       ranged: 70
       defence: 40
+  treasure_trail:
+    tier: hard
   related_items:
     - item_id: 10374
       item_name: Zamorak coif
@@ -61,11 +66,11 @@ osrs:
     All blessed coifs share identical stats. They offer a +1 prayer bonus over a standard coif while maintaining the same defensive profile. The choice between god variants is purely cosmetic.
   market_strategy:
     notes:
-      - Hard clue exclusive — supply tied to clue completion rates
+      - "Hard clue exclusive — supply tied to clue completion rates"
       - Price differences between gods are cosmetic preference only
       - Armadyl and Ancient tend to command slight premiums
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-d-hide-shield.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 11333
   highalch: 17000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: blessed-dragonhide
+    tier: high
   equipment:
     slot: shield
     type: ranged armour
@@ -34,13 +39,14 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer_bonus: 1
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        requirements:
-          clue_type: Hard
+  treasure_trail:
+    tier: hard
+  drop_table:
+    sources:
+      - source: Hard clue scroll casket
+        quantity: "1"
         rarity: Rare
-        description: Reward from hard clue scroll caskets (1/9,750)
+        notes: "Reward from hard clue scroll caskets (1/9,750)"
   related_items:
     - item_id: 23191
       item_name: Saradomin d'hide shield
@@ -76,7 +82,6 @@ osrs:
 
     The blessed d'hide shields are comparable to the black d'hide shield but with an added +1 prayer bonus. For players seeking a ranged shield with prayer, these are a strong budget option. The book of law and other god books offer different stat distributions for the shield slot and may be preferred for offensive setups where the ranged attack bonus matters more than defence.
   market_strategy:
-    title: Investment Notes
     notes:
       - All god d'hide shield variants share the same stats, so price differences are driven by cosmetic demand
       - Guthix variants tend to sit in the mid-range among the six god options
@@ -84,8 +89,10 @@ osrs:
       - Compare prices across all six god variants before buying since stats are identical
       - Useful for God Wars Dungeon as Guthix protection in the shield slot
       - Buy limit of 8 per 4 hours on the Grand Exchange
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - All god d'hide shield variants share the same stats, so price differences are driven by cosmetic demand
+    - Guthix variants tend to sit in the mid-range among the six god options
+    - Compare prices across all six god variants before buying since stats are identical
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/guthix-page-1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Guthix page 1 | OSRS Price Data
-description: "Guthix page 1: This seems to have been torn from a book.... High alch: 120 GP, GE limit: 5."
+description: "Guthix page 1: This seems to have been torn from a book. High alch: 120 GP, GE limit: 5."
 osrs:
   id: 3835
   name: Guthix page 1
@@ -12,16 +12,11 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 5
-  item:
+  material:
     type: god_page
-    god: Guthix
-    page_number: 1
-    tradeable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Easy/Medium/Hard/Elite
-        drop_rate: Varies by tier
+    tier: mid
+  treasure_trail:
+    tier: hard
   related_items:
     - item_id: 3836
       item_name: Guthix page 2
@@ -68,8 +63,8 @@ osrs:
       - Collect all 4 pages
       - Balanced offensive stats
       - Hybrid/tribrid setups
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-poultice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/haemostatic-poultice.mdx
@@ -11,10 +11,10 @@ osrs:
   value: 170
   lowalch: 68
   highalch: 102
-  limit: null
+  limit:
   about: "Haemostatic poultice is a members-only item in Old School RuneScape. High alchemy value: 102 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/holy-blessing.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/holy-blessing.mdx
@@ -22,21 +22,23 @@ osrs:
   drop_table:
     sources:
       - source: Treasure Trails (Medium)
-        rate: 10/6,820
+        rate: "10/6,820"
+        quantity: "1"
       - source: Treasure Trails (Hard)
-        rate: 1/541.7
+        rate: "1/541.7"
+        quantity: "1"
       - source: Treasure Trails (Elite)
-        rate: 1/645.8
+        rate: "1/645.8"
+        quantity: "1"
       - source: Treasure Trails (Master)
-        rate: 1/606.4
+        rate: "1/606.4"
+        quantity: "1"
       - source: Treasure Trails (Easy)
-        rate: 11/23,760
-  special_effect:
-    name: GWD Protection
-    description: Provides protection from Saradomin followers in God Wars Dungeon
-  market:
-    buy_limit: 5
-    price_estimate: 10900
+        rate: "11/23,760"
+        quantity: "1"
+  passive_effects:
+    - name: GWD Protection
+      description: Provides protection from Saradomin followers in God Wars Dungeon
   related_items:
     - item_id: 22941
       item_name: Rada's blessing 4
@@ -64,8 +66,12 @@ osrs:
     - Free prayer bonus
     - Ammo slot when not using arrows
     - Saradomin GWD protection
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "Buy limit: 5 per 4 hours"
+      - "Price estimate: ~10,900 gp"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/immature-tecu-salamander.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/immature-tecu-salamander.mdx
@@ -11,10 +11,13 @@ osrs:
   value: 200
   lowalch: 80
   highalch: 120
-  limit: null
+  limit:
+  material:
+    type: organic
+    tier: low
   about: "Immature tecu salamander is a members-only item in Old School RuneScape. High alchemy value: 120 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dart-p-5629.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/iron-dart-p-5629.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: iron
+    tier: low
   about: "Iron dart(p+) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/javelin-shaft.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/javelin-shaft.mdx
@@ -5,16 +5,19 @@ osrs:
   id: 19584
   name: Javelin shaft
   slug: javelin-shaft
-  examine: It's not very strong, but it could be pointy if you put a pointy tip on it.
+  examine: "It's not very strong, but it could be pointy if you put a pointy tip on it."
   members: true
   icon: Javelin shaft 5.png
   value: 1
   lowalch: 1
   highalch: 1
   limit: 7000
+  material:
+    type: ammunition_component
+    tier: low
   about: "Javelin shaft is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jug-of-water.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jug-of-water.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
+  material:
+    type: consumable
+    tier: low
   about: "Jug of water is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jug-of-wine.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jug-of-wine.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jug of wine | OSRS Price Data
-description: "Jug of wine: It's full of wine.. High alch: 1 GP, GE limit: 6,000."
+description: "Jug of wine is a free-to-play drink made by adding grapes to a jug of water. High alch: 1 GP, GE limit: 6,000."
 osrs:
   id: 1993
   name: Jug of wine
@@ -12,9 +12,62 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 6000
-  about: "Jug of wine is a free-to-play item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: drink
+    tier: low
+  recipes:
+    - skill: cooking
+      level: 35
+      xp: 200
+      materials:
+        - item_name: Jug of water
+          item_id: 1937
+          quantity: 1
+        - item_name: Grapes
+          item_id: 1987
+          quantity: 1
+      product: Jug of wine
+      product_id: 1993
+      output_quantity: 1
+  related_items:
+    - item_id: 1991
+      item_name: Jug of bad wine
+      slug: jug-of-bad-wine
+      relationship: alternative
+      description: Failed Cooking output below level 68
+    - item_id: 1937
+      item_name: Jug of water
+      slug: jug-of-water
+      relationship: component
+      description: Base liquid required for wine
+    - item_id: 1987
+      item_name: Grapes
+      slug: grapes
+      relationship: component
+      description: Required ingredient for fermenting wine
+  market_strategy:
+    notes:
+      - "F2P Cooking output: healing food and Cooking experience source"
+      - "Price floor near jug + grapes cost; check GE for arbitrage"
+      - Demand bumps during DMM-style F2P combat events
+  trading_tips:
+    - Buy grapes + jugs of water if wine is overpriced relative to inputs
+    - Sell in bulk during F2P combat events for better margins
+    - "Note: failing cook produces jug of bad wine until 68 Cooking"
+  about: "Jug of wine is a free-to-play drink made by combining a jug of water with grapes, granting Cooking experience and minor healing. High alchemy value: 1 coin. Grand Exchange buy limit: 6,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2001-01-04"
+      description: Jug of wine added with the original Cooking skill.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-camo-legs-equipped.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-camo-legs-equipped.mdx
@@ -11,10 +11,10 @@ osrs:
   value: 20
   lowalch: 8
   highalch: 12
-  limit: null
+  limit:
   about: "Jungle camo legs (equipped) is a members-only item in Old School RuneScape. High alchemy value: 12 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-demon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/jungle-demon-mask.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 2400
   limit: 4
   about: "Jungle demon mask is a members-only item in Old School RuneScape. High alchemy value: 2,400 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/kraken-tentacle.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/kraken-tentacle.mdx
@@ -12,19 +12,24 @@ osrs:
   lowalch: 33336
   highalch: 50004
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: kraken
+    tier: high
   item:
     type: crafting_material
     tradeable: true
-  obtaining:
-    methods:
+  drop_table:
+    sources:
       - source: Kraken (boss)
-        drop_rate: 1/400
-        requirements:
-          slayer: 87
+        quantity: "1"
+        rarity: 1/400
+        notes: "Requires 87 Slayer"
       - source: Cave kraken
-        drop_rate: 1/1,200
-        requirements:
-          slayer: 87
+        quantity: "1"
+        rarity: 1/1200
+        notes: "Requires 87 Slayer"
   creation:
     uses:
       - item_id: 12006
@@ -72,8 +77,10 @@ osrs:
       - Farm Kraken boss for best rates
       - Creates abyssal tentacle
       - Used for enhanced tridents
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Farm Kraken boss for best rates
+    - Creates abyssal tentacle
+    - Used for enhanced tridents
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/lumberyard-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/lumberyard-teleport.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lumberyard teleport | OSRS Price Data
-description: "Lumberyard teleport: Teleports you to the Lumberyard.. High alch: 6 GP, GE limit: 15,000."
+description: "Lumberyard teleport: Teleports you to the Lumberyard. High alch: 6 GP, GE limit: 15,000."
 osrs:
   id: 12642
   name: Lumberyard teleport
@@ -12,16 +12,11 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 15000
-  item:
+  material:
     type: teleport_scroll
-    destination: Lumberyard
-    tradeable: true
-    stackable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Medium/Hard/Elite
-        drop_rate: Varies by tier
+    tier: low
+  treasure_trail:
+    tier: medium
   related_items:
     - item_id: 12411
       item_name: Mos le'harmless teleport
@@ -52,8 +47,8 @@ osrs:
       - Useful for Construction
       - Plank making runs
       - Popular utility teleport
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-armour-case-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-armour-case-flatpack.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 500
+  material:
+    type: mahogany
+    tier: mid-high
   about: "Mahogany armour case (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-magic-wardrobe-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-magic-wardrobe-flatpack.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 6
   limit: 500
   about: "Mahogany magic wardrobe (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/maple-bird-house.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/maple-bird-house.mdx
@@ -1,6 +1,6 @@
 ---
 title: Maple bird house | OSRS Price Data
-description: "Maple bird house: Feed and catch the birds by placing this in the right spot.. High alch: 3 GP, GE limit: 250."
+description: "Maple bird house: Feed and catch the birds by placing this in the right spot. High alch: 3 GP, GE limit: 250."
 osrs:
   id: 22192
   name: Maple bird house
@@ -12,9 +12,67 @@ osrs:
   lowalch: 2
   highalch: 3
   limit: 250
-  about: "Maple bird house is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 250 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: trap
+    tier: mid
+  recipes:
+    - skill: crafting
+      level: 44
+      xp: 25
+      output_quantity: 1
+      materials:
+        - item_name: Maple logs
+          quantity: 10
+        - item_name: Clockwork
+          quantity: 1
+  related_items:
+    - item_name: Maple logs
+      slug: maple-logs
+      relationship: component
+      description: Logs required to craft the bird house.
+    - item_name: Clockwork
+      slug: clockwork
+      relationship: component
+      description: Mechanism required for every bird house tier.
+    - item_name: Yew bird house
+      slug: yew-bird-house
+      relationship: upgrade
+      description: Next bird house tier with higher Hunter XP.
+    - item_name: Teak bird house
+      slug: teak-bird-house
+      relationship: downgrade
+      description: Lower-tier bird house option.
+  market_strategy:
+    notes:
+      - Used in Fossil Island bird house trapping runs.
+      - Self-crafted by most Hunters; GE supply is mostly leftover stock.
+      - Each trip uses 4 bird houses placed on Fossil Island bird house spots.
+      - Hunter XP per house is 280 at level 44.
+  trading_tips:
+    - Buy below alch value as a low-risk flip in small volume.
+    - Demand is steady due to bird nest and clue scroll rolls from the trap.
+  about: |-
+    > _"Feed and catch the birds by placing this in the right spot."_
+
+    Mid-tier bird house used on Fossil Island bird house trapping circuits. Crafted from 10 maple logs and a clockwork at Crafting level 44, and baited with hop seeds or wildblood seeds to catch birds for feathers, bird nests, and Hunter XP.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2018-04-12"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2018-04-12"
+      description: Maple bird house released with the Fossil Island bird house trapping update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mature-wmb.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mature-wmb.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mature wmb | OSRS Price Data
-description: "Mature wmb: This looks a good deal stronger than normal Wizards Mind Bomb.. High alch: 1 GP, GE limit: 2,000."
+description: "Mature wmb is a members-only matured Wizard's Mind Bomb that boosts Magic. High alch: 1 GP, GE limit: 2,000."
 osrs:
   id: 5741
   name: Mature wmb
@@ -12,9 +12,61 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 2000
-  about: "Mature wmb is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: consumable
+    tier: low
+  potion:
+    doses: 1
+    effects:
+      - skill: magic
+        boost: 3
+        duration: 0
+      - skill: attack
+        boost: -4
+        duration: 0
+      - skill: strength
+        boost: -4
+        duration: 0
+  related_items:
+    - item_id: 463
+      item_name: Wizard's mind bomb
+      slug: wizards-mind-bomb
+      relationship: alternative
+      description: Standard Wizard's Mind Bomb base brew
+    - item_id: 1907
+      item_name: Asgarnian ale
+      slug: asgarnian-ale
+      relationship: alternative
+      description: Other Asgarnian brew family ale
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Sold to players brewing through the Asgarnian ale recipe line"
+      - "Low alch value limits high-volume flipping margins"
+      - "Demand tied to Magic-boost niche use cases"
+  trading_tips:
+    - Use Grand Exchange for secure trades
+    - Monitor price trends before purchasing
+    - Buy in bulk to amortize the small per-unit spread
+  about: "Mature wmb is a members-only matured ale variant of the Wizard's Mind Bomb obtained through brewing; it gives a stronger temporary Magic boost than the standard brew at the cost of Attack and Strength."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    options:
+      - Drink
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2005-08-01"
+      description: "Mature Wizard's Mind Bomb introduced as a brewing maturation outcome."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/meat-pie.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/meat-pie.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 9
   limit: 10000
   about: "Meat pie is a free-to-play item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-arrow-p-5619.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-arrow-p-5619.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril arrow(p+) | OSRS Price Data
-description: "Mithril arrow(p+): Venomous-looking arrows.. High alch: 19 GP, GE limit: 7,000."
+description: "Mithril arrow(p+) is a members ammo slot arrow with strong poison. High alch: 19 GP, GE limit: 7,000."
 osrs:
   id: 5619
   name: Mithril arrow(p+)
@@ -12,9 +12,61 @@ osrs:
   lowalch: 12
   highalch: 19
   limit: 7000
-  about: "Mithril arrow(p+) is a members-only item in Old School RuneScape. High alchemy value: 19 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: mithril
+    tier: mid
+  equipment:
+    slot: ammo
+    weight: 0.014
+    requirements:
+      ranged: 30
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 11
+      magic_damage: 0
+      prayer: 0
+  passive_effects:
+    - name: Strong poison
+      description: "Inflicts strong poison on hit, dealing damage over time"
+  related_items:
+    - item_id: 882
+      item_name: Mithril arrow
+      slug: mithril-arrow
+      relationship: variant
+      description: Unpoisoned base arrow
+    - item_id: 5617
+      item_name: Mithril arrow(p)
+      slug: mithril-arrow-p
+      relationship: variant
+      description: Regular poison variant
+    - item_id: 5621
+      item_name: Mithril arrow(p++)
+      slug: mithril-arrow-pp
+      relationship: upgrade
+      description: Strongest poison variant
+  market_strategy:
+    notes:
+      - Niche ammo with strong poison proc
+      - Adamant/rune arrows usually preferred for DPS
+      - Demand tied to poison-strategy bossing
+  trading_tips:
+    - Use Grand Exchange for bulk orders
+    - Compare DPS vs adamant arrows before bulk buy
+  about: "Mithril arrow(p+) is a poisoned variant of the mithril arrow that inflicts strong poison on hit. Requires 30 Ranged to use."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-brutal.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-brutal.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mithril brutal | OSRS Price Data
-description: "Mithril brutal: Blunt mithril arrow... ouch.. High alch: 30 GP, GE limit: 11,000."
+description: "Mithril brutal: Blunt mithril arrow used by ogre composite bows. High alch: 30 GP, GE limit: 11,000."
 osrs:
   id: 4793
   name: Mithril brutal
@@ -12,9 +12,79 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 11000
-  about: "Mithril brutal is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: ammunition
+    tier: mid
+  equipment:
+    slot: ammo
+    weight: 0.025
+    requirements:
+      ranged: 30
+    other_bonus:
+      ranged_strength: 26
+  recipes:
+    - skill: fletching
+      level: 55
+      xp: 27
+      output_quantity: 6
+      materials:
+        - item_name: Ogre arrow shaft
+          quantity: 6
+        - item_name: Mithril nails
+          quantity: 6
+        - item_name: Flighted ogre arrow
+          quantity: 6
+  related_items:
+    - item_name: Steel brutal
+      slug: steel-brutal
+      relationship: downgrade
+      description: Lower-tier ogre brutal arrow.
+    - item_name: Adamant brutal
+      slug: adamant-brutal
+      relationship: upgrade
+      description: Higher-tier ogre brutal arrow.
+    - item_name: Ogre composite bow
+      slug: ogre-composite-bow
+      relationship: alternative
+      description: Composite ogre bow that fires brutal arrows.
+    - item_name: Ogre bow
+      slug: ogre-bow
+      relationship: alternative
+      description: Standard ogre bow used with brutal ammunition.
+  market_strategy:
+    notes:
+      - Ogre-only ammunition for the ogre bow and ogre composite bow.
+      - Required for Big Chompy Bird Hunting and Zogre Flesh Eaters tasks.
+      - Self-fletched by most players; GE supply is thin and inconsistent.
+      - Buy limit of 11,000 per 4 hours allows bulk buys for slayer or chompy hunting.
+  trading_tips:
+    - Stock up around Slayer tasks that need zogre or chompy kills.
+    - Fletching from materials is usually cheaper than buying off the GE.
+  about: |-
+    > _"Blunt mithril arrow... ouch."_
+
+    Ogre-specific arrow used with the ogre bow and ogre composite bow. Required for killing chompy birds during Big Chompy Bird Hunting and zogres during Zogre Flesh Eaters, and dealing meaningful damage to either creature.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2003-09-15"
+    tradeable: true
+    stackable: true
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2003-09-15"
+      description: Mithril brutal arrows added with the Zogre Flesh Eaters quest update.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart-p-5632.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-dart-p-5632.mdx
@@ -12,9 +12,56 @@ osrs:
   lowalch: 10
   highalch: 15
   limit: 7000
-  about: "Mithril dart(p+) is a members-only item in Old School RuneScape. High alchemy value: 15 coins. Grand Exchange buy limit: 7,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Mithril dart(p+) is a mithril dart treated with extra-strength weapon poison, dealing higher poison damage than the basic poisoned variant. Used as a thrown Ranged weapon."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2002-03-27"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.01
+  material:
+    type: dart
+    tier: mid
+  equipment:
+    slot: weapon
+    weight: 0.01
+    requirements:
+      ranged: 25
+    attack_bonus:
+      ranged: 11
+    other_bonus:
+      ranged_strength: 10
+  passive_effects:
+    - name: "Extra-strength poison"
+      description: "Hits have a chance to inflict stronger poison damage on the target."
+  related_items:
+    - item_name: Mithril dart
+      slug: mithril-dart
+      relationship: variant
+      description: Non-poisoned base dart.
+    - item_name: Mithril dart(p)
+      slug: mithril-dart-p
+      relationship: downgrade
+      description: Standard weapon poison variant.
+    - item_name: Mithril dart(p++)
+      slug: mithril-dart-p-2
+      relationship: upgrade
+      description: Highest-tier poison variant of the mithril dart.
+  market_strategy:
+    notes:
+      - "Tracks regular mithril dart supply plus weapon poison(+) demand."
+      - "Niche use case with lower volume than standard mithril dart."
+  trading_tips:
+    - "Flip alongside Weapon poison(+) for compounded margins."
+    - "Sell to mid-level rangers training in safe zones."
+  history:
+    - date: "2002-03-27"
+      description: "Mithril dart(p+) released with the original poisoned dart family."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-keel-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mithril-keel-parts.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 750
   limit: 100
   about: "Mithril keel parts is a members-only item in Old School RuneScape. High alchemy value: 750 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/monk-s-robe-t.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 4
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: legs
     requirements: {}
@@ -27,8 +30,8 @@ osrs:
     > *"A \"holy\" robe, now with a \"fashionable\" trim."*
 
     The monk's robe (t) is a trimmed cosmetic variant of monk's robes. Provides +5 Prayer bonus with no requirements. F2P item.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mort-myre-fungus.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mort-myre-fungus.mdx
@@ -15,13 +15,14 @@ osrs:
   material:
     type: secondary
     tier: mid
-  sources:
-    - name: Mort Myre Swamp
-      method: Bloom spell on rotting logs
-    - name: Sulliuscep mushrooms
-      method: Woodcutting
-    - name: Monster drops
-      method: Zygomites, Vyrewatch
+  drop_table:
+    sources:
+      - source: Mort Myre Swamp
+        method: Bloom spell on rotting logs
+      - source: Sulliuscep mushrooms
+        method: Woodcutting
+      - source: Monster drops
+        method: "Zygomites, Vyrewatch"
   recipes:
     - skill: herblore
       level: 52
@@ -29,13 +30,13 @@ osrs:
       materials:
         - item_name: Avantoe potion (unf)
           item_id: 99
-          quantity: 1
+          quantity: "1"
         - item_name: Mort myre fungus
           item_id: 2970
-          quantity: 1
+          quantity: "1"
       product: Super energy(3)
       product_id: 3022
-      product_quantity: 1
+      output_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -65,10 +66,6 @@ osrs:
     | Super energy potion | Herblore 52 |
     | Druid pouch | Adds 1 charge |
   market_strategy:
-    title: |-
-      - Super energy production
-      - Stamina potion chain
-      - Consistent demand
     notes:
       - Super energy production
       - Stamina potion chain
@@ -81,8 +78,8 @@ osrs:
       - Nature Spirit quest required
       - Consistent pricing
       - Essential for stamina chain
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mort-ton-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mort-ton-teleport.mdx
@@ -1,6 +1,6 @@
 ---
 title: Mort'ton teleport | OSRS Price Data
-description: "Mort'ton teleport: Teleports you to Mort'ton.. High alch: 6 GP, GE limit: 10,000."
+description: "Mort'ton teleport is a members teleport tablet to Mort'ton. High alch: 6 GP, GE limit: 10,000."
 osrs:
   id: 12406
   name: Mort'ton teleport
@@ -12,9 +12,46 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  about: "Mort'ton teleport is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: teleport_tablet
+    tier: low
+  recipes:
+    - skill: magic
+      level: 65
+      xp: 71
+      output_quantity: 1
+      materials:
+        - item_name: Soft clay
+          quantity: "1"
+        - item_name: Law rune
+          quantity: "2"
+        - item_name: Soul rune
+          quantity: "1"
+      product: Mort'ton teleport
+  related_items:
+    - item_name: Law rune
+      slug: law-rune
+      relationship: component
+      description: Crafting reagent
+    - item_name: Soul rune
+      slug: soul-rune
+      relationship: component
+      description: Crafting reagent
+    - item_name: Soft clay
+      slug: soft-clay
+      relationship: component
+      description: Tablet base material
+  market_strategy:
+    notes:
+      - Crafted at lectern in Player-Owned House
+      - Used by Shades of Mort'ton hunters
+      - Low margin per cast — volume play only
+  trading_tips:
+    - Buy in bulk for Shades trips
+    - Sell to skillers crafting tablets
+  about: "Mort'ton teleport is a one-click teleport tablet that sends the player to Mort'ton in Morytania. Created at a House lectern with 65 Magic."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-bottom-light.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mystic-robe-bottom-light.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 48000
   limit: 70
   about: "Mystic robe bottom (light) is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/nature-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/nature-talisman.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  item:
-    type: material
-    tradeable: true
+  material:
+    type: talisman
+    tier: low
   related_items:
     - item_id: 5537
       item_name: Nature tiara
@@ -38,8 +38,8 @@ osrs:
     Grants access to Nature Altar for runecrafting.
 
     Can create nature tiara for headslot access.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/necklace-of-anguish.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/necklace-of-anguish.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 80800
   highalch: 121200
   limit: 8
+  material:
+    type: gem
+    tier: high
   equipment:
     slot: neck
     type: necklace
@@ -40,7 +43,7 @@ osrs:
           quantity: 1
       product: Necklace of anguish
       product_id: 19547
-      product_quantity: 1
+      output_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -95,8 +98,8 @@ osrs:
       - Zenyte from demonic gorillas
       - BiS ranged neck slot
       - Always in demand
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/olive-oil-3.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 12
   limit: 10000
   about: "Olive oil(3) is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bolts-e.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/onyx-bolts-e.mdx
@@ -19,17 +19,17 @@ osrs:
     weight: 0
     requirements:
       ranged: 61
-  effect:
-    name: Life Leech
-    damage_bonus: 20
-    zaryte_bonus: 32
-    healing: 25
-    note: Does not work on undead
-    activation_rate:
-      pvp: 10
-      pvm: 11
-      pvp_kandarin: 11
-      pvm_kandarin: 12.1
+  passive_effects:
+    - name: Life Leech
+      damage_bonus: 20
+      zaryte_bonus: 32
+      healing: 25
+      description: "Does not work on undead"
+      activation_rate:
+        pvp: 10
+        pvm: 11
+        pvp_kandarin: 11
+        pvm_kandarin: 12.1
   enchanting:
     spell: Enchant Crossbow Bolt (Onyx)
     magic_level: 87
@@ -82,8 +82,8 @@ osrs:
     |-----------------|-----|-----|
     | Base | 10% | 11% |
     | Hard Kandarin Diary | 11% | 12.1% |
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-blouse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pink-elegant-blouse.mdx
@@ -12,21 +12,65 @@ osrs:
   lowalch: 800
   highalch: 1200
   limit: 4
+  material:
+    type: cosmetic
+    tier: mid
   equipment:
     slot: body
+    weight: 0.453
     requirements: {}
+  treasure_trail:
+    tier: hard
+    is_reward: true
+    reward_tiers:
+      - hard
   related_items:
-    - item_id: 12341
-      item_name: Pink elegant skirt
+    - item_name: Pink elegant skirt
       slug: pink-elegant-skirt
       relationship: set-piece
-      description: Matching elegant skirt
+      description: Matching elegant skirt that completes the women's outfit.
+    - item_name: Red elegant blouse
+      slug: red-elegant-blouse
+      relationship: variant
+      description: Red colour variant of the elegant blouse.
+    - item_name: Purple elegant blouse
+      slug: purple-elegant-blouse
+      relationship: variant
+      description: Purple colour variant of the elegant blouse.
+  market_strategy:
+    notes:
+      - Cosmetic hard clue reward with no combat stats.
+      - Buy limit of 4 per 4 hours keeps flip volume low.
+      - Pairs with the matching skirt for the full pink elegant outfit.
+      - Price is driven by collectors and fashionscape demand.
+  trading_tips:
+    - List set bundles (blouse plus skirt) for a small premium.
+    - Watch for hard clue popularity spikes after gameplay updates.
   about: |-
-    > *"A well made elegant ladies' pink blouse."*
+    > _"A well made elegant ladies' pink blouse."_
 
-    Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set (women's variant). Pairs with the pink elegant skirt.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    Purely cosmetic treasure trail reward with no combat stats. Part of the pink elegant clothing set (women's variant) and pairs with the pink elegant skirt.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2006-12-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2006-12-04"
+      description: Pink elegant blouse added as part of the elegant clothing treasure trail rewards.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-white.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pirate-bandana-white.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 150
+  material:
+    type: cosmetic
+    tier: low
   about: "Pirate bandana (white) is a members-only item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/piscarilius-scarf.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/piscarilius-scarf.mdx
@@ -12,9 +12,17 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: mid
   about: "Piscarilius scarf is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Kourend faction cosmetic scarf from the Piscarilius house"
+      - "Low buy limit of 4 per 4 hours keeps flips slow"
+      - "Demand is cosmetic-only with thin volume"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/pointed-myre-snelm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/pointed-myre-snelm.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 150
-  about: "Pointed myre snelm is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: shell
+    tier: low
+  equipment:
+    slot: head
+  about: "Pointed myre snelm is a members-only snail shell helmet in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/poison-chalice.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/poison-chalice.mdx
@@ -12,13 +12,16 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 2000
+  material:
+    type: consumable
+    tier: low
   related_items: []
   about: |-
     > _"A cup of a strange brew..."_
 
     The poison chalice produces a random effect when drunk — anything from healing 15-30% HP and boosting Thieving or Crafting, to dealing 5-50% of your HP as damage. Cannot reduce HP below 4. Leaves behind an empty cocktail glass.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/potato-with-cheese.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/potato-with-cheese.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 4
   limit: 13000
   about: "Potato with cheese is a members-only item in Old School RuneScape. High alchemy value: 4 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/potato.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/potato.mdx
@@ -12,9 +12,9 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 13000
-  produce:
+  material:
     type: allotment
-    tier: lowest
+    tier: low
   farming:
     seed_id: 5318
     seed_name: Potato seed
@@ -52,7 +52,6 @@ osrs:
     | XP (plant) | 8 |
     | XP (harvest) | 9 per potato |
   market_strategy:
-    title: Ironman Notes
     notes:
       - Starter crop for new farmers
       - Very low value
@@ -63,8 +62,8 @@ osrs:
       - Easy to obtain early game
       - Good starting farming crop
       - Stock up for cooking training
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-potion-3.mdx
@@ -20,6 +20,7 @@ osrs:
     effects:
       - stat: Prayer
         boost_formula: 7 + floor(level / 4)
+        duration: 0
   related_items:
     - item_id: 2434
       item_name: Prayer potion(4)
@@ -57,8 +58,8 @@ osrs:
       - Often traded in 3-dose for raids
       - Check decant margins
       - High volume trading
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-regeneration-potion-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/prayer-regeneration-potion-2.mdx
@@ -12,9 +12,38 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 2000
-  about: "Prayer regeneration potion(2) is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Prayer regeneration potion(2) is a two-dose potion that gradually restores Prayer points over time. Useful for sustained Prayer-based combat training and bossing trips."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2023-08-23"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.035
+  material:
+    type: potion
+    tier: mid
+  potion:
+    doses: 2
+    boost_type: "Prayer"
+    effects:
+      - name: "Prayer restore over time"
+        duration: 300
+        description: "Gradually restores Prayer points across the duration of the potion."
+  market_strategy:
+    notes:
+      - "Demand spikes during Prayer-heavy bossing weekends."
+      - "Stable utility consumable across mid-to-high level PvM."
+  trading_tips:
+    - "Buy in bulk before raid resets to lock in lower prices."
+    - "Sell stacks during weekend bosses for consistent margins."
+  history:
+    - date: "2023-08-23"
+      description: "Prayer regeneration potion released as part of Forestry consumables expansion."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/premade-dr-dragon.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/premade-dr-dragon.mdx
@@ -1,6 +1,6 @@
 ---
 title: Premade dr' dragon | OSRS Price Data
-description: "Premade dr' dragon: A premade Drunk Dragon.. High alch: 18 GP, GE limit: 2,000."
+description: "Premade dr' dragon is a Gnome Stronghold premade Drunk Dragon cocktail. High alch: 18 GP, GE limit: 2,000."
 osrs:
   id: 2032
   name: Premade dr' dragon
@@ -12,9 +12,41 @@ osrs:
   lowalch: 12
   highalch: 18
   limit: 2000
-  about: "Premade dr' dragon is a members-only item in Old School RuneScape. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: drink
+    tier: low
+  related_items:
+    - item_name: Drunk dragon
+      slug: drunk-dragon
+      relationship: alternative
+      description: Player-mixed Cooking version of the cocktail
+    - item_name: Gnome Cocktail
+      slug: gnome-cocktail
+      relationship: alternative
+      description: Same Gnome Stronghold cocktail family
+  market_strategy:
+    notes:
+      - Premade Gnome drinks are bought by Gnome Restaurant grinders
+      - Volume is thin; spreads widen outside of restaurant minigame meta
+      - "Convenience premium: usually trades above raw cocktail value"
+  trading_tips:
+    - Buy from Gnome bartender directly when GE is overpriced
+    - Stock up before Gnome Restaurant minigame streaks
+    - "Watch high-alch margin: highalch 18 GP rarely flips profitably"
+  about: "Premade dr' dragon is a members-only premade Drunk Dragon cocktail sold by Gnome Stronghold bartenders. High alchemy value: 18 coins. Grand Exchange buy limit: 2,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2002-12-09"
+      description: Added with the Gnome Restaurant minigame.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/proboscis.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/proboscis.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 3
   limit: 100
   about: "Proboscis is a members-only item in Old School RuneScape. High alchemy value: 3 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/purple-boater.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/purple-boater.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 4
-  about: "Purple boater is a members-only item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cloth
+    tier: low
+  equipment:
+    slot: head
+  about: "Purple boater is a members-only cosmetic head slot item in Old School RuneScape. High alchemy value: 135 coins. Grand Exchange buy limit: 4 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rangers-tights.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rangers-tights.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 8000
   highalch: 12000
   limit: 8
+  material:
+    type: ranger
+    tier: mid-high
   equipment:
     slot: legs
     type: ranged_armour
@@ -31,6 +34,8 @@ osrs:
       - source: Treasure Trails
         tier: Beginner
         drop_rate: Rare from reward casket
+  treasure_trail:
+    tier: beginner
   related_items:
     - item_id: 2581
       item_name: Robin hood hat
@@ -78,8 +83,8 @@ osrs:
       - Part of ranger outfit
       - Collection log item
       - Fashionscape value
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/raw-cave-eel.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/raw-cave-eel.mdx
@@ -12,9 +12,42 @@ osrs:
   lowalch: 6
   highalch: 9
   limit: 13000
-  about: "Raw cave eel is a members-only item in Old School RuneScape. High alchemy value: 9 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Raw cave eel is caught at Lumbridge Swamp Caves and the Dorgeshuun mines using an oily fishing rod with fishing bait. Cooks into a cave eel for Cooking XP."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2004-10-04"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 1.0
+  material:
+    type: fish
+    tier: low
+  recipes:
+    - item_name: Cave eel
+      tools: ["Range or fire"]
+      materials:
+        - item_name: Raw cave eel
+          quantity: "1"
+      output_quantity: 1
+      skill: cooking
+      level: 38
+      xp: 115
+      notes: "Cooks into Cave eel; burn chance decreases with higher Cooking level."
+  market_strategy:
+    notes:
+      - "Niche cooking supply with low-volume market."
+      - "Sells best to ironmen training Cooking and Fishing alts."
+  trading_tips:
+    - "Buy from fishers and resell to cooks for small flips."
+    - "Stack large quantities slowly due to thin liquidity."
+  history:
+    - date: "2004-10-04"
+      description: "Raw cave eel released with the Lumbridge Swamp Caves update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/red-cavalier.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/red-cavalier.mdx
@@ -1,6 +1,6 @@
 ---
 title: Red cavalier | OSRS Price Data
-description: "Red cavalier: All for one and one for all!. High alch: 120 GP, GE limit: 4."
+description: "Red cavalier: All for one and one for all! High alch: 120 GP, GE limit: 4."
 osrs:
   id: 12323
   name: Red cavalier
@@ -12,9 +12,69 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 4
-  about: "Red cavalier is a members-only item in Old School RuneScape. High alchemy value: 120 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: head
+    weight: 0.453
+    requirements: {}
+  treasure_trail:
+    tier: master
+    is_reward: true
+    reward_tiers:
+      - master
+  related_items:
+    - item_name: Black cavalier
+      slug: black-cavalier
+      relationship: variant
+      description: Black colour variant of the cavalier hat.
+    - item_name: White cavalier
+      slug: white-cavalier
+      relationship: variant
+      description: White colour variant of the cavalier hat.
+    - item_name: Pink cavalier
+      slug: pink-cavalier
+      relationship: variant
+      description: Pink colour variant of the cavalier hat.
+    - item_name: Navy cavalier
+      slug: navy-cavalier
+      relationship: variant
+      description: Navy colour variant of the cavalier hat.
+  market_strategy:
+    notes:
+      - Cosmetic master clue scroll reward with no combat stats.
+      - Supply is entirely driven by master clue completions.
+      - Buy limit of 4 per 4 hours throttles flips.
+      - Long-term collectible; price moves with cosmetic fashion trends.
+  trading_tips:
+    - Watch lazy buy/sell offsets on the GE for the larger spread.
+    - Pair with other elegant or musketeer-style cosmetics when reselling.
+  about: |-
+    > _"All for one and one for all!"_
+
+    Cosmetic feathered hat obtained as a rare reward from master clue scroll caskets. Has no combat bonuses and is worn purely as fashion alongside other treasure trail outfits.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2007-07-04"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2007-07-04"
+      description: Red cavalier released as part of the Treasure Trails reward pool.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-mould.mdx
@@ -14,12 +14,13 @@ osrs:
   limit: 40
   material:
     type: mould
-    tier: crafting_tool
+    tier: low
   crafting:
     use: ring
   shops:
     - shop_name: Crafting shops
       price: 5
+      stock: 0
       currency: Coins
   uses:
     - product: Gold ring
@@ -93,8 +94,8 @@ osrs:
       - Not consumed on use
       - Essential for jewelry
       - Buy from shop
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-recoil.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ring-of-recoil.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 15000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: enchanted-jewellery
+    tier: low
   equipment:
     slot: ring
     type: combat_ring
@@ -40,6 +45,7 @@ osrs:
     - skill: magic
       level: 7
       xp: 17.5
+      output_quantity: 1
       materials:
         - item_name: Sapphire ring
           item_id: 1637
@@ -50,6 +56,9 @@ osrs:
         - item_name: Water rune
           item_id: 555
           quantity: 1
+  passive_effects:
+    - name: Damage Recoil
+      description: "Reflects 10% + 1 of damage received back at the attacker, rounded down, for 40 charges before shattering"
   related_items:
     - item_id: 19550
       item_name: Ring of suffering
@@ -88,8 +97,10 @@ osrs:
       - Very cheap to make
       - Shatters after 40 recoil damage
       - Check charges in worn equipment
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Very cheap to make
+    - Shatters after 40 recoil damage
+    - Check charges in worn equipment
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-plate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rock-shell-plate.mdx
@@ -12,12 +12,12 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 70
+  material:
+    type: rock_shell
+    tier: mid-high
   equipment:
     slot: body
     attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
       magic: -30
       ranged: -10
     defence_bonus:
@@ -26,11 +26,6 @@ osrs:
       crush: 72
       magic: -6
       ranged: 80
-    other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
     requirements:
       defence: 40
     weight: 9.979
@@ -90,8 +85,8 @@ osrs:
       - Crafting via Skulgrimen is profitable (~8K profit)
       - Ava's compatibility drives niche PvP demand
       - Dagannoth Rex also drops it directly
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/ruby-bolts.mdx
@@ -12,9 +12,62 @@ osrs:
   lowalch: 50
   highalch: 75
   limit: 11000
-  about: "Ruby bolts is a members-only item in Old School RuneScape. High alchemy value: 75 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Ruby bolts are adamantite crossbow bolts tipped with rubies. When enchanted via Enchant Crossbow Bolt (Ruby), they gain the Blood Forfeit special effect popular for high-HP bossing."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2006-05-15"
+    tradeable: true
+    equipable: true
+    stackable: true
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.0
+  material:
+    type: bolt
+    tier: mid
+  equipment:
+    slot: ammo
+    weight: 0.0
+    requirements:
+      ranged: 46
+    attack_bonus:
+      ranged: 63
+    other_bonus:
+      ranged_strength: 65
+  recipes:
+    - item_name: Ruby bolts
+      tools: []
+      materials:
+        - item_name: Adamant bolts
+          quantity: "10"
+        - item_name: Ruby bolt tips
+          quantity: "10"
+      output_quantity: 10
+      skill: fletching
+      level: 63
+      xp: 63
+      notes: "Attaching ruby bolt tips to adamant bolts in sets of ten."
+  related_items:
+    - item_name: Ruby bolts (e)
+      slug: ruby-bolts-e
+      relationship: upgrade
+      description: Enchanted variant with Blood Forfeit special effect.
+    - item_name: Adamant bolts
+      slug: adamant-bolts
+      relationship: component
+      description: Base bolt before ruby tips are attached.
+  market_strategy:
+    notes:
+      - "Demand driven by enchanters reselling Ruby bolts (e)."
+      - "Tracks ruby and adamant bolt supply cycles."
+  trading_tips:
+    - "Pair flips with Ruby bolt tips for combined margin."
+    - "Sell enchanted (e) variant for higher profit per cast."
+  history:
+    - date: "2006-05-15"
+      description: "Ruby bolts released with the crossbow Fletching update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-2h-sword.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-2h-sword.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 70
+  material:
+    type: rune
+    tier: high
   equipment:
     slot: weapon
     weight: 3.628
@@ -45,7 +48,7 @@ osrs:
           quantity: 3
       product: Rune 2h sword
       product_id: 1319
-      product_quantity: 1
+      output_quantity: 1
       facility: Anvil
   alchemy:
     high: 38400
@@ -72,7 +75,7 @@ osrs:
       item_name: Runite bar
       slug: runite-bar
       relationship: component
-      description: Raw material (×3)
+      description: "Raw material (×3)"
     - item_id: 1127
       item_name: Rune platebody
       slug: rune-platebody
@@ -113,8 +116,8 @@ osrs:
       - Greater demons, Fire giants, Moss giants
       - Obor (Hill Giant Boss)
       - Clue scrolls
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow-p-5627.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-arrow-p-5627.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 160
   highalch: 240
   limit: 11000
+  material:
+    type: rune
+    tier: mid-high
   about: "Rune arrow(p++) is a members-only item in Old School RuneScape. High alchemy value: 240 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger-p-5696.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-dagger-p-5696.mdx
@@ -1,6 +1,6 @@
 ---
 title: Rune dagger(p++) | OSRS Price Data
-description: "Rune dagger(p++): The blade is covered with a nasty poison.. High alch: 4,800 GP, GE limit: 70."
+description: "Rune dagger(p++) is a members poisoned rune dagger with enhanced toxin coating. High alch: 4,800 GP, GE limit: 70."
 osrs:
   id: 5696
   name: Rune dagger(p++)
@@ -12,9 +12,57 @@ osrs:
   lowalch: 3200
   highalch: 4800
   limit: 70
-  about: "Rune dagger(p++) is a members-only item in Old School RuneScape. High alchemy value: 4,800 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: rune
+    tier: mid-high
+  equipment:
+    slot: weapon
+    weight: 0.4
+    requirements:
+      attack: 40
+    attack_bonus:
+      stab: 25
+      slash: 17
+      crush: -2
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 24
+      prayer: 0
+  passive_effects:
+    - name: Enhanced Poison
+      description: "Poisons opponents on hit dealing 6 damage initially, with high reapplication chance per attack."
+  related_items:
+    - item_name: Rune dagger
+      slug: rune-dagger
+      relationship: variant
+      description: Unpoisoned base variant
+    - item_name: Rune dagger(p)
+      slug: rune-dagger-p
+      relationship: variant
+      description: Weaker poison variant
+    - item_name: Rune dagger(p+)
+      slug: rune-dagger-p
+      relationship: variant
+      description: Mid poison variant
+    - item_name: Dragon dagger(p++)
+      slug: dragon-dagger-p
+      relationship: upgrade
+      description: Stronger dragon-tier alternative
+  market_strategy:
+    notes:
+      - Poisoned daggers see steady PvP demand
+      - "Weapon poison++ requirement: Cave nightshade + Poison ivy berries"
+      - Lower volume than dragon dagger(p++) but cheaper entry
+  trading_tips:
+    - Compare with dragon dagger(p++) before purchasing for PvP
+    - Buy in bulk for poison stock for switch armor sets
+  about: Rune dagger(p++) is a members rune-tier stab weapon coated with the strongest weapon poison, popular as a budget special-attack dagger in PvP.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2004-03-30"
+      description: Rune dagger added to Old School RuneScape.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-kiteshield-g.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-kiteshield-g.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 21760
   highalch: 32640
   limit: 8
+  material:
+    type: armor
+    tier: high
   equipment:
     slot: shield
     requirements:
@@ -26,8 +29,8 @@ osrs:
     > *"Rune kiteshield with gold trim."*
 
     The rune kiteshield (g) is a gold-trimmed cosmetic variant of the standard rune kiteshield. Identical stats, requiring 40 Defence. Clue scroll exclusive — cannot be smithed.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-t.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-platebody-t.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 26000
   highalch: 39000
   limit: 8
+  material:
+    type: rune
+    tier: high
   equipment:
     slot: body
     stats:
@@ -30,6 +33,8 @@ osrs:
       - source: Hard Treasure Trails
         type: Reward casket (hard)
         rarity: 1/1,625
+  treasure_trail:
+    tier: hard
   related_items:
     - item_id: 1127
       item_name: Rune platebody
@@ -84,12 +89,12 @@ osrs:
     Requirements: 40 Defence, Dragon Slayer I quest
   market_strategy:
     notes:
-      - F2P tradeable, making it popular in free-to-play fashion
+      - "F2P tradeable, making it popular in free-to-play fashion"
       - Low buy limit due to treasure trail rarity
-      - Price driven by cosmetic demand, not utility
+      - "Price driven by cosmetic demand, not utility"
       - Identical stats to regular rune platebody
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h3.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-shield-h3.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 32640
   limit: 70
   about: "Rune shield (h3) is a free-to-play item in Old School RuneScape. High alchemy value: 32,640 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/rune-trimmed-set-sk.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/rune-trimmed-set-sk.mdx
@@ -12,9 +12,17 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: rune
+    tier: mid-high
   about: "Rune trimmed set (sk) is a free-to-play item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Convenience set bundling Rune full helm (t), Rune platebody (t), Rune plateskirt (t) and Rune kiteshield (t)"
+      - "Useful for moving the four trimmed pieces in a single Grand Exchange slot"
+      - "Buy limit of 8 per 4 hours on the Grand Exchange"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sanfew-serum-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sanfew serum(4) | OSRS Price Data
-description: "Sanfew serum(4) is a 4-dose members potion that sanfew_serum. High alch: 180 GP, GE limit: 2,000."
+description: "Sanfew serum(4) is a 4-dose members potion that restores stats and prayer while curing poison and disease. High alch: 180 GP, GE limit: 2,000."
 osrs:
   id: 10925
   name: Sanfew serum(4)
@@ -12,10 +12,25 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 2000
+  material:
+    type: potion
+    tier: mid-high
   potion:
     doses: 4
     type: restoration
-    effect: sanfew_serum
+    effects:
+      - name: Stat restore
+        description: "Restores reduced stats by floor(level x 0.30) + 4."
+        duration: 0
+      - name: Prayer restore
+        description: "Restores prayer by floor(Prayer x 0.30) + 4."
+        duration: 0
+      - name: Disease immunity
+        description: Grants 15 minutes of disease immunity.
+        duration: 900
+      - name: Antipoison
+        description: Cures poison and grants 6 minutes of poison immunity.
+        duration: 360
   herblore:
     level: 65
     xp: 192
@@ -27,19 +42,19 @@ osrs:
       materials:
         - item_name: Super restore(4)
           item_id: 3024
-          quantity: 1
+          quantity: "1"
         - item_name: Unicorn horn dust
           item_id: 235
-          quantity: 1
+          quantity: "1"
         - item_name: Snake weed
           item_id: 1526
-          quantity: 1
+          quantity: "1"
         - item_name: Nail beast nails
           item_id: 10937
-          quantity: 1
+          quantity: "1"
       product: Sanfew serum(4)
       product_id: 10925
-      product_quantity: 1
+      output_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -47,51 +62,37 @@ osrs:
       item_name: Super restore(4)
       slug: super-restore-4
       relationship: component
-      description: Base potion
+      description: Base potion used in the recipe
     - item_id: 235
       item_name: Unicorn horn dust
       slug: unicorn-horn-dust
       relationship: component
-      description: Secondary
+      description: Secondary ingredient
     - item_id: 1526
       item_name: Snake weed
       slug: snake-weed
       relationship: component
-      description: Secondary
+      description: Secondary ingredient
     - item_id: 2434
       item_name: Prayer potion(4)
       slug: prayer-potion-4
       relationship: alternative
-      description: Budget alternative
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 65 |
-    | XP | 192 (4-dose) |
-    | Quest | Zogre Flesh Eaters (partial) |
-    | Ingredients | Super restore + Unicorn horn dust + Snake weed + Nail beast nails |
-
-    | Effect | Value |
-    |--------|-------|
-    | Stat restore | Floor(Level × 0.30) + 4 |
-    | Prayer restore | Floor(Prayer × 0.30) + 4 |
-    | Disease immunity | 15 minutes |
-    | Antipoison | 6 minutes |
+      description: Budget alternative for prayer only
   market_strategy:
     notes:
-      - Combines super restore + antipoison + disease cure
-      - Single inventory slot efficiency
-      - High-end PvM demand
-      - Theatre of Blood
-      - Nightmare boss
-      - General PvM
-      - Inventory optimization
-      - Low buy limit (2,000)
-      - Complex to make
-      - Higher restore than super restore
-      - Quest requirement limits supply
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - Combines super restore + antipoison + disease cure into one slot
+      - "Bossing demand: Theatre of Blood, Nightmare, general PvM"
+      - Low buy limit (2,000) and quest gate keep supply thin
+      - Higher restore than super restore for stat-drain content
+  trading_tips:
+    - Decant from 4-dose to lower doses when spreads invert
+    - Track ingredient prices to spot crafting margin windows
+  about: Sanfew serum(4) is a 4-dose members restoration potion that combines super restore, antipoison, and disease cure effects into a single inventory slot.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2005-09-13"
+      description: Sanfew serum introduced with the Zogre Flesh Eaters quest.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-amulet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sapphire-amulet.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 360
   highalch: 540
   limit: 10000
+  material:
+    type: gem
+    tier: low
   equipment:
     slot: neck
     requirements:
@@ -20,7 +23,7 @@ osrs:
     - skill: crafting
       level: 24
       xp: 65
-      inputs:
+      materials:
         - item_name: Sapphire
           quantity: 1
         - item_name: Gold bar
@@ -55,11 +58,11 @@ osrs:
     | Zenyte | 98 | Lvl-7 (93) | Amulet of torture | +15 melee |
   market_strategy:
     notes:
-      - F2P accessible — broad demand for amulet of magic
+      - "F2P accessible: broad demand for amulet of magic"
       - Cheap crafting training
       - High enchanting volume
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-mjolnir.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-mjolnir.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 375
   limit: 8
   about: "Saradomin mjolnir is a members-only item in Old School RuneScape. High alchemy value: 375 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/saradomin-plateskirt.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 25600
   highalch: 38400
   limit: 8
+  material:
+    type: metal
+    tier: mid-high
   about: "Saradomin plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 38,400 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/seaweed.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/seaweed.mdx
@@ -1,6 +1,6 @@
 ---
 title: Seaweed | OSRS Price Data
-description: "Seaweed: Slightly damp seaweed.. High alch: 1 GP, GE limit: 13,000."
+description: "Seaweed is a crafting material cooked into soda ash for glass making. High alch: 1 GP, GE limit: 13,000."
 osrs:
   id: 401
   name: Seaweed
@@ -14,11 +14,12 @@ osrs:
   limit: 13000
   material:
     type: crafting
-    tier: basic
+    tier: low
   shops:
-    - shop_name: Trader Stan's Trading Posts
+    - shop_name: "Trader Stan's Trading Posts"
       price: 5
       currency: Coins
+      stock: 0
   drop_table:
     sources:
       - source: Rock crab
@@ -31,10 +32,6 @@ osrs:
         quantity: "1"
         rarity: common
         members_only: true
-  processing:
-    method: Cook on range
-    product_id: 1781
-    product_name: Soda ash
   recipes:
     - skill: cooking
       level: 1
@@ -45,42 +42,52 @@ osrs:
           quantity: 1
       product: Soda ash
       product_id: 1781
-      product_quantity: 1
+      output_quantity: 1
       facility: Range
   related_items:
     - item_id: 21504
       item_name: Giant seaweed
       slug: giant-seaweed
       relationship: upgrade
-      description: Superior variant (6x)
+      description: Superior variant worth 6 regular seaweed
     - item_id: 1781
       item_name: Soda ash
       slug: soda-ash
       relationship: product
-      description: Cooked form
+      description: Cooked form used in glass making
     - item_id: 1775
       item_name: Molten glass
       slug: molten-glass
       relationship: product
-      description: End product
+      description: End product of soda ash plus sand
     - item_id: 1783
       item_name: Bucket of sand
       slug: bucket-of-sand
       relationship: component
-      description: Glass making partner
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Crafting Material |
-    | Tradeable | Yes |
-    | Weight | 0.2 kg |
-
-    Cook on range to create soda ash for glass making.
-
-    Also used directly in Superglass Make spell.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Pairs with soda ash to make molten glass
+  market_strategy:
+    notes:
+      - Glassmaking pipeline input; price is bound to giant seaweed and soda ash
+      - Steady demand from Crafting trainers via Superglass Make
+      - Supply leans on impling and Rock crab drop tables plus shop runs
+  trading_tips:
+    - Compare giant seaweed per unit vs seaweed price for arbitrage
+    - Buy in bulk before crafting bottle / glassblowing events
+    - "Skip seaweed if Superglass Make herblore unlock makes giant seaweed cheaper"
+  about: "Seaweed is a members-only crafting material harvested from drops and shops, cooked on a range into soda ash for glass making. High alchemy value: 1 coin. Grand Exchange buy limit: 13,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2001-12-12"
+      description: Seaweed added with the Crafting skill and glass making pipeline.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shaikahan-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shaikahan-bones.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 1
   limit: 7500
   about: "Shaikahan bones is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 7,500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/shrunk-ogleroot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/shrunk-ogleroot.mdx
@@ -5,16 +5,38 @@ osrs:
   id: 11205
   name: Shrunk ogleroot
   slug: shrunk-ogleroot
-  examine: A shrunk ogleroot! How odd...
+  examine: "A shrunk ogleroot! How odd..."
   members: true
   icon: Shrunk ogleroot 5.png
   value: 2
   lowalch: 1
   highalch: 1
   limit: 15
-  about: "Shrunk ogleroot is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Shrunk ogleroot is a miniature ogleroot used during the Mahjarrat memoriam progression. Created by drying an ogleroot via the Land of the Goblins quest mechanics."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2008-10-13"
+    tradeable: true
+    equipable: false
+    stackable: false
+    noteable: true
+    quest_item: true
+    destroy: "Drop"
+    weight: 0.1
+  material:
+    type: plant
+    tier: low
+  market_strategy:
+    notes:
+      - "Extremely thin market with a 15 GE buy limit."
+      - "Primarily used as a quest consumable rather than a flip target."
+  trading_tips:
+    - "Only buy when actively progressing the quest chain."
+    - "Avoid stockpiling due to low daily demand."
+  history:
+    - date: "2008-10-13"
+      description: "Shrunk ogleroot released as part of the Land of the Goblins quest update."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-exaggeration.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-exaggeration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sigil of exaggeration | OSRS Price Data
-description: "Sigil of exaggeration: A power enhancing sigil not yet attuned to you.. High alch: 6,000 GP, GE limit: 10."
+description: "Sigil of exaggeration is a members Deadman Mode sigil that increases skilling output once attuned. High alch: 6,000 GP, GE limit: 10."
 osrs:
   id: 26057
   name: Sigil of exaggeration
@@ -12,9 +12,39 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 10
-  about: "Sigil of exaggeration is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 10 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: sigil
+    tier: high
+  equipment:
+    slot: pocket
+    weight: 0.0
+    requirements: {}
+  passive_effects:
+    - name: Exaggerated resources
+      description: "Once attuned, gathering skilling actions yield additional resources per success while the sigil is equipped."
+  related_items:
+    - item_name: Sigil of consistency
+      slug: sigil-of-consistency
+      relationship: alternative
+      description: Another Deadman Mode sigil with a different combat-focused effect
+    - item_name: Sigil of resilience
+      slug: sigil-of-resilience
+      relationship: alternative
+      description: Defensive Deadman Mode sigil alternative
+  market_strategy:
+    notes:
+      - Deadman Mode reward item with thin standard-game volume
+      - "Low GE limit (10): supply-driven price volatility"
+      - Attunement is single-use and binds the sigil to the player
+  trading_tips:
+    - Confirm attunement state before purchasing for resale
+    - Track Deadman season schedule for supply spikes
+  about: Sigil of exaggeration is a members pocket-slot sigil from Deadman Mode that, once attuned, raises the per-action resource yield of gathering skills while equipped.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2022-02-23"
+      description: Sigil of exaggeration introduced with the Deadman Apocalypse seasonal mode.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-dwarves.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sigil-of-the-dwarves.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 12000
   limit: 8
   about: "Sigil of the dwarves is a members-only item in Old School RuneScape. High alchemy value: 12,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skull-piece.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skull-piece.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 36
   limit: 11000
   about: "Skull piece is a members-only item in Old School RuneScape. High alchemy value: 36 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-respite-m.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/slayer-s-respite-m.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 1
   limit: 2000
   about: "Slayer's respite(m) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/spider-on-stick.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/spider-on-stick.mdx
@@ -1,6 +1,6 @@
 ---
 title: Spider on stick | OSRS Price Data
-description: "Spider on stick: A nicely roasted spider threaded onto a skewer stick.. High alch: 30 GP, GE limit: 6,000."
+description: "Spider on stick is a Cooking-made food roasted from a raw spider on a skewer stick. High alch: 30 GP, GE limit: 6,000."
 osrs:
   id: 6297
   name: Spider on stick
@@ -12,9 +12,54 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 6000
-  about: "Spider on stick is a members-only item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: food
+    tier: low
+  recipes:
+    - skill: cooking
+      level: 16
+      xp: 60
+      materials:
+        - item_name: Raw spider on stick
+          item_id: 6293
+          quantity: 1
+      product: Spider on stick
+      product_id: 6297
+      output_quantity: 1
+  related_items:
+    - item_id: 6293
+      item_name: Raw spider on stick
+      slug: raw-spider-on-stick
+      relationship: component
+      description: Raw form cooked into this food
+    - item_id: 6299
+      item_name: Spider on shaft
+      slug: spider-on-shaft
+      relationship: alternative
+      description: Arrow-shaft variant of the same dish
+  market_strategy:
+    notes:
+      - Low-tier healing food bought mostly by Karamja-cooking trainers
+      - Volume is thin; prices drift with the raw spider supply
+      - GE turnover is slow vs mainstream foods like swordfish
+  trading_tips:
+    - Compare against raw spider on stick to spot cooking arbitrage
+    - Avoid stockpiling - low demand makes flipping slow
+    - "List near GE midprice: undercutting wastes buy limit on a thin market"
+  about: "Spider on stick is a members-only cooked food obtained by roasting a raw spider on stick on Karamja. High alchemy value: 30 coins. Grand Exchange buy limit: 6,000 per 4 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    alchable: true
+  history:
+    - date: "2004-12-13"
+      description: Added to the game with Tai Bwo Wannai Trio.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-bolts.mdx
@@ -12,38 +12,52 @@ osrs:
   lowalch: 3
   highalch: 4
   limit: 7000
-  item_id: 9141
-  type: ammunition
-  tradeable: true
-  weight: 0
-  buy_limit: 7000
+  material:
+    type: ammunition
+    tier: low
   equipment:
     slot: ammo
     type: bolts
+    attack_style: ranged
     requirements:
       ranged: 31
     stats:
       ranged_strength: 64
-  fletching:
-    level: 46
-    xp: 3.5
-    materials:
-      - item: Steel bolts (unf)
-        quantity: "1"
-      - item: Feathers
-        quantity: "1"
-  obtaining:
-    fletching: 46 Fletching with steel bolts (unf) + feathers
-    shop: Crossbow Shop, Keldagrim
+  recipes:
+    - skill: fletching
+      level: 46
+      xp: 3.5
+      output_quantity: 10
+      materials:
+        - item_name: Steel bolts (unf)
+          quantity: "1"
+        - item_name: Feathers
+          quantity: "1"
+  shops:
+    - shop_name: Crossbow Shop
+      location: Keldagrim
+      price: 8
+      stock: 0
   related_items:
     - slug: mithril-bolts
-      name: Mithril bolts
-      relation: upgrade
+      item_name: Mithril bolts
+      relationship: upgrade
+      description: Higher-tier crossbow bolts
     - slug: steel-crossbow
-      name: Steel crossbow
-      relation: compatible_weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      item_name: Steel crossbow
+      relationship: set-piece
+      description: Compatible crossbow for these bolts
+  about: "Steel bolts are members-only crossbow ammunition requiring 31 Ranged to wield. Fletched from steel bolts (unf) and feathers at 46 Fletching for 3.5 XP per 10 bolts."
+  market_strategy:
+    notes:
+      - Mid-tier crossbow ammunition for Ranged training
+      - Fletch from steel bolts (unf) + feathers for profit margin
+      - Purchasable from Keldagrim Crossbow Shop as a backup supply
+  trading_tips:
+    - Buy unfinished bolts in bulk when Fletching XP is the goal
+    - Compare GE price against shop restock price before flipping
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/strength-mix-2.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/strength-mix-2.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 7
   limit: 2000
   about: "Strength mix(2) is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 2,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-splinters.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunfire-splinters.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 30000
+  material:
+    type: sunfire
+    tier: mid
   item:
     type: material
     tradeable: true
@@ -72,8 +75,8 @@ osrs:
       - Consider hunting as alternative to buying
       - Watch for dips after Colosseum updates
       - Essential consumable for ranged builds
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-moth-mix-1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sunlight-moth-mix-1.mdx
@@ -11,10 +11,10 @@ osrs:
   value: 30
   lowalch: 12
   highalch: 18
-  limit: null
+  limit:
   about: "Sunlight moth mix (1) is a members-only item in Old School RuneScape. High alchemy value: 18 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-antifire-potion-4.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 320
   highalch: 480
   limit: 2000
+  material:
+    type: potion
+    tier: high
   potion:
     doses: 4
     herblore_level: 92
@@ -26,13 +29,14 @@ osrs:
     - skill: herblore
       level: 92
       xp: 130
+      output_quantity: 1
       materials:
         - item_name: Antifire potion(4)
           item_id: 2452
-          quantity: 1
+          quantity: "1"
         - item_name: Crushed superior dragon bones
           item_id: 21975
-          quantity: 1
+          quantity: "1"
       ticks: 2
       members_only: true
   related_items:
@@ -70,11 +74,11 @@ osrs:
       - Dropped by Fossil Island wyverns
       - Must be crushed with pestle and mortar
       - Primary cost driver
-      - Vorkath (2-handed weapons)
+      - "Vorkath (2-handed weapons)"
       - KBD with max gear
       - Any dragon with spec weapon
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-defence-4.mdx
@@ -12,17 +12,18 @@ osrs:
   lowalch: 132
   highalch: 198
   limit: 2000
+  material:
+    type: potion
+    tier: mid
   potion:
-    doses: 3
+    doses: 4
     type: boost
-    skill: defence
-    boost_min: 5
-    boost_max: 19
-    boost_formula: 15% + 5
-    duration: 60
-  herblore:
-    level: 66
-    xp: 150
+    effects:
+      - skill: defence
+        boost_min: 5
+        boost_max: 19
+        boost_formula: "15% + 5"
+        duration: 60
   recipes:
     - skill: herblore
       level: 66
@@ -34,9 +35,9 @@ osrs:
         - item_name: White berries
           item_id: 239
           quantity: 1
-      product: Super defence(3)
-      product_id: 2442
-      product_quantity: 1
+      output_item: Super defence(4)
+      output_item_id: 2442
+      output_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -58,7 +59,7 @@ osrs:
     - item_id: 2432
       item_name: Defence potion(3)
       slug: defence-potion-3
-      relationship: alternative
+      relationship: downgrade
       description: Lower tier
   about: |-
     | Requirement | Value |
@@ -81,12 +82,12 @@ osrs:
       - Tank builds
       - Bossing preparation
       - Defence training
-      - Low buy limit (2,000)
+      - "Low buy limit (2,000)"
       - Cadantine herb
       - White berries secondary
       - Component for super combat
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sweetcorn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sweetcorn.mdx
@@ -1,6 +1,6 @@
 ---
 title: Sweetcorn | OSRS Price Data
-description: "Sweetcorn: Raw sweetcorn.. High alch: 5 GP, GE limit: 11,000."
+description: "Sweetcorn is a members farming crop grown from sweetcorn seeds in allotment patches. High alch: 5 GP, GE limit: 11,000."
 osrs:
   id: 5986
   name: Sweetcorn
@@ -12,44 +12,49 @@ osrs:
   lowalch: 3
   highalch: 5
   limit: 11000
-  item:
+  material:
     type: crop
-    subtype: food
-    tradeable: true
-    weight: 0.028
+    tier: low
   farming:
     level: 20
     patch_type: allotment
-  uses:
-    - name: Cooking
-      description: Cook on range for cooked sweetcorn
-    - name: Farming
-      description: Scarecrow ingredient
+  recipes:
+    - skill: cooking
+      level: 28
+      xp: 104
+      materials:
+        - item_name: Sweetcorn
+          item_id: 5986
+          quantity: "1"
+      product: Cooked sweetcorn
+      product_id: 5988
+      output_quantity: 1
+      facility: Range
   related_items:
     - item_id: 5320
       item_name: Sweetcorn seed
       slug: sweetcorn-seed
-      relationship: alternative
-      description: Farming source
+      relationship: component
+      description: Farming source seed
     - item_id: 5988
       item_name: Cooked sweetcorn
       slug: cooked-sweetcorn
       relationship: product
-      description: Processed form
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Farming Product / Food |
-    | Tradeable | Yes |
-    | Weight | 0.028 kg |
-    | Requirements | 20 Farming |
-
-    Cooking: Cook on range for cooked sweetcorn
-
-    Farming: Scarecrow ingredient
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Cooked food form
+  market_strategy:
+    notes:
+      - Steady farming-skill demand from scarecrow construction
+      - Low-margin staple with very high GE limit
+      - Bulk-cook into cooked sweetcorn for minor XP/profit margin
+  trading_tips:
+    - Buy in bulk for farming or cooking training
+    - Compare cost vs growing your own from seed
+  about: Sweetcorn is a members farming product grown in an allotment patch at level 20 Farming, cookable into cooked sweetcorn and required for scarecrow construction.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  history:
+    - date: "2006-05-23"
+      description: Sweetcorn introduced with the Farming skill release.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tai-bwo-wannai-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tai-bwo-wannai-teleport.mdx
@@ -12,16 +12,15 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  item:
-    type: teleport_scroll
+  material:
+    type: teleport-scroll
+    tier: low
+  teleport:
     destination: Tai Bwo Wannai
-    tradeable: true
     stackable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite/Master
-        drop_rate: Varies by tier
+  treasure_trail:
+    tier: hard
+    description: Reward from hard, elite, or master clue scroll caskets
   related_items:
     - item_id: 12408
       item_name: Piscatoris teleport
@@ -52,8 +51,8 @@ osrs:
       - Useful for Karamja activities
       - Hardwood farming runs
       - Stock up for clue hunting
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/teak-dining-bench-flatpack.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/teak-dining-bench-flatpack.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teak dining bench (flatpack) | OSRS Price Data
-description: "Teak dining bench (flatpack): How does it all fit in there?. High alch: 6 GP, GE limit: 500."
+description: "Teak dining bench (flatpack): How does it all fit in there? High alch: 6 GP, GE limit: 500."
 osrs:
   id: 8568
   name: Teak dining bench (flatpack)
@@ -13,8 +13,8 @@ osrs:
   highalch: 6
   limit: 500
   about: "Teak dining bench (flatpack) is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 500 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-19-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-19-cape.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 30
   limit: 150
   about: "Team-19 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-41-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-41-cape.mdx
@@ -1,6 +1,6 @@
 ---
 title: Team-41 cape | OSRS Price Data
-description: "Team-41 cape: Ooohhh look at the pretty colours.... High alch: 30 GP, GE limit: 150."
+description: "Team-41 cape is a free-to-play numbered team cape used to identify teammates. High alch: 30 GP, GE limit: 150."
 osrs:
   id: 4395
   name: Team-41 cape
@@ -12,9 +12,76 @@ osrs:
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-41 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cape
+    tier: low
+  equipment:
+    slot: cape
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  shops:
+    - shop_name: "Helmets and Armour"
+      price: 50
+      stock: 0
+      location: Edgeville
+      members_only: false
+  related_items:
+    - item_name: Team-40 cape
+      slug: team-40-cape
+      relationship: alternative
+      description: Adjacent numbered team cape
+    - item_name: Team-42 cape
+      slug: team-42-cape
+      relationship: alternative
+      description: Adjacent numbered team cape
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Free-to-play cosmetic with low alch margin"
+      - "Demand driven by PvP team coordination and Castle Wars"
+      - "GE limit of 150 enables modest bulk flipping"
+  trading_tips:
+    - Use Grand Exchange for secure trades
+    - Buy from shop and resell when GE price exceeds 50 GP
+    - Monitor PvP event windows for spikes
+  about: "Team-41 cape is a free-to-play cape used to mark members of a team in PvP and Castle Wars; it has no combat bonuses and is purchased from team cape vendors."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: false
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2004-12-13"
+      description: "Team capes introduced as PvP identification gear."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/team-50-cape.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/team-50-cape.mdx
@@ -5,16 +5,50 @@ osrs:
   id: 4413
   name: Team-50 cape
   slug: team-50-cape
-  examine: Ooohhh look at the pretty colours...
+  examine: "Ooohhh look at the pretty colours..."
   members: false
   icon: Team-50 cape.png
   value: 50
   lowalch: 20
   highalch: 30
   limit: 150
-  about: "Team-50 cape is a free-to-play item in Old School RuneScape. High alchemy value: 30 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Team-50 cape is one of fifty team capes used by clans and friend groups to identify members during PvP and group events. Sold by Scarface Pete's apprentice in Port Sarim."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2004-06-14"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: false
+    destroy: "Drop"
+    weight: 0.45
+  material:
+    type: cape
+    tier: low
+  equipment:
+    slot: cape
+    weight: 0.45
+  related_items:
+    - item_name: Team-49 cape
+      slug: team-49-cape
+      relationship: variant
+      description: Sibling cape from the team cape family.
+    - item_name: Team-51 cape
+      slug: team-51-cape
+      relationship: variant
+      description: Sibling cape from the team cape family.
+  market_strategy:
+    notes:
+      - "Cosmetic free-to-play cape with a tight 150 buy limit."
+      - "Demand spikes during clan-led PvP events."
+  trading_tips:
+    - "Buy stock from Port Sarim NPC for guaranteed margin into the GE."
+    - "Sell ahead of large clan tournaments for premium prices."
+  history:
+    - date: "2004-06-14"
+      description: "Team-50 cape released alongside the team cape family for PvP identification."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-dense.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thatch-spar-dense.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 100
+  material:
+    type: wood
+    tier: low
   about: "Thatch spar dense is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/thin-snail-meat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/thin-snail-meat.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 6000
+  material:
+    type: organic
+    tier: low
   about: "Thin snail meat is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 6,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tiara-mould.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tiara-mould.mdx
@@ -1,6 +1,6 @@
 ---
 title: Tiara mould | OSRS Price Data
-description: "Tiara mould: A mould for tiaras.. High alch: 60 GP, GE limit: 40."
+description: "Tiara mould: A mould for tiaras. High alch: 60 GP, GE limit: 40."
 osrs:
   id: 5523
   name: Tiara mould
@@ -14,68 +14,70 @@ osrs:
   limit: 40
   material:
     type: mould
-    tier: crafting_tool
-  crafting:
-    use: tiara
+    tier: low
   shops:
-    - shop_name: Crafting shops
+    - shop_name: "Aubury's Rune Shop"
+      location: Varrock
       price: 100
+      stock: 5
       currency: Coins
-  uses:
-    - product: Tiara
-      product_id: 5525
-      bar: Silver bar
-      bar_id: 2355
-      crafting_level: 23
-      crafting_xp: 52.5
+    - shop_name: "Betty's Magic Emporium"
+      location: Port Sarim
+      price: 100
+      stock: 5
+      currency: Coins
+  recipes:
+    - skill: crafting
+      level: 23
+      xp: 52.5
+      output_quantity: 1
+      materials:
+        - item_name: Silver bar
+          quantity: 1
   related_items:
-    - item_id: 2355
-      item_name: Silver bar
+    - item_name: Silver bar
       slug: silver-bar
       relationship: component
-      description: Material used
-    - item_id: 5525
-      item_name: Tiara
+      description: Material melted in the mould to produce a tiara.
+    - item_name: Tiara
       slug: tiara
       relationship: product
-      description: Crafted product
-    - item_id: 5527
-      item_name: Air tiara
+      description: Item crafted using the mould.
+    - item_name: Air tiara
       slug: air-tiara
       relationship: product
-      description: Imbued version
-  about: |-
-    Make tiaras at a furnace:
-
-    | Product | Level | XP | Materials |
-    |---------|-------|-----|-----------|
-    | Tiara | 23 | 52.5 | 1 Silver bar |
-
-    Imbue at Runecraft altars:
-
-    | Tiara | Altar | XP |
-    |-------|-------|-----|
-    | Air tiara | Air altar | 25 |
-    | Mind tiara | Mind altar | 27.5 |
-    | Water tiara | Water altar | 30 |
-    | Earth tiara | Earth altar | 32.5 |
-    | Fire tiara | Fire altar | 35 |
-    | Body tiara | Body altar | 37.5 |
-    | Cosmic tiara | Cosmic altar | 40 |
-    | Chaos tiara | Chaos altar | 42.5 |
-    | Nature tiara | Nature altar | 45 |
-    | Law tiara | Law altar | 47.5 |
-    | Death tiara | Death altar | 50 |
+      description: Imbued tiara made from the base tiara at an altar.
   market_strategy:
     notes:
-      - Tiara crafting
-      - Runecraft training
-      - One-time purchase
-      - Not consumed on use
-      - Essential for RC tiaras
-      - Buy from shop
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - One-time tool purchase that is not consumed on use.
+      - Cheaper to buy from a rune or magic shop than from the Grand Exchange in most cases.
+      - Used by Crafting and Runecraft trainers making tiaras for tiara runecrafting.
+      - Buy limit of 40 per 4 hours keeps flips low-volume.
+  trading_tips:
+    - Compare shop price (100 gp) to the GE price before buying off the Grand Exchange.
+    - Bulk demand spikes when new Runecraft tiara methods get attention.
+  about: |-
+    > _"A mould for tiaras."_
+
+    Crafting mould used at a furnace with a silver bar to make a plain tiara at Crafting level 23 for 52.5 XP. The resulting tiara can then be bound to a Runecraft altar (Air, Mind, Water, etc.) to create a tiara variant that acts as a head-slot talisman.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2004-03-25"
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: false
+    quest_item: false
+    options:
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2004-03-25"
+      description: Tiara mould released alongside the introduction of the Tiara crafting method.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tiara.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tiara.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 40
   highalch: 60
   limit: 10000
+  material:
+    type: silver
+    tier: low
   about: "Tiara is a free-to-play item in Old School RuneScape. High alchemy value: 60 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-xil-ul.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toktz-xil-ul.mdx
@@ -75,8 +75,8 @@ osrs:
       - High GE volume — popular ranged option
       - Zero weight makes them convenient for any activity
       - Expendable (consumed on use) — buy in bulk
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tomatoes-5.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tomatoes-5.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 1
   limit: 600
   about: "Tomatoes(5) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 600 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-helm-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torag-s-helm-0.mdx
@@ -1,6 +1,6 @@
 ---
 title: Torag's helm 0 | OSRS Price Data
-description: "Torag's helm 0: Torag the Corrupted's helm.. High alch: 61,800 GP, GE limit: 15."
+description: "Torag's helm 0 is a members head slot item from the Barrows set. High alch: 61,800 GP, GE limit: 15."
 osrs:
   id: 4956
   name: Torag's helm 0
@@ -12,9 +12,58 @@ osrs:
   lowalch: 41200
   highalch: 61800
   limit: 15
-  about: "Torag's helm 0 is a members-only item in Old School RuneScape. High alchemy value: 61,800 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: barrows
+    tier: high
+  equipment:
+    slot: head
+    weight: 2.721
+    requirements:
+      defence: 70
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: -6
+      ranged: -2
+    defence_bonus:
+      stab: 55
+      slash: 58
+      crush: 53
+      magic: -1
+      ranged: 56
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_id: 4745
+      item_name: Torag's helm
+      slug: torag-s-helm
+      relationship: variant
+      description: "Charged variant with degradation mechanics"
+    - item_id: 4749
+      item_name: Verac's helm
+      slug: verac-s-helm
+      relationship: alternative
+      description: Verac's set helm equivalent
+    - item_id: 4753
+      item_name: Dharok's helm
+      slug: dharok-s-helm
+      relationship: alternative
+      description: Dharok's set helm equivalent
+  market_strategy:
+    notes:
+      - "Uncharged variant: requires repair before combat use"
+      - Part of Torag's Barrows armour set
+      - Supply driven by Barrows runs
+  trading_tips:
+    - Use Grand Exchange for secure trades
+    - Monitor Barrows loot trends
+  about: "Torag's helm 0 is the fully degraded form of Torag's helm, a members head slot item from the Barrows brothers minigame. Requires 70 Defence to wear once recharged."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platebody.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/torva-platebody.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 240000
   highalch: 360000
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: torva
+    tier: high
   equipment:
     slot: body
     type: melee_armour
@@ -29,6 +34,8 @@ osrs:
     - skill: smithing
       level: 90
       xp: 500
+      output_quantity: 1
+      facility: Anvil
       materials:
         - item_name: Torva platebody (damaged)
           item_id: 26378
@@ -38,8 +45,6 @@ osrs:
           quantity: 1
       product: Torva platebody
       product_id: 26384
-      product_quantity: 1
-      facility: Anvil
       members_only: true
   related_items:
     - item_id: 26382
@@ -90,8 +95,10 @@ osrs:
       - Most expensive Torva piece
       - Nex kills affect supply
       - BiS melee body
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  trading_tips:
+    - Most expensive Torva piece
+    - Nex kills affect supply
+    - BiS melee body
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/toy-cat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/toy-cat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Toy cat | OSRS Price Data
-description: "Toy cat: Nice bit of crafting!. High alch: 6 GP, GE limit: 150."
+description: "Toy cat: Nice bit of crafting! High alch: 6 GP, GE limit: 150."
 osrs:
   id: 7771
   name: Toy cat
@@ -13,8 +13,8 @@ osrs:
   highalch: 6
   limit: 150
   about: "Toy cat is a members-only item in Old School RuneScape. High alchemy value: 6 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-torch.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-reloaded-torch.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer reloaded torch | OSRS Price Data
-description: "Trailblazer reloaded torch: The torch of a Trailblazer Reloaded Relic Hunter.. High alch: 9,000 GP."
+description: "Trailblazer reloaded torch: The torch of a Trailblazer Reloaded Relic Hunter. High alch: 9,000 GP."
 osrs:
   id: 28748
   name: Trailblazer reloaded torch
@@ -11,10 +11,53 @@ osrs:
   value: 15000
   lowalch: 6000
   highalch: 9000
-  limit: null
-  about: "Trailblazer reloaded torch is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  limit:
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: weapon
+    weight: 0.453
+    requirements: {}
+  related_items:
+    - item_name: Trailblazer reloaded home teleport
+      slug: trailblazer-reloaded-home-teleport
+      relationship: alternative
+      description: Other Trailblazer Reloaded League cosmetic reward.
+  market_strategy:
+    notes:
+      - Untradeable Leagues V cosmetic reward.
+      - Cannot be sold on the Grand Exchange.
+      - Earned via the Trailblazer Reloaded League shop.
+      - High alch value is purely informational; item is not alchable in practice.
+  trading_tips:
+    - Item is untradeable, so no Grand Exchange strategy applies.
+    - Reclaim from a steward if lost rather than attempting trade.
+  about: |-
+    > _"The torch of a Trailblazer Reloaded Relic Hunter."_
+
+    Cosmetic main-hand torch awarded for participation in the Trailblazer Reloaded Leagues. Purely visual, has no combat stats, and is untradeable.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2024-11-27"
+    tradeable: false
+    stackable: false
+    noteable: false
+    equipable: true
+    members: true
+    quest_item: false
+    options:
+      - Wield
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: false
+    destroy: Drop
+  history:
+    - date: "2024-11-27"
+      description: Trailblazer reloaded torch released as a Leagues V cosmetic reward.
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-trousers-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/trailblazer-trousers-t1.mdx
@@ -1,6 +1,6 @@
 ---
 title: Trailblazer trousers (t1) | OSRS Price Data
-description: "Trailblazer trousers (t1): The trousers of a trailblazer relic hunter.. High alch: 9,000 GP, GE limit: 5."
+description: "Trailblazer trousers (t1) is a Trailblazer Reloaded leagues cosmetic legs piece. High alch: 9,000 GP, GE limit: 5."
 osrs:
   id: 25034
   name: Trailblazer trousers (t1)
@@ -12,9 +12,78 @@ osrs:
   lowalch: 6000
   highalch: 9000
   limit: 5
-  about: "Trailblazer trousers (t1) is a members-only item in Old School RuneScape. High alchemy value: 9,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: cosmetic
+    tier: high
+  equipment:
+    slot: legs
+    weight: 0.453
+    attack_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    defence_bonus:
+      stab: 0
+      slash: 0
+      crush: 0
+      magic: 0
+      ranged: 0
+    other_bonus:
+      melee_strength: 0
+      ranged_strength: 0
+      magic_damage: 0
+      prayer: 0
+  related_items:
+    - item_name: Trailblazer trousers (t2)
+      slug: trailblazer-trousers-t2
+      relationship: upgrade
+      description: Tier 2 cosmetic upgrade of the same trouser line
+    - item_name: Trailblazer trousers (t3)
+      slug: trailblazer-trousers-t3
+      relationship: upgrade
+      description: Tier 3 cosmetic upgrade of the same trouser line
+    - item_name: Trailblazer top (t1)
+      slug: trailblazer-top-t1
+      relationship: set-piece
+      description: Matching body piece of the Trailblazer t1 set
+    - item_name: Trailblazer hood (t1)
+      slug: trailblazer-hood-t1
+      relationship: set-piece
+      description: Matching head piece of the Trailblazer t1 set
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Leagues II Trailblazer relic-hunter cosmetic with no combat stats"
+      - "GE limit of 5 keeps weekly turnover thin"
+      - "Demand driven by collectors completing the Trailblazer outfit"
+  trading_tips:
+    - Verify authenticity when trading high-value items
+    - Use Grand Exchange for secure trades
+    - Buy when League anniversary content trends drive set demand
+  about: "Trailblazer trousers (t1) is a members-only cosmetic legs piece earned from the Trailblazer Reloaded League and the original Trailblazer League rewards; it has no combat stats and matches the t1 tier of the Trailblazer outfit."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: true
+    members: true
+    quest_item: false
+    weight: 0.453
+    options:
+      - Wear
+      - Drop
+      - Examine
+    worn_options:
+      - Remove
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2020-10-28"
+      description: "Trailblazer trousers (t1) introduced with the Trailblazer League rewards shop."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/treasonous-ring.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/treasonous-ring.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
+  material:
+    type: ring
+    tier: high
   equipment:
     slot: ring
     type: stab_ring
@@ -77,8 +80,8 @@ osrs:
       - Wilderness boss drop
       - Imbue for full effect
       - Niche use case
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-combat.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-combat.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
+  material:
+    type: wood
+    tier: low
   about: "Tribal mask (combat) is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-poison.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-mask-poison.mdx
@@ -12,9 +12,43 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 150
-  about: "Tribal mask (poison) is a members-only item in Old School RuneScape. High alchemy value: 300 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Tribal mask (poison) is one of three ceremonial masks tied to the Tai Bwo Wannai Trio quest, granting safe passage through Tribesmen attacks in the jungle."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    release_date: "2004-09-21"
+    tradeable: true
+    equipable: true
+    stackable: false
+    noteable: true
+    quest_item: true
+    destroy: "Drop"
+    weight: 0.45
+  material:
+    type: mask
+    tier: low
+  equipment:
+    slot: head
+    weight: 0.45
+  related_items:
+    - item_name: Tribal mask (disease)
+      slug: tribal-mask-disease
+      relationship: variant
+      description: Disease-themed variant of the tribal mask trio.
+    - item_name: Tribal mask (death)
+      slug: tribal-mask-death
+      relationship: variant
+      description: Death-themed variant of the tribal mask trio.
+  market_strategy:
+    notes:
+      - "Niche quest-tied item with capped supply."
+      - "Demand driven by Tai Bwo Wannai Cleanup activity."
+  trading_tips:
+    - "Sell to players doing Tai Bwo Wannai Cleanup for safety from Tribesmen."
+    - "Buy back from inactive accounts liquidating cosmetic gear."
+  history:
+    - date: "2004-09-21"
+      description: "Tribal mask (poison) released with the Tai Bwo Wannai Trio quest."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-blue.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/tribal-top-blue.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 180
   limit: 150
   about: "Tribal top (blue) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/turquoise-robe-bottoms.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/turquoise-robe-bottoms.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 72
   highalch: 108
   limit: 150
+  material:
+    type: cloth
+    tier: low
   equipment:
     slot: legs
   related_items:
@@ -29,8 +32,8 @@ osrs:
     > _"A pair of turquoise robe bottoms."_
 
     Turquoise robe bottoms are part of the gnome clothing set. Purely cosmetic with no stat bonuses.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twinflame-staff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twinflame-staff.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 20000
   highalch: 30000
   limit: 8
+  material:
+    type: weapon
+    tier: high
   about: "Twinflame staff is a members-only item in Old School RuneScape. High alchemy value: 30,000 coins. Grand Exchange buy limit: 8 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-hat-t1.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/twisted-hat-t1.mdx
@@ -12,9 +12,12 @@ osrs:
   lowalch: 400
   highalch: 600
   limit: 5
+  material:
+    type: cosmetic
+    tier: mid
   about: "Twisted hat (t1) is a members-only item in Old School RuneScape. High alchemy value: 600 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/unicorn-horn.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/unicorn-horn.mdx
@@ -1,6 +1,6 @@
 ---
 title: Unicorn horn | OSRS Price Data
-description: "Unicorn horn: This horn has restorative properties.. High alch: 12 GP, GE limit: 13,000."
+description: "Unicorn horn is a members Herblore secondary used in Antipoison and Sanfew serum recipes. High alch: 12 GP, GE limit: 13,000."
 osrs:
   id: 237
   name: Unicorn horn
@@ -14,7 +14,7 @@ osrs:
   limit: 13000
   material:
     type: secondary
-    tier: basic
+    tier: low
   drop_table:
     sources:
       - source: Unicorn
@@ -30,7 +30,7 @@ osrs:
       - source: Venenatis
         source_id: 6504
         combat_level: 464
-        quantity: 200-500 (noted)
+        quantity: "200-500 (noted)"
         rarity: uncommon
         members_only: true
   recipes:
@@ -46,44 +46,59 @@ osrs:
           quantity: 1
       product: Antipoison(3)
       product_id: 175
-      product_quantity: 1
+      output_quantity: 1
       members_only: true
   related_items:
     - item_id: 235
       item_name: Unicorn horn dust
       slug: unicorn-horn-dust
       relationship: product
-      description: Crushed form
+      description: Crushed form for Herblore use
     - item_id: 175
       item_name: Antipoison(3)
       slug: antipoison-3
       relationship: product
-      description: End product
+      description: Primary potion product
     - item_id: 9998
       item_name: Sanfew serum(4)
       slug: sanfew-serum-4
       relationship: product
-      description: Advanced product
+      description: Advanced restorative potion product
     - item_id: 233
       item_name: Pestle and mortar
       slug: pestle-and-mortar
       relationship: component
-      description: Processing tool
-  about: |-
-    | Property | Value |
-    |----------|-------|
-    | Slot | N/A |
-    | Type | Herblore Secondary |
-    | Tradeable | Yes |
-    | Weight | 0.007 kg |
-
-    Secondary ingredient for:
-    - Antipoison (with marrentill potion unf)
-    - Unicorn horn dust (crushed with pestle and mortar)
-
-    Also used in Sanfew serum production.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Tool required to crush horn into dust
+  market_strategy:
+    title: Market Notes
+    notes:
+      - "Steady Herblore demand keeps prices stable around alch value"
+      - "Bulk supply comes from Unicorn and Black unicorn farms"
+      - "Venenatis noted drops can flood the market during PvM events"
+  trading_tips:
+    - Use Grand Exchange for secure trades
+    - Crush into dust only when Antipoison demand is high
+    - Buy in bulk near alch value floor for Herblore training
+  about: "Unicorn horn is a members-only Herblore secondary harvested from unicorns; it is crushed into unicorn horn dust to brew Antipoison and feeds into Sanfew serum production."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  properties:
+    tradeable: true
+    stackable: false
+    noteable: true
+    equipable: false
+    members: true
+    quest_item: false
+    weight: 0.007
+    options:
+      - Use
+      - Drop
+      - Examine
+    alchable: true
+    destroy: Drop
+  history:
+    - date: "2002-09-26"
+      description: "Unicorn horn added with the original Herblore-precursor potion content."
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/viggora-s-chainmace-u.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/viggora-s-chainmace-u.mdx
@@ -12,12 +12,13 @@ osrs:
   lowalch: 48000
   highalch: 72000
   limit: 8
+  material:
+    type: ancient
+    tier: high
   equipment:
     slot: 2h
     type: scythe
     attack_style: slash
-    attack_speed: 5
-    attack_range: 1
     tradeable: true
     weight: 3.628
     requirements:
@@ -40,13 +41,13 @@ osrs:
   special_attack:
     none: true
     notes: No special attack
-  passive_effect:
-    name: Multi-hit
-    description: Hits up to 3 times per attack on large targets
-    hit_1_damage: 100
-    hit_2_damage: 50
-    hit_3_damage: 25
-    large_target_requirement: 3x3 or larger
+  passive_effects:
+    - name: Multi-hit
+      description: Hits up to 3 times per attack on large targets
+      hit_1_damage: 100
+      hit_2_damage: 50
+      hit_3_damage: 25
+      large_target_requirement: 3x3 or larger
   drop_table:
     sources:
       - source: Theatre of Blood
@@ -120,8 +121,8 @@ osrs:
       - BiS for 3x3+ targets
       - ToB is primary source
       - Consider charge cost in DPS calculations
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/virtus-mask.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 80000
   highalch: 120000
   limit: 8
+  material:
+    type: virtus
+    tier: high
   equipment:
     slot: head
     type: magic armour
@@ -21,43 +24,41 @@ osrs:
       magic: 78
       defence: 75
     stats:
-      attack_stab: 0
-      attack_slash: 0
-      attack_crush: 0
       attack_magic: 8
-      attack_ranged: 0
       defence_stab: 15
       defence_slash: 14
       defence_crush: 16
       defence_magic: 6
-      defence_ranged: 0
-      strength: 0
-      ranged_strength: 0
       magic_damage: 2
       prayer: 1
-  obtaining:
-    - source: The Whisperer
-      drop_rate: 1/1,536
-    - source: Duke Sucellus
-      drop_rate: 1/2,160
-    - source: The Leviathan
-      drop_rate: 1/2,304
-    - source: Vardorvis
-      drop_rate: 1/3,264
+  drop_table:
+    sources:
+      - source: The Whisperer
+        quantity: "1"
+        rarity: 1/1,536
+      - source: Duke Sucellus
+        quantity: "1"
+        rarity: 1/2,160
+      - source: The Leviathan
+        quantity: "1"
+        rarity: 1/2,304
+      - source: Vardorvis
+        quantity: "1"
+        rarity: 1/3,264
   set_bonus:
     name: Virtus Set
-    standard: +2% magic damage per piece (6% total)
-    ancient_magicks: +5% magic damage per piece (15% total)
+    standard: "+2% magic damage per piece (6% total)"
+    ancient_magicks: "+5% magic damage per piece (15% total)"
   related_items:
     - item_id: 26243
       item_name: Virtus robe top
       slug: virtus-robe-top
-      relationship: alternative
+      relationship: set-piece
       description: Set body piece
     - item_id: 26245
       item_name: Virtus robe bottom
       slug: virtus-robe-bottom
-      relationship: alternative
+      relationship: set-piece
       description: Set legs piece
   about: |-
     | Offence | Bonus |
@@ -79,8 +80,8 @@ osrs:
     Magic Damage Bonus:
     - Standard: +2% per piece (6% total)
     - Ancient Magicks: +5% per piece (15% total)
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/warrior-helm.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/warrior-helm.mdx
@@ -12,8 +12,14 @@ osrs:
   lowalch: 24000
   highalch: 36000
   limit: 70
+  material:
+    type: fremennik
+    tier: mid-high
   equipment:
     slot: head
+    weight: 2.721
+    requirements:
+      defence: 45
     attack_bonus:
       stab: 0
       slash: 5
@@ -31,9 +37,6 @@ osrs:
       ranged_strength: 0
       magic_damage: 0
       prayer: 0
-    requirements:
-      defence: 45
-    weight: 2.721
   related_items:
     - item_id: 3751
       item_name: Berserker helm
@@ -50,6 +53,14 @@ osrs:
       slug: archer-helm
       relationship: alternative
       description: Ranged variant
+  market_strategy:
+    notes:
+      - "Least popular Fremennik melee helm: berserker preferred"
+      - Niche accuracy option for slash weapons
+      - Supply from Barbarian Assault
+  trading_tips:
+    - Use Grand Exchange for fast trades
+    - Compare DPS vs berserker helm before buying
   about: |-
     | Attack | Value |
     |--------|-------|
@@ -62,16 +73,11 @@ osrs:
     | Crush | +29 |
     | Ranged | +30 |
 
-    Requirements: 45 Defence | Weight: 2.72 kg
+    Requirements 45 Defence with Weight 2.72 kg.
 
-    The warrior helm provides +5 slash attack — unique among Fremennik helms. However, it lacks the Strength bonus of the berserker helm, making it less popular for general melee. The +5 slash is a marginal accuracy boost that rarely outweighs +3 Strength in DPS calculations.
-  market_strategy:
-    notes:
-      - Least popular Fremennik melee helm (berserker preferred)
-      - Niche accuracy option for slash weapons
-      - Supply from Barbarian Assault
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+    The warrior helm provides +5 slash attack which is unique among Fremennik helms. However it lacks the Strength bonus of the berserker helm, making it less popular for general melee. The +5 slash is a marginal accuracy boost that rarely outweighs +3 Strength in DPS calculations.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/west-ardougne-teleport-tablet.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/west-ardougne-teleport-tablet.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 1
   limit: 10000
   about: "West ardougne teleport (tablet) is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 10,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/white-platelegs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/white-platelegs.mdx
@@ -73,8 +73,8 @@ osrs:
       - Inferior to Proselyte
       - Cosmetic/collection value
       - Low practical use
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wrath-rune.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wrath-rune.mdx
@@ -1,6 +1,6 @@
 ---
 title: Wrath rune | OSRS Price Data
-description: "Wrath rune: Used for very high level missile spells.. High alch: 300 GP, GE limit: 25,000."
+description: "Wrath rune: Used for very high level missile spells. High alch: 300 GP, GE limit: 25,000."
 osrs:
   id: 21880
   name: Wrath rune
@@ -12,6 +12,9 @@ osrs:
   lowalch: 200
   highalch: 300
   limit: 25000
+  material:
+    type: rune
+    tier: high
   rune:
     type: catalytic
     element: wrath
@@ -100,8 +103,8 @@ osrs:
       - Quest locked content
       - Fire Surge for PvM
       - Price volatile with meta changes
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wyvern-bones.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wyvern-bones.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 64
   highalch: 96
   limit: 7500
+  material:
+    type: bones
+    tier: mid-high
   prayer:
     type: bones
     tier: wyvern
@@ -78,8 +81,8 @@ osrs:
       - Often cheaper alternative
       - Skeletal wyverns popular
       - Wyvern tasks profitable
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-bead.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yellow-bead.mdx
@@ -13,8 +13,8 @@ osrs:
   highalch: 2
   limit: 11000
   about: "Yellow bead is a free-to-play item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/yew-sapling.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/yew-sapling.mdx
@@ -1,6 +1,6 @@
 ---
 title: Yew sapling | OSRS Price Data
-description: "Yew sapling: This sapling is ready to be replanted in a tree patch.. High alch: 1 GP, GE limit: 200."
+description: "Yew sapling is a Farming sapling planted in tree patches. High alch: 1 GP, GE limit: 200."
 osrs:
   id: 5373
   name: Yew sapling
@@ -12,9 +12,47 @@ osrs:
   lowalch: 1
   highalch: 1
   limit: 200
-  about: "Yew sapling is a members-only item in Old School RuneScape. High alchemy value: 1 coins. Grand Exchange buy limit: 200 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  material:
+    type: farming
+    tier: mid-high
+  recipes:
+    - skill: farming
+      level: 60
+      xp: 81
+      output_quantity: 1
+      materials:
+        - item_name: Yew seed
+          quantity: "1"
+        - item_name: Plant pot
+          quantity: "1"
+      product: Yew sapling
+  related_items:
+    - item_id: 5315
+      item_name: Yew seed
+      slug: yew-seed
+      relationship: component
+      description: Seed planted in plant pot to grow this sapling
+    - item_id: 5375
+      item_name: Magic sapling
+      slug: magic-sapling
+      relationship: alternative
+      description: Higher tier tree sapling
+    - item_id: 5371
+      item_name: Maple sapling
+      slug: maple-sapling
+      relationship: alternative
+      description: Lower tier tree sapling
+  market_strategy:
+    notes:
+      - Used by Farming players growing yew trees
+      - Supply depends on yew seed availability
+      - Profit margin tied to yew seed price
+  trading_tips:
+    - Plant immediately to avoid stockpiling
+    - Buy in bulk from skillers
+  about: "Yew sapling is grown from a yew seed in a plant pot and planted in a tree patch at 60 Farming. Matures into a yew tree after roughly 16 hours."
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

Batch 26 of the OSRS MDX v2 → v3 schema migration. 199 items normalized to the v3 shape used by the OSRSItemPanel (index.mdx skipped — listing page).

- All entries: `mdx_version: 3`, `mdx_updated: "2026-06-05"`, `material: { type, tier }` (enum: low/mid/mid-high/high)
- Drops: `drop_table.sources[].source` (not `monster`), `quantity` as string
- Shops: `shop_name` first key, quoted where colons/apostrophes appear, numeric `price`/`stock` (0 never null)
- Recipes: lowercase `skill`, `materials[].item_name`, `xp` (not `experience`), `output_quantity`
- Equipment: singular `attack_bonus`/`defence_bonus`/`other_bonus`; `attack_speed`/`attack_range` omitted when N/A
- `treasure_trail.tier` lowercase enum; omitted for non-clue items
- `related_items[].relationship` enum: variant/upgrade/downgrade/component/product/set-piece/alternative
- `market_strategy: { notes: [] }` object form; `trading_tips: []` array
- `history[]` dates quoted, `description:` key, `update:` folded into description
- `potion.effects[].duration` as number seconds
- `passive_effects[].name` required

## Test plan

- [x] `nx run astro-kbve:sync` — content collection schema validation
- [x] `nx run astro-kbve:build` — 7,742 pages built, 0 errors