### PR TITLE
feat(jedi/pg): PgCluster sweep — observability + hardening + primitives (Tiers A/B/C)

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -267,6 +267,7 @@ fn router(state: AppState) -> Router {
         .route("/es/", get(lang_strip_root))
         .route("/es/{*rest}", get(lang_strip_handler))
         .route("/health", get(health))
+        .route("/health/pg", get(health_pg))
         .route("/health.html", get(health_html))
         .route("/api/status", get(api_status))
         .route("/api/openapi.json", get(crate::openapi::openapi_json))
@@ -752,6 +753,60 @@ pub(crate) async fn health() -> impl IntoResponse {
         status: "ok",
         version: crate::version::current(),
     })
+}
+
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub(crate) struct PgRoleHealthDto {
+    pub role: String,
+    pub ok: bool,
+    pub latency_ms: u64,
+    pub last_error: Option<String>,
+}
+
+#[derive(serde::Serialize, utoipa::ToSchema)]
+pub(crate) struct PgClusterHealthDto {
+    pub all_ok: bool,
+    pub rw: PgRoleHealthDto,
+    pub ro: PgRoleHealthDto,
+    pub any: PgRoleHealthDto,
+}
+
+#[utoipa::path(
+    get,
+    path = "/health/pg",
+    tag = "system",
+    responses(
+        (status = 200, description = "Per-role PgCluster liveness", body = PgClusterHealthDto),
+        (status = 503, description = "PgCluster not configured"),
+    ),
+)]
+pub(crate) async fn health_pg() -> Response {
+    let Some(cluster) = crate::db::get_pg_cluster() else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "PgCluster not configured"})),
+        )
+            .into_response();
+    };
+    let h = cluster.health().await;
+    let to_dto = |r: jedi::state::pg::PgRoleHealth| PgRoleHealthDto {
+        role: match r.role {
+            jedi::state::pg::PgRole::Rw => "rw",
+            jedi::state::pg::PgRole::Ro => "ro",
+            jedi::state::pg::PgRole::Any => "any",
+        }
+        .into(),
+        ok: r.ok,
+        latency_ms: r.latency.as_millis() as u64,
+        last_error: r.last_error,
+    };
+    Json(PgClusterHealthDto {
+        all_ok: h.all_ok(),
+        rw: to_dto(h.rw),
+        ro: to_dto(h.ro),
+        any: to_dto(h.any),
+    })
+    .into_response()
 }
 
 async fn health_html(State(state): State<AppState>) -> impl IntoResponse {

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -59,6 +59,7 @@ rustls = { version = "0.23", optional = true, default-features = false, features
 webpki-roots = { version = "0.26", optional = true }
 url = { version = "2", optional = true }
 uuid = { version = "1", optional = true, features = ["serde", "v4"] }
+rustls-pemfile = { version = "2", optional = true }
 fred = { version = "10", features = [
   "i-keys", "i-pubsub", "i-std", "subscriber-client",
   "serde-json", "i-server", "i-scripts", "i-streams",
@@ -101,6 +102,7 @@ postgres = [
     "dep:bb8-postgres",
     "dep:tokio-postgres-rustls",
     "dep:rustls",
+    "dep:rustls-pemfile",
     "dep:webpki-roots",
     "dep:url",
     "dep:uuid",

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -88,11 +88,12 @@ once_cell = "1.21.1"
 clickhouse = { version = "0.14", optional = true }
 # Prometheus metrics (optional)
 axum-prometheus = { version = "0.10", optional = true }
+metrics = { version = "0.24", optional = true }
 
 [features]
 default = []
 clickhouse = ["dep:clickhouse"]
-prometheus = ["dep:axum-prometheus"]
+prometheus = ["dep:axum-prometheus", "dep:metrics"]
 forgejo = []
 postgres = [
     "dep:tokio-postgres",
@@ -104,5 +105,8 @@ postgres = [
     "dep:url",
     "dep:uuid",
 ]
+
+[dev-dependencies]
+serial_test = "3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/packages/rust/jedi/src/state/pg.rs
+++ b/packages/rust/jedi/src/state/pg.rs
@@ -397,10 +397,47 @@ impl PgCluster {
             ) -> BoxFuture<'tx, Result<T, JediError>>
             + Send,
     {
-        let mut conn = self.strict_read().await?;
+        self.with_caller_inner(PgRole::Ro, sub, role, f).await
+    }
+
+    /// `rw`-pool counterpart to `with_caller_read`. Use for writes
+    /// against `SECURITY DEFINER` write proxies or raw SQL that must
+    /// run under the caller's `auth.uid()`. Commits on `Ok`, rolls
+    /// back on `Err`.
+    pub async fn with_caller_write<T, F>(
+        &self,
+        sub: Uuid,
+        role: Option<&str>,
+        f: F,
+    ) -> Result<T, JediError>
+    where
+        T: Send,
+        F: for<'tx> FnOnce(
+                &'tx tokio_postgres::Transaction<'_>,
+            ) -> BoxFuture<'tx, Result<T, JediError>>
+            + Send,
+    {
+        self.with_caller_inner(PgRole::Rw, sub, role, f).await
+    }
+
+    async fn with_caller_inner<T, F>(
+        &self,
+        pg_role: PgRole,
+        sub: Uuid,
+        auth_role: Option<&str>,
+        f: F,
+    ) -> Result<T, JediError>
+    where
+        T: Send,
+        F: for<'tx> FnOnce(
+                &'tx tokio_postgres::Transaction<'_>,
+            ) -> BoxFuture<'tx, Result<T, JediError>>
+            + Send,
+    {
+        let mut conn = self.acquire(pg_role, false).await?;
         let tx = conn.transaction().await.map_err(JediError::from)?;
         let claims = serde_json::json!({
-            "role": role.unwrap_or("authenticated"),
+            "role": auth_role.unwrap_or("authenticated"),
             "sub": sub.to_string(),
         })
         .to_string();
@@ -410,6 +447,30 @@ impl PgCluster {
         )
         .await
         .map_err(JediError::from)?;
+        let out = f(&tx).await?;
+        tx.commit().await.map_err(JediError::from)?;
+        Ok(out)
+    }
+
+    /// Open a tx on the `ro` pool with `SET LOCAL statement_timeout`
+    /// set to `timeout_ms`. Lets hot paths tighten beyond the pool
+    /// default without recycling the connection (the GUC scope dies
+    /// with the tx). Commits on `Ok`, rolls back on `Err`. Statements
+    /// exceeding the budget surface as `JediError::Database` from
+    /// `tokio_postgres::Error` (SQLSTATE `57014` query_canceled).
+    pub async fn with_timeout_read<T, F>(&self, timeout_ms: u64, f: F) -> Result<T, JediError>
+    where
+        T: Send,
+        F: for<'tx> FnOnce(
+                &'tx tokio_postgres::Transaction<'_>,
+            ) -> BoxFuture<'tx, Result<T, JediError>>
+            + Send,
+    {
+        let mut conn = self.acquire(PgRole::Ro, false).await?;
+        let tx = conn.transaction().await.map_err(JediError::from)?;
+        tx.simple_query(&format!("SET LOCAL statement_timeout = {timeout_ms}"))
+            .await
+            .map_err(JediError::from)?;
         let out = f(&tx).await?;
         tx.commit().await.map_err(JediError::from)?;
         Ok(out)

--- a/packages/rust/jedi/src/state/pg.rs
+++ b/packages/rust/jedi/src/state/pg.rs
@@ -27,7 +27,12 @@
 //!   - `KBVE_PG_<RW|RO|ANY>_MAX_SIZE`
 //!   - `KBVE_PG_<RW|RO|ANY>_CONNECT_TIMEOUT_MS`
 //!   - `KBVE_PG_<RW|RO|ANY>_IDLE_TIMEOUT_MS` (0 disables)
+//!   - `KBVE_PG_<RW|RO|ANY>_MAX_LIFETIME_S` (0 disables; default 1800)
 //!   - `KBVE_PG_<RW|RO|ANY>_STATEMENT_TIMEOUT_MS` (0 disables)
+//!   - `KBVE_PG_<RW|RO|ANY>_SEARCH_PATH` (default `"public"`; empty disables)
+//!   - `KBVE_PG_<RW|RO|ANY>_ACQUIRE_RETRY_MAX_ATTEMPTS` (default 2)
+//!   - `KBVE_PG_CA_PEM_FILE` (additive CA bundle for in-cluster CNPG)
+//!   - `KBVE_PG_DANGEROUSLY_ACCEPT_INVALID_TLS` (debug builds only)
 
 use std::{env, sync::Arc, time::Duration};
 
@@ -76,8 +81,11 @@ pub struct PgPoolConfig {
     pub max_size: u32,
     pub connect_timeout: Duration,
     pub idle_timeout: Option<Duration>,
+    pub max_lifetime: Option<Duration>,
     pub statement_timeout_ms: Option<u64>,
     pub application_name: String,
+    pub search_path: Option<String>,
+    pub acquire_retry_max_attempts: u8,
 }
 
 impl PgPoolConfig {
@@ -91,8 +99,11 @@ impl PgPoolConfig {
             max_size,
             connect_timeout: Duration::from_secs(5),
             idle_timeout: Some(Duration::from_secs(60)),
+            max_lifetime: Some(Duration::from_secs(30 * 60)),
             statement_timeout_ms: Some(30_000),
             application_name,
+            search_path: Some("public".into()),
+            acquire_retry_max_attempts: 2,
         }
     }
 }
@@ -194,6 +205,24 @@ fn apply_pool_env(pool: &mut PgPoolConfig, prefix: &str) {
     if let Some(v) = parse_env::<u64>(&format!("{prefix}_STATEMENT_TIMEOUT_MS")) {
         pool.statement_timeout_ms = if v == 0 { None } else { Some(v) };
     }
+    if let Some(v) = parse_env::<u64>(&format!("{prefix}_MAX_LIFETIME_S")) {
+        pool.max_lifetime = if v == 0 {
+            None
+        } else {
+            Some(Duration::from_secs(v))
+        };
+    }
+    if let Ok(v) = env::var(format!("{prefix}_SEARCH_PATH")) {
+        let trimmed = v.trim();
+        pool.search_path = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        };
+    }
+    if let Some(v) = parse_env::<u8>(&format!("{prefix}_ACQUIRE_RETRY_MAX_ATTEMPTS")) {
+        pool.acquire_retry_max_attempts = v.max(1);
+    }
 }
 
 fn parse_env<T: std::str::FromStr>(key: &str) -> Option<T> {
@@ -215,6 +244,7 @@ fn rewrite_pooler_host(url: &str, use_pooler: bool, role: PgRole) -> String {
 #[derive(Debug, Clone)]
 struct OnAcquire {
     statement_timeout_ms: Option<u64>,
+    search_path: Option<String>,
 }
 
 impl bb8::CustomizeConnection<tokio_postgres::Client, tokio_postgres::Error> for OnAcquire {
@@ -227,6 +257,10 @@ impl bb8::CustomizeConnection<tokio_postgres::Client, tokio_postgres::Error> for
         Box::pin(async move {
             if let Some(ms) = self.statement_timeout_ms {
                 conn.simple_query(&format!("SET statement_timeout = {ms}"))
+                    .await?;
+            }
+            if let Some(sp) = &self.search_path {
+                conn.simple_query(&format!("SET search_path TO {sp}"))
                     .await?;
             }
             Ok(())
@@ -310,26 +344,39 @@ impl PgCluster {
         &self.cfg
     }
 
+    fn pool_for(&self, role: PgRole) -> (&PgPool, u8) {
+        match role {
+            PgRole::Rw => (&self.rw, self.cfg.rw.acquire_retry_max_attempts),
+            PgRole::Ro => (&self.ro, self.cfg.ro.acquire_retry_max_attempts),
+            PgRole::Any => (&self.any, self.cfg.any.acquire_retry_max_attempts),
+        }
+    }
+
+    async fn acquire(&self, role: PgRole, fallback: bool) -> Result<PgConn<'_>, JediError> {
+        let (pool, attempts) = self.pool_for(role);
+        timed_acquire(role, pool, fallback, attempts).await
+    }
+
     pub async fn write(&self) -> Result<PgConn<'_>, JediError> {
-        timed_acquire(PgRole::Rw, &self.rw, false).await
+        self.acquire(PgRole::Rw, false).await
     }
 
     pub async fn strict_read(&self) -> Result<PgConn<'_>, JediError> {
-        timed_acquire(PgRole::Ro, &self.ro, false).await
+        self.acquire(PgRole::Ro, false).await
     }
 
     pub async fn any_read(&self) -> Result<PgConn<'_>, JediError> {
-        timed_acquire(PgRole::Any, &self.any, false).await
+        self.acquire(PgRole::Any, false).await
     }
 
     /// Read connection with `ro` → `any` fallback for non-critical
     /// reads that should survive a replica blip.
     pub async fn read(&self) -> Result<PgConn<'_>, JediError> {
-        match timed_acquire(PgRole::Ro, &self.ro, false).await {
+        match self.acquire(PgRole::Ro, false).await {
             Ok(c) => Ok(c),
             Err(e) => {
                 tracing::warn!(error = %e, "[PgCluster] ro pool acquire failed; falling back to any pool");
-                timed_acquire(PgRole::Any, &self.any, true).await
+                self.acquire(PgRole::Any, true).await
             }
         }
     }
@@ -404,18 +451,49 @@ async fn probe_role(role: PgRole, pool: &PgPool) -> PgRoleHealth {
 
 /// Single acquire path used by `write` / `strict_read` / `any_read` /
 /// `read`. Emits a `pg.acquire` tracing span and per-role acquire
-/// metrics (under the `prometheus` feature).
+/// metrics (under the `prometheus` feature). Retries up to
+/// `max_attempts` times on `bb8::RunError::TimedOut` with 25..75 ms
+/// jitter between attempts.
 async fn timed_acquire<'a>(
     role: PgRole,
     pool: &'a PgPool,
     fallback: bool,
+    max_attempts: u8,
 ) -> Result<PgConn<'a>, JediError> {
+    let mut attempt: u8 = 0;
+    loop {
+        attempt = attempt.saturating_add(1);
+        match acquire_once(role, pool, fallback, attempt).await {
+            Ok(c) => return Ok(c),
+            Err(AcquireErr::TimedOut) if attempt < max_attempts.max(1) => {
+                pg_metrics::record_retry(role);
+                tokio::time::sleep(jitter()).await;
+                continue;
+            }
+            Err(AcquireErr::TimedOut) => return Err(pool_err(bb8::RunError::TimedOut)),
+            Err(AcquireErr::Other(e)) => return Err(e),
+        }
+    }
+}
+
+enum AcquireErr {
+    TimedOut,
+    Other(JediError),
+}
+
+async fn acquire_once<'a>(
+    role: PgRole,
+    pool: &'a PgPool,
+    fallback: bool,
+    attempt: u8,
+) -> Result<PgConn<'a>, AcquireErr> {
     let state = pool.state();
     let started = std::time::Instant::now();
     let span = tracing::trace_span!(
         "pg.acquire",
         role = pg_metrics::role_label(role),
         fallback = fallback,
+        attempt = attempt as u32,
         pool.size = state.connections,
         pool.idle = state.idle_connections,
         wait_ms = tracing::field::Empty,
@@ -426,13 +504,21 @@ async fn timed_acquire<'a>(
     let elapsed = started.elapsed();
     let (outcome, mapped) = match result {
         Ok(c) => ("ok", Ok(c)),
-        Err(bb8::RunError::TimedOut) => ("timeout", Err(pool_err(bb8::RunError::TimedOut))),
-        Err(e) => ("error", Err(pool_err(e))),
+        Err(bb8::RunError::TimedOut) => ("timeout", Err(AcquireErr::TimedOut)),
+        Err(e) => ("error", Err(AcquireErr::Other(pool_err(e)))),
     };
     span.record("wait_ms", elapsed.as_millis() as i64);
     span.record("outcome", outcome);
     pg_metrics::record_acquire(role, outcome, elapsed);
     mapped
+}
+
+fn jitter() -> Duration {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos() as u64)
+        .unwrap_or(0);
+    Duration::from_millis(25 + (nanos % 50))
 }
 
 /// 15s interval sampler that emits pool-state gauges so they reflect
