### PR TITLE
feat(cryptothrone): live procedural zone scene + tile-pipeline polish

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -5,6 +5,7 @@ import { PhaserGame, laserEvents } from '@kbve/laser';
 import type { PhaserGameRef } from '@kbve/laser';
 import { PreloaderScene } from './scenes/PreloaderScene';
 import { CloudCityScene } from './scenes/CloudCityScene';
+import { ProceduralZoneScene } from './scenes/ProceduralZoneScene';
 import { GameStoreProvider, useGameDispatch } from './store/GameStoreContext';
 import { useEventBridge } from './store/useEventBridge';
 import { CharacterDialog } from './ui/CharacterDialog';
@@ -44,7 +45,7 @@ const PhaserCanvas = memo(function PhaserCanvas() {
 		() => ({
 			width: 800,
 			height: 600,
-			scenes: [PreloaderScene, CloudCityScene],
+			scenes: [PreloaderScene, CloudCityScene, ProceduralZoneScene],
 			backgroundColor: '#1a1a2e',
 			pixelArt: true,
 			plugins: {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/dungeon.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/dungeon.ts
@@ -280,6 +280,7 @@ export interface TilePalette {
 	tileSize: number;
 	tilesetImage: string;
 	tilesetColumns: number;
+	tileCount: number;
 	entries: Record<number, number[]>;
 	animations?: Record<number, TileAnimation>;
 	collision?: Record<number, boolean>;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/palette.test.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/palette.test.ts
@@ -17,9 +17,7 @@ function assertValid(p: TilePalette) {
 	for (const gids of Object.values(p.entries))
 		for (const g of gids) {
 			expect(g).toBeGreaterThanOrEqual(1);
-			expect(g).toBeLessThanOrEqual(
-				(p as { tileCount: number }).tileCount,
-			);
+			expect(g).toBeLessThanOrEqual(p.tileCount);
 		}
 }
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/tiledb.test.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/tiledb.test.ts
@@ -56,9 +56,7 @@ describe('packed palette carries catalog animation + collision', () => {
 		expect(anim, 'water gid should be animated').toBeDefined();
 		expect(anim!.frames.length).toBeGreaterThanOrEqual(2);
 		for (const f of anim!.frames)
-			expect(f).toBeLessThanOrEqual(
-				(CITY_PALETTE as { tileCount: number }).tileCount,
-			);
+			expect(f).toBeLessThanOrEqual(CITY_PALETTE.tileCount);
 	});
 
 	it('collision map covers every gid the palette can place', () => {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/PreloaderScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/PreloaderScene.ts
@@ -60,6 +60,18 @@ export class PreloaderScene extends Scene {
 	}
 
 	create() {
+		const params = new URLSearchParams(
+			typeof window !== 'undefined' ? window.location.search : '',
+		);
+		const zone = params.get('zone');
+		if (zone === 'town' || zone === 'dungeon') {
+			const seed = Number(params.get('seed'));
+			this.scene.start('ProceduralZone', {
+				zone,
+				seed: Number.isFinite(seed) && seed > 0 ? seed : undefined,
+			});
+			return;
+		}
 		this.scene.start('CloudCity');
 	}
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/ProceduralZoneScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/ProceduralZoneScene.ts
@@ -1,0 +1,149 @@
+import { Scene } from 'phaser';
+import {
+	townTilemap,
+	dungeonTilemap,
+	CITY_PALETTE,
+	DUNGEON_PALETTE,
+	type TilePalette,
+} from '../data/dungeon';
+
+type ZoneKind = 'town' | 'dungeon';
+
+/**
+ * Standalone live render of a seed-deterministic procedural zone, driven end to
+ * end by the tile pipeline: generator role grid -> packed per-biome atlas +
+ * TilePalette (gen-palette-atlas) -> Phaser tilemap. Animated tiles cycle from
+ * the palette's `animations`; layer collision comes from the palette's per-gid
+ * `collision`. Reachable via `?zone=town|dungeon&seed=N`; no server, no netcode
+ * — proves the catalog/palette renders in the real client.
+ */
+export class ProceduralZoneScene extends Scene {
+	private zone: ZoneKind = 'town';
+	private seed = 2024;
+	private layer?: Phaser.Tilemaps.TilemapLayer;
+
+	constructor() {
+		super('ProceduralZone');
+	}
+
+	init(data: { zone?: ZoneKind; seed?: number }) {
+		if (data.zone === 'town' || data.zone === 'dungeon')
+			this.zone = data.zone;
+		if (Number.isFinite(data.seed)) this.seed = Number(data.seed);
+	}
+
+	preload() {
+		this.load.spritesheet(
+			'city-atlas',
+			'/assets/map/palettes/cloud-city.atlas.png',
+			{ frameWidth: 16, frameHeight: 16 },
+		);
+		this.load.spritesheet(
+			'dungeon-atlas',
+			'/assets/map/palettes/dungeon.atlas.png',
+			{ frameWidth: 16, frameHeight: 16 },
+		);
+	}
+
+	create() {
+		const isDungeon = this.zone === 'dungeon';
+		const tm = isDungeon
+			? dungeonTilemap(this.seed)
+			: townTilemap(this.seed);
+		const palette: TilePalette = isDungeon ? DUNGEON_PALETTE : CITY_PALETTE;
+		const atlasKey = isDungeon ? 'dungeon-atlas' : 'city-atlas';
+
+		// Flat gid layer -> 2D index grid (Phaser tile index = gid - 1).
+		const flat = tm.layers[0].data;
+		const grid: number[][] = [];
+		for (let y = 0; y < tm.height; y++) {
+			const row: number[] = [];
+			for (let x = 0; x < tm.width; x++)
+				row.push(flat[y * tm.width + x] - 1);
+			grid.push(row);
+		}
+
+		const map = this.make.tilemap({
+			data: grid,
+			tileWidth: tm.tileSize,
+			tileHeight: tm.tileSize,
+		});
+		const tileset = map.addTilesetImage(atlasKey);
+		this.layer =
+			(tileset
+				? (map.createLayer(
+						0,
+						tileset,
+						0,
+						0,
+					) as Phaser.Tilemaps.TilemapLayer | null)
+				: null) ?? undefined;
+
+		if (this.layer && palette.collision) {
+			const blocking = Object.entries(palette.collision)
+				.filter(([, blocks]) => blocks)
+				.map(([gid]) => Number(gid) - 1);
+			this.layer.setCollision(blocking);
+		}
+
+		this.startTileAnimations(palette);
+
+		this.cameras.main.setBounds(
+			0,
+			0,
+			tm.width * tm.tileSize,
+			tm.height * tm.tileSize,
+		);
+		this.cameras.main.centerOn(
+			tm.spawn.x * tm.tileSize,
+			tm.spawn.y * tm.tileSize,
+		);
+		this.enablePanZoom();
+
+		this.add
+			.text(8, 8, `${tm.name} — seed ${this.seed}`, {
+				font: '12px monospace',
+				color: '#ffffff',
+				backgroundColor: '#000000a0',
+				padding: { x: 6, y: 4 },
+			})
+			.setScrollFactor(0)
+			.setDepth(1000);
+	}
+
+	/** Cycle each animated palette tile's index over its frame list. */
+	private startTileAnimations(palette: TilePalette) {
+		if (!palette.animations) return;
+		for (const anim of Object.values(palette.animations)) {
+			const indices = anim.frames.map((g) => g - 1);
+			if (indices.length < 2) continue;
+			const period = (anim.frameDurations?.[0] ?? 0.5) * 1000;
+			let frame = 0;
+			this.time.addEvent({
+				delay: period,
+				loop: anim.loop ?? true,
+				callback: () => {
+					const from = indices[frame];
+					frame = (frame + 1) % indices.length;
+					this.layer?.replaceByIndex(from, indices[frame]);
+					void from;
+				},
+			});
+		}
+	}
+
+	private enablePanZoom() {
+		const cam = this.cameras.main;
+		this.input.on('pointermove', (p: Phaser.Input.Pointer) => {
+			if (!p.isDown) return;
+			cam.scrollX -= (p.x - p.prevPosition.x) / cam.zoom;
+			cam.scrollY -= (p.y - p.prevPosition.y) / cam.zoom;
+		});
+		this.input.on(
+			'wheel',
+			(_p: unknown, _o: unknown, _dx: number, dy: number) => {
+				cam.zoom = Phaser.Math.Clamp(cam.zoom - dy * 0.001, 0.5, 4);
+			},
+		);
+	}
+}

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -338,6 +338,10 @@ export default defineConfig({
 							label: 'NpcDB',
 							items: [{ autogenerate: { directory: 'npcdb' } }],
 						},
+						{
+							label: 'TileDB',
+							items: [{ autogenerate: { directory: 'tiledb' } }],
+						},
 					],
 				},
 				{

--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -252,6 +252,29 @@
 			},
 			"cache": true
 		},
+		"sync:mapdb-zod": {
+			"executor": "nx:run-commands",
+			"dependsOn": ["devops:build"],
+			"inputs": [
+				"{workspaceRoot}/packages/data/proto/map/mapdb.proto",
+				"{workspaceRoot}/packages/data/proto/kbve/common.proto",
+				"{workspaceRoot}/packages/data/codegen/mapdb-zod-config.json",
+				"{workspaceRoot}/packages/data/codegen/gen-mapdb-zod.mjs"
+			],
+			"outputs": [
+				"{workspaceRoot}/packages/data/codegen/descriptors/mapdb.binpb",
+				"{workspaceRoot}/packages/data/codegen/generated/mapdb-schema.ts"
+			],
+			"options": {
+				"commands": [
+					"protoc --include_imports --descriptor_set_out=packages/data/codegen/descriptors/mapdb.binpb --proto_path=packages/data/proto map/mapdb.proto",
+					"npx tsx packages/data/codegen/gen-mapdb-zod.mjs"
+				],
+				"parallel": false,
+				"cwd": "{workspaceRoot}"
+			},
+			"cache": true
+		},
 		"sync:itemdb": {
 			"executor": "nx:run-commands",
 			"inputs": [

--- a/packages/data/codegen/mapdb-zod-config.json
+++ b/packages/data/codegen/mapdb-zod-config.json
@@ -5,11 +5,6 @@
 			"stripPrefix": "BIOME_",
 			"caseTransform": "lowercase"
 		},
-		"map.TileRole": {
-			"mode": "const_array",
-			"stripPrefix": "TILE_ROLE_",
-			"caseTransform": "lowercase"
-		},
 		"map.ZoneType": {
 			"mode": "const_array",
 			"stripPrefix": "ZONE_TYPE_",


### PR DESCRIPTION
Audit loop-back. Headline finding: the seed-gen + palette + tiledb pipeline (5 merged PRs) was **runtime-dead** — nothing in a live scene loaded the packed atlas. This wires it in, plus fixes the small issues the audit surfaced.

## Live zone (resolves the dead-code headline)
- **`ProceduralZoneScene`** — renders a seed-deterministic town/dungeon through the packed per-biome atlas + `TilePalette`, end to end in the real Phaser client:
  - animates tiles from `palette.animations` (water = live 2-frame cycle via `replaceByIndex`)
  - sets Phaser layer collision from `palette.collision` (per-gid)
  - pan/zoom camera, centered on spawn
- Reachable via **`?zone=town|dungeon&seed=N`** — `PreloaderScene` routes there; default path still loads `CloudCity`. Registered in `GameWindow`.
- No server/netcode — a render proof that the catalog→palette pipeline is live, not a multiplayer zone.

## Polish (audit fixes)
- **tiledb sidebar** — the 10 tile MDX pages were building but orphaned from nav; added a `TileDB` sidebar group alongside MapDB/NpcDB.
- **`sync:mapdb-zod` nx target** — editing the proto + running `sync:mapdb` regenerated JSON/C# but left `mapdb-schema.ts` stale (Zod regen was a manual `devops:build` + `tsx` step). New target regenerates descriptor + schema in one shot (`dependsOn: devops:build`).
- **removed no-op `TileRole` zod-config entry** — it never emitted an enum (`role` stayed `z.string()`); `ITileSchema`'s inline enum is the working source.
- **`TilePalette.tileCount`** added to the interface; drops the `(as { tileCount })` casts in the palette/tiledb tests.

## Verified
- vitest **17/17**
- `astro check`: the touched files (ProceduralZoneScene, dungeon.ts, Preloader, GameWindow, tests) are **type-clean**. Remaining check errors are pre-existing on dev (CloudCityScene, two .astro files) — untouched here.
- offline render of town/dungeon through the packed atlas is pixel-correct (prior PRs).

## Not done
- **No live browser screenshot** captured — scene compiles + uses the offline-proven data/atlas, but in-Phaser render is unverified here. Test live on dev: open the game with `?zone=town&seed=2024`.
- No server-authoritative dungeon zone (this is client-render only). No version bump.