### PR TITLE
feat(cryptothrone): zone registry — data-driven map loading (#12360 C8) + mdx bump

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/zones.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/zones.ts
@@ -1,0 +1,51 @@
+/**
+ * Zone registry — the data-driven map manifest behind WorldScene (#12360 C8).
+ *
+ * Each zone names its tilemap + tileset assets (so the Preloader and scene load
+ * by key, not hardcoded strings) plus its realm chat channel/game. Adding a
+ * zone is a data edit here; the scene loads any of them by `zoneKey`. The
+ * authoritative collision still comes from the GridTilemap JSON each zone
+ * points at (shared with simgrid).
+ */
+
+export interface ZoneDef {
+	/** Stable zone identifier (scene init key). */
+	key: string;
+	name: string;
+	/** Phaser cache key for the GridTilemap JSON. */
+	tilemapKey: string;
+	/** Served asset path for the GridTilemap JSON. */
+	tilemapUrl: string;
+	/** Phaser texture key for the tileset image. */
+	tilesetKey: string;
+	/** Served asset path for the tileset image. */
+	tilesetUrl: string;
+	/** Name passed to Phaser `addTilesetImage`. */
+	tilesetName: string;
+	/** Realm chat channel for this zone. */
+	channel: string;
+	/** Realm chat game key. */
+	game: string;
+}
+
+export const ZONES = {
+	'cloud-city': {
+		key: 'cloud-city',
+		name: 'Cloud City',
+		tilemapKey: 'cloud-city-tilemap',
+		tilemapUrl: '/assets/map/cloud_city.tilemap.json',
+		tilesetKey: 'cloud-city-tiles',
+		tilesetUrl: '/assets/map/cloud_tileset.png',
+		tilesetName: 'cloud_tileset',
+		channel: '#cryptothrone',
+		game: 'cryptothrone',
+	},
+} satisfies Record<string, ZoneDef>;
+
+export type ZoneKey = keyof typeof ZONES;
+
+export const DEFAULT_ZONE: ZoneKey = 'cloud-city';
+
+export function getZone(key?: string): ZoneDef {
+	return ZONES[(key as ZoneKey) ?? DEFAULT_ZONE] ?? ZONES[DEFAULT_ZONE];
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -24,6 +24,7 @@ import type {
 } from '@kbve/laser';
 import { getCtNetConfig } from '@/lib/net-config';
 import { getNPCByRef, npcIdForRef, isHostileRef } from '../data/npcs';
+import { getZone, DEFAULT_ZONE, type ZoneDef } from '../data/zones';
 
 const MAP_SCALE = 3;
 const STEP_THROTTLE_MS = 60;
@@ -112,6 +113,7 @@ export class CloudCityScene extends Scene {
 	private entityDepth = 0;
 	private lastStepAt = 0;
 	private tilePixels = 16;
+	private zone: ZoneDef = getZone(DEFAULT_ZONE);
 	private ranges: Range[] = [];
 	private rangeTile = { x: -1, y: -1 };
 	private myHp = -1;
@@ -141,11 +143,15 @@ export class CloudCityScene extends Scene {
 		super({ key: 'CloudCity' });
 	}
 
+	init(data: { zone?: string }) {
+		this.zone = getZone(data?.zone);
+	}
+
 	create() {
 		// mapdb GridTilemap (proto-canonical JSON): collision bitset + render
 		// layers. Single source of truth shared with the server (simgrid) and
 		// the client prediction BFS — no Tiled parsing.
-		const tm = this.cache.json.get('cloud-city-tilemap') as {
+		const tm = this.cache.json.get(this.zone.tilemapKey) as {
 			width: number;
 			height: number;
 			tileSize: number;
@@ -161,8 +167,8 @@ export class CloudCityScene extends Scene {
 			height: tm.height,
 		});
 		const tileset = tilemap.addTilesetImage(
-			'cloud_tileset',
-			'cloud-city-tiles',
+			this.zone.tilesetName,
+			this.zone.tilesetKey,
 			tm.tileSize,
 			tm.tileSize,
 		);

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/PreloaderScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/PreloaderScene.ts
@@ -1,4 +1,5 @@
 import { Scene } from 'phaser';
+import { getZone } from '../data/zones';
 
 export class PreloaderScene extends Scene {
 	constructor() {
@@ -30,11 +31,9 @@ export class PreloaderScene extends Scene {
 			loadingText.destroy();
 		});
 
-		this.load.image('cloud-city-tiles', '/assets/map/cloud_tileset.png');
-		this.load.json(
-			'cloud-city-tilemap',
-			'/assets/map/cloud_city.tilemap.json',
-		);
+		const zone = getZone();
+		this.load.image(zone.tilesetKey, zone.tilesetUrl);
+		this.load.json(zone.tilemapKey, zone.tilemapUrl);
 
 		this.load.spritesheet('player', '/assets/entity/charactersheet.png', {
 			frameWidth: 52,

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.21"
+version: "0.1.22"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
First slice of #12360 **C8** — make map loading data-driven via a zone registry.

## What
- **`data/zones.ts`** — `ZONES` registry: each zone names its tilemap/tileset asset keys + URLs + realm chat channel/game. `getZone(key)` / `DEFAULT_ZONE`.
- **PreloaderScene** — loads the tileset + GridTilemap JSON from `getZone()` instead of hardcoded `cloud-city-*` strings.
- **CloudCityScene** — gains `init({ zone })` + reads `tilemapKey`/`tilesetKey`/`tilesetName` from the registry (defaults to cloud-city). Functionally **zone-agnostic**: a new zone is a data edit + assets, no scene changes.
- Authoritative collision unchanged — still the per-zone GridTilemap `blocked` bitset (shared with simgrid).

## MDX
- minor bump: cryptothrone client `0.1.21 → 0.1.22` (client-only change; server simgrid untouched, server MDX left at 0.0.13).

## Verified
- Behavior-preserving — cloud-city loads identically (same asset keys/urls via the registry).
- `astro check`: touched files (zones.ts, PreloaderScene, CloudCityScene zone wiring) are type-clean. The 2 remaining CloudCityScene errors (`PlayerStats` at :327/:491) + unused-var warnings are **pre-existing**, unrelated to this change.
- vitest 17/17 for the data suites (the `data.test.ts` load failure is the pre-existing unbuilt `@kbve/itemdb-data` workspace pkg).

## Scope / next (still in #12360)
- This is the **registry + data-driven load**. Cosmetic `WorldScene` rename, live zone-switching (portal → `scene.start('World', { zone })`), and per-zone chat routing are follow-ups.
- B4 (NetEntityView lifecycle) + B6 (NetGameScene base) still pending.