### PR TITLE
fix(edge-e2e): warm routes sequentially to avoid SIGBUS (#12317)

### DIFF
--- a/apps/kbve/edge-e2e/e2e/helpers/http.ts
+++ b/apps/kbve/edge-e2e/e2e/helpers/http.ts
@@ -56,5 +56,7 @@ export async function warmRoutes(
 	paths: string[],
 	timeoutMs = DEFAULT_WARM_TIMEOUT_MS,
 ): Promise<void> {
-	await Promise.all(paths.map((p) => warmRoute(p, timeoutMs)));
+	for (const p of paths) {
+		await warmRoute(p, timeoutMs);
+	}
 }


### PR DESCRIPTION
## Problem
`CI - Docker / edge` fails (#12317): the `kbve/edge:latest` container `Exited (135)` (SIGBUS) ~2s after boot, so `/health` never warms within 45s.

Root cause: `warmRoutes` warms all **17 routes in parallel** via `Promise.all`. Each OPTIONS request still boots a worker isolate in the edge-runtime (`EdgeRuntime.userWorkers.create`), so 17 isolates spin up at once (`memoryLimitMb: 150` each ≈ 2.5GB spike) → edge-runtime native crash (SIGBUS / exit 135).

## Fix
Warm routes sequentially (`for…of`) so at most one worker isolate boots at a time. Slightly slower warm-up, no memory storm.

Closes #12317