### PR TITLE
fix(guild-vault): emit token_id in list_tokens so the row schema validates

### DIFF
--- a/apps/kbve/edge/functions/guild-vault/tokens.ts
+++ b/apps/kbve/edge/functions/guild-vault/tokens.ts
@@ -111,7 +111,8 @@ const handlers: Record<string, Handler> = {
       return safeRpcError(error, "guild_vault_rpc");
     }
 
-    const tokens = Array.isArray(data) ? data : [];
+    const rows = Array.isArray(data) ? data : [];
+    const tokens = rows.map((t) => ({ ...t, token_id: t.id }));
     return jsonResponse({ success: true, tokens, count: tokens.length });
   },
 


### PR DESCRIPTION
## The actual cause of "saved but still TODO"

`discordsh.service_list_guild_tokens` returns the PK column as **`id`**, but the proto contract (`AgentTokenRow`) and every other RPC (`set_token` returns `token_id`, `delete_token` takes `token_id`) use **`token_id`**.

#12153 added `AgentTokenRowSchema.array().safeParse(...)` runtime validation in droid's `loadTokens`. `AgentTokenRow` requires `token_id` → every list response **failed validation** (it only had `id`) → `loadTokens` set `$tokensError` and bailed → `$tokens` never populated.

Downstream effects (all observed live):
- GitHub wizard's HMAC + PAT steps stayed on **TODO** even after a successful save (the wizard derives `stored` from `$tokens`, which was empty).
- The status pill never flipped — not a hydration bug; the data layer was blind.
- Token **delete** sent an undefined `token_id` (rows only had `id`).

It also pre-dated the validation: the old code passed the raw rows through, so the wizard happened to work off `service`/`token_name` while `token_id` was quietly undefined — the strict schema just surfaced the long-standing mismatch.

## Fix

Normalize at the edge (the contract boundary): map `id` → `token_id` in the `list_tokens` response. zod strips the leftover `id`. `set_token`/`delete` already use `token_id`, so this makes the whole vault surface consistent.

## Note (answers "does it store a ton of HMACs?")

No. `set_token` upserts by `(server_id, service, token_name)` and the webhook uses a fixed `token_name` (`github-webhook-hmac`), so save/rotate **overwrites the single row** — one `github_webhook` HMAC per guild. The duplication worry came from the list being invisible; with this fix the one stored row shows.

## Optional follow-up

Could instead alias `id AS token_id` in the SQL RPC (a dbmate migration) so the DB emits the contract name directly; the edge map is the immediate, deploy-light fix.