### PR TITLE
fix(kube): label cryptothrone gameserver pods for the game Service

### DIFF
--- a/apps/kube/agones/cryptothrone/manifests/fleet.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/fleet.yaml
@@ -35,6 +35,10 @@ spec:
             sdkServer:
                 logLevel: Info
             template:
+                metadata:
+                    labels:
+                        app: cryptothrone-server
+                        app.kubernetes.io/part-of: cryptothrone
                 spec:
                     securityContext:
                         runAsNonRoot: true


### PR DESCRIPTION
## Summary
Last hop of the wss chain: gameserver is Ready, cert issued, gateway listener live — but `cryptothrone-game` had **zero endpoints**, so Envoy 503'd every request (clients see 'server closed the connection before the world loaded').

Cause: in an Agones Fleet, `spec.template.metadata.labels` lands on the **GameServer** object, not the Pod. The Pod template (`spec.template.spec.template`) had no labels, so the Service selector `app: cryptothrone-server` matched nothing:

```
$ kubectl get pod <gs-pod> -o jsonpath='{.metadata.labels}'
{"agones.dev/gameserver":"...","agones.dev/role":"gameserver",...}
```

Adds the labels at the pod template level. Validated with a server-side dry-run; rolling gameserver replacement on sync.