### PR TITLE
feat(forgejo): error info-boxes, IDB-cached lazy loads + recover stranded commits

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -8,6 +8,7 @@ import ReactForgejoRepoPanel from './ReactForgejoRepoPanel';
 import ReactForgejoUserPanel from './ReactForgejoUserPanel';
 import ReactForgejoOrgPanel from './ReactForgejoOrgPanel';
 import ReactForgejoRepoAdmin from './ReactForgejoRepoAdmin';
+import ReactForgejoIssues from './ReactForgejoIssues';
 import ReactForgejoSystemPanel from './ReactForgejoSystemPanel';
 import ReactForgejoToast from './ReactForgejoToast';
 ---
@@ -19,7 +20,8 @@ import ReactForgejoToast from './ReactForgejoToast';
 	<div id="dashboard-content" class="dashboard-content">
 		<ReactForgejoAuth client:only="react">
 			<div class="not-content forgejo-dashboard">
-				<div id="forgejo-header">
+				<div id="forgejo-header" class="forgejo-header-row">
+					<h2 class="forgejo-title">Forgejo</h2>
 					<ReactForgejoHeader client:only="react" />
 				</div>
 				<div id="forgejo-tabs">
@@ -40,6 +42,9 @@ import ReactForgejoToast from './ReactForgejoToast';
 				</div>
 				<div id="forgejo-webhooks">
 					<ReactForgejoRepoAdmin client:only="react" />
+				</div>
+				<div id="forgejo-issues">
+					<ReactForgejoIssues client:only="react" />
 				</div>
 				<div id="forgejo-system">
 					<ReactForgejoSystemPanel client:only="react" />
