### PR TITLE
fix(cryptothrone): player renders + safe spawn town + per-player character sprites

### DIFF
--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -19,6 +19,9 @@ pub const PLAYER_HP: i32 = 100;
 pub const PLAYER_ATTACK: i32 = 5;
 pub const PLAYER_TICKS_PER_TILE: u8 = 4;
 pub const PLAYER_SPAWN: Tile = Tile::new(5, 12);
+// Cloud City plaza is a safe town — hostiles can't aggro players within
+// this Chebyshev radius of spawn. Venture out to find combat.
+pub const PLAYER_SAFE_RADIUS: i32 = 8;
 
 pub const NPC_RESPAWN_TICKS: u32 = SIM_TICK_HZ * 30;
 
@@ -26,13 +29,14 @@ pub const CLERIC_REF: &str = "cleric";
 pub const CLERIC_SPAWN: Tile = Tile::new(4, 10);
 
 pub const BAT_REF: &str = "crystal-bat";
-pub const BAT_COUNT: i32 = 10;
-pub const BAT_ORIGIN: Tile = Tile::new(7, 7);
+pub const BAT_COUNT: i32 = 8;
+// Crystal cavern, far SE of the plaza — outside the safe zone.
+pub const BAT_ORIGIN: Tile = Tile::new(34, 30);
 pub const BAT_LOOT_REF: &str = "potion";
 
 pub const GOBLIN_REF: &str = "goblin";
 pub const GOBLIN_COUNT: i32 = 4;
-pub const GOBLIN_ORIGIN: Tile = Tile::new(20, 20);
+pub const GOBLIN_ORIGIN: Tile = Tile::new(24, 24);
 pub const GOBLIN_LOOT_REF: &str = "coin";
 
 pub const HOSTILE_AGGRO_RANGE: i32 = 6;
@@ -72,6 +76,7 @@ pub fn config() -> SimConfig {
         player_attack: PLAYER_ATTACK,
         spawn: PLAYER_SPAWN,
         ticks_per_tile: PLAYER_TICKS_PER_TILE,
+        safe_radius: PLAYER_SAFE_RADIUS,
     }
 }
 
@@ -162,7 +167,7 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
             &registry,
             BAT_REF,
             origin,
