### PR TITLE
chore(osrs): migrate final 24 v2 items to v3 schema (batch 27)

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-arrow.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/adamant-arrow.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 11000
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: ammo
+    tier: mid
   equipment:
     slot: ammo
     type: arrow
@@ -21,30 +26,39 @@ osrs:
   stats:
     other:
       ranged_strength: 31
-  fletching:
-    level: 60
-    xp: 10
-    method: Adamant arrowtips + headless arrows
+  recipes:
+    - skill: fletching
+      level: 60
+      xp: 10
+      materials:
+        - item_name: Adamant arrowtips
+          quantity: 1
+        - item_name: Headless arrow
+          quantity: 1
+      tools: []
+      output_quantity: 1
   drop_table:
     sources:
       - source: Ankou
         source_id: 2514
         combat_level: 75
-        quantity: 5-15
+        quantity: "5-15"
         rarity: common
       - source: Steel dragon
         source_id: 274
         combat_level: 246
-        quantity: 20-50
+        quantity: "20-50"
         rarity: common
         members_only: true
   shops:
-    - shop_name: Lowe's Archery Emporium
+    - shop_name: "Lowe's Archery Emporium"
       location: Varrock
       price: 160
-    - shop_name: Brian's Archery Supplies
+      stock: 0
+    - shop_name: "Brian's Archery Supplies"
       location: Rimmington
       price: 160
+      stock: 0
   related_items:
     - item_id: 892
       item_name: Rune arrow
@@ -78,8 +92,13 @@ osrs:
     Used with any shortbow or longbow.
 
     Mid-tier arrow for training and combat.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "Steady demand from Ranged trainers between mithril and rune tiers"
+      - "Fletching margin depends on arrowtip and headless arrow prices"
+  trading_tips:
+    - "Buy limit 11,000 per 4 hours"
+    - "Shop price 160 gp at Lowe's and Brian's archery shops"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-robe-top.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bandos-robe-top.mdx
@@ -12,6 +12,11 @@ osrs:
   lowalch: 2800
   highalch: 4200
   limit: 8
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: high
   equipment:
     slot: body
     requirements:
@@ -33,8 +38,13 @@ osrs:
     > *"Bandos Vestments."*
 
     The Bandos robe top is the body piece of the Bandos vestment set. It provides a +6 Prayer bonus and requires 20 Prayer to equip. Counts as a Bandosian item in the God Wars Dungeon.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "Low GE buy limit of 8 keeps supply tight"
+      - "Demand driven by God Wars Dungeon Bandos faction tagging"
+  trading_tips:
+    - "Buy limit 8 per 4 hours"
+    - "Counts as a Bandosian item in the God Wars Dungeon"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-legs.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bloodbark-legs.mdx
@@ -12,9 +12,19 @@ osrs:
   lowalch: 32000
   highalch: 48000
   limit: 70
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: bark
+    tier: high
   about: "Bloodbark legs is a members-only item in Old School RuneScape. High alchemy value: 48,000 coins. Grand Exchange buy limit: 70 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "High alch value of 48,000 gp supports a price floor"
+      - "Niche magic armour demand; volume is thin"
+  trading_tips:
+    - "Buy limit 70 per 4 hours"
+    - "Members-only magic leg slot armour"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-plateskirt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/bronze-plateskirt.mdx
@@ -12,9 +12,19 @@ osrs:
   lowalch: 32
   highalch: 48
   limit: 125
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: metal
+    tier: low
   about: "Bronze plateskirt is a free-to-play item in Old School RuneScape. High alchemy value: 48 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Low-tier F2P armour with minimal margin"
+      - "High alch value of 48 gp sets the price floor"
+  trading_tips:
+    - "Buy limit 125 per 4 hours"
+    - "F2P bronze tier leg slot armour"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-white-vest.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/elven-top-white-vest.mdx
@@ -11,10 +11,20 @@ osrs:
   value: 5000
   lowalch: 2000
   highalch: 3000
-  limit: null
+  limit:
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: cloth
+    tier: mid
   about: "Elven top (white vest) is a free-to-play item in Old School RuneScape. High alchemy value: 3,000 coins."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Cosmetic clothing tied to Prifddinas content"
