### PR TITLE
feat(forgejo): LFS column + activity feed, Runners tab, jedi policy guardrail

### DIFF
--- a/apps/discordsh/astro-discordsh/src/lib/servers/discordshEdge.ts
+++ b/apps/discordsh/astro-discordsh/src/lib/servers/discordshEdge.ts
@@ -59,7 +59,24 @@ export async function listServers(params: {
 	sort?: string;
 	category?: number | null;
 }): Promise<EdgeResponse> {
-	return callEdgePublic('list.servers', params);
+	// Route through Axum backend instead of edge function directly
+	const query = new URLSearchParams();
+	if (params.limit) query.set('limit', params.limit.toString());
+	if (params.page) query.set('page', params.page.toString());
+	if (params.sort) query.set('sort', params.sort);
+	if (params.category !== null && params.category !== undefined)
+		query.set('category', params.category.toString());
+
+	const res = await fetch(`/api/servers/list?${query.toString()}`);
+	const data = await res.json();
+
+	// Transform Axum response to EdgeResponse shape
+	return {
+		success: res.ok,
+		servers: data.servers,
+		total: data.total,
+		error: res.ok ? undefined : 'Failed to fetch servers',
+	};
 }
 
 const RUST_API_URL = '/api/servers/submit';

--- a/apps/discordsh/astro-discordsh/src/lib/servers/serverCache.ts
+++ b/apps/discordsh/astro-discordsh/src/lib/servers/serverCache.ts
@@ -1,0 +1,254 @@
+import type { ServerCard } from './types';
+
+// ── Cache layer for Discord servers via IndexedDB ───────────────────
+
+const CACHE_DB_NAME = 'DiscordSHCache';
+const CACHE_DB_VERSION = 1;
+const SERVERS_STORE = 'servers';
+const META_STORE = 'meta';
+
+// Cache TTL: 5 minutes
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+interface CachedServersBlob {
+	servers: ServerCard[];
+	total: number;
+	category: string | null;
+	sort: string;
+	page: number;
+	limit: number;
+	cached_at: number;
+}
+
+interface MetaRecord {
+	key: string;
+	value: unknown;
+}
+
+// ── IndexedDB wrapper ────────────────────────────────────────────────
+
+class ServerCacheDB {
+	private db: IDBDatabase | null = null;
+
+	async open(): Promise<IDBDatabase> {
+		if (this.db) return this.db;
+
+		return new Promise((resolve, reject) => {
+			const req = indexedDB.open(CACHE_DB_NAME, CACHE_DB_VERSION);
+
+			req.onerror = () => reject(req.error);
+			req.onsuccess = () => {
+				this.db = req.result;
+				resolve(req.result);
+			};
+
+			req.onupgradeneeded = (e) => {
+				const db = (e.target as IDBOpenDBRequest).result;
+
+				// Store for paginated server lists
+				if (!db.objectStoreNames.contains(SERVERS_STORE)) {
+					const store = db.createObjectStore(SERVERS_STORE, {
+						keyPath: 'cache_key',
+					});
+					store.createIndex('cached_at', 'cached_at', { unique: false });
+				}
+
+				// Store for metadata (last fetch timestamp, version, etc.)
+				if (!db.objectStoreNames.contains(META_STORE)) {
+					db.createObjectStore(META_STORE, { keyPath: 'key' });
+				}
+			};
+		});
+	}
+
+	async getCachedServers(
+		category: string | null,
+		sort: string,
+		page: number,
+		limit: number,
+	): Promise<CachedServersBlob | null> {
+		try {
+			const db = await this.open();
+			const key = buildCacheKey(category, sort, page, limit);
+
+			return new Promise((resolve, reject) => {
+				const tx = db.transaction([SERVERS_STORE], 'readonly');
+				const store = tx.objectStore(SERVERS_STORE);
+				const req = store.get(key);
+
+				req.onsuccess = () => {
+					const blob = req.result as CachedServersBlob | undefined;
+					if (!blob) {
+						resolve(null);
+						return;
+					}
+
+					// Check TTL
+					if (Date.now() - blob.cached_at > CACHE_TTL_MS) {
+						resolve(null);
+						return;
+					}
+
+					resolve(blob);
+				};
+				req.onerror = () => reject(req.error);
+			});
+		} catch (err) {
+			console.warn('[serverCache] getCachedServers error:', err);
+			return null;
+		}
+	}
+
+	async setCachedServers(
+		category: string | null,
+		sort: string,
+		page: number,
+		limit: number,
+		servers: ServerCard[],
+		total: number,
+	): Promise<void> {
+		try {
+			const db = await this.open();
+			const key = buildCacheKey(category, sort, page, limit);
+
+			const blob: CachedServersBlob & { cache_key: string } = {
+				cache_key: key,
+				servers,
+				total,
+				category,
+				sort,
+				page,
+				limit,
+				cached_at: Date.now(),
+			};
+
+			return new Promise((resolve, reject) => {
+				const tx = db.transaction([SERVERS_STORE], 'readwrite');
+				const store = tx.objectStore(SERVERS_STORE);
+				const req = store.put(blob);
+
+				req.onsuccess = () => resolve();
+				req.onerror = () => reject(req.error);
+			});
+		} catch (err) {
+			console.warn('[serverCache] setCachedServers error:', err);
+		}
+	}
+
+	async clearCache(): Promise<void> {
+		try {
+			const db = await this.open();
+			return new Promise((resolve, reject) => {
+				const tx = db.transaction([SERVERS_STORE], 'readwrite');
+				const store = tx.objectStore(SERVERS_STORE);
+				const req = store.clear();
+
+				req.onsuccess = () => resolve();
+				req.onerror = () => reject(req.error);
+			});
+		} catch (err) {
+			console.warn('[serverCache] clearCache error:', err);
+		}
+	}
+
+	async setMeta(key: string, value: unknown): Promise<void> {
+		try {
+			const db = await this.open();
+			return new Promise((resolve, reject) => {
+				const tx = db.transaction([META_STORE], 'readwrite');
+				const store = tx.objectStore(META_STORE);
+				const req = store.put({ key, value });
+
+				req.onsuccess = () => resolve();
+				req.onerror = () => reject(req.error);
+			});
+		} catch (err) {
+			console.warn('[serverCache] setMeta error:', err);
+		}
+	}
+
+	async getMeta(key: string): Promise<unknown | null> {
+		try {
+			const db = await this.open();
+			return new Promise((resolve, reject) => {
+				const tx = db.transaction([META_STORE], 'readonly');
+				const store = tx.objectStore(META_STORE);
+				const req = store.get(key);
+
+				req.onsuccess = () => {
+					const record = req.result as MetaRecord | undefined;
+					resolve(record?.value ?? null);
+				};
+				req.onerror = () => reject(req.error);
+			});
+		} catch (err) {
+			console.warn('[serverCache] getMeta error:', err);
+			return null;
+		}
+	}
+}
+
+function buildCacheKey(
+	category: string | null,
+	sort: string,
+	page: number,
+	limit: number,
+): string {
+	return `${category ?? 'all'}:${sort}:${page}:${limit}`;
+}
+
+// ── Singleton instance ───────────────────────────────────────────────
+
+const cacheDB = new ServerCacheDB();
+
+// ── Public API ───────────────────────────────────────────────────────
+
+export async function getCachedServers(opts: {
+	category?: string;
+	sort?: string;
+	page?: number;
+	limit?: number;
+}): Promise<{ servers: ServerCard[]; total: number } | null> {
+	const category = opts.category ?? null;
+	const sort = opts.sort ?? 'votes';
+	const page = opts.page ?? 1;
+	const limit = opts.limit ?? 24;
+
+	const blob = await cacheDB.getCachedServers(category, sort, page, limit);
+	if (!blob) return null;
+
+	return {
+		servers: blob.servers,
+		total: blob.total,
+	};
+}
+
+export async function setCachedServers(
+	opts: {
+		category?: string;
+		sort?: string;
+		page?: number;
+		limit?: number;
+	},
+	servers: ServerCard[],
+	total: number,
+): Promise<void> {
+	const category = opts.category ?? null;
+	const sort = opts.sort ?? 'votes';
+	const page = opts.page ?? 1;
+	const limit = opts.limit ?? 24;
+
+	await cacheDB.setCachedServers(category, sort, page, limit, servers, total);
+}
+
+export async function clearServerCache(): Promise<void> {
+	await cacheDB.clearCache();
+}
+
+export async function setCacheMeta(key: string, value: unknown): Promise<void> {
+	await cacheDB.setMeta(key, value);
+}
+
+export async function getCacheMeta(key: string): Promise<unknown | null> {
+	return cacheDB.getMeta(key);
+}

