### PR TITLE
feat(ci): auto-start windows-builder VM from the Win64 build dispatch

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,7 @@
 self-hosted-runner:
     labels:
         - arc-runner-set
+        - arc-runner-set-kbve
         - arc-runner-ue
         - arc-runner-ue-mac
         - UE5-Mac

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -806,9 +806,38 @@ jobs:
                   docker system prune -f 2>/dev/null || true
                   rm -rf /tmp/game-project /tmp/game-clone /tmp/ue5-game-output 2>/dev/null || true
 
+    win_vm_boot:
+        name: Boot Windows VM
+        needs: [guard, game_gate]
+        if: inputs.mode == 'game' && needs.guard.outputs.allowed == 'true' && needs.game_gate.outputs.should_build == 'true' && contains(inputs.build_targets, 'Win64')
+        runs-on: arc-runner-set-kbve
+        timeout-minutes: 8
+        permissions:
+            contents: read
+        steps:
+            - name: Request windows-builder VM start
+              run: |
+                  API=https://kubernetes.default.svc
+                  SA=/var/run/secrets/kubernetes.io/serviceaccount
+                  TOKEN=$(cat "$SA/token")
+                  NS=angelscript
+                  VM=windows-builder
+                  STATUS=$(curl -sS --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
+                    "$API/apis/kubevirt.io/v1/namespaces/$NS/virtualmachines/$VM" | jq -r '.status.printableStatus // "Unknown"')
+                  echo "::notice::$VM current status: $STATUS"
+                  if [ "$STATUS" = "Running" ]; then
+                    echo "VM already running — UE5-Win runner should be live."
+                    exit 0
+                  fi
+                  echo "Requesting start..."
+                  curl -sS --fail-with-body --cacert "$SA/ca.crt" -H "Authorization: Bearer $TOKEN" \
+                    -X PUT -H "Content-Type: application/json" -d '{}' \
+                    "$API/apis/subresources.kubevirt.io/v1/namespaces/$NS/virtualmachines/$VM/start"
+                  echo "::notice::$VM start requested; UE5-Win runner will register once the guest boots."
+
     game_build_windows:
         name: Game Build (Win64 client)
-        needs: [guard, game_gate]
+        needs: [guard, game_gate, win_vm_boot]
         if: inputs.mode == 'game' && needs.guard.outputs.allowed == 'true' && needs.game_gate.outputs.should_build == 'true' && contains(inputs.build_targets, 'Win64')
         runs-on: UE5-Win
         timeout-minutes: 480

--- a/apps/kube/github/runners/manifests/kustomization.yaml
+++ b/apps/kube/github/runners/manifests/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
     - cache-cleanup-cronjob.yaml
     - registry-mirror.yaml
     - valkey-sccache-externalsecret.yaml
+    - vm-starter-rbac.yaml

--- a/apps/kube/github/runners/manifests/values-kbve.yaml
+++ b/apps/kube/github/runners/manifests/values-kbve.yaml
@@ -34,6 +34,7 @@ template:
         annotations:
             kbve.com/restart-trigger: '20260504-canary-bootstrap'
     spec:
+        serviceAccountName: arc-vm-starter
         initContainers:
             - name: init-dind-externals
               image: ghcr.io/kbve/arc-runner:0.1.4

--- a/apps/kube/github/runners/manifests/vm-starter-rbac.yaml
+++ b/apps/kube/github/runners/manifests/vm-starter-rbac.yaml
@@ -1,0 +1,37 @@
+# Least-privilege RBAC for the dispatch-time Windows VM boot preamble.
+# An arc-runner-set-kbve pod (this SA) starts the windows-builder KubeVirt VM
+# when a Win64 unreal build is dispatched — replaces the GitHub-API-polling
+# KEDA start scaler. Start-only: strictly less than the vm-scaler SA (no stop,
+# no pods/exec, no deployments/scale). VM lives in angelscript; SA in arc-runners.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: arc-vm-starter
+    namespace: arc-runners
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: arc-vm-starter
+    namespace: angelscript
+rules:
+    - apiGroups: ['kubevirt.io']
+      resources: ['virtualmachines']
+      verbs: ['get']
+    - apiGroups: ['subresources.kubevirt.io']
+      resources: ['virtualmachines/start']
+      verbs: ['update']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: arc-vm-starter
+    namespace: angelscript
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: arc-vm-starter
+subjects:
+    - kind: ServiceAccount
+      name: arc-vm-starter
+      namespace: arc-runners


### PR DESCRIPTION
## Why

The Windows VM (`windows-builder`) auto-start was disabled — the KEDA `github-runner` scaler polls the GitHub API and burns rate-limit credits. So the Win64 client build sat queued until someone ran `virtctl start` by hand.

## What — event-driven, no polling

When a Win64 unreal build is dispatched, a light in-cluster `arc-runner-set-kbve` job starts the VM; the Win64 build then runs once the guest's `UE5-Win` runner registers. **One runner boots the other.**

- **`arc-vm-starter`** SA (arc-runners) + least-privilege Role/RoleBinding in `angelscript`: `virtualmachines: get` + `virtualmachines/start: update` only — strictly less than `vm-scaler` (no stop / pods-exec / deployments-scale).
- `arc-runner-set-kbve` pods run as `arc-vm-starter`, so the in-pod SA token authorizes the start (image already ships curl/jq/kubectl).
- **`win_vm_boot`** job (idempotent — skips if already `Running`) → `game_build_windows` `needs: [..., win_vm_boot]`.
- actionlint config learns the `arc-runner-set-kbve` label.

KEDA scale-**down** (activity-aware idle shutdown) unchanged — VM still stops after idle.

## Pairs with #12278

#12278 makes Win64 non-blocking for the release; this makes it actually build unattended. Together: Linux client+server publish on their own, Win64 boots its VM + builds + pushes to itch with no manual `virtctl`.

## Confirm

`arc-runner-set-kbve` is a deployed helm release (`releaseName: arc-runner-set-kbve`), so the boot job has a runner. The SA grant is start-only.