+      - "No GE buy limit listed; thin volume"
+  trading_tips:
+    - "High alch value of 3,000 gp"
+    - "Cosmetic vest from the elven city of Prifddinas"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/fire-battlestaff.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/fire-battlestaff.mdx
@@ -12,31 +12,45 @@ osrs:
   lowalch: 6200
   highalch: 9300
   limit: 18000
-  item_id: 1393
-  item_type: equipment
-  slot: weapon
-  type: battlestaff
-  attack_speed: 5
-  tradeable: true
-  weight: 2.267
-  requirements:
-    attack: 30
-    magic: 30
-  stats:
-    magic_attack: 12
-    crush_attack: 7
-    strength: 3
-  effect:
-    description: Provides unlimited fire runes when equipped. Can autocast combat spells.
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: wood
+    tier: mid-high
+  equipment:
+    slot: weapon
+    type: battlestaff
+    attack_speed: 5
+    requirements:
+      attack: 30
+      magic: 30
+    stats:
+      magic_attack: 12
+      crush_attack: 7
+      strength: 3
+  passive_effects:
+    - name: Unlimited fire runes
+      description: "Provides unlimited fire runes when equipped and can autocast combat spells"
   related_items:
-    - slug: fire-orb
-    - slug: mystic-fire-staff
+    - item_name: Fire orb
+      slug: fire-orb
+      relationship: component
+      description: "Crafted onto a battlestaff to make the fire battlestaff"
+    - item_name: Mystic fire staff
+      slug: mystic-fire-staff
+      relationship: upgrade
+      description: "Crafted upgrade with stronger magic bonuses"
   about: |-
     Provides unlimited fire runes when equipped.
 
     Can autocast combat spells.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes:
+      - "Crafted from fire orb plus battlestaff at 62 Crafting"
+      - "Demand from Magic trainers wanting free fire runes"
+  trading_tips:
+    - "Buy limit 18,000 per 4 hours"
+    - "Members-only magic weapon with unlimited fire runes when equipped"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-hull-parts.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mahogany-hull-parts.mdx
@@ -12,9 +12,19 @@ osrs:
   lowalch: 1500
   highalch: 2250
   limit: 100
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: wood
+    tier: mid
   about: "Mahogany hull parts is a members-only item in Old School RuneScape. High alchemy value: 2,250 coins. Grand Exchange buy limit: 100 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes:
+      - "Construction-style boat hull component; demand tied to relevant content"
+      - "Low GE buy limit keeps daily turnover small"
+  trading_tips:
+    - "Buy limit 100 per 4 hours"
+    - "Used to construct a mahogany boat hull"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/manta-ray.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/manta-ray.mdx
@@ -12,30 +12,24 @@ osrs:
   lowalch: 80
   highalch: 120
   limit: 10000
-  food:
-    heals: 22
-    cooking_level: 91
-    cooking_xp: 216.2
-    burn_level: 99
-  cooking:
-    level: 91
-    xp: 216.2
-    stop_burn_level: 99
-    stop_burn_level_gauntlets: 91
-    raw_item_id: 389
-    raw_item_name: Raw manta ray
-    ticks: 4
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
+  material:
+    type: food
+    tier: high
   recipes:
     - skill: cooking
       level: 91
       xp: 216.2
       materials:
         - item_name: Raw manta ray
-          item_id: 389
           quantity: 1
-      facility: Fire or range
-      ticks: 4
-      members_only: true
+      tools:
+        - Fire or range
+      output_quantity: 1
+  passive_effects:
+    - name: Healing
+      description: "Restores 22 Hitpoints when eaten"
   related_items:
     - item_id: 389
       item_name: Raw manta ray
@@ -57,21 +51,23 @@ osrs:
       slug: dark-crab
       relationship: alternative
       description: Same healing (22 HP)
+  about: "Manta ray is a members cooked food that heals 22 Hitpoints, tied with dark crab for second-highest non-overheal healing. Cooked from raw manta ray at 91 Cooking for 216.2 XP, with a stop-burn level of 99 (or 91 with cooking gauntlets). Sourced primarily from Fishing Trawler."
   market_strategy:
     notes:
