### PR TITLE
feat(cryptothrone): gameplay systems pack (regen, bounty, boss, town NPCs, day-night)

### DIFF
--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -39,6 +39,25 @@ pub const GOBLIN_COUNT: i32 = 4;
 pub const GOBLIN_ORIGIN: Tile = Tile::new(24, 24);
 pub const GOBLIN_LOOT_REF: &str = "coin";
 
+// Friendly town NPCs (player faction — never aggro, give the plaza life).
+pub const MERCHANT_REF: &str = "merchant";
+pub const MERCHANT_SPAWN: Tile = Tile::new(8, 9);
+pub const SOLDIER_REF: &str = "soldier";
+pub const SOLDIER_SPAWN: Tile = Tile::new(3, 14);
+pub const KING_REF: &str = "king";
+pub const KING_SPAWN: Tile = Tile::new(6, 6);
+
+// Boss — goblin general, deep in the camp; drops a gold bar.
+pub const BOSS_REF: &str = "goblin-general";
+pub const BOSS_SPAWN: Tile = Tile::new(27, 27);
+pub const BOSS_LOOT_REF: &str = "gold-bar";
+
+// Wolves roam the wilds (beast faction — wander but don't hunt players).
+pub const WOLF_REF: &str = "wolf";
+pub const WOLF_COUNT: i32 = 3;
+pub const WOLF_ORIGIN: Tile = Tile::new(18, 14);
+pub const WOLF_LOOT_REF: &str = "coin";
+
 pub const HOSTILE_AGGRO_RANGE: i32 = 6;
 pub const IRON_SWORD_ATTACK: i32 = 5;
 pub const IRON_SHIELD_DEFENSE: i32 = 3;
@@ -61,11 +80,17 @@ pub fn registry() -> KindRegistry {
     reg.register_npc(CLERIC_REF);
     reg.register_npc(BAT_REF);
     reg.register_npc(GOBLIN_REF);
+    reg.register_npc(MERCHANT_REF);
+    reg.register_npc(SOLDIER_REF);
+    reg.register_npc(KING_REF);
+    reg.register_npc(BOSS_REF);
+    reg.register_npc(WOLF_REF);
     for (item_ref, _, _) in GROUND_ITEMS {
         reg.register_item(item_ref);
     }
     reg.register_item(BAT_LOOT_REF);
     reg.register_item(GOBLIN_LOOT_REF);
+    reg.register_item(BOSS_LOOT_REF);
     reg
 }
 
@@ -183,6 +208,41 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
             origin,
             Some((8, 25)),
             Some(GOBLIN_LOOT_REF),
