### PR TITLE
feat(cryptothrone): wire jedi PgCluster + Valkey into website + gameserver (RBAC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,6 +4858,7 @@ dependencies = [
  "agones",
  "axum 0.7.9",
  "bevy",
+ "jedi",
  "simgrid",
  "tokio",
  "tracing",

--- a/apps/agones/cryptothrone/server/Cargo.toml
+++ b/apps/agones/cryptothrone/server/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 simgrid = { path = "../../../../packages/rust/simgrid" }
+jedi = { path = "../../../../packages/rust/jedi", features = ["postgres", "valkey"] }
 bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
 axum = { version = "0.7", default-features = false, features = ["ws", "json", "http1", "tokio"] }
 tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "signal", "sync", "time", "net"] }

--- a/apps/agones/cryptothrone/server/src/db/kv_cache.rs
+++ b/apps/agones/cryptothrone/server/src/db/kv_cache.rs
@@ -1,0 +1,17 @@
+use std::sync::Arc;
+
+use jedi::state::kv::KvCache;
+use tokio::sync::OnceCell;
+
+static KV_CACHE: OnceCell<Arc<KvCache>> = OnceCell::const_new();
+
+/// Build the two-tier KvCache (L1 LRU + L2 Valkey) from env. L2 is best-effort:
+/// if Valkey is unreachable the cache still serves from L1. Idempotent.
+pub async fn init_kv_cache() -> bool {
+    let cache = KvCache::from_env().await;
+    KV_CACHE.set(cache).is_ok()
+}
+
+pub fn get_kv_cache() -> Option<&'static Arc<KvCache>> {
+    KV_CACHE.get()
+}

--- a/apps/agones/cryptothrone/server/src/db/mod.rs
+++ b/apps/agones/cryptothrone/server/src/db/mod.rs
@@ -1,0 +1,12 @@
+//! Shared data layer — jedi PgCluster (pooled Postgres) + KvCache (Valkey).
+//! Both pull config from env (see kube manifests) and degrade gracefully when
+//! unconfigured so the game server still boots. Getters are the access points
+//! for persistence systems wired in later.
+
+mod kv_cache;
+mod pg_cluster;
+
+#[allow(unused_imports)]
+pub use kv_cache::{get_kv_cache, init_kv_cache};
+#[allow(unused_imports)]
+pub use pg_cluster::{get_pg_cluster, init_pg_cluster};

--- a/apps/agones/cryptothrone/server/src/db/pg_cluster.rs
+++ b/apps/agones/cryptothrone/server/src/db/pg_cluster.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use jedi::state::pg::PgCluster;
+use tokio::sync::OnceCell;
+
+static PG_CLUSTER: OnceCell<Option<Arc<PgCluster>>> = OnceCell::const_new();
+
+/// Build the shared PgCluster (RW/RO/ANY pools) from env. Non-fatal: if the
+/// pools can't be built the service still boots and PgCluster-backed routes
+/// degrade. Idempotent via OnceCell.
+pub async fn init_pg_cluster() -> bool {
+    PG_CLUSTER
+        .get_or_init(|| async {
+            match PgCluster::from_env().await {
+                Ok(cluster) => {
+                    tracing::info!("PgCluster initialized");
+                    Some(cluster)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "PgCluster disabled: failed to build pools");
+                    None
+                }
+            }
+        })
+        .await
+        .is_some()
+}
+
+pub fn get_pg_cluster() -> Option<&'static Arc<PgCluster>> {
+    PG_CLUSTER.get().and_then(|c| c.as_ref())
+}

--- a/apps/agones/cryptothrone/server/src/main.rs
+++ b/apps/agones/cryptothrone/server/src/main.rs
@@ -1,4 +1,5 @@
 mod agones;
+mod db;
 mod game;
 
 use std::net::SocketAddr;
@@ -18,6 +19,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .unwrap_or_else(|_| "info,cryptothrone_server=debug,simgrid=debug".into()),
         )
         .init();