-      - Same healing as dark crab
-      - No overheal effect
-      - High Cooking requirement
-      - High-level PvM
-      - Raids preparation
-      - Combat food
-      - Cooking training
-      - Tied for 2nd best healing
-      - Fishing Trawler source
-      - High burn rate
-      - Less popular than shark
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Same healing as dark crab"
+      - "No overheal effect"
+      - "High Cooking requirement"
+      - "High-level PvM"
+      - "Raids preparation"
+      - "Combat food"
+      - "Cooking training"
+      - "Tied for 2nd best healing"
+      - "Fishing Trawler source"
+      - "High burn rate"
+      - "Less popular than shark"
+  trading_tips:
+    - "Buy limit 10,000 per 4 hours"
+    - "Requires 91 Cooking to cook from raw"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/masori-chaps-f.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/masori-chaps-f.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 520000
   highalch: 780000
   limit: 8
+  material:
+    type: ranged_armour
+    tier: high
   equipment:
     slot: legs
     type: ranged_armour
@@ -40,7 +43,7 @@ osrs:
           quantity: 1
       product: Masori chaps (f)
       product_id: 27241
-      product_quantity: 1
+      output_quantity: 1
       facility: Hammer
       members_only: true
   related_items:
@@ -90,8 +93,8 @@ osrs:
       - ToA completions affect supply
       - BiS ranged legs
       - Fortified has better defence
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-kilt.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/menaphite-purple-kilt.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 150
+  material:
+    type: cloth
+    tier: low
   about: "Menaphite purple kilt is a members-only item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 150 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes: []
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/mos-le-harmless-teleport.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/mos-le-harmless-teleport.mdx
@@ -12,16 +12,11 @@ osrs:
   lowalch: 4
   highalch: 6
   limit: 10000
-  item:
-    type: teleport_scroll
-    destination: Mos Le'Harmless
-    tradeable: true
-    stackable: true
-  obtaining:
-    methods:
-      - source: Treasure Trails
-        tier: Hard/Elite/Master
-        drop_rate: Varies by tier
+  material:
+    type: scroll
+    tier: low
+  treasure_trail:
+    tier: hard
   related_items:
     - item_id: 12642
       item_name: Lumberyard teleport
@@ -52,8 +47,8 @@ osrs:
       - Essential for black mask farming
       - Useful for cave horror tasks
       - Stock up for slayer
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/oyster-pearl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/oyster-pearl.mdx
@@ -12,6 +12,9 @@ osrs:
   lowalch: 44
   highalch: 67
   limit: 11000
+  material:
+    type: gem
+    tier: low
   related_items:
     - item_id: 407
       item_name: Oyster
@@ -22,8 +25,10 @@ osrs:
     > _"A little pearl."_
 
     An oyster pearl can be used with a chisel to craft a pearl bolt tip (41 Crafting) or a pearl ring. Worth slightly less than oyster pearls.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  market_strategy:
+    notes: []
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/poison-ivy-berries.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/poison-ivy-berries.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 26
   highalch: 39
   limit: 11000
+  material:
+    type: herb
+    tier: low
   about: "Poison ivy berries is a members-only item in Old School RuneScape. High alchemy value: 39 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes: []
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-cuisse.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/proselyte-cuisse.mdx
@@ -12,19 +12,22 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 70
+  material:
+    type: armour
+    tier: mid
   equipment:
     slot: legs
     type: armour
-    prayer_bonus: 6
     requirements:
       defence: 30
       prayer: 20
-    combat_stats:
-      stab_defence: 33
-      slash_defence: 31
-      crush_defence: 29
-      magic_defence: -4
-      ranged_defence: 31
+    stats:
+      defence_stab: 33
+      defence_slash: 31
+      defence_crush: 29
+      defence_magic: -4
+      defence_ranged: 31
+      prayer: 6
   related_items:
     - item_id: 9674
       item_name: Proselyte hauberk
