### PR TITLE
fix(cryptothrone,irc-gateway): route realm chat to #general

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/zones.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/zones.ts
@@ -37,7 +37,7 @@ export const ZONES = {
 		tilesetKey: 'cloud-city-tiles',
 		tilesetUrl: '/assets/map/cloud_tileset.png',
 		tilesetName: 'cloud_tileset',
-		channel: '#cryptothrone',
+		channel: '#general',
 		game: 'cryptothrone',
 	},
 } satisfies Record<string, ZoneDef>;

--- a/apps/cryptothrone/astro-cryptothrone/src/lib/net-config.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/lib/net-config.ts
@@ -7,7 +7,7 @@ export interface CtNetConfig {
 let config: CtNetConfig | null = null;
 
 export const REALM_CHAT_GAME = 'cryptothrone';
-export const REALM_CHAT_CHANNEL = '#cryptothrone';
+export const REALM_CHAT_CHANNEL = '#general';
 
 export function resolveWsUrl(): string {
 	const env = import.meta.env.PUBLIC_CT_GAME_WS as string | undefined;

--- a/apps/irc/irc-gateway/src/gateway/history.rs
+++ b/apps/irc/irc-gateway/src/gateway/history.rs
@@ -27,7 +27,7 @@ pub const HISTORY_LEN: usize = 10;
 
 /// Channels the gateway keeps history for (union of the game + minechat
 /// channel whitelists).
-const HISTORY_CHANNELS: &[&str] = &["#cryptothrone", "#world-events", "#mc-global"];
+const HISTORY_CHANNELS: &[&str] = &["#general", "#world-events", "#mc-global"];
 
 type Store = Arc<Mutex<HashMap<String, VecDeque<ChatMessage>>>>;
 

--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -113,7 +113,7 @@ pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse
 /// negotiate their way into arbitrary channels.
 const GAME_PROFILES: &[(&str, &str, &str)] = &[
     // (game key, channel, platform)
-    ("cryptothrone", "#cryptothrone", "cryptothrone"),
+    ("cryptothrone", "#general", "cryptothrone"),
 ];
 
 fn game_profile(game: &str) -> Option<(&'static str, &'static str)> {

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.22"
+version: "0.1.23"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
@@ -11,7 +11,7 @@ tags:
 key: irc_gateway
 pipeline: docker
 app_name: irc-gateway
-version: "0.1.22"
+version: "0.1.23"
 source_path: apps/irc
 version_toml: apps/irc/version.toml
 version_target: apps/irc/irc-gateway/Cargo.toml


### PR DESCRIPTION
## Bug
In-game chat didn't reach IRC. Root cause: cryptothrone realm chat was routed to **`#cryptothrone`** — an empty channel — instead of **`#general`** where IRC users actually are. The earlier local-echo fix (#12345) made the sender see their own message, which **masked** that it never reached the real channel.

Not a serialization bug — the frame parses fine (`kind:"chat"` → `MessageKind::Chat` via snake_case; `payload` is `#[serde(default)]`). Purely the channel.

## Fix — `#cryptothrone` → `#general`, in sync across all four sites
- gateway `GAME_PROFILES` — gamechat session joins `#general`
- gateway `HISTORY_CHANNELS` — ring-buffer listener tracks `#general`
- client `REALM_CHAT_CHANNEL` (net-config) — sends + filters on `#general`
- zone registry `channel` (zones.ts) — kept consistent for future WorldScene routing

All four must agree (gateway whitelist-drops mismatched channels), hence the coordinated change.

## Versions
- cryptothrone `0.1.22 → 0.1.23`, irc-gateway `0.1.22 → 0.1.23`

## Verified
- gateway `cargo build` clean; history tests unaffected (sanitize helper tests are channel-agnostic).
- Needs a live check after deploy: send in-game → appears in `#general` for IRC clients + new joiners get backscroll.