### PR TITLE
chore(kube): reloader watch forgejo-deploy-keys (auto-restart on Forgejo token rotation)

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
         # picks up the new Postgres password. Without this the pool holds
         # stale creds and `/api/v1/wallet/*` starts 5xx-ing until manual
         # restart on every CNPG password rotation.
-        secret.reloader.stakater.com/reload: 'supabase-shared'
+        secret.reloader.stakater.com/reload: 'supabase-shared,forgejo-deploy-keys'
 spec:
     replicas: 1
     strategy:
@@ -28,7 +28,7 @@ spec:
     template:
         metadata:
             annotations:
-                rollout-restart: '2026-05-13T23:30:00Z'
+                rollout-restart: '2026-06-13T16:30:00Z'
             labels:
                 app: kbve
                 version: '1.0.22'


### PR DESCRIPTION
Prep for rotating the Forgejo API token to admin scope (issue #9789).

The kbve deploy reads `FORGEJO_AUTH_TOKEN` from the `forgejo-deploy-keys` secret, but Reloader only watched `supabase-shared` — so a token rotation needed a manual `kubectl rollout restart` before the new token took effect. Adds `forgejo-deploy-keys` to the reload list so future rotations self-restart (belt-and-suspenders with a bumped `rollout-restart` annotation).

Note: `forgejo-deploy-keys/api-token` is a **shared** token (kbve dashboard + GitHub ARC runners), so the replacement must be a full-scope admin token that keeps `repository` read/write.

No code/build impact — manifest annotation only.