### PR TITLE
fix(ci-unreal-build): normalize ssh://mc.kbve.com LFS endpoint + lowercase owner

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -426,7 +426,7 @@ jobs:
                   RAW_LFS=""
                   [ -f .lfsconfig ] && RAW_LFS=$(git config -f .lfsconfig lfs.url 2>/dev/null || true)
                   case "${RAW_LFS}" in
-                    *forgejo.kbve.com/*|*git.kbve.com/*)
+                    *forgejo.kbve.com*|*git.kbve.com*|*mc.kbve.com*)
                       if [ -z "${FORGEJO_USER}" ] || [ -z "${FORGEJO_TOKEN}" ]; then
                         echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing - cannot pull LFS from git.kbve.com"
                         exit 1
@@ -441,6 +441,7 @@ jobs:
                         *.git) REPO_PATH="${REPO_PATH}/info/lfs" ;;
                         *) REPO_PATH="${REPO_PATH%.git}.git/info/lfs" ;;
                       esac
+                      REPO_PATH="$(printf '%s' "${REPO_PATH%%/*}" | tr 'A-Z' 'a-z')/${REPO_PATH#*/}"
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local
@@ -736,7 +737,7 @@ jobs:
                   RAW_LFS=""
                   [ -f .lfsconfig ] && RAW_LFS=$(git config -f .lfsconfig lfs.url 2>/dev/null || true)
                   case "${RAW_LFS}" in
-                    *forgejo.kbve.com/*|*git.kbve.com/*)
+                    *forgejo.kbve.com*|*git.kbve.com*|*mc.kbve.com*)
                       if [ -z "${FORGEJO_USER}" ] || [ -z "${FORGEJO_TOKEN}" ]; then
                         echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing - cannot pull LFS from git.kbve.com"
                         exit 1
@@ -754,6 +755,7 @@ jobs:
                         *.git) REPO_PATH="${REPO_PATH}/info/lfs" ;;
                         *) REPO_PATH="${REPO_PATH%.git}.git/info/lfs" ;;
                       esac
+                      REPO_PATH="$(printf '%s' "${REPO_PATH%%/*}" | tr 'A-Z' 'a-z')/${REPO_PATH#*/}"
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local


### PR DESCRIPTION
## What broke

`KBVE/chuck`'s `.lfsconfig` is `ssh://git@mc.kbve.com:30022/KBVE/chuck.git`. The clone step's endpoint matcher only recognized `git.kbve.com` / `forgejo.kbve.com`, so chuck fell through to the GitHub-native fallback → SSH → **`Host key verification failed`**. And the uppercase `KBVE` owner 401s (Forgejo LFS routing is case-sensitive: `KBVE`=401, `kbve`=302).

## Fix (both game + server clone steps)

- Match `*mc.kbve.com*` and drop the trailing `/` from the patterns so `host:port` forms match (`mc.kbve.com:30022/...`).
- Lowercase the owner segment before building the token'd `https://…@git.kbve.com/<owner>/<repo>` URL.

The existing `ssh://` + `host:port` stripping already yields the right `REPO_PATH` (`KBVE/chuck.git` → `kbve/chuck.git/info/lfs`), so the pull now uses the HTTPS **token** path on the reachable `.74` host.

## Why CI-side, not the chuck repo

The dev's local `chuck` main is **128 commits ahead / 9 behind** the remote (their unpushed game content vs the friend's LFS-config commits). Pushing a `.lfsconfig` fix would mean reconciling all 128 first — too risky for a config line. Normalizing in CI unblocks both Linux builds now; the chuck `.lfsconfig` + reconcile can be done separately by the dev.