### PR TITLE
feat(irc-gateway): chat history ring buffer + fix(cryptothrone): chat echo + icon fallback

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/itemdb.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/itemdb.ts
@@ -1,6 +1,18 @@
 import rawItemdb from '@kbve/itemdb-data';
 import type { ItemData, ItemAction, ItemRarity } from '../types';
 
+// Inline SVG placeholder for item icons whose sprite is missing (the default
+// /assets/icons/<ref>.png path has no backing file for many items). A data URI
+// can't 404, so it sidesteps Cloudflare caching a missing-asset 404.
+const FALLBACK_SVG =
+	'<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">' +
+	'<rect width="32" height="32" rx="4" fill="#3f3f46"/>' +
+	'<text x="16" y="22" font-size="16" fill="#a1a1aa" text-anchor="middle" ' +
+	'font-family="monospace">?</text></svg>';
+export const ITEM_ICON_FALLBACK = `data:image/svg+xml;utf8,${encodeURIComponent(
+	FALLBACK_SVG,
+)}`;
+
 const FLAG_WEAPON = 1 << 0;
 const FLAG_ARMOR = 1 << 1;
 const FLAG_FOOD = 1 << 3;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
@@ -128,8 +128,16 @@ export function ChatBar() {
 	const submit = (e: React.FormEvent) => {
 		e.preventDefault();
 		const text = draft.trim();
-		if (!text) return;
+		if (!text || !connected) return;
 		clientRef.current?.send(text);
+		// Local echo — IRC never sends a client its own PRIVMSG back, so
+		// without this the sender never sees the message they just sent.
+		setLines((prev) =>
+			[
+				...prev,
+				{ id: ++lineCounter, from: me, text, at: timestamp() },
+			].slice(-MAX_LINES),
+		);
 		setDraft('');
 	};
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Hotbar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/Hotbar.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 import { laserEvents } from '@kbve/laser';
 import { useGameSelector } from '../store/GameStoreContext';
 import { getItemById } from '../data/items';
+import { ITEM_ICON_FALLBACK } from '../data/itemdb';
 
 const SLOTS = 4;
 
@@ -48,6 +49,11 @@ export function Hotbar() {
 							<img
 								src={item.img}
 								alt={item.name}
+								onError={(e) => {
+									const el = e.currentTarget;
+									if (el.src !== ITEM_ICON_FALLBACK)
+										el.src = ITEM_ICON_FALLBACK;
+								}}
 								className="h-full w-full object-contain p-1"
 							/>
 						)}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { laserEvents } from '@kbve/laser';
 import { getItemById } from '../data/items';