--- a/apps/discordsh/astro-discordsh/src/lib/servers/serverService.ts
+++ b/apps/discordsh/astro-discordsh/src/lib/servers/serverService.ts
@@ -1,6 +1,10 @@
 import type { ServerCard, SortOption } from './types';
 import { CATEGORIES } from './types';
-import { listServers } from './discordshEdge';
+import { listServers as listServersAxum } from './discordshEdge';
+import {
+	getCachedServers,
+	setCachedServers,
+} from './serverCache';
 
 // ── Category mapping ────────────────────────────────────────────────
 // The DB uses 1-based integer category IDs matching CATEGORIES array order.
@@ -9,9 +13,11 @@ const CATEGORY_TO_INT = new Map(
 	CATEGORIES.map((c, i) => [c.id, i + 1] as const),
 );
 
-// ── Data fetching ───────────────────────────────────────────────────
-// Fetches from the edge function (server-side pagination).
-// Falls back to static JSON if the edge call fails.
+// ── Data fetching waterfall ─────────────────────────────────────────
+// 1. IndexedDB cache (5min TTL)
+// 2. Axum backend /api/servers/list
+// 3. Supabase edge function (future fallback)
+// 4. Static JSON (offline/dev)
 
 export async function fetchServers(opts?: {
 	category?: string;
@@ -19,33 +25,55 @@ export async function fetchServers(opts?: {
 	page?: number;
 	limit?: number;
 }): Promise<{ servers: ServerCard[]; total: number }> {
+	const category = opts?.category;
+	const sort = opts?.sort ?? 'votes';
+	const page = opts?.page ?? 1;
+	const limit = opts?.limit ?? 24;
+
+	// Layer 1: IndexedDB cache
 	try {
-		const result = await listServers({
-			limit: opts?.limit ?? 24,
-			page: opts?.page ?? 1,
-			sort: opts?.sort ?? 'votes',
-			category: opts?.category
-				? (CATEGORY_TO_INT.get(opts.category) ?? null)
-				: null,
+		const cached = await getCachedServers({ category, sort, page, limit });
+		if (cached) {
+			console.info('[fetchServers] Cache hit (IDB)');
+			return cached;
+		}
+	} catch (err) {
+		console.warn('[fetchServers] IDB cache read failed:', err);
+	}
+
+	// Layer 2: Axum backend
+	try {
+		const result = await listServersAxum({
+			limit,
+			page,
+			sort,
+			category: category ? (CATEGORY_TO_INT.get(category) ?? null) : null,
 		});
 
 		if (result.success) {
-			return {
+			const data = {
 				servers: (result.servers as ServerCard[]) ?? [],
 				total: (result.total as number) ?? 0,
 			};
+
+			// Cache successful response
+			setCachedServers({ category, sort, page, limit }, data.servers, data.total).catch(
+				(err) => console.warn('[fetchServers] Cache write failed:', err),
+			);
+
+			console.info('[fetchServers] Fetched from Axum backend');
+			return data;
 		}
-		console.warn(
-			'[fetchServers] Edge error, falling back to static JSON:',
-			result.error,
-		);
+		console.warn('[fetchServers] Axum error, falling back:', result.error);
 	} catch (err) {
-		console.warn(
-			'[fetchServers] Edge unreachable, falling back to static JSON:',
-			err,
-		);
+		console.warn('[fetchServers] Axum unreachable, falling back:', err);
 	}
 
+	// Layer 3: Supabase edge (future — currently skipped)
+	// TODO: Add edge function fallback when needed
+
+	// Layer 4: Static JSON fallback
+	console.info('[fetchServers] Falling back to static JSON');
 	return fetchServersStatic(opts);
 }
 

--- a/apps/discordsh/axum-discordsh/src/api/servers.rs
+++ b/apps/discordsh/axum-discordsh/src/api/servers.rs
@@ -1,6 +1,6 @@
 use std::net::IpAddr;
 
-use axum::{Json, Router, extract::State, http::StatusCode, response::IntoResponse, routing::post};
+use axum::{Json, Router, extract::{Path, Query, State}, http::StatusCode, response::IntoResponse, routing::{get, post}};
 use serde::{Deserialize, Serialize};
 
 use super::validate::{
@@ -63,7 +63,10 @@ fn err(status: StatusCode, msg: impl Into<String>) -> (StatusCode, Json<ErrorRes
 }
 
 pub fn router() -> Router<HttpState> {
-    Router::new().route("/api/servers/submit", post(submit_server))
+    Router::new()
+        .route("/api/servers/submit", post(submit_server))
+        .route("/api/servers/list", get(list_servers))
+        .route("/api/servers/:server_id", get(get_server))
 }
 
 /// POST /api/servers/submit
@@ -205,6 +208,87 @@ async fn submit_server(
             err(StatusCode::BAD_GATEWAY, "Upstream service unavailable").into_response()
         }
     }
+}
+
+// ── List / Get Endpoints ────────────────────────────────────────────
+
+/// Query params for GET /api/servers/list
+#[derive(Debug, Deserialize)]
+pub struct ListServersQuery {
+    #[serde(default)]
+    pub category: Option<u32>,
+    #[serde(default = "default_sort")]
+    pub sort: String,
+    #[serde(default = "default_page")]
+    pub page: u32,
+    #[serde(default = "default_limit")]
+    pub limit: u32,
+}
+
+fn default_sort() -> String {
+    "votes".into()
+}
+fn default_page() -> u32 {
+    1
+}
+fn default_limit() -> u32 {
+    24
+}
+
+/// Server record returned by list/get endpoints
+#[derive(Debug, Serialize)]
+pub struct ServerRecord {
+    pub server_id: String,
+    pub name: String,
+    pub summary: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub banner_url: Option<String>,
+    pub invite_code: String,
+    pub categories: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub tags: Vec<String>,
+    pub member_count: i32,
+    pub vote_count: i32,
+    pub is_online: bool,
+}
+
+/// GET /api/servers/list
+///
+/// TODO: Replace stub with PgCluster query when pool available.
+/// Expected RPC: `rpc.list_servers(category, sort, page, limit)`
+async fn list_servers(
+    State(_state): State<HttpState>,
+    Query(params): Query<ListServersQuery>,
+) -> impl IntoResponse {
+    // Stub: return empty paginated response
+    let response = serde_json::json!({
+        "servers": [],
+        "total": 0,
+        "page": params.page,
+        "limit": params.limit,
+    });
+
+    (StatusCode::OK, Json(response))
+}
+
+/// GET /api/servers/:server_id
+///
+/// TODO: Replace stub with PgCluster query when pool available.
+/// Expected RPC: `rpc.get_server(server_id)`
+async fn get_server(
+    State(_state): State<HttpState>,
+    Path(server_id): Path<String>,
+) -> impl IntoResponse {
+    if !is_valid_snowflake(&server_id) {
+        return err(StatusCode::BAD_REQUEST, "Invalid server ID").into_response();
+    }
+
+    // Stub: return 404
+    err(StatusCode::NOT_FOUND, "Server not found").into_response()
 }
 
 #[cfg(test)]

--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -9,6 +9,7 @@ import ReactForgejoUserPanel from './ReactForgejoUserPanel';
 import ReactForgejoOrgPanel from './ReactForgejoOrgPanel';
 import ReactForgejoRepoAdmin from './ReactForgejoRepoAdmin';
 import ReactForgejoIssues from './ReactForgejoIssues';
+import ReactForgejoRunners from './ReactForgejoRunners';
 import ReactForgejoSystemPanel from './ReactForgejoSystemPanel';
 import ReactForgejoToast from './ReactForgejoToast';
 ---
@@ -45,6 +46,9 @@ import ReactForgejoToast from './ReactForgejoToast';
 				</div>
 				<div id="forgejo-issues">
 					<ReactForgejoIssues client:only="react" />
+				</div>
+				<div id="forgejo-runners">
+					<ReactForgejoRunners client:only="react" />
 				</div>
 				<div id="forgejo-system">
 					<ReactForgejoSystemPanel client:only="react" />

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
@@ -599,6 +599,15 @@ export default function ReactForgejoRepoPanel() {
 										fontFamily: 'monospace',
 									}}>
 									{formatSize(repo.size)}
+									{repo.lfs_size > 0 && (
+										<div
+											style={{
+												color: '#8b5cf6',
+												fontSize: '0.62rem',
+											}}>
+											LFS {formatSize(repo.lfs_size)}
+										</div>
+									)}
 								</td>
 								<td
 									style={{

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRunners.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRunners.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { forgejoService } from './forgejoService';
+import { ActionButton, SelectField, useTabActive, uiTokens } from './forgejoUi';
+import { Cpu, KeyRound, Copy, Check } from 'lucide-react';
+
+const { textColor, subText, border, panelBg } = uiTokens;
+
+function TokenBox({ token }: { token: string }) {
+	const [copied, setCopied] = useState(false);
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 8,
+				padding: '0.6rem 0.75rem',
+				borderRadius: 8,
+				border,
+				background: 'var(--sl-color-bg, #0d1117)',
+				marginTop: '0.75rem',
+			}}>
+			<KeyRound size={14} style={{ color: '#f59e0b', flexShrink: 0 }} />
+			<code
+				style={{
+					flex: 1,
+					color: textColor,
+					fontSize: '0.78rem',
+					wordBreak: 'break-all',
+				}}>
+				{token}
+			</code>
+			<ActionButton
+				size="sm"
+				onClick={() => {
+					navigator.clipboard?.writeText(token);
+					setCopied(true);
+					setTimeout(() => setCopied(false), 1500);
+				}}>
+				{copied ? <Check size={12} /> : <Copy size={12} />}
+			</ActionButton>
+		</div>
+	);
+}
+
+export default function ReactForgejoRunners() {
+	const active = useTabActive('runners');
+	const repos = useStore(forgejoService.$repos);
+	const orgs = useStore(forgejoService.$orgs);
+	const scope = useStore(forgejoService.$runnerScope);
+	const runners = useStore(forgejoService.$runners);
+	const token = useStore(forgejoService.$runnerToken);
+	const busy = useStore(forgejoService.$busy);
+
+	if (!active) return null;
+
+	const options = [
+		{ value: 'instance', label: 'Instance (admin)' },
+		...orgs.map((o) => ({
+			value: `org:${o.username}`,
+			label: `${o.username} (org)`,
+		})),
+		...repos.map((r) => ({ value: r.full_name, label: r.full_name })),
+	];
+
+	const isScoped = scope !== 'instance';
+
+	return (
+		<div className="not-content">
+			<div
+				style={{
+					display: 'flex',
+					gap: 12,
+					alignItems: 'flex-end',
+					flexWrap: 'wrap',
+					marginBottom: '1.25rem',
+				}}>
+				<div style={{ flex: '1 1 280px', maxWidth: 420 }}>
+					<SelectField
+						label="Runner scope"
+						value={scope}
+						onChange={(v) => forgejoService.setRunnerScope(v)}
+						options={options}
+					/>
+				</div>
+				<div style={{ marginBottom: '0.75rem' }}>
+					<ActionButton
+						variant="primary"
+						loading={busy === 'runner-token'}
+						onClick={() => forgejoService.genRunnerToken()}>
+						<KeyRound size={14} /> Registration token
+					</ActionButton>
+				</div>
+			</div>
+
+			<p style={{ color: subText, fontSize: '0.8rem', marginTop: 0 }}>
+				Generate a registration token, then register a self-hosted
+				runner:{' '}
+				<code style={{ color: textColor }}>
+					forgejo-runner register --instance &lt;url&gt; --token
+					&lt;token&gt;
+				</code>
+			</p>
+
+			{token && <TokenBox token={token} />}
+
+			{isScoped && (
+				<div style={{ marginTop: '1.5rem' }}>
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 6,
+							fontSize: '0.8rem',
+							fontWeight: 700,
+							color: textColor,
+							marginBottom: '0.75rem',
+						}}>
+						<Cpu size={14} /> Registered runners
+					</div>
+					<div
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 8,
+						}}>
+						{runners.map((r, i) => (
+							<div
+								key={r.id ?? i}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: 8,
+									padding: '0.5rem 0.7rem',
+									borderRadius: 8,
+									border,
+									background: panelBg,
+								}}>
+								<span
+									style={{
+										width: 8,
+										height: 8,
+										borderRadius: '50%',
+										background:
+											r.status === 'online' ||
+											r.status === 'idle'
+												? '#22c55e'
+												: '#6b7280',
+										flexShrink: 0,
+									}}
+								/>
+								<span
+									style={{
+										color: textColor,
+										fontSize: '0.82rem',
+										flex: 1,
+									}}>
+									{r.name ?? `runner-${r.id ?? i}`}
+								</span>
+								{r.status && (
+									<span
+										style={{
+											color: subText,
+											fontSize: '0.7rem',
+										}}>
+										{r.status}
+									</span>
+								)}
+								{Array.isArray(r.labels) &&
+									r.labels.length > 0 && (
+										<span
+											style={{
+												color: subText,
+												fontSize: '0.68rem',
+											}}>
+											{r.labels.join(', ')}
+										</span>
+									)}
+							</div>
+						))}
+						{runners.length === 0 && (
+							<span
+								style={{ color: subText, fontSize: '0.8rem' }}>
+								No runners registered for this scope.
+							</span>
+						)}
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -1,5 +1,10 @@
 import { useStore } from '@nanostores/react';
