### PR TITLE
fix(ci-unreal): unblock unreal builds — collapse dispatch inputs under 10-input cap + fleet GameMode env

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -556,54 +556,39 @@ jobs:
                     fi
                     echo "  ✓ $app — $reason, dispatching ($pipeline)"
 
-                    local extra=""
-                    [ -n "$src" ] && extra="$extra --field version_source=${src}"
-                    [ -n "$vtoml" ] && extra="$extra --field version_toml=${vtoml}"
-                    [ -n "$ver" ] && extra="$extra --field manifest_version=${ver}"
-                    [ -n "$vtgt" ] && extra="$extra --field version_target=${vtgt}"
-                    [ -n "$proj_path" ] && extra="$extra --field project_path=${proj_path}"
-                    [ -n "$engine_version" ] && extra="$extra --field engine_version=${engine_version}"
-                    extra="$extra --field build_targets=${build_targets}"
-                    [ "$features" != "[]" ] && extra="$extra --field features=${features}"
-                    [ -n "$lic" ] && extra="$extra --field license_method=${lic}"
-                    [ -n "$ext_repo" ] && extra="$extra --field external_repo_url=${ext_repo}"
-                    [ -n "$ext_ref" ] && extra="$extra --field external_repo_ref=${ext_ref}"
-                    [ -n "$srv_target" ] && extra="$extra --field server_target=${srv_target}"
-                    [ -n "$srv_config" ] && extra="$extra --field server_config=${srv_config}"
-                    [ -n "$cli_config" ] && extra="$extra --field client_config=${cli_config}"
-                    [ -n "$game_mode" ] && extra="$extra --field game_mode=${game_mode}"
-                    [ "$maps" != "[]" ] && extra="$extra --field maps=${maps}"
-                    [ "$dotnet" = "true" ] && extra="$extra --field dotnet_enabled=true"
-                    extra="$extra --field deploy_to_itch=${deploy_itch}"
-                    [ -n "$itch_user" ] && extra="$extra --field itch_user=${itch_user}"
-                    [ -n "$itch_game" ] && extra="$extra --field itch_game=${itch_game}"
-                    extra="$extra --field deploy_to_steam=${deploy_steam}"
-                    [ "$steam_apps" != "[]" ] && extra="$extra --field steam_apps=${steam_apps}"
+                    # Collapse per-game fields into JSON blobs so ci-unreal's
+                    # workflow_dispatch stays under GitHub's 10-input cap; the
+                    # engine workflow fromJSON-forwards into ci-unreal-build
+                    # (workflow_call, no cap). ci-unity/ci-godot still expect the
+                    # legacy per-field inputs — convert them before they get entries.
+                    local engine_json version_json publish_json
+                    engine_json=$(echo "$entry" | jq -c --arg app "$app" --arg sp "$shell_path" \
+                      '(.engine // {}) + {app_name:$app, shell_path:$sp, build_targets:(.engine.build_targets // []), maps:(.engine.maps // [])}')
+                    version_json=$(jq -nc --arg s "$src" --arg t "$vtoml" --arg m "$ver" \
+                      '{source:$s, toml:$t, manifest:$m}')
+                    publish_json=$(jq -nc --argjson d "$deploy_itch" --arg u "$itch_user" --arg g "$itch_game" \
+                      '{deploy_to_itch:$d, itch_user:$u, itch_game:$g}')
 
                     gh workflow run "$workflow" --repo "$REPO" --ref main \
                       --field key="$key" \
-                      --field app_name="$app" \
                       --field dispatched_at="$DISPATCHED_AT" \
-                      $extra
+                      --field engine="$engine_json" \
+                      --field version="$version_json" \
+                      --field publish="$publish_json"
                     DISPATCHED=$((DISPATCHED + 1))
 
                     # Bundled dedicated server: an unreal_game entry carrying a
                     # shell_path also ships a UE5 dedicated server off the SAME
