### PR TITLE
refactor(forgejo): route the whole dashboard through the typed /api/* surface

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -382,9 +382,25 @@ const CACHE_KEY = 'cache:forgejo:data';
 const EXPANDED_KEY = 'forgejo:expandedRepo';
 const TAB_KEY = 'forgejo:activeTab';
 const CACHE_TTL_MS = 60 * 1000;
-const PROXY_BASE = '/dashboard/forgejo/proxy';
 const API_BASE = '/dashboard/forgejo/api';
 const REFRESH_INTERVAL_MS = 30 * 1000;
+
+// Maps a Forgejo `/api/v1/...` path (the shape every call site still uses) onto
+// the typed axum surface at /dashboard/forgejo/api/*: strip the v1 prefix and
+// rename the routes that the typed layer shortened. Lets the whole service ride
+// the typed routes (normalised errors, server-side aggregation, policy) without
+// touching call sites.
+function toTypedPath(path: string): string {
+	let p = path.startsWith('/api/v1') ? path.slice('/api/v1'.length) : path;
+	p = p
+		.replace('/admin/users', '/users')
+		.replace('/admin/cron', '/cron')
+		.replace('/admin/unadopted', '/unadopted')
+		.replace('/actions/secrets', '/secrets')
+		.replace('/actions/variables', '/variables')
+		.replace('/branch_protections', '/protections');
+	return p;
+}
 const PAGE_SIZE = 50;
 const RESOURCE_TTL_MS = 60 * 1000;
 
@@ -419,7 +435,7 @@ async function apiFetch<T>(
 	path: string,
 	fallback?: T,
 ): Promise<T> {
-	const resp = await fetch(`${PROXY_BASE}${path}`, {
+	const resp = await fetch(`${API_BASE}${toTypedPath(path)}`, {
 		headers: { Authorization: `Bearer ${token}` },
 		signal: AbortSignal.timeout(10000),
 	});
@@ -477,7 +493,7 @@ async function apiMutate<T>(
 		opts.body = JSON.stringify(body);
 	}
 
-	const resp = await fetch(`${PROXY_BASE}${path}`, opts);
+	const resp = await fetch(`${API_BASE}${toTypedPath(path)}`, opts);
 	if (!resp.ok) {
 		const text = await resp.text().catch(() => '');
 		let detail = text.slice(0, 300);


### PR DESCRIPTION
The last queued Forgejo item. The dashboard read most data through the generic pass-through proxy while only `/users`, stats, storage, and runners used the typed routes.

## Change
One `toTypedPath()` transform in `apiFetch`/`apiMutate` maps the `/api/v1/...` paths every call site already uses onto the typed axum surface (`/dashboard/forgejo/api/*`): strips the `v1` prefix and renames the shortened routes (`admin/users`→`users`, `admin/cron`→`cron`, `admin/unadopted`→`unadopted`, `actions/secrets`→`secrets`, `actions/variables`→`variables`, `branch_protections`→`protections`). **No call sites change** — lowest-risk way to flip the whole service.

## Effect
Every read + write now flows through the jedi-backed typed routes: normalised `JediError` responses, server-side aggregation, and the `FORGEJO_ALLOWED_OWNERS` policy guardrail. Same server-side admin token + same `DASHBOARD_VIEW`/`MANAGE` gating, so no auth-behaviour change. The generic proxy route stays in axum (unused by the dashboard now; harmless).

## Verify
- `./kbve.sh -nx astro-kbve:build` ✓ (7742 pages)

## Note
Behaviourally this flips all dashboard data onto the typed routes — worth a smoke test on the live dashboard after merge (especially once the admin-token rotation #12348 reaches main, which the admin reads depend on). The transform keeps call sites identical, so the blast radius is the path mapping only.