-import { forgejoService, formatSize, langColor } from './forgejoService';
+import {
+	forgejoService,
+	formatSize,
+	langColor,
+	timeAgo,
+} from './forgejoService';
 import { useTabActive } from './forgejoUi';
 import {
 	Loader2,
@@ -10,6 +15,8 @@ import {
 	Tag,
 	Lock,
 	Archive,
+	Activity,
+	GitBranch,
 } from 'lucide-react';
 
 function StatCard({
@@ -240,6 +247,90 @@ function LanguageBar() {
 	);
 }
 
+function RecentActivity() {
+	const repos = useStore(forgejoService.$repos);
+	if (repos.length === 0) return null;
+	const recent = [...repos]
+		.filter((r) => r.updated_at)
+		.sort(
+			(a, b) =>
+				new Date(b.updated_at).getTime() -
+				new Date(a.updated_at).getTime(),
+		)
+		.slice(0, 8);
+	if (recent.length === 0) return null;
+	return (
+		<div style={{ marginBottom: '1.5rem' }}>
+			<div
+				style={{
+					fontSize: '0.75rem',
+					fontWeight: 600,
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					marginBottom: 8,
+					textTransform: 'uppercase',
+					letterSpacing: '0.05em',
+					display: 'flex',
+					alignItems: 'center',
+					gap: 4,
+				}}>
+				<Activity size={12} />
+				Recent Activity
+			</div>
+			<div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+				{recent.map((r) => (
+					<div
+						key={r.id}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+							padding: '0.35rem 0.6rem',
+							borderRadius: 6,
+							background: 'var(--sl-color-bg, #0d1117)',
+							fontSize: '0.78rem',
+						}}>
+						<GitBranch
+							size={11}
+							style={{
+								color: 'var(--sl-color-gray-4, #6b7280)',
+								flexShrink: 0,
+							}}
+						/>
+						<span
+							style={{
+								color: 'var(--sl-color-white, #e6edf3)',
+								fontWeight: 500,
+								overflow: 'hidden',
+								textOverflow: 'ellipsis',
+								whiteSpace: 'nowrap',
+								flex: 1,
+							}}>
+							{r.full_name}
+						</span>
+						{r.lfs_size > 0 && (
+							<span
+								style={{
+									color: '#8b5cf6',
+									fontSize: '0.65rem',
+								}}>
+								LFS {formatSize(r.lfs_size)}
+							</span>
+						)}
+						<span
+							style={{
+								color: 'var(--sl-color-gray-4, #6b7280)',
+								fontSize: '0.68rem',
+								whiteSpace: 'nowrap',
+							}}>
+							{timeAgo(r.updated_at)}
+						</span>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}
+
 export default function ReactForgejoSummary() {
 	const active = useTabActive('overview');
 	const loading = useStore(forgejoService.$loading);
@@ -364,6 +455,8 @@ export default function ReactForgejoSummary() {
 
 			{/* Language breakdown */}
 			<LanguageBar />
+
+			<RecentActivity />
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
@@ -7,6 +7,7 @@ import {
 	Building2,
 	Webhook,
 	CircleDot,
+	Cpu,
 	ServerCog,
 } from 'lucide-react';
 
@@ -21,6 +22,7 @@ const TABS: { id: ForgejoTab; label: string; icon: React.ReactNode }[] = [
 		icon: <Webhook size={14} />,
 	},
 	{ id: 'issues', label: 'Issues & PRs', icon: <CircleDot size={14} /> },
+	{ id: 'runners', label: 'Runners', icon: <Cpu size={14} /> },
 	{ id: 'system', label: 'System', icon: <ServerCog size={14} /> },
 ];
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -26,6 +26,8 @@ export interface ForgejoRepo {
 	archived: boolean;
 	empty: boolean;
 	size: number;
+	git_size: number;
+	lfs_size: number;
 	stars_count: number;
 	forks_count: number;
 	open_issues_count: number;
@@ -239,7 +241,16 @@ export type ForgejoTab =
 	| 'orgs'
 	| 'webhooks'
 	| 'issues'
+	| 'runners'
 	| 'system';
+
+export interface ForgejoRunner {
+	id?: number;
+	name?: string;
+	status?: string;
+	labels?: string[];
+	[key: string]: unknown;
+}
 
 export interface ForgejoIssue {
 	id: number;
@@ -766,6 +777,9 @@ class ForgejoService {
 	public readonly $unadopted = atom<string[]>([]);
 	public readonly $stats = atom<ForgejoStats | null>(null);
 	public readonly $storage = atom<ForgejoStorage | null>(null);
+	public readonly $runners = atom<ForgejoRunner[]>([]);
+	public readonly $runnerToken = atom<string | null>(null);
+	public readonly $runnerScope = atom<string>('instance');
 
 	public readonly $issueRepo = atom<string | null>(null);
 	public readonly $issueState = atom<'open' | 'closed'>('open');
@@ -1926,6 +1940,79 @@ class ForgejoService {
 				await this.loadIssues();
 			},
 			lock ? `#${index} locked` : `#${index} unlocked`,
+		);
+	}
+
+	// --- Actions runners ---
+
+	private _runnerListPath(scope: string): string | null {
+		if (scope === 'instance') return null;
+		if (scope.startsWith('org:')) return `/orgs/${scope.slice(4)}/runners`;
+		return `/repos/${scope}/runners`;
+	}
+
+	private _runnerTokenPath(scope: string): string {
+		if (scope === 'instance') return '/admin/runners/registration-token';
+		if (scope.startsWith('org:'))
+			return `/orgs/${scope.slice(4)}/runners/registration-token`;
+		return `/repos/${scope}/runners/registration-token`;
+	}
+
+	public setRunnerScope(scope: string): void {
+		this.$runnerScope.set(scope);
+		this.$runnerToken.set(null);
+		this.loadRunners();
+	}
+
+	public async loadRunners(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		const path = this._runnerListPath(this.$runnerScope.get());
+		if (!path) {
+			this.$runners.set([]);
+			return;
+		}
+		try {
+			const resp = await fetch(`${API_BASE}${path}`, {
+				headers: { Authorization: `Bearer ${token}` },
+				signal: AbortSignal.timeout(15000),
+			});
+			if (!resp.ok) {
+				this.$runners.set([]);
+				return;
+			}
+			const data = await resp.json();
+			const arr = Array.isArray(data)
+				? data
+				: Array.isArray(data?.runners)
+					? data.runners
+					: [];
+			this.$runners.set(arr as ForgejoRunner[]);
+		} catch {
+			this.$runners.set([]);
+		}
+	}
+
+	public genRunnerToken(): Promise<boolean> {
+		const path = this._runnerTokenPath(this.$runnerScope.get());
+		return this._run(
+			'runner-token',
+			async (t) => {
+				const resp = await fetch(`${API_BASE}${path}`, {
+					method: 'POST',
+					headers: { Authorization: `Bearer ${t}` },
+					signal: AbortSignal.timeout(15000),
+				});
+				if (!resp.ok) {
+					throw new ForgejoMutationError(
+						resp.status,
+						`Token request failed (${resp.status})`,
+					);
+				}
+				const data = await resp.json();
+				this.$runnerToken.set(data?.token ?? null);
+			},
+			'Runner registration token generated',
 		);
 	}
 

--- a/apps/kbve/astro-kbve/src/content/docs/application/css.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/css.mdx
@@ -188,17 +188,48 @@ Animate elements as the user scrolls — no scroll-event JavaScript, runs on the
 
 ### View transitions
 
-The View Transitions API animates between DOM states (and across page navigations) with a few lines of CSS.
+The View Transitions API animates between two DOM states — the browser snapshots before and after, then cross-fades or morphs between them. It works for in-page state changes (same-document) and across page navigations (cross-document / MPA).
 
-```css
-@view-transition {
-    navigation: auto;
-}
+**Same-document.** Wrap the DOM mutation in `startViewTransition`. The browser captures, applies your callback, then animates old → new. A default cross-fade comes free.
 
-.hero-image {
-    view-transition-name: hero;
+```js
+function toggle() {
+    if (!document.startViewTransition) return update(); // graceful fallback
+    document.startViewTransition(() => update());       // animated path
 }
 ```
+
+**Shared-element morph.** Give the same `view-transition-name` to an element in both states and the browser tweens it between positions — a thumbnail growing into a hero, a card expanding into a detail page.
+
+```css
+.thumbnail { view-transition-name: hero; }
+/* On the next view, the large image carries the SAME name → it morphs */
+.detail-image { view-transition-name: hero; }
+```
+
+<Aside type="caution">
+A `view-transition-name` must be **unique per snapshot** — two visible elements sharing one name aborts the transition. For lists, generate per-item names (`view-transition-name: card-{id}`).
+</Aside>
+
+**Customizing.** The transition exposes pseudo-elements you can target with normal `@keyframes` — `::view-transition-old(name)` (outgoing) and `::view-transition-new(name)` (incoming).
+
+```css
+@keyframes slide-from-right { from { transform: translateX(40px); opacity: 0; } }
+@keyframes fade-out         { to   { opacity: 0; } }
+
+::view-transition-old(root) { animation: fade-out 0.2s both; }
+::view-transition-new(root) { animation: slide-from-right 0.3s both; }
+```
+
+**Cross-document (MPA).** One CSS rule opts an entire multi-page site into transitions — no JavaScript, no SPA router.
+
+```css
+@view-transition { navigation: auto; }
+```
+
+<Aside type="tip">
+This very site is Astro. For MPA view transitions across Astro pages, drop `<ClientRouter />` (from `astro:transitions`) in your layout `<head>` and tag shared elements with the `transition:name` directive — Astro wires up the API and ships a fallback for browsers without it.
+</Aside>
 
 ### Respecting motion preferences
 
@@ -470,6 +501,124 @@ A full timeline. This is the `shimmer` keyframe the gradient-text example earlie
 
 <Aside type="tip">
 In Tailwind v4, register a keyframe-backed animation as a theme token: `@theme { --animate-float: float 3s ease-in-out infinite; }` generates the `animate-float` utility. Always pair looping animation with `motion-safe:` so it respects reduced-motion.
+</Aside>
+
+### Animation Gallery
+
+Live, self-contained keyframe demos. Each snippet carries its own `<style>` block with a uniquely-named `@keyframes`, so you can copy one and drop it anywhere — no shared config required.
+
+#### Floating
+
+export const fxFloatCode = `<style>
+@keyframes kbve-float { 0%, 100% { transform: translateY(0); } 50% { transform: translateY(-14px); } }
+.kbve-float { animation: kbve-float 3s ease-in-out infinite; }
+</style>
+<div class="flex items-center justify-center p-12 bg-gray-900">
+  <div class="kbve-float w-20 h-20 shadow-xl rounded-2xl bg-gradient-to-br from-cyan-400 to-fuchsia-500"></div>
+</div>`;
+
+<DevCode htmlCode={fxFloatCode} />
+
+#### Pulse Ring
+
+A notification dot with an expanding, fading ring — the classic "live" indicator.
+
+export const fxPulseCode = `<style>
+@keyframes kbve-ping { 75%, 100% { transform: scale(2.4); opacity: 0; } }
+.kbve-ping { animation: kbve-ping 1.4s cubic-bezier(0,0,0.2,1) infinite; }
+</style>
+<div class="flex items-center justify-center p-12 bg-gray-900">
+  <span class="relative flex w-5 h-5">
+    <span class="kbve-ping absolute inline-flex w-full h-full rounded-full bg-cyan-400"></span>
+    <span class="relative inline-flex w-5 h-5 rounded-full bg-cyan-500"></span>
+  </span>
+</div>`;
+
+<DevCode htmlCode={fxPulseCode} />
+
+#### Shimmer Text
+
+The gradient shimmer referenced earlier — now running live via an embedded keyframe.
+
+export const fxShimmerCode = `<style>
+@keyframes kbve-shimmer { to { background-position: 200% center; } }
+.kbve-shimmer {
+  background: linear-gradient(90deg, #06b6d4, #d946ef, #06b6d4);
+  background-size: 200% auto;
+  -webkit-background-clip: text; background-clip: text;
+  color: transparent;
+  animation: kbve-shimmer 3s linear infinite;
+}
+</style>
+<div class="flex items-center justify-center p-12 bg-gray-900">
+  <h1 class="kbve-shimmer text-6xl font-black">Shimmer</h1>
+</div>`;
+
+<DevCode htmlCode={fxShimmerCode} />
+
+#### Typewriter
+
+`steps()` makes the reveal tick character-by-character; a second keyframe blinks the caret.
+
+export const fxTypeCode = `<style>
+@keyframes kbve-type { from { width: 0; } to { width: 16ch; } }
+@keyframes kbve-caret { 50% { border-color: transparent; } }
+.kbve-type {
+  width: 16ch;
+  font-family: ui-monospace, monospace;
+  white-space: nowrap; overflow: hidden;
+  border-right: 3px solid #06b6d4;
+  animation: kbve-type 3s steps(16) infinite alternate, kbve-caret 0.7s step-end infinite;
+}
+</style>
+<div class="flex items-center justify-center p-12 bg-gray-900">
+  <span class="kbve-type text-2xl font-medium text-cyan-300">console.log(42)</span>
+</div>`;
+
+<DevCode htmlCode={fxTypeCode} />
+
+#### Marquee
+
+Seamless infinite scroll — duplicate the content and translate by -50%.
+
+export const fxMarqueeCode = `<style>
+@keyframes kbve-marquee { to { transform: translateX(-50%); } }
+.kbve-marquee { display: inline-flex; gap: 2rem; animation: kbve-marquee 12s linear infinite; }
+.kbve-marquee:hover { animation-play-state: paused; }
+</style>
+<div class="p-8 overflow-hidden bg-gray-900 whitespace-nowrap">
+  <div class="kbve-marquee text-lg font-semibold text-cyan-300">
+    <span>★ Astro</span><span>★ TailwindCSS</span><span>★ Rust</span><span>★ Unity</span><span>★ Supabase</span>
+    <span>★ Astro</span><span>★ TailwindCSS</span><span>★ Rust</span><span>★ Unity</span><span>★ Supabase</span>
+  </div>
+</div>`;
+
+<DevCode htmlCode={fxMarqueeCode} />
+
+#### Flip Card
+
+A 3D flip on hover with `transform-style: preserve-3d` and `backface-visibility`.
+
+export const fxFlipCode = `<style>
+.kbve-flip { perspective: 1000px; }
+.kbve-flip-inner { position: relative; width: 100%; height: 100%; transition: transform 0.6s; transform-style: preserve-3d; }
+.kbve-flip:hover .kbve-flip-inner { transform: rotateY(180deg); }
+.kbve-flip-face { position: absolute; inset: 0; backface-visibility: hidden; display: flex; align-items: center; justify-content: center; border-radius: 1rem; font-weight: 700; color: #fff; }
+.kbve-flip-back { transform: rotateY(180deg); }
+</style>
+<div class="flex items-center justify-center p-12 bg-gray-900">
+  <div class="kbve-flip w-48 h-32">
+    <div class="kbve-flip-inner">
+      <div class="kbve-flip-face bg-cyan-600">Hover me</div>
+      <div class="kbve-flip-face kbve-flip-back bg-fuchsia-600">Flipped!</div>
+    </div>
+  </div>
+</div>`;
+
+<DevCode htmlCode={fxFlipCode} />
+
+<Aside type="caution">
+Every demo here loops or runs on hover purely for illustration. In production wrap looping motion in `@media (prefers-reduced-motion: no-preference)` so it respects the user's setting.
 </Aside>
 
 ---

--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.197"
+version: "1.0.198"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 version_target: apps/kbve/axum-kbve/Cargo.toml

--- a/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
+++ b/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
@@ -19,7 +19,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use jedi::entity::error::JediError;
-use jedi::entity::forgejo::{ForgejoClient, ForgejoStats, ForgejoStorage};
+use jedi::entity::forgejo::{ForgejoClient, ForgejoPolicy, ForgejoStats, ForgejoStorage};
 
 use super::proxy::{require_dashboard_manage_with_query, require_dashboard_view};
 
@@ -74,9 +74,12 @@ pub fn init_forgejo_api() -> bool {
         Ok(t) => t,
         Err(_) => return false,
     };
-    FORGEJO_API
-        .set(ForgejoClient::new(&upstream, &token))
-        .is_ok()
+    let mut client = ForgejoClient::new(&upstream, &token);
+    if let Ok(owners) = std::env::var("FORGEJO_ALLOWED_OWNERS") {
+        let policy = ForgejoPolicy::from_owners(owners.split(','));
+        client = client.with_policy(policy);
+    }
+    FORGEJO_API.set(client).is_ok()
 }
 
 fn client() -> Result<&'static ForgejoClient, Response> {

--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::time::Duration;
 
+use super::policy::ForgejoPolicy;
 use super::types::*;
 use crate::entity::error::JediError;
 
@@ -22,6 +23,7 @@ pub struct ForgejoClient {
     client: Client,
     token: String,
     base_url: String,
+    policy: ForgejoPolicy,
 }
 
 impl ForgejoClient {
@@ -37,7 +39,15 @@ impl ForgejoClient {
             client,
             token: token.to_string(),
             base_url: base_url.trim_end_matches('/').to_string(),
+            policy: ForgejoPolicy::open(),
         }
+    }
+
+    /// Restrict owner-scoped mutations to the policy's allowlist. Reads and
+    /// admin-global ops (user CRUD, cron, unadopted) are unaffected.
+    pub fn with_policy(mut self, policy: ForgejoPolicy) -> Self {
+        self.policy = policy;
+        self
     }
 
     // ── Core helpers ─────────────────────────────────────────────────
@@ -174,6 +184,7 @@ impl ForgejoClient {
         user: &str,
         body: &Value,
     ) -> Result<ForgejoRepo, JediError> {
+        self.policy.check_owner(user)?;
         self.write(
             Method::POST,
             &format!("/api/v1/admin/users/{user}/repos"),
@@ -187,6 +198,7 @@ impl ForgejoClient {
         org: &str,
         body: &Value,
     ) -> Result<ForgejoRepo, JediError> {
+        self.policy.check_owner(org)?;
         self.write(
             Method::POST,
             &format!("/api/v1/orgs/{org}/repos"),
@@ -201,6 +213,7 @@ impl ForgejoClient {
         repo: &str,
         body: &Value,
     ) -> Result<ForgejoRepo, JediError> {
+        self.policy.check_owner(owner)?;
         self.write(
             Method::PATCH,
             &format!("/api/v1/repos/{owner}/{repo}"),
@@ -210,6 +223,7 @@ impl ForgejoClient {
     }
 
     pub async fn delete_repo(&self, owner: &str, repo: &str) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}"),
@@ -224,6 +238,7 @@ impl ForgejoClient {
         repo: &str,
         body: &Value,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::POST,
             &format!("/api/v1/repos/{owner}/{repo}/transfer"),
@@ -292,6 +307,7 @@ impl ForgejoClient {
         user: &str,
         body: &Value,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::PUT,
             &format!("/api/v1/repos/{owner}/{repo}/collaborators/{user}"),
@@ -306,6 +322,7 @@ impl ForgejoClient {
         repo: &str,
         user: &str,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/collaborators/{user}"),
@@ -360,11 +377,13 @@ impl ForgejoClient {
     }
 
     pub async fn edit_org(&self, org: &str, body: &Value) -> Result<ForgejoOrg, JediError> {
+        self.policy.check_owner(org)?;
         self.write(Method::PATCH, &format!("/api/v1/orgs/{org}"), Some(body))
             .await
     }
 
     pub async fn delete_org(&self, org: &str) -> Result<(), JediError> {
+        self.policy.check_owner(org)?;
         self.write_empty(Method::DELETE, &format!("/api/v1/orgs/{org}"), None)
             .await
     }
@@ -382,6 +401,7 @@ impl ForgejoClient {
     }
 
     pub async fn remove_org_member(&self, org: &str, user: &str) -> Result<(), JediError> {
+        self.policy.check_owner(org)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/orgs/{org}/members/{user}"),
@@ -399,6 +419,7 @@ impl ForgejoClient {
     }
 
     pub async fn create_team(&self, org: &str, body: &Value) -> Result<ForgejoTeam, JediError> {
+        self.policy.check_owner(org)?;
         self.write(
             Method::POST,
             &format!("/api/v1/orgs/{org}/teams"),
@@ -463,6 +484,7 @@ impl ForgejoClient {
         repo: &str,
         body: &Value,
     ) -> Result<ForgejoHook, JediError> {
+        self.policy.check_owner(owner)?;
         self.write(
             Method::POST,
             &format!("/api/v1/repos/{owner}/{repo}/hooks"),
@@ -472,6 +494,7 @@ impl ForgejoClient {
     }
 
     pub async fn delete_hook(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/hooks/{id}"),
@@ -481,6 +504,7 @@ impl ForgejoClient {
     }
 
     pub async fn test_hook(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::POST,
             &format!("/api/v1/repos/{owner}/{repo}/hooks/{id}/tests"),
@@ -510,6 +534,7 @@ impl ForgejoClient {
         repo: &str,
         body: &Value,
     ) -> Result<ForgejoRelease, JediError> {
+        self.policy.check_owner(owner)?;
         self.write(
             Method::POST,
             &format!("/api/v1/repos/{owner}/{repo}/releases"),
@@ -519,6 +544,7 @@ impl ForgejoClient {
     }
 
     pub async fn delete_release(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/releases/{id}"),
@@ -547,6 +573,7 @@ impl ForgejoClient {
         repo: &str,
         body: &Value,
     ) -> Result<ForgejoBranchProtection, JediError> {
+        self.policy.check_owner(owner)?;
         self.write(
             Method::POST,
             &format!("/api/v1/repos/{owner}/{repo}/branch_protections"),
@@ -561,6 +588,7 @@ impl ForgejoClient {
         repo: &str,
         name: &str,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/branch_protections/{name}"),
@@ -591,6 +619,7 @@ impl ForgejoClient {
         name: &str,
         body: &Value,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::PUT,
             &format!("/api/v1/repos/{owner}/{repo}/actions/secrets/{name}"),
@@ -605,6 +634,7 @@ impl ForgejoClient {
         repo: &str,
         name: &str,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/actions/secrets/{name}"),
@@ -633,6 +663,7 @@ impl ForgejoClient {
         name: &str,
         body: &Value,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::POST,
             &format!("/api/v1/repos/{owner}/{repo}/actions/variables/{name}"),
@@ -647,6 +678,7 @@ impl ForgejoClient {
         repo: &str,
         name: &str,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/actions/variables/{name}"),
@@ -683,6 +715,7 @@ impl ForgejoClient {
         index: u64,
         body: &Value,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::PATCH,
             &format!("/api/v1/repos/{owner}/{repo}/issues/{index}"),
@@ -698,6 +731,7 @@ impl ForgejoClient {
         index: u64,
         body: &Value,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::PUT,
             &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/lock"),
@@ -707,6 +741,7 @@ impl ForgejoClient {
     }
 
     pub async fn unlock_issue(&self, owner: &str, repo: &str, index: u64) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/lock"),
@@ -737,6 +772,7 @@ impl ForgejoClient {
     }
 
     pub async fn adopt_unadopted(&self, owner: &str, repo: &str) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::POST,
             &format!("/api/v1/admin/unadopted/{owner}/{repo}"),
@@ -746,6 +782,7 @@ impl ForgejoClient {
     }
 
     pub async fn delete_unadopted(&self, owner: &str, repo: &str) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/admin/unadopted/{owner}/{repo}"),

--- a/packages/rust/jedi/src/entity/forgejo/mod.rs
+++ b/packages/rust/jedi/src/entity/forgejo/mod.rs
@@ -1,5 +1,7 @@
 mod client;
+mod policy;
 mod types;
 
 pub use client::*;
+pub use policy::*;
 pub use types::*;

--- a/packages/rust/jedi/src/entity/forgejo/policy.rs
+++ b/packages/rust/jedi/src/entity/forgejo/policy.rs
@@ -1,0 +1,48 @@
+//! Server-side access control for the Forgejo client, mirroring the GitHub
+//! client's `RepoPolicy`. An open policy (default) permits every owner; a
+//! restricted policy only permits owners on its allowlist, so a consumer with
+//! a narrow mandate (or the dashboard via `FORGEJO_ALLOWED_OWNERS`) can't
+//! mutate repos/orgs outside it even with an admin token.
+
+use std::collections::HashSet;
+
+use crate::entity::error::JediError;
+
+#[derive(Clone, Debug, Default)]
+pub struct ForgejoPolicy {
+    allowed_owners: Option<HashSet<String>>,
+}
+
+impl ForgejoPolicy {
+    /// Permit every owner.
+    pub fn open() -> Self {
+        Self {
+            allowed_owners: None,
+        }
+    }
+
+    /// Permit only the given owners (case-insensitive). Empty input stays open.
+    pub fn from_owners<I, S>(owners: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let set: HashSet<String> = owners
+            .into_iter()
+            .map(|o| o.as_ref().trim().to_ascii_lowercase())
+            .filter(|o| !o.is_empty())
+            .collect();
+        Self {
+            allowed_owners: if set.is_empty() { None } else { Some(set) },
+        }
+    }
+
+    /// Reject before any HTTP call if `owner` is outside the allowlist.
+    pub fn check_owner(&self, owner: &str) -> Result<(), JediError> {
+        match &self.allowed_owners {
+            None => Ok(()),
+            Some(set) if set.contains(&owner.to_ascii_lowercase()) => Ok(()),
+            Some(_) => Err(JediError::Forbidden),
+        }
+    }
+}


### PR DESCRIPTION
Heavy Forgejo session — three of the queued items, closing the last Phase-1 dashboard items of #9789.

## Per-repo LFS + activity (closes Phase-1 LFS + activity-feed items)
- `ForgejoRepo` carries `git_size`/`lfs_size`; the **Repositories** table shows an `LFS <size>` sub-line per repo.
- New **Recent Activity** card on the Overview: most-recently-updated repos with LFS tag + relative time.

## Runners tab (foundation for self-hosted Actions runners)
New **Runners** tab: scope selector (instance / org / repo), a **Registration token** action (admin/org/repo), and a registered-runner list — over the typed `/dashboard/forgejo/api/*` routes merged earlier. Now the dashboard can hand out the tokens needed to register self-hosted runners.

## jedi policy guardrail
`jedi/entity/forgejo/policy.rs` — `ForgejoPolicy` allowlist (open by default), enforced on **all 27 owner-scoped write methods** via `check_owner`. axum opts in through **`FORGEJO_ALLOWED_OWNERS`** (comma list) — defense-in-depth so even an admin token can't mutate repos/orgs outside the allowlist. Admin-global ops (user CRUD, cron, migrate, team-by-id) are intentionally ungated. Default behavior unchanged (env unset → open).

## Verify
- `./kbve.sh -nx axum-kbve:build` ✓
- `./kbve.sh -nx astro-kbve:build` ✓ (7742 pages)

## Deferred (own PR)
Frontend typed-route migration (repoint forgejoService reads/writes off the proxy onto `/dashboard/forgejo/api/*`) — left separate; it touches the whole working service and deserves focused testing.