### PR TITLE
fix(unreal): correct plugin dependency declarations + drop bad include path

### DIFF
--- a/apps/rentearth/unreal-rentearth/rentearth.uproject
+++ b/apps/rentearth/unreal-rentearth/rentearth.uproject
@@ -23,6 +23,10 @@
 	],
 	"Plugins": [
 		{
+			"Name": "StructUtils",
+			"Enabled": true
+		},
+		{
 			"Name": "ChaosSolverPlugin",
 			"Enabled": true
 		},

--- a/packages/unreal/KBVECombat/KBVECombat.uplugin
+++ b/packages/unreal/KBVECombat/KBVECombat.uplugin
@@ -21,6 +21,10 @@
 	],
 	"Plugins": [
 		{
+			"Name": "MassGameplay",
+			"Enabled": true
+		},
+		{
 			"Name": "KBVEGameplay",
 			"Enabled": true
 		}

--- a/packages/unreal/KBVEGameplay/KBVEGameplay.uplugin
+++ b/packages/unreal/KBVEGameplay/KBVEGameplay.uplugin
@@ -14,7 +14,7 @@
 	"Installed": false,
 	"EnabledByDefault": false,
 	"Plugins": [
-		{ "Name": "MassEntity", "Enabled": true }
+		{ "Name": "MassGameplay", "Enabled": true }
 	],
 	"Modules": [
 		{

--- a/packages/unreal/KBVEItemDB/KBVEItemDB.uplugin
+++ b/packages/unreal/KBVEItemDB/KBVEItemDB.uplugin
@@ -14,7 +14,9 @@
 	"Installed": false,
 	"EnabledByDefault": false,
 	"Plugins": [
-		{ "Name": "MassEntity", "Enabled": true }
+		{ "Name": "MassGameplay", "Enabled": true },
+		{ "Name": "KBVEYYJson", "Enabled": true },
+		{ "Name": "KBVESQLite", "Enabled": true }
 	],
 	"Modules": [
 		{ "Name": "KBVEItemDB", "Type": "Runtime", "LoadingPhase": "Default" }

--- a/packages/unreal/KBVEMapDB/KBVEMapDB.uplugin
+++ b/packages/unreal/KBVEMapDB/KBVEMapDB.uplugin
@@ -13,6 +13,6 @@
 	"IsExperimentalVersion": false,
 	"Installed": false,
 	"EnabledByDefault": false,
-	"Plugins": [ { "Name": "MassEntity", "Enabled": true } ],
+	"Plugins": [ { "Name": "MassGameplay", "Enabled": true } ],
 	"Modules": [ { "Name": "KBVEMapDB", "Type": "Runtime", "LoadingPhase": "Default" } ]
 }

--- a/packages/unreal/KBVENPCDB/KBVENPCDB.uplugin
+++ b/packages/unreal/KBVENPCDB/KBVENPCDB.uplugin
@@ -15,7 +15,7 @@
 	"EnabledByDefault": false,
 	"Plugins": [
 		{
-			"Name": "MassEntity",
+			"Name": "MassGameplay",
 			"Enabled": true
 		},
 		{

--- a/packages/unreal/KBVEWorld/KBVEWorld.uplugin
+++ b/packages/unreal/KBVEWorld/KBVEWorld.uplugin
@@ -23,6 +23,18 @@
 	],
 	"Plugins": [
 		{
+			"Name": "MassGameplay",
+			"Enabled": true
+		},
+		{
+			"Name": "StructUtils",
+			"Enabled": true
+		},
+		{
+			"Name": "KBVESQLite",
+			"Enabled": true
+		},
+		{
 			"Name": "ProceduralMeshComponent",
 			"Enabled": true
 		},

--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/KBVEWorld.Build.cs
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/KBVEWorld.Build.cs
@@ -41,15 +41,5 @@ public class KBVEWorld : ModuleRules
 				"AssetRegistry"
 			});
 		}
-
-		PublicIncludePaths.AddRange(new string[]
-		{
-			"KBVEWorld/Public"
-		});
-
-		PrivateIncludePaths.AddRange(new string[]
-		{
-			"KBVEWorld/Private"
-		});
 	}
 }

--- a/packages/unreal/UEDevOps/UEDevOps.uplugin
+++ b/packages/unreal/UEDevOps/UEDevOps.uplugin
@@ -29,6 +29,10 @@
 	],
 	"Plugins": [
 		{
+			"Name": "EditorScriptingUtilities",
+			"Enabled": true
+		},
+		{
 			"Name": "KBVEYYJson",
 			"Enabled": true
 		},


### PR DESCRIPTION
Clears UBT warnings across the KBVE Unreal plugins (UE 5.7).

## Changes
- **KBVEWorld.Build.cs** — remove `PublicIncludePaths`/`PrivateIncludePaths` AddRange that resolved against `Engine/Source` (`…/Engine/Source/KBVEWorld/Public` does not exist). UBT auto-adds a module's own `Public`/`Private`.
- **Missing plugin deps** (module-dep present, plugin-dep missing):
  - `KBVEWorld` → +MassGameplay, +StructUtils, +KBVESQLite
  - `KBVEItemDB` → +KBVEYYJson, +KBVESQLite
  - `KBVECombat` → +MassGameplay (owns MassCommon)
  - `UEDevOps` → +EditorScriptingUtilities
  - `rentearth.uproject` → +StructUtils
- **MassEntity deprecation (5.5)** — replace the deprecated `MassEntity` plugin dep with `MassGameplay` (provides the MassEntity module + MassCommon) in `KBVEGameplay`, `KBVEMapDB`, `KBVEItemDB`, `KBVENPCDB`. Also clears the transitive deprecation warnings for `KBVEMover`, `KBVECombat`, `chuckEditor`, `rentearth`.

## Notes
- No C++ logic touched — descriptor + Build.cs only.
- `"MassEntity"` left in `chuck.uproject`/`rentearth.uproject` `AdditionalDependencies` (those are module names, still valid).
- Residual caveat: Mass can't be used in 5.7 without the MassEntity plugin existing (MassGameplay depends on it), so one engine-level deprecation line may persist — Epic's to retire.