### PR TITLE
feat(irc-gateway): per-username chat anti-spam (throttle + flood kick + cleanup)

### DIFF
--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -263,6 +263,21 @@ async fn session(client_ws: WebSocket, nick: String, channels: Vec<String>, plat
                 continue;
             }
 
+            // Anti-spam — keyed by the authenticated nick. Over-limit messages
+            // are dropped before they reach ergo (so the relay never floods and
+            // gets banned); a sustained flood disconnects the session.
+            match crate::gateway::ratelimit::check(&nick_c2i) {
+                crate::gateway::ratelimit::Verdict::Allow => {}
+                crate::gateway::ratelimit::Verdict::Throttle => {
+                    debug!(user = %nick_c2i, "rate-limited; dropping message");
+                    continue;
+                }
+                crate::gateway::ratelimit::Verdict::Kick => {
+                    warn!(user = %nick_c2i, "flood detected; disconnecting session");
+                    break;
+                }
+            }
+
             // Keep the Custom kind tag tight so it can't smuggle control
             // characters through the IRC wire format.
             if let MessageKind::Custom(ref s) = parsed.kind {

--- a/apps/irc/irc-gateway/src/gateway/mod.rs
+++ b/apps/irc/irc-gateway/src/gateway/mod.rs
@@ -1,5 +1,6 @@
 pub mod history;
 pub mod irc;
 pub mod minechat;
+pub mod ratelimit;
 pub mod rest;
 pub mod websocket;

--- a/apps/irc/irc-gateway/src/gateway/ratelimit.rs
+++ b/apps/irc/irc-gateway/src/gateway/ratelimit.rs
@@ -1,0 +1,139 @@
+//! Per-username chat anti-spam (in-process, fixed window).
+//!
+//! Keyed by the authenticated nick (JWT -> username), shared across all
+//! sessions in this gateway process. Throttled messages are dropped before
+//! they reach ergo, so a spamming player can't make the relay's IRC connection
+//! flood and earn a server-side ban. Sustained flooding escalates to a kick.
+//!
+//! This is the in-process layer; a future valkey-backed `KvCache::check_rate`
+//! will share the same `Verdict` across gateway replicas + discordsh.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Messages allowed per window before throttling.
+const MAX_PER_WINDOW: u32 = 10;
+/// Total messages in a window that mark a flood and disconnect the session.
+const KICK_CEILING: u32 = 30;
+/// Counting window.
+const WINDOW: Duration = Duration::from_secs(10);
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Verdict {
+    /// Forward the message.
+    Allow,
+    /// Over the per-window limit — drop it (don't forward to ergo).
+    Throttle,
+    /// Sustained flood — disconnect the session.
+    Kick,
+}
+
+struct Bucket {
+    window_start: Instant,
+    count: u32,
+    last_seen: Instant,
+}
+
+#[derive(Default)]
+struct Buckets {
+    map: HashMap<String, Bucket>,
+}
+
+impl Buckets {
+    fn check(&mut self, user: &str, now: Instant) -> Verdict {
+        let b = self.map.entry(user.to_string()).or_insert(Bucket {
+            window_start: now,
+            count: 0,
+            last_seen: now,
+        });
+        b.last_seen = now;
+        if now.duration_since(b.window_start) >= WINDOW {
+            b.window_start = now;
+            b.count = 1;
+            return Verdict::Allow;
+        }
+        b.count += 1;
+        if b.count > KICK_CEILING {
+            Verdict::Kick
+        } else if b.count > MAX_PER_WINDOW {
+            Verdict::Throttle
+        } else {
+            Verdict::Allow
+        }
+    }
+
+    fn prune(&mut self, now: Instant, idle: Duration) {
+        self.map
+            .retain(|_, b| now.duration_since(b.last_seen) < idle);
+    }
+}
+
+fn global() -> &'static Mutex<Buckets> {
+    static B: OnceLock<Mutex<Buckets>> = OnceLock::new();
+    B.get_or_init(|| Mutex::new(Buckets::default()))
+}
+
+/// Record one message for `user` and decide what to do with it.
+pub fn check(user: &str) -> Verdict {
+    global()
+        .lock()
+        .expect("ratelimit mutex poisoned")
+        .check(user, Instant::now())
+}
+
+/// Drop buckets idle longer than `idle`, to bound memory. Call periodically.
+pub fn prune(idle: Duration) {
+    global()
+        .lock()
+        .expect("ratelimit mutex poisoned")
+        .prune(Instant::now(), idle);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allows_then_throttles_then_kicks() {
+        let mut b = Buckets::default();
+        let t0 = Instant::now();
+        for _ in 0..MAX_PER_WINDOW {
+            assert_eq!(b.check("u", t0), Verdict::Allow);
+        }
+        assert_eq!(b.check("u", t0), Verdict::Throttle);
+        let mut last = Verdict::Throttle;
+        for _ in 0..KICK_CEILING {
+            last = b.check("u", t0);
+        }
+        assert_eq!(last, Verdict::Kick);
+    }
+
+    #[test]
+    fn window_reset_allows_again() {
+        let mut b = Buckets::default();
+        let t0 = Instant::now();
+        for _ in 0..(MAX_PER_WINDOW + 5) {
+            b.check("u", t0);
+        }
+        assert_eq!(b.check("u", t0 + WINDOW), Verdict::Allow);
+    }
+
+    #[test]
+    fn users_are_independent() {
+        let mut b = Buckets::default();
+        let t0 = Instant::now();
+        for _ in 0..(KICK_CEILING + 2) {
+            b.check("flooder", t0);
+        }
+        assert_eq!(b.check("calm", t0), Verdict::Allow);
+    }
+
+    #[test]
+    fn prune_drops_idle_buckets() {
+        let mut b = Buckets::default();
+        b.check("old", Instant::now());
+        b.prune(Instant::now(), Duration::from_secs(0));
+        assert!(b.map.is_empty());
+    }
+}

