### PR TITLE
fix(simgrid): single session per username — evict prior ghost on reconnect

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.15"
+version: "0.0.16"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -1,11 +1,12 @@
-use std::sync::{Arc, RwLock};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, RwLock};
 
 use axum::Router;
 use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use axum::routing::get;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, watch};
 
 use crate::proto::{self, ClientMessage, Input, ServerEvent};
 
@@ -55,6 +56,20 @@ impl Roster {
             .map(|e| e.kbve_username.clone())
     }
 
+    /// Slots already held by this username — used to evict prior sessions so a
+    /// player can't appear as two ghosts of the same name.
+    pub(crate) fn slots_for_username(&self, name: &str) -> Vec<proto::PlayerSlot> {
+        self.slots
+            .iter()
+            .enumerate()
+            .filter_map(|(i, s)| {
+                s.as_ref()
+                    .filter(|e| e.kbve_username == name)
+                    .map(|_| proto::PlayerSlot(i as u16))
+            })
+            .collect()
+    }
+
     pub fn snapshot(&self) -> Vec<proto::PlayerView> {
         self.slots
             .iter()
@@ -87,6 +102,9 @@ pub struct ServerState {
     pub require_username: bool,
     pub roster: Arc<RwLock<Roster>>,
     pub registry: Vec<proto::KindEntry>,
+    /// Per-slot eviction signal: a reconnecting username kicks its prior
+    /// session(s) so the same player never lingers as two ghosts.
+    kicks: Arc<Mutex<HashMap<u16, watch::Sender<bool>>>>,
 }
 
 impl ServerState {
@@ -106,6 +124,7 @@ impl ServerState {
             require_username,
             roster: Arc::new(RwLock::new(Roster::new(capacity))),
             registry: Vec::new(),
+            kicks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -124,6 +143,7 @@ enum WireFormat {
 struct AdmittedPlayer {
     slot: proto::PlayerSlot,
     format: WireFormat,
+    kick_rx: watch::Receiver<bool>,
 }
 
 fn decode_client(msg: &Message) -> Option<(ClientMessage, WireFormat)> {
@@ -169,6 +189,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
     };
     let slot = admitted.slot;
     let format = admitted.format;
+    let mut kick_rx = admitted.kick_rx;
     let roster_handle = state.roster.clone();
 
     let welcome = ServerEvent::Welcome {
@@ -189,6 +210,10 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
     loop {
         tokio::select! {
             biased;
+            _ = kick_rx.changed() => {
+                tracing::info!(slot = slot.0, "session evicted by a newer login");
+                break;
+            }
             evt = async {
                 match &mut rx {
                     Some(r) => r.recv().await.ok(),
@@ -224,6 +249,12 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
         }
     }
 
+    // Drop our kick channel before freeing the slot: while the slot is still
+    // claimed no other join can take it, so we can't clobber a reused slot's
+    // fresh kick sender.
+    if let Ok(mut kicks) = state.kicks.lock() {
+        kicks.remove(&slot.0);
+    }
     release_slot(&roster_handle, slot);
 }
 
@@ -338,25 +369,49 @@ async fn claim_slot(
     format: WireFormat,
 ) -> Option<AdmittedPlayer> {
     let name = kbve_username.clone();
-    let slot = match state.roster.write() {
-        Ok(mut r) => r.claim(kbve_username),
-        Err(_) => None,
+    // Find any prior session(s) for this username, then claim a fresh slot —
+    // both under one write lock so two simultaneous joins can't race.
+    let (slot, prior) = match state.roster.write() {
+        Ok(mut r) => {
+            let prior = r.slots_for_username(&name);
+            (r.claim(kbve_username), prior)
+        }
+        Err(_) => (None, Vec::new()),
     };
-    match slot {
-        Some(slot) => {
-            tracing::info!(slot = slot.0, username = %name, "player joined");
-            Some(AdmittedPlayer { slot, format })
+    let Some(slot) = slot else {
+        let capacity = state
+            .roster
+            .read()
+            .map(|r| r.capacity())
+            .unwrap_or_default();
+        send_reject(socket, format, &format!("match full ({capacity} players)")).await;
+        return None;
+    };
+
+    // Newest wins: kick prior sessions so this player isn't two ghosts. Each
+    // kicked session breaks its loop and releases its own slot (the sim then
+    // despawns that ghost and persists its state by username).
+    if !prior.is_empty()
+        && let Ok(kicks) = state.kicks.lock()
+    {
+        for old in &prior {
+            if let Some(tx) = kicks.get(&old.0) {
+                let _ = tx.send(true);
+            }
         }
-        None => {
-            let capacity = state
-                .roster
-                .read()
-                .map(|r| r.capacity())
-                .unwrap_or_default();
-            send_reject(socket, format, &format!("match full ({capacity} players)")).await;
-            None
-        }
+        tracing::info!(username = %name, evicted = prior.len(), "evicted prior session(s)");
     }
+
+    let (kick_tx, kick_rx) = watch::channel(false);
+    if let Ok(mut kicks) = state.kicks.lock() {
+        kicks.insert(slot.0, kick_tx);
+    }
+    tracing::info!(slot = slot.0, username = %name, "player joined");
+    Some(AdmittedPlayer {
+        slot,
+        format,
+        kick_rx,
+    })
 }
 
 async fn send_reject(socket: &mut WebSocket, format: WireFormat, reason: &str) {
@@ -391,7 +446,26 @@ fn inject_roster(evt: ServerEvent, roster: &Arc<RwLock<Roster>>) -> ServerEvent 
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_username;
+    use super::{Roster, resolve_username};
+
+    #[test]
+    fn roster_dedups_username_for_eviction() {
+        let mut r = Roster::new(4);
+        let s0 = r.claim("ann".into()).unwrap();
+        let _s1 = r.claim("bob".into()).unwrap();
+
+        // ann reconnects: her prior slot is found, a fresh slot is claimed.
+        let prior: Vec<u16> = r.slots_for_username("ann").iter().map(|s| s.0).collect();
+        assert_eq!(prior, vec![s0.0]);
+        let s2 = r.claim("ann".into()).unwrap();
+        assert_ne!(s2.0, s0.0);
+        assert_eq!(r.slots_for_username("ann").len(), 2);
+
+        // After the old session releases, only the new one remains.
+        r.release(s0);
+        let after: Vec<u16> = r.slots_for_username("ann").iter().map(|s| s.0).collect();
+        assert_eq!(after, vec![s2.0]);
+    }
 
     #[test]
     fn require_username_rejects_empty() {


### PR DESCRIPTION
## Bug
The same player could connect twice and show up as **two ghosts of the same username**. `Roster::claim` just took the first empty slot — no dedup by identity — so a second connection for an already-joined user got a second slot + entity.

## Fix — newest wins
On join, any prior session(s) for that username are **evicted**: a per-slot `watch` kick signal wakes the old session, which breaks its loop and releases its slot. `sync_roster` then despawns the old ghost and persists its state by username, and the new session reloads it — so the reconnecting player keeps their progress and appears once.

- `Roster::slots_for_username` to find a name's existing slots.
- `ServerState` gains a per-slot kick registry (`HashMap<u16, watch::Sender<bool>>`).
- `claim_slot` finds prior slots **and** claims a fresh one under one write lock (no join race), then kicks the prior session(s).
- `handle_socket` selects on its kick signal; on exit it removes its kick entry **before** releasing the slot, so a reused slot's fresh sender can't be clobbered.

Stale-ghost safe: a lingering dead session (browser closed without clean disconnect) is kicked on the next login, so a player is never locked out (vs first-wins).

## Verified
- simgrid `cargo test` **36/36** (incl. new `roster_dedups_username_for_eviction`), clippy clean.
- cryptothrone-server `0.0.15 → 0.0.16`.

Needs a live confirm after deploy: open the game twice as the same user → the first ghost disappears, only the newest remains.