### PR TITLE
feat(cryptothrone): client-side movement prediction + reconciliation

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -24,6 +24,13 @@ const STEP_THROTTLE_MS = 60;
 const SLOT_NONE = 0xffff;
 const PLAYER_SPRITE_VARIANTS = 8;
 
+const DIR_DELTA: Record<string, { x: number; y: number }> = {
+	Up: { x: 0, y: -1 },
+	Down: { x: 0, y: 1 },
+	Left: { x: -1, y: 0 },
+	Right: { x: 1, y: 0 },
+};
+
 function spriteVariantForName(name: string): number {
 	let h = 2166136261;
 	for (let i = 0; i < name.length; i++) {
@@ -104,6 +111,10 @@ export class CloudCityScene extends Scene {
 	private prevXp = -1;
 	private hoverThrottle = 0;
 	private laserUnsubs: (() => void)[] = [];
+	private blocked = new Set<string>();
+	private predicted = { x: 0, y: 0 };
+	private predicting = false;
+	private predictSeeded = false;
 
 	constructor() {
 		super({ key: 'CloudCity' });
@@ -123,6 +134,13 @@ export class CloudCityScene extends Scene {
 			if (layer) {
 				layer.setScale(MAP_SCALE);
 				layer.setDepth(i);
+				// Mirror the server's ge_collide walkability so client
+				// prediction matches authority and rarely needs to snap back.
+				layer.forEachTile((t) => {
+					if (t && t.properties && t.properties.ge_collide) {
+						this.blocked.add(`${t.x},${t.y}`);
+					}
+				});
 			}
 		}
 		this.entityDepth = tilemap.layers.length + 1;
@@ -492,11 +510,31 @@ export class CloudCityScene extends Scene {
 				) {
 					this.myEid = e.eid;
 					this.cameras.main.startFollow(sprite, true);
+					this.predicted = { x: e.tile.x, y: e.tile.y };
+					this.predictSeeded = true;
 					// Seed range tracker to spawn so a range dialog only
 					// fires when the player walks into a zone, not when
 					// they spawn already standing in one.
 					this.rangeTile = { x: e.tile.x, y: e.tile.y };
 				}
+			} else if (e.eid === this.myEid && this.predicting) {
+				// Reconcile prediction: trust the local position unless it
+				// drifts too far from authority (rejected move / lag spike),
+				// then snap back to the server.
+				const drift = Math.max(
+					Math.abs(e.tile.x - this.predicted.x),
+					Math.abs(e.tile.y - this.predicted.y),
+				);
+				if (drift > 2) {
+					this.predicted = { x: e.tile.x, y: e.tile.y };
+					this.gridEngine.setPosition(existing.charId, {
+						x: e.tile.x,
+						y: e.tile.y,
+					});
+				}
+				existing.tile = { ...this.predicted };
+				existing.hp = e.hp;
+				existing.maxHp = e.max_hp;
 			} else {
 				if (
 					existing.tile.x !== e.tile.x ||
@@ -508,6 +546,8 @@ export class CloudCityScene extends Scene {
 					});
 					existing.tile = { x: e.tile.x, y: e.tile.y };
 				}
+				if (e.eid === this.myEid)
+					this.predicted = { x: e.tile.x, y: e.tile.y };
 				existing.hp = e.hp;
 				existing.maxHp = e.max_hp;
 			}
@@ -715,6 +755,7 @@ export class CloudCityScene extends Scene {
 		}
 
 		laserEvents.emit('target:clear', {});
+		this.predicting = false;
 		this.client.moveTo(tile);
 	}
 
@@ -893,17 +934,34 @@ export class CloudCityScene extends Scene {
 			this.attackNearby();
 		}
 
-		if (time - this.lastStepAt < STEP_THROTTLE_MS) return;
-
 		let dir: Dir | null = null;
 		if (this.cursors.up.isDown) dir = 'Up';
 		else if (this.cursors.down.isDown) dir = 'Down';
 		else if (this.cursors.left.isDown) dir = 'Left';
 		else if (this.cursors.right.isDown) dir = 'Right';
 
-		if (dir) {
-			this.client.step(dir);
-			this.lastStepAt = time;
+		if (!dir || this.myEid < 0 || !this.predictSeeded) return;
+
+		const myChar = `e${this.myEid}`;
+		// One predicted tile at a time: wait for the local tween to finish so
+		// prediction tracks the server's tile rate instead of outrunning it.
+		if (this.gridEngine.isMoving(myChar)) return;
+
+		const delta = DIR_DELTA[dir];
+		const cand = {
+			x: this.predicted.x + delta.x,
+			y: this.predicted.y + delta.y,
+		};
+		// Predict only into tiles the server would also allow. Blocked tiles
+		// just send a Step (server stays authoritative) without local motion.
+		if (!this.blocked.has(`${cand.x},${cand.y}`)) {
+			this.predicting = true;
+			this.predicted = cand;
+			this.gridEngine.moveTo(myChar, cand);
+			const me = this.tracked.get(this.myEid);
+			if (me) me.tile = { ...cand };
 		}
+		this.client.step(dir);
+		this.lastStepAt = time;
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.17"
+version: "0.1.18"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## Summary
Keyboard movement felt laggy because the sprite only moved **after** a round trip (send Step → server tick → snapshot 100ms later → tween). This adds client-side prediction so the player moves instantly, with the server still authoritative.

### How it works
- At load, the client builds a `blocked` tile set from the same `ge_collide` data the server uses, so predictions match authority.
- On a keyboard step: predict the next tile locally, move the sprite immediately (one tile at a time, gated on the tween finishing so it tracks the server rate), and send the `Step`.
- On each snapshot, reconcile the own entity: trust the predicted position while it's within **2 tiles** of the server; on larger drift (a rejected move or lag spike) **snap back** to the authoritative tile.
- **Click-to-move stays server-driven** (pathfinding) — prediction only applies to keyboard input; clicking flips back to authoritative follow.

This is the responsive-movement + 'verify and snap back if fake' model requested.

## Testing
- astro-cryptothrone 29/29, e2e 57/57
- **Live-verified** against a local server: instant local motion, correct stop at the x=9 wall (matched the authoritative WS probe), no snap-spam, zero runtime errors (gridEngine isMoving/moveTo/setPosition/forEachTile all exercised)

Ships as client **0.1.18**.