### PR TITLE
cryptothrone: lean @kbve/astro/ui — cut droid SharedWorkers from embed (main-thread only)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/GameWindow.tsx
@@ -3,7 +3,7 @@ import Phaser from 'phaser';
 import GridEngine from 'grid-engine';
 import { PhaserGame, laserEvents } from '@kbve/laser';
 import type { PhaserGameRef } from '@kbve/laser';
-import { NotContent } from '@kbve/astro';
+import { NotContent } from '@kbve/astro/ui';
 import { PreloaderScene } from './scenes/PreloaderScene';
 import { CloudCityScene } from './scenes/CloudCityScene';
 import { ProceduralZoneScene } from './scenes/ProceduralZoneScene';

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CharacterDialog.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CharacterDialog.tsx
@@ -1,4 +1,4 @@
-import { FloatingWindow } from '@kbve/astro';
+import { FloatingWindow } from '@kbve/astro/ui';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 
 export function CharacterDialog() {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { RealmChatClient, type RealmChatState } from '@kbve/laser';
-import { FloatingWindow } from '@kbve/astro';
+import { FloatingWindow } from '@kbve/astro/ui';
 import { useGameSelector } from '../store/GameStoreContext';
 import {
 	getCtNetConfig,

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DialogueModal.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DialogueModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { FloatingWindow } from '@kbve/astro';
+import { FloatingWindow } from '@kbve/astro/ui';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 import { getDialogueById } from '../data/npcs';
 import { TypewriterText } from './TypewriterText';

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { FloatingWindow } from '@kbve/astro';
+import { FloatingWindow } from '@kbve/astro/ui';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 
 function rollDie(): number {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KeybindHelp.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KeybindHelp.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { FloatingWindow } from '@kbve/astro';
+import { FloatingWindow } from '@kbve/astro/ui';
 
 const BINDS: [string, string][] = [
 	['Arrows / WASD', 'Move'],

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/StickySidebar.tsx
@@ -1,4 +1,4 @@
-import { FloatingWindow } from '@kbve/astro';
+import { FloatingWindow } from '@kbve/astro/ui';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
 import { StatsSection } from './StatsSection';
 import { ToggleButton } from './ToggleButton';

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -9,6 +9,7 @@
 		"paths": {
 			"@/*": ["src/*"],
 			"@kbve/astro": ["../../../packages/npm/astro/src/index.ts"],
+			"@kbve/astro/ui": ["../../../packages/npm/astro/src/ui.ts"],
 			"@kbve/astro/components/*": [
 				"../../../packages/npm/astro/src/components/*"
 			],

--- a/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
@@ -23,6 +23,7 @@ export default defineConfig({
 	resolve: {
 		alias: [
 			{ find: /^@\//, replacement: resolve(here, 'src') + '/' },
+			{ find: '@kbve/astro/ui', replacement: pkg('npm/astro/src/ui.ts') },
 			{ find: '@kbve/astro', replacement: pkg('npm/astro/src/index.ts') },
 			{ find: '@kbve/droid', replacement: pkg('npm/droid/src/index.ts') },
 			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },

--- a/packages/npm/astro/src/ui.ts
+++ b/packages/npm/astro/src/ui.ts
@@ -1,0 +1,28 @@
+// Lean UI subpath: pure-React overlay primitives with ZERO @kbve/droid
+// dependency, so consumers (the cryptothrone embed / Discord Activity) don't
+// drag the droid SharedWorker infrastructure into their bundle. The Discord
+// iframe sandbox has no SharedWorkers anyway — this path is main-thread only.
+
+export { NotContent } from './react/NotContent';
+export type { NotContentProps } from './react/NotContent';
+export { FloatingWindow } from './react/FloatingWindow';
+export type { FloatingWindowProps, WindowLayer } from './react/FloatingWindow';
+export { Drawer } from './react/Drawer';
+export type { DrawerProps, DrawerSide } from './react/Drawer';
+export { Popover } from './react/Popover';
+export type { PopoverProps, PopoverPlacement } from './react/Popover';
+
+export { useDraggable } from './hooks/useDraggable';
+export type {
+	Position,
+	UseDraggableOptions,
+	UseDraggableResult,
+} from './hooks/useDraggable';
+export { useResizable } from './hooks/useResizable';
+export type {
+	Size,
+	UseResizableOptions,
+	UseResizableResult,
+} from './hooks/useResizable';
+
+export { cn } from './utils/cn';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,6 +16,7 @@
 		"baseUrl": ".",
 		"paths": {
 			"@kbve/astro": ["packages/npm/astro/src/index.ts"],
+			"@kbve/astro/ui": ["packages/npm/astro/src/ui.ts"],
 			"@kbve/astro/components/*": ["packages/npm/astro/src/components/*"],
 			"@kbve/devops": ["packages/npm/devops/src/index.ts"],
 			"@kbve/droid": ["packages/npm/droid/src/index.ts"],


### PR DESCRIPTION
Follow-up to the merged P1 (#12363). Makes the embed bundle main-thread only and single-file, per the Discord-iframe constraint (no SharedWorkers / no multithreading).

## Why
The Discord Activity iframe has no SharedWorkers — and the game never needed them: it runs main-thread on `@kbve/laser` plain WebSockets. The droid SharedWorker infrastructure was only pulled into `embed.js` because the game UI imported `FloatingWindow`/`NotContent` through the heavy `@kbve/astro` **barrel**, which re-exports droid.

## Change
- **New `@kbve/astro/ui`** — pure-React overlay primitives (FloatingWindow, NotContent, Drawer, Popover, useDraggable/useResizable, cn) with **zero droid dependency**.
- Point the 7 game UI files at `@kbve/astro/ui`. `ReactGameGate` stays on the barrel — it's the web-only Supabase gate, not in the embed graph.
- tsconfig path aliases (base + app) + embed vite alias.

## Result (rebuilt embed)
- modules transformed **2137 → 131**
- separate worker assets (ws/db/supabase, ~575 KB) **gone**
- `public/embed/` is now **embed.js + example.html only** — a true single file (3.6 MB)
- **zero `SharedWorker` references** in the bundle → main-thread only

## Verify
- `build-embed` green, single-file output
- `astro-cryptothrone:test` — 7 files, 46 passing

Part of #12362. Sets up P3 (Discord) to run entirely on main thread + dedicated workers.
