### PR TITLE
feat(kube/kbve): wire PgCluster (rw/ro/any) + KvCache (Valkey) via ESO

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -14,7 +14,7 @@ metadata:
         # picks up the new Postgres password. Without this the pool holds
         # stale creds and `/api/v1/wallet/*` starts 5xx-ing until manual
         # restart on every CNPG password rotation.
-        secret.reloader.stakater.com/reload: 'supabase-shared,forgejo-deploy-keys'
+        secret.reloader.stakater.com/reload: 'supabase-shared,forgejo-deploy-keys,valkey-auth'
 spec:
     replicas: 1
     strategy:
@@ -211,6 +211,42 @@ spec:
                             secretKeyRef:
                                 name: supabase-shared
                                 key: db-url-ro
+                      # PgCluster (jedi::state::pg) three-pool wiring
+                      # matching the CNPG instance topology. Same
+                      # `postgres` creds as WALLET_DATABASE_URL above;
+                      # only the host service differs (rw / ro / -r any).
+                      # PgCluster::from_env falls back through DATABASE_URL_PROD
+                      # and WALLET_DATABASE_URL, but spelling the canonical
+                      # KBVE_PG_* names lets `kbve.wallet` migrate off
+                      # diesel-async later without touching this manifest.
+                      - name: KBVE_PG_RW_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url
+                      - name: KBVE_PG_RO_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url-ro
+                      - name: KBVE_PG_ANY_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: db-url-any
+                      # KvCache (jedi::state::kv) L2 backing. valkey-auth
+                      # is cloned into the kbve namespace by Kyverno
+                      # (apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml).
+                      # init_kv_cache() warn-logs and stays L1-only if
+                      # this URL is unreachable, so a Valkey outage never
+                      # breaks `/api/v1/wallet/me/*`.
+                      - name: VALKEY_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: valkey-auth
+                                key: valkey-password
+                      - name: KBVE_KV_URL
+                        value: 'redis://default:$(VALKEY_PASSWORD)@valkey.valkey.svc.cluster.local:6379/3'
                       # HMAC-SHA256 key for the referral handler's IP +
                       # subnet hashing. Sourced from referral-config in
                       # this namespace (built by kbve-externalsecret.yaml

--- a/apps/kube/kbve/manifest/kbve-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/kbve-externalsecret.yaml
@@ -40,6 +40,7 @@ spec:
                 service-role-key: '{{ .servicekey }}'
                 db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
                 db-url-ro: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-pooler-ro.kilobase.svc.cluster.local:5432/supabase'
+                db-url-any: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-r.kilobase.svc.cluster.local:5432/supabase'
                 twitch-client-id: '{{ .twitchclientid }}'
                 twitch-client-secret: '{{ .twitchclientsecret }}'
     data:

--- a/apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml
+++ b/apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml
@@ -52,3 +52,19 @@ spec:
               clone:
                   namespace: valkey
                   name: valkey-auth
+        - name: clone-valkey-auth-kbve
+          match:
+              resources:
+                  kinds:
+                      - Namespace
+                  names:
+                      - kbve
+          generate:
+              apiVersion: v1
+              kind: Secret
+              name: valkey-auth
+              namespace: kbve
+              synchronize: true
+              clone:
+                  namespace: valkey
+                  name: valkey-auth

--- a/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
+++ b/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
@@ -23,6 +23,9 @@ spec:
               - namespaceSelector:
                     matchLabels:
                         kubernetes.io/metadata.name: discordsh
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: kbve
           ports:
               - port: 6379
                 protocol: TCP


### PR DESCRIPTION
axum-kbve's PgCluster (#12359) + KvCache (#12384) cores landed but the deployment env wasn't sourced from k8s yet. This closes the operational gap so the Rust code actually receives the URLs in prod.

## PgCluster — three-pool env wiring

