### PR TITLE
feat(jedi+forgejo): complete typed client surface + 20 typed read routes

### DIFF
--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -171,7 +171,7 @@ async fn main() -> anyhow::Result<()> {
         warn!("Forgejo proxy not configured (FORGEJO_UPSTREAM_URL not set)");
     }
 
-    if transport::proxy::init_forgejo_api() {
+    if transport::forgejo_api::init_forgejo_api() {
         info!("Forgejo typed API initialized - /dashboard/forgejo/api/* enabled");
     }
 

--- a/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
+++ b/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
@@ -1,0 +1,351 @@
+//! Typed Forgejo read routes backed by the jedi `forgejo` client.
+//!
+//! Reads only — typed responses + normalised `JediError` JSON, gated by
+//! DASHBOARD_VIEW. Mutations continue through the method-gated generic proxy
+//! (`/dashboard/forgejo/proxy/*`); the jedi write methods exist for future
+//! server-side validation/policy and are wired here when that lands.
+
+use std::sync::OnceLock;
+
+use axum::{
+    Json, Router,
+    extract::Path,
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use jedi::entity::forgejo::ForgejoClient;
+
+use super::proxy::require_dashboard_view;
+
+static FORGEJO_API: OnceLock<ForgejoClient> = OnceLock::new();
+
+pub fn init_forgejo_api() -> bool {
+    let upstream = match std::env::var("FORGEJO_UPSTREAM_URL") {
+        Ok(u) => u,
+        Err(_) => return false,
+    };
+    let token = match std::env::var("FORGEJO_AUTH_TOKEN") {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    FORGEJO_API
+        .set(ForgejoClient::new(&upstream, &token))
+        .is_ok()
+}
+
+fn client() -> Result<&'static ForgejoClient, Response> {
+    FORGEJO_API.get().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({"error": "Forgejo API not configured"})),
+        )
+            .into_response()
+    })
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ListQuery {
+    page: Option<u32>,
+    limit: Option<u32>,
+    q: Option<String>,
+    state: Option<String>,
+    #[serde(rename = "type")]
+    kind: Option<String>,
+}
+
+impl ListQuery {
+    fn page(&self) -> u32 {
+        self.page.unwrap_or(1)
+    }
+    fn limit(&self) -> u32 {
+        self.limit.unwrap_or(50)
+    }
+}
+
+async fn gate(headers: &HeaderMap) -> Result<&'static ForgejoClient, Response> {
+    require_dashboard_view(headers, "Forgejo-API").await?;
+    client()
+}
+
+macro_rules! reply {
+    ($expr:expr) => {
+        match $expr {
+            Ok(v) => Json(v).into_response(),
+            Err(e) => e.into_response(),
+        }
+    };
+}
+
+// ── Top-level reads ──────────────────────────────────────────────────
+
+async fn users(headers: HeaderMap, q: axum::extract::Query<ListQuery>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_admin_users(q.page(), q.limit()).await)
+}
+
+async fn orgs(headers: HeaderMap, q: axum::extract::Query<ListQuery>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_orgs(q.page(), q.limit()).await)
+}
+
+async fn repos_search(headers: HeaderMap, q: axum::extract::Query<ListQuery>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.search_repos(q.page(), q.limit(), q.q.as_deref()).await)
+}
+
+async fn version(headers: HeaderMap) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.version().await)
+}
+
+async fn cron(headers: HeaderMap, q: axum::extract::Query<ListQuery>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_cron(q.limit()).await)
+}
+
+async fn unadopted(headers: HeaderMap, q: axum::extract::Query<ListQuery>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_unadopted(q.limit()).await)
+}
+
+// ── Per-repo reads ───────────────────────────────────────────────────
+
+async fn repo(headers: HeaderMap, Path((owner, repo)): Path<(String, String)>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.get_repo(&owner, &repo).await)
+}
+
+async fn branches(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_branches(&owner, &repo, q.limit()).await)
+}
+
+async fn commits(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_commits(&owner, &repo, q.limit()).await)
+}
+
+async fn languages(headers: HeaderMap, Path((owner, repo)): Path<(String, String)>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_languages(&owner, &repo).await)
+}
+
+async fn collaborators(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_collaborators(&owner, &repo, q.limit()).await)
+}
+
+async fn releases(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_releases(&owner, &repo, q.limit()).await)
+}
+
+async fn hooks(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_hooks(&owner, &repo, q.limit()).await)
+}
+
+async fn protections(headers: HeaderMap, Path((owner, repo)): Path<(String, String)>) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_branch_protections(&owner, &repo).await)
+}
+
+async fn secrets(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_secrets(&owner, &repo, q.limit()).await)
+}
+
+async fn variables(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_variables(&owner, &repo, q.limit()).await)
+}
+
+async fn issues(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    let state = q.state.as_deref().unwrap_or("open");
+    let kind = q.kind.as_deref().unwrap_or("issues");
+    reply!(c.list_issues(&owner, &repo, state, kind, q.limit()).await)
+}
+
+// ── Org / team reads ─────────────────────────────────────────────────
+
+async fn org_members(
+    headers: HeaderMap,
+    Path(org): Path<String>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_org_members(&org, q.limit()).await)
+}
+
+async fn teams(
+    headers: HeaderMap,
+    Path(org): Path<String>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_teams(&org, q.limit()).await)
+}
+
+async fn team_members(
+    headers: HeaderMap,
+    Path(team_id): Path<u64>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = match gate(&headers).await {
+        Ok(c) => c,
+        Err(r) => return r,
+    };
+    reply!(c.list_team_members(team_id, q.limit()).await)
+}
+
+pub fn routes() -> Router {
+    let base = "/dashboard/forgejo/api";
+    Router::new()
+        .route(&format!("{base}/users"), get(users))
+        .route(&format!("{base}/orgs"), get(orgs))
+        .route(&format!("{base}/repos/search"), get(repos_search))
+        .route(&format!("{base}/version"), get(version))
+        .route(&format!("{base}/cron"), get(cron))
+        .route(&format!("{base}/unadopted"), get(unadopted))
+        .route(&format!("{base}/repos/{{owner}}/{{repo}}"), get(repo))
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/branches"),
+            get(branches),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/commits"),
+            get(commits),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/languages"),
+            get(languages),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/collaborators"),
+            get(collaborators),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/releases"),
+            get(releases),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/hooks"),
+            get(hooks),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/protections"),
+            get(protections),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/secrets"),
+            get(secrets),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/variables"),
+            get(variables),
+        )
+        .route(
+            &format!("{base}/repos/{{owner}}/{{repo}}/issues"),
+            get(issues),
+        )
+        .route(&format!("{base}/orgs/{{org}}/members"), get(org_members))
+        .route(&format!("{base}/orgs/{{org}}/teams"), get(teams))
+        .route(
+            &format!("{base}/teams/{{team_id}}/members"),
+            get(team_members),
+        )
+}

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -611,10 +611,7 @@ fn router(state: AppState) -> Router {
             "/dashboard/forgejo/proxy",
             any(super::proxy::forgejo_proxy_handler),
         )
