### PR TITLE
fix(cryptothrone-server): COPY jedi into Docker build context

### DIFF
--- a/apps/agones/cryptothrone/server/Dockerfile
+++ b/apps/agones/cryptothrone/server/Dockerfile
@@ -12,11 +12,14 @@ COPY Cargo.lock ./
 
 COPY apps/agones/cryptothrone/server/Cargo.toml apps/agones/cryptothrone/server/Cargo.toml
 COPY packages/rust/simgrid/Cargo.toml packages/rust/simgrid/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
 
 RUN mkdir -p apps/agones/cryptothrone/server/src && \
     echo "fn main() {}" > apps/agones/cryptothrone/server/src/main.rs && \
     mkdir -p packages/rust/simgrid/src && \
-    echo "" > packages/rust/simgrid/src/lib.rs
+    echo "" > packages/rust/simgrid/src/lib.rs && \
+    mkdir -p packages/rust/jedi/src && \
+    echo "" > packages/rust/jedi/src/lib.rs
 
 RUN cargo chef prepare --recipe-path recipe.json --bin cryptothrone-server
 
@@ -57,6 +60,7 @@ COPY apps/agones/cryptothrone/server/Cargo.workspace.toml Cargo.toml
 COPY Cargo.lock ./
 
 COPY packages/rust/simgrid packages/rust/simgrid
+COPY packages/rust/jedi packages/rust/jedi
 COPY packages/data/codegen/generated/npcdb-data.json packages/data/codegen/generated/npcdb-data.json
 COPY apps/agones/cryptothrone/server apps/agones/cryptothrone/server
 


### PR DESCRIPTION
## What failed
`Publish Docker / publish` for **cryptothrone-server 0.0.14** ([run](https://github.com/KBVE/kbve/actions/runs/27491223067/job/81256629609)):
```
cargo chef prepare ... failed to load manifest for workspace member /app/apps/agones/cryptothrone/server
  failed to load manifest for dependency `jedi`
  failed to read /app/packages/rust/jedi/Cargo.toml
```
#12393 added a `jedi` dep to the gameserver, but its Dockerfile only copied `simgrid` into the build context — so chef couldn't read jedi's manifest.

## Fix
Mirror the simgrid / axum-cryptothrone pattern:
- **planner stage**: `COPY packages/rust/jedi/Cargo.toml` + stub `src/lib.rs`
- **final builder**: `COPY packages/rust/jedi packages/rust/jedi` (full source incl `build.rs`, which no-ops without `BUILD_PROTO`)

jedi has no local path deps, so nothing else to copy. axum-cryptothrone already did this (it pre-depped jedi) — only the gameserver Dockerfile lagged.

## No version bump
0.0.14 never published (the build failed → "Tag 0.0.14 not found on GHCR"), so the version gate still publishes 0.0.14 on re-run. Riding the pending version.

Can't build the chisel-based image locally; the Cargo wiring matches the two working Dockerfiles.