### PR TITLE
chore(edge): bump to 0.1.43 to publish list_tokens token_id fix

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/edge.mdx
@@ -11,7 +11,7 @@ tags:
 key: edge
 pipeline: docker
 app_name: edge
-version: "0.1.42"
+version: "0.1.43"
 source_path: apps/kbve/edge
 version_toml: apps/kbve/edge/version.toml
 version_target: apps/kbve/edge/deno.json


### PR DESCRIPTION
Republishes the edge functions so #12311 actually deploys.

The edge was last published at **0.1.42** — *before* #12311 (id → token_id in guild-vault `list_tokens`) merged. So prod is still running edge 0.1.42, which emits `id`, while the client (astro-kbve/droid) now strictly validates `AgentTokenRow` (requires `token_id`, #12153). Result: every `list_tokens` response fails validation → `$tokens` empty → the GitHub wizard HMAC/PAT steps stay on **TODO** after a successful save.

Patch-bump the edge MDX `version:` 0.1.42 → 0.1.43 (only the MDX field; `version.toml` auto-syncs post-publish) to trigger the edge republish. Once deployed, the list emits `token_id`, validation passes, `$tokens` fills, and the wizard sees the stored secret (pill flips to done; no more reset prompt).