@@ -68,12 +71,12 @@ osrs:
     notes:
       - Requires quest completion
       - Shop purchase only
-      - No GE trading (untradeable)
+      - "No GE trading (untradeable)"
       - Must complete The Slug Menace
       - Buy from Sir Tiffy for ~5k
       - Best prayer legs available
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts-p.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/runite-bolts-p.mdx
@@ -12,9 +12,14 @@ osrs:
   lowalch: 120
   highalch: 180
   limit: 11000
+  material:
+    type: ammunition
+    tier: high
   about: "Runite bolts (p) is a members-only item in Old School RuneScape. High alchemy value: 180 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  market_strategy:
+    notes: []
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/skills-necklace.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/skills-necklace.mdx
@@ -12,27 +12,20 @@ osrs:
   lowalch: 8080
   highalch: 12120
   limit: 10000
+  material:
+    type: jewellery
+    tier: mid-high
   equipment:
     slot: neck
-    attack_bonus:
-      stab: 0
-      slash: 0
-      crush: 0
-      magic: 0
-      ranged: 0
-    defence_bonus:
-      stab: 3
-      slash: 3
-      crush: 3
-      magic: 3
-      ranged: 3
-    other_bonus:
-      melee_strength: 0
-      ranged_strength: 0
-      magic_damage: 0
-      prayer: 0
+    type: jewellery
     requirements:
       crafting: 72
+    stats:
+      defence_stab: 3
+      defence_slash: 3
+      defence_crush: 3
+      defence_magic: 3
+      defence_ranged: 3
   related_items:
     - item_id: 11126
       item_name: Combat bracelet
@@ -61,8 +54,8 @@ osrs:
       - Rechargeable at Legends' Guild
       - Popular for guild access
       - Useful for skilling teleports
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dragon-mask.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/steel-dragon-mask.mdx
@@ -12,9 +12,40 @@ osrs:
   lowalch: 4000
   highalch: 6000
   limit: 4
-  about: "Steel dragon mask is a members-only item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Steel dragon mask is a members-only cosmetic head slot item in Old School RuneScape. High alchemy value: 6,000 coins. Grand Exchange buy limit: 4 per 4 hours."
+  material:
+    type: cosmetic
+    tier: mid
+  equipment:
+    slot: head
+    type: cosmetic
+    tradeable: true
+  related_items:
+    - item_id: 12522
+      item_name: Bronze dragon mask
+      slug: bronze-dragon-mask
+      relationship: alternative
+      description: Cosmetic dragon mask variant
+    - item_id: 12524
+      item_name: Iron dragon mask
+      slug: iron-dragon-mask
+      relationship: alternative
+      description: Cosmetic dragon mask variant
+    - item_id: 12369
+      item_name: Mithril dragon mask
+      slug: mithril-dragon-mask
+      relationship: alternative
+      description: Cosmetic dragon mask variant
+  market_strategy:
+    notes:
+      - Cosmetic head slot item with no combat utility
+      - Low buy limit (4 per 4 hours) restricts volume trading
+      - Niche collector demand drives price
+  trading_tips:
+    - Watch for promotional events that influence supply
+    - Compare price to other dragon mask variants for arbitrage
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-4.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/super-attack-4.mdx
@@ -12,8 +12,12 @@ osrs:
   lowalch: 90
   highalch: 135
   limit: 2000
+  about: "Super attack(4) is a 4-dose Attack-boosting potion brewed at Herblore 45. It is a core ingredient for Super combat potion(4) and a staple melee boost for bossing and Slayer."
+  material:
+    type: potion
+    tier: mid
   potion:
-    doses: 3
+    doses: 4
     type: boost
     skill: attack
     boost_min: 5
@@ -34,9 +38,9 @@ osrs:
         - item_name: Eye of newt
           item_id: 221
           quantity: 1
-      product: Super attack(3)
-      product_id: 2436
-      product_quantity: 1
+      output_item: Super attack(4)
+      output_id: 2436
+      output_quantity: 1
       facility: None
       members_only: true
   related_items:
@@ -49,7 +53,7 @@ osrs:
       item_name: Eye of newt
       slug: eye-of-newt
       relationship: component
