### PR TITLE
feat(astro): social/bluesky BlueskySocialComponent + wire bluesky.mdx

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/bluesky.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/bluesky.mdx
@@ -13,69 +13,12 @@ tableOfContents: false
 ---
 
 import Adsense from '@/components/astropad/adsense/Adsense.astro';
+import BlueskySocialComponent from '@kbve/astro/components/social/bluesky/BlueskySocialComponent.astro';
 
 ## Follow on Bluesky
 
 Decentralized social on the AT Protocol. Same updates, no algorithm games.
 
-<div class="bsky-page">
-  <a
-    class="bsky-cta"
-    href="https://bsky.app/profile/kbve.com"
-    target="_blank"
-    rel="noopener noreferrer">
-    <span class="bsky-cta__icon" aria-hidden="true">☁</span>
-    <span class="bsky-cta__label">Follow @kbve.com on Bluesky</span>
-  </a>
-
-  <div class="bsky-embed">
-    <iframe
-      src="https://embed.bsky.app/profile/kbve.com"
-      title="KBVE Bluesky profile"
-      frameborder="0"
-      loading="lazy"
-      referrerpolicy="strict-origin-when-cross-origin"></iframe>
-  </div>
-</div>
+<BlueskySocialComponent handle="kbve.com" />
 
 <Adsense />
-
-<style is:global>{`
-  .bsky-page {
-    max-width: 720px;
-    margin: 1.5rem auto;
-    display: grid;
-    gap: 1rem;
-  }
-  .bsky-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.75rem 1.25rem;
-    border-radius: 10px;
-    background: #0085ff;
-    color: #fff;
-    font-weight: 600;
-    text-decoration: none;
-    width: fit-content;
-    box-shadow: 0 6px 20px color-mix(in srgb, #0085ff 30%, transparent);
-    transition: transform 0.12s ease;
-  }
-  .bsky-cta:hover { transform: translateY(-1px); }
-  .bsky-cta__icon { font-size: 1.1rem; line-height: 1; }
-  .bsky-embed {
-    position: relative;
-    width: 100%;
-    min-height: 600px;
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid var(--sl-color-gray-5, #2a2a33);
-    background: var(--sl-color-bg-nav, #131318);
-  }
-  .bsky-embed iframe {
-    width: 100%;
-    height: 100%;
-    min-height: 600px;
-    border: 0;
-  }
-`}</style>

--- a/packages/npm/astro/package.json
+++ b/packages/npm/astro/package.json
@@ -53,7 +53,8 @@
 		"./components/tooltip/social/sttService": "./components/tooltip/social/sttService.js",
 		"./components/hero/scroll/ScrollZoomHero.astro": "./components/hero/scroll/ScrollZoomHero.astro",
 		"./components/hero/observer/ObserverCollections.astro": "./components/hero/observer/ObserverCollections.astro",
-		"./components/hero/observer/ObserverSelection.astro": "./components/hero/observer/ObserverSelection.astro"
+		"./components/hero/observer/ObserverSelection.astro": "./components/hero/observer/ObserverSelection.astro",
+		"./components/social/bluesky/BlueskySocialComponent.astro": "./components/social/bluesky/BlueskySocialComponent.astro"
 	},
 	"files": [
 		"astro.es.js",

--- a/packages/npm/astro/src/components/social/bluesky/BlueskySocialComponent.astro
+++ b/packages/npm/astro/src/components/social/bluesky/BlueskySocialComponent.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+	handle?: string;
+	label?: string;
+	embedHeight?: number;
+	showEmbed?: boolean;
+	class?: string;
+}
+
+const {
+	handle = 'kbve.com',
+	label,
+	embedHeight = 600,
+	showEmbed = true,
+	class: className = '',
+} = Astro.props;
+
+const profileUrl = `https://bsky.app/profile/${handle}`;
+const embedUrl = `https://embed.bsky.app/profile/${handle}`;
+const ctaLabel = label ?? `Follow @${handle} on Bluesky`;
+---
+
+<div class:list={['mx-auto my-6 grid w-full max-w-3xl gap-4', className]}>
+	<a
+		class="inline-flex w-fit items-center gap-2 rounded-xl bg-[#0085ff] px-5 py-3 font-semibold text-white shadow-lg shadow-sky-500/30 transition-transform duration-150 hover:-translate-y-px focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-300"
+		href={profileUrl}
+		target="_blank"
+		rel="noopener noreferrer">
+		<span class="text-lg leading-none" aria-hidden="true">☁</span>
+		<span>{ctaLabel}</span>
+	</a>
+
+	{
+		showEmbed && (
+			<div
+				class="relative w-full overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-900"
+				style={`min-height:${embedHeight}px`}>
+				<iframe
+					src={embedUrl}
+					title={`${handle} Bluesky profile`}
+					class="h-full w-full border-0"
+					style={`min-height:${embedHeight}px`}
+					loading="lazy"
+					referrerpolicy="strict-origin-when-cross-origin"
+				/>
+			</div>
+		)
+	}
+</div>


### PR DESCRIPTION
## Summary

Introduces a per-platform `social/<platform>/` layout under `@kbve/astro/components/` so social-network UI lives once and gets imported across projects.

- New `packages/npm/astro/src/components/social/bluesky/BlueskySocialComponent.astro`
  - Props: `handle` (default `kbve.com`), `label`, `embedHeight` (default 600), `showEmbed` (default true), `class`
  - Tailwind utilities inline (no scoped `<style>` block) — matches existing `AskamaCard.astro` style
- `package.json` exports add `./components/social/bluesky/BlueskySocialComponent.astro`
- `apps/kbve/astro-kbve/src/content/docs/bluesky.mdx` drops the inline CTA + iframe + 40-line `<style is:global>` block and consumes the component:

```mdx
import BlueskySocialComponent from '@kbve/astro/components/social/bluesky/BlueskySocialComponent.astro';

<BlueskySocialComponent handle="kbve.com" />
```

Same skeleton scales to `social/twitter/`, `social/youtube/`, `social/tiktok/`, `social/twitch/` — one folder per platform; multiple components per folder when needed (embed/card/button/share).

## Test plan

- [x] `nx run astro-kbve:sync` — schema validation
- [x] `nx run astro-kbve:build` — 7,753 pages built, 0 errors