### PR TITLE
fix(kube): 3600s backend timeout on cryptothrone game WS route

### DIFF
--- a/apps/kube/agones/cryptothrone/manifests/game-httproute.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/game-httproute.yaml
@@ -16,6 +16,10 @@ spec:
               - path:
                     type: PathPrefix
                     value: /
+          timeouts:
+              # Long-lived WebSocket — override Envoy's ~15s default backend
+              # timeout so wss connections survive (matches kbve /ws rule).
+              backendRequest: 3600s
           backendRefs:
               - name: cryptothrone-game
                 port: 7979


### PR DESCRIPTION
## Summary
The `cryptothrone-game-route` HTTPRoute had no timeouts, so Envoy applied its default (~15s) backend timeout — long enough to connect and load the world, then the wss connection dies mid-session.

Adds `timeouts.backendRequest: 3600s`, matching the proven kbve gateway `/ws` rule. Validated with a server-side dry-run.

ArgoCD applies on the next dev→main; HTTPRoute change is hitless.