### PR TITLE
feat(cryptothrone): bigger safe town + healing-fountain regen

### DIFF
--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -21,7 +21,7 @@ pub const PLAYER_TICKS_PER_TILE: u8 = 3;
 pub const PLAYER_SPAWN: Tile = Tile::new(5, 12);
 // Cloud City plaza is a safe town — hostiles can't aggro players within
 // this Chebyshev radius of spawn. Venture out to find combat.
-pub const PLAYER_SAFE_RADIUS: i32 = 8;
+pub const PLAYER_SAFE_RADIUS: i32 = 12;
 
 pub const NPC_RESPAWN_TICKS: u32 = SIM_TICK_HZ * 30;
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.9"
+version: "0.0.10"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -183,6 +183,7 @@ pub struct KillCounts(pub HashMap<u16, u32>);
 
 pub const REGEN_PERIOD_TICKS: u32 = SIM_TICK_HZ * 2;
 pub const REGEN_AMOUNT: i32 = 2;
+pub const TOWN_REGEN_AMOUNT: i32 = 6;
 pub const CRIT_CHANCE_PCT: u64 = 15;
 
 #[derive(Clone, Copy)]
@@ -1102,14 +1103,27 @@ fn hostile_ai(
 }
 
 #[allow(clippy::type_complexity)]
-fn regen_players(clock: Res<SimClock>, mut q: Query<&mut Health, With<PlayerSlotTag>>) {
+fn regen_players(
+    clock: Res<SimClock>,
+    config: Res<SimConfig>,
+    mut q: Query<(&mut Health, &GridPos), With<PlayerSlotTag>>,
+) {
     if !clock.tick.is_multiple_of(REGEN_PERIOD_TICKS) {
         return;
     }
-    for mut hp in q.iter_mut() {
-        if hp.hp > 0 && hp.hp < hp.max_hp {
-            hp.hp = (hp.hp + REGEN_AMOUNT).min(hp.max_hp);
+    for (mut hp, pos) in q.iter_mut() {
+        if hp.hp <= 0 || hp.hp >= hp.max_hp {
+            continue;
         }
+        // The town fountain mends faster — return to the plaza to recover.
+        let in_town =
+            config.safe_radius > 0 && pos.tile.chebyshev(config.spawn) <= config.safe_radius;
+        let amount = if in_town {
+            TOWN_REGEN_AMOUNT
+        } else {
+            REGEN_AMOUNT
+        };
+        hp.hp = (hp.hp + amount).min(hp.max_hp);
     }
 }
 


### PR DESCRIPTION
## Summary
Gameplay-loop pass tied to the safe zone.

- **Bigger safe town** — spawn safe radius 8 → 12 tiles; the plaza is a roomier no-aggro zone
- **Healing fountain** — players inside the safe zone regen 3× faster (6 hp/tick vs 2 in the field), giving the loop a reason to retreat to town and recover between fights

Bumps **server 0.0.10** (0.0.9 already published + live, so the change needs a fresh version to deploy).

## Testing
- simgrid 29/29, clippy clean (verified via cargo directly — nx wrapper flaked in the worktree)