+        ) {
+            spawn_npc_from_spec(&mut commands, &spec);
+        }
+    }
+
+    for (ref_id, tile) in [
+        (MERCHANT_REF, MERCHANT_SPAWN),
+        (SOLDIER_REF, SOLDIER_SPAWN),
+        (KING_REF, KING_SPAWN),
+    ] {
+        if let Some(spec) = npc_spec(&db, &registry, ref_id, tile, Some((2, 40)), None) {
+            spawn_npc_from_spec(&mut commands, &spec);
+        }
+    }
+
+    if let Some(spec) = npc_spec(
+        &db,
+        &registry,
+        BOSS_REF,
+        BOSS_SPAWN,
+        Some((4, 30)),
+        Some(BOSS_LOOT_REF),
+    ) {
+        spawn_npc_from_spec(&mut commands, &spec);
+    }
+
+    for i in 0..WOLF_COUNT {
+        let origin = Tile::new(WOLF_ORIGIN.x + i * 2, WOLF_ORIGIN.y);
+        if let Some(spec) = npc_spec(
+            &db,
+            &registry,
+            WOLF_REF,
+            origin,
+            Some((10, 22)),
+            Some(WOLF_LOOT_REF),
         ) {
             spawn_npc_from_spec(&mut commands, &spec);
         }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -23,6 +23,8 @@ import { CombatLog } from './ui/CombatLog';
 import { TargetFrame } from './ui/TargetFrame';
 import { Hotbar } from './ui/Hotbar';
 import { KeybindHelp } from './ui/KeybindHelp';
+import { QuestTracker } from './ui/QuestTracker';
+import { DayNight } from './ui/DayNight';
 
 /**
  * Isolated Phaser canvas — never re-renders when game store changes.
@@ -108,6 +110,8 @@ function GameUI({ username }: { username?: string }) {
 			<TargetFrame />
 			<Hotbar />
 			<KeybindHelp />
+			<QuestTracker />
+			<DayNight />
 			<ConnectionOverlay />
 		</>
 	);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -41,6 +41,12 @@ interface RefSprite {
 
 const REF_SPRITES: Record<string, RefSprite> = {
 	cleric: { key: 'monks', mapping: 0 },
+	merchant: { key: 'monks', mapping: 1 },
+	soldier: { key: 'monks', mapping: 2 },
+	king: { key: 'monks', mapping: 3 },
+	goblin: { key: 'monks', mapping: 4 },
+	'goblin-general': { key: 'monks', mapping: 5 },
+	wolf: { key: 'monks', mapping: 6 },
 	'crystal-bat': { key: 'monster_bird', anim: 'bird' },
 };
 
@@ -238,6 +244,7 @@ export class CloudCityScene extends Scene {
 					xpNext: st.xp_next,
 					maxHp: st.max_hp,
 					attack: st.attack,
+					kills: st.kills ?? 0,
 				},
 			});
 			if (this.prevLevel >= 0 && st.level > this.prevLevel) {
@@ -494,6 +501,10 @@ export class CloudCityScene extends Scene {
 		this.checkHostileProximity();
 		this.syncRoster(snap);
 		this.runPendingAction();
+		const DAY_MS = 600000;
+		laserEvents.emit('world:time', {
+			phase: (snap.server_time_ms % DAY_MS) / DAY_MS,
+		});
 	}
 
 	private runPendingAction() {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/types.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/types.ts
@@ -5,6 +5,7 @@ export interface PlayerStats {
 	xp?: number;
 	xpNext?: number;
 	attack?: number;
+	kills?: number;
 	mp: number;
 	maxMp: number;
 	ep: number;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DayNight.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DayNight.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+function tint(phase: number): string {
+	if (phase < 0.05 || phase >= 0.92) return 'rgba(10,14,40,0.45)'; // night
+	if (phase < 0.15) return 'rgba(255,150,80,0.18)'; // dawn
+	if (phase < 0.7) return 'rgba(0,0,0,0)'; // day
+	if (phase < 0.85) return 'rgba(255,120,60,0.2)'; // dusk
+	return 'rgba(20,20,60,0.3)'; // evening
+}
+
+export function DayNight() {
+	const [color, setColor] = useState('rgba(0,0,0,0)');
+	useEffect(() => {
+		return laserEvents.on('world:time', (d) => {
+			setColor(tint((d as { phase: number }).phase));
+		});
+	}, []);
+	return (
+		<div
+			className="pointer-events-none absolute inset-0 z-10 transition-colors duration-1000"
+			style={{ backgroundColor: color }}
+			aria-hidden="true"
+		/>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/QuestTracker.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/QuestTracker.tsx
@@ -1,0 +1,25 @@
+import { useGameSelector } from '../store/GameStoreContext';
+
+const GOAL = 10;
+
+export function QuestTracker() {
+	const kills = useGameSelector((s) => s.player.stats.kills ?? 0);
+	const done = Math.min(kills, GOAL);
+	return (
+		<div className="pointer-events-none absolute left-3 top-16 z-30 w-44 rounded-lg border border-white/10 bg-black/55 px-3 py-2 backdrop-blur-md">
+			<p className="text-[0.6rem] font-semibold uppercase tracking-widest text-amber-300/80">
+				Bounty
+			</p>
+			<p className="mt-0.5 text-xs text-stone-300">Cull the hostiles</p>
+			<div className="mt-1.5 h-1.5 w-full rounded bg-gray-700">
+				<div
+					className="h-full rounded bg-amber-400 transition-all"
+					style={{ width: `${(done / GOAL) * 100}%` }}
+				/>
+			</div>
+			<p className="mt-0.5 text-right font-mono text-[0.6rem] text-stone-400">
+				{done}/{GOAL}
+			</p>
+		</div>
+	);
+}

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -131,6 +131,7 @@ export interface StatsEvent {
 	xp_next: number;
 	max_hp: number;
 	attack: number;
+	kills?: number;
 }
 
 export type ServerEvent =

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -104,6 +104,7 @@ pub struct SavedPlayer {
     pub armor: Option<String>,
     pub level: i32,
     pub xp: i32,
+    pub kills: u32,
 }
 
 impl Default for SavedPlayer {
@@ -115,6 +116,7 @@ impl Default for SavedPlayer {
             armor: None,
             level: 1,
             xp: 0,
+            kills: 0,
         }
     }
 }
@@ -175,6 +177,12 @@ pub fn level_attack(base_attack: i32, level: i32) -> i32 {
 
 #[derive(Resource, Default)]
 pub struct RespawnQueue(Vec<(u32, NpcSpec)>);
+
+#[derive(Resource, Default)]
+pub struct KillCounts(pub HashMap<u16, u32>);
+
+pub const REGEN_PERIOD_TICKS: u32 = SIM_TICK_HZ * 2;
+pub const REGEN_AMOUNT: i32 = 2;
 
 #[derive(Clone, Copy)]
 pub struct AggroSpec {
@@ -361,6 +369,7 @@ pub fn build_app(
         .insert_resource(ConsumableEffects::default())
         .insert_resource(EquipmentEffects::default())
         .insert_resource(RespawnQueue::default())
+        .insert_resource(KillCounts::default())
         .insert_resource(Occupancy::default())
         .insert_resource(map)
         .insert_resource(config)
@@ -396,7 +405,12 @@ pub fn build_app(
         )
         .add_systems(
             Update,
-            (advance_movement, chain_steps, respawn_players)
+            (
+                advance_movement,
+                chain_steps,
+                respawn_players,
+                regen_players,
+            )
                 .chain()
                 .in_set(SimSet::Movement),
         )
@@ -416,6 +430,7 @@ fn sync_roster(
     bcast: Res<SnapshotBroadcast>,
     mut spawned: ResMut<SpawnedSlots>,
     mut store: ResMut<PlayerStore>,
+    mut kill_counts: ResMut<KillCounts>,
     equipment: Res<EquipmentEffects>,
     q_saved: Query<(&Inventory, &Health, &Equipped, &XpState)>,
     mut commands: Commands,
@@ -440,6 +455,8 @@ fn sync_roster(
         let saved = store.by_username.get(username).cloned();
         let level = saved.as_ref().map(|s| s.level.max(1)).unwrap_or(1);
         let xp = saved.as_ref().map(|s| s.xp).unwrap_or(0);
+        let kills = saved.as_ref().map(|s| s.kills).unwrap_or(0);
+        kill_counts.0.insert(slot.0, kills);
         let max_hp = level_max_hp(config.player_hp, level);
         let hp = saved
             .as_ref()
@@ -471,7 +488,7 @@ fn sync_roster(
         if armor.is_some() {
             send_equipped(&bcast, *slot, "armor", armor.as_deref(), attack, defense);
         }
-        send_stats(&bcast, *slot, level, xp, max_hp, attack);
+        send_stats(&bcast, *slot, level, xp, max_hp, attack, kills);
         let entity = commands
             .spawn((
                 PlayerSlotTag(*slot),
@@ -502,6 +519,7 @@ fn sync_roster(
         .collect();
     for k in gone {
         if let Some((entity, username)) = spawned.by_slot.remove(&k) {
+            let kills = kill_counts.0.remove(&k).unwrap_or(0);
             if !username.is_empty()
                 && let Ok((inv, hp, equipped, xp)) = q_saved.get(entity)
             {
@@ -514,6 +532,7 @@ fn sync_roster(
                         armor: equipped.armor.clone(),
                         level: xp.level,
                         xp: xp.xp,
+                        kills,
                     },
                 );
             }
@@ -718,6 +737,7 @@ fn apply_actions(
     config: Res<SimConfig>,
     equipment: Res<EquipmentEffects>,
     mut respawns: ResMut<RespawnQueue>,
+    mut kill_counts: ResMut<KillCounts>,
     mut commands: Commands,
     mut q_players: Query<(
         Entity,
@@ -808,12 +828,17 @@ fn apply_actions(
                     {
                         commands.spawn(bundle);
                     }
+                    let kills = {
+                        let k = kill_counts.0.entry(slot.0).or_default();
+                        *k += 1;
+                        *k
+                    };
                     if let Ok((_, _, _, mut stats, _, mut php, mut xp, equipped)) =
                         q_players.get_mut(player_entity)
                     {
                         award_xp(
                             &bcast, slot, &config, &equipment, kill_xp, &mut xp, &mut php,
-                            &mut stats, equipped,
+                            &mut stats, equipped, kills,
                         );
                     }
                 }
@@ -861,6 +886,7 @@ fn award_xp(
     hp: &mut Health,
     stats: &mut CombatStats,
     equipped: &Equipped,
+    kills: u32,
 ) {
     xp.xp += gained.max(0);
     let mut leveled = false;
@@ -879,7 +905,7 @@ fn award_xp(
         hp.hp = hp.max_hp;
         stats.attack = level_attack(config.player_attack, xp.level) + weapon_bonus.attack;
     }
-    send_stats(bcast, slot, xp.level, xp.xp, hp.max_hp, stats.attack);
+    send_stats(bcast, slot, xp.level, xp.xp, hp.max_hp, stats.attack, kills);
 }
 
 fn send_equipped(
@@ -912,6 +938,7 @@ fn send_stats(
     xp: i32,
     max_hp: i32,
     attack: i32,
+    kills: u32,
 ) {
     let payload = json!({
         "level": level,
@@ -919,6 +946,7 @@ fn send_stats(
         "xp_next": xp_to_next(level),
         "max_hp": max_hp,
         "attack": attack,
+        "kills": kills,
     })
     .to_string()
     .into_bytes();
@@ -1068,6 +1096,17 @@ fn hostile_ai(
 }
 
 #[allow(clippy::type_complexity)]
+fn regen_players(clock: Res<SimClock>, mut q: Query<&mut Health, With<PlayerSlotTag>>) {
+    if !clock.tick.is_multiple_of(REGEN_PERIOD_TICKS) {
+        return;
+    }
+    for mut hp in q.iter_mut() {
+        if hp.hp > 0 && hp.hp < hp.max_hp {
+            hp.hp = (hp.hp + REGEN_AMOUNT).min(hp.max_hp);
+        }
+    }
+}
+
 fn respawn_players(
     config: Res<SimConfig>,
     mut q: Query<
@@ -1634,6 +1673,75 @@ mod tests {
             }
         }
         assert!(saw_player_hit, "hostile never reached/attacked the player");
+    }
+
+    #[test]
+    fn regen_heals_wounded_player_over_time() {
+        let (mut app, _rx, _tx, roster) = harness(51);
+        let _slot = join(&roster, "wounded");
+        app.update();
+        let player = player_entity(&mut app);
+        {
+            let mut hp = app.world_mut().get_mut::<Health>(player).unwrap();
+            hp.hp = 40;
+        }
+        for _ in 0..(REGEN_PERIOD_TICKS as usize * 3 + 2) {
+            app.update();
+        }
+        let hp = app.world().get::<Health>(player).unwrap().hp;
+        assert!(hp > 40, "regen did not heal (hp={hp})");
+        assert!(hp <= 100, "regen overhealed past max (hp={hp})");
+    }
+
+    #[test]
+    fn kills_counted_in_stats_payload() {
+        let (mut app, mut rx, input_tx, roster) = harness(53);
+        let slot = join(&roster, "hunter");
+        app.update();
+        let registry = app.world().resource::<KindRegistry>().clone();
+        let kind = registry.kind_of("training-dummy").unwrap();
+        let mut spec = hostile_spec(kind, Tile::new(9, 8));
+        spec.aggro = None;
+        spec.max_hp = 1;
+        spec.respawn_ticks = 0;
+        let mob = {
+            let mut q = bevy::ecs::world::CommandQueue::default();
+            let mut commands = Commands::new(&mut q, app.world());
+            spawn_npc_from_spec(&mut commands, &spec);
+            q.apply(app.world_mut());
+            let mut qq = app
+                .world_mut()
+                .query_filtered::<(Entity, &EntityKind), Without<PlayerSlotTag>>();
+            qq.iter(app.world())
+                .find(|(_, k)| k.0 == kind)
+                .map(|(e, _)| e)
+                .unwrap()
+        };
+        app.update();
+        input_tx
+            .send((
+                slot,
+                Input::Action {
+                    id: proto::ACTION_ATTACK,
+                    target: Some(proto::EntityId(mob.index_u32())),
+                },
+            ))
+            .unwrap();
+        for _ in 0..4 {
+            app.update();
+        }
+        let mut saw = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, payload, .. } = evt
+                && kind == proto::EPHEMERAL_STATS
+            {
+                let t = String::from_utf8(payload).unwrap();
+                if t.contains("\"kills\":1") {
+                    saw = true;
+                }
+            }
+        }
+        assert!(saw, "kills not reflected in stats payload");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Second integration batch — server gameplay systems + their client surfacing. **Stacks on #12267** (HUD pack); diff cleans up once that merges.

### Server (simgrid + cryptothrone-server)
1. **HP regen** — wounded players heal +2 every 2s; in combat the hostile damage outpaces it, out of combat you recover
2. **Kill tracking** — `KillCounts` resource, included in the stats ephemeral, persisted across rejoin
3. **Town NPCs** — friendly merchant / soldier / king (player faction, never aggro) bring the plaza to life
4. **Boss** — goblin-general (lvl 5, 140 hp) deep in the goblin camp, drops a gold bar
5. **Wolves** — roam the wilds (beast faction: wander, don't hunt players)

### Client
6. **Bounty tracker** — kills toward a goal of 10
7. **Day/night** — screen tint cycling from snapshot server time (dawn/day/dusk/night)
8. **NPC sprite variety** — distinct charactersheet frames per NPC ref
9. kills threaded through `StatsEvent`

## Testing
- simgrid 29/29 (new: `regen_heals_wounded_player_over_time`, `kills_counted_in_stats_payload`), clippy clean both crates
- laser tests pass, astro 29/29, e2e 57/57
- **Live-verified**: local server screenshot shows town NPCs, bounty tracker, all HUD — zero console errors