### PR TITLE
feat(forgejo): true storage incl LFS/packages/artifacts (quota) + git·LFS split

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -252,6 +252,7 @@ export default function ReactForgejoSummary() {
 	const totalSize = useStore(forgejoService.$totalSize);
 	const totalReleases = useStore(forgejoService.$totalReleases);
 	const stats = useStore(forgejoService.$stats);
+	const storage = useStore(forgejoService.$storage);
 
 	if (!active) return null;
 
@@ -260,6 +261,25 @@ export default function ReactForgejoSummary() {
 	const publicValue = stats ? stats.public : publicCount;
 	const privateValue = stats ? stats.private : privateCount;
 	const archivedValue = stats ? stats.archived : archivedCount;
+
+	const usingQuota = !!storage?.quota_enabled;
+	const sizeKb = usingQuota
+		? Math.round(storage!.total_bytes / 1024)
+		: sizeValue;
+	const sizeSub = usingQuota
+		? [
+				storage!.lfs_bytes > 0 &&
+					`LFS ${formatSize(storage!.lfs_bytes / 1024)}`,
+				storage!.packages_bytes > 0 &&
+					`pkg ${formatSize(storage!.packages_bytes / 1024)}`,
+				storage!.artifacts_bytes > 0 &&
+					`artifacts ${formatSize(storage!.artifacts_bytes / 1024)}`,
+			]
+				.filter(Boolean)
+				.join(' · ') || `across ${repoValue} repositories`
+		: stats && stats.lfs_size_kb > 0
+			? `git ${formatSize(stats.git_size_kb)} · LFS ${formatSize(stats.lfs_size_kb)}`
+			: `across ${repoValue} repositories`;
 
 	if (loading && totalRepos === 0) {
 		return (
@@ -312,10 +332,10 @@ export default function ReactForgejoSummary() {
 				}}>
 				<StatCard
 					icon={<HardDrive size={12} />}
-					label="Total Storage"
-					value={formatSize(sizeValue)}
+					label={usingQuota ? 'Total Storage' : 'Repo Storage'}
+					value={formatSize(sizeKb)}
 					color="#06b6d4"
-					sub={`across ${repoValue} repositories`}
+					sub={sizeSub}
 				/>
 				<StatCard
 					icon={<BookOpen size={12} />}

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -202,12 +202,26 @@ export interface ForgejoVersion {
 export interface ForgejoStats {
 	repo_count: number;
 	total_size_kb: number;
+	git_size_kb: number;
+	lfs_size_kb: number;
 	public: number;
 	private: number;
 	mirror: number;
 	archived: number;
 	fork: number;
 	truncated: boolean;
+}
+
+export interface ForgejoStorage {
+	quota_enabled: boolean;
+	owners_counted: number;
+	truncated: boolean;
+	repos_bytes: number;
+	lfs_bytes: number;
+	attachments_bytes: number;
+	artifacts_bytes: number;
+	packages_bytes: number;
+	total_bytes: number;
 }
 
 export interface ForgejoCollaborator extends ForgejoUser {
@@ -751,6 +765,7 @@ class ForgejoService {
 	public readonly $cronTasks = atom<ForgejoCronTask[]>([]);
 	public readonly $unadopted = atom<string[]>([]);
 	public readonly $stats = atom<ForgejoStats | null>(null);
+	public readonly $storage = atom<ForgejoStorage | null>(null);
 
 	public readonly $issueRepo = atom<string | null>(null);
 	public readonly $issueState = atom<'open' | 'closed'>('open');
@@ -940,6 +955,7 @@ class ForgejoService {
 			this.$lastUpdated.set(new Date());
 			void saveCache(repos.items, users.items, orgs.items);
 			void this.fetchStats();
+			void this.fetchStorage();
 		} catch (e: unknown) {
 			if (e instanceof AccessRestrictedError) {
 				this.$authState.set('forbidden');
@@ -968,6 +984,24 @@ class ForgejoService {
 			const data = (await resp.json()) as ForgejoStats;
 			if (data && typeof data.total_size_kb === 'number') {
 				this.$stats.set(data);
+			}
+		} catch {
+			return;
+		}
+	}
+
+	public async fetchStorage(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		try {
+			const resp = await fetch(`${API_BASE}/storage`, {
+				headers: { Authorization: `Bearer ${token}` },
+				signal: AbortSignal.timeout(30000),
+			});
+			if (!resp.ok) return;
+			const data = (await resp.json()) as ForgejoStorage;
+			if (data && typeof data.total_bytes === 'number') {
+				this.$storage.set(data);
 			}
 		} catch {
 			return;

--- a/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
+++ b/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
@@ -325,6 +325,11 @@ async fn stats(headers: HeaderMap) -> Response {
     reply!(c.repo_stats().await)
 }
 
+async fn storage(headers: HeaderMap) -> Response {
+    let c = vc!(headers);
+    reply!(c.instance_storage().await)
+}
+
 async fn repo_runners(headers: HeaderMap, Path((owner, repo)): Path<(String, String)>) -> Response {
     let c = vc!(headers);
     reply!(c.list_repo_runners(&owner, &repo).await)
@@ -654,6 +659,7 @@ pub fn routes() -> Router {
     Router::new()
         // top-level
         .route(&p("/stats"), get(stats))
+        .route(&p("/storage"), get(storage))
         .route(&p("/version"), get(version))
         .route(&p("/cron"), get(cron))
         .route(&p("/cron/{task}"), post(run_cron))

--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -770,6 +770,8 @@ impl ForgejoClient {
             for r in &batch {
                 stats.repo_count += 1;
                 stats.total_size_kb += r.size;
+                stats.git_size_kb += r.git_size;
+                stats.lfs_size_kb += r.lfs_size;
                 if r.private {
                     stats.private += 1;
                 } else {
@@ -795,6 +797,68 @@ impl ForgejoClient {
             }
         }
         Ok(stats)
+    }
+
+    async fn owner_quota(&self, owner: &str) -> Result<QuotaInfo, JediError> {
+        self.get(&format!("/api/v1/admin/users/{owner}/quota"), &[])
+            .await
+    }
+
+    /// Aggregates true used storage from Forgejo's per-owner quota API across
+    /// every user and org: git repos, LFS, packages, Actions artifacts and
+    /// attachments (all in bytes). Requires quota tracking enabled on the
+    /// instance; when disabled the totals come back zero and callers should
+    /// fall back to [`repo_stats`].
+    pub async fn instance_storage(&self) -> Result<ForgejoStorage, JediError> {
+        const PAGE: u32 = 50;
+        const MAX_OWNERS: usize = 1000;
+        let mut storage = ForgejoStorage::default();
+        let mut owners: Vec<String> = Vec::new();
+
+        let mut page = 1u32;
+        loop {
+            let batch = self.list_admin_users(page, PAGE).await?;
+            let n = batch.len() as u32;
+            owners.extend(batch.into_iter().map(|u| u.login));
+            if n < PAGE || owners.len() >= MAX_OWNERS {
+                break;
+            }
+            page += 1;
+        }
+        let mut page = 1u32;
+        loop {
+            let batch = self.list_orgs(page, PAGE).await?;
+            let n = batch.len() as u32;
+            owners.extend(batch.into_iter().map(|o| o.username));
+            if n < PAGE || owners.len() >= MAX_OWNERS {
+                break;
+            }
+            page += 1;
+        }
+        if owners.len() > MAX_OWNERS {
+            owners.truncate(MAX_OWNERS);
+            storage.truncated = true;
+        }
+
+        for owner in &owners {
+            if let Ok(q) = self.owner_quota(owner).await {
+                let s = &q.used.size;
+                storage.repos_bytes += s.repos.public + s.repos.private;
+                storage.lfs_bytes += s.git.lfs;
+                storage.attachments_bytes +=
+                    s.assets.attachments.issues + s.assets.attachments.releases;
+                storage.artifacts_bytes += s.assets.artifacts;
+                storage.packages_bytes += s.assets.packages.all;
+                storage.owners_counted += 1;
+            }
+        }
+        storage.total_bytes = storage.repos_bytes
+            + storage.lfs_bytes
+            + storage.attachments_bytes
+            + storage.artifacts_bytes
+            + storage.packages_bytes;
+        storage.quota_enabled = storage.total_bytes > 0;
+        Ok(storage)
     }
 
     // ── Actions runners ──────────────────────────────────────────────

--- a/packages/rust/jedi/src/entity/forgejo/types.rs
+++ b/packages/rust/jedi/src/entity/forgejo/types.rs
@@ -26,6 +26,10 @@ pub struct ForgejoRepo {
     #[serde(default)]
     pub size: u64,
     #[serde(default)]
+    pub git_size: u64,
+    #[serde(default)]
+    pub lfs_size: u64,
+    #[serde(default)]
     pub default_branch: String,
     #[serde(default)]
     pub updated_at: String,
@@ -286,12 +290,91 @@ pub struct ForgejoVersion {
 pub struct ForgejoStats {
     pub repo_count: u64,
     pub total_size_kb: u64,
+    pub git_size_kb: u64,
+    pub lfs_size_kb: u64,
     pub public: u64,
     pub private: u64,
     pub mirror: u64,
     pub archived: u64,
     pub fork: u64,
     pub truncated: bool,
+}
+
+// Forgejo quota API ("used" bytes). Fields default to 0 so instances with
+// quota tracking disabled (or older versions) deserialize to an empty quota.
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaInfo {
+    #[serde(default)]
+    pub used: QuotaUsed,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaUsed {
+    #[serde(default)]
+    pub size: QuotaUsedSize,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaUsedSize {
+    #[serde(default)]
+    pub repos: QuotaRepos,
+    #[serde(default)]
+    pub git: QuotaGit,
+    #[serde(default)]
+    pub assets: QuotaAssets,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaRepos {
+    #[serde(default)]
+    pub public: u64,
+    #[serde(default)]
+    pub private: u64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaGit {
+    #[serde(rename = "LFS", default)]
+    pub lfs: u64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaAssets {
+    #[serde(default)]
+    pub attachments: QuotaAttachments,
+    #[serde(default)]
+    pub artifacts: u64,
+    #[serde(default)]
+    pub packages: QuotaPackages,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaAttachments {
+    #[serde(default)]
+    pub issues: u64,
+    #[serde(default)]
+    pub releases: u64,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct QuotaPackages {
+    #[serde(default)]
+    pub all: u64,
+}
+
+/// Instance storage aggregated from per-owner Forgejo quota (bytes).
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ForgejoStorage {
+    pub quota_enabled: bool,
+    pub owners_counted: u64,
+    pub truncated: bool,
+    pub repos_bytes: u64,
+    pub lfs_bytes: u64,
+    pub attachments_bytes: u64,
+    pub artifacts_bytes: u64,
+    pub packages_bytes: u64,
+    pub total_bytes: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Makes the dashboard's storage number account for **LFS and the other categories**, answering "does it account for LFS?". Builds on #12298.

## #1 — git vs LFS split (cheap, from data we already get)
`ForgejoRepo` now captures `git_size` + `lfs_size` (recent Forgejo exposes these; older versions just yield 0 via serde defaults). `repo_stats()` sums them, so the Overview can show the git-vs-LFS split of repository storage. LFS was already inside Forgejo's total `size`; now it's explicit.

## #2 — true used storage via the Quota API
Repo size doesn't include packages / Actions artifacts / attachments. Forgejo's **quota API** does. New `ForgejoClient::instance_storage()` pages every user + org, sums `quota.used` per owner (bytes): `repos`, `git.LFS`, `assets.artifacts`, `assets.attachments`, `assets.packages` — with `quota_enabled` + `truncated` flags. New typed route **`GET /dashboard/forgejo/api/storage`** (DASHBOARD_VIEW).

The Overview now shows true **Total Storage** with an `LFS · pkg · artifacts` breakdown when quota tracking is enabled; when it's off, it falls back to the repo-size sum (labelled **Repo Storage**).

> Caveat: quota tracking is opt-in on the instance (`[quota] ENABLED = true`). When disabled the totals come back zero and the UI uses the repo-size fallback.

Skipped node/`df` filesystem usage by request (don't need the overhead data).

## Verify
- `./kbve.sh -nx axum-kbve:build` ✓
- `./kbve.sh -nx astro-kbve:build` ✓ (7742 pages)