### PR TITLE
fix(rows): cap per-tenant DB pool at 10 — fixes api-beta 503 (ows connection exhaustion)

### DIFF
--- a/apps/kube/rows/tenants/base/deployment.yaml
+++ b/apps/kube/rows/tenants/base/deployment.yaml
@@ -41,6 +41,8 @@ spec:
                         value: '4324'
                       - name: RUST_LOG
                         value: 'info'
+                      - name: DB_MAX_CONNECTIONS
+                        value: '10'
                       - name: OWS_API_KEY
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## api-beta.chuckrpg.com — why it's 503

DNS + Cloudflare + gateway + HTTPRoute are all correct. The **backend is down**: `rows-chuckrpg-beta` has crashlooped 21h (163 restarts) on:

```
Error: pool timed out while waiting for an open connection
FATAL: too many connections for role "ows"
```

rows defaults `DB_MAX_CONNECTIONS=50` (`apps/rows/src/db.rs`). Every `ows` client — dev + beta + rentearth tenants, plus the legacy `rows`-ns backend — opens a 50-connection pool, exhausting the `ows` role limit. dev grabbed its connections first; beta gets none → crashloop → 503.

## Fix

Set `DB_MAX_CONNECTIONS=10` in the tenant base (applies to dev/beta/rentearth). 3 tenants × 10 + the legacy backend fits under the role limit → beta gets connections and serves → api-beta returns 200.

## Follow-up (frees the most headroom)
Retire the legacy unrouted `rows`-ns backend (still holding a 50-conn pool, superseded by the per-tenant tenants). Separate ArgoCD app, not in app-of-apps — needs its own teardown.

## Status note
The Linux dedicated-server build is now cooking (past the git-lfs fix #12325). This unblocks the *runtime* side — once the server binary lands + beta backend serves, the agones beta gameservers can reach a healthy ROWS at api-beta.