### PR TITLE
refactor(agones): de-hardcode fleet GameMode via OWS_GAME_MODE env

### DIFF
--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
@@ -67,11 +67,13 @@ spec:
                                     -nosteam \
                                     -unattended \
                                     -port=${GAME_PORT:-7777} \
-                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    -GameMode=${OWS_GAME_MODE} \
                                     ${OWS_EXTRA_ARGS:-}
                           env:
                               - name: GAME_PORT
                                 value: '7777'
+                              - name: OWS_GAME_MODE
+                                value: /Script/Chuck.ChuckGameMode
                               - name: OWS_API_PATH
                                 value: http://rows.rows-chuckrpg-beta.svc.cluster.local:4322/
                               - name: OWS_INSTANCE_MANAGEMENT_PATH

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
@@ -67,11 +67,13 @@ spec:
                                     -nosteam \
                                     -unattended \
                                     -port=${GAME_PORT:-7777} \
-                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    -GameMode=${OWS_GAME_MODE} \
                                     ${OWS_EXTRA_ARGS:-}
                           env:
                               - name: GAME_PORT
                                 value: '7777'
+                              - name: OWS_GAME_MODE
+                                value: /Script/Chuck.ChuckGameMode
                               - name: OWS_API_PATH
                                 value: http://rows.rows-chuckrpg-dev.svc.cluster.local:4322/
                               - name: OWS_INSTANCE_MANAGEMENT_PATH

--- a/apps/kube/agones/rows/manifests/fleet.yaml
+++ b/apps/kube/agones/rows/manifests/fleet.yaml
@@ -83,11 +83,13 @@ spec:
                                     -nosteam \
                                     -unattended \
                                     -port=${GAME_PORT:-7777} \
-                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    -GameMode=${OWS_GAME_MODE} \
                                     ${OWS_EXTRA_ARGS:-}
                           env:
                               - name: GAME_PORT
                                 value: '7777'
+                              - name: OWS_GAME_MODE
+                                value: /Script/Chuck.ChuckGameMode
                               # ROWS — single binary replaces all C# OWS microservices
                               # All API paths point to the same ROWS service
                               - name: OWS_API_PATH


### PR DESCRIPTION
Last de-hardcode for the multi-game build path: the fleet server launch no longer bakes in chuck.

Replace `-GameMode=/Script/Chuck.ChuckGameMode` with `-GameMode=${OWS_GAME_MODE}`, sourced from an `OWS_GAME_MODE` env per fleet (set to `/Script/Chuck.ChuckGameMode` for the chuck fleets). The launch script is now game-agnostic — a non-chuck game's fleet just sets its own `OWS_GAME_MODE` (mirrors the per-game `engine.game_mode` registry field).

Applied to `ows-hubworld` + `chuckrpg-dev` + `chuckrpg-beta` fleets. YAML validated; behavior unchanged (env = the old literal).

Beta secrets were already real-sealed (#12136), so nothing else outstanding in the dev batch — ready to cut the dev→main release (bump `unreal-chuck-beta` version: to trigger the chuckServerBeta build).