-        .route(
-            "/dashboard/forgejo/api/users",
-            axum::routing::get(super::proxy::forgejo_users_handler),
-        )
+        .merge(super::forgejo_api::routes())
         .route(
             "/dashboard/vm/proxy/{*path}",
             any(super::proxy::kubevirt_proxy_handler),

--- a/apps/kbve/axum-kbve/src/transport/mod.rs
+++ b/apps/kbve/axum-kbve/src/transport/mod.rs
@@ -1,3 +1,4 @@
+pub mod forgejo_api;
 pub mod https;
 pub mod market;
 pub mod mc_lot;

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -368,7 +368,10 @@ fn extract_auth_token(headers: &HeaderMap, query: Option<&str>) -> Option<String
     None
 }
 
-async fn require_dashboard_view(headers: &HeaderMap, service_name: &str) -> Result<(), Response> {
+pub(crate) async fn require_dashboard_view(
+    headers: &HeaderMap,
+    service_name: &str,
+) -> Result<(), Response> {
     require_dashboard_view_with_query(headers, None, service_name).await
 }
 
@@ -871,62 +874,6 @@ pub async fn forgejo_proxy_handler(path: Option<Path<String>>, req: Request<Body
             axum::Json(json!({"error": "Forgejo proxy not configured"})),
         )
             .into_response(),
-    }
-}
-
-static FORGEJO_API: OnceLock<jedi::entity::forgejo::ForgejoClient> = OnceLock::new();
-
-pub fn init_forgejo_api() -> bool {
-    let upstream = match std::env::var("FORGEJO_UPSTREAM_URL") {
-        Ok(u) => u,
-        Err(_) => return false,
-    };
-    let token = match std::env::var("FORGEJO_AUTH_TOKEN") {
-        Ok(t) => t,
-        Err(_) => return false,
-    };
-    FORGEJO_API
-        .set(jedi::entity::forgejo::ForgejoClient::new(&upstream, &token))
-        .is_ok()
-}
-
-fn query_u32(query: Option<&str>, key: &str, default: u32) -> u32 {
-    query
-        .and_then(|qs| {
-            qs.split('&').find_map(|pair| {
-                pair.strip_prefix(key)
-                    .and_then(|rest| rest.strip_prefix('='))
-                    .and_then(|v| v.parse::<u32>().ok())
-            })
-        })
-        .unwrap_or(default)
-}
-
-/// Typed Forgejo route: real admin user list. Normalised errors via JediError.
-pub async fn forgejo_users_handler(req: Request<Body>) -> Response {
-    let headers = req.headers().clone();
-    let query = req.uri().query().map(|q| q.to_string());
-
-    if let Err(resp) =
-        require_dashboard_view_with_query(&headers, query.as_deref(), "Forgejo-API").await
-    {
-        return resp;
-    }
-    let client = match FORGEJO_API.get() {
-        Some(c) => c,
-        None => {
-            return (
-                StatusCode::SERVICE_UNAVAILABLE,
-                axum::Json(json!({"error": "Forgejo API not configured"})),
-            )
-                .into_response();
-        }
-    };
-    let page = query_u32(query.as_deref(), "page", 1);
-    let limit = query_u32(query.as_deref(), "limit", 50);
-    match client.list_admin_users(page, limit).await {
-        Ok(users) => axum::Json(users).into_response(),
-        Err(e) => e.into_response(),
     }
 }
 

