### PR TITLE
docs(astro-kbve): CSS reference — forms, inputs & native components

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/css.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/css.mdx
@@ -343,6 +343,79 @@ Unlayered styles beat layered ones, so anything outside a layer always wins — 
 
 ---
 
+## Typography
+
+Readable type is mostly a few well-chosen defaults: a sensible measure, comfortable line height, and a scale that adapts to the viewport.
+
+### Fluid type scale
+
+Combine `clamp()` with custom properties for a scale that breathes between phone and desktop without breakpoints.
+
+```css
+:root {
+    --step--1: clamp(0.83rem, 0.78rem + 0.24vw, 0.96rem);
+    --step-0:  clamp(1rem,    0.91rem + 0.43vw, 1.25rem);
+    --step-1:  clamp(1.2rem,  1.07rem + 0.65vw, 1.56rem);
+    --step-2:  clamp(1.44rem, 1.26rem + 0.93vw, 1.95rem);
+    --step-3:  clamp(1.73rem, 1.47rem + 1.29vw, 2.44rem);
+}
+
+h1 { font-size: var(--step-3); }
+h2 { font-size: var(--step-2); }
+p  { font-size: var(--step-0); }
+```
+
+<Aside type="tip">
+Generate the whole scale with [Utopia](https://utopia.fyi/). Tailwind v4: drop the steps into `@theme { --text-step-0: clamp(...); }` to get `text-step-0` utilities.
+</Aside>
+
+### Measure and rhythm
+
+```css
+.prose {
+    max-width: 65ch;      /* ~65 characters is the readable sweet spot */
+    line-height: 1.6;     /* unitless — scales with font-size */
+    text-wrap: pretty;    /* avoids orphaned last words */
+}
+```
+
+### Variable fonts
+
+One file, every weight and width. Animate the axes live with `font-variation-settings`.
+
+```css
+@font-face {
+    font-family: "Inter var";
+    src: url("/fonts/inter.woff2") format("woff2");
+    font-weight: 100 900;        /* the full axis range */
+    font-display: swap;          /* show fallback text immediately, swap when loaded */
+}
+
+.heading {
+    font-family: "Inter var", sans-serif;
+    font-weight: 720;            /* any value in range, not just 700 */
+}
+```
+
+<Aside type="caution">
+`font-display: swap` avoids invisible text (FOIT) but causes a layout shift on swap. Pair with `size-adjust` / `ascent-override` on a fallback `@font-face` to keep metrics matched and kill the shift.
+</Aside>
+
+### Truncation & clamping
+
+export const truncateCode = `<div class="max-w-xs p-6 space-y-4 bg-white rounded-lg">
+  <p class="font-medium text-gray-800 truncate">Single line that gets cut with an ellipsis when it overflows its container</p>
+  <p class="text-sm text-gray-600 line-clamp-3">Multi-line clamp limits a block to a fixed number of lines and adds an ellipsis. Useful for card descriptions and previews where you want a uniform height regardless of how much copy each item carries. Anything past the third line is hidden.</p>
+</div>`;
+
+<DevCode htmlCode={truncateCode} />
+
+<Aside>
+`truncate` = `overflow:hidden; text-overflow:ellipsis; white-space:nowrap`. `line-clamp-N` uses `-webkit-line-clamp` (now standardized) for the multi-line version.
+</Aside>
+
+---
+
 ## Transitions & Animation
 
 Two mechanisms: `transition` interpolates between two states (a hover, a class toggle), while `@keyframes` + `animation` runs a defined timeline that can loop and have many steps.
@@ -1341,6 +1414,67 @@ export const progressCode = `<div class="max-w-md p-8 space-y-5 bg-white">
 </div>`;
 
 <DevCode htmlCode={progressCode} />
+
+---
+
+### Stat Cards
+
+export const statCardCode = `<div class="grid grid-cols-1 gap-4 p-6 sm:grid-cols-3 bg-gray-50">
+  <div class="p-5 bg-white rounded-xl shadow-sm">
+    <p class="text-sm text-gray-500">Revenue</p>
+    <p class="mt-1 text-3xl font-bold text-gray-900">$48.2k</p>
+    <p class="mt-1 text-sm font-medium text-green-600">↑ 12.5%</p>
+  </div>
+  <div class="p-5 bg-white rounded-xl shadow-sm">
+    <p class="text-sm text-gray-500">Users</p>
+    <p class="mt-1 text-3xl font-bold text-gray-900">2,318</p>
+    <p class="mt-1 text-sm font-medium text-green-600">↑ 4.1%</p>
+  </div>
+  <div class="p-5 bg-white rounded-xl shadow-sm">
+    <p class="text-sm text-gray-500">Churn</p>
+    <p class="mt-1 text-3xl font-bold text-gray-900">1.2%</p>
+    <p class="mt-1 text-sm font-medium text-red-600">↓ 0.3%</p>
+  </div>
+</div>`;
+
+<DevCode htmlCode={statCardCode} />
+
+---
+
+### Profile Card
+
+export const profileCardCode = `<div class="flex items-center justify-center p-10 bg-gradient-to-br from-cyan-500 to-fuchsia-600">
+  <div class="max-w-xs overflow-hidden text-center bg-white shadow-xl rounded-2xl">
+    <div class="h-20 bg-gradient-to-r from-cyan-400 to-fuchsia-400"></div>
+    <div class="px-6 pb-6 -mt-10">
+      <div class="flex items-center justify-center w-20 h-20 mx-auto text-2xl font-bold text-white border-4 border-white rounded-full bg-gray-800">KB</div>
+      <h3 class="mt-3 text-lg font-bold text-gray-900">KBVE Dev</h3>
+      <p class="text-sm text-gray-500">Platform Engineer</p>
+      <button class="px-4 py-2 mt-4 text-sm font-medium text-white rounded-lg bg-cyan-600 hover:bg-cyan-700">Follow</button>
+    </div>
+  </div>
+</div>`;
+
+<DevCode htmlCode={profileCardCode} />
+
+---
+
+### Pricing Card
+
+export const pricingCardCode = `<div class="flex items-center justify-center p-10 bg-gray-900">
+  <div class="max-w-xs p-8 border-2 bg-gray-950 border-cyan-500 rounded-2xl shadow-[0_0_30px_rgba(6,182,212,0.3)]">
+    <span class="inline-block px-3 py-1 text-xs font-semibold tracking-wide text-cyan-300 uppercase rounded-full bg-cyan-500/10">Pro</span>
+    <p class="mt-4 text-4xl font-extrabold text-white">$12<span class="text-base font-medium text-gray-400">/mo</span></p>
+    <ul class="mt-6 space-y-2 text-sm text-gray-300">
+      <li class="flex gap-2"><span class="text-cyan-400">✓</span> Unlimited projects</li>
+      <li class="flex gap-2"><span class="text-cyan-400">✓</span> Priority support</li>
+      <li class="flex gap-2"><span class="text-cyan-400">✓</span> Custom domains</li>
+    </ul>
+    <button class="w-full py-2.5 mt-8 font-medium text-white rounded-lg bg-cyan-600 hover:bg-cyan-500">Choose Pro</button>
+  </div>
+</div>`;
+
+<DevCode htmlCode={pricingCardCode} />
 
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/application/css.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/css.mdx
@@ -1017,6 +1017,77 @@ Other quick wins: keep text contrast at WCAG AA (4.5:1 for body copy), never con
 
 ---
 
+## Forms & Inputs
+
+Forms carry the most CSS edge cases — native controls, focus states and validation feedback. Modern CSS handles most of it without JavaScript.
+
+### Theming native controls
+
+`accent-color` recolors checkboxes, radios, range sliders and progress bars in one line — no custom markup.
+
+export const accentCode = `<form class="flex flex-col gap-4 p-8 max-w-sm bg-white rounded-lg" style="accent-color:#06b6d4">
+  <label class="flex items-center gap-2 text-gray-800"><input type="checkbox" checked> Remember me</label>
+  <div class="flex gap-4 text-gray-800">
+    <label class="flex items-center gap-2"><input type="radio" name="plan" checked> Free</label>
+    <label class="flex items-center gap-2"><input type="radio" name="plan"> Pro</label>
+  </div>
+  <input type="range" min="0" max="100" value="60">
+  <progress value="0.6"></progress>
+</form>`;
+
+<DevCode htmlCode={accentCode} />
+
+### Validation states
+
+`:user-invalid` and `:user-valid` only react **after** the user has interacted with a field — unlike `:invalid`, which fires on page load before anyone has typed. This is the correct hook for inline error styling.
+
+export const validationCode = `<form class="flex flex-col gap-4 p-8 max-w-sm bg-white rounded-lg">
+  <div class="flex flex-col gap-1">
+    <label class="text-sm font-medium text-gray-700">Email (try an invalid one)</label>
+    <input type="email" required placeholder="you@example.com"
+      class="px-3 py-2 text-gray-800 bg-white border-2 rounded-md outline-none border-gray-300 focus:border-cyan-500 user-invalid:border-red-500 user-valid:border-green-500">
+  </div>
+</form>`;
+
+<DevCode htmlCode={validationCode} />
+
+<Aside>
+Tailwind exposes these as the `user-invalid:` and `user-valid:` variants. The pure-CSS form is `input:user-invalid { border-color: red; }`.
+</Aside>
+
+### Input group with leading icon
+
+export const inputGroupCode = `<form class="p-8 max-w-sm bg-gray-50 rounded-lg">
+  <div class="relative">
+    <span class="absolute inset-y-0 left-0 flex items-center pl-3 text-gray-400">
+      <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
+    </span>
+    <input type="search" placeholder="Search…"
+      class="w-full py-2 pl-10 pr-4 text-gray-800 bg-white border border-gray-300 rounded-lg outline-none focus:border-cyan-500 focus:ring-2 focus:ring-cyan-200">
+  </div>
+</form>`;
+
+<DevCode htmlCode={inputGroupCode} />
+
+### Floating label
+
+A label that rides above the field once it has focus or content — driven by `:placeholder-shown` and `peer`, no JavaScript.
+
+export const floatingLabelCode = `<form class="p-8 max-w-sm bg-white rounded-lg">
+  <div class="relative">
+    <input id="name" type="text" placeholder=" "
+      class="block w-full px-3 pt-5 pb-2 text-gray-800 bg-transparent border-2 rounded-md outline-none peer border-gray-300 focus:border-cyan-500">
+    <label for="name"
+      class="absolute text-gray-500 duration-200 transform -translate-y-3 scale-75 top-3 left-3 origin-[0] peer-placeholder-shown:translate-y-0 peer-placeholder-shown:scale-100 peer-focus:-translate-y-3 peer-focus:scale-75 peer-focus:text-cyan-600">
+      Full name
+    </label>
+  </div>
+</form>`;
+
+<DevCode htmlCode={floatingLabelCode} />
+
+---
+
 ## Custom Components
 
 Reusable visual effects. Text-effect snippets use arbitrary values (`[text-shadow:...]`) so they render on any Tailwind build, with the native v4 utility noted alongside.
@@ -1202,6 +1273,74 @@ export const badgeCode = `<div class="flex flex-wrap items-center gap-3 p-10 bg-
 </div>`;
 
 <DevCode htmlCode={badgeCode} />
+
+---
+
+### Accordion
+
+The native `<details>` / `<summary>` element is an accordion with zero JavaScript — open state, keyboard support and accessibility are built in. Style the marker and the open state with the `open` attribute and `details[open]`.
+
+export const accordionCode = `<div class="max-w-md p-4 space-y-2 bg-gray-50 rounded-lg">
+  <details class="p-4 bg-white rounded-lg shadow-sm group" open>
+    <summary class="flex items-center justify-between font-medium text-gray-800 cursor-pointer list-none">
+      What is TailwindCSS?
+      <svg class="w-5 h-5 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+    </summary>
+    <p class="mt-3 text-sm text-gray-600">A utility-first CSS framework for composing designs directly in your markup.</p>
+  </details>
+  <details class="p-4 bg-white rounded-lg shadow-sm group">
+    <summary class="flex items-center justify-between font-medium text-gray-800 cursor-pointer list-none">
+      Does it need JavaScript?
+      <svg class="w-5 h-5 transition-transform group-open:rotate-180" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path></svg>
+    </summary>
+    <p class="mt-3 text-sm text-gray-600">No — this accordion is pure HTML and CSS via the details element.</p>
+  </details>
+</div>`;
+
+<DevCode htmlCode={accordionCode} />
+
+<Aside>
+`list-none` (plus `summary::-webkit-details-marker { display:none }` in CSS) hides the default disclosure triangle so you can supply your own chevron.
+</Aside>
+
+---
+
+### Alert Banners
+
+export const alertCode = `<div class="max-w-md p-6 space-y-3 bg-gray-50">
+  <div class="flex gap-3 p-4 border-l-4 rounded-md bg-green-50 border-green-500">
+    <span class="font-bold text-green-600">✓</span>
+    <p class="text-sm text-green-800">Saved successfully.</p>
+  </div>
+  <div class="flex gap-3 p-4 border-l-4 rounded-md bg-amber-50 border-amber-500">
+    <span class="font-bold text-amber-600">!</span>
+    <p class="text-sm text-amber-800">Your session expires soon.</p>
+  </div>
+  <div class="flex gap-3 p-4 border-l-4 rounded-md bg-red-50 border-red-500">
+    <span class="font-bold text-red-600">✕</span>
+    <p class="text-sm text-red-800">Something went wrong.</p>
+  </div>
+</div>`;
+
+<DevCode htmlCode={alertCode} />
+
+---
+
+### Progress Bar
+
+export const progressCode = `<div class="max-w-md p-8 space-y-5 bg-white">
+  <div class="w-full h-2 overflow-hidden bg-gray-200 rounded-full">
+    <div class="h-full rounded-full bg-cyan-500" style="width:70%"></div>
+  </div>
+  <div class="w-full h-3 overflow-hidden bg-gray-200 rounded-full">
+    <div class="h-full rounded-full bg-gradient-to-r from-cyan-500 to-fuchsia-500" style="width:45%"></div>
+  </div>
+  <div class="relative w-full h-4 overflow-hidden bg-gray-200 rounded-full">
+    <div class="flex items-center justify-end h-full pr-2 text-xs font-medium text-white rounded-full bg-emerald-500" style="width:88%">88%</div>
+  </div>
+</div>`;
+
+<DevCode htmlCode={progressCode} />
 
 ---
 


### PR DESCRIPTION
## Summary

Continues the `application/css.mdx` reference (after #12337 / #12339, both merged). Fills the forms gap and adds JS-free native components.

- **Forms & Inputs** — `accent-color` native-control theming, `:user-valid` / `:user-invalid` validation (fires only after interaction), icon input group, pure-CSS floating label
- **Native components** — `<details>` accordion (no JS), alert banners, progress bars

## Verification
- `nx run astro-kbve:build` — green, 7753 pages, no css.mdx errors

Part of #1559