+import { ITEM_ICON_FALLBACK } from '../data/itemdb';
 
 const RARITY_BORDER: Record<string, string> = {
 	common: 'border-stone-400/50',
@@ -82,6 +83,11 @@ export function InventoryGrid({ backpack }: InventoryGridProps) {
 								<img
 									src={item.img}
 									alt={item.name}
+									onError={(e) => {
+										const el = e.currentTarget;
+										if (el.src !== ITEM_ICON_FALLBACK)
+											el.src = ITEM_ICON_FALLBACK;
+									}}
 									className={`w-8 h-8 border ${
 										RARITY_BORDER[item.rarity] ??
 										'border-yellow-400/50'

--- a/apps/irc/irc-gateway/src/gateway/history.rs
+++ b/apps/irc/irc-gateway/src/gateway/history.rs
@@ -1,0 +1,185 @@
+//! Per-channel chat history ring buffer.
+//!
+//! Each `/minechat` and `/gamechat` session is an independent ergo proxy with
+//! no shared state, so a freshly-connected client sees an empty channel even
+//! when others have been talking. This module keeps the last [`HISTORY_LEN`]
+//! messages per channel so a new client can be shown recent backscroll on
+//! connect.
+//!
+//! A single dedicated "listener" task per channel owns the writes: it holds its
+//! own ergo connection, joins the channel, and appends every PRIVMSG it sees to
+//! the buffer. Client sessions are pure readers ([`recent`]) — this avoids the
+//! N-fold duplication you'd get if every client connection appended what it
+//! received.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use bevy_chat::ChatMessage;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::time::sleep;
+use tracing::{debug, info, warn};
+
+/// Messages retained per channel.
+pub const HISTORY_LEN: usize = 10;
+
+/// Channels the gateway keeps history for (union of the game + minechat
+/// channel whitelists).
+const HISTORY_CHANNELS: &[&str] = &["#cryptothrone", "#world-events", "#mc-global"];
+
+type Store = Arc<Mutex<HashMap<String, VecDeque<ChatMessage>>>>;
+
+fn store() -> &'static Store {
+    static STORE: OnceLock<Store> = OnceLock::new();
+    STORE.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
+}
+
+/// Append a message to a channel's ring buffer, evicting the oldest past
+/// [`HISTORY_LEN`].
+fn push(channel: &str, msg: ChatMessage) {
+    let mut guard = store().lock().expect("history mutex poisoned");
+    let buf = guard.entry(channel.to_string()).or_default();
+    if buf.len() == HISTORY_LEN {
+        buf.pop_front();
+    }
+    buf.push_back(msg);
+}
+
+/// Snapshot a channel's buffered messages, oldest first.
+pub fn recent(channel: &str) -> Vec<ChatMessage> {
+    store()
+        .lock()
+        .expect("history mutex poisoned")
+        .get(channel)
+        .map(|b| b.iter().cloned().collect())
+        .unwrap_or_default()
+}
+
+/// Spawn one always-on listener task per tracked channel. Call once at startup.
+pub fn spawn_listeners() {
+    for ch in HISTORY_CHANNELS {
+        tokio::spawn(run_listener(ch.to_string()));
+    }
+}
+
+/// Keep a listener alive for a channel, reconnecting with a fixed backoff.
+async fn run_listener(channel: String) {
+    loop {
+        if let Err(e) = listen_once(&channel).await {
+            warn!(channel = %channel, "history listener dropped: {e}");
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn listen_once(channel: &str) -> std::io::Result<()> {
+    let host = std::env::var("ERGO_IRC_HOST")
+        .unwrap_or_else(|_| "ergo-irc-service.irc.svc.cluster.local".into());
+    let port: u16 = std::env::var("ERGO_IRC_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(6667);
+
+    let stream = TcpStream::connect(format!("{host}:{port}")).await?;
+    let (r, mut w) = stream.into_split();
+    let mut reader = BufReader::new(r);
+
+    let nick = format!("hist-{}", sanitize_channel(channel));
+    write_line(&mut w, &format!("NICK {nick}")).await?;
+    write_line(&mut w, &format!("USER {nick} 0 * :history listener")).await?;
+    write_line(&mut w, &format!("JOIN {channel}")).await?;
+    info!(channel = %channel, nick = %nick, "history listener joined");
+
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let n = reader.read_line(&mut line).await?;
+        if n == 0 {
+            return Ok(());
+        }
+        let raw = line[..n].trim_end_matches(['\r', '\n']).to_string();
+        if let Some(rest) = raw.strip_prefix("PING ") {
+            write_line(&mut w, &format!("PONG {rest}")).await?;
+            continue;
+        }
+        if let Some((ch, payload)) = parse_privmsg(&raw) {
+            if ch != channel {
+                continue;
+            }
+            if let Some(mut msg) = ChatMessage::from_irc_privmsg(&ch, &payload) {
+                if msg.platform.is_empty() {
+                    msg.platform = "irc".into();
+                }
+                debug!(channel = %channel, "history buffered a message");
+                push(channel, msg);
+            }
+        }
+    }
+}
+
+async fn write_line(w: &mut tokio::net::tcp::OwnedWriteHalf, line: &str) -> std::io::Result<()> {
+    w.write_all(line.as_bytes()).await?;
+    w.write_all(b"\r\n").await?;
+    w.flush().await
+}
+
+/// `#cryptothrone` -> `cryptothrone`; keep alphanumerics, lowercase.
+fn sanitize_channel(channel: &str) -> String {
+    channel
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+/// Parse `:nick!user@host PRIVMSG #channel :payload` -> `(channel, payload)`.
+fn parse_privmsg(line: &str) -> Option<(String, String)> {
+    let rest = if let Some(rest) = line.strip_prefix(':') {
+        rest.split_once(' ').map(|(_p, r)| r)?
+    } else {
+        line
+    };
+    let mut parts = rest.splitn(3, ' ');
+    if parts.next()? != "PRIVMSG" {
+        return None;
+    }
+    let channel = parts.next()?.to_string();
+    let trailing = parts.next()?;
+    let payload = trailing.strip_prefix(':').unwrap_or(trailing).to_string();
+    Some((channel, payload))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn msg(text: &str) -> ChatMessage {
+        ChatMessage::from_irc_privmsg("#t", &format!("[CHAT] a@irc: {text}")).unwrap()
+    }
+
+    #[test]
+    fn ring_buffer_evicts_oldest_and_keeps_order() {
+        let ch = "#ring-test";
+        for i in 0..HISTORY_LEN + 3 {
+            push(ch, msg(&format!("m{i}")));
+        }
+        let got = recent(ch);
+        assert_eq!(got.len(), HISTORY_LEN);
+        // oldest three (m0,m1,m2) evicted; newest retained in order
+        assert_eq!(got.first().unwrap().content, "m3");
+        assert_eq!(got.last().unwrap().content, format!("m{}", HISTORY_LEN + 2));
+    }
+
+    #[test]
+    fn sanitize_channel_strips_hash() {
+        assert_eq!(sanitize_channel("#cryptothrone"), "cryptothrone");
+        assert_eq!(sanitize_channel("#world-events"), "worldevents");
+    }
+
+    #[test]
+    fn recent_empty_for_unknown_channel() {
+        assert!(recent("#never-seen").is_empty());
+    }
+}

--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -212,6 +212,17 @@ async fn session(client_ws: WebSocket, nick: String, channels: Vec<String>, plat
     }
 
     let (mut client_tx, mut client_rx) = client_ws.split();
+
+    // Replay recent channel history so a fresh client lands in a room with
+    // context instead of an empty log.
+    for ch in &channels {
+        for msg in crate::gateway::history::recent(ch) {
+            if send_json(&mut client_tx, &msg).await.is_err() {
+                return;
+            }
+        }
+    }
+
     let (pulse_tx, mut pulse_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
 
     let nick_c2i = nick.clone();

--- a/apps/irc/irc-gateway/src/gateway/mod.rs
+++ b/apps/irc/irc-gateway/src/gateway/mod.rs
@@ -1,3 +1,4 @@
+pub mod history;
 pub mod irc;
 pub mod minechat;
 pub mod rest;

--- a/apps/irc/irc-gateway/src/main.rs
+++ b/apps/irc/irc-gateway/src/main.rs
@@ -31,6 +31,8 @@ async fn main() -> anyhow::Result<()> {
 
     info!("IRC Gateway v{}", env!("CARGO_PKG_VERSION"));
 
+    gateway::history::spawn_listeners();
+
     let http = tokio::spawn(transport::https::serve());
     let irc = tokio::spawn(gateway::irc::serve());
 


### PR DESCRIPTION
Three reported issues, diagnosed + fixed.

## #2 — chat connected (green) but typed message doesn't show
IRC servers never echo a client's own PRIVMSG back, and `ChatBar.submit` had no local echo — so your message went to *other* clients but never back to you (it'd show on a second computer). Fix: optimistic **local echo** on send (guarded on `connected`). One source-of-truth choice; no gateway round-trip lag.

## #3 — irc-gateway ring buffer (backscroll on join)
Gateway sessions were stateless per-connection (each an independent ergo proxy), so a fresh client landed in an empty room. New **`gateway/history.rs`**: keeps the last 10 messages per channel via **one dedicated listener task per channel** (its own ergo connection = single writer, no N-fold duplication). minechat/gamechat sessions **replay recent history to the client on connect** before the live stream. Listeners spawn at startup, reconnect with backoff.

## #1 — https://cryptothrone.com/assets/icons/coin.png 404 (cache question)
Diagnosis: it genuinely 404s **and** Cloudflare cached the 404 (`cf-cache-status: HIT`, `max-age=86400`) — the working computer just had a stale browser-cached 200. Root cause: `itemdb.ts` defaults icons to `/assets/icons/<ref>.png` but **those files don't exist anywhere in the repo**. Fix here: inline **data-URI fallback** (can't 404) via `onError` on the Hotbar + InventoryGrid icons, so missing icons degrade gracefully instead of caching 404s.

## Verified
- gateway `cargo test` **43/43** (incl. new history ring-buffer tests); touched files clippy-clean.
- cryptothrone vitest **17/17** for touched areas.
- `astro check`: touched client files type-clean.

## Notes / not done
- **Real item-icon sourcing is a separate effort** — the icons truly don't exist; a follow-up should generate them (atlas-slice pipeline, like the tile slicer) or point at a CDN. This PR only stops the broken-icon UX.
- **CF caching 404s** is an origin/edge config issue (don't send `cache-control` on 404 / page rule / purge) — ops follow-up, not code.
- No version bump.