-                    # version gate (1:1 with the client). build.toml supplies the
-                    # repo / server target / UE image.
+                    # version gate (1:1 with the client). shell_path rides inside
+                    # the engine blob; build.toml supplies repo / target / UE image.
                     if [ "$pipeline" = "unreal_game" ] && [ -n "$shell_path" ]; then
                       echo "  ✓ $app — bundled dedicated server, dispatching (ue5_server)"
-                      local srv_extra=""
-                      [ -n "$src" ] && srv_extra="$srv_extra --field version_source=${src}"
-                      [ -n "$vtoml" ] && srv_extra="$srv_extra --field version_toml=${vtoml}"
-                      [ -n "$ver" ] && srv_extra="$srv_extra --field manifest_version=${ver}"
                       gh workflow run ci-unreal.yml --repo "$REPO" --ref main \
                         --field task=server \
                         --field key="$key" \
-                        --field app_name="$app" \
-                        --field shell_path="$shell_path" \
                         --field dispatched_at="$DISPATCHED_AT" \
-                        $srv_extra
+                        --field engine="$engine_json" \
+                        --field version="$version_json"
                       DISPATCHED=$((DISPATCHED + 1))
                     fi
                   }

--- a/.github/workflows/ci-unreal.yml
+++ b/.github/workflows/ci-unreal.yml
@@ -1,6 +1,6 @@
 name: CI - Unreal Engine
 
-run-name: 'CI - Unreal / ${{ inputs.task }} ${{ inputs.app_name }}${{ inputs.shell_path }}'
+run-name: 'CI - Unreal / ${{ inputs.task }} ${{ inputs.key }}'
 
 on:
     workflow_dispatch:
@@ -15,123 +15,31 @@ on:
                     - server
                     - win-setup
                     - mac-setup
-
             key:
                 description: '[game] Manifest key'
                 required: false
                 type: string
                 default: ''
-            app_name:
-                description: '[game] UE project / build name'
-                required: false
-                type: string
-                default: ''
-            project_path:
-                description: '[game] Path to dir containing the .uproject (within game repo)'
-                required: false
-                type: string
-                default: ''
-            engine_version:
-                description: '[game] UE version pin (e.g. 5.7.4)'
-                required: false
-                type: string
-                default: '5.7.4'
-            build_targets:
-                description: '[game] JSON array of platform targets (e.g. ["Win64","Linux"])'
-                required: false
-                type: string
-                default: '["Linux"]'
-            external_repo_url:
-                description: '[game] Game repo (owner/name)'
-                required: false
-                type: string
-                default: ''
-            external_repo_ref:
-                description: '[game] Branch/ref of external_repo_url'
-                required: false
-                type: string
-                default: ''
-            server_target:
-                description: '[game] UE server target'
-                required: false
-                type: string
-                default: ''
-            server_config:
-                description: '[game] UE -serverconfig'
-                required: false
-                type: string
-                default: ''
-            client_config:
-                description: '[game] UE -clientconfig'
-                required: false
-                type: string
-                default: ''
-            game_mode:
-                description: '[game] Server launch game mode'
-                required: false
-                type: string
-                default: ''
-            maps:
-                description: '[game] JSON array of maps to cook'
-                required: false
-                type: string
-                default: ''
-            license_method:
-                description: '[game] License method (manifest passthrough)'
-                required: false
-                type: string
-                default: ''
-            version_source:
-                description: '[game] Path to version source (mdx)'
-                required: false
-                type: string
-                default: ''
-            version_toml:
-                description: '[game] Path to version.toml'
-                required: false
-                type: string
-                default: ''
-            manifest_version:
-                description: '[game] Version from manifest'
-                required: false
-                type: string
-                default: ''
-            deploy_to_itch:
-                description: '[game] Deploy to itch.io after build'
-                required: false
-                type: boolean
-                default: false
-            itch_user:
-                description: '[game] Itch.io publisher user'
-                required: false
-                type: string
-                default: 'kbve'
-            itch_game:
-                description: '[game] Itch.io game slug'
-                required: false
-                type: string
-                default: ''
-            deploy_to_steam:
-                description: '[game] Deploy to Steam (manifest passthrough)'
-                required: false
-                type: boolean
-                default: false
-            steam_apps:
-                description: '[game] JSON array of Steam app configs (manifest passthrough)'
-                required: false
-                type: string
-                default: '[]'
             dispatched_at:
                 description: 'Unix timestamp when dispatched (queue guard)'
                 required: false
                 type: string
                 default: ''
