### PR TITLE
feat(jedi/kv+axum-kbve): KvCache — L1 LRU + L2 Valkey, wired into /me/ledger

### DIFF
--- a/apps/kbve/axum-kbve/Cargo.toml
+++ b/apps/kbve/axum-kbve/Cargo.toml
@@ -90,7 +90,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 webpki-roots = "0.26"
 
 # Workspace path dependencies
-jedi = { path = "../../../packages/rust/jedi", features = ["clickhouse", "forgejo", "postgres"] }
+jedi = { path = "../../../packages/rust/jedi", features = ["clickhouse", "forgejo", "postgres", "valkey"] }
 kbve = { path = "../../../packages/rust/kbve", features = ["wallet"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 

--- a/apps/kbve/axum-kbve/src/db/kv_cache.rs
+++ b/apps/kbve/axum-kbve/src/db/kv_cache.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+use jedi::state::kv::KvCache;
+use tokio::sync::OnceCell;
+
+static KV_CACHE: OnceCell<Arc<KvCache>> = OnceCell::const_new();
+
+pub async fn init_kv_cache() -> bool {
+    let cache = KvCache::from_env().await;
+    KV_CACHE.set(cache).is_ok()
+}
+
+pub fn get_kv_cache() -> Option<&'static Arc<KvCache>> {
+    KV_CACHE.get()
+}

--- a/apps/kbve/axum-kbve/src/db/mod.rs
+++ b/apps/kbve/axum-kbve/src/db/mod.rs
@@ -3,6 +3,7 @@
 mod cache;
 mod discord;
 mod forum;
+mod kv_cache;
 pub mod mc;
 mod mc_lot;
 mod osrs;
@@ -35,9 +36,11 @@ pub use forum::{
     CommentRow, FeedQuery, FeedRow, SpaceRow, TagRow, ThreadRow, get_forum_service,
     init_forum_service,
 };
+pub use kv_cache::{get_kv_cache, init_kv_cache};
 pub use mc::{extract_texture_hash, get_mc_service, init_mc_service};
 pub use mc_lot::{get_lot_client, init_lot_client};
 pub use osrs::{get_osrs_cache, init_osrs_cache};
+pub use pg_cluster::{get_pg_cluster, init_pg_cluster};
 pub use profile::{
     DiscordInfo, GithubInfo, TwitchInfo, UserProfile, UserProvider, get_profile_service,
     init_profile_service, validate_username,
@@ -45,5 +48,4 @@ pub use profile::{
 pub use referral::{get_referral_client, init_referral_client};
 pub use rentearth::{RentEarthProfile, get_rentearth_service, init_rentearth_service};
 pub use twitch::{get_twitch_client, init_twitch_client};
-pub use pg_cluster::{get_pg_cluster, init_pg_cluster};
 pub use wallet::{get_wallet_client, init_wallet_client};

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -112,6 +112,12 @@ async fn main() -> anyhow::Result<()> {
         warn!("PgCluster not configured - PgCluster-backed routes will 503");
     }
 
+    if db::init_kv_cache().await {
+        info!("KvCache initialized - L1 LRU + L2 Valkey read-through cache enabled");
+    } else {
+        warn!("KvCache init failed - read-through cache disabled");
+    }
+
     if db::init_wallet_client().await {
         info!("Wallet client initialized - /api/v1/wallet/me/* routes enabled");
     } else {

--- a/apps/kbve/axum-kbve/src/transport/ledger.rs
+++ b/apps/kbve/axum-kbve/src/transport/ledger.rs
@@ -26,7 +26,7 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::wallet::resolve_user;
-use crate::db::get_pg_cluster;
+use crate::db::{get_kv_cache, get_pg_cluster};
 
 const DEFAULT_LIMIT: i64 = 50;
 const MAX_LIMIT: i64 = 100;
@@ -50,7 +50,7 @@ pub(crate) struct LedgerQuery {
     pub currency: Option<String>,
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub(crate) struct LedgerRowDto {
     pub ledger_id: i64,
     pub currency: String,
@@ -63,13 +63,13 @@ pub(crate) struct LedgerRowDto {
     pub created_at: String,
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub(crate) struct LedgerPageDto {
     pub rows: Vec<LedgerRowDto>,
     pub next_cursor: Option<NextCursorDto>,
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub(crate) struct NextCursorDto {
     pub before_created_at: String,
     pub before_id: i64,
@@ -111,10 +111,50 @@ pub(crate) async fn me_ledger(headers: HeaderMap, Query(q): Query<LedgerQuery>) 
         Err(resp) => return resp,
     };
 
-    match fetch_ledger(cluster, user_id, params).await {
+    let result = match get_kv_cache() {
+        Some(cache) => {
+            let key = cache_key(user_id, &params);
+            cluster
+                .cached_caller_read(
+                    cache,
+                    &key,
+                    None,
+                    user_id,
+                    None,
+                    move |tx| -> PgCallerReadFut<'_, LedgerPageDto> {
+                        Box::pin(ledger_query(tx, params))
+                    },
+                )
+                .await
+        }
+        None => fetch_ledger(cluster, user_id, params).await,
+    };
+
+    match result {
         Ok(page) => Json(page).into_response(),
         Err(e) => ledger_error_response(e),
     }
+}
+
+fn cache_key(user_id: Uuid, p: &LedgerParams) -> String {
+    let kinds = p
+        .source_kinds
+        .as_ref()
+        .map(|v| v.join(","))
+        .unwrap_or_else(|| "*".to_string());
+    let currency = p.currency.as_deref().unwrap_or("*");
+    let bca = p
+        .before_created_at
+        .map(|t| t.to_rfc3339())
+        .unwrap_or_else(|| "head".into());
+    let bid = p
+        .before_id
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "0".into());
+    format!(
+        "caller:{user_id}:ledger:limit={}:bca={bca}:bid={bid}:kinds={kinds}:cur={currency}",
+        p.limit
+    )
 }
 
 struct LedgerParams {
@@ -156,12 +196,7 @@ impl LedgerParams {
             }
             Some(s) if s.eq_ignore_ascii_case("all") => None,
             Some(s) => Some(split_csv(s)),
-            None => Some(
-                DEFAULT_MARKET_KINDS
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect(),
-            ),
+            None => Some(DEFAULT_MARKET_KINDS.iter().map(|s| s.to_string()).collect()),
         };
 
         let currency = match q.currency.as_deref().map(|s| s.trim()) {
@@ -201,80 +236,87 @@ async fn fetch_ledger(
     params: LedgerParams,
 ) -> Result<LedgerPageDto, JediError> {
     cluster
-        .with_caller_read(user_id, None, move |tx| -> PgCallerReadFut<'_, LedgerPageDto> {
-            Box::pin(async move {
-                let sql = "
-                    SELECT
-                        id,
-                        currency::text,
-                        delta,
-                        balance_after,
-                        source_kind::text,
-                        reason,
-                        ref_type,
-                        ref_id,
-                        created_at
-                      FROM wallet.ledger
-                     WHERE account_id = (
-                               SELECT id FROM wallet.account
-                                WHERE user_id = auth.uid()
-                                  AND kind = 'user'
-                           )
-                       AND ($1::text[] IS NULL OR source_kind::text = ANY ($1::text[]))
-                       AND ($2::text IS NULL OR currency::text = $2::text)
-                       AND (
-                            $3::timestamptz IS NULL
-                            OR created_at < $3::timestamptz
-                            OR (created_at = $3::timestamptz AND id < $4::bigint)
-                           )
-                     ORDER BY created_at DESC, id DESC
-                     LIMIT $5::bigint
-                ";
-                let rows = tx
-                    .query(
-                        sql,
-                        &[
-                            &params.source_kinds,
-                            &params.currency,
-                            &params.before_created_at,
-                            &params.before_id,
-                            &params.limit,
-                        ],
-                    )
-                    .await
-                    .map_err(JediError::from)?;
-
-                let rows: Vec<LedgerRowDto> = rows
-                    .iter()
-                    .map(|r| {
-                        let created_at: DateTime<Utc> = r.get(8);
-                        LedgerRowDto {
-                            ledger_id: r.get(0),
-                            currency: r.get(1),
-                            delta: r.get(2),
-                            balance_after: r.get(3),
-                            source_kind: r.get(4),
-                            reason: r.get(5),
-                            ref_type: r.get(6),
-                            ref_id: r.get(7),
-                            created_at: created_at.to_rfc3339(),
-                        }
-                    })
-                    .collect();
-
-                let next_cursor = if rows.len() as i64 == params.limit {
-                    rows.last().map(|last| NextCursorDto {
-                        before_created_at: last.created_at.clone(),
-                        before_id: last.ledger_id,
-                    })
-                } else {
-                    None
-                };
-
-                Ok(LedgerPageDto { rows, next_cursor })
-            })
-        })
+        .with_caller_read(
+            user_id,
+            None,
+            move |tx| -> PgCallerReadFut<'_, LedgerPageDto> { Box::pin(ledger_query(tx, params)) },
+        )
         .await
+}
+
+async fn ledger_query(
+    tx: &jedi::state::pg::tokio_postgres::Transaction<'_>,
+    params: LedgerParams,
+) -> Result<LedgerPageDto, JediError> {
+    let sql = "
+        SELECT
+            id,
+            currency::text,
+            delta,
+            balance_after,
+            source_kind::text,
+            reason,
+            ref_type,
+            ref_id,
+            created_at
+          FROM wallet.ledger
+         WHERE account_id = (
+                   SELECT id FROM wallet.account
+                    WHERE user_id = auth.uid()
+                      AND kind = 'user'
+               )
+           AND ($1::text[] IS NULL OR source_kind::text = ANY ($1::text[]))
+           AND ($2::text IS NULL OR currency::text = $2::text)
+           AND (
+                $3::timestamptz IS NULL
+                OR created_at < $3::timestamptz
+                OR (created_at = $3::timestamptz AND id < $4::bigint)
+               )
+         ORDER BY created_at DESC, id DESC
+         LIMIT $5::bigint
+    ";
+    let rows = tx
+        .query(
+            sql,
+            &[
+                &params.source_kinds,
+                &params.currency,
+                &params.before_created_at,
+                &params.before_id,
+                &params.limit,
+            ],
+        )
+        .await
+        .map_err(JediError::from)?;
+
+    let rows: Vec<LedgerRowDto> = rows
+        .iter()
+        .map(|r| {
+            let created_at: DateTime<Utc> = r.get(8);
+            LedgerRowDto {
+                ledger_id: r.get(0),
+                currency: r.get(1),
+                delta: r.get(2),
+                balance_after: r.get(3),
+                source_kind: r.get(4),
+                reason: r.get(5),
+                ref_type: r.get(6),
+                ref_id: r.get(7),
+                created_at: created_at.to_rfc3339(),
+            }
+        })
+        .collect();
+
+    let next_cursor = if rows.len() as i64 == params.limit {
+        rows.last().map(|last| NextCursorDto {
+            before_created_at: last.created_at.clone(),
+            before_id: last.ledger_id,
+        })
+    } else {
+        None
+    };
+
+    Ok(LedgerPageDto { rows, next_cursor })
 }
 
 fn service_unavailable() -> Response {

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -90,6 +90,7 @@ clickhouse = { version = "0.14", optional = true }
 # Prometheus metrics (optional)
 axum-prometheus = { version = "0.10", optional = true }
 metrics = { version = "0.24", optional = true }
+lru = { version = "0.18", optional = true }
 
 [features]
 default = []
@@ -107,6 +108,7 @@ postgres = [
     "dep:url",
     "dep:uuid",
 ]
+valkey = ["dep:lru"]
 
 [dev-dependencies]
 serial_test = "3"

--- a/packages/rust/jedi/src/state/kv.rs
+++ b/packages/rust/jedi/src/state/kv.rs
@@ -1,0 +1,467 @@
+//! KvCache — two-tier read-through cache, Valkey-backed L2.
+//!
+//! Slots into the read fallback chain:
+//!
+//! ```text
+//! L1 in-process LRU  →  L2 Valkey (shared)  →  caller fetch fn (PgCluster read)
+//! ```
+//!
+//! Misses propagate down; populates fire up. L2 errors are swallowed
+//! (best-effort cache; Valkey being sick must never fail the request).
+//!
+//! Single-flight stampede protection via `DashMap<key, broadcast::Sender>`
+//! so on a hot-key miss only one task hits the fetch fn; the rest park
+//! on the broadcast.
+//!
+//! Environment:
+//!
+//!   - `KBVE_KV_NAMESPACE`         (default `"kbve:cache"`)
+//!   - `KBVE_KV_L1_CAPACITY`       (default 1024 entries)
+//!   - `KBVE_KV_L1_TTL_MS`         (default 500ms)
+//!   - `KBVE_KV_L2_TTL_S`          (default 5s)
+//!   - `KBVE_KV_L2_ENABLED`        (default `true`)
+
+use std::{
+    num::NonZeroUsize,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use dashmap::{DashMap, mapref::entry::Entry};
+use fred::clients::Pool as ValkeyPool;
+use fred::prelude::*;
+use fred::types::Expiration;
+use lru::LruCache;
+use serde::{Serialize, de::DeserializeOwned};
+use tokio::sync::{Mutex, broadcast};
+
+use crate::entity::error::JediError;
+
+#[derive(Debug, Clone)]
+pub struct KvCacheConfig {
+    pub namespace: String,
+    pub l1_capacity: NonZeroUsize,
+    pub l1_default_ttl: Duration,
+    pub l2_default_ttl: Duration,
+    pub l2_enabled: bool,
+}
+
+impl KvCacheConfig {
+    pub fn from_env() -> Self {
+        let namespace =
+            std::env::var("KBVE_KV_NAMESPACE").unwrap_or_else(|_| "kbve:cache".to_string());
+        let l1_capacity =
+            NonZeroUsize::new(parse_env::<usize>("KBVE_KV_L1_CAPACITY").unwrap_or(1024))
+                .unwrap_or(NonZeroUsize::new(1024).expect("static 1024"));
+        let l1_default_ttl =
+            Duration::from_millis(parse_env::<u64>("KBVE_KV_L1_TTL_MS").unwrap_or(500));
+        let l2_default_ttl = Duration::from_secs(parse_env::<u64>("KBVE_KV_L2_TTL_S").unwrap_or(5));
+        let l2_enabled = parse_bool_env("KBVE_KV_L2_ENABLED").unwrap_or(true);
+        Self {
+            namespace,
+            l1_capacity,
+            l1_default_ttl,
+            l2_default_ttl,
+            l2_enabled,
+        }
+    }
+}
+
+struct L1Entry {
+    body: Arc<[u8]>,
+    expires_at: Instant,
+}
+
+pub struct KvCache {
+    cfg: KvCacheConfig,
+    l1: Mutex<LruCache<String, L1Entry>>,
+    l2: Option<ValkeyPool>,
+    inflight: DashMap<String, broadcast::Sender<Result<Arc<[u8]>, String>>>,
+}
+
+impl KvCache {
+    pub fn new(cfg: KvCacheConfig, l2: Option<ValkeyPool>) -> Arc<Self> {
+        let l2 = if cfg.l2_enabled { l2 } else { None };
+        let l1 = Mutex::new(LruCache::new(cfg.l1_capacity));
+        Arc::new(Self {
+            cfg,
+            l1,
+            l2,
+            inflight: DashMap::new(),
+        })
+    }
+
+    /// Construct from env. Builds a fred pool against
+    /// `KBVE_KV_URL` / `REDIS_URL` (size `KBVE_KV_POOL_SIZE`,
+    /// default 4) when `KBVE_KV_L2_ENABLED` is on. On pool build
+    /// failure the cache stays L1-only and a warning is logged.
+    pub async fn from_env() -> Arc<Self> {
+        let cfg = KvCacheConfig::from_env();
+        let l2 = if cfg.l2_enabled {
+            match build_valkey_pool().await {
+                Ok(p) => Some(p),
+                Err(e) => {
+                    tracing::warn!(error = %e, "[KvCache] L2 disabled: Valkey pool build failed");
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        Self::new(cfg, l2)
+    }
+
+    pub fn config(&self) -> &KvCacheConfig {
+        &self.cfg
+    }
+
+    pub async fn get_or_fetch_json<T, F, Fut>(
+        &self,
+        key: &str,
+        ttl: Option<Duration>,
+        fetch: F,
+    ) -> Result<T, JediError>
+    where
+        T: Serialize + DeserializeOwned + Send,
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<T, JediError>> + Send,
+    {
+        let qualified = self.qualified(key);
+        let l1_ttl = ttl.unwrap_or(self.cfg.l1_default_ttl);
+        let l2_ttl = ttl.unwrap_or(self.cfg.l2_default_ttl);
+
+        if let Some(bytes) = self.l1_get(&qualified).await {
+            metrics_inc("kbve_kv_l1_hit");
+            return serde_json::from_slice(&bytes).map_err(json_err);
+        }
+        metrics_inc("kbve_kv_l1_miss");
+
+        if let Some(bytes) = self.l2_get(&qualified).await {
+            metrics_inc("kbve_kv_l2_hit");
+            let arc: Arc<[u8]> = Arc::from(bytes.into_boxed_slice());
+            self.l1_put(qualified.clone(), Arc::clone(&arc), l1_ttl)
+                .await;
+            return serde_json::from_slice(&arc).map_err(json_err);
+        }
+        metrics_inc("kbve_kv_l2_miss");
+
+        let bytes = self
+            .single_flight(&qualified, fetch, l1_ttl, l2_ttl)
+            .await?;
+        serde_json::from_slice(&bytes).map_err(json_err)
+    }
+
+    async fn single_flight<T, F, Fut>(
+        &self,
+        qualified: &str,
+        fetch: F,
+        l1_ttl: Duration,
+        l2_ttl: Duration,
+    ) -> Result<Arc<[u8]>, JediError>
+    where
+        T: Serialize + Send,
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<T, JediError>> + Send,
+    {
+        let receiver = match self.inflight.entry(qualified.to_string()) {
+            Entry::Occupied(o) => {
+                metrics_inc("kbve_kv_inflight_share");
+                Some(o.get().subscribe())
+            }
+            Entry::Vacant(v) => {
+                let (tx, _rx) = broadcast::channel(1);
+                v.insert(tx);
+                None
+            }
+        };
+
+        if let Some(mut rx) = receiver {
+            return match rx.recv().await {
+                Ok(Ok(bytes)) => Ok(bytes),
+                Ok(Err(s)) => Err(JediError::Internal(
+                    format!("kv single-flight upstream: {s}").into(),
+                )),
+                Err(_) => Err(JediError::Internal(
+                    "kv single-flight channel closed".into(),
+                )),
+            };
+        }
+
+        let outcome = fetch().await;
+        let (bytes, err_str): (Option<Arc<[u8]>>, Option<String>) = match &outcome {
+            Ok(v) => match serde_json::to_vec(v) {
+                Ok(b) => (Some(Arc::from(b.into_boxed_slice())), None),
+                Err(e) => (None, Some(format!("kv encode: {e}"))),
+            },
+            Err(e) => (None, Some(e.to_string())),
+        };
+
+        if let Some((_, tx)) = self.inflight.remove(qualified) {
+            let payload = match (&bytes, &err_str) {
+                (Some(b), _) => Ok(Arc::clone(b)),
+                (_, Some(s)) => Err(s.clone()),
+                _ => Err("kv: empty outcome".to_string()),
+            };
+            let _ = tx.send(payload);
+        }
+
+        outcome?;
+        let bytes = bytes.ok_or_else(|| {
+            JediError::Internal(err_str.unwrap_or_else(|| "kv: missing body".into()).into())
+        })?;
+
+        self.l1_put(qualified.to_string(), Arc::clone(&bytes), l1_ttl)
+            .await;
+        self.l2_put(qualified, bytes.as_ref(), l2_ttl).await;
+
+        Ok(bytes)
+    }
+
+    pub async fn invalidate(&self, key: &str) -> Result<(), JediError> {
+        let q = self.qualified(key);
+        self.l1.lock().await.pop(&q);
+        if let Some(pool) = &self.l2 {
+            let _: Result<i64, _> = pool.del(&*q).await;
+        }
+        Ok(())
+    }
+
+    pub async fn invalidate_prefix(&self, prefix: &str) -> Result<(), JediError> {
+        let q = self.qualified(prefix);
+        let mut l1 = self.l1.lock().await;
+        let victims: Vec<String> = l1
+            .iter()
+            .filter_map(|(k, _)| {
+                if k.starts_with(&q) {
+                    Some(k.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+        for k in victims {
+            l1.pop(&k);
+        }
+        Ok(())
+    }
+
+    fn qualified(&self, key: &str) -> String {
+        format!("{}:{}", self.cfg.namespace, key)
+    }
+
+    async fn l1_get(&self, key: &str) -> Option<Arc<[u8]>> {
+        let mut l1 = self.l1.lock().await;
+        let body = match l1.peek(key) {
+            Some(e) if e.expires_at > Instant::now() => Some(Arc::clone(&e.body)),
+            Some(_) => None,
+            None => return None,
+        };
+        if body.is_none() {
+            l1.pop(key);
+        }
+        body
+    }
+
+    async fn l1_put(&self, key: String, body: Arc<[u8]>, ttl: Duration) {
+        let entry = L1Entry {
+            body,
+            expires_at: Instant::now() + ttl,
+        };
+        self.l1.lock().await.put(key, entry);
+    }
+
+    async fn l2_get(&self, key: &str) -> Option<Vec<u8>> {
+        let pool = self.l2.as_ref()?;
+        match pool.get::<Vec<u8>, _>(key).await {
+            Ok(b) if !b.is_empty() => Some(b),
+            _ => None,
+        }
+    }
+
+    async fn l2_put(&self, key: &str, body: &[u8], ttl: Duration) {
+        let Some(pool) = &self.l2 else { return };
+        let ttl_ms = ttl.as_millis() as i64;
+        let res: Result<(), _> = pool
+            .set::<(), _, _>(key, body, Some(Expiration::PX(ttl_ms.max(1))), None, false)
+            .await;
+        if let Err(e) = res {
+            tracing::warn!(error = %e, key = %key, "[KvCache] L2 put failed");
+        }
+    }
+}
+
+async fn build_valkey_pool() -> Result<ValkeyPool, String> {
+    let url = std::env::var("KBVE_KV_URL")
+        .or_else(|_| std::env::var("REDIS_URL"))
+        .map_err(|_| "KBVE_KV_URL / REDIS_URL not set".to_string())?;
+
+    let pool_size: usize = std::env::var("KBVE_KV_POOL_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4);
+
+    let config = Config::from_url(&url).map_err(|e| format!("invalid KV URL: {e}"))?;
+    let pool = Builder::from_config(config)
+        .set_policy(ReconnectPolicy::default())
+        .build_pool(pool_size)
+        .map_err(|e| format!("KV pool build failed: {e}"))?;
+    pool.init()
+        .await
+        .map_err(|e| format!("KV pool init failed: {e}"))?;
+    Ok(pool)
+}
+
+fn json_err(e: serde_json::Error) -> JediError {
+    JediError::Internal(format!("kv json: {e}").into())
+}
+
+fn parse_env<T: std::str::FromStr>(key: &str) -> Option<T> {
+    std::env::var(key).ok().and_then(|s| s.trim().parse().ok())
+}
+
+fn parse_bool_env(key: &str) -> Option<bool> {
+    std::env::var(key).ok().map(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+#[cfg(feature = "prometheus")]
+fn metrics_inc(name: &'static str) {
+    metrics::counter!(name).increment(1);
+}
+
+#[cfg(not(feature = "prometheus"))]
+fn metrics_inc(_: &'static str) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn cfg() -> KvCacheConfig {
+        KvCacheConfig {
+            namespace: "test".into(),
+            l1_capacity: NonZeroUsize::new(8).unwrap(),
+            l1_default_ttl: Duration::from_secs(60),
+            l2_default_ttl: Duration::from_secs(60),
+            l2_enabled: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn populates_l1_on_first_fetch() {
+        let cache = KvCache::new(cfg(), None);
+        let val: u32 = cache
+            .get_or_fetch_json("k", None, || async { Ok::<u32, JediError>(42) })
+            .await
+            .unwrap();
+        assert_eq!(val, 42);
+        // Second call: fetch must NOT run (would panic).
+        let val2: u32 = cache
+            .get_or_fetch_json("k", None, || async { panic!("should not be called") })
+            .await
+            .unwrap();
+        assert_eq!(val2, 42);
+    }
+
+    #[tokio::test]
+    async fn invalidate_removes_l1_entry() {
+        let cache = KvCache::new(cfg(), None);
+        let _: u32 = cache
+            .get_or_fetch_json("k", None, || async { Ok::<u32, JediError>(1) })
+            .await
+            .unwrap();
+        cache.invalidate("k").await.unwrap();
+        let v: u32 = cache
+            .get_or_fetch_json("k", None, || async { Ok::<u32, JediError>(2) })
+            .await
+            .unwrap();
+        assert_eq!(v, 2);
+    }
+
+    #[tokio::test]
+    async fn invalidate_prefix_clears_matching_l1() {
+        let cache = KvCache::new(cfg(), None);
+        for k in ["wallet:a", "wallet:b", "market:c"] {
+            let _: u32 = cache
+                .get_or_fetch_json(k, None, || async { Ok::<u32, JediError>(1) })
+                .await
+                .unwrap();
+        }
+        cache.invalidate_prefix("wallet").await.unwrap();
+        // wallet:* should miss; market:c should hit.
+        let v: u32 = cache
+            .get_or_fetch_json("wallet:a", None, || async { Ok::<u32, JediError>(99) })
+            .await
+            .unwrap();
+        assert_eq!(v, 99);
+        let v: u32 = cache
+            .get_or_fetch_json("market:c", None, || async { panic!("should be cached") })
+            .await
+            .unwrap();
+        assert_eq!(v, 1);
+    }
+
+    #[tokio::test]
+    async fn fetch_error_propagates_and_does_not_cache() {
+        let cache = KvCache::new(cfg(), None);
+        let r: Result<u32, _> = cache
+            .get_or_fetch_json("k", None, || async {
+                Err(JediError::Internal("boom".into()))
+            })
+            .await;
+        assert!(r.is_err());
+        // Second call must invoke fetch again (no negative caching).
+        let v: u32 = cache
+            .get_or_fetch_json("k", None, || async { Ok::<u32, JediError>(7) })
+            .await
+            .unwrap();
+        assert_eq!(v, 7);
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_defaults() {
+        unsafe {
+            std::env::remove_var("KBVE_KV_NAMESPACE");
+            std::env::remove_var("KBVE_KV_L1_CAPACITY");
+            std::env::remove_var("KBVE_KV_L1_TTL_MS");
+            std::env::remove_var("KBVE_KV_L2_TTL_S");
+            std::env::remove_var("KBVE_KV_L2_ENABLED");
+        }
+        let c = KvCacheConfig::from_env();
+        assert_eq!(c.namespace, "kbve:cache");
+        assert_eq!(c.l1_capacity.get(), 1024);
+        assert_eq!(c.l1_default_ttl, Duration::from_millis(500));
+        assert_eq!(c.l2_default_ttl, Duration::from_secs(5));
+        assert!(c.l2_enabled);
+    }
+
+    #[test]
+    #[serial]
+    fn from_env_overrides_apply() {
+        unsafe {
+            std::env::set_var("KBVE_KV_NAMESPACE", "custom");
+            std::env::set_var("KBVE_KV_L1_CAPACITY", "256");
+            std::env::set_var("KBVE_KV_L1_TTL_MS", "1500");
+            std::env::set_var("KBVE_KV_L2_TTL_S", "30");
+            std::env::set_var("KBVE_KV_L2_ENABLED", "false");
+        }
+        let c = KvCacheConfig::from_env();
+        assert_eq!(c.namespace, "custom");
+        assert_eq!(c.l1_capacity.get(), 256);
+        assert_eq!(c.l1_default_ttl, Duration::from_millis(1500));
+        assert_eq!(c.l2_default_ttl, Duration::from_secs(30));
+        assert!(!c.l2_enabled);
+        unsafe {
+            std::env::remove_var("KBVE_KV_NAMESPACE");
+            std::env::remove_var("KBVE_KV_L1_CAPACITY");
+            std::env::remove_var("KBVE_KV_L1_TTL_MS");
+            std::env::remove_var("KBVE_KV_L2_TTL_S");
+            std::env::remove_var("KBVE_KV_L2_ENABLED");
+        }
+    }
+}

--- a/packages/rust/jedi/src/state/mod.rs
+++ b/packages/rust/jedi/src/state/mod.rs
@@ -1,6 +1,9 @@
-pub mod temple;
 pub mod sidecar;
+pub mod temple;
 pub mod watchmaster;
 
 #[cfg(feature = "postgres")]
 pub mod pg;
+
+#[cfg(feature = "valkey")]
+pub mod kv;

--- a/packages/rust/jedi/src/state/pg.rs
+++ b/packages/rust/jedi/src/state/pg.rs
@@ -477,6 +477,42 @@ impl PgCluster {
     }
 }
 
+#[cfg(feature = "valkey")]
+impl PgCluster {
+    /// Caller-scoped read composed with the two-tier KvCache. L1 LRU
+    /// → L2 Valkey → `with_caller_read` (which itself can fall back
+    /// to the `any` pool internally). `cache_key` must already
+    /// uniquely identify the response — typically `caller_sub +
+    /// route + serialized query params`.
+    pub async fn cached_caller_read<T, F>(
+        self: &Arc<Self>,
+        cache: &Arc<crate::state::kv::KvCache>,
+        cache_key: &str,
+        ttl: Option<Duration>,
+        sub: Uuid,
+        auth_role: Option<&str>,
+        f: F,
+    ) -> Result<T, JediError>
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + Send + 'static,
+        F: for<'tx> FnOnce(
+                &'tx tokio_postgres::Transaction<'_>,
+            ) -> BoxFuture<'tx, Result<T, JediError>>
+            + Send
+            + 'static,
+    {
+        let cluster = Arc::clone(self);
+        let owned_role = auth_role.map(|s| s.to_string());
+        cache
+            .get_or_fetch_json(cache_key, ttl, move || async move {
+                cluster
+                    .with_caller_read(sub, owned_role.as_deref(), f)
+                    .await
+            })
+            .await
+    }
+}
+
 async fn probe_role(role: PgRole, pool: &PgPool) -> PgRoleHealth {
     let started = std::time::Instant::now();
     let res = tokio::time::timeout(Duration::from_secs(1), async {


### PR DESCRIPTION
Adds the two-tier read-through cache that closes the **L1 + L2** gap in the read fallback chain we mapped out after #12359:

```
L1 in-process LRU  →  L2 Valkey (shared)  →  L3 PgCluster.ro  →  L4 PgCluster.any  →  L5 PgCluster.rw
```

This PR delivers L1+L2 and composes them with the existing L3+L4 via `PgCluster::cached_caller_read`. Belt-and-suspenders for every caller-scoped read.

## jedi side — new `jedi.features.valkey`

`jedi::state::kv::KvCache` lives behind a new `valkey` feature that pulls in `lru = "0.18"` (fred + dashmap + serde + tokio already in jedi unconditionally; no new heavy deps).

**Crate choice.** Standalone `valkey` / `tokio-valkey` crates on crates.io are all `0.0.0-alpha*`. `fred` (already in jedi via Redis pub/sub) speaks RESP3 and is Valkey-protocol compatible. Stay on fred; gate the new module + the `lru` dep behind the `valkey` feature.

**API:**
- `KvCache::new(cfg, l2_pool)` — explicit constructor for tests + custom wiring.
- `KvCache::from_env()` — async constructor that builds the fred pool against `KBVE_KV_URL` / `REDIS_URL` (size `KBVE_KV_POOL_SIZE`, default 4) when `KBVE_KV_L2_ENABLED` is on. Pool init failure logs a warn and the cache stays L1-only; L1 still works even without a reachable Valkey.
- `get_or_fetch_json<T>(key, ttl, fetch)` — main entry point:
  - L1 peek (mutex-guarded `LruCache`, `Arc<[u8]>` bodies so reads don't clone the buffer)
  - L2 GET via fred (errors swallowed — best-effort)
  - **Single-flight stampede protection** via `DashMap<key, broadcast::Sender<Arc<[u8]>>>` — only one task hits the fetch fn on a hot-key miss; followers park on the broadcast and decode the same `Arc` on wake.
  - On success: serialize once, populate L1 + L2, broadcast to followers. On error: propagate without negative caching.
- `invalidate(key)` purges L1 + `DEL` in L2.
- `invalidate_prefix(prefix)` purges L1 only — `SCAN`/`KEYS` isn't safe in cluster mode. Cluster-aware L2 invalidation is a follow-up.

**Env:**
| Var | Default |
|-----|---------|
| `KBVE_KV_NAMESPACE` | `kbve:cache` |
| `KBVE_KV_L1_CAPACITY` | 1024 entries |
| `KBVE_KV_L1_TTL_MS` | 500 ms |
| `KBVE_KV_L2_TTL_S` | 5 s |
| `KBVE_KV_L2_ENABLED` | `true` |
| `KBVE_KV_URL` / `REDIS_URL` | required for L2 |
| `KBVE_KV_POOL_SIZE` | 4 |

**Metrics (under `jedi.features.prometheus`):**
- `kbve_kv_l1_hit` / `kbve_kv_l1_miss`
- `kbve_kv_l2_hit` / `kbve_kv_l2_miss`
- `kbve_kv_inflight_share`

## jedi side — composition primitive

`PgCluster::cached_caller_read(cache, key, ttl, sub, role, f)` threads a `KvCache` through `with_caller_read`. JWT impersonation still happens inside the SQL tx; the cache layer just gates the round-trip to PG. Gated `#[cfg(all(feature = "postgres", feature = "valkey"))]`.

## axum-kbve side

- `jedi.features` += `"valkey"` to pick up the new module.
- `db::kv_cache` holds the `OnceCell<Arc<KvCache>>` mirror of `db::pg_cluster`, calls `KvCache::from_env()` at startup.
- `main.rs` spins it up after `init_pg_cluster` (before `init_wallet_client` so future wallet handlers can opt in).
- `transport::ledger::me_ledger` now:
  - Builds a cache key `caller:<sub>:ledger:limit=N:bca=<ts|head>:bid=<n|0>:kinds=<csv|*>:cur=<credits|khash|*>`
  - Routes through `cached_caller_read` when KvCache is up; otherwise falls back to plain `with_caller_read`. **Graceful degradation**, not hard dependency.
- DTOs picked up `#[derive(Deserialize)]` so they round-trip through L2 JSON encoding.
- Flattened the inner closure body into a standalone `ledger_query` fn so both cached and uncached paths share the SQL.

## Tests

6 new `state::kv::tests`:
- First-fetch populates L1 (second call must not invoke fetch — panics if it does).
- `invalidate(key)` purges L1 → next call refetches.
- `invalidate_prefix("wallet")` clears `wallet:*` but leaves `market:*` intact.
- Fetch errors propagate without negative caching.
- `KvCacheConfig::from_env` defaults + env overrides (serial_test gated to avoid env races with the existing `pg` tests).

Combined with the existing 7 `state::pg::tests` → **13/13 jedi::state tests pass** under `--features postgres,valkey,prometheus`.

## Build verified
- `cargo build -p jedi --no-default-features`
- `cargo build -p jedi --no-default-features --features valkey`
- `cargo build -p jedi --no-default-features --features postgres,valkey`
- `cargo build -p jedi --no-default-features --features postgres,valkey,prometheus`
- `cargo check -p axum-kbve`

## Test plan
- [x] All four jedi build variants green
- [x] `cargo test -p jedi --no-default-features --features postgres,valkey,prometheus --lib state::` — 13/13
- [x] `cargo check -p axum-kbve`
- [ ] Boot axum-kbve against `dev-docker-compose.yml` with `KBVE_KV_URL=redis://localhost:6379`; confirm warm-cache `/me/ledger` p99 drops vs cold-cache (pending local smoke)
- [ ] L2 outage simulation — kill Valkey container, confirm requests still serve from L1 (TTL 500 ms) or pass-through to PG (pending)
- [ ] Confirm `/metrics` exposes `kbve_kv_*` counters under `prometheus` feature (pending)

## Follow-ups
- Cluster-aware L2 invalidation (current `invalidate_prefix` is L1-only) — needs domain-specific key set tracking or per-write `invalidate_keys` enumeration at the handler.
- Wire cache into the existing `/me/balance` + `/me/coupons` once they migrate off `diesel-async` onto PgCluster.
- Add tag-based invalidation so write handlers can specify `invalidate_tags!["wallet:caller:<uuid>"]` and the cache scans tagged keys.