### PR TITLE
feat(cryptothrone): critical hits, heartbeat keepalive, camera zoom, auto-pickup

### DIFF
--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -17,7 +17,7 @@ const NPCDB_JSON: &[u8] =
 
 pub const PLAYER_HP: i32 = 100;
 pub const PLAYER_ATTACK: i32 = 5;
-pub const PLAYER_TICKS_PER_TILE: u8 = 4;
+pub const PLAYER_TICKS_PER_TILE: u8 = 3;
 pub const PLAYER_SPAWN: Tile = Tile::new(5, 12);
 // Cloud City plaza is a safe town — hostiles can't aggro players within
 // this Chebyshev radius of spawn. Venture out to find combat.

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -98,6 +98,8 @@ export class CloudCityScene extends Scene {
 	private fpsAt = 0;
 	private lastPosKey = '';
 	private currentZone = '';
+	private heartbeatTimer = 0;
+	private lastAutoPickup = 0;
 	private prevLevel = -1;
 	private prevXp = -1;
 	private hoverThrottle = 0;
@@ -179,6 +181,7 @@ export class CloudCityScene extends Scene {
 		this.events.once('shutdown', () => {
 			window.clearTimeout(this.slowTimer);
 			window.clearTimeout(this.reconnectTimer);
+			window.clearInterval(this.heartbeatTimer);
 			this.laserUnsubs.forEach((off) => off());
 			this.laserUnsubs = [];
 			this.netTerminal = true;
@@ -221,8 +224,12 @@ export class CloudCityScene extends Scene {
 			laserEvents.emit('combat:event', c);
 			this.showFloatingText(
 				c.target,
-				`-${c.dmg}`,
-				c.target === this.myEid ? '#f87171' : '#fbbf24',
+				c.crit ? `CRIT ${c.dmg}!` : `-${c.dmg}`,
+				c.crit
+					? '#fb7185'
+					: c.target === this.myEid
+						? '#f87171'
+						: '#fbbf24',
 			);
 			this.flashSprite(c.target);
 			if (c.died && c.target === this.myEid) {
@@ -329,6 +336,23 @@ export class CloudCityScene extends Scene {
 			}
 		}, 8000);
 		client.connect();
+
+		this.heartbeatTimer = window.setInterval(() => {
+			this.client?.heartbeat();
+		}, 20000);
+
+		// Camera zoom: +/- keys and mouse wheel, clamped.
+		const zoom = (delta: number) => {
+			const cam = this.cameras.main;
+			cam.setZoom(Phaser.Math.Clamp(cam.zoom + delta, 0.6, 2.2));
+		};
+		this.input.keyboard?.on('keydown-PLUS', () => zoom(0.2));
+		this.input.keyboard?.on('keydown-MINUS', () => zoom(-0.2));
+		this.input.on(
+			'wheel',
+			(_p: unknown, _o: unknown, _dx: number, dy: number) =>
+				zoom(dy > 0 ? -0.15 : 0.15),
+		);
 	}
 
 	private makeGroundItemTexture() {
@@ -844,10 +868,26 @@ export class CloudCityScene extends Scene {
 		return 'The Wilds';
 	}
 
+	private autoPickup(time: number) {
+		if (!this.client || this.myEid < 0 || time - this.lastAutoPickup < 300)
+			return;
+		const me = this.myTile();
+		if (!me) return;
+		for (const [eid, t] of this.tracked) {
+			if (this.kindCat(t.kind) !== KIND_CAT_ITEM) continue;
+			if (this.chebyshev(me, t.tile) <= 1) {
+				this.lastAutoPickup = time;
+				this.client.action(ACTION_PICKUP, eid);
+				return;
+			}
+		}
+	}
+
 	update(time: number) {
 		if (!this.client) return;
 		this.updateHpBars();
 		this.updateOverlays(time);
+		this.autoPickup(time);
 
 		if (Phaser.Input.Keyboard.JustDown(this.attackKey)) {
 			this.attackNearby();

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -20,7 +20,7 @@ import { getCtNetConfig } from '@/lib/net-config';
 import { getNPCByRef, npcIdForRef, isHostileRef } from '../data/npcs';
 
 const MAP_SCALE = 3;
-const STEP_THROTTLE_MS = 90;
+const STEP_THROTTLE_MS = 60;
 const SLOT_NONE = 0xffff;
 const PLAYER_SPRITE_VARIANTS = 8;
 
@@ -430,7 +430,7 @@ export class CloudCityScene extends Scene {
 					id: charId,
 					sprite,
 					startPosition: { x: e.tile.x, y: e.tile.y },
-					speed: 4,
+					speed: 7,
 					collides: false,
 				};
 				if (mapping !== undefined) {

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.8"
+version: "0.0.9"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.16"
+version: "0.1.17"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/packages/npm/laser/src/lib/net/game-client.ts
+++ b/packages/npm/laser/src/lib/net/game-client.ts
@@ -148,6 +148,10 @@ export class GameClient {
 		this.sendInputs([{ Action: { id, target } }]);
 	}
 
+	heartbeat(): void {
+		this.sendInputs([{ Heartbeat: { client_tick: this.clientTick } }]);
+	}
+
 	useItem(itemRef: string): void {
 		this.sendInputs([{ UseItem: { item_ref: itemRef } }]);
 	}

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -106,6 +106,7 @@ export interface CombatEvent {
 	target_ref: string | null;
 	dmg: number;
 	died: boolean;
+	crit?: boolean;
 }
 
 export interface PickupEvent {

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -183,6 +183,7 @@ pub struct KillCounts(pub HashMap<u16, u32>);
 
 pub const REGEN_PERIOD_TICKS: u32 = SIM_TICK_HZ * 2;
 pub const REGEN_AMOUNT: i32 = 2;
+pub const CRIT_CHANCE_PCT: u64 = 15;
 
 #[derive(Clone, Copy)]
 pub struct AggroSpec {
@@ -734,6 +735,7 @@ fn apply_actions(
     registry: Res<KindRegistry>,
     bcast: Res<SnapshotBroadcast>,
     clock: Res<SimClock>,
+    seed: Res<SimSeed>,
     config: Res<SimConfig>,
     equipment: Res<EquipmentEffects>,
     mut respawns: ResMut<RespawnQueue>,
@@ -795,7 +797,10 @@ fn apply_actions(
                 if attacker_tile.chebyshev(mob_pos.tile) > 1 {
                     continue;
                 }
-                let damage = (attack - mob_defense.map(|d| d.0).unwrap_or(0)).max(1);
+                let base = (attack - mob_defense.map(|d| d.0).unwrap_or(0)).max(1);
+                let crit = hash3(seed.0, player_entity.index_u32() as u64, clock.tick as u64) % 100
+                    < CRIT_CHANCE_PCT;
+                let damage = if crit { base * 2 } else { base };
                 let kill_xp = mob_level.map(|l| l.0).unwrap_or(1).max(1) * XP_PER_NPC_LEVEL;
                 hp.hp -= damage;
                 let died = hp.hp <= 0;
@@ -804,6 +809,7 @@ fn apply_actions(
                     "target": target_entity.index_u32(),
                     "target_ref": registry.ref_of(kind.0),
                     "dmg": damage,
+                    "crit": crit,
                     "died": died,
                 })
                 .to_string()


### PR DESCRIPTION
## Summary
Across-the-board stability + fun pass. **Stacks on #12279** (movement); rides the same 0.1.17 / 0.0.9 release.

### Fun
- **Critical hits** — 15% chance for 2× damage (server-rolled via the seeded hash, deterministic + replay-safe). Combat event carries `crit`; client shows a rose 'CRIT N!' float instead of the normal damage number
- **Camera zoom** — `+`/`-` keys and mouse wheel, clamped 0.6–2.2×
- **Auto-pickup** — walking onto or beside a ground item grabs it automatically (300ms throttle), no click required

### Stability
- **Heartbeat keepalive** — the client sends a Heartbeat every 20s so idle players aren't dropped by Cloudflare/Envoy idle timeouts; interval cleared on scene shutdown

## Testing
- simgrid 29/29, clippy clean both crates
- laser + astro-cryptothrone tests pass, e2e 57/57
- crit is unit-covered via the existing attack path (additive payload field)

## Sequencing
#12279 → this; both ship as 0.1.17 / 0.0.9.