### PR TITLE
cryptothrone: P1 embed foundation — standalone embed.js mount (#12362)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/.gitignore
+++ b/apps/cryptothrone/astro-cryptothrone/.gitignore
@@ -1,1 +1,6 @@
 coverage/
+
+# Embed bundle is built per deploy (nx build-embed). Never commit the artifact —
+# source of truth is src/embed/.
+public/embed/embed.js
+public/embed/assets/

--- a/apps/cryptothrone/astro-cryptothrone/project.json
+++ b/apps/cryptothrone/astro-cryptothrone/project.json
@@ -29,6 +29,18 @@
 			},
 			"cache": true
 		},
+		"build-embed": {
+			"executor": "nx:run-commands",
+			"outputs": ["{projectRoot}/public/embed"],
+			"options": {
+				"cwd": "apps/cryptothrone/astro-cryptothrone",
+				"commands": [
+					"NODE_OPTIONS=\"--max-old-space-size=4096\" npx vite build --config vite.embed.config.mts"
+				],
+				"parallel": false
+			},
+			"cache": true
+		},
 		"preview": {
 			"dependsOn": [
 				{

--- a/apps/cryptothrone/astro-cryptothrone/public/embed/example.html
+++ b/apps/cryptothrone/astro-cryptothrone/public/embed/example.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>CryptoThrone embed — example</title>
+		<style>
+			body {
+				margin: 0;
+				background: #0b0b14;
+				color: #e5e5e5;
+				font-family: system-ui, sans-serif;
+			}
+			header {
+				padding: 12px 16px;
+				border-bottom: 1px solid #222;
+			}
+			main {
+				padding: 16px;
+			}
+			code {
+				background: #1a1a2e;
+				padding: 2px 6px;
+				border-radius: 4px;
+			}
+		</style>
+	</head>
+	<body>
+		<header>
+			<strong>CryptoThrone</strong> — standalone embed demo
+		</header>
+		<main>
+			<p>
+				Drop the game into any page with a target element + the bundle.
+				A Supabase <code>jwt</code> and <code>username</code> are
+				required (the embed takes auth as input — it does not run the
+				Supabase login gate).
+			</p>
+
+			<!-- Declarative mount: the bundle auto-mounts [data-cryptothrone]. -->
+			<div
+				data-cryptothrone
+				data-jwt="PASTE_SUPABASE_JWT"
+				data-username="PASTE_USERNAME"
+				data-height="600px"></div>
+
+			<script src="/embed/embed.js" defer></script>
+
+			<!-- Or mount programmatically:
+			<script>
+				window.addEventListener('load', () => {
+					window.Cryptothrone.mount({
+						el: '#game',
+						jwt: '...',
+						username: '...',
+						gameWs: 'wss://game.cryptothrone.com/ws',
+						height: '600px',
+					});
+				});
+			</script>
+			-->
+		</main>
+	</body>
+</html>

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/embed-env.d.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/embed-env.d.ts
@@ -1,0 +1,4 @@
+declare module '*.css?inline' {
+	const css: string;
+	export default css;
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/index.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/index.tsx
@@ -1,0 +1,135 @@
+import { StrictMode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import GameWindow from '../components/game/GameWindow';
+import { setCtNetConfig } from '../lib/net-config';
+import embedCss from '../styles/global.css?inline';
+
+/**
+ * Standalone embed entry. Boots the full cryptothrone game into a shadow root
+ * on any page, with auth supplied as input (jwt + username) instead of the
+ * Astro/Supabase gate. Build target: `build-embed` -> public/embed/embed.js.
+ *
+ *   <div data-cryptothrone data-jwt="..." data-username="..."></div>
+ *   <script src="https://cryptothrone.com/embed/embed.js" defer></script>
+ */
+export interface CryptothroneOptions {
+	el: HTMLElement | string;
+	jwt: string;
+	username: string;
+	/** Game server WebSocket. Defaults to wss://game.cryptothrone.com/ws. */
+	gameWs?: string;
+	height?: string;
+}
+
+interface MountedInstance {
+	root: Root;
+	host: HTMLElement;
+}
+
+const DEFAULT_GAME_WS = 'wss://game.cryptothrone.com/ws';
+const DEFAULT_HEIGHT = '600px';
+
+const instances = new WeakMap<HTMLElement, MountedInstance>();
+
+function resolveEl(el: HTMLElement | string): HTMLElement | null {
+	if (typeof el === 'string') {
+		return document.querySelector<HTMLElement>(el);
+	}
+	return el instanceof HTMLElement ? el : null;
+}
+
+export function mount(opts: CryptothroneOptions): void {
+	const target = resolveEl(opts.el);
+	if (!target) {
+		console.error('[Cryptothrone] mount target not found:', opts.el);
+		return;
+	}
+	if (instances.has(target)) {
+		console.warn('[Cryptothrone] already mounted; unmount first');
+		return;
+	}
+	if (!opts.jwt || !opts.username) {
+		console.error('[Cryptothrone] mount requires jwt + username');
+		return;
+	}
+
+	setCtNetConfig({
+		jwt: opts.jwt,
+		username: opts.username,
+		wsUrl: opts.gameWs ?? DEFAULT_GAME_WS,
+	});
+
+	target.style.display = 'block';
+	target.style.height = opts.height ?? DEFAULT_HEIGHT;
+	target.style.width = '100%';
+
+	const shadow = target.attachShadow({ mode: 'open' });
+
+	const styleEl = document.createElement('style');
+	styleEl.textContent = embedCss;
+	shadow.appendChild(styleEl);
+
+	const wrapper = document.createElement('div');
+	wrapper.style.width = '100%';
+	wrapper.style.height = '100%';
+	shadow.appendChild(wrapper);
+
+	const root = createRoot(wrapper);
+	root.render(
+		<StrictMode>
+			<GameWindow username={opts.username} />
+		</StrictMode>,
+	);
+
+	instances.set(target, { root, host: target });
+}
+
+export function unmount(el: HTMLElement | string): void {
+	const target = resolveEl(el);
+	if (!target) return;
+	const inst = instances.get(target);
+	if (!inst) return;
+	try {
+		inst.root.unmount();
+	} finally {
+		instances.delete(target);
+		while (target.firstChild) target.removeChild(target.firstChild);
+	}
+}
+
+function autoMount(): void {
+	const targets = document.querySelectorAll<HTMLElement>(
+		'[data-cryptothrone], [id^="cryptothrone"]',
+	);
+	for (const el of Array.from(targets)) {
+		if (instances.has(el)) continue;
+		const jwt = el.dataset.jwt;
+		const username = el.dataset.username;
+		if (!jwt || !username) continue;
+		mount({
+			el,
+			jwt,
+			username,
+			gameWs: el.dataset.gameWs,
+			height: el.dataset.height,
+		});
+	}
+}
+
+if (typeof document !== 'undefined') {
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', autoMount, {
+			once: true,
+		});
+	} else {
+		autoMount();
+	}
+}
+
+const api = { mount, unmount, version: '0.1.0' as const };
+
+if (typeof window !== 'undefined') {
+	(window as unknown as { Cryptothrone: typeof api }).Cryptothrone = api;
+}
+
+export default api;

--- a/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
@@ -1,0 +1,62 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+// Standalone library build for the embed.js bundle (ESM config — the tailwind
+// vite plugin is ESM-only).
+// Output: apps/cryptothrone/astro-cryptothrone/public/embed/embed.js
+//
+// Bundles React, Phaser, grid-engine, @kbve/laser, and the whole game UI into
+// one self-contained IIFE that mounts into a shadow root. The game's Tailwind
+// is compiled and inlined (global.css?inline) so the bundle needs no external
+// stylesheet. Host pages drop in:
+//   <div data-cryptothrone data-jwt="..." data-username="..."></div>
+//   <script src="https://cryptothrone.com/embed/embed.js" defer></script>
+const here = fileURLToPath(new URL('.', import.meta.url));
+
+const pkg = (p: string) => resolve(here, '../../../packages', p);
+
+export default defineConfig({
+	plugins: [react(), tailwindcss()],
+	resolve: {
+		alias: [
+			{ find: /^@\//, replacement: resolve(here, 'src') + '/' },
+			{ find: '@kbve/astro', replacement: pkg('npm/astro/src/index.ts') },
+			{ find: '@kbve/droid', replacement: pkg('npm/droid/src/index.ts') },
+			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
+			{
+				find: '@kbve/itemdb-data',
+				replacement: pkg('data/codegen/generated/itemdb-data.json'),
+			},
+			{
+				find: '@kbve/npcdb-data',
+				replacement: pkg('data/codegen/generated/npcdb-data.json'),
+			},
+		],
+	},
+	publicDir: false,
+	define: {
+		'process.env.NODE_ENV': JSON.stringify('production'),
+	},
+	build: {
+		outDir: 'public/embed',
+		emptyOutDir: false,
+		minify: 'terser',
+		sourcemap: false,
+		target: 'es2020',
+		lib: {
+			entry: resolve(here, 'src/embed/index.tsx'),
+			name: 'Cryptothrone',
+			formats: ['iife'],
+			fileName: () => 'embed.js',
+		},
+		rollupOptions: {
+			output: {
+				inlineDynamicImports: true,
+				exports: 'named',
+			},
+		},
+	},
+});


### PR DESCRIPTION
**P1 of #12362** — the host-agnostic mount foundation that the Discord Activity, `embed.js`, and itch builds all share. Clones the proven `apps/irc/astro-irc/src/embed/` pattern.

## What's here
- **`src/embed/index.tsx`** — `Cryptothrone.mount({el, jwt, username, gameWs?, height?})` / `unmount` / `autoMount([data-cryptothrone])` / `window.Cryptothrone`. Boots the full `GameWindow` into a **shadow root**; **auth is an input** (jwt + username), not the Supabase login gate — so the same game runs in any host.
- **`vite.embed.config.mts`** — IIFE lib build (ESM config because the tailwind vite plugin is ESM-only), tsconfig-path aliases wired manually, `global.css?inline` so the game's Tailwind ships **inlined** (no external stylesheet).
- **`build-embed`** nx target → `public/embed/embed.js` (gitignored artifact, built per deploy like IRC's `chat.js`).
- **`example.html`** harness.

## Verification
- `nx run astro-cryptothrone:build-embed` → **embed.js builds, 3.98 MB (1.26 MB gzip)**, whole game in one IIFE.
- `astro-cryptothrone:test` — 7 files, 46 passing.
- `astro check` OOMs in the worktree (environmental — the check target lacks the heap bump the build target has; CI runs it with proper resources). The vite build resolves the full graph incl. the `?inline` CSS, and a `*.css?inline` type decl is added.

## Known P1 follow-ups (not blockers)
- Importing `{ FloatingWindow }` from the `@kbve/astro` barrel drags the droid SharedWorkers into the bundle → most of the 3.98 MB. Add a lighter UI subpath export.
- `FloatingWindow` uses `position: fixed` → windows float over the host page, not the game container; needs a container-relative mode for embed.
- `document.activeElement` guards (WASD-while-typing) resolve to the shadow host in embed mode.

## Next phases (#12362)
P2 itch (index.html + zip), P3 Discord Activity (isolated entry + auth bridge + `/.proxy/` WS mapping).

Part of #12362.
