### PR TITLE
cryptothrone: P3a Discord Activity client adapter (#12362)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/.gitignore
+++ b/apps/cryptothrone/astro-cryptothrone/.gitignore
@@ -4,3 +4,5 @@ coverage/
 # source of truth is src/embed/.
 public/embed/embed.js
 public/embed/assets/
+public/discord/discord.js
+public/discord/assets/

--- a/apps/cryptothrone/astro-cryptothrone/project.json
+++ b/apps/cryptothrone/astro-cryptothrone/project.json
@@ -41,6 +41,18 @@
 			},
 			"cache": true
 		},
+		"build-discord": {
+			"executor": "nx:run-commands",
+			"outputs": ["{projectRoot}/public/discord"],
+			"options": {
+				"cwd": "apps/cryptothrone/astro-cryptothrone",
+				"commands": [
+					"NODE_OPTIONS=\"--max-old-space-size=4096\" npx vite build --config vite.discord.config.mts"
+				],
+				"parallel": false
+			},
+			"cache": true
+		},
 		"preview": {
 			"dependsOn": [
 				{

--- a/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
+++ b/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta
+			name="viewport"
+			content="width=device-width, initial-scale=1, viewport-fit=cover" />
+		<title>CryptoThrone</title>
+		<style>
+			html,
+			body {
+				margin: 0;
+				height: 100%;
+				background: #0b0b14;
+				color: #e5e5e5;
+				font-family: system-ui, sans-serif;
+				overflow: hidden;
+			}
+			#app {
+				width: 100vw;
+				height: 100vh;
+			}
+		</style>
+	</head>
+	<body>
+		<!-- Discord Activity root. discord.js runs the OAuth handshake, bridges
+		     to a game-server session, then mounts the game into #app. -->
+		<div id="app">Loading CryptoThrone…</div>
+		<script src="/discord/discord.js" defer></script>
+	</body>
+</html>

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -1,0 +1,87 @@
+import { DiscordSDK, patchUrlMappings } from '@discord/embedded-app-sdk';
+import { mount } from './index';
+
+/**
+ * Discord Activity entry — the isolated Discord path. Runs entirely on the main
+ * thread (the Activity iframe has no SharedWorkers): does the Discord OAuth
+ * handshake, exchanges it for a game-server session via a backend endpoint, then
+ * boots the same shadow-root game mount as the standalone embed.
+ *
+ * Build target: `build-discord` -> public/discord/discord.js, loaded by
+ * public/discord/index.html (the Activity root URL configured in the Discord
+ * developer portal).
+ */
+const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
+	| string
+	| undefined;
+
+// Backend bridge (P3b): exchanges the Discord OAuth code for a Discord
+// access_token AND a game-server session {jwt, username}, linking the Discord
+// user to a KBVE profile. Routed through Discord's proxy.
+const SESSION_ENDPOINT = '/.proxy/api/discord/session';
+
+// Host mappings so the game's plain `new WebSocket('wss://game.cryptothrone…')`
+// calls are transparently rewritten through Discord's proxy — net-config and
+// the rest of the game stay unchanged. These prefixes must match the URL
+// Mappings configured in the Discord developer portal.
+const URL_MAPPINGS: { prefix: string; target: string }[] = [
+	{ prefix: '/cryptothrone-game', target: 'game.cryptothrone.com' },
+	{ prefix: '/cryptothrone-chat', target: 'chat.kbve.com' },
+];
+
+interface DiscordSession {
+	access_token: string;
+	jwt: string;
+	username: string;
+}
+
+function fail(msg: string, ...extra: unknown[]): void {
+	console.error(`[Cryptothrone/Discord] ${msg}`, ...extra);
+	const root = document.getElementById('app');
+	if (root) {
+		root.textContent = `Could not start the Activity: ${msg}`;
+	}
+}
+
+async function boot(): Promise<void> {
+	if (!CLIENT_ID) {
+		fail('missing PUBLIC_DISCORD_CLIENT_ID at build time');
+		return;
+	}
+
+	patchUrlMappings(URL_MAPPINGS);
+
+	const sdk = new DiscordSDK(CLIENT_ID);
+	await sdk.ready();
+
+	const { code } = await sdk.commands.authorize({
+		client_id: CLIENT_ID,
+		response_type: 'code',
+		state: '',
+		prompt: 'none',
+		scope: ['identify', 'guilds'],
+	});
+
+	const res = await fetch(SESSION_ENDPOINT, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ code }),
+	});
+	if (!res.ok) {
+		fail(`session exchange failed (${res.status})`);
+		return;
+	}
+	const session = (await res.json()) as DiscordSession;
+
+	await sdk.commands.authenticate({ access_token: session.access_token });
+
+	const el = document.getElementById('app') ?? document.body;
+	mount({
+		el,
+		jwt: session.jwt,
+		username: session.username,
+		height: '100vh',
+	});
+}
+
+void boot().catch((err) => fail('boot failed', err));