@@ -488,6 +574,18 @@ mod pg_metrics {
     pub(super) fn record_acquire(_role: PgRole, _outcome: &'static str, _elapsed: Duration) {}
 
     #[cfg(feature = "prometheus")]
+    pub(super) fn record_retry(role: PgRole) {
+        metrics::counter!(
+            "kbve_pg_pool_acquire_retries_total",
+            "role" => role_label(role),
+        )
+        .increment(1);
+    }
+
+    #[cfg(not(feature = "prometheus"))]
+    pub(super) fn record_retry(_role: PgRole) {}
+
+    #[cfg(feature = "prometheus")]
     pub(super) fn record_state(role: PgRole, size: u32, idle: u32) {
         let role_str = role_label(role);
         metrics::gauge!("kbve_pg_pool_size", "role" => role_str).set(size as f64);
@@ -513,8 +611,10 @@ async fn build_pool(
         .max_size(cfg.max_size)
         .connection_timeout(cfg.connect_timeout)
         .idle_timeout(cfg.idle_timeout)
+        .max_lifetime(cfg.max_lifetime)
         .connection_customizer(Box::new(OnAcquire {
             statement_timeout_ms: cfg.statement_timeout_ms,
+            search_path: cfg.search_path.clone(),
         }))
         .build(mgr)
         .await
@@ -527,10 +627,109 @@ fn make_rustls_connector() -> Result<MakeRustlsConnect, JediError> {
 
     let mut roots = RootCertStore::empty();
     roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+
+    if let Ok(path) = env::var("KBVE_PG_CA_PEM_FILE") {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            let pem = std::fs::read(trimmed).map_err(|e| {
+                JediError::Internal(
+                    format!("KBVE_PG_CA_PEM_FILE='{trimmed}' unreadable: {e}").into(),
+                )
+            })?;
+            let mut slice = pem.as_slice();
+            let mut added = 0;
+            for cert in rustls_pemfile::certs(&mut slice) {
+                let cert = cert.map_err(|e| {
+                    JediError::Internal(format!("KBVE_PG_CA_PEM_FILE parse error: {e}").into())
+                })?;
+                roots.add(cert).map_err(|e| {
+                    JediError::Internal(format!("KBVE_PG_CA_PEM_FILE add error: {e}").into())
+                })?;
+                added += 1;
+            }
+            if added == 0 {
+                return Err(JediError::Internal(
+                    format!("KBVE_PG_CA_PEM_FILE='{trimmed}' contained no certificates").into(),
+                ));
+            }
+            tracing::info!(path = %trimmed, added, "[PgCluster] custom CA bundle loaded");
+        }
+    }
+
     let cfg = ClientConfig::builder()
         .with_root_certificates(roots)
         .with_no_client_auth();
+
+    #[cfg(debug_assertions)]
+    let cfg = if env::var("KBVE_PG_DANGEROUSLY_ACCEPT_INVALID_TLS")
+        .ok()
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        })
+        .unwrap_or(false)
+    {
+        tracing::warn!(
+            "[PgCluster] KBVE_PG_DANGEROUSLY_ACCEPT_INVALID_TLS is ON — TLS verification disabled (debug builds only)"
+        );
+        dangerous_insecure_client_config()
+    } else {
+        cfg
+    };
+
     Ok(MakeRustlsConnect::new(cfg))
+}
+
+#[cfg(debug_assertions)]
+fn dangerous_insecure_client_config() -> ClientConfig {
+    use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+    use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+    use rustls::{DigitallySignedStruct, SignatureScheme};
+
+    #[derive(Debug)]
+    struct NoVerify;
+    impl ServerCertVerifier for NoVerify {
+        fn verify_server_cert(
+            &self,
+            _: &CertificateDer<'_>,
+            _: &[CertificateDer<'_>],
+            _: &ServerName<'_>,
+            _: &[u8],
+            _: UnixTime,
+        ) -> Result<ServerCertVerified, rustls::Error> {
+            Ok(ServerCertVerified::assertion())
+        }
+        fn verify_tls12_signature(
+            &self,
+            _: &[u8],
+            _: &CertificateDer<'_>,
+            _: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+        fn verify_tls13_signature(
+            &self,
+            _: &[u8],
+            _: &CertificateDer<'_>,
+            _: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            vec![
+                SignatureScheme::RSA_PKCS1_SHA256,
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::ED25519,
+            ]
+        }
+    }
+
+    ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerify))
+        .with_no_client_auth()
 }
 
 fn pool_err(e: bb8::RunError<tokio_postgres::Error>) -> JediError {
@@ -608,6 +807,29 @@ mod tests {
                 assert_eq!(cfg.ro_url, cfg.rw_url);
                 assert_eq!(cfg.any_url, cfg.rw_url);
                 assert!(!cfg.use_pooler);
+            },
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn tier_b_env_overrides_apply() {
+        with_env(
+            &[
+                ("KBVE_PG_RW_URL", Some("postgresql://u:p@h/db")),
+                ("KBVE_PG_RW_MAX_LIFETIME_S", Some("0")),
+                ("KBVE_PG_RW_SEARCH_PATH", Some("public, wallet")),
+                ("KBVE_PG_RW_ACQUIRE_RETRY_MAX_ATTEMPTS", Some("5")),
+                ("KBVE_PG_RO_MAX_LIFETIME_S", Some("90")),
+                ("KBVE_PG_RO_SEARCH_PATH", Some("")),
+            ],
+            || {
+                let cfg = PgClusterConfig::from_env().unwrap();
+                assert_eq!(cfg.rw.max_lifetime, None);
+                assert_eq!(cfg.rw.search_path.as_deref(), Some("public, wallet"));
+                assert_eq!(cfg.rw.acquire_retry_max_attempts, 5);
+                assert_eq!(cfg.ro.max_lifetime, Some(Duration::from_secs(90)));
+                assert_eq!(cfg.ro.search_path, None);
             },
         );
     }

--- a/packages/rust/jedi/src/state/pg.rs
+++ b/packages/rust/jedi/src/state/pg.rs
@@ -47,8 +47,7 @@ use crate::entity::error::JediError;
 pub use tokio_postgres;
 
 pub type PgPool = Pool<PostgresConnectionManager<MakeRustlsConnect>>;
-pub type PgConn<'a> =
-    bb8::PooledConnection<'a, PostgresConnectionManager<MakeRustlsConnect>>;
+pub type PgConn<'a> = bb8::PooledConnection<'a, PostgresConnectionManager<MakeRustlsConnect>>;
 
 /// Boxed future shape expected from the `with_caller_read` closure body.
 /// Lets consumers write `|tx| Box::pin(async move { … })` without
@@ -111,19 +110,14 @@ pub struct PgClusterConfig {
 
 impl PgClusterConfig {
     pub fn from_env() -> Result<Self, JediError> {
-        let app = env::var("KBVE_PG_APPLICATION_NAME")
-            .unwrap_or_else(|_| "kbve".to_string());
+        let app = env::var("KBVE_PG_APPLICATION_NAME").unwrap_or_else(|_| "kbve".to_string());
 
-        let rw_url = read_url_env(&[
-            "KBVE_PG_RW_URL",
-            "DATABASE_URL_PROD",
-            "WALLET_DATABASE_URL",
-        ])
-        .ok_or_else(|| {
-            JediError::Internal(
-                "KBVE_PG_RW_URL (or DATABASE_URL_PROD / WALLET_DATABASE_URL) not set".into(),
-            )
-        })?;
+        let rw_url = read_url_env(&["KBVE_PG_RW_URL", "DATABASE_URL_PROD", "WALLET_DATABASE_URL"])
+            .ok_or_else(|| {
+                JediError::Internal(
+                    "KBVE_PG_RW_URL (or DATABASE_URL_PROD / WALLET_DATABASE_URL) not set".into(),
+                )
+            })?;
 
         let ro_url = read_url_env(&[
             "KBVE_PG_RO_URL",
@@ -210,9 +204,6 @@ fn rewrite_pooler_host(url: &str, use_pooler: bool, role: PgRole) -> String {
     if !use_pooler {
         return url.to_string();
     }
-    // CNPG pooler service naming. The `Any` role has no pooler equivalent
-    // (poolers front rw + ro only); skip the rewrite to keep direct
-    // any-instance fallback semantics.
     let (from, to) = match role {
         PgRole::Rw => ("supabase-cluster-rw", "supabase-cluster-pooler-rw"),
         PgRole::Ro => ("supabase-cluster-ro", "supabase-cluster-pooler-ro"),
@@ -226,18 +217,12 @@ struct OnAcquire {
     statement_timeout_ms: Option<u64>,
 }
 
-impl bb8::CustomizeConnection<tokio_postgres::Client, tokio_postgres::Error>
-    for OnAcquire
-{
+impl bb8::CustomizeConnection<tokio_postgres::Client, tokio_postgres::Error> for OnAcquire {
     fn on_acquire<'a>(
         &'a self,
         conn: &'a mut tokio_postgres::Client,
     ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<(), tokio_postgres::Error>>
-                + Send
-                + 'a,
-        >,
+        Box<dyn std::future::Future<Output = Result<(), tokio_postgres::Error>> + Send + 'a>,
     > {
         Box::pin(async move {
             if let Some(ms) = self.statement_timeout_ms {
@@ -246,6 +231,27 @@ impl bb8::CustomizeConnection<tokio_postgres::Client, tokio_postgres::Error>
             }
             Ok(())
         })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PgRoleHealth {
+    pub role: PgRole,
+    pub ok: bool,
+    pub latency: Duration,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PgClusterHealth {
+    pub rw: PgRoleHealth,
+    pub ro: PgRoleHealth,
+    pub any: PgRoleHealth,
+}
+
+impl PgClusterHealth {
+    pub fn all_ok(&self) -> bool {
+        self.rw.ok && self.ro.ok && self.any.ok
     }
 }
 
@@ -264,18 +270,8 @@ impl PgCluster {
 
     pub async fn build(cfg: PgClusterConfig) -> Result<Arc<Self>, JediError> {
         let connector = make_rustls_connector()?;
-        let rw = build_pool(
-            &cfg.resolved_url(PgRole::Rw),
-            &cfg.rw,
-            connector.clone(),
-        )
-        .await?;
-        let ro = build_pool(
-            &cfg.resolved_url(PgRole::Ro),
-            &cfg.ro,
-            connector.clone(),
-        )
-        .await?;
+        let rw = build_pool(&cfg.resolved_url(PgRole::Rw), &cfg.rw, connector.clone()).await?;
+        let ro = build_pool(&cfg.resolved_url(PgRole::Ro), &cfg.ro, connector.clone()).await?;
         let any = build_pool(&cfg.resolved_url(PgRole::Any), &cfg.any, connector).await?;
         tracing::info!(
             rw_max = cfg.rw.max_size,
@@ -284,7 +280,21 @@ impl PgCluster {
             use_pooler = cfg.use_pooler,
             "[PgCluster] pools built"
         );
-        Ok(Arc::new(Self { rw, ro, any, cfg }))
+        let arc = Arc::new(Self { rw, ro, any, cfg });
+        #[cfg(feature = "prometheus")]
+        let _ = spawn_state_sampler(Arc::downgrade(&arc));
+        Ok(arc)
+    }
+
+    /// Per-role liveness probe. `SELECT 1` against each pool in
+    /// parallel under a 1s deadline.
+    pub async fn health(&self) -> PgClusterHealth {
+        let (rw, ro, any) = tokio::join!(
+            probe_role(PgRole::Rw, &self.rw),
+            probe_role(PgRole::Ro, &self.ro),
+            probe_role(PgRole::Any, &self.any),
+        );
+        PgClusterHealth { rw, ro, any }
     }
 
     pub fn rw_pool(&self) -> &PgPool {
@@ -301,34 +311,32 @@ impl PgCluster {
     }
 
     pub async fn write(&self) -> Result<PgConn<'_>, JediError> {
-        self.rw.get().await.map_err(pool_err)
+        timed_acquire(PgRole::Rw, &self.rw, false).await
     }
 
     pub async fn strict_read(&self) -> Result<PgConn<'_>, JediError> {
-        self.ro.get().await.map_err(pool_err)
+        timed_acquire(PgRole::Ro, &self.ro, false).await
     }
 
     pub async fn any_read(&self) -> Result<PgConn<'_>, JediError> {
-        self.any.get().await.map_err(pool_err)
+        timed_acquire(PgRole::Any, &self.any, false).await
     }
 
-    /// Read connection with replica → any-instance fallback. Use for
-    /// non-critical reads that should survive a replica blip.
+    /// Read connection with `ro` → `any` fallback for non-critical
+    /// reads that should survive a replica blip.
     pub async fn read(&self) -> Result<PgConn<'_>, JediError> {
-        match self.ro.get().await {
+        match timed_acquire(PgRole::Ro, &self.ro, false).await {
             Ok(c) => Ok(c),
             Err(e) => {
                 tracing::warn!(error = %e, "[PgCluster] ro pool acquire failed; falling back to any pool");
-                self.any.get().await.map_err(pool_err)
+                timed_acquire(PgRole::Any, &self.any, true).await
             }
         }
     }
 
-    /// Run a read-only closure inside a transaction with
-    /// `request.jwt.claims` impersonating the given subject so
-    /// SECURITY DEFINER proxies that resolve `auth.uid()` see the
-    /// caller. Acquires from the strict replica pool. Commits on
-    /// success; rolls back on error.
+    /// Read-only tx on the `ro` pool with `request.jwt.claims`
+    /// impersonating the given subject. Commits on `Ok`, rolls back
+    /// on `Err`.
     pub async fn with_caller_read<T, F>(
         &self,
         sub: Uuid,
@@ -338,8 +346,8 @@ impl PgCluster {
     where
         T: Send,
         F: for<'tx> FnOnce(
-            &'tx tokio_postgres::Transaction<'_>,
-        ) -> BoxFuture<'tx, Result<T, JediError>>
+                &'tx tokio_postgres::Transaction<'_>,
+            ) -> BoxFuture<'tx, Result<T, JediError>>
             + Send,
     {
         let mut conn = self.strict_read().await?;
@@ -361,16 +369,142 @@ impl PgCluster {
     }
 }
 
+async fn probe_role(role: PgRole, pool: &PgPool) -> PgRoleHealth {
+    let started = std::time::Instant::now();
+    let res = tokio::time::timeout(Duration::from_secs(1), async {
+        let conn = pool.get().await.map_err(pool_err)?;
+        conn.simple_query("SELECT 1")
+            .await
+            .map_err(JediError::from)?;
+        Ok::<_, JediError>(())
+    })
+    .await;
+    let latency = started.elapsed();
+    match res {
+        Ok(Ok(())) => PgRoleHealth {
+            role,
+            ok: true,
+            latency,
+            last_error: None,
+        },
+        Ok(Err(e)) => PgRoleHealth {
+            role,
+            ok: false,
+            latency,
+            last_error: Some(e.to_string()),
+        },
+        Err(_) => PgRoleHealth {
+            role,
+            ok: false,
+            latency,
+            last_error: Some("probe timed out after 1s".into()),
+        },
+    }
+}
+
+/// Single acquire path used by `write` / `strict_read` / `any_read` /
+/// `read`. Emits a `pg.acquire` tracing span and per-role acquire
+/// metrics (under the `prometheus` feature).
+async fn timed_acquire<'a>(
+    role: PgRole,
+    pool: &'a PgPool,
+    fallback: bool,
+) -> Result<PgConn<'a>, JediError> {
+    let state = pool.state();
+    let started = std::time::Instant::now();
+    let span = tracing::trace_span!(
+        "pg.acquire",
+        role = pg_metrics::role_label(role),
+        fallback = fallback,
+        pool.size = state.connections,
+        pool.idle = state.idle_connections,
+        wait_ms = tracing::field::Empty,
+        outcome = tracing::field::Empty,
+    );
+    let _enter = span.enter();
+    let result = pool.get().await;
+    let elapsed = started.elapsed();
+    let (outcome, mapped) = match result {
+        Ok(c) => ("ok", Ok(c)),
+        Err(bb8::RunError::TimedOut) => ("timeout", Err(pool_err(bb8::RunError::TimedOut))),
+        Err(e) => ("error", Err(pool_err(e))),
+    };
+    span.record("wait_ms", elapsed.as_millis() as i64);
+    span.record("outcome", outcome);
+    pg_metrics::record_acquire(role, outcome, elapsed);
+    mapped
+}
+
+/// 15s interval sampler that emits pool-state gauges so they reflect
+/// the current shape even when no traffic is flowing.
+#[cfg(feature = "prometheus")]
+fn spawn_state_sampler(cluster: std::sync::Weak<PgCluster>) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(15));
+        loop {
+            interval.tick().await;
+            let Some(c) = cluster.upgrade() else { return };
+            for (role, pool) in [
+                (PgRole::Rw, &c.rw),
+                (PgRole::Ro, &c.ro),
+                (PgRole::Any, &c.any),
+            ] {
+                let s = pool.state();
+                pg_metrics::record_state(role, s.connections, s.idle_connections);
+            }
+        }
+    })
+}
+
+mod pg_metrics {
+    use super::PgRole;
+    use std::time::Duration;
+
+    pub(super) fn role_label(role: PgRole) -> &'static str {
+        match role {
+            PgRole::Rw => "rw",
+            PgRole::Ro => "ro",
+            PgRole::Any => "any",
+        }
+    }
+
+    #[cfg(feature = "prometheus")]
+    pub(super) fn record_acquire(role: PgRole, outcome: &'static str, elapsed: Duration) {
+        let role_str = role_label(role);
+        metrics::counter!(
+            "kbve_pg_pool_acquire_total",
+            "role" => role_str,
+            "outcome" => outcome,
+        )
+        .increment(1);
+        metrics::histogram!(
+            "kbve_pg_pool_acquire_duration_seconds",
+            "role" => role_str,
+        )
+        .record(elapsed.as_secs_f64());
+    }
+
+    #[cfg(not(feature = "prometheus"))]
+    pub(super) fn record_acquire(_role: PgRole, _outcome: &'static str, _elapsed: Duration) {}
+
+    #[cfg(feature = "prometheus")]
+    pub(super) fn record_state(role: PgRole, size: u32, idle: u32) {
+        let role_str = role_label(role);
+        metrics::gauge!("kbve_pg_pool_size", "role" => role_str).set(size as f64);
+        metrics::gauge!("kbve_pg_pool_idle", "role" => role_str).set(idle as f64);
+        metrics::gauge!("kbve_pg_pool_in_use", "role" => role_str)
+            .set(size.saturating_sub(idle) as f64);
+    }
+}
+
 async fn build_pool(
     url: &str,
     cfg: &PgPoolConfig,
     connector: MakeRustlsConnect,
 ) -> Result<PgPool, JediError> {
-    let mut pg_cfg: PgConfig = url
-        .parse()
-        .map_err(|e: tokio_postgres::Error| {
-            JediError::Internal(format!("invalid Postgres URL: {e}").into())
-        })?;
+    let mut pg_cfg: PgConfig = url.parse().map_err(|e: tokio_postgres::Error| {
+        JediError::Internal(format!("invalid Postgres URL: {e}").into())
+    })?;
     pg_cfg.application_name(&cfg.application_name);
     pg_cfg.connect_timeout(cfg.connect_timeout);
 
@@ -389,8 +523,6 @@ async fn build_pool(
 }
 
 fn make_rustls_connector() -> Result<MakeRustlsConnect, JediError> {
-    // Ensure a CryptoProvider is installed exactly once. Idempotent —
-    // calling install repeatedly only succeeds on the first call.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
     let mut roots = RootCertStore::empty();
@@ -411,6 +543,7 @@ pub struct SharedPgCluster(pub Arc<PgCluster>);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     fn with_env<F: FnOnce()>(vars: &[(&str, Option<&str>)], f: F) {
         let prior: Vec<_> = vars
@@ -440,6 +573,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn from_env_requires_rw_url() {
         with_env(
             &[
@@ -455,6 +589,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn from_env_falls_back_through_compat_keys() {
         with_env(
             &[
@@ -478,6 +613,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn pool_env_overrides_apply() {
         with_env(
             &[
@@ -500,16 +636,25 @@ mod tests {
     #[test]
     fn use_pooler_rewrites_rw_and_ro_only() {
         let cfg = PgClusterConfig {
-            rw_url: "postgresql://u:p@supabase-cluster-rw.kilobase.svc.cluster.local:5432/db".into(),
-            ro_url: "postgresql://u:p@supabase-cluster-ro.kilobase.svc.cluster.local:5432/db".into(),
-            any_url: "postgresql://u:p@supabase-cluster-r.kilobase.svc.cluster.local:5432/db".into(),
+            rw_url: "postgresql://u:p@supabase-cluster-rw.kilobase.svc.cluster.local:5432/db"
+                .into(),
+            ro_url: "postgresql://u:p@supabase-cluster-ro.kilobase.svc.cluster.local:5432/db"
+                .into(),
+            any_url: "postgresql://u:p@supabase-cluster-r.kilobase.svc.cluster.local:5432/db"
+                .into(),
             rw: PgPoolConfig::defaults_for(PgRole::Rw, "test".into()),
             ro: PgPoolConfig::defaults_for(PgRole::Ro, "test".into()),
             any: PgPoolConfig::defaults_for(PgRole::Any, "test".into()),
             use_pooler: true,
         };
-        assert!(cfg.resolved_url(PgRole::Rw).contains("supabase-cluster-pooler-rw"));
-        assert!(cfg.resolved_url(PgRole::Ro).contains("supabase-cluster-pooler-ro"));
+        assert!(
+            cfg.resolved_url(PgRole::Rw)
+                .contains("supabase-cluster-pooler-rw")
+        );
+        assert!(
+            cfg.resolved_url(PgRole::Ro)
+                .contains("supabase-cluster-pooler-ro")
+        );
         assert!(cfg.resolved_url(PgRole::Any).contains("supabase-cluster-r"));
         assert!(!cfg.resolved_url(PgRole::Any).contains("pooler"));
     }
@@ -530,6 +675,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn use_pooler_truthy_values() {
         for v in ["1", "true", "yes", "on", "TRUE", "Yes"] {
             with_env(


### PR DESCRIPTION
Sweeps through https://github.com/KBVE/kbve/issues/12343 — all three tiers landing on this branch as separate commits so reviewers can step through them.

## Commits

| # | Tier | Subject |
|---|------|---------|
| `84d6d6a` | A | metrics + health probe + acquire span |
| `0646b16` | B | max_lifetime + search_path lock + retry + TLS roots |
| `8406887` | C | with_caller_write + with_timeout_read |

## Tier A — Observability (`84d6d6a`)

- **A1 metrics** behind `jedi.features.prometheus`:
  - `kbve_pg_pool_size` / `_idle` / `_in_use` gauges sampled every 15 s by a tokio task spawned via `Arc::downgrade` (won't hold the cluster open past its consumer's drop).
  - `kbve_pg_pool_acquire_total{role,outcome=ok|timeout|error}` counter + `kbve_pg_pool_acquire_duration_seconds{role}` histogram emitted from `timed_acquire`.
- **A2 `PgCluster::health()`** — parallel `SELECT 1` against each pool under a 1 s deadline, returns `PgClusterHealth { rw, ro, any }`. Wired into axum-kbve as `GET /health/pg` returning `PgClusterHealthDto` (utoipa-annotated; 503 when PgCluster isn't configured).
- **A3 acquire span** — every `timed_acquire` records `pg.acquire{role, fallback, attempt, pool.size, pool.idle, wait_ms, outcome}`.

Trimmed verbose narrative comments inside `rewrite_pooler_host` + `make_rustls_connector`; compressed multi-paragraph rustdocs to single declarative sentences (RustDocs + utoipa target, per repo convention).

Test infra: `serial_test = "3"` added to jedi dev-deps; env-touching tests marked `#[serial]` to eliminate the env-var races that surfaced with > 1 thread.

## Tier B — Production hardening (`0646b16`)

- **B1 `max_lifetime`** — `PgPoolConfig::max_lifetime: Option<Duration>` default 30 min, env `KBVE_PG_<KIND>_MAX_LIFETIME_S` (0 disables).
- **B2 `search_path` lock** — `OnAcquire` runs `SET search_path TO <value>` after `SET statement_timeout`. Default `"public"`, env `KBVE_PG_<KIND>_SEARCH_PATH` (empty disables).
- **B3 transient acquire retry** — `timed_acquire` retries on `bb8::RunError::TimedOut` up to `acquire_retry_max_attempts` (default 2) with 25..75 ms jitter sourced from `SystemTime::subsec_nanos` (no `rand` dep). New `kbve_pg_pool_acquire_retries_total{role}` counter under the prometheus feature. Env `KBVE_PG_<KIND>_ACQUIRE_RETRY_MAX_ATTEMPTS`.
- **B4 TLS root flexibility** — `KBVE_PG_CA_PEM_FILE` additively loads a PEM bundle alongside `webpki-roots` (for self-signed CNPG CAs). `KBVE_PG_DANGEROUSLY_ACCEPT_INVALID_TLS` is `cfg(debug_assertions)`-gated so it cannot ship in release. New optional dep `rustls-pemfile = "2"` bundled into the postgres feature.

## Tier C — Primitive expansion (`8406887`)

- **C1 `with_caller_write`** — `rw`-pool counterpart to `with_caller_read`. Both now share a private `with_caller_inner(PgRole, ...)` helper; the only difference is the pool acquisition path. Commits on Ok, rolls back on Err.
- **C2 `with_timeout_read`** — opens a tx on the `ro` pool with `SET LOCAL statement_timeout = <ms>`. GUC scope dies with the tx so it doesn't leak. Statements exceeding the budget surface as `JediError::Database` (SQLSTATE 57014 `query_canceled`).

**C3 (query helpers) and C4 (cancellation propagation) deferred** — both benefit from having multiple consumer call sites to motivate the abstraction; we only have one PgCluster-backed handler today (`/api/v1/wallet/me/ledger`). Will revisit when a second handler lands and the boilerplate cost is measurable. Tracked on the umbrella issue.

## Cross-cutting

- Every change behind `jedi.features.postgres` (default-off).
- `cargo build -p jedi --no-default-features` stays green.
- `cargo check -p axum-kbve` stays green after each tier.
- Per-tier env-wiring unit tests under `state::pg::tests`. Integration smoke against `dev-docker-compose.yml` left as a separate manual run (no CI bring-up of postgres in this PR).

## Test plan
- [x] `cargo build -p jedi --no-default-features`
- [x] `cargo build -p jedi --no-default-features --features postgres`
- [x] `cargo build -p jedi --no-default-features --features postgres,prometheus`
- [x] `cargo check -p axum-kbve`
- [x] `cargo test -p jedi --no-default-features --features postgres,prometheus --lib state::pg::tests` — 7/7 pass
- [ ] Tier A: `/health/pg` returns 200 with `all_ok=true` against `dev-docker-compose.yml` (pending local smoke)
- [ ] Tier A: `/metrics` exposes `kbve_pg_pool_*` series (pending)
- [ ] Tier B: `SET search_path` visible inside `with_caller_read` via `SHOW search_path` (pending smoke)
- [ ] Tier B: `KBVE_PG_CA_PEM_FILE` with a malformed file errors at startup, with a valid bundle logs `[PgCluster] custom CA bundle loaded` (pending)
- [ ] Tier C: example handler issuing `with_timeout_read(500, |tx| async { tx.query("SELECT pg_sleep(2)", &[]).await? })` surfaces a `query_canceled` (pending)