### PR TITLE
fix(ci-unreal-build): Win64/mac client no longer gates the game release

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -994,18 +994,12 @@ jobs:
 
     game_post_publish:
         name: Game Post-publish version sync
-        needs: [game_gate, game_build_linux, game_build_windows, game_build_mac]
+        needs: [game_gate, game_build_linux]
         if: |
             inputs.mode == 'game' &&
-            always() &&
             needs.game_gate.outputs.should_build == 'true' &&
             inputs.version_toml != '' &&
-            (needs.game_build_linux.result == 'success' || needs.game_build_linux.result == 'skipped') &&
-            (needs.game_build_windows.result == 'success' || needs.game_build_windows.result == 'skipped') &&
-            (needs.game_build_mac.result == 'success' || needs.game_build_mac.result == 'skipped') &&
-            !(needs.game_build_linux.result == 'skipped' &&
-              needs.game_build_windows.result == 'skipped' &&
-              needs.game_build_mac.result == 'skipped')
+            needs.game_build_linux.result == 'success'
         permissions:
             contents: write
             pull-requests: write


### PR DESCRIPTION
## Why

`game_post_publish` listed `game_build_windows` + `game_build_mac` in `needs:`, so the version-sync (version.toml bump + ticket close) waited for the **Win64 job to reach a terminal state**. The Win64 job runs on the `windows-builder` KubeVirt VM, whose auto-start is currently **disabled** (`keda/scaled-jobs.yaml` — github-runner scaler commented out to save API quota). So the Win64 job sits `queued` indefinitely → post_publish never runs → `version.toml` never bumps → ci-main re-dispatches beta on **every main push** (the 03:40/04:27/05:07 pile-up).

## Fix

Each platform build already does its **own** itch deploy in-job, so they publish independently. Key `game_post_publish` on `game_build_linux` success only; Win64/mac become best-effort — they build + push whenever their runner is available, and never block the release.

Result: Linux client + dedicated server finalize the release (publish + version bump → stops the re-dispatch loop) without waiting on the Windows VM. Win64 still builds + pushes to itch once the VM is up.

## Not covered here

- Separately, `arc-runner-ue` hasn't picked up the queued Linux client/server jobs (~40min, no runner). That's runner-availability, needs a cluster look — tracked separately.
- Auto-starting the Windows VM from the Actions queue (no-poll) is the planned follow-up.