+
+    // Shared data layer — pooled Postgres + Valkey cache, both non-fatal so the
+    // game server still boots when unconfigured.
+    if db::init_pg_cluster().await {
+        tracing::info!("PgCluster initialized — pooled Postgres available");
+    } else {
+        tracing::info!("PgCluster not configured — persistence degrades");
+    }
+    if db::init_kv_cache().await {
+        tracing::info!("KvCache initialized — L1 LRU + L2 Valkey enabled");
+    }
 
     let addr: SocketAddr = std::env::var("CT_SERVER_ADDR")
         .unwrap_or_else(|_| "0.0.0.0:7979".into())

--- a/apps/cryptothrone/axum-cryptothrone/Cargo.toml
+++ b/apps/cryptothrone/axum-cryptothrone/Cargo.toml
@@ -35,7 +35,7 @@ k8s-openapi = { version = "0.27", features = ["v1_32"] }
 rustls = { version = "0.23", features = ["ring"] }
 
 # Workspace path dependencies
-jedi = { path = "../../../packages/rust/jedi", features = ["postgres"] }
+jedi = { path = "../../../packages/rust/jedi", features = ["postgres", "valkey"] }
 kbve = { path = "../../../packages/rust/kbve" }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/apps/cryptothrone/axum-cryptothrone/src/db/kv_cache.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/db/kv_cache.rs
@@ -1,0 +1,17 @@
+use std::sync::Arc;
+
+use jedi::state::kv::KvCache;
+use tokio::sync::OnceCell;
+
+static KV_CACHE: OnceCell<Arc<KvCache>> = OnceCell::const_new();
+
+/// Build the two-tier KvCache (L1 LRU + L2 Valkey) from env. L2 is best-effort:
+/// if Valkey is unreachable the cache still serves from L1. Idempotent.
+pub async fn init_kv_cache() -> bool {
+    let cache = KvCache::from_env().await;
+    KV_CACHE.set(cache).is_ok()
+}
+
+pub fn get_kv_cache() -> Option<&'static Arc<KvCache>> {
+    KV_CACHE.get()
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/db/mod.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/db/mod.rs
@@ -1,0 +1,11 @@
+//! Shared data layer — jedi PgCluster (pooled Postgres) + KvCache (Valkey).
+//! Both pull config from env (see kube manifests) and degrade gracefully when
+//! unconfigured so the website still boots.
+
+mod kv_cache;
+mod pg_cluster;
+
+#[allow(unused_imports)]
+pub use kv_cache::{get_kv_cache, init_kv_cache};
+#[allow(unused_imports)]
+pub use pg_cluster::{get_pg_cluster, init_pg_cluster};

--- a/apps/cryptothrone/axum-cryptothrone/src/db/pg_cluster.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/db/pg_cluster.rs
@@ -1,0 +1,31 @@
+use std::sync::Arc;
+
+use jedi::state::pg::PgCluster;
+use tokio::sync::OnceCell;
+
+static PG_CLUSTER: OnceCell<Option<Arc<PgCluster>>> = OnceCell::const_new();
+
+/// Build the shared PgCluster (RW/RO/ANY pools) from env. Non-fatal: if the
+/// pools can't be built the service still boots and PgCluster-backed routes
+/// degrade. Idempotent via OnceCell.
+pub async fn init_pg_cluster() -> bool {
+    PG_CLUSTER
+        .get_or_init(|| async {
+            match PgCluster::from_env().await {
+                Ok(cluster) => {
+                    tracing::info!("PgCluster initialized");
+                    Some(cluster)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "PgCluster disabled: failed to build pools");
+                    None
+                }
+            }
+        })
+        .await
+        .is_some()
+}
+
+pub fn get_pg_cluster() -> Option<&'static Arc<PgCluster>> {
+    PG_CLUSTER.get().and_then(|c| c.as_ref())
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/main.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/main.rs
@@ -1,6 +1,7 @@
 mod agones;
 mod astro;
 mod auth;
+mod db;
 mod discord;
 mod transport;
 
@@ -32,6 +33,15 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     info!("CryptoThrone v{}", env!("CARGO_PKG_VERSION"));
+
+    if db::init_pg_cluster().await {
+        info!("PgCluster initialized — pooled Postgres available");
+    } else {
+        info!("PgCluster not configured — DB-backed routes degrade");
+    }
+    if db::init_kv_cache().await {
+        info!("KvCache initialized — L1 LRU + L2 Valkey read-through enabled");
+    }
 
     let http = tokio::spawn(transport::https::serve());
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.13"
+version: "0.0.14"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.24"
+version: "0.1.25"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/apps/kube/agones/cryptothrone/manifests/fleet.yaml
+++ b/apps/kube/agones/cryptothrone/manifests/fleet.yaml
@@ -63,6 +63,30 @@ spec:
                                     secretKeyRef:
                                         name: supabase-shared
                                         key: SUPABASE_JWT_SECRET
