### PR TITLE
chore(arc-runner): bump image 0.1.4 → 0.1.5 (rebuild on runner 2.335.1)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -54,7 +54,7 @@
 		{
 			"key": "arc_runner",
 			"app_name": "arc-runner",
-			"version": "0.1.4",
+			"version": "0.1.5",
 			"version_toml": "packages/docker/arc-runner/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx",
 			"source_path": "packages/docker/arc-runner",
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.16",
+			"version": "0.1.18",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -120,7 +120,7 @@
 		{
 			"key": "cryptothrone_server",
 			"app_name": "cryptothrone-server",
-			"version": "0.0.8",
+			"version": "0.0.10",
 			"version_toml": "apps/agones/cryptothrone/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
 			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",

--- a/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/arc-runner.mdx
@@ -12,7 +12,7 @@ tags:
 key: arc_runner
 pipeline: docker
 app_name: arc-runner
-version: "0.1.4"
+version: "0.1.5"
 source_path: packages/docker/arc-runner
 version_toml: packages/docker/arc-runner/version.toml
 runner: ubuntu-latest
@@ -66,7 +66,7 @@ The image runs as the upstream `runner` user by default. The pod spec sets `runA
 
 | Arg | Default | Purpose |
 |-----|---------|---------|
-| `ACTIONS_RUNNER_VERSION` | `2.334.0` | Upstream `ghcr.io/actions/actions-runner` tag the image is layered onto. Bump to follow upstream minor releases. |
+| `ACTIONS_RUNNER_VERSION` | `2.335.1` | Upstream `ghcr.io/actions/actions-runner` tag the image is layered onto. Bump to follow upstream minor releases. |
 | `KUBECTL_VERSION` | `1.31.0` | Pinned `kubectl` release. SHA verified against `dl.k8s.io/release/v<KUBECTL_VERSION>/bin/linux/amd64/kubectl.sha256` at build. |
 | `DBMATE_VERSION` | `2.28.0` | Pinned `dbmate` release. Tracks the in-cluster `ci-dbmate-deploy` Job image for parity. |
 


### PR DESCRIPTION
## Why

#12304 bumps the upstream UE scale sets + the `arc-runner` Dockerfile to runner **2.335.1**. But the *internal* `ghcr.io/kbve/arc-runner` image (used by `arc-runner-set` + `arc-runner-set-kbve`, incl. `win_vm_boot`) is still the old `:0.1.4` build baked on the deprecated runner. This bumps the MDX `version:` `0.1.4 → 0.1.5` so CI rebuilds the image off the 2.335.1 Dockerfile.

## What

- `arc-runner.mdx` `version:` → `0.1.5` (CI-registry convention — version gate triggers the rebuild).
- Doc `ACTIONS_RUNNER_VERSION` default → `2.335.1`.
- Manifest regenerated (build + `sync:ci-manifest`).

Post-publish atom PR auto-syncs `version.toml` + the `values.yaml` / `values-kbve.yaml` `:0.1.4 → :0.1.5` image tags (+ restart annotation), rolling the kbve scale sets onto a non-deprecated runner.

## Order

Depends on **#12304** (the Dockerfile 2.335.1 change) being on main when the 0.1.5 build runs, so the rebuild picks up the new runner version. They land together in the next dev→main release.

## Note

Manifest also catches up pre-existing dev MDX bumps (`cryptothrone` 0.1.18, `cryptothrone-server` 0.0.10) the stale manifest hadn't reflected — their own pending publishes, not introduced here.