### PR TITLE
cryptothrone: finish A1 overlay migration (StickySidebar + KeybindHelp → FloatingWindow)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KeybindHelp.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KeybindHelp.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
+import { FloatingWindow } from '@kbve/astro';
 
 const BINDS: [string, string][] = [
-	['Arrows', 'Move'],
+	['Arrows / WASD', 'Move'],
 	['Click', 'Move / interact'],
 	['Space', 'Attack adjacent'],
 	['1–4', 'Use consumable'],
@@ -27,11 +28,24 @@ export function KeybindHelp() {
 	}, []);
 	if (!open) return null;
 	return (
-		<div className="pointer-events-auto absolute inset-0 z-40 flex items-center justify-center bg-black/40 backdrop-blur-[1px]">
-			<div className="w-64 rounded-xl border border-amber-200/15 bg-black/80 p-5 backdrop-blur-xl">
-				<h3 className="mb-3 text-center text-sm font-bold text-amber-300">
-					Controls
-				</h3>
+		<FloatingWindow
+			storageKey="ct-controls-window"
+			layer="modal"
+			initial={{
+				x:
+					typeof window !== 'undefined'
+						? Math.max(12, (window.innerWidth - 288) / 2)
+						: 200,
+				y:
+					typeof window !== 'undefined'
+						? Math.max(12, (window.innerHeight - 300) / 3)
+						: 100,
+			}}
+			size={{ width: 288, height: 300 }}
+			resizable={false}
+			title="Controls"
+			onClose={() => setOpen(false)}>
+			<div className="p-4">
 				<ul className="space-y-1.5">
 					{BINDS.map(([k, v]) => (
 						<li
@@ -44,13 +58,7 @@ export function KeybindHelp() {
 						</li>
 					))}
 				</ul>
-				<button
-					type="button"
-					onClick={() => setOpen(false)}
-					className="mt-4 w-full rounded-lg bg-amber-500/90 py-1.5 text-xs font-semibold text-black hover:bg-amber-400">
-					Close
-				</button>
 			</div>
-		</div>
+		</FloatingWindow>
 	);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
@@ -1,3 +1,4 @@
+import { FloatingWindow } from '@kbve/astro';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 import { StatsSection } from './StatsSection';
 import { ToggleButton } from './ToggleButton';
@@ -12,96 +13,109 @@ export function StickySidebar() {
 	const dispatch = useGameDispatch();
 
 	return (
-		<div className="fixed top-4 left-3 w-[350px] p-4 bg-zinc-800 text-yellow-400 border border-yellow-300 rounded-lg z-20 transition duration-500 opacity-50 hover:opacity-100 max-h-[90vh] overflow-y-auto">
-			<div className="flex gap-2 mb-4">
-				<ToggleButton
-					isCollapsed={settings.isStatsCollapsed}
-					onToggle={() =>
-						dispatch({
-							type: 'TOGGLE_SETTING',
-							payload: { key: 'isStatsCollapsed' },
-						})
-					}
-					label="Stats"
-				/>
-				<ToggleButton
-					isCollapsed={settings.isSettingsCollapsed}
-					onToggle={() =>
-						dispatch({
-							type: 'TOGGLE_SETTING',
-							payload: { key: 'isSettingsCollapsed' },
-						})
-					}
-					label="Settings"
-				/>
-			</div>
+		<FloatingWindow
+			storageKey="ct-sidebar-window"
+			initial={{ x: 12, y: 16 }}
+			size={{ width: 350, height: 520 }}
+			minWidth={280}
+			minHeight={220}
+			title="Character"
+			className="opacity-60 transition-opacity duration-500 hover:opacity-100">
+			<div className="p-4 text-yellow-400">
+				<div className="flex gap-2 mb-4">
+					<ToggleButton
+						isCollapsed={settings.isStatsCollapsed}
+						onToggle={() =>
+							dispatch({
+								type: 'TOGGLE_SETTING',
+								payload: { key: 'isStatsCollapsed' },
+							})
+						}
+						label="Stats"
+					/>
+					<ToggleButton
+						isCollapsed={settings.isSettingsCollapsed}
+						onToggle={() =>
+							dispatch({
+								type: 'TOGGLE_SETTING',
+								payload: { key: 'isSettingsCollapsed' },
+							})
+						}
+						label="Settings"
+					/>
+				</div>
 
-			<div
-				className={`transition-all duration-500 ${settings.isSettingsCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-screen'}`}>
-				<div className="mb-4">
-					<h2 className="text-lg font-semibold mb-2">Settings</h2>
-					<label className="flex items-center cursor-pointer gap-2">
-						<span className="text-sm">Debug Mode</span>
-						<input
-							type="checkbox"
-							checked={settings.debugMode}
-							onChange={() =>
-								dispatch({
-									type: 'TOGGLE_SETTING',
-									payload: { key: 'debugMode' },
-								})
-							}
-							className="sr-only peer"
-						/>
-						<div className="relative w-10 h-4 bg-gray-400 rounded-full peer-checked:bg-yellow-500 transition-colors">
-							<div
-								className={`absolute w-6 h-6 bg-white rounded-full -top-1 -left-1 transition-transform ${settings.debugMode ? 'translate-x-full' : ''}`}
+				<div
+					className={`transition-all duration-500 ${settings.isSettingsCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-screen'}`}>
+					<div className="mb-4">
+						<h2 className="text-lg font-semibold mb-2">Settings</h2>
+						<label className="flex items-center cursor-pointer gap-2">
+							<span className="text-sm">Debug Mode</span>
+							<input
+								type="checkbox"
+								checked={settings.debugMode}
+								onChange={() =>
+									dispatch({
+										type: 'TOGGLE_SETTING',
+										payload: { key: 'debugMode' },
+									})
+								}
+								className="sr-only peer"
 							/>
-						</div>
-					</label>
+							<div className="relative w-10 h-4 bg-gray-400 rounded-full peer-checked:bg-yellow-500 transition-colors">
+								<div
+									className={`absolute w-6 h-6 bg-white rounded-full -top-1 -left-1 transition-transform ${settings.debugMode ? 'translate-x-full' : ''}`}
+								/>
+							</div>
+						</label>
+					</div>
+				</div>
+
+				<div
+					className={`transition-all duration-500 ${settings.isStatsCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-screen'}`}>
+					<StatsSection stats={player.stats} />
+
+					<div className="mb-4">
+						<h2 className="text-lg font-semibold mb-2">User</h2>
+						<p className="text-sm">
+							{player.stats.username || 'Guest'}
+						</p>
+					</div>
+
+					<OnlinePlayers />
+
+					<div className="mb-4">
+						<h2 className="text-lg font-semibold mb-2">
+							Inventory
+						</h2>
+						<InventoryGrid backpack={player.inventory.backpack} />
+					</div>
+
+					<div className="mb-4">
+						<h2 className="text-lg font-semibold mb-2">
+							Equipment
+						</h2>
+						<EquipmentSummary />
+						<ul className="grid grid-cols-8 gap-2">
+							{Object.entries(player.inventory.equipment).map(
+								([slot, itemId]) => {
+									const item = itemId
+										? getItemById(itemId)
+										: null;
+									return (
+										<li
+											key={slot}
+											className="flex items-center justify-center border border-gray-500 bg-gray-700 w-8 h-8 text-xs text-gray-400"
+											title={item ? item.name : slot}>
+											{item ? item.name[0] : ''}
+										</li>
+									);
+								},
+							)}
+						</ul>
+					</div>
 				</div>
 			</div>
-
-			<div
-				className={`transition-all duration-500 ${settings.isStatsCollapsed ? 'max-h-0 overflow-hidden' : 'max-h-screen'}`}>
-				<StatsSection stats={player.stats} />
-
-				<div className="mb-4">
-					<h2 className="text-lg font-semibold mb-2">User</h2>
-					<p className="text-sm">
-						{player.stats.username || 'Guest'}
-					</p>
-				</div>
-
-				<OnlinePlayers />
-
-				<div className="mb-4">
-					<h2 className="text-lg font-semibold mb-2">Inventory</h2>
-					<InventoryGrid backpack={player.inventory.backpack} />
-				</div>
-
-				<div className="mb-4">
-					<h2 className="text-lg font-semibold mb-2">Equipment</h2>
-					<EquipmentSummary />
-					<ul className="grid grid-cols-8 gap-2">
-						{Object.entries(player.inventory.equipment).map(
-							([slot, itemId]) => {
-								const item = itemId
-									? getItemById(itemId)
-									: null;
-								return (
-									<li
-										key={slot}
-										className="flex items-center justify-center border border-gray-500 bg-gray-700 w-8 h-8 text-xs text-gray-400"
-										title={item ? item.name : slot}>
-										{item ? item.name[0] : ''}
-									</li>
-								);
-							},
-						)}
-					</ul>
-				</div>
-			</div>
-		</div>
+		</FloatingWindow>
 	);
 }


### PR DESCRIPTION
Finishes the **A1 overlay migration** layer from #12340 — the remaining window-style overlays move onto the shared draggable `FloatingWindow` chrome.

## Changes
- **StickySidebar** → draggable/resizable `FloatingWindow` that remembers position (was a fixed left panel).
- **KeybindHelp** → modal-layer `FloatingWindow` (dogfoods the A2 `layer` prop); stale `Arrows` bind now reads `Arrows / WASD` to match the movement keys added earlier.

After this, every window-style overlay (ChatBar, DialogueModal, CharacterDialog, DiceRollModal, StickySidebar, KeybindHelp) is on FloatingWindow. The fixed HUD widgets (CoordsBar, GoldCounter, Minimap, Hotbar, etc.) intentionally stay as positioned HUD, not windows.

## Verification
- `astro-cryptothrone:check` — 3 pre-existing baseline errors, 0 new
- `astro-cryptothrone:test` — 7 files, 46 passing

## Remaining in #12340
Only the live-loop layers: **B4 NetEntityView**, **B6 NetGameScene base**, **C8 zone-agnostic WorldScene**. These rewrite `applySnapshot`/scene wiring and need a run-the-game verification pass — own PR.
