### PR TITLE
ci(docker-test): resilient playwright OS-dep install (fixes #12373 flake)

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -60,6 +60,16 @@ jobs:
                   swap-storage: false
                   docker-images: true
 
+            - name: Disable flaky third-party apt sources
+              # The GitHub runner ships packages.microsoft.com / azure-cli apt
+              # sources that intermittently return 403 and break `apt-get update`
+              # inside `playwright install-deps`. We don't need them — remove so
+              # OS-dep installs stay resilient (recurring CI flake, #12373).
+              run: |
+                  sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                             /etc/apt/sources.list.d/azure-cli.list \
+                             /etc/apt/sources.list.d/microsoft*.list 2>/dev/null || true
+
             - name: Checkout the monorepo
               uses: actions/checkout@v6
               continue-on-error: true
@@ -287,7 +297,28 @@ jobs:
             - name: Install Playwright OS deps (cache hit)
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.baked-playwright.outputs.all_present != 'true' && steps.playwright-cache.outputs.cache-hit == 'true' }}
               timeout-minutes: 10
-              run: pnpm exec playwright install-deps ${{ steps.detect-playwright.outputs.browsers }}
+              env:
+                  BROWSERS: ${{ steps.detect-playwright.outputs.browsers }}
+              run: |
+                  set -uo pipefail
+                  # Belt-and-suspenders for the apt OS-dep install: the flaky
+                  # third-party apt source is already stripped above; retry to
+                  # ride transient mirror blips, then fall back to the full
+                  # `install --with-deps` path as a last resort.
+                  install_deps() {
+                    echo "::group::playwright install-deps ($1)"
+                    sudo apt-get update || true
+                    pnpm exec playwright install-deps ${BROWSERS}
+                    local rc=$?
+                    echo "::endgroup::"
+                    return $rc
+                  }
+                  install_deps "try 1" && exit 0
+                  echo "::warning::install-deps try 1 failed; retrying"
+                  sleep 10
+                  install_deps "try 2" && exit 0
+                  echo "::warning::install-deps exhausted; trying install --with-deps"
+                  pnpm exec playwright install --with-deps ${BROWSERS}
 
             - name: Nx e2e ${{ inputs.project }}
               env:


### PR DESCRIPTION
Fixes the recurring #12373 flake: `Install Playwright OS deps (cache hit)` failed because the GitHub runner's pre-baked **packages.microsoft.com / azure-cli** apt sources returned **403** during `apt-get update` inside `playwright install-deps`.

## Why the existing belt-and-suspenders didn't catch it
The robust chain in "Install Playwright Browsers" (cdn → azureedge → `mcr.microsoft.com/playwright` image) recovers **browser-binary downloads**. The #12373 failure is **apt OS deps** (host system libs), a different mechanism — the CDN/azure host override doesn't touch apt, and the docker-image fallback supplies browsers, not host `.so` libs (e2e runs on the runner host). And the **cache-hit OS-dep step** was a bare `playwright install-deps` with no recovery at all.

## Fix
- **Strip the flaky third-party apt sources** (`microsoft-prod.list`, `azure-cli.list`) right after Free-disk-space — root cause of the 403; we don't need them.
- **Belt-and-suspenders on the cache-hit OS-dep step**: `apt-get update` + `install-deps` with 2 retries, then a final `playwright install --with-deps` fallback — mirroring the browsers step's resilience.

## Notes
- Workflow-only (`docker-test-app.yml`), shared by all Docker-tested apps — not just cryptothrone.
- Recovers automatically; #12373 itself was transient (later cryptothrone runs already passed) but this prevents recurrence. Safe to close #12373.
- YAML validates; the only shellcheck notes are pre-existing lines.