-      description: Secondary
+      description: Secondary ingredient
     - item_id: 12695
       item_name: Super combat potion(4)
       slug: super-combat-potion-4
@@ -60,33 +64,17 @@ osrs:
       slug: attack-potion-3
       relationship: alternative
       description: Lower tier
-  about: |-
-    | Requirement | Value |
-    |-------------|-------|
-    | Herblore Level | 45 |
-    | XP | 100 |
-    | Ingredients | Irit leaf + Eye of newt |
-
-    | Effect | Value |
-    |--------|-------|
-    | Attack boost | +5 to +19 (15% + 5) |
-    | Duration | 60s per level lost |
-    | Preserve prayer | 90s per level lost |
   market_strategy:
     notes:
-      - Super combat ingredient
-      - Standalone attack boost
-      - High demand
-      - Super combat production
-      - Melee PvM
-      - Bossing preparation
-      - Slayer tasks
-      - Low buy limit (2,000)
-      - Irit leaf herb
-      - Eye of newt secondary
-      - Component for super combat
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      - "Core ingredient for Super combat potion(4): drives steady demand"
+      - Standalone Attack boost used in melee PvM and Slayer
+      - "Low buy limit (2,000): caps high-volume flipping"
+      - Tied to Irit leaf supply
+  trading_tips:
+    - Track Irit leaf and Eye of newt prices to estimate brew margin
+    - Watch Super combat potion(4) demand for downstream price pressure
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/sweetcorn-bowl.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/sweetcorn-bowl.mdx
@@ -12,9 +12,31 @@ osrs:
   lowalch: 5
   highalch: 7
   limit: 13000
-  about: "Sweetcorn (bowl) is a members-only item in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 13,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Sweetcorn (bowl) is a members-only cooking ingredient in Old School RuneScape. High alchemy value: 7 coins. Grand Exchange buy limit: 13,000 per 4 hours."
+  material:
+    type: food
+    tier: low
+  related_items:
+    - item_id: 5986
+      item_name: Sweetcorn
+      slug: sweetcorn
+      relationship: component
+      description: Raw sweetcorn used to fill the bowl
+    - item_id: 1923
+      item_name: Bowl
+      slug: bowl
+      relationship: component
+      description: Empty bowl container
+  market_strategy:
+    notes:
+      - High buy limit (13,000) supports bulk cooking-ingredient flips
+      - Tied to stew and curry recipes for steady baseline demand
+      - Margins per unit are small; profit lives in volume
+  trading_tips:
+    - Pair with Bowl and Spice prices to gauge stew/curry recipe arbitrage
+    - Watch for spikes during cooking-related events or quests
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/target-teleport-scroll.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/target-teleport-scroll.mdx
@@ -12,9 +12,26 @@ osrs:
   lowalch: 12000
   highalch: 18000
   limit: 5
-  about: "Target teleport scroll is a members-only item in Old School RuneScape. High alchemy value: 18,000 coins. Grand Exchange buy limit: 5 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Target teleport scroll is a members-only consumable that permanently unlocks the level 85 Target Teleport spell on the standard spellbook. High alchemy value: 18,000 coins. Grand Exchange buy limit: 5 per 4 hours."
+  material:
+    type: scroll
+    tier: high
+  related_items:
+    - item_id: 12845
+      item_name: Bounty teleport scroll
+      slug: bounty-teleport-scroll
+      relationship: alternative
+      description: Lower-level Bounty Hunter teleport scroll
+  market_strategy:
+    notes:
+      - One-time consumable tied to Bounty Hunter PvP content
+      - "Very low buy limit (5 per 4 hours): caps daily volume"
+      - Demand tracks PvP and Bounty Hunter activity cycles
+  trading_tips:
+    - Stockpile during quiet PvP weeks for resale during BH events
+    - Compare against Bounty teleport scroll price for relative demand
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-toxic-trident.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/uncharged-toxic-trident.mdx
@@ -12,6 +12,10 @@ osrs:
   lowalch: 31200
   highalch: 46800
   limit: 8
