### PR TITLE
feat(axum-cryptothrone): P3b Discord session bridge (#12362)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1533,6 +1533,7 @@ dependencies = [
  "kbve",
  "kube",
  "num_cpus",
+ "reqwest 0.12.28",
  "rustls 0.23.37",
  "serde",
  "serde_json",

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.toml
@@ -29,12 +29,13 @@ dotenvy = "0.15"
 http = "1"
 serde = { version = "1.0", features = ["derive"] }
 jsonwebtoken = { version = "9.3", default-features = false }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 kube = { version = "3", default-features = false, features = ["client", "rustls-tls"] }
 k8s-openapi = { version = "0.27", features = ["v1_32"] }
 rustls = { version = "0.23", features = ["ring"] }
 
 # Workspace path dependencies
-jedi = { path = "../../../packages/rust/jedi" }
+jedi = { path = "../../../packages/rust/jedi", features = ["postgres"] }
 kbve = { path = "../../../packages/rust/kbve" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/apps/cryptothrone/axum-cryptothrone/src/discord.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/discord.rs
@@ -1,0 +1,195 @@
+//! Discord Activity session bridge.
+//!
+//! POST `/api/discord/session` — the backend half of the isolated Discord path.
+//! Takes the Discord OAuth `code` from the Activity, exchanges it for a Discord
+//! access token + user, resolves the linked KBVE profile, and mints a
+//! Supabase-compatible HS256 JWT the game server already accepts (same claims
+//! the GoTrue custom-access-token hook injects: `sub`, `exp`, `kbve_username`,
+//! `role`, `aud`). Returns `{access_token, jwt, username}`.
+
+use std::{
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use axum::{
+    Extension, Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use jedi::state::pg::{PgCluster, tokio_postgres::Row};
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde::{Deserialize, Serialize};
+
+const DISCORD_TOKEN_URL: &str = "https://discord.com/api/v10/oauth2/token";
+const DISCORD_USER_URL: &str = "https://discord.com/api/v10/users/@me";
+/// Game session lifetime. Activities are short-lived; the game reconnects with
+/// a fresh exchange if it outlives this.
+const JWT_TTL_SECS: u64 = 6 * 60 * 60;
+
+#[derive(Deserialize)]
+pub struct SessionRequest {
+    code: String,
+}
+
+#[derive(Serialize)]
+pub struct SessionResponse {
+    /// Discord access token — fed back to `discordSdk.commands.authenticate`.
+    access_token: String,
+    /// Supabase-valid HS256 JWT for the game server.
+    jwt: String,
+    username: String,
+}
+
+#[derive(Deserialize)]
+struct DiscordToken {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct DiscordUser {
+    id: String,
+}
+
+#[derive(Serialize)]
+struct MintedClaims {
+    sub: String,
+    exp: i64,
+    kbve_username: String,
+    role: String,
+    aud: String,
+}
+
+pub async fn session(
+    Extension(pg): Extension<Option<Arc<PgCluster>>>,
+    Json(req): Json<SessionRequest>,
+) -> Response {
+    let client_id = std::env::var("DISCORD_CLIENT_ID").unwrap_or_default();
+    let client_secret = std::env::var("DISCORD_CLIENT_SECRET").unwrap_or_default();
+    let redirect_uri = std::env::var("DISCORD_REDIRECT_URI").unwrap_or_default();
+    let jwt_secret = std::env::var("SUPABASE_JWT_SECRET").unwrap_or_default();
+    if client_id.is_empty() || client_secret.is_empty() || jwt_secret.is_empty() {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "discord session bridge not configured",
+        )
+            .into_response();
+    }
+    let Some(pg) = pg else {
+        return (StatusCode::SERVICE_UNAVAILABLE, "database offline").into_response();
+    };
+
+    let http = reqwest::Client::new();
+
+    // 1. OAuth code -> Discord access token.
+    let token: DiscordToken = match http
+        .post(DISCORD_TOKEN_URL)
+        .form(&[
+            ("client_id", client_id.as_str()),
+            ("client_secret", client_secret.as_str()),
+            ("grant_type", "authorization_code"),
+            ("code", req.code.as_str()),
+            ("redirect_uri", redirect_uri.as_str()),
+        ])
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    {
+        Ok(r) => match r.json().await {
+            Ok(t) => t,
+            Err(_) => return (StatusCode::BAD_GATEWAY, "bad token response").into_response(),
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "discord code exchange failed");
+            return (StatusCode::UNAUTHORIZED, "discord code exchange failed").into_response();
+        }
+    };
+
+    // 2. Access token -> Discord user id (snowflake).
+    let user: DiscordUser = match http
+        .get(DISCORD_USER_URL)
+        .bearer_auth(&token.access_token)
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+    {
+        Ok(r) => match r.json().await {
+            Ok(u) => u,
+            Err(_) => return (StatusCode::BAD_GATEWAY, "bad user response").into_response(),
+        },
+        Err(e) => {
+            tracing::warn!(error = %e, "discord /users/@me failed");
+            return (StatusCode::BAD_GATEWAY, "discord user fetch failed").into_response();
+        }
+    };
+
+    // 3. Discord id -> linked KBVE profile (user_id + kbve_username).
+    let conn = match pg.read().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(error = %e, "pg acquire failed");
+            return (StatusCode::SERVICE_UNAVAILABLE, "database unavailable").into_response();
+        }
+    };
+    let row: Row = match conn
+        .query_opt(
+            "SELECT user_id::text, kbve_username \
+             FROM tracker.find_claim_identity_by_discord_id($1)",
+            &[&user.id],
+        )
+        .await
+    {
+        Ok(Some(row)) => row,
+        Ok(None) => {
+            return (
+                StatusCode::FORBIDDEN,
+                "Discord account is not linked to a KBVE profile",
+            )
+                .into_response();
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "discord profile lookup failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "profile lookup failed").into_response();
+        }
+    };
+    let user_id: String = row.get(0);
+    let kbve_username: Option<String> = row.get(1);
+    let Some(kbve_username) = kbve_username.filter(|u| !u.is_empty()) else {
+        return (StatusCode::FORBIDDEN, "linked KBVE profile has no username").into_response();
+    };
+
+    // 4. Mint the Supabase-valid HS256 JWT the game server accepts.
+    let exp = now_secs().saturating_add(JWT_TTL_SECS) as i64;
+    let claims = MintedClaims {
+        sub: user_id,
+        exp,
+        kbve_username: kbve_username.clone(),
+        role: "authenticated".into(),
+        aud: "authenticated".into(),
+    };
+    let jwt = match encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(jwt_secret.as_bytes()),
+    ) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!(error = %e, "jwt mint failed");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "jwt mint failed").into_response();
+        }
+    };
+
+    Json(SessionResponse {
+        access_token: token.access_token,
+        jwt,
+        username: kbve_username,
+    })
+    .into_response()
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/main.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/main.rs
@@ -1,6 +1,7 @@
 mod agones;
 mod astro;
 mod auth;
