### PR TITLE
fix(ci-unreal-build): Fork Guard trusts github-actions[bot] on KBVE/kbve

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -229,6 +229,10 @@ jobs:
                           return;
                         }
                       }
+                      if (context.actor === 'github-actions[bot]' && context.payload.repository?.full_name === 'KBVE/kbve') {
+                        core.setOutput('allowed', 'true');
+                        return;
+                      }
                       try {
                         const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
                           owner: context.repo.owner,


### PR DESCRIPTION
## Why

With `actions: write` granted (#12261), CI-Unreal dispatches finally **start** — but every job downstream of `guard` **skips**, so nothing builds or publishes (version.toml stayed 0.3.19).

`guard` (Fork Guard) gates all jobs on `needs.guard.outputs.allowed == 'true'`, which requires the triggering actor to be a write/admin collaborator. ci-main's automated release dispatch runs as **`github-actions[bot]`** (`GITHUB_TOKEN`) → `getCollaboratorPermissionLevel` fails → `allowed=false` → whole build skips.

## Fix

Trust `github-actions[bot]` when `repository.full_name == 'KBVE/kbve'`. The bot can only reach this reusable via ci-main, which runs on `main` (protected branch), so it's a trusted internal dispatch. Fork-PR blocking and the human write-collaborator check are unchanged.

## After merge → main

The next ci-main dispatch of `unreal_chuck_beta` runs the real jobs: Server Config → version gate (0.3.20 > 0.3.19 → build) → Linux+Win64 client (Shipping) → itch `kbve/chuckrpg`; bundled `chuckServerBeta` → PVC `chuckServerBeta`; post-publish sync bumps version.toml → 0.3.20.

Chain of real fixes: #12261 (actions:write, startup) → this (guard, jobs actually run).