+  about: "Uncharged toxic trident is the uncharged base form of the Trident of the swamp, requiring 75 Magic to wield once charged. It is created by attaching a Magic fang to an uncharged Trident of the seas."
+  material:
+    type: magic
+    tier: high
   equipment:
     slot: weapon
     type: staff
@@ -22,28 +26,53 @@ osrs:
     stats:
       attack_magic: 25
       defence_magic: 15
-  creation:
-    method: Attach magic fang to uncharged trident
-    requirements:
-      crafting: 59
-  features:
-    - Built-in spell with venom
-    - Charges with runes and scales
-    - 25% venom chance
+  passive_effects:
+    - name: Built-in autocast
+      description: Casts a built-in magic attack with no rune cost once charged
+    - name: Venom chance
+      description: Has a 25% chance to inflict venom on targets once charged
+  recipes:
+    - skill: crafting
+      level: 59
+      xp: 0
+      materials:
+        - item_name: Trident of the seas (full)
+          item_id: 11905
+          quantity: 1
+        - item_name: Magic fang
+          item_id: 12932
+          quantity: 1
+      output_item: Uncharged toxic trident
+      output_id: 12900
+      output_quantity: 1
+      facility: None
+      members_only: true
   related_items:
     - item_id: 11907
       item_name: Trident of the seas
       slug: trident-of-the-seas
       relationship: downgrade
-      description: Base version
+      description: Base seas trident
     - item_id: 12932
       item_name: Magic fang
       slug: magic-fang
       relationship: component
-      description: Upgrade component
-  about: Built-in spell with venom. Charges with runes and scales.
-  mdx_version: 2
-  mdx_updated: '2026-04-09'
+      description: Upgrade component dropped by Zulrah
+    - item_id: 12899
+      item_name: Trident of the swamp
+      slug: trident-of-the-swamp
+      relationship: upgrade
+      description: Charged toxic trident variant
+  market_strategy:
+    notes:
+      - Built-in venom autocast drives PvM demand once charged
+      - "Low buy limit (8 per 4 hours): caps speculative volume"
+      - Tied to Magic fang supply from Zulrah drops
+  trading_tips:
+    - Track Magic fang and Trident of the seas prices for assembly margin
+    - Watch Zulrah drop-rate updates for supply shocks
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-flail-0.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/verac-s-flail-0.mdx
@@ -12,9 +12,45 @@ osrs:
   lowalch: 64000
   highalch: 96000
   limit: 15
-  about: "Verac's flail 0 is a members-only item in Old School RuneScape. High alchemy value: 96,000 coins. Grand Exchange buy limit: 15 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Verac's flail 0 is the fully-degraded form of Verac the Defiled's barrows flail. It must be repaired at an armour stand or NPC before it can be used in combat."
+  material:
+    type: barrows
+    tier: high
+  equipment:
+    slot: weapon
+    type: flail
+    tradeable: true
+  related_items:
+    - item_id: 4755
+      item_name: "Verac's flail"
+      slug: verac-s-flail
+      relationship: variant
+      description: Fully repaired Verac's flail
+    - item_id: 4753
+      item_name: "Verac's helm"
+      slug: verac-s-helm
+      relationship: set-piece
+      description: Verac's barrows set helmet
+    - item_id: 4757
+      item_name: "Verac's plateskirt"
+      slug: verac-s-plateskirt
+      relationship: set-piece
+      description: Verac's barrows set plateskirt
+    - item_id: 4759
+      item_name: "Verac's brassard"
+      slug: verac-s-brassard
+      relationship: set-piece
+      description: Verac's barrows set brassard
+  market_strategy:
+    notes:
+      - Degraded barrows item priced below the repaired variant
+      - "Low buy limit (15 per 4 hours): caps flip volume"
+      - Demand driven by Barrows runners and repair flippers
+  trading_tips:
+    - Compare against the repaired Verac's flail price minus repair cost for arbitrage
+    - Watch barrows minigame popularity for supply changes
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-shield.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wooden-shield.mdx
@@ -12,9 +12,35 @@ osrs:
   lowalch: 8
   highalch: 12
   limit: 125
