### PR TITLE
fix(arc-runner-ue): kbve image (git-lfs) — Linux server + client builds fail without it

### DIFF
--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -21,11 +21,11 @@ maxRunners: 3
 template:
     metadata:
         annotations:
-            kbve.com/restart-trigger: '20260613-dind-emptydir'
+            kbve.com/restart-trigger: '20260613-ue-runner-gitlfs'
     spec:
         initContainers:
             - name: init-dind-externals
-              image: ghcr.io/actions/actions-runner:2.335.1
+              image: ghcr.io/kbve/arc-runner:0.1.5
               command:
                   [
                       'cp',
@@ -39,7 +39,7 @@ template:
                     mountPath: /home/runner/tmpDir
         containers:
             - name: runner
-              image: ghcr.io/actions/actions-runner:2.335.1
+              image: ghcr.io/kbve/arc-runner:0.1.5
               command: ['/home/runner/run.sh']
               env:
                   - name: DOCKER_HOST


### PR DESCRIPTION
## Root cause (the real build failure, now past all infra)

The Linux dedicated-server build got all the way to the game LFS pull and died:

```
git -c lfs.url=... lfs pull --include="apps/chuckrpg/unreal-chuck/**"
##[notice]Pulling LFS for apps/chuckrpg/unreal-chuck from https://git.kbve.com/KBVE/chuck.git/info/lfs
git: 'lfs' is not a git command.
##[error]Process completed with exit code 1.
```

`arc-runner-ue` runs the **upstream `ghcr.io/actions/actions-runner` image, which has no git-lfs**. But the build clones the game + pulls UE assets from the chuck Forgejo over **LFS**, so git-lfs is mandatory. This hits **both** Linux targets — the dedicated server *and* the Linux client (which clones `KBVE/chuck` + pulls its LFS).

## Fix

Point `arc-runner-ue`'s runner + init containers at **`ghcr.io/kbve/arc-runner:0.1.5`** — the custom image that bakes `git-lfs` (+ unzip/jq/gh) and is already on runner **2.335.1** (#12306). dind sidecar unchanged. `restart-trigger` bumped to roll the pods.

## After sync

Linux server + client builds get past the LFS pull → cook → server binary lands on the `chuckServerBeta` PVC, Linux client → itch. Win64 client builds on the VM (its `arc-runner-set-kbve` already on the kbve image). This is the last known blocker on the Linux path.