--- a/apps/irc/irc-gateway/src/main.rs
+++ b/apps/irc/irc-gateway/src/main.rs
@@ -33,6 +33,15 @@ async fn main() -> anyhow::Result<()> {
 
     gateway::history::spawn_listeners();
 
+    // Drop idle anti-spam buckets every minute so memory stays bounded.
+    tokio::spawn(async {
+        let mut tick = tokio::time::interval(std::time::Duration::from_secs(60));
+        loop {
+            tick.tick().await;
+            gateway::ratelimit::prune(std::time::Duration::from_secs(300));
+        }
+    });
+
     let http = tokio::spawn(transport::https::serve());
     let irc = tokio::spawn(gateway::irc::serve());
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
@@ -11,7 +11,7 @@ tags:
 key: irc_gateway
 pipeline: docker
 app_name: irc-gateway
-version: "0.1.24"
+version: "0.1.25"
 source_path: apps/irc
 version_toml: apps/irc/version.toml
 version_target: apps/irc/irc-gateway/Cargo.toml


### PR DESCRIPTION
First phase of the chat-relay anti-spam. Keyed by the authenticated nick (JWT → username) so the relay's ergo connection can't be made to flood and earn a ban.

## What
`gateway/ratelimit.rs` — fixed-window per-username limiter on the `c2i` path (covers `/gamechat` + `/minechat`):
- **≤10 msgs / 10s** → forwarded
- **over the limit** → dropped *before* reaching ergo (relay never floods)
- **sustained flood (>30/window)** → session disconnected (kick)
- idle buckets pruned every 60s (5m idle); the 90s read-deadline cleanup already existed
- keyed by username → can't be dodged by reconnecting

Logic lives in an isolatable `Buckets` struct so the public global wrapper stays thin and tests are parallel-safe.

## Verified
- gateway `cargo test` **47/47** (incl. 4 new limiter tests); touched files clippy-clean (the 6 `websocket.rs` clippy errors are pre-existing, unrelated).
- irc-gateway `0.1.24 → 0.1.25`.

## Next (phase 2 — the valkey/discordsh link)
Add a shared **`KvCache::check_rate`** to jedi (valkey `INCR`+`EXPIRE`) and wire gateway valkey (jedi `valkey` feature + `KBVE_KV_URL` env + irc-ns valkey RBAC/NetworkPolicy, mirroring cryptothrone). Same `Verdict` interface drops in — then the limit is **persistent + shared across gateway replicas and discordsh**, so a banned/timed-out user is enforced everywhere. This PR's in-process layer is the immediate protection and the fallback when valkey is unconfigured.