### PR TITLE
feat(cryptothrone): realm chat over irc-gateway, off the game socket (protocol v5)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -158,10 +158,6 @@ export class CloudCityScene extends Scene {
 				const d = data as { ref: string };
 				if (d?.ref) this.client?.equipItem(d.ref);
 			}),
-			laserEvents.on('chat:send', (data) => {
-				const d = data as { text: string };
-				if (d?.text) this.client?.say(d.text);
-			}),
 		);
 
 		this.events.once('shutdown', () => {
@@ -219,9 +215,6 @@ export class CloudCityScene extends Scene {
 						'You died! The well pulls you back to the plaza, body intact, pride bruised.',
 				});
 			}
-		});
-		client.on('chat', (c) => {
-			laserEvents.emit('chat:message', c);
 		});
 		client.on('itemUsed', (u) => {
 			laserEvents.emit('item:used', u);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState } from 'react';
-import { laserEvents } from '@kbve/laser';
+import { RealmChatClient } from '@kbve/laser';
 import { useGameSelector } from '../store/GameStoreContext';
+import {
+	getCtNetConfig,
+	resolveChatUrl,
+	REALM_CHAT_GAME,
+	REALM_CHAT_CHANNEL,
+} from '@/lib/net-config';
 
 interface ChatLine {
 	id: number;
@@ -41,6 +47,8 @@ export function ChatBar() {
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const focusedRef = useRef(false);
 	focusedRef.current = focused;
+	const clientRef = useRef<RealmChatClient | null>(null);
+	const [connected, setConnected] = useState(false);
 
 	useEffect(() => {
 		const onKey = (e: KeyboardEvent) => {
@@ -63,8 +71,16 @@ export function ChatBar() {
 	}, []);
 
 	useEffect(() => {
-		return laserEvents.on('chat:message', (data) => {
-			const msg = data as { from: string; text: string };
+		const cfg = getCtNetConfig();
+		if (!cfg) return;
+		const client = new RealmChatClient({
+			url: resolveChatUrl(),
+			jwt: cfg.jwt,
+			game: REALM_CHAT_GAME,
+			channel: REALM_CHAT_CHANNEL,
+		});
+		clientRef.current = client;
+		const offMsg = client.on('message', (msg) => {
 			setLines((prev) =>
 				[
 					...prev,
@@ -78,6 +94,16 @@ export function ChatBar() {
 			);
 			if (!focusedRef.current) setUnread((n) => n + 1);
 		});
+		const offOpen = client.on('open', () => setConnected(true));
+		const offClose = client.on('close', () => setConnected(false));
+		client.connect();
+		return () => {
+			offMsg();
+			offOpen();
+			offClose();
+			client.close();
+			clientRef.current = null;
+		};
 	}, []);
 
 	useEffect(() => {
@@ -93,7 +119,7 @@ export function ChatBar() {
 		e.preventDefault();
 		const text = draft.trim();
 		if (!text) return;
-		laserEvents.emit('chat:send', { text });
+		clientRef.current?.send(text);
 		setDraft('');
 	};
 
@@ -106,7 +132,13 @@ export function ChatBar() {
 			}`}>
 			<div className="overflow-hidden rounded-xl border border-white/10 bg-black/60 shadow-xl shadow-black/40 backdrop-blur-xl">
 				<div className="flex items-center justify-between border-b border-white/5 px-3 py-1.5">
-					<span className="text-[0.65rem] font-semibold uppercase tracking-widest text-amber-300/80">
+					<span className="flex items-center gap-1.5 text-[0.65rem] font-semibold uppercase tracking-widest text-amber-300/80">
+						<span
+							className={`h-1.5 w-1.5 rounded-full ${
+								connected ? 'bg-emerald-400' : 'bg-stone-500'
+							}`}
+							aria-hidden="true"
+						/>
 						Realm chat
 					</span>
 					{unread > 0 && (

--- a/apps/cryptothrone/astro-cryptothrone/src/lib/net-config.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/lib/net-config.ts
@@ -6,9 +6,17 @@ export interface CtNetConfig {
 
 let config: CtNetConfig | null = null;
 
+export const REALM_CHAT_GAME = 'cryptothrone';
+export const REALM_CHAT_CHANNEL = '#cryptothrone';
+
 export function resolveWsUrl(): string {
 	const env = import.meta.env.PUBLIC_CT_GAME_WS as string | undefined;
 	return env && env.length > 0 ? env : 'wss://game.cryptothrone.com/ws';
+}
+
+export function resolveChatUrl(): string {
+	const env = import.meta.env.PUBLIC_CT_CHAT_WS as string | undefined;
+	return env && env.length > 0 ? env : 'wss://chat.kbve.com/gamechat';
 }
 
 export function setCtNetConfig(next: CtNetConfig): void {

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.5"
+version: "0.0.6"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.13"
+version: "0.1.14"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -53,6 +53,12 @@ export { RAPIER, createRapierPhysics } from './lib/physics/rapier';
 
 // Net — WS client speaking the simgrid JSON wire
 export { GameClient } from './lib/net/game-client';
+export { RealmChatClient } from './lib/net/realm-chat-client';
+export type {
+	RealmChatOptions,
+	RealmChatMessage,
+	RealmChatEventMap,
+} from './lib/net/realm-chat-client';
 export type {
 	GameClientOptions,
 	GameClientEventMap,
@@ -65,7 +71,6 @@ export {
 	EPHEMERAL_INVENTORY,
 	EPHEMERAL_COMBAT,
 	EPHEMERAL_PICKUP,
-	EPHEMERAL_CHAT,
 	EPHEMERAL_ITEM_USED,
 	EPHEMERAL_EQUIPPED,
 	EPHEMERAL_STATS,
@@ -95,7 +100,6 @@ export type {
 	InventorySync,
 	CombatEvent,
 	PickupEvent,
-	ChatEvent,
 	ItemUsedEvent,
 	EquippedEvent,
 	StatsEvent,

--- a/packages/npm/laser/src/lib/net/game-client.ts
+++ b/packages/npm/laser/src/lib/net/game-client.ts
@@ -1,13 +1,11 @@
 import { LaserEventBus } from '../core/events';
 import {
-	EPHEMERAL_CHAT,
 	EPHEMERAL_COMBAT,
 	EPHEMERAL_EQUIPPED,
 	EPHEMERAL_INVENTORY,
 	EPHEMERAL_ITEM_USED,
 	EPHEMERAL_PICKUP,
 	EPHEMERAL_STATS,
-	type ChatEvent,
 	type ClientMessage,
 	type CombatEvent,
 	type Dir,
@@ -36,7 +34,6 @@ export type GameClientEventMap = {
 	inventory: InventorySync;
 	combat: CombatEvent;
 	pickup: PickupEvent;
-	chat: ChatEvent;
 	itemUsed: ItemUsedEvent;
 	equipped: EquippedEvent;
 	stats: StatsEvent;
@@ -112,9 +109,6 @@ export class GameClient {
 		} else if (evt.kind === EPHEMERAL_PICKUP) {
 			const data = decodeEphemeralPayload<PickupEvent>(evt.payload);
 			if (data) this.bus.emit('pickup', data);
-		} else if (evt.kind === EPHEMERAL_CHAT) {
-			const data = decodeEphemeralPayload<ChatEvent>(evt.payload);
-			if (data) this.bus.emit('chat', data);
 		} else if (evt.kind === EPHEMERAL_ITEM_USED) {
 			const data = decodeEphemeralPayload<ItemUsedEvent>(evt.payload);
 			if (data) this.bus.emit('itemUsed', data);
@@ -160,10 +154,6 @@ export class GameClient {
 
 	equipItem(itemRef: string): void {
 		this.sendInputs([{ EquipItem: { item_ref: itemRef } }]);
-	}
-
-	say(text: string): void {
-		this.sendInputs([{ Say: { text } }]);
 	}
 
 	face(facing: Facing): void {

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 4;
+export const PROTOCOL_VERSION = 5;
 
 export const ACTION_ATTACK = 1;
 export const ACTION_PICKUP = 2;
@@ -6,7 +6,6 @@ export const ACTION_PICKUP = 2;
 export const EPHEMERAL_INVENTORY = 1;
 export const EPHEMERAL_COMBAT = 2;
 export const EPHEMERAL_PICKUP = 3;
-export const EPHEMERAL_CHAT = 4;
 export const EPHEMERAL_ITEM_USED = 5;
 export const EPHEMERAL_EQUIPPED = 6;
 export const EPHEMERAL_STATS = 7;
@@ -30,7 +29,6 @@ export type Input =
 	| { Action: { id: number; target: number | null } }
 	| { UseItem: { item_ref: string } }
 	| { EquipItem: { item_ref: string } }
-	| { Say: { text: string } }
 	| { Heartbeat: { client_tick: number } }
 	| 'Leave';
 
@@ -113,11 +111,6 @@ export interface CombatEvent {
 export interface PickupEvent {
 	item_ref: string;
 	count: number;
-}
-
-export interface ChatEvent {
-	from: string;
-	text: string;
 }
 
 export interface ItemUsedEvent {

--- a/packages/npm/laser/src/lib/net/realm-chat-client.ts
+++ b/packages/npm/laser/src/lib/net/realm-chat-client.ts
@@ -1,0 +1,125 @@
+import { LaserEventBus } from '../core/events';
+
+/**
+ * JSON wire frame for the irc-gateway `/gamechat` endpoint (bevy_chat
+ * ChatMessage). The gateway pins `sender`/`platform` server-side from the
+ * authenticated session, so outbound values are placeholders.
+ */
+interface ChatFrame {
+	kind: string;
+	sender: string;
+	platform: string;
+	channel: string;
+	content: string;
+	payload?: unknown;
+}
+
+export interface RealmChatMessage {
+	from: string;
+	text: string;
+}
+
+export type RealmChatEventMap = {
+	open: void;
+	message: RealmChatMessage;
+	close: void;
+	error: string;
+};
+
+export interface RealmChatOptions {
+	/** Base gamechat URL, e.g. wss://chat.kbve.com/gamechat */
+	url: string;
+	jwt: string;
+	/** Game key registered in the gateway GAME_PROFILES, e.g. "cryptothrone" */
+	game: string;
+	/** Channel the gateway routes this game to, e.g. "#cryptothrone" */
+	channel: string;
+}
+
+/**
+ * Realm chat over the shared irc-gateway (ergo IRC), independent of the
+ * game server's WebSocket. Reconnects with backoff while the page is open.
+ */
+export class RealmChatClient {
+	private ws: WebSocket | null = null;
+	private closed = false;
+	private attempts = 0;
+	private reconnectTimer = 0;
+	private readonly bus = new LaserEventBus<RealmChatEventMap>();
+	private readonly opts: RealmChatOptions;
+
+	constructor(opts: RealmChatOptions) {
+		this.opts = opts;
+	}
+
+	on<K extends keyof RealmChatEventMap>(
+		event: K,
+		handler: (data: RealmChatEventMap[K]) => void,
+	): () => void {
+		return this.bus.on(event, handler);
+	}
+
+	connect(): void {
+		if (this.ws || this.closed) return;
+		const sep = this.opts.url.includes('?') ? '&' : '?';
+		const url = `${this.opts.url}${sep}game=${encodeURIComponent(
+			this.opts.game,
+		)}&token=${encodeURIComponent(this.opts.jwt)}`;
+		const ws = new WebSocket(url);
+		this.ws = ws;
+
+		ws.addEventListener('open', () => {
+			this.attempts = 0;
+			this.bus.emit('open', undefined);
+		});
+		ws.addEventListener('message', (ev: MessageEvent) => {
+			let frame: ChatFrame;
+			try {
+				frame = JSON.parse(
+					typeof ev.data === 'string' ? ev.data : String(ev.data),
+				);
+			} catch {
+				return;
+			}
+			if (frame.kind !== 'chat') return;
+			if (frame.channel && frame.channel !== this.opts.channel) return;
+			this.bus.emit('message', {
+				from: frame.sender,
+				text: frame.content,
+			});
+		});
+		ws.addEventListener('error', () => this.bus.emit('error', 'socket'));
+		ws.addEventListener('close', () => {
+			this.ws = null;
+			this.bus.emit('close', undefined);
+			if (this.closed) return;
+			this.attempts += 1;
+			const delay = Math.min(1000 * 2 ** (this.attempts - 1), 15000);
+			this.reconnectTimer = window.setTimeout(
+				() => this.connect(),
+				delay,
+			);
+		});
+	}
+
+	send(text: string): void {
+		const trimmed = text.trim().slice(0, 200);
+		if (!trimmed || !this.ws || this.ws.readyState !== WebSocket.OPEN)
+			return;
+		const frame: ChatFrame = {
+			kind: 'chat',
+			sender: '',
+			platform: '',
+			channel: this.opts.channel,
+			content: trimmed,
+		};
+		this.ws.send(JSON.stringify(frame));
+	}
+
+	close(): void {
+		this.closed = true;
+		window.clearTimeout(this.reconnectTimer);
+		this.ws?.close();
+		this.ws = null;
+	}
+}

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 4;
+pub const PROTOCOL_VERSION: u32 = 5;
 pub const DEFAULT_MAX_PLAYERS: usize = 64;
 
 pub const ACTION_ATTACK: u16 = 1;
@@ -9,12 +9,9 @@ pub const ACTION_PICKUP: u16 = 2;
 pub const EPHEMERAL_INVENTORY: u16 = 1;
 pub const EPHEMERAL_COMBAT: u16 = 2;
 pub const EPHEMERAL_PICKUP: u16 = 3;
-pub const EPHEMERAL_CHAT: u16 = 4;
 pub const EPHEMERAL_ITEM_USED: u16 = 5;
 pub const EPHEMERAL_EQUIPPED: u16 = 6;
 pub const EPHEMERAL_STATS: u16 = 7;
-
-pub const MAX_CHAT_LEN: usize = 200;
 
 pub const KIND_CAT_PLAYER: u8 = 0;
 pub const KIND_CAT_NPC: u8 = 1;
@@ -108,7 +105,6 @@ pub enum Input {
     Action { id: u16, target: Option<EntityId> },
     UseItem { item_ref: String },
     EquipItem { item_ref: String },
-    Say { text: String },
     Heartbeat { client_tick: u32 },
     Leave,
 }

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -545,7 +545,6 @@ fn rebuild_occupancy(
 fn drain_inputs(
     queue: Res<InputQueue>,
     map: Res<WalkableMap>,
-    roster: Res<RosterHandle>,
     effects: Res<ConsumableEffects>,
     equipment: Res<EquipmentEffects>,
     config: Res<SimConfig>,
@@ -672,25 +671,6 @@ fn drain_inputs(
                         stats.attack,
                         defense.0,
                     );
-                }
-                Input::Say { text } => {
-                    let trimmed = text.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    let msg: String = trimmed.chars().take(proto::MAX_CHAT_LEN).collect();
-                    let from = match roster.0.read() {
-                        Ok(r) => r.username(slot.0).unwrap_or_default(),
-                        Err(p) => p.into_inner().username(slot.0).unwrap_or_default(),
-                    };
-                    let payload = json!({ "from": from, "text": msg })
-                        .to_string()
-                        .into_bytes();
-                    let _ = bcast.tx.send(ServerEvent::Ephemeral {
-                        kind: proto::EPHEMERAL_CHAT,
-                        to: proto::PLAYER_SLOT_NONE,
-                        payload,
-                    });
                 }
                 Input::Action { .. } | Input::Heartbeat { .. } | Input::Leave => {}
             }
@@ -1992,38 +1972,6 @@ mod tests {
         let payload = restored.expect("no inventory restore on rejoin");
         assert!(payload.contains("potion"), "payload: {payload}");
         assert!(payload.contains("3"), "payload: {payload}");
-    }
-
-    #[test]
-    fn say_broadcasts_chat() {
-        let (mut app, mut rx, input_tx, roster) = harness(29);
-        let slot = join(&roster, "talker");
-        app.update();
-
-        input_tx
-            .send((
-                slot,
-                Input::Say {
-                    text: "  hello world  ".into(),
-                },
-            ))
-            .unwrap();
-        for _ in 0..3 {
-            app.update();
-        }
-
-        let mut chat = None;
-        while let Ok(evt) = rx.try_recv() {
-            if let ServerEvent::Ephemeral { kind, to, payload } = evt
-                && kind == proto::EPHEMERAL_CHAT
-            {
-                assert_eq!(to, proto::PLAYER_SLOT_NONE);
-                chat = Some(String::from_utf8(payload).unwrap());
-            }
-        }
-        let payload = chat.expect("no chat broadcast");
-        assert!(payload.contains("hello world"), "payload: {payload}");
-        assert!(payload.contains("talker"), "payload: {payload}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Moves cryptothrone realm chat off the game WebSocket and onto the shared irc-gateway, so chat is one backend across games and the game server no longer carries it. **Depends on #12263** (the `/gamechat` endpoint) — merge/deploy that first.

### Client
- `ChatBar` now owns a **`RealmChatClient`** (new, in `@kbve/laser`) that connects to `wss://chat.kbve.com/gamechat?game=cryptothrone&token=<jwt>`, parses bevy_chat ChatMessage JSON, and reconnects with backoff — fully independent of the game link
- Chat connection status dot in the panel header
- `resolveChatUrl()` + game/channel consts in net-config (`PUBLIC_CT_CHAT_WS` override)

### Protocol v4 → v5 (game socket)
- Removed `Say` input, `EPHEMERAL_CHAT`, `MAX_CHAT_LEN`, simgrid's Say handler, `GameClient.say()`
- simgrid is consumed only by cryptothrone-server, so the break is contained; client + server ship together

### Release
- cryptothrone client 0.1.13 → **0.1.14**, server 0.0.5 → **0.0.6**

## Testing
- simgrid 27/27, clippy clean (both crates)
- laser tests pass, astro-cryptothrone 29/29, site builds
- e2e preview 57 passed / 0 failed

## Sequencing
1. #12263 (gateway /gamechat) → main
2. this PR → main
Until the gateway endpoint is live, the chat dot just shows disconnected; the game itself is unaffected.