### PR TITLE
fix(cryptothrone): gate interactables behind explicit interact (E) + data-driven

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/interactables.test.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/interactables.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { getZoneInteractables, interactableAt } from './interactables';
+
+describe('zone interactables', () => {
+	it('returns cloud-city interactables and none for unknown zones', () => {
+		expect(getZoneInteractables('cloud-city').length).toBeGreaterThan(0);
+		expect(getZoneInteractables('nowhere')).toEqual([]);
+	});
+
+	it('matches a tile inside an interactable, misses outside', () => {
+		const list = getZoneInteractables('cloud-city');
+		const sign = list.find((i) => i.ref === 'sign')!;
+		const { xMin, xMax, yMin, yMax } = sign.bounds;
+		// inside the sign bounds
+		expect(interactableAt(list, xMin, yMin)?.ref).toBe('sign');
+		expect(interactableAt(list, xMax, yMax)?.ref).toBe('sign');
+		// far outside any interactable
+		expect(interactableAt(list, 40, 40)).toBeUndefined();
+		// one past the edge
+		expect(interactableAt(list, xMax + 1, yMax + 1)?.ref).not.toBe('sign');
+	});
+
+	it('every interactable has a message and valid bounds', () => {
+		for (const it of getZoneInteractables('cloud-city')) {
+			expect(it.message.length).toBeGreaterThan(0);
+			expect(it.bounds.xMin).toBeLessThanOrEqual(it.bounds.xMax);
+			expect(it.bounds.yMin).toBeLessThanOrEqual(it.bounds.yMax);
+		}
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/interactables.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/interactables.ts
@@ -1,0 +1,76 @@
+/**
+ * Per-zone interactable registry.
+ *
+ * Static, sprite-less points of interest (signs, statues, wells) defined as map
+ * regions. They open a dialog ONLY when the player explicitly interacts (E /
+ * click) while standing in the region — never automatically on walk-through.
+ * Keyed by zone (see data/zones.ts) so each map carries its own; adding one is
+ * a data edit here.
+ */
+
+export interface InteractBounds {
+	xMin: number;
+	xMax: number;
+	yMin: number;
+	yMax: number;
+}
+
+export interface Interactable {
+	/** Stable id. */
+	ref: string;
+	/** Tile region that counts as "at" this interactable. */
+	bounds: InteractBounds;
+	/** Dialog body shown on interact. */
+	message: string;
+	/** Speaker name in the dialog header. */
+	name?: string;
+	/** Portrait shown beside the dialog. */
+	characterImage?: string;
+	/** Full-bleed dialog background. */
+	backgroundImage?: string;
+}
+
+const ZONE_INTERACTABLES: Record<string, Interactable[]> = {
+	'cloud-city': [
+		{
+			ref: 'well',
+			bounds: { xMin: 2, xMax: 5, yMin: 10, yMax: 14 },
+			message:
+				'Seems like there are no fish in the sand pits. This area could be fixed up a bit.',
+		},
+		{
+			ref: 'sign',
+			bounds: { xMin: 2, xMax: 5, yMin: 2, yMax: 5 },
+			name: 'Wooden Sign',
+			message: 'Welcome to Cloud City!',
+			backgroundImage: '/assets/background/woodensign.webp',
+		},
+		{
+			ref: 'tombstone',
+			bounds: { xMin: 7, xMax: 10, yMin: 9, yMax: 10 },
+			name: 'Samson Statue',
+			message:
+				'Samson the Great was an amazing sailor, died drinking dat drank.',
+			characterImage: '/assets/npc/samson.png',
+			backgroundImage: '/assets/background/animetombstone.webp',
+		},
+	],
+};
+
+export function getZoneInteractables(zoneKey: string): Interactable[] {
+	return ZONE_INTERACTABLES[zoneKey] ?? [];
+}
+
+export function interactableAt(
+	list: Interactable[],
+	x: number,
+	y: number,
+): Interactable | undefined {
+	return list.find(
+		(it) =>
+			x >= it.bounds.xMin &&
+			x <= it.bounds.xMax &&
+			y >= it.bounds.yMin &&
+			y <= it.bounds.yMax,
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -15,7 +15,6 @@ import {
 	KIND_CAT_PLAYER,
 } from '@kbve/laser';
 import type {
-	Range,
 	CharacterEventData,
 	Dir,
 	Snapshot,
@@ -25,6 +24,11 @@ import type {
 import { getCtNetConfig } from '@/lib/net-config';
 import { getNPCByRef, npcIdForRef, isHostileRef } from '../data/npcs';
 import { getZone, DEFAULT_ZONE, type ZoneDef } from '../data/zones';
+import {
+	getZoneInteractables,
+	interactableAt,
+	type Interactable,
+} from '../data/interactables';
 
 const MAP_SCALE = 3;
 const STEP_THROTTLE_MS = 60;
@@ -114,8 +118,8 @@ export class CloudCityScene extends Scene {
 	private lastStepAt = 0;
 	private tilePixels = 16;
 	private zone: ZoneDef = getZone(DEFAULT_ZONE);
-	private ranges: Range[] = [];
-	private rangeTile = { x: -1, y: -1 };
+	private interactables: Interactable[] = [];
+	private interactKey!: Phaser.Input.Keyboard.Key;
 	private myHp = -1;
 	private myMaxHp = -1;
 	private nearbyHostiles = 0;
@@ -222,7 +226,8 @@ export class CloudCityScene extends Scene {
 			right: this.input.keyboard!.addKey(Codes.D, false),
 		};
 		this.attackKey = this.input.keyboard!.addKey(Codes.SPACE, false);
-		this.loadRanges();
+		this.interactKey = this.input.keyboard!.addKey(Codes.E, false);
+		this.interactables = getZoneInteractables(this.zone.key);
 
 		const cfg = getCtNetConfig();
 		if (!cfg) {
@@ -541,10 +546,6 @@ export class CloudCityScene extends Scene {
 					this.cameras.main.startFollow(sprite, true);
 					this.predicted = { x: e.tile.x, y: e.tile.y };
 					this.predictSeeded = true;
-					// Seed range tracker to spawn so a range dialog only
-					// fires when the player walks into a zone, not when
-					// they spawn already standing in one.
-					this.rangeTile = { x: e.tile.x, y: e.tile.y };
 				}
 			} else if (e.eid === this.myEid) {
 				// Reconcile prediction: trust the local position unless it
@@ -595,7 +596,6 @@ export class CloudCityScene extends Scene {
 			if (this.pendingAction?.eid === eid) this.pendingAction = null;
 		}
 
-		this.checkRanges();
 		this.checkHostileProximity();
 		this.syncRoster(snap);
 		this.runPendingAction();
@@ -856,69 +856,22 @@ export class CloudCityScene extends Scene {
 		}
 	}
 
-	private checkRanges() {
+	/**
+	 * Fire the interactable the player is standing in, if any. Called only on
+	 * an explicit interact press — never on movement — so sprite-less points
+	 * of interest (signs, statues) don't pop dialogs as you walk past.
+	 */
+	private tryInteract() {
 		if (this.myEid < 0) return;
 		const me = this.tracked.get(this.myEid);
 		if (!me) return;
-		if (me.tile.x === this.rangeTile.x && me.tile.y === this.rangeTile.y) {
-			return;
-		}
-		this.rangeTile = { x: me.tile.x, y: me.tile.y };
-		for (const range of this.ranges) {
-			const b = range.bounds;
-			if (
-				me.tile.x >= b.xMin &&
-				me.tile.x <= b.xMax &&
-				me.tile.y >= b.yMin &&
-				me.tile.y <= b.yMax
-			) {
-				range.action();
-				break;
-			}
-		}
-	}
-
-	private loadRanges() {
-		this.ranges = [
-			{
-				name: 'well',
-				bounds: { xMin: 2, xMax: 5, yMin: 10, yMax: 14 },
-				action: () => {
-					const eventData: CharacterEventData = {
-						message:
-							'Seems like there are no fish in the sand pits. This area could be fixed up a bit.',
-					};
-					laserEvents.emit('char:event', eventData);
-				},
-			},
-			{
-				name: 'sign',
-				bounds: { xMin: 2, xMax: 5, yMin: 2, yMax: 5 },
-				action: () => {
-					const eventData: CharacterEventData = {
-						message: 'Welcome to Cloud City!',
-						character_name: 'Wooden Sign',
-						background_image: '/assets/background/woodensign.webp',
-					};
-					laserEvents.emit('char:event', eventData);
-				},
-			},
-			{
-				name: 'tombstone',
-				bounds: { xMin: 7, xMax: 10, yMin: 9, yMax: 10 },
-				action: () => {
-					const eventData: CharacterEventData = {
-						message:
-							'Samson the Great was an amazing sailor, died drinking dat drank.',
-						character_name: 'Samson Statue',
-						character_image: '/assets/npc/samson.png',
-						background_image:
-							'/assets/background/animetombstone.webp',
-					};
-					laserEvents.emit('char:event', eventData);
-				},
-			},
-		];
+		const it = interactableAt(this.interactables, me.tile.x, me.tile.y);
+		if (!it) return;
+		const eventData: CharacterEventData = { message: it.message };
+		if (it.name) eventData.character_name = it.name;
+		if (it.characterImage) eventData.character_image = it.characterImage;
+		if (it.backgroundImage) eventData.background_image = it.backgroundImage;
+		laserEvents.emit('char:event', eventData);
 	}
 
 	private updateOverlays(time: number) {
@@ -1001,6 +954,10 @@ export class CloudCityScene extends Scene {
 
 		if (Phaser.Input.Keyboard.JustDown(this.attackKey)) {
 			this.attackNearby();
+		}
+
+		if (Phaser.Input.Keyboard.JustDown(this.interactKey)) {
+			this.tryInteract();
 		}
 
 		if (this.myEid < 0 || !this.predictSeeded) return;

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.23"
+version: "0.1.24"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## Bug
Well / Wooden Sign / Samson Statue dialogs popped **automatically** the moment the player walked into their map region — `checkRanges()` ran on every snapshot and fired the dialog on bounds-entry. Sprite-less points of interest opening at random while moving.

## Fix + refactor (for growth)
- **`data/interactables.ts`** — per-zone interactable registry: `{ ref, bounds, message, name?, characterImage?, backgroundImage? }`, keyed by zone (ties into the zone registry from C8). Adding/editing an interactable is now a data edit, not scene code.
- **Scene** loads the active zone's interactables; new **E interact key** → `tryInteract()` fires the interactable the player is **standing in** — explicit only.
- **Removed** the walk-into-bounds auto-trigger (`checkRanges` + `rangeTile` seeding) and the hardcoded `loadRanges()` list. Dropped the now-unused `Range` import.

## Verified
- `interactables.test.ts` 3/3 (bounds hit/miss, registry, data validity).
- `astro check`: touched files type-clean. The 2 remaining `CloudCityScene` errors (`PlayerStats` at :332/:496) are **pre-existing** partial stat-event payloads, unrelated.
- MDX bump cryptothrone `0.1.23 → 0.1.24`.

## Behavior
Walking through the well/sign/statue regions no longer opens anything. Stand in the region + press **E** → dialog. NPC click-to-interact unchanged.