### PR TITLE
fix(astro-kbve): de-flake forum-tags test timeout (#12330)

### DIFF
--- a/apps/kbve/astro-kbve/vitest.config.ts
+++ b/apps/kbve/astro-kbve/vitest.config.ts
@@ -6,6 +6,8 @@ export default defineConfig({
 		globals: true,
 		environment: 'node',
 		include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+		testTimeout: 20000,
+		hookTimeout: 20000,
 	},
 	resolve: {
 		alias: {


### PR DESCRIPTION
## Problem
`src/data/forum-tags.test.ts` intermittently fails with `Test timed out in 5000ms` (#12330). The mock fetch resolves synchronously and a prior fix already mocks `AbortSignal.timeout`, so this is not a real hang — it's vitest's default 5s `testTimeout` being exceeded by module-resolution starvation under heavy CI parallelism (the *first* test in the file is the one that trips).

## Fix
Raise `testTimeout`/`hookTimeout` to 20s in `vitest.config.ts`. Still low enough to catch genuine hangs.

Verified: `vitest run forum-tags.test.ts` → 8/8 pass.

Closes #12330