### PR TITLE
feat(jedi+forgejo): feature-gated typed Forgejo client + first typed route

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -347,6 +347,7 @@ const EXPANDED_KEY = 'forgejo:expandedRepo';
 const TAB_KEY = 'forgejo:activeTab';
 const CACHE_TTL_MS = 60 * 1000;
 const PROXY_BASE = '/dashboard/forgejo/proxy';
+const API_BASE = '/dashboard/forgejo/api';
 const REFRESH_INTERVAL_MS = 30 * 1000;
 const PAGE_SIZE = 50;
 const RESOURCE_TTL_MS = 60 * 1000;
@@ -487,11 +488,20 @@ async function fetchUsersPage(
 	token: string,
 	page: number,
 ): Promise<ForgejoUser[] | null> {
-	return apiFetch<ForgejoUser[] | null>(
-		token,
-		`/api/v1/admin/users?limit=${PAGE_SIZE}&page=${page}`,
-		null,
-	);
+	try {
+		const resp = await fetch(
+			`${API_BASE}/users?page=${page}&limit=${PAGE_SIZE}`,
+			{
+				headers: { Authorization: `Bearer ${token}` },
+				signal: AbortSignal.timeout(10000),
+			},
+		);
+		if (!resp.ok) return null;
+		const data = await resp.json();
+		return Array.isArray(data) ? data : null;
+	} catch {
+		return null;
+	}
 }
 
 async function fetchUsers(token: string): Promise<ForgejoUser[]> {

--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -90,7 +90,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 webpki-roots = "0.26"
 
 # Workspace path dependencies
-jedi = { path = "../../../packages/rust/jedi", features = ["clickhouse"] }
+jedi = { path = "../../../packages/rust/jedi", features = ["clickhouse", "forgejo"] }
 kbve = { path = "../../../packages/rust/kbve", features = ["wallet"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -171,6 +171,10 @@ async fn main() -> anyhow::Result<()> {
         warn!("Forgejo proxy not configured (FORGEJO_UPSTREAM_URL not set)");
     }
 
+    if transport::proxy::init_forgejo_api() {
+        info!("Forgejo typed API initialized - /dashboard/forgejo/api/* enabled");
+    }
+
     if transport::proxy::init_edge_proxy() {
         info!("Edge proxy initialized - /dashboard/edge/proxy enabled");
     } else {

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -612,6 +612,10 @@ fn router(state: AppState) -> Router {
             any(super::proxy::forgejo_proxy_handler),
         )
         .route(
+            "/dashboard/forgejo/api/users",
+            axum::routing::get(super::proxy::forgejo_users_handler),
+        )
+        .route(
             "/dashboard/vm/proxy/{*path}",
             any(super::proxy::kubevirt_proxy_handler),
         )

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -874,6 +874,62 @@ pub async fn forgejo_proxy_handler(path: Option<Path<String>>, req: Request<Body
     }
 }
 
+static FORGEJO_API: OnceLock<jedi::entity::forgejo::ForgejoClient> = OnceLock::new();
+
+pub fn init_forgejo_api() -> bool {
+    let upstream = match std::env::var("FORGEJO_UPSTREAM_URL") {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    let token = match std::env::var("FORGEJO_AUTH_TOKEN") {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    FORGEJO_API
+        .set(jedi::entity::forgejo::ForgejoClient::new(&upstream, &token))
+        .is_ok()
+}
+
+fn query_u32(query: Option<&str>, key: &str, default: u32) -> u32 {
+    query
+        .and_then(|qs| {
+            qs.split('&').find_map(|pair| {
+                pair.strip_prefix(key)
+                    .and_then(|rest| rest.strip_prefix('='))
+                    .and_then(|v| v.parse::<u32>().ok())
+            })
+        })
+        .unwrap_or(default)
+}
+
+/// Typed Forgejo route: real admin user list. Normalised errors via JediError.
+pub async fn forgejo_users_handler(req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(|q| q.to_string());
+
+    if let Err(resp) =
+        require_dashboard_view_with_query(&headers, query.as_deref(), "Forgejo-API").await
+    {
+        return resp;
+    }
+    let client = match FORGEJO_API.get() {
+        Some(c) => c,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                axum::Json(json!({"error": "Forgejo API not configured"})),
+            )
+                .into_response();
+        }
+    };
+    let page = query_u32(query.as_deref(), "page", 1);
+    let limit = query_u32(query.as_deref(), "limit", 50);
+    match client.list_admin_users(page, limit).await {
+        Ok(users) => axum::Json(users).into_response(),
+        Err(e) => e.into_response(),
+    }
+}
+
 static KUBEVIRT: OnceLock<ServiceProxy> = OnceLock::new();
 
 pub fn init_kubevirt_proxy() -> bool {

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -88,5 +88,6 @@ axum-prometheus = { version = "0.10", optional = true }
 default = []
 clickhouse = ["dep:clickhouse"]
 prometheus = ["dep:axum-prometheus"]
+forgejo = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -1,0 +1,129 @@
+//! Thin typed wrapper around the Forgejo (Gitea-compatible) REST API v1.
+//!
+//! Hand-written, mirroring the GitHub client. Callers provide the upstream
+//! base URL and an admin/sudo token at construction. Errors are normalised to
+//! [`JediError`] so handlers can return them directly.
+//!
+//! # Example
+//! ```ignore
+//! let fj = ForgejoClient::new("https://git.example.com", "token");
+//! let users = fj.list_admin_users(1, 50).await?;
+//! ```
+
+use reqwest::{Client, Response, StatusCode};
+use std::borrow::Cow;
+use std::time::Duration;
+
+use super::types::*;
+use crate::entity::error::JediError;
+
+const USER_AGENT: &str = "kbve-jedi/1.0";
+
+#[derive(Clone)]
+pub struct ForgejoClient {
+    client: Client,
+    token: String,
+    base_url: String,
+}
+
+impl ForgejoClient {
+    pub fn new(base_url: &str, token: &str) -> Self {
+        let client = Client::builder()
+            .user_agent(USER_AGENT)
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("Failed to build reqwest client for ForgejoClient");
+
+        Self {
+            client,
+            token: token.to_string(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+        }
+    }
+
+    pub async fn search_repos(
+        &self,
+        page: u32,
+        limit: u32,
+        query: Option<&str>,
+    ) -> Result<Vec<ForgejoRepo>, JediError> {
+        let url = format!("{}/api/v1/repos/search", self.base_url);
+        let mut req = self.client.get(&url).bearer_auth(&self.token).query(&[
+            ("page", page.to_string()),
+            ("limit", limit.to_string()),
+            ("sort", "updated".to_string()),
+        ]);
+        if let Some(q) = query.filter(|q| !q.is_empty()) {
+            req = req.query(&[("q", q)]);
+        }
+        let resp = self.send(req).await?;
+        let results: ForgejoSearchResults<ForgejoRepo> = self.parse_response(resp).await?;
+        Ok(results.data)
+    }
+
+    pub async fn list_admin_users(
+        &self,
+        page: u32,
+        limit: u32,
+    ) -> Result<Vec<ForgejoUser>, JediError> {
+        let url = format!("{}/api/v1/admin/users", self.base_url);
+        let req = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[("page", page.to_string()), ("limit", limit.to_string())]);
+        let resp = self.send(req).await?;
+        self.parse_response(resp).await
+    }
+
+    pub async fn list_orgs(&self, page: u32, limit: u32) -> Result<Vec<ForgejoOrg>, JediError> {
+        let url = format!("{}/api/v1/orgs", self.base_url);
+        let req = self
+            .client
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[("page", page.to_string()), ("limit", limit.to_string())]);
+        let resp = self.send(req).await?;
+        self.parse_response(resp).await
+    }
+
+    async fn send(&self, req: reqwest::RequestBuilder) -> Result<Response, JediError> {
+        req.send().await.map_err(|e| {
+            if e.is_timeout() {
+                JediError::Timeout
+            } else {
+                JediError::Internal(Cow::Owned(format!("Forgejo request failed: {e}")))
+            }
+        })
+    }
+
+    async fn parse_response<T: serde::de::DeserializeOwned>(
+        &self,
+        resp: Response,
+    ) -> Result<T, JediError> {
+        let status = resp.status();
+        if status.is_success() {
+            let text = resp
+                .text()
+                .await
+                .map_err(|e| JediError::Parse(format!("Failed to read response body: {e}")))?;
+            serde_json::from_str(&text)
+                .map_err(|e| JediError::Parse(format!("JSON parse error: {e}")))
+        } else {
+            let body = resp.text().await.unwrap_or_default();
+            let message = serde_json::from_str::<serde_json::Value>(&body)
+                .ok()
+                .and_then(|v| v.get("message").and_then(|m| m.as_str()).map(String::from))
+                .unwrap_or(body);
+            match status {
+                StatusCode::UNAUTHORIZED => Err(JediError::Unauthorized),
+                StatusCode::FORBIDDEN => Err(JediError::Forbidden),
+                StatusCode::NOT_FOUND => Err(JediError::NotFound),
+                _ => Err(JediError::Internal(Cow::Owned(format!(
+                    "Forgejo API error {status}: {message}"
+                )))),
+            }
+        }
+    }
+}

--- a/packages/rust/jedi/src/entity/forgejo/mod.rs
+++ b/packages/rust/jedi/src/entity/forgejo/mod.rs
@@ -1,0 +1,5 @@
+mod client;
+mod types;
+
+pub use client::*;
+pub use types::*;

--- a/packages/rust/jedi/src/entity/forgejo/types.rs
+++ b/packages/rust/jedi/src/entity/forgejo/types.rs
@@ -1,0 +1,81 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoOwner {
+    pub id: u64,
+    pub login: String,
+    #[serde(default)]
+    pub avatar_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoRepo {
+    pub id: u64,
+    pub name: String,
+    pub full_name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub private: bool,
+    #[serde(default)]
+    pub fork: bool,
+    #[serde(default)]
+    pub mirror: bool,
+    #[serde(default)]
+    pub archived: bool,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub default_branch: String,
+    #[serde(default)]
+    pub updated_at: String,
+    #[serde(default)]
+    pub language: String,
+    pub owner: ForgejoOwner,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoUser {
+    pub id: u64,
+    pub login: String,
+    #[serde(default)]
+    pub full_name: String,
+    #[serde(default)]
+    pub email: String,
+    #[serde(default)]
+    pub avatar_url: String,
+    #[serde(default)]
+    pub is_admin: bool,
+    #[serde(default)]
+    pub last_login: String,
+    #[serde(default)]
+    pub created: String,
+    #[serde(default = "default_true")]
+    pub active: bool,
+    #[serde(default)]
+    pub prohibit_login: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoOrg {
+    pub id: u64,
+    pub username: String,
+    #[serde(default)]
+    pub full_name: String,
+    #[serde(default)]
+    pub avatar_url: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub visibility: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ForgejoSearchResults<T> {
+    #[serde(default = "Vec::new")]
+    pub data: Vec<T>,
+}
+
+fn default_true() -> bool {
+    true
+}

--- a/packages/rust/jedi/src/entity/mod.rs
+++ b/packages/rust/jedi/src/entity/mod.rs
@@ -3,6 +3,8 @@ pub mod bitwise;
 pub mod envelope;
 pub mod error;
 pub mod flex;
+#[cfg(feature = "forgejo")]
+pub mod forgejo;
 pub mod github;
 pub mod hash;
 pub mod pipe;


### PR DESCRIPTION
Re-lands the jedi typed-Forgejo-client commit that **stranded** as a post-merge push on #12235 (the squash captured the error-UX/cache/issues commits, this one landed after → never reached dev). Single clean commit this time.

## What
- New hand-written, **feature-gated** Forgejo client in the shared **jedi** crate (`entity/forgejo`, behind a `forgejo` Cargo feature) — reqwest + normalized `JediError`, modeled on jedi's existing GitHub client. *Not* wrapping the auto-generated `forgejo-api` crate (9/16 releases breaking — poor dep for a shared crate). First cut: `search_repos` / `list_admin_users` / `list_orgs`.
- **axum-kbve** enables the feature + exposes one typed route **`GET /dashboard/forgejo/api/users`** (real admin user list, `DASHBOARD_VIEW`-gated, structured error JSON). Handler takes `Request<Body>` and pulls headers/query manually, matching the existing proxy/firecracker handler pattern.
- **Frontend** user pagination hits the typed route, falling back to the proxy/collaborator path on any non-2xx. Generic proxy stays for the long tail.

## Verify
- `./kbve.sh -nx axum-kbve:build` ✓
- `./kbve.sh -nx astro-kbve:build` ✓ (7742 pages)