--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -2,16 +2,14 @@
 //!
 //! Hand-written, mirroring the GitHub client. Callers provide the upstream
 //! base URL and an admin/sudo token at construction. Errors are normalised to
-//! [`JediError`] so handlers can return them directly.
-//!
-//! # Example
-//! ```ignore
-//! let fj = ForgejoClient::new("https://git.example.com", "token");
-//! let users = fj.list_admin_users(1, 50).await?;
-//! ```
+//! [`JediError`] so handlers can return them directly. Reads return typed
+//! structs; writes accept a `serde_json::Value` body and return the typed
+//! created/updated resource (or `()` for empty responses).
 
-use reqwest::{Client, Response, StatusCode};
+use reqwest::{Client, Method, RequestBuilder, Response, StatusCode};
+use serde_json::Value;
 use std::borrow::Cow;
+use std::collections::HashMap;
 use std::time::Duration;
 
 use super::types::*;
@@ -31,7 +29,7 @@ impl ForgejoClient {
         let client = Client::builder()
             .user_agent(USER_AGENT)
             .connect_timeout(Duration::from_secs(5))
-            .timeout(Duration::from_secs(15))
+            .timeout(Duration::from_secs(20))
             .build()
             .expect("Failed to build reqwest client for ForgejoClient");
 
@@ -42,53 +40,13 @@ impl ForgejoClient {
         }
     }
 
