### PR TITLE
chore(cryptothrone): roll client 0.1.27 + server 0.0.15 — ship Discord Activity

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.14"
+version: "0.0.15"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.26"
+version: "0.1.27"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
Double MDX bump to build out the merged Discord Activity integration.

- client `0.1.26 -> 0.1.27` (axum-cryptothrone: build-discord/build-embed, /discord frame CSP, session bridge, sealed creds)
- server `0.0.14 -> 0.0.15`

The 0.1.26 publish hadn't synced (deployment image still pinned at 0.1.25), so rolling both forward to trigger a clean build + post-publish image sync.