### PR TITLE
feat(chat): valkey-shared anti-spam (phase 2) + client-side throttle

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
@@ -19,6 +19,14 @@ interface ChatLine {
 const MAX_LINES = 50;
 const MAX_INPUT = 200;
 
+// Client-side throttle — first line of defense, kept just under the gateway's
+// per-username limit so a normal user is stopped here before the server has to
+// drop/kick. The server (irc-gateway) stays authoritative.
+const CLIENT_MAX_PER_WINDOW = 8;
+const CLIENT_WINDOW_MS = 10_000;
+const CLIENT_MIN_INTERVAL_MS = 600;
+const THROTTLE_NOTICE = 'Slow down — sending messages too fast.';
+
 let lineCounter = 0;
 
 const NAME_HUES = [28, 162, 200, 262, 330, 95];
@@ -49,6 +57,7 @@ export function ChatBar() {
 	const focusedRef = useRef(false);
 	focusedRef.current = focused;
 	const clientRef = useRef<RealmChatClient | null>(null);
+	const sendTimesRef = useRef<number[]>([]);
 	const [chatState, setChatState] = useState<RealmChatState>({
 		status: 'connecting',
 		attempts: 0,
@@ -129,6 +138,34 @@ export function ChatBar() {
 		e.preventDefault();
 		const text = draft.trim();
 		if (!text || !connected) return;
+
+		// Client-side throttle: block before flooding the socket; the gateway
+		// stays authoritative. Keep the draft so the user can resend shortly.
+		const now = Date.now();
+		const recent = sendTimesRef.current.filter(
+			(t) => now - t < CLIENT_WINDOW_MS,
+		);
+		const tooSoon =
+			recent.length > 0 &&
+			now - recent[recent.length - 1] < CLIENT_MIN_INTERVAL_MS;
+		if (tooSoon || recent.length >= CLIENT_MAX_PER_WINDOW) {
+			setLines((prev) =>
+				prev[prev.length - 1]?.text === THROTTLE_NOTICE
+					? prev
+					: [
+							...prev,
+							{
+								id: ++lineCounter,
+								from: 'system',
+								text: THROTTLE_NOTICE,
+								at: timestamp(),
+							},
+						].slice(-MAX_LINES),
+			);
+			return;
+		}
+		sendTimesRef.current = [...recent, now];
+
 		clientRef.current?.send(text);
 		// Local echo — IRC never sends a client its own PRIVMSG back, so
 		// without this the sender never sees the message they just sent.

--- a/apps/irc/irc-gateway/Cargo.toml
+++ b/apps/irc/irc-gateway/Cargo.toml
@@ -25,7 +25,7 @@ jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 
 # Workspace path dependencies
-jedi = { path = "../../../packages/rust/jedi" }
+jedi = { path = "../../../packages/rust/jedi", features = ["valkey"] }
 kbve = { path = "../../../packages/rust/kbve" }
 
 # Shared chat message schema — ChatMessage + MessageKind +

--- a/apps/irc/irc-gateway/src/gateway/kv.rs
+++ b/apps/irc/irc-gateway/src/gateway/kv.rs
@@ -1,0 +1,21 @@
+//! Shared Valkey handle (jedi KvCache) for the gateway. Used by the anti-spam
+//! limiter so rate counters are shared across gateway replicas and with other
+//! services (discordsh) that point at the same KBVE_KV_URL. Non-fatal: if
+//! Valkey is unconfigured the limiter falls back to its in-process window.
+
+use std::sync::Arc;
+
+use jedi::state::kv::KvCache;
+use tokio::sync::OnceCell;
+
+static KV: OnceCell<Arc<KvCache>> = OnceCell::const_new();
+
+/// Build the KvCache from env (KBVE_KV_URL / KBVE_KV_*). Idempotent.
+pub async fn init() -> bool {
+    let cache = KvCache::from_env().await;
+    KV.set(cache).is_ok()
+}
+
+pub fn get() -> Option<&'static Arc<KvCache>> {
+    KV.get()
+}

--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -266,7 +266,7 @@ async fn session(client_ws: WebSocket, nick: String, channels: Vec<String>, plat
             // Anti-spam — keyed by the authenticated nick. Over-limit messages
             // are dropped before they reach ergo (so the relay never floods and
             // gets banned); a sustained flood disconnects the session.
-            match crate::gateway::ratelimit::check(&nick_c2i) {
+            match crate::gateway::ratelimit::verdict(&nick_c2i).await {
                 crate::gateway::ratelimit::Verdict::Allow => {}
                 crate::gateway::ratelimit::Verdict::Throttle => {
                     debug!(user = %nick_c2i, "rate-limited; dropping message");

--- a/apps/irc/irc-gateway/src/gateway/mod.rs
+++ b/apps/irc/irc-gateway/src/gateway/mod.rs
@@ -1,5 +1,6 @@
 pub mod history;
 pub mod irc;
+pub mod kv;
 pub mod minechat;
 pub mod ratelimit;
 pub mod rest;

--- a/apps/irc/irc-gateway/src/gateway/ratelimit.rs
+++ b/apps/irc/irc-gateway/src/gateway/ratelimit.rs
@@ -40,6 +40,18 @@ struct Buckets {
     map: HashMap<String, Bucket>,
 }
 
+/// Map a per-window message count to a verdict. Shared by the in-process and
+/// valkey-backed paths so both enforce the same thresholds.
+fn classify(count: u32) -> Verdict {
+    if count > KICK_CEILING {
+        Verdict::Kick
+    } else if count > MAX_PER_WINDOW {
+        Verdict::Throttle
+    } else {
+        Verdict::Allow
+    }
+}
+
 impl Buckets {
     fn check(&mut self, user: &str, now: Instant) -> Verdict {
         let b = self.map.entry(user.to_string()).or_insert(Bucket {
@@ -54,13 +66,7 @@ impl Buckets {
             return Verdict::Allow;
         }
         b.count += 1;
-        if b.count > KICK_CEILING {
-            Verdict::Kick
-        } else if b.count > MAX_PER_WINDOW {
-            Verdict::Throttle
-        } else {
-            Verdict::Allow
-        }
+        classify(b.count)
     }
 
     fn prune(&mut self, now: Instant, idle: Duration) {
@@ -74,12 +80,24 @@ fn global() -> &'static Mutex<Buckets> {
     B.get_or_init(|| Mutex::new(Buckets::default()))
 }
 
-/// Record one message for `user` and decide what to do with it.
+/// Record one message for `user` and decide what to do with it (in-process).
 pub fn check(user: &str) -> Verdict {
     global()
         .lock()
         .expect("ratelimit mutex poisoned")
         .check(user, Instant::now())
+}
+
+/// Decide a verdict for `user`, preferring the shared valkey counter (so the
+/// limit holds across gateway replicas + discordsh) and falling back to the
+/// in-process window when valkey is unavailable.
+pub async fn verdict(user: &str) -> Verdict {
+    if let Some(kv) = crate::gateway::kv::get() {
+        if let Some(count) = kv.check_rate(user, WINDOW.as_secs()).await {
+            return classify(count.min(u32::MAX as u64) as u32);
+        }
+    }
+    check(user)
 }
 
 /// Drop buckets idle longer than `idle`, to bound memory. Call periodically.

--- a/apps/irc/irc-gateway/src/main.rs
+++ b/apps/irc/irc-gateway/src/main.rs
@@ -31,6 +31,10 @@ async fn main() -> anyhow::Result<()> {
 
     info!("IRC Gateway v{}", env!("CARGO_PKG_VERSION"));
 
+    if gateway::kv::init().await {
+        info!("KvCache initialized — anti-spam counters shared via Valkey when configured");
+    }
+
     gateway::history::spawn_listeners();
 
     // Drop idle anti-spam buckets every minute so memory stays bounded.

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.28"
+version: "0.1.29"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx
@@ -11,7 +11,7 @@ tags:
 key: irc_gateway
 pipeline: docker
 app_name: irc-gateway
-version: "0.1.25"
+version: "0.1.26"
 source_path: apps/irc
 version_toml: apps/irc/version.toml
 version_target: apps/irc/irc-gateway/Cargo.toml

--- a/apps/kube/irc/manifests/irc-gateway-deployment.yaml
+++ b/apps/kube/irc/manifests/irc-gateway-deployment.yaml
@@ -1,75 +1,84 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: irc-gateway-deployment
-  namespace: irc
-  labels:
-    app: irc-gateway
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: irc-gateway
-  template:
-    metadata:
-      annotations:
-        rollout-restart: "2026-06-14T15:27:33Z"
-      labels:
+    name: irc-gateway-deployment
+    namespace: irc
+    labels:
         app: irc-gateway
-        version: "0.1.25"
-    spec:
-      containers:
-      - name: irc-gateway
-        image: ghcr.io/kbve/irc-gateway:0.1.25
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 4321
-          protocol: TCP
-          name: http
-        - containerPort: 6667
-          protocol: TCP
-          name: irc
-        env:
-        - name: HTTP_PORT
-          value: "4321"
-        - name: IRC_PROXY_PORT
-          value: "6667"
-        - name: ERGO_WS_URL
-          value: "ws://ergo-irc-service.irc.svc.cluster.local:8080"
-        - name: ERGO_IRC_HOST
-          value: "ergo-irc-service.irc.svc.cluster.local"
-        - name: ERGO_IRC_PORT
-          value: "6667"
-        - name: JWT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: supabase-shared
-              key: jwt-secret
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "500m"
-          limits:
-            memory: "512Mi"
-            cpu: "1000m"
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: irc-gateway
+    template:
+        metadata:
+            annotations:
+                rollout-restart: '2026-06-14T15:27:33Z'
+            labels:
+                app: irc-gateway
+                version: '0.1.25'
+        spec:
+            containers:
+                - name: irc-gateway
+                  image: ghcr.io/kbve/irc-gateway:0.1.25
+                  imagePullPolicy: Always
+                  ports:
+                      - containerPort: 4321
+                        protocol: TCP
+                        name: http
+                      - containerPort: 6667
+                        protocol: TCP
+                        name: irc
+                  env:
+                      - name: HTTP_PORT
+                        value: '4321'
+                      - name: IRC_PROXY_PORT
+                        value: '6667'
+                      - name: ERGO_WS_URL
+                        value: 'ws://ergo-irc-service.irc.svc.cluster.local:8080'
+                      - name: ERGO_IRC_HOST
+                        value: 'ergo-irc-service.irc.svc.cluster.local'
+                      - name: ERGO_IRC_PORT
+                        value: '6667'
+                      - name: JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: jwt-secret
+                      # KBVE_KV_URL (jedi KvCache -> Valkey) for shared anti-spam counters.
+                      # Optional so the pod boots before the ExternalSecret renders; the
+                      # limiter falls back to its in-process window until then.
+                      - name: KBVE_KV_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: irc-gateway-valkey
+                                key: KBVE_KV_URL
+                                optional: true
+                  resources:
+                      requests:
+                          memory: '256Mi'
+                          cpu: '500m'
+                      limits:
+                          memory: '512Mi'
+                          cpu: '1000m'
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: irc-gateway-service
-  namespace: irc
-  labels:
-    app: irc-gateway
+    name: irc-gateway-service
+    namespace: irc
+    labels:
+        app: irc-gateway
 spec:
-  type: ClusterIP
-  selector:
-    app: irc-gateway
-  ports:
-  - port: 4321
-    targetPort: 4321
-    protocol: TCP
-    name: http
-  - port: 6667
-    targetPort: 6667
-    protocol: TCP
-    name: irc
+    type: ClusterIP
+    selector:
+        app: irc-gateway
+    ports:
+        - port: 4321
+          targetPort: 4321
+          protocol: TCP
+          name: http
+        - port: 6667
+          targetPort: 6667
+          protocol: TCP
+          name: irc

--- a/apps/kube/irc/manifests/irc-gateway-externalsecret.yaml
+++ b/apps/kube/irc/manifests/irc-gateway-externalsecret.yaml
@@ -1,59 +1,106 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: irc-gateway-external-secrets
-  namespace: irc
+    name: irc-gateway-external-secrets
+    namespace: irc
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
-  name: kilobase-remote-secret-store
-  namespace: irc
+    name: kilobase-remote-secret-store
+    namespace: irc
 spec:
-  provider:
-    kubernetes:
-      remoteNamespace: kilobase
-      auth:
-        serviceAccount:
-          name: irc-gateway-external-secrets
-          namespace: irc
-      server:
-        url: https://kubernetes.default.svc
-        caProvider:
-          type: ConfigMap
-          name: kube-root-ca.crt
-          key: ca.crt
-          namespace: kube-system
+    provider:
+        kubernetes:
+            remoteNamespace: kilobase
+            auth:
+                serviceAccount:
+                    name: irc-gateway-external-secrets
+                    namespace: irc
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: irc-gateway-supabase-secrets
-  namespace: irc
+    name: irc-gateway-supabase-secrets
+    namespace: irc
 spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: kilobase-remote-secret-store
-    kind: SecretStore
-  target:
-    name: supabase-shared
-    creationPolicy: Owner
-    template:
-      engineVersion: v2
-      data:
-        jwt-secret: "{{ .jwtsecret }}"
-        anon-key: "{{ .anonkey }}"
-        service-role-key: "{{ .servicekey }}"
-  data:
-  - secretKey: jwtsecret
-    remoteRef:
-      key: supabase-jwt
-      property: secret
-  - secretKey: anonkey
-    remoteRef:
-      key: supabase-jwt
-      property: anon-key
-  - secretKey: servicekey
-    remoteRef:
-      key: supabase-jwt
-      property: service-key
+    refreshInterval: 1h
+    secretStoreRef:
+        name: kilobase-remote-secret-store
+        kind: SecretStore
+    target:
+        name: supabase-shared
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                jwt-secret: '{{ .jwtsecret }}'
+                anon-key: '{{ .anonkey }}'
+                service-role-key: '{{ .servicekey }}'
+    data:
+        - secretKey: jwtsecret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+        - secretKey: anonkey
+          remoteRef:
+              key: supabase-jwt
+              property: anon-key
+        - secretKey: servicekey
+          remoteRef:
+              key: supabase-jwt
+              property: service-key
+---
+# Valkey password from the valkey namespace, composed into a full KBVE_KV_URL
+# for jedi KvCache (shared anti-spam counters). Needs irc-gateway-external-secrets
+# granted read on valkey-auth (apps/kube/valkey/manifests/irc-gateway-valkey-rbac.yaml).
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: valkey-remote-secret-store
+    namespace: irc
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: valkey
+            auth:
+                serviceAccount:
+                    name: irc-gateway-external-secrets
+                    namespace: irc
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: irc-gateway-valkey-secrets
+    namespace: irc
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: valkey-remote-secret-store
+        kind: SecretStore
+    target:
+        name: irc-gateway-valkey
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                KBVE_KV_URL: 'redis://:{{ .valkeypassword | urlquery }}@valkey.valkey.svc.cluster.local:6379'
+    data:
+        - secretKey: valkeypassword
+          remoteRef:
+              key: valkey-auth
+              property: valkey-password

--- a/apps/kube/valkey/manifests/irc-gateway-valkey-rbac.yaml
+++ b/apps/kube/valkey/manifests/irc-gateway-valkey-rbac.yaml
@@ -1,0 +1,16 @@
+# Lets the irc-gateway ExternalSecrets ServiceAccount read valkey-auth out of
+# the valkey namespace, so its valkey-remote-secret-store can compose KBVE_KV_URL
+# for the chat anti-spam limiter. Reuses the existing valkey-auth-reader Role.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: irc-gateway-read-valkey-auth
+    namespace: valkey
+subjects:
+    - kind: ServiceAccount
+      name: irc-gateway-external-secrets
+      namespace: irc
+roleRef:
+    kind: Role
+    name: valkey-auth-reader
+    apiGroup: rbac.authorization.k8s.io

--- a/apps/kube/valkey/manifests/kustomization.yaml
+++ b/apps/kube/valkey/manifests/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
     - valkey-auth-sync-rbac.yaml
     - valkey-auth-sync-policy.yaml
     - cryptothrone-valkey-rbac.yaml
+    - irc-gateway-valkey-rbac.yaml

--- a/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
+++ b/apps/kube/valkey/manifests/valkey-networkpolicy.yaml
@@ -29,6 +29,9 @@ spec:
               - namespaceSelector:
                     matchLabels:
                         kubernetes.io/metadata.name: cryptothrone
+              - namespaceSelector:
+                    matchLabels:
+                        kubernetes.io/metadata.name: irc
           ports:
               - port: 6379
                 protocol: TCP

--- a/packages/rust/jedi/src/state/kv.rs
+++ b/packages/rust/jedi/src/state/kv.rs
@@ -288,6 +288,22 @@ impl KvCache {
             tracing::warn!(error = %e, key = %key, "[KvCache] L2 put failed");
         }
     }
+
+    /// Atomic per-window counter for rate limiting, shared via valkey across
+    /// every service pointed at the same `KBVE_KV_URL`. Increments the counter
+    /// for `key` in the current window and returns the post-increment count, or
+    /// `None` when L2 (valkey) is unavailable so callers can fall back to an
+    /// in-process limiter. The key expires after `window_secs`, so the window
+    /// is fixed (resets once the counter ages out).
+    pub async fn check_rate(&self, key: &str, window_secs: u64) -> Option<u64> {
+        let pool = self.l2.as_ref()?;
+        let rkey = self.qualified(&format!("rl:{key}"));
+        let count: i64 = pool.incr::<i64, _>(&rkey).await.ok()?;
+        if count == 1 {
+            let _ = pool.expire::<(), _>(&rkey, window_secs as i64, None).await;
+        }
+        Some(count.max(0) as u64)
+    }
 }
 
 async fn build_valkey_pool() -> Result<ValkeyPool, String> {


### PR DESCRIPTION
Phase 2 of the chat-relay anti-spam (#12419 was phase 1). The limit is now **shared across gateway replicas and with discordsh** via valkey, with a **client-side first line of defense**. Server stays authoritative.

## jedi (shared primitive)
- `KvCache::check_rate(key, window_secs)` — atomic valkey `INCR` + `EXPIRE`, returns the per-window count, or `None` when L2 (valkey) is unavailable so callers fall back. Any service on the same `KBVE_KV_URL` shares the counter.

## irc-gateway
- jedi `valkey` feature; `gateway::kv` inits `KvCache::from_env` (non-fatal).
- `ratelimit::verdict()` prefers the **shared valkey counter**, falls back to the **in-process window** (phase 1) when valkey is unconfigured — same `Verdict` + thresholds. c2i uses the async verdict.
- **kube:** valkey `SecretStore`+`ExternalSecret` render `KBVE_KV_URL` in the `irc` ns; `RoleBinding` grants `irc-gateway-external-secrets` read on `valkey-auth`; `irc` added to the valkey ingress `NetworkPolicy`; `KBVE_KV_URL` wired into the deployment (optional → boots before render).

## cryptothrone client
- `ChatBar` throttles outgoing sends (8 / 10s + 600ms min gap — under the gateway's 10/10s) with a "slow down" notice. First line of defense; the gateway still enforces.

## Verified
- gateway `cargo test` **47/47**; jedi (valkey) + gateway build clean; valkey kustomize + all edited YAML valid.
- irc-gateway `0.1.25 → 0.1.26`, cryptothrone `0.1.28 → 0.1.29`.

## Deploy notes
- Until the ESO/RBAC/netpol land, the gateway uses the in-process limiter (graceful). After: counters are shared/persistent in valkey.
- Verify the valkey password is URL-safe post-`urlquery` (jedi parses `KBVE_KV_URL` as a URL), and that `irc-gateway-external-secrets` can read `valkey-auth`.
- The discordsh link is now available (same `KvCache::check_rate`) — wiring discordsh's chat path to it is a follow-up.