-
-            shell_path:
-                description: '[server] Shell project path (e.g. apps/chuckrpg/unreal-chuck)'
+            engine:
+                description: '[game] JSON engine config: app_name, project_path, version, build_targets, external_repo_url, external_repo_ref, server_target, server_config, client_config, game_mode, maps, shell_path'
                 required: false
                 type: string
-                default: 'apps/chuckrpg/unreal-chuck'
+                default: '{}'
+            version:
+                description: '[game] JSON version config: source, toml, manifest'
+                required: false
+                type: string
+                default: '{}'
+            publish:
+                description: '[game] JSON publish config: deploy_to_itch, itch_user, itch_game'
+                required: false
+                type: string
+                default: '{}'
 
 permissions:
     contents: write
@@ -147,23 +55,23 @@ jobs:
         with:
             mode: game
             key: ${{ inputs.key }}
-            app_name: ${{ inputs.app_name }}
-            project_path: ${{ inputs.project_path }}
-            engine_version: ${{ inputs.engine_version }}
-            build_targets: ${{ inputs.build_targets }}
-            external_repo_url: ${{ inputs.external_repo_url }}
-            external_repo_ref: ${{ inputs.external_repo_ref }}
-            server_target: ${{ inputs.server_target }}
-            server_config: ${{ inputs.server_config }}
-            client_config: ${{ inputs.client_config }}
-            game_mode: ${{ inputs.game_mode }}
-            maps: ${{ inputs.maps }}
-            version_source: ${{ inputs.version_source }}
-            version_toml: ${{ inputs.version_toml }}
-            manifest_version: ${{ inputs.manifest_version }}
-            deploy_to_itch: ${{ inputs.deploy_to_itch }}
-            itch_username: ${{ inputs.itch_user }}
-            itch_game_id: ${{ inputs.itch_game }}
+            app_name: ${{ fromJSON(inputs.engine).app_name }}
+            project_path: ${{ fromJSON(inputs.engine).project_path }}
+            engine_version: ${{ fromJSON(inputs.engine).version }}
+            build_targets: ${{ toJSON(fromJSON(inputs.engine).build_targets) }}
+            external_repo_url: ${{ fromJSON(inputs.engine).external_repo_url }}
+            external_repo_ref: ${{ fromJSON(inputs.engine).external_repo_ref }}
+            server_target: ${{ fromJSON(inputs.engine).server_target }}
+            server_config: ${{ fromJSON(inputs.engine).server_config }}
+            client_config: ${{ fromJSON(inputs.engine).client_config }}
+            game_mode: ${{ fromJSON(inputs.engine).game_mode }}
+            maps: ${{ toJSON(fromJSON(inputs.engine).maps) }}
+            version_source: ${{ fromJSON(inputs.version).source }}
+            version_toml: ${{ fromJSON(inputs.version).toml }}
+            manifest_version: ${{ fromJSON(inputs.version).manifest }}
+            deploy_to_itch: ${{ fromJSON(inputs.publish).deploy_to_itch }}
+            itch_username: ${{ fromJSON(inputs.publish).itch_user }}
+            itch_game_id: ${{ fromJSON(inputs.publish).itch_game }}
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}
@@ -176,10 +84,10 @@ jobs:
         uses: KBVE/kbve/.github/workflows/ci-unreal-build.yml@dev
         with:
             mode: server
-            shell_path: ${{ inputs.shell_path }}
-            manifest_version: ${{ inputs.manifest_version }}
-            version_source: ${{ inputs.version_source }}
-            version_toml: ${{ inputs.version_toml }}
+            shell_path: ${{ fromJSON(inputs.engine).shell_path }}
+            manifest_version: ${{ fromJSON(inputs.version).manifest }}
+            version_source: ${{ fromJSON(inputs.version).source }}
+            version_toml: ${{ fromJSON(inputs.version).toml }}
         secrets:
             UNITY_PAT: ${{ secrets.UNITY_PAT }}
             butler_api: ${{ secrets.ITCH_API }}