+                              # jedi PgCluster (pooled Postgres) + KvCache
+                              # (Valkey). All optional so a GameServer still
+                              # starts before the ExternalSecrets render; jedi
+                              # init is non-fatal on the Rust side too.
+                              - name: KBVE_PG_APPLICATION_NAME
+                                value: 'cryptothrone-server'
+                              - name: KBVE_PG_RW_URL
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: supabase-shared
+                                        key: KBVE_PG_RW_URL
+                                        optional: true
+                              - name: KBVE_PG_RO_URL
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: supabase-shared
+                                        key: KBVE_PG_RO_URL
+                                        optional: true
+                              - name: KBVE_KV_URL
+                                valueFrom:
+                                    secretKeyRef:
+                                        name: cryptothrone-valkey
+                                        key: KBVE_KV_URL
+                                        optional: true
                           ports:
                               - name: ws
                                 containerPort: 7979

--- a/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
@@ -69,6 +69,10 @@ spec:
                         value: 'cryptothrone'
                       - name: CT_AGONES_FLEET
                         value: 'cryptothrone-server'
+                      # jedi PgCluster pool identity (KBVE_PG_RW_URL / RO_URL
+                      # arrive via the supabase-shared envFrom below).
+                      - name: KBVE_PG_APPLICATION_NAME
+                        value: 'axum-cryptothrone'
                   envFrom:
                       # Optional so the pod still boots before the
                       # ExternalSecret has rendered or the kilobase
@@ -76,6 +80,11 @@ spec:
                       # exists Reloader rolls the Deployment automatically.
                       - secretRef:
                             name: supabase-shared
+                            optional: true
+                      # KBVE_KV_URL (jedi KvCache → Valkey). Optional for the
+                      # same boot-before-render reason.
+                      - secretRef:
+                            name: cryptothrone-valkey
                             optional: true
                   resources:
                       requests:

--- a/apps/kube/cryptothrone/manifest/cryptothrone-externalsecret.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-externalsecret.yaml
@@ -54,6 +54,10 @@ spec:
                 SUPABASE_SERVICE_ROLE_KEY: '{{ .servicekey }}'
                 SUPABASE_JWT_SECRET: '{{ .jwtsecret }}'
                 DATABASE_URL: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
+                # jedi PgCluster pool URLs (RW primary + RO replica). Consumed
+                # by axum-cryptothrone + the cryptothrone-server gameserver.
+                KBVE_PG_RW_URL: 'postgres://postgres:{{ .dbpassword | urlquery }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase?sslmode=disable'
+                KBVE_PG_RO_URL: 'postgres://postgres:{{ .dbpassword | urlquery }}@supabase-cluster-ro.kilobase.svc.cluster.local:5432/supabase?sslmode=disable'
     data:
         - secretKey: jwtsecret
           remoteRef:
@@ -71,3 +75,52 @@ spec:
           remoteRef:
               key: supabase-postgres
               property: password
+---
+# Second SecretStore + ExternalSecret reaching into the valkey namespace for
+# the shared Valkey password, composed into a full KBVE_KV_URL (jedi KvCache
+# reads KBVE_KV_URL / REDIS_URL only). Requires cryptothrone-external-secrets
+# to be granted get on valkey-auth in the valkey namespace
+# (apps/kube/valkey/manifests/cryptothrone-valkey-rbac.yaml).
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: valkey-remote-secret-store
+    namespace: cryptothrone
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: valkey
+            auth:
+                serviceAccount:
+                    name: cryptothrone-external-secrets
+                    namespace: cryptothrone
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: cryptothrone-valkey-secrets
+    namespace: cryptothrone
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: valkey-remote-secret-store
+        kind: SecretStore
+    target:
+        name: cryptothrone-valkey
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                KBVE_KV_URL: 'redis://:{{ .valkeypassword | urlquery }}@valkey.valkey.svc.cluster.local:6379'
+    data:
+        - secretKey: valkeypassword
+          remoteRef:
+              key: valkey-auth
+              property: valkey-password

