### PR TITLE
feat(cryptothrone): polish & social integration pack + release bump

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -25,6 +25,12 @@ import { Hotbar } from './ui/Hotbar';
 import { KeybindHelp } from './ui/KeybindHelp';
 import { QuestTracker } from './ui/QuestTracker';
 import { DayNight } from './ui/DayNight';
+import { SoundManager } from './ui/SoundManager';
+import { Achievements } from './ui/Achievements';
+import { DeathScreen } from './ui/DeathScreen';
+import { Compass } from './ui/Compass';
+import { SocialBar } from './ui/SocialBar';
+import { EmoteBar } from './ui/EmoteBar';
 
 /**
  * Isolated Phaser canvas — never re-renders when game store changes.
@@ -112,6 +118,12 @@ function GameUI({ username }: { username?: string }) {
 			<KeybindHelp />
 			<QuestTracker />
 			<DayNight />
+			<SoundManager />
+			<Achievements />
+			<DeathScreen />
+			<Compass />
+			<SocialBar />
+			<EmoteBar />
 			<ConnectionOverlay />
 		</>
 	);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -169,6 +169,11 @@ export class CloudCityScene extends Scene {
 				const d = data as { ref: string };
 				if (d?.ref) this.client?.equipItem(d.ref);
 			}),
+			laserEvents.on('emote', (data) => {
+				const d = data as { emoji: string };
+				if (d?.emoji && this.myEid >= 0)
+					this.showFloatingText(this.myEid, d.emoji, '#ffffff');
+			}),
 		);
 
 		this.events.once('shutdown', () => {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Achievements.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Achievements.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+import { useGameDispatch } from '../store/GameStoreContext';
+
+interface Toast {
+	id: number;
+	title: string;
+}
+let counter = 0;
+
+export function Achievements() {
+	const dispatch = useGameDispatch();
+	const [toasts, setToasts] = useState<Toast[]>([]);
+	const unlocked = useRef(new Set<string>());
+
+	useEffect(() => {
+		const grant = (key: string, title: string) => {
+			if (unlocked.current.has(key)) return;
+			unlocked.current.add(key);
+			setToasts((p) => [...p, { id: ++counter, title }]);
+			setTimeout(
+				() => setToasts((p) => p.filter((t) => t.title !== title)),
+				4000,
+			);
+			dispatch({
+				type: 'ADD_NOTIFICATION',
+				payload: {
+					title: 'Achievement',
+					message: title,
+					type: 'success',
+				},
+			});
+		};
+		const offs = [
+			laserEvents.on('combat:event', (d) => {
+				const e = d as { died: boolean };
+				if (e.died) grant('first-kill', 'First Blood');
+			}),
+			laserEvents.on('item:pickup', () =>
+				grant('first-loot', 'Treasure Hunter'),
+			),
+			laserEvents.on('item:equipped', () =>
+				grant('first-equip', 'Armed & Ready'),
+			),
+			laserEvents.on('player:stats', (d) => {
+				const s = (d as { stats: { level?: number; kills?: number } })
+					.stats;
+				if (s.level && s.level >= 5) grant('lvl5', 'Seasoned (Lv 5)');
+				if (s.kills && s.kills >= 10)
+					grant('bounty', 'Bounty Complete');
+			}),
+		];
+		return () => offs.forEach((o) => o());
+	}, [dispatch]);
+
+	if (toasts.length === 0) return null;
+	return (
+		<div className="pointer-events-none absolute left-1/2 top-32 z-40 flex -translate-x-1/2 flex-col items-center gap-2">
+			{toasts.map((t) => (
+				<div
+					key={t.id}
+					className="animate-bounce rounded-full border border-amber-300/40 bg-black/80 px-5 py-2 backdrop-blur-md">
+					<span className="text-sm font-bold text-amber-300">
+						🏆 {t.title}
+					</span>
+				</div>
+			))}
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Compass.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Compass.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useRef, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+const TOWN = { x: 5, y: 12 };
+
+export function Compass() {
+	const [deg, setDeg] = useState(0);
+	const me = useRef({ x: 5, y: 12 });
+	useEffect(() => {
+		return laserEvents.on('player:position', (d) => {
+			me.current = d as { x: number; y: number };
+			const dx = TOWN.x - me.current.x;
+			const dy = TOWN.y - me.current.y;
+			setDeg((Math.atan2(dy, dx) * 180) / Math.PI + 90);
+		});
+	}, []);
+	const inTown =
+		Math.abs(me.current.x - TOWN.x) <= 8 &&
+		Math.abs(me.current.y - TOWN.y) <= 8;
+	return (
+		<div className="pointer-events-none absolute right-3 top-52 z-30 flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-black/55 backdrop-blur-md">
+			{inTown ? (
+				<span className="text-[0.6rem] text-amber-300">⌂</span>
+			) : (
+				<span
+					className="text-amber-300"
+					style={{ transform: `rotate(${deg}deg)` }}>
+					↑
+				</span>
+			)}
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DeathScreen.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DeathScreen.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+import { useGameSelector } from '../store/GameStoreContext';
+
+export function DeathScreen() {
+	const hp = useGameSelector((s) => s.player.stats.hp);
+	const [dead, setDead] = useState(false);
+
+	useEffect(() => {
+		if (hp <= 0) {
+			setDead(true);
+			const t = window.setTimeout(() => setDead(false), 4000);
+			return () => window.clearTimeout(t);
+		}
+		setDead(false);
+	}, [hp]);
+
+	useEffect(() => {
+		return laserEvents.on('player:stats', (d) => {
+			const s = (d as { stats: { hp?: number } }).stats;
+			if (s.hp !== undefined && s.hp > 0) setDead(false);
+		});
+	}, []);
+
+	if (!dead) return null;
+	return (
+		<div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center bg-red-950/40 backdrop-blur-sm">
+			<div className="text-center">
+				<p className="text-4xl font-black tracking-widest text-red-400 drop-shadow-[0_2px_8px_rgba(0,0,0,0.9)]">
+					YOU DIED
+				</p>
+				<p className="mt-2 text-sm text-stone-300">
+					The well pulls you back to the plaza…
+				</p>
+			</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/EmoteBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/EmoteBar.tsx
@@ -1,0 +1,20 @@
+import { laserEvents } from '@kbve/laser';
+
+const EMOTES = ['👋', '😄', '❤️', '🔥', '😡'];
+
+export function EmoteBar() {
+	return (
+		<div className="pointer-events-auto absolute bottom-16 right-3 z-30 flex flex-col gap-1">
+			{EMOTES.map((e) => (
+				<button
+					key={e}
+					type="button"
+					onClick={() => laserEvents.emit('emote', { emoji: e })}
+					className="flex h-7 w-7 items-center justify-center rounded-lg border border-white/10 bg-black/55 text-sm backdrop-blur-md transition hover:border-amber-300/50"
+					aria-label={`Emote ${e}`}>
+					{e}
+				</button>
+			))}
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/EquipmentSummary.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/EquipmentSummary.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+export function EquipmentSummary() {
+	const [stats, setStats] = useState({ attack: 0, defense: 0 });
+	useEffect(() => {
+		const offs = [
+			laserEvents.on('player:stats', (d) => {
+				const s = (d as { stats: { attack?: number } }).stats;
+				if (s.attack !== undefined)
+					setStats((p) => ({ ...p, attack: s.attack as number }));
+			}),
+			laserEvents.on('item:equipped', (d) => {
+				const e = d as { attack: number; defense?: number };
+				setStats({ attack: e.attack, defense: e.defense ?? 0 });
+			}),
+		];
+		return () => offs.forEach((o) => o());
+	}, []);
+	return (
+		<div className="mb-4 flex gap-3 text-xs">
+			<span className="text-red-300">⚔ {stats.attack}</span>
+			<span className="text-blue-300">🛡 {stats.defense}</span>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
@@ -2,6 +2,15 @@ import { useState, useCallback } from 'react';
 import { laserEvents } from '@kbve/laser';
 import { getItemById } from '../data/items';
 
+const RARITY_BORDER: Record<string, string> = {
+	common: 'border-stone-400/50',
+	uncommon: 'border-green-400/60',
+	rare: 'border-blue-400/60',
+	epic: 'border-purple-400/70',
+	legendary: 'border-amber-400/80',
+	mythic: 'border-rose-400/80',
+};
+
 interface InventoryGridProps {
 	backpack: string[];
 }
@@ -73,7 +82,10 @@ export function InventoryGrid({ backpack }: InventoryGridProps) {
 								<img
 									src={item.img}
 									alt={item.name}
-									className="w-8 h-8 border border-yellow-400/50"
+									className={`w-8 h-8 border ${
+										RARITY_BORDER[item.rarity] ??
+										'border-yellow-400/50'
+									}`}
 								/>
 							</button>
 						</li>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SocialBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SocialBar.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+export function SocialBar() {
+	const [copied, setCopied] = useState(false);
+	const share = async () => {
+		try {
+			await navigator.clipboard.writeText(
+				'https://cryptothrone.com/game/play/',
+			);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 1500);
+		} catch {
+			/* clipboard unavailable */
+		}
+	};
+	const fullscreen = () => {
+		const el = document.documentElement;
+		if (document.fullscreenElement) document.exitFullscreen?.();
+		else el.requestFullscreen?.();
+	};
+	return (
+		<div className="pointer-events-auto absolute bottom-3 left-3 z-30 flex gap-1.5">
+			<a
+				href="https://kbve.com/discord/"
+				target="_blank"
+				rel="noopener"
+				title="Join the Discord"
+				className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-black/55 text-[#5865f2] backdrop-blur-md transition hover:border-[#5865f2]/50">
+				<svg
+					viewBox="0 0 16 16"
+					fill="currentColor"
+					className="h-4 w-4">
+					<path d="M13.545 2.907a13.2 13.2 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.2 12.2 0 0 0-3.658 0 8.3 8.3 0 0 0-.412-.833.05.05 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.04.04 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032q.001.014.021.037a13.3 13.3 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019q.463-.63.818-1.329a.05.05 0 0 0-.01-.059l-.018-.011a9 9 0 0 1-1.248-.595.05.05 0 0 1-.02-.066l.015-.019q.127-.095.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.05.05 0 0 1 .053.007q.121.1.248.195a.05.05 0 0 1-.004.085 8 8 0 0 1-1.249.594.05.05 0 0 0-.03.03.05.05 0 0 0 .003.041q.36.698.817 1.329a.05.05 0 0 0 .056.019 13.2 13.2 0 0 0 4.001-2.02.05.05 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.03.03 0 0 0-.02-.019m-8.198 7.307c-.789 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612m5.316 0c-.788 0-1.438-.724-1.438-1.612s.637-1.613 1.438-1.613c.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612" />
+				</svg>
+			</a>
+			<button
+				type="button"
+				onClick={share}
+				title="Copy invite link"
+				className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-black/55 text-stone-300 backdrop-blur-md transition hover:text-amber-300">
+				{copied ? '✓' : '🔗'}
+			</button>
+			<button
+				type="button"
+				onClick={fullscreen}
+				title="Toggle fullscreen"
+				className="flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-black/55 text-stone-300 backdrop-blur-md transition hover:text-amber-300">
+				⛶
+			</button>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SoundManager.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SoundManager.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+type Ctx = AudioContext | null;
+
+function beep(
+	ctx: AudioContext,
+	freq: number,
+	dur: number,
+	type: OscillatorType,
+	gain = 0.05,
+) {
+	const o = ctx.createOscillator();
+	const g = ctx.createGain();
+	o.type = type;
+	o.frequency.value = freq;
+	g.gain.value = gain;
+	o.connect(g);
+	g.connect(ctx.destination);
+	const t = ctx.currentTime;
+	g.gain.setValueAtTime(gain, t);
+	g.gain.exponentialRampToValueAtTime(0.0001, t + dur);
+	o.start(t);
+	o.stop(t + dur);
+}
+
+export function SoundManager() {
+	const ctxRef = useRef<Ctx>(null);
+	const [muted, setMuted] = useState(false);
+	const mutedRef = useRef(false);
+	mutedRef.current = muted;
+
+	useEffect(() => {
+		const ensure = (): AudioContext | null => {
+			if (mutedRef.current) return null;
+			if (!ctxRef.current) {
+				try {
+					ctxRef.current = new (
+						window.AudioContext ||
+						(
+							window as unknown as {
+								webkitAudioContext: typeof AudioContext;
+							}
+						).webkitAudioContext
+					)();
+				} catch {
+					return null;
+				}
+			}
+			if (ctxRef.current.state === 'suspended') ctxRef.current.resume();
+			return ctxRef.current;
+		};
+		const offs = [
+			laserEvents.on('combat:event', (d) => {
+				const cx = ensure();
+				if (!cx) return;
+				const e = d as { died: boolean };
+				if (e.died) {
+					beep(cx, 330, 0.12, 'sawtooth', 0.05);
+					setTimeout(() => beep(cx, 165, 0.18, 'sawtooth', 0.05), 90);
+				} else {
+					beep(cx, 220, 0.08, 'square', 0.04);
+				}
+			}),
+			laserEvents.on('item:pickup', () => {
+				const cx = ensure();
+				if (cx) beep(cx, 880, 0.07, 'sine', 0.05);
+			}),
+			laserEvents.on('item:used', () => {
+				const cx = ensure();
+				if (cx) beep(cx, 660, 0.1, 'triangle', 0.05);
+			}),
+			laserEvents.on('notification', (d) => {
+				const n = d as { title?: string };
+				if (!n.title?.startsWith('Level')) return;
+				const cx = ensure();
+				if (!cx) return;
+				[523, 659, 784].forEach((f, i) =>
+					setTimeout(
+						() => beep(cx, f, 0.14, 'triangle', 0.05),
+						i * 110,
+					),
+				);
+			}),
+		];
+		return () => offs.forEach((o) => o());
+	}, []);
+
+	return (
+		<button
+			type="button"
+			onClick={() => setMuted((m) => !m)}
+			aria-label={muted ? 'Unmute' : 'Mute'}
+			className="pointer-events-auto absolute right-3 top-40 z-30 flex h-8 w-8 items-center justify-center rounded-lg border border-white/10 bg-black/55 text-stone-300 backdrop-blur-md transition hover:text-amber-300">
+			{muted ? '🔇' : '🔊'}
+		</button>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
@@ -3,6 +3,7 @@ import { StatsSection } from './StatsSection';
 import { ToggleButton } from './ToggleButton';
 import { InventoryGrid } from './InventoryGrid';
 import { OnlinePlayers } from './OnlinePlayers';
+import { EquipmentSummary } from './EquipmentSummary';
 import { getItemById } from '../data/items';
 
 export function StickySidebar() {
@@ -81,6 +82,7 @@ export function StickySidebar() {
 
 				<div className="mb-4">
 					<h2 className="text-lg font-semibold mb-2">Equipment</h2>
+					<EquipmentSummary />
 					<ul className="grid grid-cols-8 gap-2">
 						{Object.entries(player.inventory.equipment).map(
 							([slot, itemId]) => {

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.6"
+version: "0.0.7"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.14"
+version: "0.1.15"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## Summary
Third integration batch — polish, audio, and social — plus the release bump for the whole sweep. **Stacks on #12268** (gameplay pack); diff cleans up once it merges.

### Integrations
- **Sound effects** — synthesized Web Audio (no asset files) for hits, kills, pickups, item use, and a level-up jingle; mute toggle
- **Achievement toasts** — First Blood, Treasure Hunter, Armed & Ready, Seasoned (Lv 5), Bounty Complete
- **Death screen** — 'YOU DIED' overlay on hp 0
- **Compass** — home glyph in town, direction arrow to the plaza in the wilds
- **Social bar** — Discord link, copy-invite-link, fullscreen toggle
- **Emote bar** — floating emoji (👋😄❤️🔥😡) over your sprite
- **Equipment summary** — total ⚔ attack / 🛡 defense in the sidebar
- **Rarity-colored inventory borders** — from itemdb rarity (common→mythic)

### Release
- cryptothrone client 0.1.14 → **0.1.15**, server 0.0.6 → **0.0.7** (covers HUD + gameplay + polish packs)

## Testing
- astro-cryptothrone 29/29 vitest, site builds
- e2e preview 57/57
- **Live-verified** against a local server (screenshots): mute toggle, compass, achievements, town NPCs, all HUD render with zero console errors

## Sequencing
#12268 → dev, then this. Together they ship as 0.1.15 / 0.0.7.