--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
@@ -67,11 +67,13 @@ spec:
                                     -nosteam \
                                     -unattended \
                                     -port=${GAME_PORT:-7777} \
-                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    -GameMode=${OWS_GAME_MODE} \
                                     ${OWS_EXTRA_ARGS:-}
                           env:
                               - name: GAME_PORT
                                 value: '7777'
+                              - name: OWS_GAME_MODE
+                                value: /Script/Chuck.ChuckGameMode
                               - name: OWS_API_PATH
                                 value: http://rows.rows-chuckrpg-beta.svc.cluster.local:4322/
                               - name: OWS_INSTANCE_MANAGEMENT_PATH

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
@@ -67,11 +67,13 @@ spec:
                                     -nosteam \
                                     -unattended \
                                     -port=${GAME_PORT:-7777} \
-                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    -GameMode=${OWS_GAME_MODE} \
                                     ${OWS_EXTRA_ARGS:-}
                           env:
                               - name: GAME_PORT
                                 value: '7777'
+                              - name: OWS_GAME_MODE
+                                value: /Script/Chuck.ChuckGameMode
                               - name: OWS_API_PATH
                                 value: http://rows.rows-chuckrpg-dev.svc.cluster.local:4322/
                               - name: OWS_INSTANCE_MANAGEMENT_PATH

--- a/apps/kube/agones/rows/manifests/fleet.yaml
+++ b/apps/kube/agones/rows/manifests/fleet.yaml
@@ -83,11 +83,13 @@ spec:
                                     -nosteam \
                                     -unattended \
                                     -port=${GAME_PORT:-7777} \
-                                    -GameMode=/Script/Chuck.ChuckGameMode \
+                                    -GameMode=${OWS_GAME_MODE} \
                                     ${OWS_EXTRA_ARGS:-}
                           env:
                               - name: GAME_PORT
                                 value: '7777'
+                              - name: OWS_GAME_MODE
+                                value: /Script/Chuck.ChuckGameMode
                               # ROWS — single binary replaces all C# OWS microservices
                               # All API paths point to the same ROWS service
                               - name: OWS_API_PATH


### PR DESCRIPTION
## Why

`ci-unreal.yml` carried **24** `workflow_dispatch` inputs. GitHub rejects any `workflow_dispatch` with **>10 inputs** at startup, so every dispatch from `ci-main` produced a `startup_failure` ("workflow file issue"). Net result: **no chuck unreal build has ever run** — historical run record is 0 successes / 24 startup_failures / 6 failures. The dev entry (MDX version ahead of `version.toml`) fires on every main push, so it loops visibly.

This predates the recent engine-field work — the dispatch was already at 18 inputs (over the cap) before the de-hardcoding added 6 more.

## What

- **ci-unreal.yml**: collapse the per-game fields into three JSON blobs — `engine`, `version`, `publish`. Dispatch now has **6 inputs** (`task`, `key`, `dispatched_at`, `engine`, `version`, `publish`). The jobs `fromJSON`-forward into `ci-unreal-build`, which is `workflow_call` (no input cap) and is unchanged.
- **ci-main.yml**: `dispatch_game_engine` builds the blobs via `jq` and dispatches the 6 fields (game + bundled server).
- Also includes the prior commit: fleet `GameMode` de-hardcoded via `OWS_GAME_MODE` env.

## Notes

- `ci-unity` (16 inputs) and `ci-godot` (13 inputs) are **also over the cap**, but they have **no manifest entries** so they never dispatch. They still use legacy per-field inputs and must convert to the blob shape before they get entries.
- Validated: `actionlint` clean, input count = 6, jq blobs produce valid JSON with full engine config (build_targets, server_target, configs, maps) flowing through.

## Verify after merge

First main push should produce a `ci-unreal` run that actually **starts** (no `startup_failure`).