### PR TITLE
feat(simgrid): log join admissions and rejections

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -63,6 +63,7 @@ export class CloudCityScene extends Scene {
 	private nearbyHostiles = 0;
 	private slowTimer = 0;
 	private netReady = false;
+	private netTerminal = false;
 	private rosterKey = '';
 	private laserUnsubs: (() => void)[] = [];
 
@@ -179,14 +180,16 @@ export class CloudCityScene extends Scene {
 		});
 		client.on('reject', (reason) => {
 			window.clearTimeout(this.slowTimer);
+			this.netTerminal = true;
 			laserEvents.emit('net:status', {
 				status: 'rejected',
 				detail: `The server turned you away: ${reason}`,
 			});
 		});
 		client.on('error', () => {
-			if (this.netReady) return;
+			if (this.netReady || this.netTerminal) return;
 			window.clearTimeout(this.slowTimer);
+			this.netTerminal = true;
 			laserEvents.emit('net:status', {
 				status: 'error',
 				detail: 'Could not reach the game server. Check your connection and try again.',
@@ -194,6 +197,7 @@ export class CloudCityScene extends Scene {
 		});
 		client.on('close', () => {
 			window.clearTimeout(this.slowTimer);
+			if (this.netTerminal) return;
 			laserEvents.emit('net:status', {
 				status: 'disconnected',
 				detail: this.netReady

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -327,12 +327,16 @@ async fn claim_slot(
     kbve_username: String,
     format: WireFormat,
 ) -> Option<AdmittedPlayer> {
+    let name = kbve_username.clone();
     let slot = match state.roster.write() {
         Ok(mut r) => r.claim(kbve_username),
         Err(_) => None,
     };
     match slot {
-        Some(slot) => Some(AdmittedPlayer { slot, format }),
+        Some(slot) => {
+            tracing::info!(slot = slot.0, username = %name, "player joined");
+            Some(AdmittedPlayer { slot, format })
+        }
         None => {
             send_reject(socket, format, "match full").await;
             None
@@ -341,6 +345,7 @@ async fn claim_slot(
 }
 
 async fn send_reject(socket: &mut WebSocket, format: WireFormat, reason: &str) {
+    tracing::info!(reason, "join rejected");
     let evt = ServerEvent::Reject {
         reason: reason.to_string(),
     };


### PR DESCRIPTION
## Summary
Follow-up to #12242 (merged before this landed on the branch): rejects were invisible server-side — diagnosing live join failures required browser devtools.

- `send_reject` logs the reason at info level
- successful slot claims log `slot` + `username`

Live probes through CF → gateway → fleet confirmed both reject paths:
```
stale v3 client → Reject: protocol mismatch: client=3, server=4
v4 + unsigned jwt → Reject: auth rejected: invalid token: InvalidSignature
```

Ships with the next cryptothrone-server MDX bump.

## Testing
- simgrid 27/27, clippy clean