### PR TITLE
fix(arc-runner-ue): shared /tmp so dind -v mounts resolve (UE cook)

### DIFF
--- a/apps/kube/github/runners/manifests/values-ue.yaml
+++ b/apps/kube/github/runners/manifests/values-ue.yaml
@@ -21,7 +21,7 @@ maxRunners: 3
 template:
     metadata:
         annotations:
-            kbve.com/restart-trigger: '20260613-ue-runner-gitlfs'
+            kbve.com/restart-trigger: '20260614-ue-shared-tmp'
     spec:
         initContainers:
             - name: init-dind-externals
@@ -72,6 +72,11 @@ template:
                   # OWS cooked server output
                   - name: ows-server-build
                     mountPath: /mnt/longhorn/ows-server
+                  # Shared scratch so docker-in-docker -v mounts resolve: the
+                  # runner materializes the project + reads build output here,
+                  # and dind's containers bind-mount the same /tmp paths.
+                  - name: shared-tmp
+                    mountPath: /tmp
             # Docker-in-Docker sidecar with persistent image cache
             - name: dind
               image: docker:29.3.0-dind
@@ -99,6 +104,8 @@ template:
                     mountPath: /home/runner/externals
                   - name: dind-storage
                     mountPath: /var/lib/docker
+                  - name: shared-tmp
+                    mountPath: /tmp
         volumes:
             - name: work
               emptyDir: {}
@@ -107,6 +114,8 @@ template:
             - name: dind-externals
               emptyDir: {}
             - name: dind-storage
+              emptyDir: {}
+            - name: shared-tmp
               emptyDir: {}
             - name: engine-cache
               persistentVolumeClaim:


### PR DESCRIPTION
## What the cook exposed

The server build got all the way into `BuildCookRun` (past LFS — the case fix worked) and died:

```
Notice: Mounting /tmp/game-project -> /project, building chuck.uproject
Could not find a project file /project/chuck.uproject
```

The runner materializes the project to **its** `/tmp/game-project`, but `docker run -v /tmp/game-project:/project` is resolved by the **dind daemon** — and `/tmp` was not a shared volume between the runner and dind. So `/project` (and `/output`) were empty in the UE container. Only `/home/runner/_work` was shared.

This hits **both** the dedicated server and the Linux client (both mount `/tmp/game-project` + `/tmp/ue5-*-output`).

## Fix

Add a `shared-tmp` emptyDir mounted at `/tmp` in **both** the runner and dind containers. The existing `/tmp/game-project` (input) and `/tmp/ue5-build-output` / `ue5-game-output` (output) bind-mounts now line up across the dind boundary. No workflow change. Bump restart-trigger to roll the pods.

## After merge → dev (reusable runs @dev)
Next dispatch: project mounts into `/project`, UE cooks `chuckServerBeta`, output lands in the shared `/tmp` → deploy step copies it to the `chuckServerBeta` PVC. Same for the Linux client → itch.