--- a/apps/kube/valkey/manifests/cryptothrone-valkey-rbac.yaml
+++ b/apps/kube/valkey/manifests/cryptothrone-valkey-rbac.yaml
@@ -1,0 +1,18 @@
+# Lets the cryptothrone ExternalSecrets ServiceAccount read the shared
+# valkey-auth secret out of the valkey namespace, so the valkey-remote-secret-store
+# SecretStore (apps/kube/cryptothrone/manifest/cryptothrone-externalsecret.yaml)
+# can compose KBVE_KV_URL for axum-cryptothrone + the cryptothrone-server
+# gameserver. Reuses the existing valkey-auth-reader Role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: cryptothrone-read-valkey-auth
+    namespace: valkey
+subjects:
+    - kind: ServiceAccount
+      name: cryptothrone-external-secrets
+      namespace: cryptothrone
+roleRef:
+    kind: Role
+    name: valkey-auth-reader
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/kube/valkey/manifests/kustomization.yaml
+++ b/apps/kube/valkey/manifests/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
     - valkey-sccache-rbac.yaml
     - valkey-auth-sync-rbac.yaml
     - valkey-auth-sync-policy.yaml
+    - cryptothrone-valkey-rbac.yaml

--- a/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
+++ b/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
@@ -26,6 +26,9 @@ spec:
               - namespaceSelector:
                     matchLabels:
                         kubernetes.io/metadata.name: kbve
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: cryptothrone
           ports:
               - port: 6379
                 protocol: TCP


### PR DESCRIPTION
Both cryptothrone services now share the jedi data layer — pooled Postgres (kilobase/supabase cluster) + Valkey KvCache — with cross-namespace RBAC. Requested: website + gameserver access to valkey + pgcluster/pool.

## Rust
- **axum-cryptothrone** (website): new `db` module (`pg_cluster.rs` + `kv_cache.rs`, OnceCell init mirroring axum-kbve), `jedi` features `["postgres","valkey"]`, non-fatal init in `main`. `get_pg_cluster()` / `get_kv_cache()` are the access points for routes.
- **cryptothrone-server** (agones gameserver): add `jedi` dep + the same `db` module + non-fatal init in `main`.
- Both **degrade gracefully** — the service boots even if pools/cache are unconfigured (init logs a warning, returns `false`).

## Kube / RBAC
- **ExternalSecret** (cryptothrone): renders `KBVE_PG_RW_URL` / `KBVE_PG_RO_URL` into `supabase-shared` (reuses the existing `supabase-postgres` password, `sslmode=disable`, url-encoded). New **valkey SecretStore + ExternalSecret** render `KBVE_KV_URL` from `valkey-auth` in the valkey ns (url-encoded password).
- **valkey RBAC**: `RoleBinding` granting `cryptothrone-external-secrets` read on `valkey-auth` (reuses the existing `valkey-auth-reader` Role) + **added `cryptothrone` to the valkey ingress NetworkPolicy** allowlist (was missing → pods couldn't reach `valkey:6379`).
- **deployment + fleet env**: `KBVE_PG_APPLICATION_NAME` per service + `KBVE_PG_*` / `KBVE_KV_URL` via optional secretKeyRef/envFrom (boot-before-render safe).
- kilobase RBAC unchanged — PG URLs reuse the already-granted `supabase-postgres` secret.

## Versions
- cryptothrone `0.1.24 → 0.1.25`, cryptothrone-server `0.0.13 → 0.0.14`. (Deployment/fleet image tags left for the post-publish atom sync.)

## Verified
- `cargo build` clean: axum-cryptothrone (409 crates) + cryptothrone-server.
- `kubectl kustomize` validates both cryptothrone + valkey manifests.

## Needs deploy-time verification (can't test from here)
- ESO rendering of `supabase-shared` (new PG keys) + `cryptothrone-valkey` once RBAC lands; Reloader rolls the deployment.
- That the Valkey password is URL-safe after `urlquery` encoding (jedi parses `KBVE_KV_URL` via `Config::from_url`).
- Confirm `cryptothrone-external-secrets` is in the kilobase `kilobase-secrets-reader-*` RoleBinding (existing manifest comment says required).