-            Some((20, 20)),
+            Some((6, 20)),
             Some(BAT_LOOT_REF),
         ) {
             spawn_npc_from_spec(&mut commands, &spec);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -22,6 +22,16 @@ import { getNPCByRef, npcIdForRef, isHostileRef } from '../data/npcs';
 const MAP_SCALE = 3;
 const STEP_THROTTLE_MS = 90;
 const SLOT_NONE = 0xffff;
+const PLAYER_SPRITE_VARIANTS = 8;
+
+function spriteVariantForName(name: string): number {
+	let h = 2166136261;
+	for (let i = 0; i < name.length; i++) {
+		h ^= name.charCodeAt(i);
+		h = Math.imul(h, 16777619);
+	}
+	return (h >>> 0) % PLAYER_SPRITE_VARIANTS;
+}
 
 interface RefSprite {
 	key: string;
@@ -56,9 +66,10 @@ export class CloudCityScene extends Scene {
 	private client: GameClient | null = null;
 
 	private mySlot = SLOT_NONE;
+	private slotUsername = new Map<number, string>();
 	private myEid = -1;
 	private tracked = new Map<number, Tracked>();
-	private registry = new Map<number, KindEntry>();
+	private kindRegistry = new Map<number, KindEntry>();
 	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
 	private attackKey!: Phaser.Input.Keyboard.Key;
 	private entityDepth = 0;
@@ -182,9 +193,9 @@ export class CloudCityScene extends Scene {
 			window.clearTimeout(this.slowTimer);
 			laserEvents.emit('net:status', { status: 'ready' });
 			this.mySlot = w.your_slot;
-			this.registry.clear();
+			this.kindRegistry.clear();
 			for (const entry of w.registry ?? []) {
-				this.registry.set(entry.kind, entry);
+				this.kindRegistry.set(entry.kind, entry);
 			}
 		});
 		client.on('snapshot', (s) => this.applySnapshot(s));
@@ -322,23 +333,28 @@ export class CloudCityScene extends Scene {
 	}
 
 	private kindCat(kind: number): number {
-		return this.registry.get(kind)?.cat ?? KIND_CAT_NPC;
+		return this.kindRegistry.get(kind)?.cat ?? KIND_CAT_NPC;
 	}
 
 	private kindRef(kind: number): string | null {
-		return this.registry.get(kind)?.ref ?? null;
+		return this.kindRegistry.get(kind)?.ref ?? null;
 	}
 
-	private makeSprite(kind: number): {
+	private makeSprite(
+		kind: number,
+		owner: number,
+	): {
 		sprite: Phaser.GameObjects.Sprite;
 		mapping?: number;
 	} {
 		const cat = this.kindCat(kind);
-		if (cat === KIND_CAT_PLAYER || this.registry.size === 0) {
+		if (cat === KIND_CAT_PLAYER || this.kindRegistry.size === 0) {
 			const sprite = this.add.sprite(0, 0, 'player');
 			sprite.scale = 1.5;
 			sprite.setDepth(this.entityDepth);
-			return { sprite, mapping: 6 };
+			const username = this.slotUsername.get(owner);
+			const mapping = username ? spriteVariantForName(username) : 6;
+			return { sprite, mapping };
 		}
 		if (cat === KIND_CAT_ITEM) {
 			const sprite = this.add.sprite(0, 0, 'ground-item');
@@ -380,6 +396,9 @@ export class CloudCityScene extends Scene {
 
 	private applySnapshot(snap: Snapshot) {
 		const seen = new Set<number>();
+		for (const pv of snap.players) {
+			this.slotUsername.set(pv.slot, pv.kbve_username);
+		}
 
 		for (const e of snap.entities) {
 			if (
@@ -395,7 +414,7 @@ export class CloudCityScene extends Scene {
 			seen.add(e.eid);
 			const existing = this.tracked.get(e.eid);
 			if (!existing) {
-				const { sprite, mapping } = this.makeSprite(e.kind);
+				const { sprite, mapping } = this.makeSprite(e.kind, e.owner);
 				const charId = `e${e.eid}`;
 				const conf: Record<string, unknown> = {
 					id: charId,
@@ -423,6 +442,10 @@ export class CloudCityScene extends Scene {
 				) {
 					this.myEid = e.eid;
 					this.cameras.main.startFollow(sprite, true);
+					// Seed range tracker to spawn so a range dialog only
+					// fires when the player walks into a zone, not when
+					// they spawn already standing in one.
+					this.rangeTile = { x: e.tile.x, y: e.tile.y };
 				}
 			} else {
 				if (

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -43,11 +43,15 @@ pub struct SimConfig {
     pub player_attack: i32,
     pub spawn: Tile,
     pub ticks_per_tile: u8,
+    /// Hostiles won't target players within this Chebyshev distance of
+    /// `spawn` — a safe starting town. 0 disables the safe zone.
+    pub safe_radius: i32,
 }
 
 impl Default for SimConfig {
     fn default() -> Self {
         Self {
+            safe_radius: 0,
             player_kind: PLAYER_KIND,
             player_hp: 100,
             player_attack: 5,
@@ -1006,6 +1010,7 @@ fn dir_between(from: Tile, to: Tile) -> Option<Dir> {
 #[allow(clippy::type_complexity)]
 fn hostile_ai(
     clock: Res<SimClock>,
+    config: Res<SimConfig>,
     map: Res<WalkableMap>,
     bcast: Res<SnapshotBroadcast>,
     mut occ: ResMut<Occupancy>,
@@ -1016,6 +1021,11 @@ fn hostile_ai(
         let mut nearest: Option<(Entity, Tile, i32)> = None;
         for (pe, ppos, hp, _) in q_players.iter() {
             if hp.hp <= 0 {
+                continue;
+            }
+            // Players inside the spawn safe zone are untouchable — the
+            // starting town stays peaceful so nobody loads into combat.
+            if config.safe_radius > 0 && ppos.tile.chebyshev(config.spawn) <= config.safe_radius {
                 continue;
             }
             let d = pos.tile.chebyshev(ppos.tile);
@@ -1553,6 +1563,63 @@ mod tests {
             .world_mut()
             .query_filtered::<Entity, With<PlayerSlotTag>>();
         q.iter(app.world()).next().expect("player spawned")
+    }
+
+    #[test]
+    fn safe_zone_blocks_hostile_aggro() {
+        let (tx, mut rx) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+        let (input_tx, input_rx) = mpsc::unbounded_channel();
+        let roster = Arc::new(RwLock::new(Roster::new(4)));
+        let map = WalkableMap::open(32, 32);
+        let mut registry = KindRegistry::new();
+        registry.register_npc("training-dummy");
+        let mut app = build_app(
+            tx,
+            input_rx,
+            roster.clone(),
+            7,
+            SimConfig {
+                spawn: Tile::new(8, 8),
+                safe_radius: 5,
+                ..SimConfig::default()
+            },
+            map,
+            registry,
+        );
+        let _ = &input_tx;
+        join(&roster, "townie");
+        app.update();
+
+        let registry = app.world().resource::<KindRegistry>().clone();
+        let kind = registry.kind_of("training-dummy").unwrap();
+        // Hostile spawns adjacent to the player, well inside the safe zone.
+        let spec = hostile_spec(kind, Tile::new(9, 8));
+        {
+            let mut q = bevy::ecs::world::CommandQueue::default();
+            let mut commands = Commands::new(&mut q, app.world());
+            spawn_npc_from_spec(&mut commands, &spec);
+            q.apply(app.world_mut());
+        }
+        let player = player_entity(&mut app);
+        let hp0 = app.world().get::<Health>(player).unwrap().hp;
+        for _ in 0..60 {
+            app.update();
+        }
+        let hp1 = app.world().get::<Health>(player).unwrap().hp;
+        assert_eq!(hp1, hp0, "safe-zone player took damage");
+
+        let mut hit = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, payload, .. } = evt
+                && kind == proto::EPHEMERAL_COMBAT
+            {
+                let t = String::from_utf8(payload).unwrap();
+                if t.contains("\"target_ref\":\"player\"") {
+                    hit = true;
+                }
+            }
+        }
+        assert!(!hit, "hostile attacked a player in the safe zone");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
You couldn't see your player and spawned straight into combat. Root-caused both by running the server locally (dev-accept) and driving a real client against it.

### The invisible-player bug (the big one)
The scene field `registry` **collides with Phaser.Scene's built-in `registry`** (a DataManager). Phaser's scene boot overwrites the class-field Map, so:
- `registry.clear()` threw in the `welcome` handler (DataManager has no `.clear()`)
- the kind-registry stayed empty → every player entity misclassified as an NPC → rendered as a monk sprite, and `e.kind === KIND_CAT_PLAYER` never matched so **the camera never followed**

Renamed the field to `kindRegistry`. **Verified live** against a local server: player renders, camera follows, two players show distinct sprites, roster shows both.

### Safe spawn town (no more auto-combat)
- `SimConfig.safe_radius` — hostiles can't aggro players within N Chebyshev tiles of spawn. cryptothrone sets 8, so the Cloud City plaza is peaceful and nobody loads into a fight
- Crystal-bat cavern moved from (7,7) — which overlapped the spawn — out to (34,30) with a tight wander radius; goblin camp (20,20)→(24,24). Combat is now opt-in: leave town to find it

### Per-player character sprites
- Each player's sprite frame (8 charactersheet variants) is derived deterministically from their username (FNV hash), so players look distinct instead of all sharing frame 6

### Spawn polish
- Range dialogs (well/sign/tombstone) only fire when you walk **into** a zone, not when you spawn standing in one

## Testing
- simgrid 28/28 (new: `safe_zone_blocks_hostile_aggro`), clippy clean both crates
- astro-cryptothrone 29/29, site builds
- e2e preview 57 passed / 0 failed
- **Live-verified**: local cryptothrone-server in dev-accept mode + real Playwright client — confirmed player render, camera follow, distinct sprites, safe spawn, roster, movement (screenshots captured)