-  about: "Wooden shield is a free-to-play item in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 125 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Wooden shield is a free-to-play entry-level shield in Old School RuneScape. High alchemy value: 12 coins. Grand Exchange buy limit: 125 per 4 hours."
+  material:
+    type: wood
+    tier: low
+  equipment:
+    slot: shield
+    type: shield
+    tradeable: true
+  related_items:
+    - item_id: 1173
+      item_name: Bronze sq shield
+      slug: bronze-sq-shield
+      relationship: upgrade
+      description: Entry-level metal square shield
+    - item_id: 1189
+      item_name: Bronze kiteshield
+      slug: bronze-kiteshield
+      relationship: upgrade
+      description: Bronze kiteshield upgrade path
+  market_strategy:
+    notes:
+      - Free-to-play starter shield with very low intrinsic value
+      - "Low buy limit (125 per 4 hours): caps bulk flipping"
+      - Steady low-level demand from new accounts and tutorial flow
+  trading_tips:
+    - Margins are tiny; trade only if you can move close to the limit
+    - Watch new-player promotional periods for short-term demand bumps
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';

--- a/apps/kbve/astro-kbve/src/content/docs/osrs/wrath-talisman.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/osrs/wrath-talisman.mdx
@@ -12,9 +12,31 @@ osrs:
   lowalch: 1
   highalch: 2
   limit: 11000
-  about: "Wrath talisman is a members-only item in Old School RuneScape. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
-  mdx_version: 2
-  mdx_updated: "2026-04-10"
+  about: "Wrath talisman is a members-only Runecraft talisman used to access the Wrath altar for crafting Wrath runes. High alchemy value: 2 coins. Grand Exchange buy limit: 11,000 per 4 hours."
+  material:
+    type: talisman
+    tier: low
+  related_items:
+    - item_id: 21880
+      item_name: Wrath rune
+      slug: wrath-rune
+      relationship: product
+      description: Rune crafted at the Wrath altar
+    - item_id: 1448
+      item_name: Mind talisman
+      slug: mind-talisman
+      relationship: alternative
+      description: Other Runecraft altar talisman
+  market_strategy:
+    notes:
+      - High buy limit (11,000) supports bulk Runecraft supply flips
+      - Demand tied to Wrath rune crafting and high-level Runecraft training
+      - Per-unit profit is small; volume drives returns
+  trading_tips:
+    - Track Wrath rune price for downstream Runecraft demand signal
+    - Watch for Runecraft-related updates that shift altar usage
+  mdx_version: 3
+  mdx_updated: "2026-06-05"
 ---
 
 import OSRSItemPanel from '@/components/osrs/OSRSItemPanel.astro';


### PR DESCRIPTION
## Summary

Batch 27 of the OSRS MDX v2 → v3 schema migration — final tail of remaining v2 items (index.mdx is the listing page, not an item, skipped). After this, all OSRS item MDX files in the collection are on v3.

- All entries: `mdx_version: 3`, `mdx_updated: "2026-06-05"`, `material: { type, tier }` (enum: low/mid/mid-high/high)
- Drops: `drop_table.sources[].source` (not `monster`), `quantity` as string
- Shops: `shop_name` first key, quoted where colons/apostrophes appear, numeric `price`/`stock` (0 never null)
- Recipes: lowercase `skill`, `materials[].item_name`, `xp` (not `experience`), `output_quantity`
- Equipment: singular `attack_bonus`/`defence_bonus`/`other_bonus`; `attack_speed`/`attack_range` omitted when N/A
- `treasure_trail.tier` lowercase enum; omitted for non-clue items
- `related_items[].relationship` enum: variant/upgrade/downgrade/component/product/set-piece/alternative
- `market_strategy: { notes: [] }` object form; `trading_tips: []` array
- `history[]` dates quoted, `description:` key, `update:` folded into description
- `potion.effects[].duration` as number seconds
- `passive_effects[].name` required

## Test plan

- [x] `nx run astro-kbve:sync` — content collection schema validation
- [x] `nx run astro-kbve:build` — 7,742 pages built, 0 errors