### PR TITLE
perf(cryptothrone): faster, smoother player movement

### DIFF
--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -17,7 +17,7 @@ const NPCDB_JSON: &[u8] =
 
 pub const PLAYER_HP: i32 = 100;
 pub const PLAYER_ATTACK: i32 = 5;
-pub const PLAYER_TICKS_PER_TILE: u8 = 4;
+pub const PLAYER_TICKS_PER_TILE: u8 = 3;
 pub const PLAYER_SPAWN: Tile = Tile::new(5, 12);
 // Cloud City plaza is a safe town — hostiles can't aggro players within
 // this Chebyshev radius of spawn. Venture out to find combat.

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -20,7 +20,7 @@ import { getCtNetConfig } from '@/lib/net-config';
 import { getNPCByRef, npcIdForRef, isHostileRef } from '../data/npcs';
 
 const MAP_SCALE = 3;
-const STEP_THROTTLE_MS = 90;
+const STEP_THROTTLE_MS = 60;
 const SLOT_NONE = 0xffff;
 const PLAYER_SPRITE_VARIANTS = 8;
 
@@ -430,7 +430,7 @@ export class CloudCityScene extends Scene {
 					id: charId,
 					sprite,
 					startPosition: { x: e.tile.x, y: e.tile.y },
-					speed: 4,
+					speed: 7,
 					collides: false,
 				};
 				if (mapping !== undefined) {

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.8"
+version: "0.0.9"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.16"
+version: "0.1.17"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## Summary
Movement felt slow for two compounding reasons:
1. **Base speed** was 5 tiles/sec (`ticks_per_tile=4` @ 20 tps).
2. **The client tween lagged the server** — gridEngine ran at `speed: 4` (4 t/s) while the server moved at 5 t/s, so the sprite was always behind the authoritative position and snapped to catch up → jerky/sluggish feel.

Fixes:
- `PLAYER_TICKS_PER_TILE` 4 → **3** → 6.67 t/s (+33%)
- gridEngine character `speed` 4 → **7** so the tween keeps pace with (just ahead of) the server — removes the lag/snap
- `STEP_THROTTLE_MS` 90 → **60** so held-key input keeps the server's step buffer full for continuous motion

Verified with a raw WebSocket probe against a local server: step-chaining works and the clean-burst rate measured **6.67 t/s** (sprite walked 5→8 in ~300ms before hitting map geometry).

Ships as client **0.1.17** / server **0.0.9**.

## Testing
- simgrid 29/29, clippy clean; astro 29/29, e2e 57/57
- raw-WS movement-rate probe (server-authoritative)