### PR TITLE
fix(arc-runner-ue): dind storage on emptyDir, not NFS RWX (overlayfs whiteout fail)

### DIFF
--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -21,7 +21,7 @@ maxRunners: 3
 template:
     metadata:
         annotations:
-            kbve.com/restart-trigger: '20260322-runner-as-uid1000'
+            kbve.com/restart-trigger: '20260613-dind-emptydir'
     spec:
         initContainers:
             - name: init-dind-externals
@@ -107,8 +107,7 @@ template:
             - name: dind-externals
               emptyDir: {}
             - name: dind-storage
-              persistentVolumeClaim:
-                  claimName: arc-dind-ue-cache
+              emptyDir: {}
             - name: engine-cache
               persistentVolumeClaim:
                   claimName: arc-engine-cache


### PR DESCRIPTION
## Why

With the runner version fixed (2.335.1), the `arc-runner-ue` server build finally *ran* — and failed extracting the Epic UE container image:

```
failed to convert whiteout file "usr/lib/i386-linux-gnu/.wh..wh..opq": operation not supported
##[error]Process completed with exit code 1.
```

dind uses the `overlayfs` storage driver, but `dind-storage` (`/var/lib/docker`) was backed by **`arc-dind-ue-cache` — a longhorn RWX (NFS) volume**. **overlayfs opaque-whiteout files (`.wh..wh..opq`) aren't supported on NFS**, so any image with opaque dirs (the UE image) fails to extract.

## Fix

Point `dind-storage` at **`emptyDir`** (local node disk) so overlayfs works — matching `values.yaml` + `values-kbve.yaml`, which already use `emptyDir` for dind (only `values-ue` was on the RWX PVC). Bump `restart-trigger` to roll the pods.

**Trade-off:** loses the cross-pod docker layer cache (the UE image re-pulls per runner pod), but the build actually runs. Correctness over cache.

## Follow-ups
- `arc-dind-ue-cache` PVC is now unreferenced → prune it to reclaim longhorn space.
- (Optional) if UE-image re-pull cost hurts, revisit with a node-local hostPath or a registry pull-through cache instead of NFS.

## Chain
2.335.1 (#12304/#12306) made runners execute → this makes their dind actually pull/extract images → the Linux client + dedicated server builds should now compile + cook.