### PR TITLE
feat(cryptothrone): real bitECS EntityStore + lean @kbve/laser/ecs subpath

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/components.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/components.ts
@@ -1,8 +1,9 @@
-export const MAX_ENTITIES = 1024;
+export const MAX_ENTITIES = 4096;
 
+// Tile position (grid coords), mirrored from the authoritative server snapshot.
 export const Position = {
-	x: [] as number[],
-	y: [] as number[],
+	x: new Int32Array(MAX_ENTITIES),
+	y: new Int32Array(MAX_ENTITIES),
 };
 
 export const Health = {
@@ -10,10 +11,24 @@ export const Health = {
 	maxHp: new Float32Array(MAX_ENTITIES),
 };
 
+// Server kind id (indexes the welcome KindEntry registry → ref / category).
+export const Kind = {
+	value: new Int32Array(MAX_ENTITIES),
+};
+
+// Owning player slot (players only; SLOT_NONE for NPCs/items).
+export const Owner = {
+	slot: new Int32Array(MAX_ENTITIES),
+};
+
+// Interest flag for culling far entities (sprite/sim pause).
 export const Active = {
 	value: new Uint8Array(MAX_ENTITIES),
 };
 
+// Category tags — an entity carries exactly one of these; hostile NPCs also
+// carry MonsterTag so the proximity/cull queries can target them.
 export const PlayerTag: Record<string, never> = {};
 export const NpcTag: Record<string, never> = {};
+export const ItemTag: Record<string, never> = {};
 export const MonsterTag: Record<string, never> = {};

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/store.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/store.spec.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { EntityStore } from './store';
+
+interface Ref {
+	tag: string;
+}
+
+function store() {
+	return new EntityStore<Ref>();
+}
+
+const base = {
+	tile: { x: 0, y: 0 },
+	kind: 1,
+	owner: 0xffff,
+	hostile: false,
+	hp: 10,
+	maxHp: 10,
+};
+
+describe('EntityStore', () => {
+	it('spawns and resolves data by server id', () => {
+		const s = store();
+		s.spawn(
+			42,
+			{ ...base, cat: 'npc', tile: { x: 3, y: 5 }, hp: 7, kind: 9 },
+			{ tag: 'goblin' },
+		);
+		expect(s.has(42)).toBe(true);
+		expect(s.size()).toBe(1);
+		expect(s.tile(42)).toEqual({ x: 3, y: 5 });
+		expect(s.hp(42)).toBe(7);
+		expect(s.maxHp(42)).toBe(10);
+		expect(s.kind(42)).toBe(9);
+		expect(s.refs(42)).toEqual({ tag: 'goblin' });
+	});
+
+	it('updates tile and health in place', () => {
+		const s = store();
+		s.spawn(1, { ...base, cat: 'player' }, { tag: 'p' });
+		s.update(1, { tile: { x: 8, y: 2 }, hp: 3 });
+		expect(s.tile(1)).toEqual({ x: 8, y: 2 });
+		expect(s.hp(1)).toBe(3);
+		expect(s.maxHp(1)).toBe(10);
+	});
+
+	it('despawns and returns refs, dropping the entity', () => {
+		const s = store();
+		s.spawn(5, { ...base, cat: 'item' }, { tag: 'arrow' });
+		const refs = s.despawn(5);
+		expect(refs).toEqual({ tag: 'arrow' });
+		expect(s.has(5)).toBe(false);
+		expect(s.size()).toBe(0);
+		expect(s.tile(5)).toBeNull();
+	});
+
+	it('finds an entity at a tile, excluding self', () => {
+		const s = store();
+		s.spawn(
+			1,
+			{ ...base, cat: 'player', tile: { x: 4, y: 4 } },
+			{
+				tag: 'me',
+			},
+		);
+		s.spawn(
+			2,
+			{ ...base, cat: 'npc', tile: { x: 4, y: 4 } },
+			{
+				tag: 'other',
+			},
+		);
+		expect(s.at(4, 4, 1)?.serverEid).toBe(2);
+		expect(s.at(4, 4, 2)?.serverEid).toBe(1);
+		expect(s.at(9, 9, 1)).toBeNull();
+	});
+
+	it('counts hostiles in range via the Monster query', () => {
+		const s = store();
+		s.spawn(
+			1,
+			{ ...base, cat: 'player', tile: { x: 0, y: 0 } },
+			{
+				tag: 'me',
+			},
+		);
+		s.spawn(
+			2,
+			{ ...base, cat: 'npc', hostile: true, tile: { x: 2, y: 0 } },
+			{ tag: 'goblin' },
+		);
+		s.spawn(
+			3,
+			{ ...base, cat: 'npc', hostile: true, tile: { x: 10, y: 0 } },
+			{ tag: 'far-goblin' },
+		);
+		s.spawn(
+			4,
+			{ ...base, cat: 'npc', hostile: false, tile: { x: 1, y: 0 } },
+			{ tag: 'friendly' },
+		);
+		// radius 3 around (0,0): goblin@2 in, far-goblin@10 out, friendly not Monster
+		expect(s.hostilesInRange(0, 0, 3)).toBe(1);
+		expect(s.hostilesInRange(0, 0, 12)).toBe(2);
+	});
+
+	it('lists server ids by category', () => {
+		const s = store();
+		s.spawn(1, { ...base, cat: 'player' }, { tag: 'p' });
+		s.spawn(2, { ...base, cat: 'npc' }, { tag: 'n' });
+		s.spawn(3, { ...base, cat: 'item' }, { tag: 'i' });
+		expect(s.serverIdsWith('player')).toContain(1);
+		expect(s.serverIdsWith('npc')).toContain(2);
+		expect(s.serverIdsWith('item')).toContain(3);
+		expect(s.serverIdsWith('player')).not.toContain(2);
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/store.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/store.ts
@@ -1,0 +1,190 @@
+import {
+	createWorld,
+	addEntity,
+	removeEntity,
+	addComponent,
+	SideMap,
+	queryInRange,
+	query,
+	type World,
+} from '@kbve/laser/ecs';
+import {
+	Position,
+	Health,
+	Kind,
+	Owner,
+	Active,
+	PlayerTag,
+	NpcTag,
+	ItemTag,
+	MonsterTag,
+} from './components';
+
+export type EntityCat = 'player' | 'npc' | 'item';
+
+export interface SpawnData {
+	tile: { x: number; y: number };
+	kind: number;
+	cat: EntityCat;
+	owner: number;
+	hostile: boolean;
+	hp: number;
+	maxHp: number;
+}
+
+export interface UpdateData {
+	tile?: { x: number; y: number };
+	hp?: number;
+	maxHp?: number;
+}
+
+/**
+ * ECS-backed entity registry. bitECS owns the blittable data (Position, Health,
+ * Kind, Owner, Active + category tags); a SideMap holds the per-entity managed
+ * refs (R — Phaser sprite/charId/nameplate/hpBar in the scene, stubs in tests).
+ * Keyed externally by the server entity id; mapped to a dense bitECS eid
+ * internally. Player and NPC are the same kind of entity — they differ only by
+ * which tag/components they carry.
+ */
+export class EntityStore<R> {
+	readonly world: World = createWorld();
+	private toEid = new Map<number, number>();
+	private toServer = new Map<number, number>();
+	private sideRefs = new SideMap<R>();
+
+	private tagFor(cat: EntityCat): Record<string, never> {
+		return cat === 'player' ? PlayerTag : cat === 'npc' ? NpcTag : ItemTag;
+	}
+
+	has(serverEid: number): boolean {
+		return this.toEid.has(serverEid);
+	}
+
+	size(): number {
+		return this.toEid.size;
+	}
+
+	spawn(serverEid: number, data: SpawnData, refs: R): number {
+		const eid = addEntity(this.world);
+		addComponent(this.world, eid, Position);
+		addComponent(this.world, eid, Health);
+		addComponent(this.world, eid, Kind);
+		addComponent(this.world, eid, Owner);
+		addComponent(this.world, eid, Active);
+		addComponent(this.world, eid, this.tagFor(data.cat));
+		if (data.hostile) addComponent(this.world, eid, MonsterTag);
+		Position.x[eid] = data.tile.x;
+		Position.y[eid] = data.tile.y;
+		Health.hp[eid] = data.hp;
+		Health.maxHp[eid] = data.maxHp;
+		Kind.value[eid] = data.kind;
+		Owner.slot[eid] = data.owner;
+		Active.value[eid] = 1;
+		this.toEid.set(serverEid, eid);
+		this.toServer.set(eid, serverEid);
+		this.sideRefs.set(eid, refs);
+		return eid;
+	}
+
+	update(serverEid: number, data: UpdateData): void {
+		const eid = this.toEid.get(serverEid);
+		if (eid === undefined) return;
+		if (data.tile) {
+			Position.x[eid] = data.tile.x;
+			Position.y[eid] = data.tile.y;
+		}
+		if (data.hp !== undefined) Health.hp[eid] = data.hp;
+		if (data.maxHp !== undefined) Health.maxHp[eid] = data.maxHp;
+	}
+
+	/** Remove the entity; returns its refs so the caller can tear down sprites. */
+	despawn(serverEid: number): R | undefined {
+		const eid = this.toEid.get(serverEid);
+		if (eid === undefined) return undefined;
+		const refs = this.sideRefs.delete(eid);
+		removeEntity(this.world, eid);
+		this.toEid.delete(serverEid);
+		this.toServer.delete(eid);
+		return refs;
+	}
+
+	refs(serverEid: number): R | undefined {
+		const eid = this.toEid.get(serverEid);
+		return eid === undefined ? undefined : this.sideRefs.get(eid);
+	}
+
+	eid(serverEid: number): number | undefined {
+		return this.toEid.get(serverEid);
+	}
+
+	tile(serverEid: number): { x: number; y: number } | null {
+		const eid = this.toEid.get(serverEid);
+		if (eid === undefined) return null;
+		return { x: Position.x[eid], y: Position.y[eid] };
+	}
+
+	hp(serverEid: number): number {
+		const eid = this.toEid.get(serverEid);
+		return eid === undefined ? 0 : Health.hp[eid];
+	}
+
+	maxHp(serverEid: number): number {
+		const eid = this.toEid.get(serverEid);
+		return eid === undefined ? 0 : Health.maxHp[eid];
+	}
+
+	kind(serverEid: number): number {
+		const eid = this.toEid.get(serverEid);
+		return eid === undefined ? -1 : Kind.value[eid];
+	}
+
+	/** Iterate every live entity as [serverEid, eid, refs]. */
+	*entries(): Generator<[number, number, R]> {
+		for (const [serverEid, eid] of this.toEid) {
+			const refs = this.sideRefs.get(eid);
+			if (refs !== undefined) yield [serverEid, eid, refs];
+		}
+	}
+
+	/** First server entity occupying a tile (excluding `exceptServer`). */
+	at(
+		tx: number,
+		ty: number,
+		exceptServer: number,
+	): { serverEid: number; eid: number; refs: R } | null {
+		for (const [serverEid, eid, refs] of this.entries()) {
+			if (serverEid === exceptServer) continue;
+			if (Position.x[eid] === tx && Position.y[eid] === ty) {
+				return { serverEid, eid, refs };
+			}
+		}
+		return null;
+	}
+
+	/** Count hostile (Monster-tagged) entities within `radius` of a point. */
+	hostilesInRange(cx: number, cy: number, radius: number): number {
+		let n = 0;
+		for (const _ of queryInRange(
+			this.world,
+			[Position, MonsterTag],
+			Position,
+			cx,
+			cy,
+			radius,
+		)) {
+			n += 1;
+		}
+		return n;
+	}
+
+	/** All server eids of a category (for roster/debug). */
+	serverIdsWith(cat: EntityCat): number[] {
+		const tag = this.tagFor(cat);
+		const out: number[] = [];
+		for (const eid of query(this.world, [tag])) {
+			const s = this.toServer.get(eid);
+			if (s !== undefined) out.push(s);
+		}
+		return out;
+	}
+}

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -15,6 +15,7 @@
 			],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/laser/ecs": ["../../../packages/npm/laser/src/ecs.ts"],
 			"@kbve/itemdb-data": [
 				"../../../packages/data/codegen/generated/itemdb-data.json"
 			],

--- a/packages/npm/laser/src/ecs.ts
+++ b/packages/npm/laser/src/ecs.ts
@@ -1,0 +1,11 @@
+// Lean ECS subpath: bitecs core + spatial helpers with ZERO Phaser/R3F/Rapier
+// dependency, so consumers (and their unit tests in jsdom) don't evaluate the
+// heavy rendering modules the main barrel pulls in.
+
+export * from './lib/ecs/bitecs';
+export {
+	SideMap,
+	nearestInRange,
+	queryInRange,
+	type PositionLike,
+} from './lib/ecs/helpers';

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,7 +21,8 @@
 			"@kbve/devops": ["packages/npm/devops/src/index.ts"],
 			"@kbve/droid": ["packages/npm/droid/src/index.ts"],
 			"@kbve/khashvault": ["packages/npm/khashvault/src/index.ts"],
-			"@kbve/laser": ["packages/npm/laser/src/index.ts"]
+			"@kbve/laser": ["packages/npm/laser/src/index.ts"],
+			"@kbve/laser/ecs": ["packages/npm/laser/src/ecs.ts"]
 		}
 	},
 	"exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
Foundation for treating player + NPC as the **same kind of entity** (component-driven, no `kindCat` branching) — replaces the orphaned `ecs/world` scaffold with a scene-ready, **unit-tested** registry.

## What's here
- **`@kbve/laser/ecs`** — lean subpath exporting bitecs + spatial helpers with **zero Phaser/Rapier**. The full `@kbve/laser` barrel dies in jsdom (Phaser canvas), so unit tests + lean consumers import this instead (mirrors the `@kbve/astro/ui` split).
- **components** — `Position` / `Health` / `Kind` / `Owner` / `Active` + `Player`/`Npc`/`Item`/`Monster` tags (SoA, eid-indexed).
- **`EntityStore<R>`** — bitECS owns the **data**, a `SideMap` owns the **managed refs** (R = Phaser objects in the scene, stubs in tests). Keyed by server eid, mapped to a dense bitECS eid. API: `spawn`/`update`/`despawn`, `tile`/`hp`/`kind` reads, `at()` / `hostilesInRange()` (real Monster query) / `serverIdsWith()`.
- **6 unit tests** (`store.spec`) — 55 cryptothrone tests green.

## Why a foundation PR
This is the data/query core, fully tested. The **next PR rewires `CloudCityScene`** to delegate entity tracking to the store (drops `this.tracked` + the `kindCat` switches). That touches the live entity/render/click loop and I can't runtime-verify it headlessly, so it ships separately for live testing rather than blind-bundling it here.

Nothing in the live scene imports the store yet, so this is inert + safe to land on its own.