### PR TITLE
fix(arc): remove dangling dind-cache-pvc.yaml ref — unfreezes arc-runners ArgoCD app

### DIFF
--- a/apps/kube/github/runners/manifests/kustomization.yaml
+++ b/apps/kube/github/runners/manifests/kustomization.yaml
@@ -11,7 +11,6 @@ resources:
     - github-arc-externalsecret.yaml
     - longhorn-sdb-storageclass.yaml
     - runner-cache-pvc.yaml
-    - dind-cache-pvc.yaml
     - engine-cache-pvc.yaml
     - ows-server-build-pvc.yaml
     - cache-cleanup-cronjob.yaml


### PR DESCRIPTION
## Critical — this is why the git-lfs fix never took

The `arc-runners` ArgoCD app is **frozen** (`Unknown` / ComparisonError):

```
kustomize build .../github/runners/manifests failed:
accumulating resources from 'dind-cache-pvc.yaml': no such file or directory
```

#12323 deleted `dind-cache-pvc.yaml`, but its `kustomization.yaml` entry survived (the edit was clobbered during that PR; only the file-delete landed). kustomize can't build a kustomization that references a missing file → ArgoCD can't render manifests → **the whole app stopped reconciling**.

Consequence: **every runner change since has been stuck**, including #12325 (`arc-runner-ue` → `ghcr.io/kbve/arc-runner:0.1.5` with git-lfs). The live `ephemeralrunnerset` still runs `actions-runner:2.335.1` (no git-lfs), so the Linux server + client builds keep dying on `git: 'lfs' is not a git command`.

## Fix

Remove the dangling `- dind-cache-pvc.yaml` line. `kustomize build` passes (verified locally). On sync:
- `arc-runners` app reconciles again
- the git-lfs runner image (#12325) finally rolls onto `arc-runner-ue`
- Linux server + client builds get past the LFS pull into the cook

Also unblocks the DB pool cap (#12336) reaching the tenant pods if anything there was gated on the same app.