### PR TITLE
fix(cryptothrone): ship embed.js/discord.js — force republish + dist verify (0.1.28)

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -39,7 +39,11 @@ WORKDIR /app/apps/cryptothrone/astro-cryptothrone
 RUN rm -rf .astro && npx astro sync && \
     NODE_OPTIONS="--max-old-space-size=4096" npx vite build --config vite.embed.config.mts && \
     NODE_OPTIONS="--max-old-space-size=4096" npx vite build --config vite.discord.config.mts && \
-    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build
+    UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build && \
+    # Fail loud if the embed/discord bundles didn't make it into dist (a stale
+    # cached astro-builder layer once shipped without them -> silent 404s).
+    test -f ../../../dist/apps/astro-cryptothrone/embed/embed.js && \
+    test -f ../../../dist/apps/astro-cryptothrone/discord/discord.js
 
 # ============================================================================
 # [STAGE B] - Precompress Static Assets

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.27"
+version: "0.1.28"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## Root cause
`/discord/discord.js` + `/embed/embed.js` 404 on the live 0.1.27 image. Build logs confirm the astro-builder stage **does** produce both bundles (`public/embed/embed.js` 3.7MB, `public/discord/discord.js` 3.9MB / 200 modules) and astro copies them into dist. But the *deployed* 0.1.27 was pushed by an earlier build with a **stale cached astro-builder layer** (no bundles), and the version gate then **skipped Publish** for every later 0.1.27 build — so the good image couldn't ship.

This is NOT a routing or script-tag issue: the static router's root `fallback_service = ServeDir(templates/dist)` already serves `/discord/*` and `/embed/*`; the files were simply absent from the running image. (The Safari 'grey' script = the 404.)

## Fix
- **bump 0.1.27 → 0.1.28** so `Publish Docker` runs again.
- **Dockerfile assertion** after `astro build`: `test -f .../embed/embed.js && test -f .../discord/discord.js`. Fails loud if a bundle is ever missing, and — by changing the RUN string — busts the stale astro-builder cache so the bundles rebuild fresh.

## After merge
0.1.28 publishes → post-publish syncs the deployment image → ArgoCD rolls → `/health` = 0.1.28, `/discord/discord.js` + `/embed/embed.js` return 200, and the Activity script loads.