--- a/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
@@ -1,0 +1,57 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import { fileURLToPath } from 'node:url';
+import { resolve } from 'node:path';
+
+// Discord Activity bundle. Same game graph as embed.js, but the entry runs the
+// Discord OAuth handshake first (src/embed/discord.tsx). Main-thread only — the
+// Activity iframe has no SharedWorkers (the game already imports the lean
+// @kbve/astro/ui, so no droid workers are pulled in).
+// Output: apps/cryptothrone/astro-cryptothrone/public/discord/discord.js
+const here = fileURLToPath(new URL('.', import.meta.url));
+const pkg = (p: string) => resolve(here, '../../../packages', p);
+
+export default defineConfig({
+	plugins: [react(), tailwindcss()],
+	resolve: {
+		alias: [
+			{ find: /^@\//, replacement: resolve(here, 'src') + '/' },
+			{ find: '@kbve/astro/ui', replacement: pkg('npm/astro/src/ui.ts') },
+			{ find: '@kbve/astro', replacement: pkg('npm/astro/src/index.ts') },
+			{ find: '@kbve/droid', replacement: pkg('npm/droid/src/index.ts') },
+			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
+			{
+				find: '@kbve/itemdb-data',
+				replacement: pkg('data/codegen/generated/itemdb-data.json'),
+			},
+			{
+				find: '@kbve/npcdb-data',
+				replacement: pkg('data/codegen/generated/npcdb-data.json'),
+			},
+		],
+	},
+	publicDir: false,
+	define: {
+		'process.env.NODE_ENV': JSON.stringify('production'),
+	},
+	build: {
+		outDir: 'public/discord',
+		emptyOutDir: false,
+		minify: 'terser',
+		sourcemap: false,
+		target: 'es2020',
+		lib: {
+			entry: resolve(here, 'src/embed/discord.tsx'),
+			name: 'CryptothroneDiscord',
+			formats: ['iife'],
+			fileName: () => 'discord.js',
+		},
+		rollupOptions: {
+			output: {
+				inlineDynamicImports: true,
+				exports: 'named',
+			},
+		},
+	},
+});


### PR DESCRIPTION
**P3a of #12362** — the client side of the isolated Discord Activity path. Runs entirely on the **main thread** (the Activity iframe has no SharedWorkers; the game uses the lean `@kbve/astro/ui` from #12366 so no droid workers are bundled).

> Stacked on #12366 (lean ui). The leanui commit drops from this diff once #12366 merges + I rebase.

## What's here
- **`src/embed/discord.tsx`** — the Activity entry:
  1. `patchUrlMappings([game, chat])` so the game's plain `new WebSocket('wss://game.cryptothrone.com/ws')` calls route through Discord's proxy **transparently** — net-config and the rest of the game are untouched.
  2. `new DiscordSDK(clientId)` → `ready()` → `commands.authorize({scope:['identify','guilds']})` → `code`.
  3. POST `code` to `/.proxy/api/discord/session` (the backend bridge) → `{access_token, jwt, username}`.
  4. `commands.authenticate({access_token})`.
  5. `mount({el, jwt, username})` — the **same shadow-root game mount** as the standalone embed.
- **`public/discord/index.html`** — Activity root (`#app`) that loads `discord.js`.
- **`vite.discord.config.mts` + `build-discord` target** → `public/discord/discord.js` (gitignored single-file IIFE, 3.7 MB).

## Verification
- `nx run astro-cryptothrone:build-discord` → builds clean, single file (199 modules = embed's 131 + the Discord SDK), **no worker assets**.

## Blocked on (P3b — infra, next ticket/PR)
- **Backend bridge** `/.proxy/api/discord/session`: exchange the Discord OAuth `code` (needs `client_secret`) → Discord `access_token` + a game-server **Supabase JWT** for the linked KBVE profile.
- **Discord dev-portal app**: client id/secret (sealed), URL Mappings matching the `patchUrlMappings` prefixes, CSP.
- Runtime can only be verified inside the Discord client against a registered app — not headless.

Part of #12362.
