### PR TITLE
fix(ci-unreal-build): re-land ssh/mc.kbve.com LFS normalization (#12374 didn't stick)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -426,7 +426,7 @@ jobs:
                   RAW_LFS=""
                   [ -f .lfsconfig ] && RAW_LFS=$(git config -f .lfsconfig lfs.url 2>/dev/null || true)
                   case "${RAW_LFS}" in
-                    *forgejo.kbve.com/*|*git.kbve.com/*)
+                    *forgejo.kbve.com*|*git.kbve.com*|*mc.kbve.com*)
                       if [ -z "${FORGEJO_USER}" ] || [ -z "${FORGEJO_TOKEN}" ]; then
                         echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing - cannot pull LFS from git.kbve.com"
                         exit 1
@@ -441,6 +441,7 @@ jobs:
                         *.git) REPO_PATH="${REPO_PATH}/info/lfs" ;;
                         *) REPO_PATH="${REPO_PATH%.git}.git/info/lfs" ;;
                       esac
+                      REPO_PATH="$(printf '%s' "${REPO_PATH%%/*}" | tr 'A-Z' 'a-z')/${REPO_PATH#*/}"
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local
@@ -736,7 +737,7 @@ jobs:
                   RAW_LFS=""
                   [ -f .lfsconfig ] && RAW_LFS=$(git config -f .lfsconfig lfs.url 2>/dev/null || true)
                   case "${RAW_LFS}" in
-                    *forgejo.kbve.com/*|*git.kbve.com/*)
+                    *forgejo.kbve.com*|*git.kbve.com*|*mc.kbve.com*)
                       if [ -z "${FORGEJO_USER}" ] || [ -z "${FORGEJO_TOKEN}" ]; then
                         echo "::error::FORGEJO_USER / FORGEJO_TOKEN missing - cannot pull LFS from git.kbve.com"
                         exit 1
@@ -754,6 +755,7 @@ jobs:
                         *.git) REPO_PATH="${REPO_PATH}/info/lfs" ;;
                         *) REPO_PATH="${REPO_PATH%.git}.git/info/lfs" ;;
                       esac
+                      REPO_PATH="$(printf '%s' "${REPO_PATH%%/*}" | tr 'A-Z' 'a-z')/${REPO_PATH#*/}"
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local


### PR DESCRIPTION
## Why a re-land

#12374 showed as MERGED, but its change **never actually landed on dev** — `git log -- ci-unreal-build.yml` shows #12365 as the last commit to touch the file, not #12374 (a squash-vs-stale-base anomaly). So the build still does the GitHub-native SSH fallback and dies on `Host key verification failed` against `ssh://mc.kbve.com`.

## What

Re-apply on current dev, both game + server clone steps:
- match `*mc.kbve.com*` (drop the trailing `/` so `host:port` forms match)
- lowercase the owner before the token'd `https://…@git.kbve.com/<owner>/<repo>/info/lfs`

Verified the diff is non-empty this time (4 insertions / 2 deletions, 2 patterns + 2 lowercase lines). actionlint clean.

## After merge to dev (the reusable runs `@dev`)
Next dispatch: chuck's `ssh://git@mc.kbve.com:30022/KBVE/chuck.git` → `https://<token>@git.kbve.com/kbve/chuck.git/info/lfs` → LFS resolves over HTTPS on `.74`. No SSH host-key fail.