### PR TITLE
fix(ci-unreal-build): keep LFS owner case (KBVE) — lowercasing 302-bounced to /dashboard

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -441,7 +441,6 @@ jobs:
                         *.git) REPO_PATH="${REPO_PATH}/info/lfs" ;;
                         *) REPO_PATH="${REPO_PATH%.git}.git/info/lfs" ;;
                       esac
-                      REPO_PATH="$(printf '%s' "${REPO_PATH%%/*}" | tr 'A-Z' 'a-z')/${REPO_PATH#*/}"
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local
@@ -755,7 +754,6 @@ jobs:
                         *.git) REPO_PATH="${REPO_PATH}/info/lfs" ;;
                         *) REPO_PATH="${REPO_PATH%.git}.git/info/lfs" ;;
                       esac
-                      REPO_PATH="$(printf '%s' "${REPO_PATH%%/*}" | tr 'A-Z' 'a-z')/${REPO_PATH#*/}"
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local


### PR DESCRIPTION
## What the last run showed

#12385's normalization worked — `normalized from ssh://…mc.kbve.com… → git.kbve.com/kbve/chuck.git/info/lfs`. But the batch POST then failed:

```
batch response: Client error ... host=kbve.com:443 path=/dashboard ... HTTP 405
```

The owner-lowercasing was **backwards**. Forgejo LFS routing case rule (from the field note): `KBVE/chuck` = **401** (the real repo — `FORGEJO_USER:TOKEN` clears it to 200), `kbve/chuck` = **302** (a redirect that bounces to `kbve.com/dashboard` → 405 on the POST). So lowercasing routed us into the redirect.

## Fix

Drop the `tr 'A-Z' 'a-z'` owner-lowercasing in both clone steps. Keep the `mc.kbve.com` endpoint match (correct). `REPO_PATH` now preserves the `.lfsconfig` case (`KBVE/chuck.git/info/lfs`) and the token auth resolves the 401.

Net of #12385 + this: `ssh://git@mc.kbve.com:30022/KBVE/chuck.git` → `https://<token>@git.kbve.com/KBVE/chuck.git/info/lfs` → 200.