@@ -75,6 +80,22 @@ import ReactForgejoToast from './ReactForgejoToast';
 		flex-direction: column;
 		color: var(--sl-color-text, #e6edf3);
 		min-height: 60vh;
+	}
+
+	.forgejo-header-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+		margin-bottom: 1.5rem;
+	}
+
+	.forgejo-title {
+		margin: 0;
+		font-size: 1.5rem;
+		font-weight: 700;
+		color: var(--sl-color-text, #e6edf3);
 	}
 
 	:global(@keyframes spin) {

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoHeader.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoHeader.tsx
@@ -11,33 +11,18 @@ export default function ReactForgejoHeader() {
 			className="not-content"
 			style={{
 				display: 'flex',
-				justifyContent: 'space-between',
 				alignItems: 'center',
-				marginBottom: '1.5rem',
-				flexWrap: 'wrap',
-				gap: '0.5rem',
+				gap: '0.75rem',
 			}}>
-			<div>
-				<h2
+			{lastUpdated && (
+				<span
 					style={{
-						color: 'var(--sl-color-text, #e6edf3)',
-						margin: 0,
-						fontSize: '1.5rem',
-						fontWeight: 700,
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.75rem',
 					}}>
-					Forgejo
-				</h2>
-				{lastUpdated && (
-					<p
-						style={{
-							color: 'var(--sl-color-gray-3, #8b949e)',
-							margin: '0.25rem 0 0',
-							fontSize: '0.75rem',
-						}}>
-						Last updated: {lastUpdated.toLocaleTimeString()}
-					</p>
-				)}
-			</div>
+					Updated {lastUpdated.toLocaleTimeString()}
+				</span>
+			)}
 			<button
 				onClick={() => forgejoService.refresh()}
 				disabled={loading}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
@@ -1,6 +1,12 @@
 import { useStore } from '@nanostores/react';
 import { forgejoService, timeAgo } from './forgejoService';
-import { ActionButton, SelectField, useTabActive, uiTokens } from './forgejoUi';
+import {
+	ActionButton,
+	SelectField,
+	useTabActive,
+	uiTokens,
+	ForgejoNotice,
+} from './forgejoUi';
 import {
 	CircleDot,
 	GitPullRequest,
@@ -74,6 +80,10 @@ export default function ReactForgejoIssues() {
 
 	return (
 		<div className="not-content">
+			<ForgejoNotice
+				ctx="issues"
+				onRetry={() => forgejoService.loadIssues()}
+			/>
 			<div
 				style={{
 					display: 'flex',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
@@ -1,0 +1,311 @@
+import { useStore } from '@nanostores/react';
+import { forgejoService, timeAgo } from './forgejoService';
+import { ActionButton, SelectField, useTabActive, uiTokens } from './forgejoUi';
+import {
+	CircleDot,
+	GitPullRequest,
+	Lock,
+	Unlock,
+	CheckCircle2,
+	RotateCcw,
+	MessageSquare,
+	ExternalLink,
+	Loader2,
+} from 'lucide-react';
+
+const { textColor, subText, border, panelBg } = uiTokens;
+
+function Segmented({
+	value,
+	options,
+	onChange,
+}: {
+	value: string;
+	options: { value: string; label: string }[];
+	onChange: (v: string) => void;
+}) {
+	return (
+		<div
+			style={{
+				display: 'inline-flex',
+				border,
+				borderRadius: 8,
+				overflow: 'hidden',
+			}}>
+			{options.map((o) => {
+				const on = o.value === value;
+				return (
+					<button
+						key={o.value}
+						type="button"
+						onClick={() => onChange(o.value)}
+						style={{
+							padding: '0.35rem 0.75rem',
+							border: 'none',
+							background: on
+								? 'rgba(6, 182, 212, 0.13)'
+								: 'transparent',
+							color: on
+								? 'var(--sl-color-accent, #06b6d4)'
+								: subText,
+							fontSize: '0.78rem',
+							fontWeight: 600,
+							cursor: 'pointer',
+						}}>
+						{o.label}
+					</button>
+				);
+			})}
+		</div>
+	);
+}
+
+export default function ReactForgejoIssues() {
+	const active = useTabActive('issues');
+	const repos = useStore(forgejoService.$repos);
+	const selected = useStore(forgejoService.$issueRepo);
+	const issues = useStore(forgejoService.$issues);
+	const state = useStore(forgejoService.$issueState);
+	const type = useStore(forgejoService.$issueType);
+	const loading = useStore(forgejoService.$issuesLoading);
+	const busy = useStore(forgejoService.$busy);
+
+	if (!active) return null;
+
+	return (
+		<div className="not-content">
+			<div
+				style={{
+					display: 'flex',
+					gap: 12,
+					alignItems: 'flex-end',
+					flexWrap: 'wrap',
+					marginBottom: '1.25rem',
+				}}>
+				<div style={{ flex: '1 1 280px', maxWidth: 420 }}>
+					<SelectField
+						label="Repository"
+						value={selected ?? ''}
+						onChange={(v) => forgejoService.selectIssueRepo(v)}
+						options={[
+							{ value: '', label: 'Select a repository…' },
+							...repos.map((r) => ({
+								value: r.full_name,
+								label: r.full_name,
+							})),
+						]}
+					/>
+				</div>
+				<div style={{ marginBottom: '0.75rem' }}>
+					<Segmented
+						value={type}
+						onChange={(v) =>
+							forgejoService.setIssueType(v as 'issues' | 'pulls')
+						}
+						options={[
+							{ value: 'issues', label: 'Issues' },
+							{ value: 'pulls', label: 'Pull requests' },
+						]}
+					/>
+				</div>
+				<div style={{ marginBottom: '0.75rem' }}>
+					<Segmented
+						value={state}
+						onChange={(v) =>
+							forgejoService.setIssueState(v as 'open' | 'closed')
+						}
+						options={[
+							{ value: 'open', label: 'Open' },
+							{ value: 'closed', label: 'Closed' },
+						]}
+					/>
+				</div>
+			</div>
+
+			{!selected && (
+				<span style={{ color: subText, fontSize: '0.85rem' }}>
+					Choose a repository to moderate its issues and pull
+					requests.
+				</span>
+			)}
+
+			{selected && loading && issues.length === 0 && (
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'center',
+						padding: '2rem',
+					}}>
+					<Loader2
+						size={22}
+						style={{
+							animation: 'spin 1s linear infinite',
+							color: 'var(--sl-color-accent, #06b6d4)',
+						}}
+					/>
+				</div>
+			)}
+
+			{selected && (
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 8,
+					}}>
+					{issues.map((it) => {
+						const isPull = !!it.pull_request;
+						return (
+							<div
+								key={it.id}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: 10,
+									padding: '0.6rem 0.8rem',
+									borderRadius: 8,
+									border,
+									background: panelBg,
+								}}>
+								{isPull ? (
+									<GitPullRequest
+										size={15}
+										style={{
+											color:
+												it.state === 'open'
+													? '#22c55e'
+													: '#8b5cf6',
+											flexShrink: 0,
+										}}
+									/>
+								) : (
+									<CircleDot
+										size={15}
+										style={{
+											color:
+												it.state === 'open'
+													? '#22c55e'
+													: '#6b7280',
+											flexShrink: 0,
+										}}
+									/>
+								)}
+								<div style={{ flex: 1, minWidth: 0 }}>
+									<div
+										style={{
+											color: textColor,
+											fontSize: '0.85rem',
+											fontWeight: 500,
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+											whiteSpace: 'nowrap',
+										}}>
+										<span style={{ color: subText }}>
+											#{it.number}
+										</span>{' '}
+										{it.title}
+										{it.is_locked && (
+											<Lock
+												size={11}
+												style={{
+													color: '#f59e0b',
+													marginLeft: 6,
+													verticalAlign: 'middle',
+												}}
+											/>
+										)}
+									</div>
+									<div
+										style={{
+											color: subText,
+											fontSize: '0.7rem',
+											display: 'flex',
+											gap: 10,
+											marginTop: 2,
+										}}>
+										<span>@{it.user?.login}</span>
+										<span>{timeAgo(it.created_at)}</span>
+										{it.comments > 0 && (
+											<span
+												style={{
+													display: 'inline-flex',
+													alignItems: 'center',
+													gap: 3,
+												}}>
+												<MessageSquare size={10} />
+												{it.comments}
+											</span>
+										)}
+									</div>
+								</div>
+
+								<a
+									href={it.html_url}
+									target="_blank"
+									rel="noreferrer"
+									style={{ color: subText, display: 'flex' }}
+									title="Open in Forgejo">
+									<ExternalLink size={13} />
+								</a>
+								<ActionButton
+									size="sm"
+									title={it.is_locked ? 'Unlock' : 'Lock'}
+									loading={busy === `issue-lock-${it.number}`}
+									onClick={() =>
+										forgejoService.setIssueLock(
+											it.number,
+											!it.is_locked,
+										)
+									}>
+									{it.is_locked ? (
+										<Unlock size={12} />
+									) : (
+										<Lock size={12} />
+									)}
+								</ActionButton>
+								{it.state === 'open' ? (
+									<ActionButton
+										size="sm"
+										variant="danger"
+										title="Close"
+										loading={
+											busy === `issue-state-${it.number}`
+										}
+										onClick={() =>
+											forgejoService.setIssueOpenState(
+												it.number,
+												'closed',
+											)
+										}>
+										<CheckCircle2 size={12} />
+									</ActionButton>
+								) : (
+									<ActionButton
+										size="sm"
+										title="Reopen"
+										loading={
+											busy === `issue-state-${it.number}`
+										}
+										onClick={() =>
+											forgejoService.setIssueOpenState(
+												it.number,
+												'open',
+											)
+										}>
+										<RotateCcw size={12} />
+									</ActionButton>
+								)}
+							</div>
+						);
+					})}
+					{!loading && issues.length === 0 && (
+						<span style={{ color: subText, fontSize: '0.85rem' }}>
+							No {state}{' '}
+							{type === 'pulls' ? 'pull requests' : 'issues'}.
+						</span>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgPanel.tsx
@@ -16,6 +16,7 @@ import {
 	useTabActive,
 	uiTokens,
 	LoadMoreButton,
+	ForgejoNotice,
 } from './forgejoUi';
 import {
 	Plus,
@@ -519,6 +520,7 @@ export default function ReactForgejoOrgPanel() {
 
 	return (
 		<div className="not-content">
+			<ForgejoNotice ctx="orgs" />
 			<div
 				style={{
 					display: 'flex',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoAdmin.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoAdmin.tsx
@@ -11,6 +11,7 @@ import {
 	useForm,
 	useTabActive,
 	uiTokens,
+	ForgejoNotice,
 } from './forgejoUi';
 import {
 	Plus,
@@ -408,6 +409,14 @@ export default function ReactForgejoRepoAdmin() {
 
 	return (
 		<div className="not-content">
+			<ForgejoNotice
+				ctx="repoAdmin"
+				onRetry={
+					selected
+						? () => forgejoService.selectRepo(selected)
+						: undefined
+				}
+			/>
 			<div style={{ maxWidth: 420, marginBottom: '1.5rem' }}>
 				<SelectField
 					label="Repository"

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
@@ -18,6 +18,7 @@ import {
 	useTabActive,
 	uiTokens,
 	LoadMoreButton,
+	ForgejoNotice,
 } from './forgejoUi';
 import {
 	Plus,
@@ -361,6 +362,10 @@ function CollaboratorsModal({
 			title={`Collaborators · ${repo.full_name}`}
 			onClose={onClose}
 			width={520}>
+			<ForgejoNotice
+				ctx="collaborators"
+				onRetry={() => forgejoService.loadCollaborators(repo.full_name)}
+			/>
 			<div
 				style={{
 					display: 'flex',

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSystemPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSystemPanel.tsx
@@ -1,7 +1,12 @@
 import { useEffect } from 'react';
 import { useStore } from '@nanostores/react';
 import { forgejoService, timeAgo } from './forgejoService';
-import { ActionButton, useTabActive, uiTokens } from './forgejoUi';
+import {
+	ActionButton,
+	useTabActive,
+	uiTokens,
+	ForgejoNotice,
+} from './forgejoUi';
 import {
 	ServerCog,
 	Play,
@@ -51,6 +56,10 @@ export default function ReactForgejoSystemPanel() {
 				flexDirection: 'column',
 				gap: '1.25rem',
 			}}>
+			<ForgejoNotice
+				ctx="system"
+				onRetry={() => forgejoService.loadSystem()}
+			/>
 			<div style={cardStyle}>
 				<h3 style={cardTitle}>
 					<ServerCog size={14} /> Server

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
@@ -6,6 +6,7 @@ import {
 	Users,
 	Building2,
 	Webhook,
+	CircleDot,
 	ServerCog,
 } from 'lucide-react';
 
@@ -19,6 +20,7 @@ const TABS: { id: ForgejoTab; label: string; icon: React.ReactNode }[] = [
 		label: 'Repo Admin',
 		icon: <Webhook size={14} />,
 	},
+	{ id: 'issues', label: 'Issues & PRs', icon: <CircleDot size={14} /> },
 	{ id: 'system', label: 'System', icon: <ServerCog size={14} /> },
 ];
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -323,6 +323,14 @@ export interface ToastMsg {
 	msg: string;
 }
 
+export type NoticeKind = 'info' | 'warn' | 'error';
+
+export interface Notice {
+	kind: NoticeKind;
+	msg: string;
+	detail?: string;
+}
+
 interface CachedData {
 	ts: number;
 	repos: ForgejoRepo[];
@@ -341,6 +349,7 @@ const CACHE_TTL_MS = 60 * 1000;
 const PROXY_BASE = '/dashboard/forgejo/proxy';
 const REFRESH_INTERVAL_MS = 30 * 1000;
 const PAGE_SIZE = 50;
+const RESOURCE_TTL_MS = 60 * 1000;
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -697,6 +706,7 @@ class ForgejoService {
 	);
 	public readonly $toast = atom<ToastMsg | null>(null);
 	public readonly $busy = atom<string | null>(null);
+	public readonly $notices = atom<Record<string, Notice>>({});
 
 	public readonly $teams = atom<Record<string, ForgejoTeam[]>>({});
 	public readonly $orgMembers = atom<Record<string, ForgejoUser[]>>({});
@@ -1094,6 +1104,61 @@ class ForgejoService {
 		this.$toast.set(null);
 	}
 
+	public setNotice(ctx: string, notice: Notice): void {
+		this.$notices.set({ ...this.$notices.get(), [ctx]: notice });
+	}
+
+	public clearNotice(ctx: string): void {
+		const next = { ...this.$notices.get() };
+		if (ctx in next) {
+			delete next[ctx];
+			this.$notices.set(next);
+		}
+	}
+
+	private _noticeFor(e: unknown): Notice {
+		if (e instanceof AccessRestrictedError) {
+			return {
+				kind: 'warn',
+				msg: 'Access restricted',
+				detail: 'The Forgejo token lacks permission for this resource.',
+			};
+		}
+		if (e instanceof UpstreamUnavailableError) {
+			return {
+				kind: 'error',
+				msg: 'Forgejo upstream unreachable',
+				detail: e.reason,
+			};
+		}
+		return {
+			kind: 'error',
+			msg: 'Could not load data',
+			detail: e instanceof Error ? e.message : 'Unknown error',
+		};
+	}
+
+	private async _loadResource<T>(
+		ctx: string,
+		cacheKey: string,
+		path: string,
+		apply: (data: T) => void,
+		ttl = RESOURCE_TTL_MS,
+	): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		const cached = await cacheGet<T>(cacheKey, ttl);
+		if (cached !== null) apply(cached);
+		try {
+			const data = await apiFetch<T>(token, path);
+			apply(data);
+			void cacheSet(cacheKey, data);
+			this.clearNotice(ctx);
+		} catch (e) {
+			if (cached === null) this.setNotice(ctx, this._noticeFor(e));
+		}
+	}
+
 	private async _run(
 		id: string,
 		fn: (token: string) => Promise<void>,
@@ -1204,17 +1269,16 @@ class ForgejoService {
 	}
 
 	public async loadCollaborators(fullName: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const collabs = await apiFetch<ForgejoCollaborator[]>(
-			token,
-			`/api/v1/repos/${fullName}/collaborators?limit=50`,
-			[] as ForgejoCollaborator[],
+		await this._loadResource<ForgejoCollaborator[]>(
+			'collaborators',
+			`forgejo:collab:${fullName}`,
+			`/api/v1/repos/${fullName}/collaborators?limit=${PAGE_SIZE}`,
+			(d) =>
+				this.$collaborators.set({
+					...this.$collaborators.get(),
+					[fullName]: d,
+				}),
 		);
-		this.$collaborators.set({
-			...this.$collaborators.get(),
-			[fullName]: collabs,
-		});
 	}
 
 	public addCollaborator(
@@ -1333,14 +1397,13 @@ class ForgejoService {
 	}
 
 	public async loadOrgMembers(org: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const members = await apiFetch<ForgejoUser[]>(
-			token,
-			`/api/v1/orgs/${org}/members?limit=50`,
-			[] as ForgejoUser[],
+		await this._loadResource<ForgejoUser[]>(
+			'orgs',
+			`forgejo:orgmembers:${org}`,
+			`/api/v1/orgs/${org}/members?limit=${PAGE_SIZE}`,
+			(d) =>
+				this.$orgMembers.set({ ...this.$orgMembers.get(), [org]: d }),
 		);
-		this.$orgMembers.set({ ...this.$orgMembers.get(), [org]: members });
 	}
 
 	public removeOrgMember(org: string, user: string): Promise<boolean> {
@@ -1359,14 +1422,12 @@ class ForgejoService {
 	}
 
 	public async loadTeams(org: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const teams = await apiFetch<ForgejoTeam[]>(
-			token,
-			`/api/v1/orgs/${org}/teams?limit=50`,
-			[] as ForgejoTeam[],
+		await this._loadResource<ForgejoTeam[]>(
+			'orgs',
+			`forgejo:teams:${org}`,
+			`/api/v1/orgs/${org}/teams?limit=${PAGE_SIZE}`,
+			(d) => this.$teams.set({ ...this.$teams.get(), [org]: d }),
 		);
-		this.$teams.set({ ...this.$teams.get(), [org]: teams });
 	}
 
 	public createTeam(org: string, input: CreateTeamInput): Promise<boolean> {
@@ -1392,17 +1453,16 @@ class ForgejoService {
 	}
 
 	public async loadTeamMembers(teamId: number): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const members = await apiFetch<ForgejoUser[]>(
-			token,
-			`/api/v1/teams/${teamId}/members?limit=50`,
-			[] as ForgejoUser[],
+		await this._loadResource<ForgejoUser[]>(
+			'orgs',
+			`forgejo:teammembers:${teamId}`,
+			`/api/v1/teams/${teamId}/members?limit=${PAGE_SIZE}`,
+			(d) =>
+				this.$teamMembers.set({
+					...this.$teamMembers.get(),
+					[teamId]: d,
+				}),
 		);
-		this.$teamMembers.set({
-			...this.$teamMembers.get(),
-			[teamId]: members,
-		});
 	}
 
 	public addTeamMember(teamId: number, user: string): Promise<boolean> {
@@ -1438,14 +1498,16 @@ class ForgejoService {
 	// --- Webhook actions ---
 
 	public async loadRepoHooks(fullName: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const hooks = await apiFetch<ForgejoHook[]>(
-			token,
-			`/api/v1/repos/${fullName}/hooks?limit=50`,
-			[] as ForgejoHook[],
+		await this._loadResource<ForgejoHook[]>(
+			'repoAdmin',
+			`forgejo:hooks:${fullName}`,
+			`/api/v1/repos/${fullName}/hooks?limit=${PAGE_SIZE}`,
+			(d) =>
+				this.$repoHooks.set({
+					...this.$repoHooks.get(),
+					[fullName]: d,
+				}),
 		);
-		this.$repoHooks.set({ ...this.$repoHooks.get(), [fullName]: hooks });
 	}
 
 	public createHook(
@@ -1503,17 +1565,16 @@ class ForgejoService {
 	// --- Release actions ---
 
 	public async loadRepoReleases(fullName: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const releases = await apiFetch<ForgejoRelease[]>(
-			token,
+		await this._loadResource<ForgejoRelease[]>(
+			'repoAdmin',
+			`forgejo:releases:${fullName}`,
 			`/api/v1/repos/${fullName}/releases?limit=20`,
-			[] as ForgejoRelease[],
+			(d) =>
+				this.$repoReleases.set({
+					...this.$repoReleases.get(),
+					[fullName]: d,
+				}),
 		);
-		this.$repoReleases.set({
-			...this.$repoReleases.get(),
-			[fullName]: releases,
-		});
 	}
 
 	public createRelease(
@@ -1553,17 +1614,16 @@ class ForgejoService {
 	// --- Branch protection actions ---
 
 	public async loadRepoProtections(fullName: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const rules = await apiFetch<ForgejoBranchProtection[]>(
-			token,
+		await this._loadResource<ForgejoBranchProtection[]>(
+			'repoAdmin',
+			`forgejo:protections:${fullName}`,
 			`/api/v1/repos/${fullName}/branch_protections`,
-			[] as ForgejoBranchProtection[],
+			(d) =>
+				this.$repoProtections.set({
+					...this.$repoProtections.get(),
+					[fullName]: d,
+				}),
 		);
-		this.$repoProtections.set({
-			...this.$repoProtections.get(),
-			[fullName]: rules,
-		});
 	}
 
 	public createProtection(
@@ -1606,31 +1666,29 @@ class ForgejoService {
 	// --- Secrets & variables actions ---
 
 	public async loadRepoSecrets(fullName: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const secrets = await apiFetch<ForgejoSecret[]>(
-			token,
+		await this._loadResource<ForgejoSecret[]>(
+			'repoAdmin',
+			`forgejo:secrets:${fullName}`,
 			`/api/v1/repos/${fullName}/actions/secrets?limit=${PAGE_SIZE}`,
-			[] as ForgejoSecret[],
+			(d) =>
+				this.$repoSecrets.set({
+					...this.$repoSecrets.get(),
+					[fullName]: d,
+				}),
 		);
-		this.$repoSecrets.set({
-			...this.$repoSecrets.get(),
-			[fullName]: secrets,
-		});
 	}
 
 	public async loadRepoVariables(fullName: string): Promise<void> {
-		const token = this.$accessToken.get();
-		if (!token) return;
-		const variables = await apiFetch<ForgejoVariable[]>(
-			token,
+		await this._loadResource<ForgejoVariable[]>(
+			'repoAdmin',
+			`forgejo:variables:${fullName}`,
 			`/api/v1/repos/${fullName}/actions/variables?limit=${PAGE_SIZE}`,
-			[] as ForgejoVariable[],
+			(d) =>
+				this.$repoVariables.set({
+					...this.$repoVariables.get(),
+					[fullName]: d,
+				}),
 		);
-		this.$repoVariables.set({
-			...this.$repoVariables.get(),
-			[fullName]: variables,
-		});
 	}
 
 	public setSecret(
@@ -1738,9 +1796,12 @@ class ForgejoService {
 			const issues = await apiFetch<ForgejoIssue[]>(
 				token,
 				`/api/v1/repos/${repo}/issues?state=${this.$issueState.get()}&type=${this.$issueType.get()}&limit=${PAGE_SIZE}`,
-				[] as ForgejoIssue[],
 			);
 			this.$issues.set(Array.isArray(issues) ? issues : []);
+			this.clearNotice('issues');
+		} catch (e) {
+			this.$issues.set([]);
+			this.setNotice('issues', this._noticeFor(e));
 		} finally {
 			this.$issuesLoading.set(false);
 		}
@@ -1798,24 +1859,40 @@ class ForgejoService {
 	public async loadSystem(): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
-		const [version, cron, unadopted] = await Promise.all([
-			apiFetch<ForgejoVersion>(token, '/api/v1/version', {
-				version: 'unknown',
-			}),
+		const [version, cron, unadopted] = await Promise.allSettled([
+			apiFetch<ForgejoVersion>(token, '/api/v1/version'),
 			apiFetch<ForgejoCronTask[]>(
 				token,
-				'/api/v1/admin/cron?limit=50',
-				[] as ForgejoCronTask[],
+				`/api/v1/admin/cron?limit=${PAGE_SIZE}`,
 			),
 			apiFetch<string[]>(
 				token,
-				'/api/v1/admin/unadopted?limit=50',
-				[] as string[],
+				`/api/v1/admin/unadopted?limit=${PAGE_SIZE}`,
 			),
 		]);
-		this.$version.set(version.version ?? 'unknown');
-		this.$cronTasks.set(Array.isArray(cron) ? cron : []);
-		this.$unadopted.set(Array.isArray(unadopted) ? unadopted : []);
+		this.$version.set(
+			version.status === 'fulfilled'
+				? (version.value.version ?? 'unknown')
+				: 'unknown',
+		);
+		this.$cronTasks.set(
+			cron.status === 'fulfilled' && Array.isArray(cron.value)
+				? cron.value
+				: [],
+		);
+		this.$unadopted.set(
+			unadopted.status === 'fulfilled' && Array.isArray(unadopted.value)
+				? unadopted.value
+				: [],
+		);
+		const failed = [version, cron, unadopted].find(
+			(r) => r.status === 'rejected',
+		);
+		if (failed && failed.status === 'rejected') {
+			this.setNotice('system', this._noticeFor(failed.reason));
+		} else {
+			this.clearNotice('system');
+		}
 	}
 
 	public runCron(task: string): Promise<boolean> {

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -213,7 +213,21 @@ export type ForgejoTab =
 	| 'users'
 	| 'orgs'
 	| 'webhooks'
+	| 'issues'
 	| 'system';
+
+export interface ForgejoIssue {
+	id: number;
+	number: number;
+	title: string;
+	state: 'open' | 'closed';
+	is_locked: boolean;
+	comments: number;
+	created_at: string;
+	html_url: string;
+	user: { login: string; avatar_url: string };
+	pull_request?: { merged: boolean } | null;
+}
 
 export interface CreateRepoInput {
 	owner: string;
@@ -705,6 +719,12 @@ class ForgejoService {
 	public readonly $version = atom<string | null>(null);
 	public readonly $cronTasks = atom<ForgejoCronTask[]>([]);
 	public readonly $unadopted = atom<string[]>([]);
+
+	public readonly $issueRepo = atom<string | null>(null);
+	public readonly $issueState = atom<'open' | 'closed'>('open');
+	public readonly $issueType = atom<'issues' | 'pulls'>('issues');
+	public readonly $issues = atom<ForgejoIssue[]>([]);
+	public readonly $issuesLoading = atom<boolean>(false);
 
 	// Pagination + search
 	public readonly $repoQuery = atom<string>('');
@@ -1690,6 +1710,87 @@ class ForgejoService {
 		this.loadRepoProtections(fullName);
 		this.loadRepoSecrets(fullName);
 		this.loadRepoVariables(fullName);
+	}
+
+	// --- Issue & PR moderation actions ---
+
+	public selectIssueRepo(fullName: string): void {
+		this.$issueRepo.set(fullName);
+		this.loadIssues();
+	}
+
+	public setIssueState(state: 'open' | 'closed'): void {
+		this.$issueState.set(state);
+		this.loadIssues();
+	}
+
+	public setIssueType(type: 'issues' | 'pulls'): void {
+		this.$issueType.set(type);
+		this.loadIssues();
+	}
+
+	public async loadIssues(): Promise<void> {
+		const token = this.$accessToken.get();
+		const repo = this.$issueRepo.get();
+		if (!token || !repo) return;
+		this.$issuesLoading.set(true);
+		try {
+			const issues = await apiFetch<ForgejoIssue[]>(
+				token,
+				`/api/v1/repos/${repo}/issues?state=${this.$issueState.get()}&type=${this.$issueType.get()}&limit=${PAGE_SIZE}`,
+				[] as ForgejoIssue[],
+			);
+			this.$issues.set(Array.isArray(issues) ? issues : []);
+		} finally {
+			this.$issuesLoading.set(false);
+		}
+	}
+
+	public setIssueOpenState(
+		index: number,
+		state: 'open' | 'closed',
+	): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`issue-state-${index}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'PATCH',
+					`/api/v1/repos/${repo}/issues/${index}`,
+					{ state },
+				);
+				await this.loadIssues();
+			},
+			state === 'closed' ? `#${index} closed` : `#${index} reopened`,
+		);
+	}
+
+	public setIssueLock(index: number, lock: boolean): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`issue-lock-${index}`,
+			async (t) => {
+				if (!repo) return;
+				if (lock) {
+					await apiMutate(
+						t,
+						'PUT',
+						`/api/v1/repos/${repo}/issues/${index}/lock`,
+						{ lock_reason: 'too heated' },
+					);
+				} else {
+					await apiMutate(
+						t,
+						'DELETE',
+						`/api/v1/repos/${repo}/issues/${index}/lock`,
+					);
+				}
+				await this.loadIssues();
+			},
+			lock ? `#${index} locked` : `#${index} unlocked`,
+		);
 	}
 
 	// --- System actions ---

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -1,6 +1,7 @@
 import { atom, computed } from 'nanostores';
 import { persistentAtom } from '@nanostores/persistent';
 import { initSupa, getSupa } from '@/lib/supa';
+import { cacheGet, cacheSet } from '@/lib/idb-cache';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -571,29 +572,21 @@ async function fetchRepoLanguages(
 // Cache helpers
 // ---------------------------------------------------------------------------
 
-function loadCache(): CachedData | null {
-	try {
-		const raw = localStorage.getItem(CACHE_KEY);
-		if (!raw) return null;
-		const parsed: CachedData = JSON.parse(raw);
-		if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
-		return parsed;
-	} catch {
-		return null;
-	}
+function loadCache(): Promise<CachedData | null> {
+	return cacheGet<CachedData>(CACHE_KEY, CACHE_TTL_MS);
 }
 
 function saveCache(
 	repos: ForgejoRepo[],
 	users: ForgejoUser[],
 	orgs: ForgejoOrg[],
-): void {
-	try {
-		const data: CachedData = { ts: Date.now(), repos, users, orgs };
-		localStorage.setItem(CACHE_KEY, JSON.stringify(data));
-	} catch {
-		// ignore quota errors
-	}
+): Promise<void> {
+	return cacheSet<CachedData>(CACHE_KEY, {
+		ts: Date.now(),
+		repos,
+		users,
+		orgs,
+	});
 }
 
 // ---------------------------------------------------------------------------
@@ -893,7 +886,7 @@ class ForgejoService {
 			this.$orgs.set(orgs.items);
 			this.$orgsHasMore.set(orgs.hasMore);
 			this.$lastUpdated.set(new Date());
-			saveCache(repos.items, users.items, orgs.items);
+			void saveCache(repos.items, users.items, orgs.items);
 		} catch (e: unknown) {
 			if (e instanceof AccessRestrictedError) {
 				this.$authState.set('forbidden');
@@ -910,11 +903,11 @@ class ForgejoService {
 		}
 	}
 
-	public loadCacheAndFetch(): void {
+	public async loadCacheAndFetch(): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
 
-		const cached = loadCache();
+		const cached = await loadCache();
 		if (cached) {
 			this.$repos.set(cached.repos);
 			this.$users.set(cached.users);

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoUi.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoUi.tsx
@@ -1,14 +1,142 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { useStore } from '@nanostores/react';
-import { X, Loader2, AlertTriangle, CheckCircle2, Info } from 'lucide-react';
+import {
+	X,
+	Loader2,
+	AlertTriangle,
+	CheckCircle2,
+	Info,
+	XCircle,
+	RotateCcw,
+} from 'lucide-react';
 import {
 	forgejoService,
 	type ForgejoTab,
 	type ToastMsg,
+	type Notice,
+	type NoticeKind,
 } from './forgejoService';
 
 export function useTabActive(tab: ForgejoTab): boolean {
 	return useStore(forgejoService.$activeTab) === tab;
+}
+
+const NOTICE_PALETTE: Record<
+	NoticeKind,
+	{ color: string; bg: string; Icon: typeof Info }
+> = {
+	info: { color: '#06b6d4', bg: 'rgba(6,182,212,0.1)', Icon: Info },
+	warn: { color: '#f59e0b', bg: 'rgba(245,158,11,0.1)', Icon: AlertTriangle },
+	error: { color: '#ef4444', bg: 'rgba(239,68,68,0.1)', Icon: XCircle },
+};
+
+export function InfoBox({
+	notice,
+	onDismiss,
+	onRetry,
+}: {
+	notice: Notice;
+	onDismiss?: () => void;
+	onRetry?: () => void;
+}) {
+	const p = NOTICE_PALETTE[notice.kind];
+	return (
+		<div
+			className="not-content"
+			style={{
+				display: 'flex',
+				alignItems: 'flex-start',
+				gap: 10,
+				padding: '0.7rem 0.9rem',
+				borderRadius: 10,
+				background: p.bg,
+				border: `1px solid ${p.color}40`,
+				marginBottom: '1rem',
+			}}>
+			<p.Icon
+				size={16}
+				style={{ color: p.color, flexShrink: 0, marginTop: 1 }}
+			/>
+			<div style={{ flex: 1, minWidth: 0 }}>
+				<div
+					style={{
+						color: 'var(--sl-color-text, #e6edf3)',
+						fontSize: '0.82rem',
+						fontWeight: 600,
+					}}>
+					{notice.msg}
+				</div>
+				{notice.detail && (
+					<div
+						style={{
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.74rem',
+							marginTop: 2,
+							wordBreak: 'break-word',
+						}}>
+						{notice.detail}
+					</div>
+				)}
+			</div>
+			{onRetry && (
+				<button
+					type="button"
+					onClick={onRetry}
+					title="Retry"
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: 4,
+						padding: '0.2rem 0.5rem',
+						borderRadius: 6,
+						border: `1px solid ${p.color}55`,
+						background: 'transparent',
+						color: p.color,
+						fontSize: '0.72rem',
+						fontWeight: 600,
+						cursor: 'pointer',
+						flexShrink: 0,
+					}}>
+					<RotateCcw size={11} /> Retry
+				</button>
+			)}
+			{onDismiss && (
+				<button
+					type="button"
+					onClick={onDismiss}
+					title="Dismiss"
+					style={{
+						background: 'transparent',
+						border: 'none',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						cursor: 'pointer',
+						display: 'flex',
+						flexShrink: 0,
+					}}>
+					<X size={14} />
+				</button>
+			)}
+		</div>
+	);
+}
+
+export function ForgejoNotice({
+	ctx,
+	onRetry,
+}: {
+	ctx: string;
+	onRetry?: () => void;
+}) {
+	const notices = useStore(forgejoService.$notices);
+	const notice = notices[ctx];
+	if (!notice) return null;
+	return (
+		<InfoBox
+			notice={notice}
+			onDismiss={() => forgejoService.clearNotice(ctx)}
+			onRetry={onRetry}
+		/>
+	);
 }
 
 export function LoadMoreButton({

--- a/apps/kbve/astro-kbve/src/lib/cache-db.ts
+++ b/apps/kbve/astro-kbve/src/lib/cache-db.ts
@@ -1,0 +1,20 @@
+import Dexie, { type Table } from 'dexie';
+
+export const CACHE_DB_NAME = 'kbve-cache-v1';
+
+export interface CacheRecord {
+	key: string;
+	value: string;
+	ts: number;
+}
+
+export class CacheDB extends Dexie {
+	cache!: Table<CacheRecord, string>;
+
+	constructor() {
+		super(CACHE_DB_NAME);
+		this.version(1).stores({
+			cache: 'key, ts',
+		});
+	}
+}

--- a/apps/kbve/astro-kbve/src/lib/idb-cache.ts
+++ b/apps/kbve/astro-kbve/src/lib/idb-cache.ts
@@ -1,0 +1,217 @@
+import { CacheDB, type CacheRecord } from './cache-db';
+
+interface CacheBackend {
+	name: string;
+	get(key: string): Promise<CacheRecord | null>;
+	set(rec: CacheRecord): Promise<void>;
+	del(key: string): Promise<void>;
+}
+
+const WORKER_PROBE_TIMEOUT_MS = 1500;
+const WORKER_OP_TIMEOUT_MS = 4000;
+
+function sharedWorkerBackend(): CacheBackend | null {
+	if (typeof window === 'undefined' || !('SharedWorker' in window))
+		return null;
+
+	let port: MessagePort;
+	try {
+		const worker = new SharedWorker(
+			new URL('../workers/supabase.shared.ts', import.meta.url),
+			{ type: 'module' },
+		);
+		port = worker.port;
+	} catch {
+		return null;
+	}
+
+	const pending = new Map<
+		string,
+		{ resolve: (v: any) => void; reject: (e: any) => void }
+	>();
+
+	port.onmessage = (e) => {
+		const { id, ok, data, error } = e.data ?? {};
+		if (!id || !pending.has(id)) return;
+		const { resolve, reject } = pending.get(id)!;
+		pending.delete(id);
+		ok ? resolve(data) : reject(new Error(error));
+	};
+	port.start();
+
+	const send = <T>(
+		type: string,
+		payload: any,
+		timeoutMs: number,
+	): Promise<T> =>
+		new Promise<T>((resolve, reject) => {
+			const id = crypto.randomUUID();
+			const timer = setTimeout(() => {
+				if (pending.delete(id)) reject(new Error('worker timeout'));
+			}, timeoutMs);
+			pending.set(id, {
+				resolve: (v) => {
+					clearTimeout(timer);
+					resolve(v);
+				},
+				reject: (e) => {
+					clearTimeout(timer);
+					reject(e);
+				},
+			});
+			port.postMessage({ id, type, payload });
+		});
+
+	return {
+		name: 'sharedworker',
+		async get(key) {
+			return send<CacheRecord | null>(
+				'cache.get',
+				{ key },
+				WORKER_OP_TIMEOUT_MS,
+			);
+		},
+		async set(rec) {
+			await send('cache.set', rec, WORKER_OP_TIMEOUT_MS);
+		},
+		async del(key) {
+			await send('cache.del', { key }, WORKER_OP_TIMEOUT_MS);
+		},
+	};
+}
+
+function dexieBackend(): CacheBackend | null {
+	if (typeof indexedDB === 'undefined') return null;
+	let db: CacheDB | null = null;
+	const ensure = (): CacheDB => {
+		if (!db) db = new CacheDB();
+		return db;
+	};
+	return {
+		name: 'dexie',
+		async get(key) {
+			return (await ensure().cache.get(key)) ?? null;
+		},
+		async set(rec) {
+			await ensure().cache.put(rec);
+		},
+		async del(key) {
+			await ensure().cache.delete(key);
+		},
+	};
+}
+
+function localStorageBackend(): CacheBackend | null {
+	if (typeof localStorage === 'undefined') return null;
+	const k = (key: string) => `idbc:${key}`;
+	return {
+		name: 'localstorage',
+		async get(key) {
+			const raw = localStorage.getItem(k(key));
+			return raw ? (JSON.parse(raw) as CacheRecord) : null;
+		},
+		async set(rec) {
+			try {
+				localStorage.setItem(k(rec.key), JSON.stringify(rec));
+			} catch {
+				/* quota — skip */
+			}
+		},
+		async del(key) {
+			localStorage.removeItem(k(key));
+		},
+	};
+}
+
+function memoryBackend(): CacheBackend {
+	const mem = new Map<string, CacheRecord>();
+	return {
+		name: 'memory',
+		async get(key) {
+			return mem.get(key) ?? null;
+		},
+		async set(rec) {
+			mem.set(rec.key, rec);
+		},
+		async del(key) {
+			mem.delete(key);
+		},
+	};
+}
+
+async function probe(backend: CacheBackend): Promise<boolean> {
+	try {
+		await Promise.race([
+			backend.get('__probe__'),
+			new Promise((_, reject) =>
+				setTimeout(
+					() => reject(new Error('probe timeout')),
+					WORKER_PROBE_TIMEOUT_MS,
+				),
+			),
+		]);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+let _backend: Promise<CacheBackend> | null = null;
+
+async function pickBackend(): Promise<CacheBackend> {
+	const sw = sharedWorkerBackend();
+	if (sw && (await probe(sw))) return sw;
+
+	const dx = dexieBackend();
+	if (dx && (await probe(dx))) return dx;
+
+	const ls = localStorageBackend();
+	if (ls) return ls;
+
+	return memoryBackend();
+}
+
+function backend(): Promise<CacheBackend> {
+	if (!_backend) _backend = pickBackend();
+	return _backend;
+}
+
+export async function cacheGet<T>(
+	key: string,
+	ttlMs: number,
+): Promise<T | null> {
+	try {
+		const b = await backend();
+		const rec = await b.get(key);
+		if (!rec) return null;
+		if (Date.now() - rec.ts > ttlMs) {
+			void b.del(key).catch(() => {});
+			return null;
+		}
+		return JSON.parse(rec.value) as T;
+	} catch {
+		return null;
+	}
+}
+
+export async function cacheSet<T>(key: string, value: T): Promise<void> {
+	try {
+		const b = await backend();
+		await b.set({ key, value: JSON.stringify(value), ts: Date.now() });
+	} catch {
+		/* best-effort cache */
+	}
+}
+
+export async function cacheDel(key: string): Promise<void> {
+	try {
+		const b = await backend();
+		await b.del(key);
+	} catch {
+		/* ignore */
+	}
+}
+
+export async function cacheBackendName(): Promise<string> {
+	return (await backend()).name;
+}

--- a/apps/kbve/astro-kbve/src/workers/supabase.shared.ts
+++ b/apps/kbve/astro-kbve/src/workers/supabase.shared.ts
@@ -4,6 +4,9 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import Dexie, { type Table } from 'dexie';
 import { getWorkerCommunication } from '../lib/worker-comm';
+import { CacheDB } from '../lib/cache-db';
+
+const cacheDb = new CacheDB();
 
 type Req =
 	| {
@@ -72,7 +75,14 @@ type Req =
 	| { id: string; type: 'ws.connect'; payload?: { wsUrl?: string } }
 	| { id: string; type: 'ws.disconnect' }
 	| { id: string; type: 'ws.send'; payload: { data: any } }
-	| { id: string; type: 'ws.status' };
+	| { id: string; type: 'ws.status' }
+	| { id: string; type: 'cache.get'; payload: { key: string } }
+	| {
+			id: string;
+			type: 'cache.set';
+			payload: { key: string; value: string; ts: number };
+	  }
+	| { id: string; type: 'cache.del'; payload: { key: string } };
 
 type Res =
 	| { id: string; ok: true; data?: any }
@@ -500,6 +510,28 @@ function reply(port: MessagePort, msg: Res) {
 		const m = e.data;
 		try {
 			switch (m.type) {
+				case 'cache.get': {
+					const rec = await cacheDb.cache.get(m.payload.key);
+					reply(port, { id: m.id, ok: true, data: rec ?? null });
+					break;
+				}
+
+				case 'cache.set': {
+					await cacheDb.cache.put({
+						key: m.payload.key,
+						value: m.payload.value,
+						ts: m.payload.ts,
+					});
+					reply(port, { id: m.id, ok: true });
+					break;
+				}
+
+				case 'cache.del': {
+					await cacheDb.cache.delete(m.payload.key);
+					reply(port, { id: m.id, ok: true });
+					break;
+				}
+
 				case 'init': {
 					const c = await ensureClient(
 						m.payload.url,


### PR DESCRIPTION
Forgejo-ecosystem pass. Also **re-lands two commits that stranded** as post-merge pushes on #12224 (the squash there only captured pagination/branch-protection/secrets) — recovered via cherry-pick.

## Re-landed (were stranded on #12224)
- **Issues & PRs tab** + header server-HTML chrome.
- **Dexie agnostic API cache** (SharedWorker → main-thread Dexie → localStorage → memory) + shared-worker cache handlers.

## Staff error UX
- Reads no longer fail silently: notices store + `InfoBox`/`ForgejoNotice` (info/warn/error, dismissible, Retry). 403→"access restricted", 502→"upstream unreachable". Rendered in Repo Admin, Issues, System, Orgs, collaborators modal.
- DRY `_loadResource(ctx, cacheKey, path, apply)` gives every lazy loader cache-first render via the IDB facade + notice-on-error. `loadSystem` uses `allSettled` so a non-admin token still shows the version.

## Typed Forgejo client (jedi) — feature-gated, additive
- New hand-written **`jedi/entity/forgejo`** client (reqwest, normalized `JediError`), modeled on jedi's existing GitHub client rather than wrapping the auto-gen `forgejo-api` crate (9/16 releases breaking — bad dep for a shared crate). Behind a `forgejo` Cargo feature so only services that need it compile it. First cut: `search_repos` / `list_admin_users` / `list_orgs`.
- axum-kbve enables the feature + exposes one typed route **`GET /dashboard/forgejo/api/users`** (real admin user list, `DASHBOARD_VIEW`-gated, structured error JSON). Frontend user pagination now hits the typed route, falling back to the proxy/collaborator path on any non-2xx. The generic proxy stays for the long tail — typed routes grow from here.

## Verify
- `./kbve.sh -nx axum-kbve:build` ✓
- `./kbve.sh -nx astro-kbve:build` ✓ (7742 pages)