| Env | Source | Backing CNPG service |
|-----|--------|----------------------|
| `KBVE_PG_RW_URL`  | `supabase-shared.db-url`     | `supabase-cluster-rw`  |
| `KBVE_PG_RO_URL`  | `supabase-shared.db-url-ro`  | `supabase-cluster-pooler-ro` |
| `KBVE_PG_ANY_URL` | `supabase-shared.db-url-any` *(new)* | `supabase-cluster-r`  |

`kbve-externalsecret.yaml` gains the `db-url-any` template key keyed off `supabase-cluster-r.kilobase.svc.cluster.local`. CNPG auto-creates the `-r` service for any-healthy reads.

Existing `WALLET_DATABASE_URL{,_RO}` env vars stay in place for `kbve.wallet`'s diesel-async pool until that migration ships; PgCluster also falls back through them via `from_env`, but spelling the canonical `KBVE_PG_*` names lets the wallet rewrite drop those keys without touching this manifest.

## KvCache — Valkey L2 wiring

`valkey-auth` Secret lives in the `valkey` namespace. Pattern matches the existing forgejo / n8n / discordsh consumers:

- **Kyverno clone** — new rule `clone-valkey-auth-kbve` in [`apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml`](apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml) mirrors `valkey-auth` into `kbve`. No new RBAC; reuses the cluster-scoped Kyverno SA.
- **NetworkPolicy** — `kbve` added to the `valkey-allow-consumers` ingress allowlist on port 6379.
- **Env** — `VALKEY_PASSWORD` from the cloned Secret, then:
  ```yaml
  - name: KBVE_KV_URL
    value: 'redis://default:$(VALKEY_PASSWORD)@valkey.valkey.svc.cluster.local:6379/3'
  ```
  Database index `/3` chosen to avoid forgejo's `/0/1/2` allocation. `init_kv_cache()` degrades to L1-only when this URL is unreachable so a Valkey blip never 5xx's `/api/v1/wallet/me/*`.

## Reloader

`secret.reloader.stakater.com/reload` annotation extended to include `valkey-auth` so a password rotation rolls the axum-kbve pods automatically (matches the existing `supabase-shared` hook for CNPG password rotations).

## Reconcile order on first apply

1. Kyverno ClusterPolicy generates `valkey-auth` Secret into the `kbve` namespace on Namespace match.
2. ESO materializes `supabase-shared` (already in place; only the new `db-url-any` key is added on this PR).
3. Reloader rolls the axum-kbve deployment when either Secret changes.

If `valkey-auth` isn't materialized yet: pod boots, `init_kv_cache` warn-logs, `/me/ledger` still works against PG.
If `db-url-any` isn't materialized yet: PgCluster falls back to `rw_url` for the `any` pool (the `from_env` default).

## Files changed
- [apps/kube/kbve/manifest/kbve-externalsecret.yaml](apps/kube/kbve/manifest/kbve-externalsecret.yaml)
- [apps/kube/kbve/manifest/kbve-deployment.yaml](apps/kube/kbve/manifest/kbve-deployment.yaml)
- [apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml](apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml)
- [apps/kube/valkey/manifests/valkey-networkpolicy.yaml](apps/kube/valkey/manifests/valkey-networkpolicy.yaml)

## Test plan
- [x] `python3 -c 'list(yaml.safe_load_all(open(f)))'` on all 4 changed manifests
- [ ] Apply on dev → main → ArgoCD reconcile in cluster
- [ ] Confirm `kubectl -n kbve get secret valkey-auth` exists after Kyverno reconcile
- [ ] Confirm `kubectl -n kbve get secret supabase-shared -o jsonpath='{.data.db-url-any}' | base64 -d` returns the `-r` host URL
- [ ] Roll axum-kbve; check logs for `KvCache initialized - L1 LRU + L2 Valkey read-through cache enabled` (vs the L1-only fallback line)
- [ ] Curl `/health/pg` returns `all_ok=true` on all three roles
- [ ] Curl `/api/v1/wallet/me/ledger` with a valid bearer twice; second call's L1 hit reflected in `kbve_kv_l1_hit` counter