+mod discord;
 mod transport;
 
 use tracing::info;

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -33,7 +33,16 @@ pub async fn serve() -> Result<()> {
     info!("HTTP listening on http://{addr}");
 
     let allocator = Arc::new(AgonesAllocator::try_new().await);
-    let app = router().layer(Extension(allocator));
+    // Optional DB — only the Discord session bridge needs it; the service still
+    // serves static + allocation when KBVE_PG_* is unset.
+    let pg = match jedi::state::pg::PgCluster::from_env().await {
+        Ok(c) => Some(c),
+        Err(e) => {
+            tracing::warn!(error = %e, "PgCluster offline; /api/discord/session disabled");
+            None
+        }
+    };
+    let app = router().layer(Extension(allocator)).layer(Extension(pg));
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal())
@@ -97,7 +106,8 @@ fn router() -> Router {
     let dynamic_router = Router::new()
         .route("/health", get(health))
         .route("/api/v1/speed", get(speed))
-        .route("/api/join", post(join));
+        .route("/api/join", post(join))
+        .route("/api/discord/session", post(crate::discord::session));
 
     static_router.merge(dynamic_router).layer(middleware)
 }


### PR DESCRIPTION
**P3b of #12362** — the backend session bridge for the Discord Activity. The client (P3a, #12378) POSTs the Discord OAuth `code` here and gets back a game-server session.

## Endpoint: `POST /api/discord/session` (axum-cryptothrone)
1. exchange the Discord OAuth `code` → Discord `access_token` (`oauth2/token`, needs client_secret)
2. `access_token` → Discord user id (`users/@me`)
3. resolve the linked KBVE profile via the **existing** RPC `tracker.find_claim_identity_by_discord_id(discord_id)` → `user_id` + `profile.username`, over `jedi::PgCluster` (ro pool)
4. mint a **Supabase-valid HS256 JWT** with the exact claims the game server's `verify_supabase_jwt` accepts (`sub`, `exp`, `kbve_username`, `role`, `aud`) via `SUPABASE_JWT_SECRET`

Returns `{access_token, jwt, username}` → the Activity calls `authenticate({access_token})` then `mount({jwt, username})`.

`PgCluster` is optional (jedi `postgres` feature): the service still serves static + allocation when `KBVE_PG_*` is unset; the endpoint 503s.

## Verification
- `cargo check -p axum-cryptothrone` clean, `cargo test` 8 passing.

## Infra checklist (not code — needed to go live)
- **Secrets** on the axum-cryptothrone deployment: `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, `DISCORD_REDIRECT_URI`, `SUPABASE_JWT_SECRET` (must match the game server's), `KBVE_PG_RW_URL` (+ DB network policy to kilobase).
- **Discord developer portal**: create the Activity app; set OAuth2 redirect; configure **URL Mappings** so `/.proxy/api/discord/session` → this service and the `patchUrlMappings` prefixes (`/cryptothrone-game`→game.cryptothrone.com, `/cryptothrone-chat`→chat.kbve.com) route correctly.
- **DB grant**: confirm the service's DB role can `EXECUTE tracker.find_claim_identity_by_discord_id` (SECURITY DEFINER, but EXECUTE grant still required).
- **Linking**: a Discord user only resolves if they've linked Discord to their KBVE/Supabase account (`auth.identities` provider='discord'). Unlinked → 403; the Activity should surface a "link your account" path.

## Depends on
P3a client (#12378). Together they complete #12362 P3 (Discord Activity), modulo the infra above.
