### PR TITLE
fix(cryptothrone): surface reject reasons — client overlay + server logs

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -63,6 +63,7 @@ export class CloudCityScene extends Scene {
 	private nearbyHostiles = 0;
 	private slowTimer = 0;
 	private netReady = false;
+	private netTerminal = false;
 	private rosterKey = '';
 	private laserUnsubs: (() => void)[] = [];
 
@@ -179,14 +180,16 @@ export class CloudCityScene extends Scene {
 		});
 		client.on('reject', (reason) => {
 			window.clearTimeout(this.slowTimer);
+			this.netTerminal = true;
 			laserEvents.emit('net:status', {
 				status: 'rejected',
 				detail: `The server turned you away: ${reason}`,
 			});
 		});
 		client.on('error', () => {
-			if (this.netReady) return;
+			if (this.netReady || this.netTerminal) return;
 			window.clearTimeout(this.slowTimer);
+			this.netTerminal = true;
 			laserEvents.emit('net:status', {
 				status: 'error',
 				detail: 'Could not reach the game server. Check your connection and try again.',
@@ -194,6 +197,7 @@ export class CloudCityScene extends Scene {
 		});
 		client.on('close', () => {
 			window.clearTimeout(this.slowTimer);
+			if (this.netTerminal) return;
 			laserEvents.emit('net:status', {
 				status: 'disconnected',
 				detail: this.netReady


### PR DESCRIPTION
## Summary
Live join failures showed the generic 'game server closed the connection before the world loaded' and nothing server-side, making diagnosis devtools-only.

**Client**: the server sends `Reject{reason}` then closes; the scene's close handler overwrote the rejected status with the generic disconnect message. Terminal statuses now stick, so the overlay shows the server's actual reason (e.g. `protocol mismatch: client=3, server=4` or `auth rejected: …`).

**Server (simgrid)**: `send_reject` logs the reason; successful claims log slot + username. Live probes confirmed both reject paths work end-to-end through Cloudflare → Cilium gateway → fleet:
```
stale v3 client → Reject: protocol mismatch: client=3, server=4
v4 + unsigned jwt → Reject: auth rejected: invalid token: InvalidSignature
```

## Testing
- simgrid 27/27, clippy clean
- astro-cryptothrone 29/29, site builds