### PR TITLE
fix(kube): gateway-only cryptothrone fleet — portPolicy None, drop privileged PSA

### DIFF
--- a/apps/kube/agones/cryptothrone/manifests/fleet.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/fleet.yaml
@@ -21,8 +21,11 @@ spec:
                 app.kubernetes.io/part-of: cryptothrone
         spec:
             ports:
+                # No hostPort — clients reach the server through the Cilium
+                # gateway (HTTPRoute -> cryptothrone-game Service), so the
+                # pod stays compatible with baseline PodSecurity.
                 - name: ws
-                  portPolicy: Dynamic
+                  portPolicy: None
                   containerPort: 7979
                   protocol: TCP
             health:

--- a/apps/kube/agones/cryptothrone/manifests/namespace.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/namespace.yaml
@@ -5,6 +5,3 @@ metadata:
     labels:
         app.kubernetes.io/part-of: cryptothrone
         kbve.com/stack: agones
-        pod-security.kubernetes.io/enforce: privileged
-        pod-security.kubernetes.io/audit: privileged
-        pod-security.kubernetes.io/warn: privileged

--- a/apps/kube/agones/nd-server/manifests/namespace.yaml
+++ b/apps/kube/agones/nd-server/manifests/namespace.yaml
@@ -6,6 +6,3 @@ metadata:
         app.kubernetes.io/part-of: nexus-defense
         # Cilium hubble/observability tagging — keeps the netflow board grouped.
         kbve.com/stack: agones
-        pod-security.kubernetes.io/enforce: privileged
-        pod-security.kubernetes.io/audit: privileged
-        pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
## Summary
Follow-up to #12228, per review: traffic already resolves through the **Cilium gateway** (`game.cryptothrone.com` listener → HTTPRoute → `cryptothrone-game` ClusterIP → pod :7979), so the fleet doesn't need a hostPort at all — and without a hostPort there's no PodSecurity violation to grant privileged for.

- fleet `ws` port: `portPolicy: Dynamic` → `None` (Agones 1.56, beta default-on; validated with a server-side dry-run against live admission)
- revert the privileged PSA labels on `cryptothrone` (namespace also hosts the website deployment — keeping it baseline is a real posture win) and `nexus-defense`

If nd-server later wants gameservers in its own namespace, it can adopt the same gateway-only pattern.