### PR TITLE
feat(cryptothrone): HUD integration pack (minimap, target frame, hotbar, +)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
@@ -69,7 +69,7 @@ test.describe('Phaser runtime (WebGL)', () => {
 		);
 		await seedFakeSession(page);
 		await page.goto('/game/play/', { waitUntil: 'domcontentloaded' });
-		const canvas = page.locator('.game-fullscreen canvas');
+		const canvas = page.locator('.game-fullscreen canvas').first();
 		await expect(canvas).toBeAttached({ timeout: 30_000 });
 		const box = await canvas.boundingBox();
 		expect(box?.width ?? 0).toBeGreaterThan(0);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -15,6 +15,14 @@ import { DialogueModal } from './ui/DialogueModal';
 import { DiceRollModal } from './ui/DiceRollModal';
 import { ChatBar } from './ui/ChatBar';
 import { ConnectionOverlay } from './ui/ConnectionOverlay';
+import { ZoneBanner } from './ui/ZoneBanner';
+import { CoordsBar } from './ui/CoordsBar';
+import { GoldCounter } from './ui/GoldCounter';
+import { Minimap } from './ui/Minimap';
+import { CombatLog } from './ui/CombatLog';
+import { TargetFrame } from './ui/TargetFrame';
+import { Hotbar } from './ui/Hotbar';
+import { KeybindHelp } from './ui/KeybindHelp';
 
 /**
  * Isolated Phaser canvas — never re-renders when game store changes.
@@ -92,6 +100,14 @@ function GameUI({ username }: { username?: string }) {
 			<CharacterDialog />
 			<NotificationToast />
 			<ChatBar />
+			<ZoneBanner />
+			<CoordsBar />
+			<GoldCounter />
+			<Minimap />
+			<CombatLog />
+			<TargetFrame />
+			<Hotbar />
+			<KeybindHelp />
 			<ConnectionOverlay />
 		</>
 	);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -54,6 +54,7 @@ interface Tracked {
 	hp: number;
 	maxHp: number;
 	hpBar?: Phaser.GameObjects.Graphics;
+	nameplate?: Phaser.GameObjects.Text;
 }
 
 interface PendingAction {
@@ -87,6 +88,10 @@ export class CloudCityScene extends Scene {
 	private reconnectAttempts = 0;
 	private rosterKey = '';
 	private pendingAction: PendingAction | null = null;
+	private fpsFrames = 0;
+	private fpsAt = 0;
+	private lastPosKey = '';
+	private currentZone = '';
 	private prevLevel = -1;
 	private prevXp = -1;
 	private hoverThrottle = 0;
@@ -420,14 +425,30 @@ export class CloudCityScene extends Scene {
 					conf.walkingAnimationMapping = mapping;
 				}
 				this.gridEngine.addCharacter(conf);
-				this.tracked.set(e.eid, {
+				const tracked: Tracked = {
 					sprite,
 					charId,
 					tile: { x: e.tile.x, y: e.tile.y },
 					kind: e.kind,
 					hp: e.hp,
 					maxHp: e.max_hp,
-				});
+				};
+				if (this.kindCat(e.kind) === KIND_CAT_PLAYER) {
+					const name = this.slotUsername.get(e.owner);
+					if (name) {
+						tracked.nameplate = this.add
+							.text(sprite.x, sprite.y - 34, name, {
+								fontFamily: 'monospace',
+								fontSize: '11px',
+								color: '#fcd34d',
+								stroke: '#000000',
+								strokeThickness: 3,
+							})
+							.setOrigin(0.5, 1)
+							.setDepth(this.entityDepth + 2);
+					}
+				}
+				this.tracked.set(e.eid, tracked);
 				if (
 					this.kindCat(e.kind) === KIND_CAT_PLAYER &&
 					e.owner === this.mySlot &&
@@ -462,6 +483,7 @@ export class CloudCityScene extends Scene {
 				this.gridEngine.removeCharacter(t.charId);
 			}
 			t.hpBar?.destroy();
+			t.nameplate?.destroy();
 			t.sprite.destroy();
 			this.tracked.delete(eid);
 			if (eid === this.myEid) this.myEid = -1;
@@ -610,6 +632,15 @@ export class CloudCityScene extends Scene {
 		this.pendingAction = null;
 		const hit = this.entityAt(tile);
 		if (hit) {
+			const ref = this.kindRef(hit.t.kind);
+			const npc = ref ? getNPCByRef(ref) : undefined;
+			laserEvents.emit('target:set', {
+				eid: hit.eid,
+				name: npc?.name ?? ref ?? 'Unknown',
+				hp: hit.t.hp,
+				maxHp: hit.t.maxHp,
+				cat: this.kindCat(hit.t.kind),
+			});
 			const cat = this.kindCat(hit.t.kind);
 			const me = this.myTile();
 			if (cat === KIND_CAT_ITEM) {
@@ -643,6 +674,7 @@ export class CloudCityScene extends Scene {
 			}
 		}
 
+		laserEvents.emit('target:clear', {});
 		this.client.moveTo(tile);
 	}
 
@@ -744,9 +776,62 @@ export class CloudCityScene extends Scene {
 		];
 	}
 
+	private updateOverlays(time: number) {
+		for (const [, t] of this.tracked) {
+			if (t.nameplate) {
+				t.nameplate.setPosition(t.sprite.x, t.sprite.y - 34);
+			}
+		}
+		// FPS — emit roughly once per second.
+		this.fpsFrames += 1;
+		if (time - this.fpsAt >= 1000) {
+			const fps = Math.round(
+				(this.fpsFrames * 1000) / (time - this.fpsAt),
+			);
+			this.fpsAt = time;
+			this.fpsFrames = 0;
+			laserEvents.emit('perf:fps', { fps });
+		}
+		// Other players (for the minimap).
+		const others: { x: number; y: number }[] = [];
+		for (const [eid, t] of this.tracked) {
+			if (
+				eid !== this.myEid &&
+				this.kindCat(t.kind) === KIND_CAT_PLAYER
+			) {
+				others.push({ x: t.tile.x, y: t.tile.y });
+			}
+		}
+		laserEvents.emit('world:players', { players: others });
+		// Player tile position.
+		const me = this.myTile();
+		if (me) {
+			const key = `${me.x},${me.y}`;
+			if (key !== this.lastPosKey) {
+				this.lastPosKey = key;
+				laserEvents.emit('player:position', { x: me.x, y: me.y });
+			}
+			const zone = this.zoneForTile(me);
+			if (zone !== this.currentZone) {
+				this.currentZone = zone;
+				laserEvents.emit('zone:enter', { name: zone });
+			}
+		}
+	}
+
+	private zoneForTile(t: { x: number; y: number }): string {
+		const near = (cx: number, cy: number, r: number) =>
+			Math.max(Math.abs(t.x - cx), Math.abs(t.y - cy)) <= r;
+		if (near(5, 12, 8)) return 'Cloud City Plaza';
+		if (near(24, 24, 7)) return 'Goblin Camp';
+		if (near(34, 30, 8)) return 'Crystal Cavern';
+		return 'The Wilds';
+	}
+
 	update(time: number) {
 		if (!this.client) return;
 		this.updateHpBars();
+		this.updateOverlays(time);
 
 		if (Phaser.Input.Keyboard.JustDown(this.attackKey)) {
 			this.attackNearby();

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CombatLog.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CombatLog.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+interface Entry {
+	id: number;
+	text: string;
+	tone: string;
+}
+let counter = 0;
+const MAX = 8;
+
+export function CombatLog() {
+	const [entries, setEntries] = useState<Entry[]>([]);
+	const meRef = useRef(-1);
+
+	useEffect(() => {
+		const push = (text: string, tone: string) =>
+			setEntries((prev) =>
+				[...prev, { id: ++counter, text, tone }].slice(-MAX),
+			);
+		const offs = [
+			laserEvents.on('combat:event', (d) => {
+				const c = d as {
+					target_ref: string | null;
+					dmg: number;
+					died: boolean;
+				};
+				const name = c.target_ref ?? 'enemy';
+				push(
+					c.died ? `${name} was slain` : `Hit ${name} for ${c.dmg}`,
+					c.died ? 'text-emerald-300' : 'text-stone-300',
+				);
+			}),
+			laserEvents.on('item:pickup', (d) => {
+				const p = d as { item_ref: string; count: number };
+				push(
+					`Picked up ${p.item_ref}${p.count > 1 ? ` ×${p.count}` : ''}`,
+					'text-amber-200',
+				);
+			}),
+			laserEvents.on('item:used', (d) => {
+				const u = d as { item_ref: string; heal: number };
+				push(
+					`Used ${u.item_ref}${u.heal > 0 ? ` (+${u.heal} HP)` : ''}`,
+					'text-green-300',
+				);
+			}),
+		];
+		return () => offs.forEach((o) => o());
+	}, []);
+	void meRef;
+
+	if (entries.length === 0) return null;
+	return (
+		<div className="pointer-events-none absolute bottom-3 left-1/2 z-20 w-72 -translate-x-1/2 space-y-0.5 text-center">
+			{entries.map((e) => (
+				<div
+					key={e.id}
+					className={`truncate font-mono text-[0.65rem] ${e.tone} drop-shadow-[0_1px_2px_rgba(0,0,0,0.9)]`}>
+					{e.text}
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CoordsBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CoordsBar.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+export function CoordsBar() {
+	const [pos, setPos] = useState({ x: 0, y: 0 });
+	const [fps, setFps] = useState(0);
+	const [zone, setZone] = useState('—');
+	const [clock, setClock] = useState('');
+
+	useEffect(() => {
+		const offs = [
+			laserEvents.on('player:position', (d) =>
+				setPos(d as { x: number; y: number }),
+			),
+			laserEvents.on('perf:fps', (d) =>
+				setFps((d as { fps: number }).fps),
+			),
+			laserEvents.on('zone:enter', (d) =>
+				setZone((d as { name: string }).name),
+			),
+		];
+		const t = window.setInterval(
+			() =>
+				setClock(
+					new Date().toLocaleTimeString(undefined, {
+						hour: '2-digit',
+						minute: '2-digit',
+					}),
+				),
+			1000,
+		);
+		return () => {
+			offs.forEach((o) => o());
+			window.clearInterval(t);
+		};
+	}, []);
+
+	return (
+		<div className="pointer-events-none absolute right-3 top-16 z-30 rounded-lg border border-white/10 bg-black/55 px-3 py-1.5 text-right font-mono text-[0.65rem] leading-relaxed text-stone-300 backdrop-blur-md">
+			<div className="text-amber-300">{zone}</div>
+			<div>
+				{pos.x},{pos.y}
+			</div>
+			<div className="text-stone-500">
+				{fps} fps · {clock}
+			</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/GoldCounter.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/GoldCounter.tsx
@@ -1,0 +1,16 @@
+import { useGameSelector } from '../store/GameStoreContext';
+
+export function GoldCounter() {
+	const backpack = useGameSelector((s) => s.player.inventory.backpack);
+	const gold = backpack.filter((id) => id === 'coin').length;
+	return (
+		<div className="pointer-events-none absolute left-1/2 top-3 z-30 -translate-x-1/2">
+			<div className="flex items-center gap-1.5 rounded-full border border-amber-300/25 bg-black/55 px-3 py-1 backdrop-blur-md">
+				<span className="inline-block h-3 w-3 rounded-full bg-gradient-to-b from-amber-200 to-amber-500" />
+				<span className="font-mono text-xs font-semibold text-amber-200">
+					{gold}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Hotbar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Hotbar.tsx
@@ -1,0 +1,62 @@
+import { useEffect } from 'react';
+import { laserEvents } from '@kbve/laser';
+import { useGameSelector } from '../store/GameStoreContext';
+import { getItemById } from '../data/items';
+
+const SLOTS = 4;
+
+export function Hotbar() {
+	const backpack = useGameSelector((s) => s.player.inventory.backpack);
+	const consumables = Array.from(new Set(backpack)).filter((id) => {
+		const item = getItemById(id);
+		return item?.type === 'consumable';
+	});
+	const slots = consumables.slice(0, SLOTS);
+
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			const active = document.activeElement;
+			if (
+				active instanceof HTMLInputElement ||
+				active instanceof HTMLTextAreaElement
+			)
+				return;
+			const n = Number(e.key);
+			if (n >= 1 && n <= SLOTS && slots[n - 1]) {
+				laserEvents.emit('item:use', { ref: slots[n - 1] });
+			}
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, [slots]);
+
+	if (slots.length === 0) return null;
+	return (
+		<div className="pointer-events-auto absolute bottom-3 left-1/2 z-30 flex -translate-x-1/2 gap-1.5">
+			{slots.map((id, i) => {
+				const item = getItemById(id);
+				return (
+					<button
+						key={id}
+						type="button"
+						onClick={() =>
+							laserEvents.emit('item:use', { ref: id })
+						}
+						title={`${item?.name ?? id} (${i + 1})`}
+						className="relative h-11 w-11 rounded-lg border border-amber-300/30 bg-black/55 backdrop-blur-md transition hover:border-amber-300">
+						{item?.img && (
+							<img
+								src={item.img}
+								alt={item.name}
+								className="h-full w-full object-contain p-1"
+							/>
+						)}
+						<span className="absolute bottom-0 right-0.5 font-mono text-[0.6rem] text-stone-400">
+							{i + 1}
+						</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KeybindHelp.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KeybindHelp.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+const BINDS: [string, string][] = [
+	['Arrows', 'Move'],
+	['Click', 'Move / interact'],
+	['Space', 'Attack adjacent'],
+	['1–4', 'Use consumable'],
+	['Enter', 'Chat'],
+	['?', 'Toggle this help'],
+];
+
+export function KeybindHelp() {
+	const [open, setOpen] = useState(false);
+	useEffect(() => {
+		const onKey = (e: KeyboardEvent) => {
+			const active = document.activeElement;
+			if (
+				active instanceof HTMLInputElement ||
+				active instanceof HTMLTextAreaElement
+			)
+				return;
+			if (e.key === '?') setOpen((v) => !v);
+			if (e.key === 'Escape') setOpen(false);
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, []);
+	if (!open) return null;
+	return (
+		<div className="pointer-events-auto absolute inset-0 z-40 flex items-center justify-center bg-black/40 backdrop-blur-[1px]">
+			<div className="w-64 rounded-xl border border-amber-200/15 bg-black/80 p-5 backdrop-blur-xl">
+				<h3 className="mb-3 text-center text-sm font-bold text-amber-300">
+					Controls
+				</h3>
+				<ul className="space-y-1.5">
+					{BINDS.map(([k, v]) => (
+						<li
+							key={k}
+							className="flex justify-between text-xs text-stone-300">
+							<kbd className="rounded bg-white/10 px-1.5 py-0.5 font-mono text-[0.65rem]">
+								{k}
+							</kbd>
+							<span>{v}</span>
+						</li>
+					))}
+				</ul>
+				<button
+					type="button"
+					onClick={() => setOpen(false)}
+					className="mt-4 w-full rounded-lg bg-amber-500/90 py-1.5 text-xs font-semibold text-black hover:bg-amber-400">
+					Close
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Minimap.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Minimap.tsx
@@ -1,0 +1,56 @@
+import { useEffect, useRef } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+const MAP_W = 50;
+const MAP_H = 50;
+const SIZE = 120;
+
+export function Minimap() {
+	const ref = useRef<HTMLCanvasElement>(null);
+	const me = useRef({ x: 5, y: 12 });
+	const others = useRef<{ x: number; y: number }[]>([]);
+
+	useEffect(() => {
+		const draw = () => {
+			const cv = ref.current;
+			if (!cv) return;
+			const ctx = cv.getContext('2d');
+			if (!ctx) return;
+			ctx.clearRect(0, 0, SIZE, SIZE);
+			ctx.fillStyle = 'rgba(20,20,30,0.7)';
+			ctx.fillRect(0, 0, SIZE, SIZE);
+			const sx = SIZE / MAP_W;
+			const sy = SIZE / MAP_H;
+			ctx.fillStyle = '#34d399';
+			for (const o of others.current)
+				ctx.fillRect(o.x * sx - 1, o.y * sy - 1, 3, 3);
+			ctx.fillStyle = '#fbbf24';
+			ctx.fillRect(me.current.x * sx - 2, me.current.y * sy - 2, 4, 4);
+		};
+		const offs = [
+			laserEvents.on('player:position', (d) => {
+				me.current = d as { x: number; y: number };
+				draw();
+			}),
+			laserEvents.on('world:players', (d) => {
+				others.current = (
+					d as { players: { x: number; y: number }[] }
+				).players;
+				draw();
+			}),
+		];
+		draw();
+		return () => offs.forEach((o) => o());
+	}, []);
+
+	return (
+		<div className="pointer-events-none absolute bottom-3 right-3 z-30">
+			<canvas
+				ref={ref}
+				width={SIZE}
+				height={SIZE}
+				className="rounded-lg border border-white/10 bg-black/50 backdrop-blur-md"
+			/>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/OnlinePlayers.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/OnlinePlayers.tsx
@@ -24,14 +24,18 @@ export function OnlinePlayers() {
 								className="h-1.5 w-1.5 rounded-full bg-emerald-400"
 								aria-hidden="true"
 							/>
-							<span className="truncate">
+							<a
+								href={`https://kbve.com/@${p.username}`}
+								target="_blank"
+								rel="noopener"
+								className="truncate text-stone-300 no-underline hover:text-amber-300">
 								{p.username}
 								{p.username === me && (
 									<span className="ml-1 text-xs text-gray-500">
 										(you)
 									</span>
 								)}
-							</span>
+							</a>
 						</li>
 					))}
 				</ul>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/TargetFrame.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/TargetFrame.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+interface Target {
+	name: string;
+	hp: number;
+	maxHp: number;
+	cat: number;
+}
+
+export function TargetFrame() {
+	const [target, setTarget] = useState<Target | null>(null);
+	useEffect(() => {
+		const offs = [
+			laserEvents.on('target:set', (d) => setTarget(d as Target)),
+			laserEvents.on('target:clear', () => setTarget(null)),
+		];
+		return () => offs.forEach((o) => o());
+	}, []);
+	if (!target || target.maxHp <= 0) return null;
+	const pct = Math.max(0, Math.min(100, (target.hp / target.maxHp) * 100));
+	return (
+		<div className="pointer-events-none absolute left-1/2 top-12 z-30 w-44 -translate-x-1/2">
+			<div className="rounded-lg border border-white/10 bg-black/60 px-3 py-1.5 backdrop-blur-md">
+				<p className="truncate text-center text-xs font-semibold text-stone-200">
+					{target.name}
+				</p>
+				<div className="mt-1 h-1.5 w-full rounded bg-gray-700">
+					<div
+						className="h-full rounded bg-red-500 transition-all"
+						style={{ width: `${pct}%` }}
+					/>
+				</div>
+				<p className="mt-0.5 text-center font-mono text-[0.6rem] text-stone-400">
+					{target.hp}/{target.maxHp}
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ZoneBanner.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ZoneBanner.tsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+export function ZoneBanner() {
+	const [zone, setZone] = useState<string | null>(null);
+	useEffect(() => {
+		let timer = 0;
+		const off = laserEvents.on('zone:enter', (data) => {
+			const z = (data as { name: string }).name;
+			setZone(z);
+			window.clearTimeout(timer);
+			timer = window.setTimeout(() => setZone(null), 3200);
+		});
+		return () => {
+			off();
+			window.clearTimeout(timer);
+		};
+	}, []);
+	if (!zone) return null;
+	return (
+		<div className="pointer-events-none absolute left-1/2 top-20 z-30 -translate-x-1/2 animate-pulse">
+			<div className="rounded-full border border-amber-200/20 bg-black/50 px-6 py-1.5 text-center backdrop-blur-md">
+				<p className="bg-gradient-to-r from-amber-200 via-amber-400 to-amber-200 bg-clip-text text-lg font-bold tracking-wide text-transparent">
+					{zone}
+				</p>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
First batch of a large integration sweep — client-side HUD/UX, all additive overlays wired to new scene events.

New scene emits: `player:position`, `perf:fps`, `zone:enter`, `target:set`/`target:clear`, `world:players`.

Integrations:
1. **Nameplates** — usernames over player sprites (Phaser text, follow sprites)
2. **Minimap** — self + other players as dots on a 50×50 canvas
3. **Coords bar** — live zone name, tile coords, fps, clock
4. **Zone banner** — gold center banner on area enter (Cloud City Plaza / Goblin Camp / Crystal Cavern / The Wilds)
5. **Gold counter** — coins from inventory, top-center
6. **Combat log** — rolling log of hits, kills, pickups, item use
7. **Target frame** — click any entity → name + HP bar
8. **Consumable hotbar** — keys 1–4 use consumables, clickable
9. **Keybind help** — `?` toggles a controls overlay
10. **Profile links** — roster usernames link to kbve.com/@user

## Testing
- astro-cryptothrone 29/29 vitest, site builds
- e2e preview 57/57 (WebGL canvas test scoped to the game canvas now that the minimap adds a second canvas)
- **Live-verified** against a local server: nameplate, gold, coords/zone bar, minimap, roster all render with 2 players, zero console errors (screenshot)