### PR TITLE
feat(axum-kbve/wallet): port /me/balance + /me/coupons onto PgCluster+KvCache, invalidate on writes

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -11,19 +11,34 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
+use jedi::entity::error::JediError;
+use jedi::state::pg::PgCallerReadFut;
 use kbve::wallet::{
     CreditRequest, CurrencyKind, DebitRequest, SourceKind, TransferRequest, WalletError,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
 use super::https::auth_user_id;
 use crate::auth::{extract_bearer_token, get_jwt_cache};
-use crate::db::get_wallet_client;
+use crate::db::{get_kv_cache, get_pg_cluster, get_wallet_client};
 
-#[derive(Serialize, ToSchema)]
+const BALANCE_SQL: &str = "
+    SELECT account_id, credits, khash, updated_at
+      FROM public.proxy_wallet_get_balance_readonly()
+";
+
+const COUPONS_SQL: &str = "
+    SELECT coupon_id, template_code, template_label,
+           reward_kind::text, reward_payload,
+           status::text, granted_at, expires_at, redeemed_at
+      FROM public.proxy_wallet_list_coupons_readonly()
+";
+
+#[derive(Serialize, Deserialize, ToSchema)]
 pub(crate) struct BalanceDto {
     pub account_id: Uuid,
     pub credits: i64,
@@ -31,7 +46,7 @@ pub(crate) struct BalanceDto {
     pub updated_at: String,
 }
 
-#[derive(Serialize, ToSchema)]
+#[derive(Serialize, Deserialize, ToSchema)]
 pub(crate) struct CouponDto {
     pub coupon_id: i64,
     pub template_code: String,
@@ -164,6 +179,36 @@ pub(crate) async fn me_balance(headers: HeaderMap) -> Response {
         Err(resp) => return resp,
     };
 
+    if let Some(cluster) = get_pg_cluster() {
+        let cluster = Arc::clone(cluster);
+        let result = match get_kv_cache() {
+            Some(cache) => {
+                let key = format!("caller:{user_id}:balance");
+                cluster
+                    .cached_caller_read(
+                        cache,
+                        &key,
+                        None,
+                        user_id,
+                        None,
+                        |tx| -> PgCallerReadFut<'_, BalanceDto> { Box::pin(balance_query(tx)) },
+                    )
+                    .await
+            }
+            None => {
+                cluster
+                    .with_caller_read(user_id, None, |tx| -> PgCallerReadFut<'_, BalanceDto> {
+                        Box::pin(balance_query(tx))
+                    })
+                    .await
+            }
+        };
+        return match result {
+            Ok(b) => Json(b).into_response(),
+            Err(e) => jedi_error_response(e),
+        };
+    }
+
     let client = match get_wallet_client() {
         Some(c) => c,
         None => return service_unavailable(),
@@ -179,6 +224,62 @@ pub(crate) async fn me_balance(headers: HeaderMap) -> Response {
         .into_response(),
         Err(e) => wallet_error_response(e),
     }
+}
+
+async fn balance_query(
+    tx: &jedi::state::pg::tokio_postgres::Transaction<'_>,
+) -> Result<BalanceDto, JediError> {
+    let row = tx
+        .query_one(BALANCE_SQL, &[])
+        .await
+        .map_err(JediError::from)?;
+    let updated_at: chrono::DateTime<chrono::Utc> = row.get(3);
+    Ok(BalanceDto {
+        account_id: row.get(0),
+        credits: row.get(1),
+        khash: row.get(2),
+        updated_at: updated_at.to_rfc3339(),
+    })
+}
+
+async fn coupons_query(
+    tx: &jedi::state::pg::tokio_postgres::Transaction<'_>,
+) -> Result<Vec<CouponDto>, JediError> {
+    let rows = tx.query(COUPONS_SQL, &[]).await.map_err(JediError::from)?;
+    rows.iter()
+        .map(|r| {
+            let granted_at: chrono::DateTime<chrono::Utc> = r.get(6);
+            let expires_at: Option<chrono::DateTime<chrono::Utc>> = r.get(7);
+            let redeemed_at: Option<chrono::DateTime<chrono::Utc>> = r.get(8);
+            Ok(CouponDto {
+                coupon_id: r.get(0),
+                template_code: r.get(1),
+                template_label: r.get(2),
+                reward_kind: r.get(3),
+                reward_payload: r.get(4),
+                status: r.get(5),
+                granted_at: granted_at.to_rfc3339(),
+                expires_at: expires_at.map(|t| t.to_rfc3339()),
+                redeemed_at: redeemed_at.map(|t| t.to_rfc3339()),
+            })
+        })
+        .collect()
+}
+
+fn jedi_error_response(err: JediError) -> Response {
+    let msg = err.to_string();
+    let (status, code) = match &err {
+        JediError::Timeout => (StatusCode::REQUEST_TIMEOUT, "timeout"),
+        JediError::Unauthorized => (StatusCode::UNAUTHORIZED, "unauthorized"),
+        JediError::Forbidden => (StatusCode::FORBIDDEN, "forbidden"),
+        JediError::NotFound => (StatusCode::NOT_FOUND, "not_found"),
+        JediError::BadRequest(_) => (StatusCode::BAD_REQUEST, "invalid_argument"),
+        _ => {
+            tracing::error!(error = %err, "wallet PgCluster path failed");
+            (StatusCode::INTERNAL_SERVER_ERROR, "internal")
+        }
+    };
+    (status, Json(json!({ "error": code, "message": msg }))).into_response()
 }
 
 /// `GET /api/v1/wallet/me/coupons` — returns the caller's coupons
@@ -199,6 +300,36 @@ pub(crate) async fn me_coupons(headers: HeaderMap) -> Response {
         Ok(id) => id,
         Err(resp) => return resp,
     };
+
+    if let Some(cluster) = get_pg_cluster() {
+        let cluster = Arc::clone(cluster);
+        let result = match get_kv_cache() {
+            Some(cache) => {
+                let key = format!("caller:{user_id}:coupons");
+                cluster
+                    .cached_caller_read(
+                        cache,
+                        &key,
+                        None,
+                        user_id,
+                        None,
+                        |tx| -> PgCallerReadFut<'_, Vec<CouponDto>> { Box::pin(coupons_query(tx)) },
+                    )
+                    .await
+            }
+            None => {
+                cluster
+                    .with_caller_read(user_id, None, |tx| -> PgCallerReadFut<'_, Vec<CouponDto>> {
+                        Box::pin(coupons_query(tx))
+                    })
+                    .await
+            }
+        };
+        return match result {
+            Ok(rows) => Json(rows).into_response(),
+            Err(e) => jedi_error_response(e),
+        };
+    }
 
     let client = match get_wallet_client() {
         Some(c) => c,
@@ -263,14 +394,30 @@ pub(crate) async fn me_redeem_coupon(
         .user_redeem_coupon(user_id, body.coupon_id, body.idempotency_key)
         .await
     {
-        Ok(r) => Json(RedeemCouponDto {
-            success: r.success,
-            reward_kind: r.reward_kind.as_pg().to_string(),
-            reward_payload: r.reward_payload,
-            ledger_id: r.ledger_id,
-        })
-        .into_response(),
+        Ok(r) => {
+            invalidate_caller_cache(user_id).await;
+            Json(RedeemCouponDto {
+                success: r.success,
+                reward_kind: r.reward_kind.as_pg().to_string(),
+                reward_payload: r.reward_payload,
+                ledger_id: r.ledger_id,
+            })
+            .into_response()
+        }
         Err(e) => wallet_error_response(e),
+    }
+}
+
+/// Invalidate all cached entries scoped to a caller subject. Hooks
+/// into wallet write paths after a successful commit so the next
+/// /me/balance / /me/coupons / /me/ledger read can't serve stale
+/// data within the L1/L2 TTL window. Best-effort; cache errors
+/// are logged but not returned.
+pub(crate) async fn invalidate_caller_cache(user_id: Uuid) {
+    let Some(cache) = get_kv_cache() else { return };
+    let prefix = format!("caller:{user_id}");
+    if let Err(e) = cache.invalidate_prefix(&prefix).await {
+        tracing::warn!(error = %e, user_id = %user_id, "[wallet] cache invalidate_prefix failed");
     }
 }
 
@@ -777,11 +924,14 @@ pub(crate) async fn service_credit_user(
         idempotency_key: body.idempotency_key,
     };
     match client.credit(req).await {
-        Ok(ledger_id) => Json(ServiceCreditUserDto {
-            account_id,
-            ledger_id,
-        })
-        .into_response(),
+        Ok(ledger_id) => {
+            invalidate_caller_cache(body.user_id).await;
+            Json(ServiceCreditUserDto {
+                account_id,
+                ledger_id,
+            })
+            .into_response()
+        }
         Err(e) => wallet_error_response(e),
     }
 }


### PR DESCRIPTION
Completes the read-path migration of caller-scoped wallet endpoints onto the same PgCluster + KvCache stack `/me/ledger` already uses.

## Reads now go through the full fallback chain
```
L1 LRU → L2 Valkey → L3 ro pool → L4 any pool → L5 (WalletClient diesel-async fallback)
```

| Endpoint | Before | After |
|----------|--------|-------|
| `GET /me/balance` | WalletClient diesel-async only | `PgCluster::cached_caller_read` → `with_caller_read` → WalletClient |
| `GET /me/coupons` | WalletClient diesel-async only | `PgCluster::cached_caller_read` → `with_caller_read` → WalletClient |
| `GET /me/ledger` | `cached_caller_read` (shipped #12384) | unchanged |

All three share a common `caller:<user_id>:` cache-key prefix so a single `invalidate_prefix` call busts every read for that subject.

## Writes now invalidate the caller's cache

New `invalidate_caller_cache(user_id)` calls `KvCache::invalidate_prefix("caller:<user_id>")` after a successful commit. Best-effort: cache errors are logged + swallowed, never returned.

| Route | Invalidates | Notes |
|-------|-------------|-------|
| `/me/redeem-coupon` | caller's `user_id` from JWT | new |
| `/service/credit-user` | `body.user_id` | new |
| `/service/credit / debit / transfer` | nothing yet | keyed on `account_id`; would need user lookup. TTL bounds staleness (5 s default). Follow-up: tag-based invalidation. |
| `/service/redeem-coupon` | nothing yet | redeeming user not in scope. Same TTL-bound staleness. |

## DTO + helpers

- `BalanceDto` and `CouponDto` picked up `#[derive(Deserialize)]` so the cache JSON round-trip works.
- New `balance_query` / `coupons_query` helpers extract rows from a `tokio_postgres::Transaction`. They call the same `proxy_wallet_get_balance_readonly()` / `proxy_wallet_list_coupons_readonly()` SECURITY DEFINER procs the diesel-async path was already using — zero SQL change.
- New `jedi_error_response(JediError)` mirrors `wallet_error_response(WalletError)` shape so PgCluster-path errors return the same JSON envelope.

## Test plan
- [x] `cargo check -p axum-kbve` clean
- [ ] Curl `/me/balance` twice; second call hits L1 (`kbve_kv_l1_hit` counter increments)
- [ ] Curl `/me/balance` from two pod replicas; second pod hits L2 (`kbve_kv_l2_hit` increments)
- [ ] `POST /me/redeem-coupon` then immediate `GET /me/balance` returns the updated balance (cache busted, not pre-redeem stale value)
- [ ] Kill Valkey, confirm `/me/balance` still serves from L1 then falls through to PgCluster — no 5xx
- [ ] Set bad PgCluster URL, confirm `/me/balance` falls back through to WalletClient diesel-async

## Follow-ups (tracked on #12343)
- Tag-based invalidation so account-keyed service writes can bust per-account caches without a user-id lookup
- Cluster-aware L2 `invalidate_prefix` (currently L1 only)
- Drop `WalletClient` / diesel-async entirely from `kbve.wallet` once service routes are also ported