### PR TITLE
fix(ci-unreal): forward server_target/server_config to bundled server build

### DIFF
--- a/.github/workflows/ci-unreal.yml
+++ b/.github/workflows/ci-unreal.yml
@@ -85,6 +85,8 @@ jobs:
         with:
             mode: server
             shell_path: ${{ fromJSON(inputs.engine).shell_path }}
+            server_target: ${{ fromJSON(inputs.engine).server_target }}
+            server_config: ${{ fromJSON(inputs.engine).server_config }}
             manifest_version: ${{ fromJSON(inputs.version).manifest }}
             version_source: ${{ fromJSON(inputs.version).source }}
             version_toml: ${{ fromJSON(inputs.version).toml }}


### PR DESCRIPTION
## Why

The bundled dedicated-server build fell back to `build.toml` (`chuckServer` / `Development`) because the server dispatch never forwarded the manifest's `server_target` / `server_config`. ci-unreal-build deploys to `/mnt/longhorn/ows-server/<server_target>/<version>`, and the beta fleet `ows-chuckrpg-beta` mounts subPath `chuckServerBeta`. So the binary would land under `chuckServer/` and the beta fleet would find nothing → server never starts.

## What

Forward `server_target` / `server_config` from the engine blob into the server job (`chuckServerBeta` / `Shipping` for beta). ci-unreal-build already treats these inputs as overrides over build.toml (`ci-unreal-build.yml:303-304`), so each channel builds its own target into the PVC path its fleet mounts.

## Verify after merge

Beta cut writes the server to `/mnt/longhorn/ows-server/chuckServerBeta/<version>`, aligning with the fleet subPath.

Final piece before the chuckrpg beta release cut (after #12243, #12245).