-    pub async fn search_repos(
-        &self,
-        page: u32,
-        limit: u32,
-        query: Option<&str>,
-    ) -> Result<Vec<ForgejoRepo>, JediError> {
-        let url = format!("{}/api/v1/repos/search", self.base_url);
-        let mut req = self.client.get(&url).bearer_auth(&self.token).query(&[
-            ("page", page.to_string()),
-            ("limit", limit.to_string()),
-            ("sort", "updated".to_string()),
-        ]);
-        if let Some(q) = query.filter(|q| !q.is_empty()) {
-            req = req.query(&[("q", q)]);
-        }
-        let resp = self.send(req).await?;
-        let results: ForgejoSearchResults<ForgejoRepo> = self.parse_response(resp).await?;
-        Ok(results.data)
+    // ── Core helpers ─────────────────────────────────────────────────
+
+    fn url(&self, path: &str) -> String {
+        format!("{}{}", self.base_url, path)
     }
 
-    pub async fn list_admin_users(
-        &self,
-        page: u32,
-        limit: u32,
-    ) -> Result<Vec<ForgejoUser>, JediError> {
-        let url = format!("{}/api/v1/admin/users", self.base_url);
-        let req = self
-            .client
-            .get(&url)
-            .bearer_auth(&self.token)
-            .query(&[("page", page.to_string()), ("limit", limit.to_string())]);
-        let resp = self.send(req).await?;
-        self.parse_response(resp).await
-    }
-
-    pub async fn list_orgs(&self, page: u32, limit: u32) -> Result<Vec<ForgejoOrg>, JediError> {
-        let url = format!("{}/api/v1/orgs", self.base_url);
-        let req = self
-            .client
-            .get(&url)
-            .bearer_auth(&self.token)
-            .query(&[("page", page.to_string()), ("limit", limit.to_string())]);
-        let resp = self.send(req).await?;
-        self.parse_response(resp).await
-    }
-
-    async fn send(&self, req: reqwest::RequestBuilder) -> Result<Response, JediError> {
+    async fn send(&self, req: RequestBuilder) -> Result<Response, JediError> {
         req.send().await.map_err(|e| {
             if e.is_timeout() {
                 JediError::Timeout
@@ -111,19 +69,688 @@ impl ForgejoClient {
             serde_json::from_str(&text)
                 .map_err(|e| JediError::Parse(format!("JSON parse error: {e}")))
         } else {
-            let body = resp.text().await.unwrap_or_default();
-            let message = serde_json::from_str::<serde_json::Value>(&body)
-                .ok()
-                .and_then(|v| v.get("message").and_then(|m| m.as_str()).map(String::from))
-                .unwrap_or(body);
-            match status {
-                StatusCode::UNAUTHORIZED => Err(JediError::Unauthorized),
-                StatusCode::FORBIDDEN => Err(JediError::Forbidden),
-                StatusCode::NOT_FOUND => Err(JediError::NotFound),
-                _ => Err(JediError::Internal(Cow::Owned(format!(
-                    "Forgejo API error {status}: {message}"
-                )))),
-            }
+            Err(self.error_for(resp).await)
         }
+    }
+
+    async fn error_for(&self, resp: Response) -> JediError {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        let message = serde_json::from_str::<Value>(&body)
+            .ok()
+            .and_then(|v| v.get("message").and_then(|m| m.as_str()).map(String::from))
+            .unwrap_or(body);
+        match status {
+            StatusCode::UNAUTHORIZED => JediError::Unauthorized,
+            StatusCode::FORBIDDEN => JediError::Forbidden,
+            StatusCode::NOT_FOUND => JediError::NotFound,
+            StatusCode::BAD_REQUEST | StatusCode::CONFLICT | StatusCode::UNPROCESSABLE_ENTITY => {
+                JediError::BadRequest(message)
+            }
+            _ => JediError::Internal(Cow::Owned(format!("Forgejo API error {status}: {message}"))),
+        }
+    }
+
+    async fn get<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+        query: &[(&str, String)],
+    ) -> Result<T, JediError> {
+        let mut req = self.client.get(self.url(path)).bearer_auth(&self.token);
+        if !query.is_empty() {
+            req = req.query(query);
+        }
+        let resp = self.send(req).await?;
+        self.parse_response(resp).await
+    }
+
+    async fn write<T: serde::de::DeserializeOwned>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<T, JediError> {
+        let mut req = self
+            .client
+            .request(method, self.url(path))
+            .bearer_auth(&self.token);
+        if let Some(b) = body {
+            req = req.json(b);
+        }
+        let resp = self.send(req).await?;
+        self.parse_response(resp).await
+    }
+
+    async fn write_empty(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&Value>,
+    ) -> Result<(), JediError> {
+        let mut req = self
+            .client
+            .request(method, self.url(path))
+            .bearer_auth(&self.token);
+        if let Some(b) = body {
+            req = req.json(b);
+        }
+        let resp = self.send(req).await?;
+        if resp.status().is_success() {
+            Ok(())
+        } else {
+            Err(self.error_for(resp).await)
+        }
+    }
+
+    fn page_query(page: u32, limit: u32) -> Vec<(&'static str, String)> {
+        vec![("page", page.to_string()), ("limit", limit.to_string())]
+    }
+
+    // ── Repos ────────────────────────────────────────────────────────
+
+    pub async fn search_repos(
+        &self,
+        page: u32,
+        limit: u32,
+        query: Option<&str>,
+    ) -> Result<Vec<ForgejoRepo>, JediError> {
+        let mut q = Self::page_query(page, limit);
+        q.push(("sort", "updated".to_string()));
+        if let Some(s) = query.filter(|s| !s.is_empty()) {
+            q.push(("q", s.to_string()));
+        }
+        let results: ForgejoSearchResults<ForgejoRepo> =
+            self.get("/api/v1/repos/search", &q).await?;
+        Ok(results.data)
+    }
+
+    pub async fn get_repo(&self, owner: &str, repo: &str) -> Result<ForgejoRepo, JediError> {
+        self.get(&format!("/api/v1/repos/{owner}/{repo}"), &[])
+            .await
+    }
+
+    pub async fn create_repo_for_user(
+        &self,
+        user: &str,
+        body: &Value,
+    ) -> Result<ForgejoRepo, JediError> {
+        self.write(
+            Method::POST,
+            &format!("/api/v1/admin/users/{user}/repos"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn create_repo_for_org(
+        &self,
+        org: &str,
+        body: &Value,
+    ) -> Result<ForgejoRepo, JediError> {
+        self.write(
+            Method::POST,
+            &format!("/api/v1/orgs/{org}/repos"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn edit_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoRepo, JediError> {
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_repo(&self, owner: &str, repo: &str) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn transfer_repo(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/transfer"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn migrate_repo(&self, body: &Value) -> Result<ForgejoRepo, JediError> {
+        self.write(Method::POST, "/api/v1/repos/migrate", Some(body))
+            .await
+    }
+
+    pub async fn list_branches(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoBranch>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/branches"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn list_commits(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoCommit>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/commits"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn list_languages(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<HashMap<String, u64>, JediError> {
+        self.get(&format!("/api/v1/repos/{owner}/{repo}/languages"), &[])
+            .await
+    }
+
+    pub async fn list_collaborators(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoCollaborator>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/collaborators"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn add_collaborator(
+        &self,
+        owner: &str,
+        repo: &str,
+        user: &str,
+        body: &Value,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::PUT,
+            &format!("/api/v1/repos/{owner}/{repo}/collaborators/{user}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn remove_collaborator(
+        &self,
+        owner: &str,
+        repo: &str,
+        user: &str,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/collaborators/{user}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Users (admin) ────────────────────────────────────────────────
+
+    pub async fn list_admin_users(
+        &self,
+        page: u32,
+        limit: u32,
+    ) -> Result<Vec<ForgejoUser>, JediError> {
+        self.get("/api/v1/admin/users", &Self::page_query(page, limit))
+            .await
+    }
+
+    pub async fn create_user(&self, body: &Value) -> Result<ForgejoUser, JediError> {
+        self.write(Method::POST, "/api/v1/admin/users", Some(body))
+            .await
+    }
+
+    pub async fn edit_user(&self, login: &str, body: &Value) -> Result<ForgejoUser, JediError> {
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/admin/users/{login}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_user(&self, login: &str, purge: bool) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/admin/users/{login}?purge={purge}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Orgs & teams ─────────────────────────────────────────────────
+
+    pub async fn list_orgs(&self, page: u32, limit: u32) -> Result<Vec<ForgejoOrg>, JediError> {
+        self.get("/api/v1/orgs", &Self::page_query(page, limit))
+            .await
+    }
+
+    pub async fn create_org(&self, body: &Value) -> Result<ForgejoOrg, JediError> {
+        self.write(Method::POST, "/api/v1/orgs", Some(body)).await
+    }
+
+    pub async fn edit_org(&self, org: &str, body: &Value) -> Result<ForgejoOrg, JediError> {
+        self.write(Method::PATCH, &format!("/api/v1/orgs/{org}"), Some(body))
+            .await
+    }
+
+    pub async fn delete_org(&self, org: &str) -> Result<(), JediError> {
+        self.write_empty(Method::DELETE, &format!("/api/v1/orgs/{org}"), None)
+            .await
+    }
+
+    pub async fn list_org_members(
+        &self,
+        org: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoUser>, JediError> {
+        self.get(
+            &format!("/api/v1/orgs/{org}/members"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn remove_org_member(&self, org: &str, user: &str) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/orgs/{org}/members/{user}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn list_teams(&self, org: &str, limit: u32) -> Result<Vec<ForgejoTeam>, JediError> {
+        self.get(
+            &format!("/api/v1/orgs/{org}/teams"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_team(&self, org: &str, body: &Value) -> Result<ForgejoTeam, JediError> {
+        self.write(
+            Method::POST,
+            &format!("/api/v1/orgs/{org}/teams"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_team(&self, team_id: u64) -> Result<(), JediError> {
+        self.write_empty(Method::DELETE, &format!("/api/v1/teams/{team_id}"), None)
+            .await
+    }
+
+    pub async fn list_team_members(
+        &self,
+        team_id: u64,
+        limit: u32,
+    ) -> Result<Vec<ForgejoUser>, JediError> {
+        self.get(
+            &format!("/api/v1/teams/{team_id}/members"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn add_team_member(&self, team_id: u64, user: &str) -> Result<(), JediError> {
+        self.write_empty(
+            Method::PUT,
+            &format!("/api/v1/teams/{team_id}/members/{user}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn remove_team_member(&self, team_id: u64, user: &str) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/teams/{team_id}/members/{user}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Webhooks ─────────────────────────────────────────────────────
+
+    pub async fn list_hooks(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoHook>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/hooks"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_hook(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoHook, JediError> {
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/hooks"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_hook(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/hooks/{id}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn test_hook(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
+        self.write_empty(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/hooks/{id}/tests"),
+            None,
+        )
+        .await
+    }
+
+    // ── Releases ─────────────────────────────────────────────────────
+
+    pub async fn list_releases(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoRelease>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/releases"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_release(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoRelease, JediError> {
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/releases"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_release(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/releases/{id}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Branch protection ────────────────────────────────────────────
+
+    pub async fn list_branch_protections(
+        &self,
+        owner: &str,
+        repo: &str,
+    ) -> Result<Vec<ForgejoBranchProtection>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/branch_protections"),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn create_branch_protection(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoBranchProtection, JediError> {
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/branch_protections"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_branch_protection(
+        &self,
+        owner: &str,
+        repo: &str,
+        name: &str,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/branch_protections/{name}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Actions secrets & variables ──────────────────────────────────
+
+    pub async fn list_secrets(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoSecret>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/actions/secrets"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn set_secret(
+        &self,
+        owner: &str,
+        repo: &str,
+        name: &str,
+        body: &Value,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::PUT,
+            &format!("/api/v1/repos/{owner}/{repo}/actions/secrets/{name}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_secret(
+        &self,
+        owner: &str,
+        repo: &str,
+        name: &str,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/actions/secrets/{name}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn list_variables(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoVariable>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/actions/variables"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_variable(
+        &self,
+        owner: &str,
+        repo: &str,
+        name: &str,
+        body: &Value,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/actions/variables/{name}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_variable(
+        &self,
+        owner: &str,
+        repo: &str,
+        name: &str,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/actions/variables/{name}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Issues & PR moderation ───────────────────────────────────────
+
+    pub async fn list_issues(
+        &self,
+        owner: &str,
+        repo: &str,
+        state: &str,
+        kind: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoIssue>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/issues"),
+            &[
+                ("state", state.to_string()),
+                ("type", kind.to_string()),
+                ("limit", limit.to_string()),
+            ],
+        )
+        .await
+    }
+
+    pub async fn set_issue_state(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+        body: &Value,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/issues/{index}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn lock_issue(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+        body: &Value,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::PUT,
+            &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/lock"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn unlock_issue(&self, owner: &str, repo: &str, index: u64) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/lock"),
+            None,
+        )
+        .await
+    }
+
+    // ── System / admin ───────────────────────────────────────────────
+
+    pub async fn version(&self) -> Result<ForgejoVersion, JediError> {
+        self.get("/api/v1/version", &[]).await
+    }
+
+    pub async fn list_cron(&self, limit: u32) -> Result<Vec<ForgejoCronTask>, JediError> {
+        self.get("/api/v1/admin/cron", &[("limit", limit.to_string())])
+            .await
+    }
+
+    pub async fn run_cron(&self, task: &str) -> Result<(), JediError> {
+        self.write_empty(Method::POST, &format!("/api/v1/admin/cron/{task}"), None)
+            .await
+    }
+
+    pub async fn list_unadopted(&self, limit: u32) -> Result<Vec<String>, JediError> {
+        self.get("/api/v1/admin/unadopted", &[("limit", limit.to_string())])
+            .await
+    }
+
+    pub async fn adopt_unadopted(&self, owner: &str, repo: &str) -> Result<(), JediError> {
+        self.write_empty(
+            Method::POST,
+            &format!("/api/v1/admin/unadopted/{owner}/{repo}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn delete_unadopted(&self, owner: &str, repo: &str) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/admin/unadopted/{owner}/{repo}"),
+            None,
+        )
+        .await
     }
 }

--- a/packages/rust/jedi/src/entity/forgejo/types.rs
+++ b/packages/rust/jedi/src/entity/forgejo/types.rs
@@ -70,6 +70,218 @@ pub struct ForgejoOrg {
     pub visibility: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoCollaborator {
+    #[serde(flatten)]
+    pub user: ForgejoUser,
+    #[serde(default)]
+    pub permissions: Option<ForgejoPermissions>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoPermissions {
+    #[serde(default)]
+    pub admin: bool,
+    #[serde(default)]
+    pub push: bool,
+    #[serde(default)]
+    pub pull: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoCommitAuthor {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub email: String,
+    #[serde(default)]
+    pub date: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoBranchCommit {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub timestamp: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoBranch {
+    pub name: String,
+    #[serde(default)]
+    pub commit: Option<ForgejoBranchCommit>,
+    #[serde(default)]
+    pub protected: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoCommitDetail {
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub author: Option<ForgejoCommitAuthor>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoCommit {
+    pub sha: String,
+    #[serde(default)]
+    pub commit: Option<ForgejoCommitDetail>,
+    #[serde(default)]
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoReleaseAsset {
+    pub id: u64,
+    pub name: String,
+    #[serde(default)]
+    pub size: u64,
+    #[serde(default)]
+    pub download_count: u64,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub browser_download_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoRelease {
+    pub id: u64,
+    pub tag_name: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub draft: bool,
+    #[serde(default)]
+    pub prerelease: bool,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub published_at: String,
+    #[serde(default)]
+    pub assets: Vec<ForgejoReleaseAsset>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoTeam {
+    pub id: u64,
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub permission: String,
+    #[serde(default)]
+    pub units: Vec<String>,
+    #[serde(default)]
+    pub includes_all_repositories: bool,
+    #[serde(default)]
+    pub can_create_org_repo: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoHook {
+    pub id: u64,
+    #[serde(rename = "type", default)]
+    pub hook_type: String,
+    #[serde(default)]
+    pub active: bool,
+    #[serde(default)]
+    pub events: Vec<String>,
+    #[serde(default)]
+    pub config: std::collections::HashMap<String, String>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoBranchProtection {
+    #[serde(default)]
+    pub branch_name: String,
+    #[serde(default)]
+    pub rule_name: String,
+    #[serde(default)]
+    pub enable_push: bool,
+    #[serde(default)]
+    pub required_approvals: u32,
+    #[serde(default)]
+    pub enable_status_check: bool,
+    #[serde(default)]
+    pub require_signed_commits: bool,
+    #[serde(default)]
+    pub block_on_outdated_branch: bool,
+    #[serde(default)]
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoSecret {
+    pub name: String,
+    #[serde(default)]
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoVariable {
+    pub name: String,
+    #[serde(default)]
+    pub data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoPullMeta {
+    #[serde(default)]
+    pub merged: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoIssue {
+    pub id: u64,
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub is_locked: bool,
+    #[serde(default)]
+    pub comments: u64,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub html_url: String,
+    #[serde(default)]
+    pub user: Option<ForgejoOwner>,
+    #[serde(default)]
+    pub pull_request: Option<ForgejoPullMeta>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoCronTask {
+    pub name: String,
+    #[serde(default)]
+    pub schedule: String,
+    #[serde(default)]
+    pub next: String,
+    #[serde(default)]
+    pub prev: String,
+    #[serde(default)]
+    pub exec_times: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoVersion {
+    #[serde(default)]
+    pub version: String,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct ForgejoSearchResults<T> {
     #[serde(default = "Vec::new")]


### PR DESCRIPTION
Sweep to bring the jedi `forgejo` feature up to full API coverage, then hook the typed surface into axum-kbve. Builds on #12240.

## jedi forgejo client — now complete (~50 methods)
- **Typed reads:** repos search/get, branches, commits, languages, collaborators, releases, hooks, branch protections, secrets, variables, issues, admin users, orgs, org members, teams, team members, version, cron, unadopted.
- **Writes:** create/edit/delete for repos (user/org owner) · users · orgs · teams · collaborators · hooks · releases · branch protections · secrets · variables · issue state + lock/unlock · cron run · adopt/delete unadopted. Writes take a `serde_json::Value` body; all errors normalize to `JediError` (401/403/404/400/409/422 mapped).
- All response structs added to `types.rs`.

## axum-kbve — typed read routes
- New `transport/forgejo_api` module exposes **20 typed READ routes** under `/dashboard/forgejo/api/*`, `DASHBOARD_VIEW`-gated, returning typed JSON / structured `JediError`. Merged into the router; `require_dashboard_view` is now `pub(crate)`; the one-off users handler moved into the module.
- **Writes stay on the existing method-gated generic proxy** (`/dashboard/forgejo/proxy/*`) — a typed route that just forwards a `Value` body is functionally identical to the gated proxy, so adding 25 write routes now buys nothing. The jedi write methods exist for when we add server-side validation/policy; routes get wired then.

## Verify
- `cargo check -p jedi --features forgejo` ✓
- `./kbve.sh -nx axum-kbve:build` ✓

## Next (not in this PR)
Migrate frontend reads from the proxy to `/dashboard/forgejo/api/*` (typed, cached, normalized errors), then add a `policy.rs` for server-side access control and wire write routes behind it.