### PR TITLE
cryptothrone game layers: simgrid ghosting + FloatingWindow migrations + z-bands

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/tiledb.test.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/tiledb.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { CITY_PALETTE, DUNGEON_PALETTE, Role } from './dungeon';
+
+// nx runs vitest with cwd at the project dir, not the workspace root, so anchor
+// on this file and walk up to the repo that holds the generated catalog.
+function resolveFromWorkspace(rel: string): string {
+	let dir = dirname(fileURLToPath(import.meta.url));
+	for (let i = 0; i < 12; i++) {
+		const candidate = resolve(dir, rel);
+		if (existsSync(candidate)) return candidate;
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
+	}
+	throw new Error(`could not locate ${rel} from ${import.meta.url}`);
+}
 
 const ROLE_NAMES = new Set([
 	'unspecified',
@@ -20,8 +35,7 @@ const ROLE_NAMES = new Set([
 
 const catalog: Array<Record<string, unknown>> = JSON.parse(
 	readFileSync(
-		resolve(
-			process.cwd(),
+		resolveFromWorkspace(
 			'packages/data/codegen/generated/tiledb-data.json',
 		),
 		'utf8',

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -3,6 +3,10 @@ import {
 	GameClient,
 	laserEvents,
 	createBirdAnimation,
+	flashEntity,
+	floatingText,
+	drawHealthBar,
+	attachCameraZoom,
 	ACTION_ATTACK,
 	ACTION_PICKUP,
 	KIND_CAT_ITEM,
@@ -364,18 +368,7 @@ export class CloudCityScene extends Scene {
 			this.client?.heartbeat();
 		}, 20000);
 
-		// Camera zoom: +/- keys and mouse wheel, clamped.
-		const zoom = (delta: number) => {
-			const cam = this.cameras.main;
-			cam.setZoom(Phaser.Math.Clamp(cam.zoom + delta, 0.6, 2.2));
-		};
-		this.input.keyboard?.on('keydown-PLUS', () => zoom(0.2));
-		this.input.keyboard?.on('keydown-MINUS', () => zoom(-0.2));
-		this.input.on(
-			'wheel',
-			(_p: unknown, _o: unknown, _dx: number, dy: number) =>
-				zoom(dy > 0 ? -0.15 : 0.15),
-		);
+		attachCameraZoom(this);
 	}
 
 	/**
@@ -464,24 +457,14 @@ export class CloudCityScene extends Scene {
 	private showFloatingText(eid: number, text: string, color: string) {
 		const target = this.tracked.get(eid);
 		if (!target) return;
-		const label = this.add
-			.text(target.sprite.x, target.sprite.y - 14, text, {
-				fontFamily: 'monospace',
-				fontSize: '14px',
-				color,
-				stroke: '#000000',
-				strokeThickness: 3,
-			})
-			.setOrigin(0.5, 1)
-			.setDepth(this.entityDepth + 1);
-		this.tweens.add({
-			targets: label,
-			y: label.y - 28,
-			alpha: 0,
-			duration: 900,
-			ease: 'Cubic.easeOut',
-			onComplete: () => label.destroy(),
-		});
+		floatingText(
+			this,
+			target.sprite.x,
+			target.sprite.y - 14,
+			text,
+			color,
+			this.entityDepth + 1,
+		);
 	}
 
 	private applySnapshot(snap: Snapshot) {
@@ -647,9 +630,7 @@ export class CloudCityScene extends Scene {
 	private flashSprite(eid: number) {
 		const target = this.tracked.get(eid);
 		if (!target) return;
-		target.sprite.setTintFill(0xffffff);
-		this.time.delayedCall(60, () => target.sprite.setTint(0xff6b6b));
-		this.time.delayedCall(180, () => target.sprite.clearTint());
+		flashEntity(this, target.sprite);
 	}
 
 	private updateHpBars() {
@@ -670,21 +651,7 @@ export class CloudCityScene extends Scene {
 			if (!t.hpBar) {
 				t.hpBar = this.add.graphics().setDepth(this.entityDepth + 1);
 			}
-			const w = 26;
-			const pct = Math.max(0, Math.min(1, t.hp / t.maxHp));
-			t.hpBar.clear();
-			t.hpBar.fillStyle(0x000000, 0.6);
-			t.hpBar.fillRect(t.sprite.x - w / 2, t.sprite.y - 30, w, 4);
-			t.hpBar.fillStyle(
-				pct > 0.5 ? 0x4ade80 : pct > 0.25 ? 0xfbbf24 : 0xf87171,
-				1,
-			);
-			t.hpBar.fillRect(
-				t.sprite.x - w / 2 + 0.5,
-				t.sprite.y - 29.5,
-				(w - 1) * pct,
-				3,
-			);
+			drawHealthBar(t.hpBar, t.sprite.x, t.sprite.y - 30, t.hp, t.maxHp);
 		}
 	}
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -7,6 +7,7 @@ import {
 	floatingText,
 	drawHealthBar,
 	attachCameraZoom,
+	findTilePath,
 	ACTION_ATTACK,
 	ACTION_PICKUP,
 	KIND_CAT_ITEM,
@@ -810,60 +811,10 @@ export class CloudCityScene extends Scene {
 	 */
 	private startMoveTo(tile: { x: number; y: number }) {
 		if (!this.client) return;
-		this.predictedPath = this.findLocalPath(this.predicted, tile);
+		this.predictedPath = findTilePath(this.predicted, tile, (x, y) =>
+			this.blocked.has(`${x},${y}`),
+		);
 		this.client.moveTo(tile);
-	}
-
-	private findLocalPath(
-		from: { x: number; y: number },
-		to: { x: number; y: number },
-	): { x: number; y: number }[] {
-		if (
-			(from.x === to.x && from.y === to.y) ||
-			this.blocked.has(`${to.x},${to.y}`)
-		)
-			return [];
-		// BFS mirroring the server (grid.rs find_path): neighbour order
-		// up/down/left/right, shortest path, capped length — same inputs +
-		// same tie-breaking keep client and server routes identical.
-		const MAX = 64;
-		const key = (x: number, y: number) => `${x},${y}`;
-		const prev = new Map<string, string | null>();
-		prev.set(key(from.x, from.y), null);
-		const queue = [from];
-		const dirs = [
-			[0, -1],
-			[0, 1],
-			[-1, 0],
-			[1, 0],
-		];
-		let found = false;
-		while (queue.length) {
-			const cur = queue.shift()!;
-			if (cur.x === to.x && cur.y === to.y) {
-				found = true;
-				break;
-			}
-			for (const [dx, dy] of dirs) {
-				const nx = cur.x + dx;
-				const ny = cur.y + dy;
-				const k = key(nx, ny);
-				if (prev.has(k) || this.blocked.has(k)) continue;
-				prev.set(k, key(cur.x, cur.y));
-				queue.push({ x: nx, y: ny });
-			}
-		}
-		if (!found) return [];
-		const path: { x: number; y: number }[] = [];
-		let cur: string | null = key(to.x, to.y);
-		while (cur && cur !== key(from.x, from.y)) {
-			const [x, y] = cur.split(',').map(Number);
-			path.push({ x, y });
-			cur = prev.get(cur) ?? null;
-			if (path.length > MAX) return [];
-		}
-		path.reverse();
-		return path;
 	}
 
 	private onPointerMove(pointer: Phaser.Input.Pointer) {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CharacterDialog.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CharacterDialog.tsx
@@ -1,3 +1,4 @@
+import { FloatingWindow } from '@kbve/astro';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 
 export function CharacterDialog() {
@@ -9,48 +10,54 @@ export function CharacterDialog() {
 	const handleClose = () => dispatch({ type: 'SET_MODAL', payload: null });
 
 	return (
-		<div className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900/50">
+		<FloatingWindow
+			storageKey="ct-character-dialog"
+			initial={{
+				x:
+					typeof window !== 'undefined'
+						? Math.max(12, (window.innerWidth - 640) / 2)
+						: 120,
+				y:
+					typeof window !== 'undefined'
+						? Math.max(12, (window.innerHeight - 420) / 3)
+						: 80,
+			}}
+			size={{ width: 640, height: 420 }}
+			minWidth={380}
+			minHeight={260}
+			title={modal.characterName || 'NPC'}
+			onClose={handleClose}>
 			<div
-				className="flex flex-col lg:flex-row bg-zinc-950 border border-yellow-500 shadow-sm rounded-xl bg-cover min-w-[700px] max-w-[900px] min-h-[400px]"
+				className="flex h-full flex-col bg-zinc-950 bg-cover lg:flex-row"
 				style={{
 					backgroundImage: modal.backgroundImage
 						? `url(${modal.backgroundImage})`
 						: undefined,
 				}}>
-				<div className="w-full lg:w-1/3 p-4 rounded-l-xl flex flex-col items-center justify-center relative">
-					<h3 className="font-bold text-yellow-400 bg-zinc-950/80 rounded-2xl text-center mb-4 p-2">
-						{modal.characterName || 'NPC'}
-					</h3>
+				<div className="flex w-full flex-col items-center justify-center p-4 lg:w-1/3">
 					{modal.characterImage && (
 						<img
 							src={modal.characterImage}
 							alt={modal.characterName || 'NPC'}
-							className="w-full h-auto rounded-md"
+							className="h-auto w-full rounded-md"
 						/>
 					)}
 				</div>
-				<div className="w-full lg:w-2/3 p-4 flex flex-col justify-between">
-					<div className="flex justify-end">
-						<button
-							onClick={handleClose}
-							className="text-yellow-400 hover:bg-gray-100/10 rounded-full p-1 text-xl">
-							&times;
-						</button>
-					</div>
-					<div className="p-4 overflow-y-auto flex-1">
-						<p className="text-yellow-400 bg-zinc-950/80 rounded-xl p-4">
+				<div className="flex w-full flex-col lg:w-2/3">
+					<div className="flex-1 overflow-y-auto p-4">
+						<p className="rounded-xl bg-zinc-950/80 p-4 text-yellow-400">
 							{modal.message}
 						</p>
 					</div>
-					<div className="flex justify-end py-3 px-4 border-t border-gray-700">
+					<div className="flex justify-end border-t border-gray-700 px-4 py-3">
 						<button
 							onClick={handleClose}
-							className="px-5 py-2 bg-yellow-500 hover:bg-yellow-400 text-white rounded transition-all">
+							className="rounded bg-yellow-500 px-5 py-2 text-white transition-all hover:bg-yellow-400">
 							Okay
 						</button>
 					</div>
 				</div>
 			</div>
-		</div>
+		</FloatingWindow>
 	);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { FloatingWindow } from '@kbve/astro';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 
 function rollDie(): number {
@@ -98,21 +99,33 @@ export function DiceRollModal() {
 	if (!diceRoll) return null;
 
 	return (
-		<div className="fixed inset-0 flex items-center justify-center z-50 bg-zinc-800/50 text-white">
-			<div className="bg-zinc-800 p-6 rounded-lg shadow-lg w-96 border border-yellow-500">
-				<h2 className="text-lg text-yellow-400 font-bold mb-4">
-					Steal Attempt
-				</h2>
+		<FloatingWindow
+			storageKey="ct-dice-window"
+			initial={{
+				x:
+					typeof window !== 'undefined'
+						? Math.max(12, (window.innerWidth - 360) / 2)
+						: 200,
+				y:
+					typeof window !== 'undefined'
+						? Math.max(12, (window.innerHeight - 320) / 3)
+						: 100,
+			}}
+			size={{ width: 360, height: 320 }}
+			resizable={false}
+			title="Steal Attempt"
+			onClose={handleClose}>
+			<div className="p-5 text-white">
 				<p className="mb-4 text-sm">
 					Roll the dice to steal from {diceRoll.npcName}. You need 17
 					or higher to succeed.
 				</p>
 
-				<div className="flex justify-center gap-3 mb-4">
+				<div className="mb-4 flex justify-center gap-3">
 					{diceRoll.diceValues.map((val, idx) => (
 						<div
 							key={idx}
-							className={`w-14 h-14 flex items-center justify-center bg-gray-700 border-2 rounded-lg text-3xl ${rolling ? 'border-yellow-300 animate-pulse' : val > 0 ? 'border-yellow-500' : 'border-gray-500'}`}>
+							className={`flex h-14 w-14 items-center justify-center rounded-lg border-2 bg-gray-700 text-3xl ${rolling ? 'animate-pulse border-yellow-300' : val > 0 ? 'border-yellow-500' : 'border-gray-500'}`}>
 							{val > 0 ? DICE_FACES[val] : '?'}
 						</div>
 					))}
@@ -121,7 +134,7 @@ export function DiceRollModal() {
 				{diceRoll.totalRoll !== null &&
 					diceRoll.phase === 'result' &&
 					!rolling && (
-						<p className="text-center text-lg mb-4">
+						<p className="mb-4 text-center text-lg">
 							Total:{' '}
 							<span
 								className={`font-bold ${diceRoll.totalRoll >= 17 ? 'text-green-400' : diceRoll.totalRoll <= 4 ? 'text-red-400' : 'text-yellow-400'}`}>
@@ -135,18 +148,18 @@ export function DiceRollModal() {
 						<button
 							onClick={handleRoll}
 							disabled={rolling}
-							className="flex-1 py-2 bg-yellow-500 hover:bg-yellow-400 text-white rounded transition-all disabled:opacity-50">
+							className="flex-1 rounded bg-yellow-500 py-2 text-white transition-all hover:bg-yellow-400 disabled:opacity-50">
 							{rolling ? 'Rolling...' : 'Roll Dice'}
 						</button>
 					)}
 					<button
 						onClick={handleClose}
 						disabled={rolling}
-						className="flex-1 py-2 bg-red-500 hover:bg-red-600 text-white rounded transition-all disabled:opacity-50">
+						className="flex-1 rounded bg-red-500 py-2 text-white transition-all hover:bg-red-600 disabled:opacity-50">
 						Close
 					</button>
 				</div>
 			</div>
-		</div>
+		</FloatingWindow>
 	);
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.12"
+version: "0.0.13"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.20"
+version: "0.1.21"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -16,7 +16,7 @@ export type { TooltipOverlayProps } from './react/TooltipOverlay';
 export { NotContent } from './react/NotContent';
 export type { NotContentProps } from './react/NotContent';
 export { FloatingWindow } from './react/FloatingWindow';
-export type { FloatingWindowProps } from './react/FloatingWindow';
+export type { FloatingWindowProps, WindowLayer } from './react/FloatingWindow';
 
 export { useDraggable } from './hooks/useDraggable';
 export type {

--- a/packages/npm/astro/src/index.ts
+++ b/packages/npm/astro/src/index.ts
@@ -15,6 +15,10 @@ export { TooltipOverlay } from './react/TooltipOverlay';
 export type { TooltipOverlayProps } from './react/TooltipOverlay';
 export { NotContent } from './react/NotContent';
 export type { NotContentProps } from './react/NotContent';
+export { Drawer } from './react/Drawer';
+export type { DrawerProps, DrawerSide } from './react/Drawer';
+export { Popover } from './react/Popover';
+export type { PopoverProps, PopoverPlacement } from './react/Popover';
 export { FloatingWindow } from './react/FloatingWindow';
 export type { FloatingWindowProps, WindowLayer } from './react/FloatingWindow';
 

--- a/packages/npm/astro/src/react/Drawer.tsx
+++ b/packages/npm/astro/src/react/Drawer.tsx
@@ -1,0 +1,171 @@
+import { useEffect, type CSSProperties, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../utils/cn';
+
+export type DrawerSide = 'left' | 'right' | 'top' | 'bottom';
+
+export interface DrawerProps {
+	open: boolean;
+	onClose?: () => void;
+	/** Edge the drawer slides in from. Defaults to `right`. */
+	side?: DrawerSide;
+	/** Width (left/right) or height (top/bottom) of the panel. */
+	size?: number | string;
+	title?: ReactNode;
+	children?: ReactNode;
+	/** Dim + blur behind the panel. Defaults to true. */
+	backdrop?: boolean;
+	closeOnBackdrop?: boolean;
+	closeOnEsc?: boolean;
+	className?: string;
+}
+
+const HORIZONTAL = (side: DrawerSide) => side === 'left' || side === 'right';
+
+function hiddenTransform(side: DrawerSide): string {
+	switch (side) {
+		case 'left':
+			return 'translateX(-100%)';
+		case 'right':
+			return 'translateX(100%)';
+		case 'top':
+			return 'translateY(-100%)';
+		case 'bottom':
+			return 'translateY(100%)';
+	}
+}
+
+/**
+ * Edge-anchored sliding panel. Starlight-safe (`.not-content` baked in), portal
+ * rendered, with backdrop + Escape dismissal. Sits in the modal z-band so it
+ * covers floating panels.
+ */
+export function Drawer({
+	open,
+	onClose,
+	side = 'right',
+	size = 320,
+	title,
+	children,
+	backdrop = true,
+	closeOnBackdrop = true,
+	closeOnEsc = true,
+	className,
+}: DrawerProps) {
+	useEffect(() => {
+		if (!open || !closeOnEsc) return;
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose?.();
+		};
+		document.addEventListener('keydown', handler);
+		return () => document.removeEventListener('keydown', handler);
+	}, [open, closeOnEsc, onClose]);
+
+	useEffect(() => {
+		if (!open) return;
+		const prev = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = prev;
+		};
+	}, [open]);
+
+	const horizontal = HORIZONTAL(side);
+	const dim = typeof size === 'number' ? `${size}px` : size;
+
+	const backdropStyle: CSSProperties = {
+		position: 'fixed',
+		inset: 0,
+		zIndex: 1000,
+		transition: 'opacity 200ms ease, visibility 200ms ease',
+		opacity: open ? 1 : 0,
+		visibility: open ? 'visible' : 'hidden',
+		pointerEvents: open ? 'auto' : 'none',
+		backgroundColor: backdrop
+			? 'var(--sl-color-backdrop-overlay, rgba(0,0,0,0.5))'
+			: 'transparent',
+		backdropFilter: backdrop ? 'blur(2px)' : undefined,
+	};
+
+	const panelStyle: CSSProperties = {
+		position: 'fixed',
+		zIndex: 1001,
+		top: side === 'bottom' ? 'auto' : 0,
+		bottom: side === 'top' ? 'auto' : 0,
+		left: side === 'right' ? 'auto' : 0,
+		right: side === 'left' ? 'auto' : 0,
+		width: horizontal ? dim : '100%',
+		height: horizontal ? '100%' : dim,
+		display: 'flex',
+		flexDirection: 'column',
+		background: 'var(--sl-color-bg-nav, #18181b)',
+		color: 'var(--sl-color-text, #f4f4f5)',
+		borderRight:
+			side === 'left' ? '1px solid rgba(255,255,255,0.1)' : undefined,
+		borderLeft:
+			side === 'right' ? '1px solid rgba(255,255,255,0.1)' : undefined,
+		borderBottom:
+			side === 'top' ? '1px solid rgba(255,255,255,0.1)' : undefined,
+		borderTop:
+			side === 'bottom' ? '1px solid rgba(255,255,255,0.1)' : undefined,
+		boxShadow: '0 0 40px rgba(0,0,0,0.4)',
+		transform: open ? 'none' : hiddenTransform(side),
+		transition: 'transform 220ms cubic-bezier(0.4,0,0.2,1)',
+	};
+
+	return createPortal(
+		<div
+			style={backdropStyle}
+			aria-hidden={!open}
+			onClick={(e) => {
+				if (open && closeOnBackdrop && e.target === e.currentTarget)
+					onClose?.();
+			}}>
+			<aside
+				className={cn('not-content', className)}
+				style={panelStyle}
+				role="dialog"
+				aria-modal={open}>
+				{(title || onClose) && (
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							justifyContent: 'space-between',
+							gap: 8,
+							padding: '10px 14px',
+							borderBottom: '1px solid rgba(255,255,255,0.08)',
+						}}>
+						<span style={{ fontWeight: 600 }}>{title}</span>
+						{onClose && (
+							<button
+								type="button"
+								onClick={onClose}
+								aria-label="Close"
+								style={{
+									background: 'none',
+									border: 'none',
+									color: 'var(--sl-color-gray-3, #a1a1aa)',
+									cursor: 'pointer',
+									fontSize: 18,
+									lineHeight: 1,
+									padding: 2,
+								}}>
+								&#x2715;
+							</button>
+						)}
+					</div>
+				)}
+				<div
+					style={{
+						flex: '1 1 auto',
+						minHeight: 0,
+						overflow: 'auto',
+					}}>
+					{children}
+				</div>
+			</aside>
+		</div>,
+		document.body,
+	);
+}

--- a/packages/npm/astro/src/react/FloatingWindow.tsx
+++ b/packages/npm/astro/src/react/FloatingWindow.tsx
@@ -11,12 +11,21 @@ import { cn } from '../utils/cn';
 import { useDraggable, type Position } from '../hooks/useDraggable';
 import { useResizable, type Size } from '../hooks/useResizable';
 
-// Base below the game's blocking-modal band (z-50+) so floating panels stay
-// under dialogs/overlays. A dedicated z-order manager will supersede this.
-let zCounter = 30;
-function nextZ(): number {
-	zCounter += 1;
-	return zCounter;
+export type WindowLayer = 'panel' | 'modal';
+
+// Two bounded z bands: panels float beneath blocking overlays, modal windows
+// sit above panels. Click-to-front advances within a band and clamps at its
+// ceiling so the counter never climbs into the next band.
+const Z_BANDS: Record<WindowLayer, { base: number; ceil: number }> = {
+	panel: { base: 30, ceil: 799 },
+	modal: { base: 800, ceil: 1599 },
+};
+const zTop: Record<WindowLayer, number> = { panel: 30, modal: 800 };
+
+function nextZ(layer: WindowLayer): number {
+	const band = Z_BANDS[layer];
+	zTop[layer] = Math.min(zTop[layer] + 1, band.ceil);
+	return zTop[layer];
 }
 
 interface Persisted extends Position, Partial<Size> {}
@@ -55,6 +64,8 @@ export interface FloatingWindowProps {
 	headerActions?: ReactNode;
 	/** Persist position + size under this localStorage key. */
 	storageKey?: string;
+	/** z-order band: `panel` floats under blocking overlays, `modal` above panels. */
+	layer?: WindowLayer;
 	/** Render into document.body instead of in place. */
 	portal?: boolean;
 	className?: string;
@@ -79,6 +90,7 @@ export function FloatingWindow({
 	onClose,
 	headerActions,
 	storageKey,
+	layer = 'panel',
 	portal = false,
 	className,
 	bodyClassName,
@@ -86,8 +98,8 @@ export function FloatingWindow({
 }: FloatingWindowProps) {
 	const persisted = useMemo(() => loadPersisted(storageKey), [storageKey]);
 	const panelRef = useRef<HTMLDivElement>(null);
-	const [z, setZ] = useState<number>(() => nextZ());
-	const bringForward = useCallback(() => setZ(nextZ()), []);
+	const [z, setZ] = useState<number>(() => nextZ(layer));
+	const bringForward = useCallback(() => setZ(nextZ(layer)), [layer]);
 
 	const clamp = useCallback((p: Position): Position => {
 		if (typeof window === 'undefined') return p;

--- a/packages/npm/astro/src/react/Popover.tsx
+++ b/packages/npm/astro/src/react/Popover.tsx
@@ -1,0 +1,133 @@
+import {
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+	type CSSProperties,
+	type ReactNode,
+	type RefObject,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../utils/cn';
+
+export type PopoverPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface PopoverProps {
+	open: boolean;
+	onClose?: () => void;
+	/** Element the popover anchors to. */
+	anchorRef: RefObject<HTMLElement | null>;
+	placement?: PopoverPlacement;
+	offset?: number;
+	children?: ReactNode;
+	className?: string;
+}
+
+/**
+ * Interactive anchored popover: positions next to an element, clamps to the
+ * viewport, and dismisses on outside-click or Escape. Starlight-safe
+ * (`.not-content`), portal rendered. Unlike TooltipOverlay this is for
+ * click-driven content (menus, pickers), not hover hints.
+ */
+export function Popover({
+	open,
+	onClose,
+	anchorRef,
+	placement = 'bottom',
+	offset = 8,
+	children,
+	className,
+}: PopoverProps) {
+	const panelRef = useRef<HTMLDivElement>(null);
+	const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+	useLayoutEffect(() => {
+		if (!open) {
+			setPos(null);
+			return;
+		}
+		const compute = () => {
+			const a = anchorRef.current?.getBoundingClientRect();
+			if (!a) return;
+			const p = panelRef.current?.getBoundingClientRect();
+			const pw = p?.width ?? 0;
+			const ph = p?.height ?? 0;
+			let top = 0;
+			let left = 0;
+			switch (placement) {
+				case 'bottom':
+					top = a.bottom + offset;
+					left = a.left + a.width / 2 - pw / 2;
+					break;
+				case 'top':
+					top = a.top - ph - offset;
+					left = a.left + a.width / 2 - pw / 2;
+					break;
+				case 'right':
+					left = a.right + offset;
+					top = a.top + a.height / 2 - ph / 2;
+					break;
+				case 'left':
+					left = a.left - pw - offset;
+					top = a.top + a.height / 2 - ph / 2;
+					break;
+			}
+			left = Math.max(8, Math.min(left, window.innerWidth - pw - 8));
+			top = Math.max(8, Math.min(top, window.innerHeight - ph - 8));
+			setPos({ top, left });
+		};
+		compute();
+		window.addEventListener('resize', compute);
+		window.addEventListener('scroll', compute, true);
+		return () => {
+			window.removeEventListener('resize', compute);
+			window.removeEventListener('scroll', compute, true);
+		};
+	}, [open, placement, offset, anchorRef]);
+
+	useEffect(() => {
+		if (!open) return;
+		const onDoc = (e: MouseEvent) => {
+			const t = e.target as Node;
+			if (panelRef.current?.contains(t)) return;
+			if (anchorRef.current?.contains(t)) return;
+			onClose?.();
+		};
+		const onKey = (e: KeyboardEvent) => {
+			if (e.key === 'Escape') onClose?.();
+		};
+		document.addEventListener('mousedown', onDoc);
+		document.addEventListener('keydown', onKey);
+		return () => {
+			document.removeEventListener('mousedown', onDoc);
+			document.removeEventListener('keydown', onKey);
+		};
+	}, [open, onClose, anchorRef]);
+
+	if (!open) return null;
+
+	const style: CSSProperties = {
+		position: 'fixed',
+		top: pos?.top ?? 0,
+		left: pos?.left ?? 0,
+		zIndex: 1100,
+		visibility: pos ? 'visible' : 'hidden',
+		minWidth: 120,
+		borderRadius: 8,
+		border: '1px solid rgba(255,255,255,0.1)',
+		background: 'var(--sl-color-bg-nav, #18181b)',
+		color: 'var(--sl-color-text, #f4f4f5)',
+		boxShadow: '0 12px 32px rgba(0,0,0,0.4)',
+	};
+
+	return createPortal(
+		<div
+			ref={panelRef}
+			className={cn('not-content', className)}
+			style={style}
+			role="dialog">
+			{children}
+		</div>,
+		document.body,
+	);
+}

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -25,6 +25,13 @@ export { PlayerController } from './lib/phaser/player-controller';
 export { VirtualJoystick } from './lib/phaser/virtual-joystick';
 export type { VirtualJoystickConfig } from './lib/phaser/virtual-joystick';
 export {
+	flashEntity,
+	floatingText,
+	drawHealthBar,
+	attachCameraZoom,
+} from './lib/phaser/entity-fx';
+export type { CameraZoomOptions } from './lib/phaser/entity-fx';
+export {
 	getBirdNum,
 	isBird,
 	createBirdSprites,

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -31,6 +31,10 @@ export {
 	attachCameraZoom,
 } from './lib/phaser/entity-fx';
 export type { CameraZoomOptions } from './lib/phaser/entity-fx';
+
+// Tile prediction — BFS pathing that mirrors the server grid
+export { findTilePath } from './lib/tile/path';
+export type { TileXY } from './lib/tile/path';
 export {
 	getBirdNum,
 	isBird,

--- a/packages/npm/laser/src/lib/phaser/entity-fx.ts
+++ b/packages/npm/laser/src/lib/phaser/entity-fx.ts
@@ -1,0 +1,86 @@
+import Phaser from 'phaser';
+
+/** Quick hit-flash: white fill, settle to a hit colour, then clear. */
+export function flashEntity(
+	scene: Phaser.Scene,
+	sprite: Phaser.GameObjects.Sprite,
+	hitColor = 0xff6b6b,
+): void {
+	sprite.setTint(0xffffff).setTintMode(Phaser.TintModes.FILL);
+	scene.time.delayedCall(60, () => sprite.setTint(hitColor));
+	scene.time.delayedCall(180, () => {
+		sprite.clearTint();
+		sprite.setTintMode(Phaser.TintModes.MULTIPLY);
+	});
+}
+
+/** Rising, fading combat/emote text that destroys itself when done. */
+export function floatingText(
+	scene: Phaser.Scene,
+	x: number,
+	y: number,
+	text: string,
+	color: string,
+	depth: number,
+): Phaser.GameObjects.Text {
+	const label = scene.add
+		.text(x, y, text, {
+			fontFamily: 'monospace',
+			fontSize: '14px',
+			color,
+			stroke: '#000000',
+			strokeThickness: 3,
+		})
+		.setOrigin(0.5, 1)
+		.setDepth(depth);
+	scene.tweens.add({
+		targets: label,
+		y: y - 28,
+		alpha: 0,
+		duration: 900,
+		ease: 'Cubic.easeOut',
+		onComplete: () => label.destroy(),
+	});
+	return label;
+}
+
+/** Draw a health bar into an existing graphics object (green→amber→red). */
+export function drawHealthBar(
+	g: Phaser.GameObjects.Graphics,
+	centerX: number,
+	topY: number,
+	hp: number,
+	maxHp: number,
+	width = 26,
+): void {
+	const pct = Math.max(0, Math.min(1, hp / maxHp));
+	g.clear();
+	g.fillStyle(0x000000, 0.6);
+	g.fillRect(centerX - width / 2, topY, width, 4);
+	g.fillStyle(pct > 0.5 ? 0x4ade80 : pct > 0.25 ? 0xfbbf24 : 0xf87171, 1);
+	g.fillRect(centerX - width / 2 + 0.5, topY + 0.5, (width - 1) * pct, 3);
+}
+
+export interface CameraZoomOptions {
+	min?: number;
+	max?: number;
+	step?: number;
+}
+
+/** Wire +/- keys and the mouse wheel to clamped main-camera zoom. */
+export function attachCameraZoom(
+	scene: Phaser.Scene,
+	{ min = 0.6, max = 2.2, step = 0.2 }: CameraZoomOptions = {},
+): void {
+	const zoom = (delta: number) => {
+		const cam = scene.cameras.main;
+		cam.setZoom(Phaser.Math.Clamp(cam.zoom + delta, min, max));
+	};
+	scene.input.keyboard?.on('keydown-PLUS', () => zoom(step));
+	scene.input.keyboard?.on('keydown-MINUS', () => zoom(-step));
+	scene.input.on(
+		'wheel',
+		(_p: unknown, _o: unknown, _dx: number, dy: number) =>
+			zoom(dy > 0 ? -step * 0.75 : step * 0.75),
+	);
+}

--- a/packages/npm/laser/src/lib/tile/path.spec.ts
+++ b/packages/npm/laser/src/lib/tile/path.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { findTilePath } from './path';
+
+const noBlocks = () => false;
+
+describe('findTilePath', () => {
+	it('returns empty when already at target', () => {
+		expect(findTilePath({ x: 2, y: 2 }, { x: 2, y: 2 }, noBlocks)).toEqual(
+			[],
+		);
+	});
+
+	it('returns empty when target is blocked', () => {
+		const blocked = (x: number, y: number) => x === 3 && y === 0;
+		expect(findTilePath({ x: 0, y: 0 }, { x: 3, y: 0 }, blocked)).toEqual(
+			[],
+		);
+	});
+
+	it('walks a straight line excluding the origin', () => {
+		const path = findTilePath({ x: 0, y: 0 }, { x: 3, y: 0 }, noBlocks);
+		expect(path).toEqual([
+			{ x: 1, y: 0 },
+			{ x: 2, y: 0 },
+			{ x: 3, y: 0 },
+		]);
+	});
+
+	it('routes around a wall', () => {
+		// Wall along x=1 for y=0..2, leaving a gap at y=3.
+		const blocked = (x: number, y: number) => x === 1 && y <= 2;
+		const path = findTilePath({ x: 0, y: 0 }, { x: 2, y: 0 }, blocked);
+		expect(path.length).toBeGreaterThan(2);
+		expect(path[path.length - 1]).toEqual({ x: 2, y: 0 });
+		// Never steps onto the wall.
+		expect(path.every((t) => !(t.x === 1 && t.y <= 2))).toBe(true);
+	});
+
+	it('returns empty when unreachable', () => {
+		// Fully wall off the target column.
+		const blocked = (x: number) => x === 1;
+		expect(findTilePath({ x: 0, y: 0 }, { x: 2, y: 0 }, blocked)).toEqual(
+			[],
+		);
+	});
+});

--- a/packages/npm/laser/src/lib/tile/path.ts
+++ b/packages/npm/laser/src/lib/tile/path.ts
@@ -1,0 +1,65 @@
+export interface TileXY {
+	x: number;
+	y: number;
+}
+
+/**
+ * BFS shortest path over a 4-neighbour grid, mirroring the server
+ * (simgrid grid.rs find_path): neighbour order up/down/left/right, capped
+ * length — identical inputs and tie-breaking keep client prediction and
+ * server routes in sync. Returns the steps after `from` (excluding it), or
+ * an empty array when the target is blocked or unreachable.
+ */
+export function findTilePath(
+	from: TileXY,
+	to: TileXY,
+	isBlocked: (x: number, y: number) => boolean,
+	maxLen = 64,
+): TileXY[] {
+	if ((from.x === to.x && from.y === to.y) || isBlocked(to.x, to.y)) {
+		return [];
+	}
+	const key = (x: number, y: number) => `${x},${y}`;
+	const prev = new Map<string, string | null>();
+	prev.set(key(from.x, from.y), null);
+	const queue: TileXY[] = [from];
+	const dirs = [
+		[0, -1],
+		[0, 1],
+		[-1, 0],
+		[1, 0],
+	];
+	// The grid is conceptually unbounded here (callers only supply a blocked
+	// predicate), so cap explored nodes to the reachable diamond for maxLen —
+	// otherwise an unreachable target would expand the open plane forever.
+	const explorationCap = (maxLen * 2 + 1) ** 2;
+	let explored = 0;
+	let found = false;
+	while (queue.length) {
+		if (++explored > explorationCap) return [];
+		const cur = queue.shift()!;
+		if (cur.x === to.x && cur.y === to.y) {
+			found = true;
+			break;
+		}
+		for (const [dx, dy] of dirs) {
+			const nx = cur.x + dx;
+			const ny = cur.y + dy;
+			const k = key(nx, ny);
+			if (prev.has(k) || isBlocked(nx, ny)) continue;
+			prev.set(k, key(cur.x, cur.y));
+			queue.push({ x: nx, y: ny });
+		}
+	}
+	if (!found) return [];
+	const path: TileXY[] = [];
+	let cur: string | null = key(to.x, to.y);
+	while (cur && cur !== key(from.x, from.y)) {
+		const [x, y] = cur.split(',').map(Number);
+		path.push({ x, y });
+		cur = prev.get(cur) ?? null;
+		if (path.length > maxLen) return [];
+	}
+	path.reverse();
+	return path;
+}

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -998,9 +998,6 @@ fn follow_path(
             path.steps.clear();
             continue;
         }
-        if !occ.is_free(next) && occ.occupant(next) != Some(entity) {
-            continue;
-        }
         let dir = dir_between(pos.tile, next);
         if let Some(dir) = dir {
             pos.facing = dir.facing();
@@ -1191,9 +1188,6 @@ fn try_move(
         return false;
     }
     if !map.is_walkable(candidate) {
-        return false;
-    }
-    if !occ.is_free(candidate) && occ.occupant(candidate) != Some(entity) {
         return false;
     }
     mv.target = Some(candidate);


### PR DESCRIPTION
Sweeps a batch of the abstraction-layer sub-issues from #12340, in a dedicated worktree.

## Changes

**D9 — simgrid entity ghosting (server)** `fa67887`
- Remove the dynamic entity-occupancy gates in `try_move()` + `follow_path()` so players/NPCs pass through each other. Terrain collision (`is_walkable` / blocked bitset) and `find_path` unchanged.
- Matches the client (gridEngine `collides:false`), eliminating the rubber-band when the client walks through an entity the server treated as solid.
- 35 simgrid tests green.

**A1 — overlay migrations** `17e3818`
- `CharacterDialog` + `DiceRollModal` moved off hand-rolled centered-modal chrome onto the shared draggable `FloatingWindow` (matches ChatBar + the NPC DialogueModal). Both now draggable + remember position.

**A2 — bounded z-order bands** `1025ec1`
- Replace FloatingWindow's unbounded z-counter with two bounded bands (`panel` 30–799, `modal` 800–1599) + a `layer` prop. Click-to-front clamps at the band ceiling so panels never climb into the modal band. Retires the interim z-base=30 hack.

## Deploy note
The simgrid ghosting change is **code-only** — it won't reach the live server until a release bump triggers CI for the simgrid-backed server artifact. Confirm which CI item maps to the realtime server before bumping its MDX `version:`; intentionally **not** bumped here.

## Verification
- `simgrid:test` — 35 passed
- `astro:build` — green
- `astro-cryptothrone:check` — 4 pre-existing baseline errors (PlayerStats partials, gridEngine arg, upstream vitest.config), 0 new

## Deferred (follow-up PRs)
B7 Phaser helpers, B4 NetEntityView, B5 TilePredictor, B6 NetGameScene, C8 zone-agnostic WorldScene (#12315), A3 Drawer/Popover — tracked in #12340.

Closes part of #12340.
