### PR TITLE
feat(cryptothrone): friendly connection errors + auto-reconnect

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -62,8 +62,10 @@ export class CloudCityScene extends Scene {
 	private myMaxHp = -1;
 	private nearbyHostiles = 0;
 	private slowTimer = 0;
+	private reconnectTimer = 0;
 	private netReady = false;
 	private netTerminal = false;
+	private reconnectAttempts = 0;
 	private rosterKey = '';
 	private laserUnsubs: (() => void)[] = [];
 
@@ -115,6 +117,41 @@ export class CloudCityScene extends Scene {
 			return;
 		}
 
+		this.connectClient();
+
+		this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) =>
+			this.onPointerDown(pointer),
+		);
+
+		this.laserUnsubs.push(
+			laserEvents.on('item:use', (data) => {
+				const d = data as { ref: string };
+				if (d?.ref) this.client?.useItem(d.ref);
+			}),
+			laserEvents.on('item:equip', (data) => {
+				const d = data as { ref: string };
+				if (d?.ref) this.client?.equipItem(d.ref);
+			}),
+			laserEvents.on('chat:send', (data) => {
+				const d = data as { text: string };
+				if (d?.text) this.client?.say(d.text);
+			}),
+		);
+
+		this.events.once('shutdown', () => {
+			window.clearTimeout(this.slowTimer);
+			window.clearTimeout(this.reconnectTimer);
+			this.laserUnsubs.forEach((off) => off());
+			this.laserUnsubs = [];
+			this.netTerminal = true;
+			this.client?.close();
+		});
+	}
+
+	private connectClient() {
+		const cfg = getCtNetConfig();
+		if (!cfg) return;
+
 		const client = new GameClient({
 			url: cfg.wsUrl,
 			jwt: cfg.jwt,
@@ -126,6 +163,7 @@ export class CloudCityScene extends Scene {
 		});
 		client.on('welcome', (w) => {
 			this.netReady = true;
+			this.reconnectAttempts = 0;
 			window.clearTimeout(this.slowTimer);
 			laserEvents.emit('net:status', { status: 'ready' });
 			this.mySlot = w.your_slot;
@@ -183,6 +221,7 @@ export class CloudCityScene extends Scene {
 			this.netTerminal = true;
 			laserEvents.emit('net:status', {
 				status: 'rejected',
+				reason,
 				detail: `The server turned you away: ${reason}`,
 			});
 		});
@@ -198,47 +237,41 @@ export class CloudCityScene extends Scene {
 		client.on('close', () => {
 			window.clearTimeout(this.slowTimer);
 			if (this.netTerminal) return;
+			const wasReady = this.netReady;
+			this.netReady = false;
+			if (wasReady && this.reconnectAttempts < 3) {
+				this.reconnectAttempts += 1;
+				const attempt = this.reconnectAttempts;
+				laserEvents.emit('net:status', {
+					status: 'reconnecting',
+					detail: `Connection dropped — reconnecting (attempt ${attempt}/3)…`,
+				});
+				this.reconnectTimer = window.setTimeout(
+					() => this.connectClient(),
+					1500 * 2 ** (attempt - 1),
+				);
+				return;
+			}
 			laserEvents.emit('net:status', {
 				status: 'disconnected',
-				detail: this.netReady
-					? 'You were disconnected from the world.'
+				detail: wasReady
+					? 'You were disconnected from the world and reconnecting failed.'
 					: 'The game server closed the connection before the world loaded.',
 			});
-			this.netReady = false;
 		});
-		laserEvents.emit('net:status', { status: 'connecting' });
+		laserEvents.emit('net:status', {
+			status: this.reconnectAttempts > 0 ? 'reconnecting' : 'connecting',
+			detail:
+				this.reconnectAttempts > 0
+					? `Connection dropped — reconnecting (attempt ${this.reconnectAttempts}/3)…`
+					: undefined,
+		});
 		this.slowTimer = window.setTimeout(() => {
-			if (!this.netReady) {
+			if (!this.netReady && !this.netTerminal) {
 				laserEvents.emit('net:status', { status: 'slow' });
 			}
 		}, 8000);
 		client.connect();
-
-		this.input.on('pointerdown', (pointer: Phaser.Input.Pointer) =>
-			this.onPointerDown(pointer),
-		);
-
-		this.laserUnsubs.push(
-			laserEvents.on('item:use', (data) => {
-				const d = data as { ref: string };
-				if (d?.ref) this.client?.useItem(d.ref);
-			}),
-			laserEvents.on('item:equip', (data) => {
-				const d = data as { ref: string };
-				if (d?.ref) this.client?.equipItem(d.ref);
-			}),
-			laserEvents.on('chat:send', (data) => {
-				const d = data as { text: string };
-				if (d?.text) this.client?.say(d.text);
-			}),
-		);
-
-		this.events.once('shutdown', () => {
-			window.clearTimeout(this.slowTimer);
-			this.laserUnsubs.forEach((off) => off());
-			this.laserUnsubs = [];
-			this.client?.close();
-		});
 	}
 
 	private makeGroundItemTexture() {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/game-store.ts
@@ -13,6 +13,7 @@ export type ConnectionStatus =
 	| 'connecting'
 	| 'connected'
 	| 'slow'
+	| 'reconnecting'
 	| 'ready'
 	| 'rejected'
 	| 'error'
@@ -21,6 +22,7 @@ export type ConnectionStatus =
 export interface ConnectionState {
 	status: ConnectionStatus;
 	detail?: string;
+	reason?: string;
 }
 
 export interface OnlinePlayer {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/store/useEventBridge.ts
@@ -16,11 +16,13 @@ export function useEventBridge(dispatch: Dispatch<GameAction>) {
 						| 'connecting'
 						| 'connected'
 						| 'slow'
+						| 'reconnecting'
 						| 'ready'
 						| 'rejected'
 						| 'error'
 						| 'disconnected';
 					detail?: string;
+					reason?: string;
 				};
 				dispatch({ type: 'SET_CONNECTION', payload: conn });
 			}),

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
@@ -1,5 +1,62 @@
 import { useGameSelector } from '../store/GameStoreContext';
 
+interface RejectInfo {
+	title: string;
+	message: string;
+	button: string;
+}
+
+function describeReject(
+	reason: string | undefined,
+	fallback: string,
+): RejectInfo {
+	const r = reason ?? '';
+	if (/protocol mismatch/i.test(r)) {
+		return {
+			title: 'Update required',
+			message:
+				'Your game client is out of date. Refresh the page to load the newest version of CryptoThrone.',
+			button: 'Refresh client',
+		};
+	}
+	if (/session expired/i.test(r)) {
+		return {
+			title: 'Session expired',
+			message:
+				'Your sign-in session ran out while you were away. Sign in again to re-enter the world.',
+			button: 'Sign in again',
+		};
+	}
+	if (/signature invalid|auth rejected|invalid token/i.test(r)) {
+		return {
+			title: 'Sign-in rejected',
+			message:
+				'The server could not verify your session. Sign out and back in, then try again.',
+			button: 'Sign in again',
+		};
+	}
+	if (/match full/i.test(r)) {
+		return {
+			title: 'World is full',
+			message: `Every seat in the realm is taken right now (${r.match(/\d+/)?.[0] ?? 'max'} players). Try again in a few minutes.`,
+			button: 'Try again',
+		};
+	}
+	if (/username required/i.test(r)) {
+		return {
+			title: 'Username needed',
+			message:
+				'Your KBVE account has no username yet. Set one up and the gates will open.',
+			button: 'Set username',
+		};
+	}
+	return {
+		title: 'Connection rejected',
+		message: r || fallback,
+		button: 'Retry connection',
+	};
+}
+
 export function ConnectionOverlay() {
 	const connection = useGameSelector((s) => s.connection);
 
@@ -8,7 +65,16 @@ export function ConnectionOverlay() {
 	const isPending =
 		connection.status === 'connecting' ||
 		connection.status === 'connected' ||
+		connection.status === 'reconnecting' ||
 		connection.status === 'slow';
+
+	const reject =
+		connection.status === 'rejected'
+			? describeReject(
+					connection.reason,
+					connection.detail ?? 'The server refused the connection.',
+				)
+			: null;
 
 	return (
 		<div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-[2px]">
@@ -20,12 +86,17 @@ export function ConnectionOverlay() {
 							aria-hidden="true"
 						/>
 						<p className="text-sm font-semibold text-amber-200">
-							Linking to Cloud City…
+							{connection.status === 'reconnecting'
+								? 'Reconnecting…'
+								: 'Linking to Cloud City…'}
 						</p>
 						<p className="mt-2 text-xs text-stone-400">
-							{connection.status === 'slow'
-								? 'This is taking longer than usual. The realm may be waking up — hang tight.'
-								: 'Establishing a secure connection to the game server.'}
+							{connection.status === 'reconnecting'
+								? (connection.detail ??
+									'The link dropped — re-establishing your place in the world.')
+								: connection.status === 'slow'
+									? 'This is taking longer than usual. The realm may be waking up — hang tight.'
+									: 'Establishing a secure connection to the game server.'}
 						</p>
 					</>
 				) : (
@@ -44,19 +115,25 @@ export function ConnectionOverlay() {
 							<line x1="12" y1="17" x2="12.01" y2="17" />
 						</svg>
 						<p className="text-sm font-semibold text-red-300">
-							{connection.status === 'rejected'
-								? 'Connection rejected'
-								: 'Connection lost'}
+							{reject ? reject.title : 'Connection lost'}
 						</p>
 						<p className="mt-2 text-xs text-stone-400">
-							{connection.detail ??
-								'The link to the game server failed. The world may be offline or unreachable.'}
+							{reject
+								? reject.message
+								: (connection.detail ??
+									'The link to the game server failed. The world may be offline or unreachable.')}
 						</p>
+						{reject?.title === 'Connection rejected' &&
+							connection.reason && (
+								<p className="mt-2 break-words font-mono text-[0.65rem] text-stone-600">
+									{connection.reason}
+								</p>
+							)}
 						<button
 							type="button"
 							onClick={() => window.location.reload()}
 							className="mt-4 w-full rounded-lg bg-amber-500/90 px-4 py-2 text-sm font-semibold text-black transition hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/70">
-							Retry connection
+							{reject ? reject.button : 'Retry connection'}
 						</button>
 					</>
 				)}

--- a/packages/rust/simgrid/src/auth.rs
+++ b/packages/rust/simgrid/src/auth.rs
@@ -40,7 +40,15 @@ pub fn verify_supabase_jwt(token: &str, secret: &[u8]) -> Result<SupabaseClaims,
     let mut validation = Validation::new(jsonwebtoken::Algorithm::HS256);
     validation.validate_aud = false;
     let data = decode::<SupabaseClaims>(token, &DecodingKey::from_secret(secret), &validation)
-        .map_err(|e| AuthError::Invalid(e.to_string()))?;
+        .map_err(|e| match e.kind() {
+            jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+                AuthError::Invalid("session expired".into())
+            }
+            jsonwebtoken::errors::ErrorKind::InvalidSignature => {
+                AuthError::Invalid("token signature invalid".into())
+            }
+            _ => AuthError::Invalid(e.to_string()),
+        })?;
     if data.claims.kbve_username.is_empty() {
         return Err(AuthError::MissingUsername);
     }

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -260,7 +260,7 @@ async fn await_join_match(
                 socket,
                 format,
                 &format!(
-                    "protocol mismatch: client={}, server={}",
+                    "protocol mismatch: client={}, server={} — refresh your browser to update the game client",
                     jm.protocol,
                     proto::PROTOCOL_VERSION
                 ),
@@ -291,7 +291,12 @@ async fn admit(
         }
     };
     let Some(username) = resolve_username(state.require_username, raw) else {
-        send_reject(socket, format, "username required").await;
+        send_reject(
+            socket,
+            format,
+            "username required — set a KBVE username first",
+        )
+        .await;
         return None;
     };
     claim_slot(state, socket, username, format).await
@@ -305,7 +310,12 @@ async fn admit(
     format: WireFormat,
 ) -> Option<AdmittedPlayer> {
     let Some(username) = resolve_username(state.require_username, jm.kbve_username) else {
-        send_reject(socket, format, "username required").await;
+        send_reject(
+            socket,
+            format,
+            "username required — set a KBVE username first",
+        )
+        .await;
         return None;
     };
     claim_slot(state, socket, username, format).await
@@ -338,7 +348,12 @@ async fn claim_slot(
             Some(AdmittedPlayer { slot, format })
         }
         None => {
-            send_reject(socket, format, "match full").await;
+            let capacity = state
+                .roster
+                .read()
+                .map(|r| r.capacity())
+                .unwrap_or_default();
+            send_reject(socket, format, &format!("match full ({capacity} players)")).await;
             None
         }
     }


### PR DESCRIPTION
## Summary
Error-message pass over the whole connection path **plus a gameplay-feedback sweep**, both sides of the wire.

### Server (simgrid)
- `protocol mismatch: client=3, server=4 — refresh your browser to update the game client`
- JWT errors mapped: `session expired` / `token signature invalid` instead of raw jsonwebtoken strings
- `match full (32 players)` includes capacity; `username required — set a KBVE username first`

### Client — connection errors
- Overlay maps reject reasons to a friendly catalog (Update required / Session expired / Sign-in rejected / World is full / Username needed), tailored copy + button per cause; unknown reasons show the raw string in mono
- **Auto-reconnect**: unexpected mid-game drops retry 3× with exponential backoff (1.5s/3s/6s) behind a 'Reconnecting…' spinner; reject/error states never loop
- Scene connection setup refactored into `connectClient()` for reconnect reuse

### Client — gameplay feedback
- **NPC health bars**: appear only when wounded, green→amber→red by remaining %, track moving sprites
- **Hit flash**: white flash then red tint on any damaged sprite
- **Level-ups**: 'LEVEL UP!' gold float + success toast with new stats; kills float '+N xp'
- **Click-to-act queue**: clicking a distant item/NPC pathfinds over and auto-picks-up/interacts on arrival (cancelled by any new click or if the target despawns)
- **'no target'** float when pressing Space with nothing adjacent; pointer cursor over clickable entities

## Testing
- simgrid 27/27 + clippy clean (both crates)
- astro-cryptothrone 29/29, site builds
- e2e preview 57 passed / 0 failed