### PR TITLE
feat(jedi/forgejo): cover PRs, issue comments, labels, milestones, SSH keys

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
+++ b/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
@@ -325,6 +325,61 @@ async fn issues(
     reply!(c.list_issues(&owner, &repo, state, kind, q.limit()).await)
 }
 
+async fn pulls(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    let state = q.state.as_deref().unwrap_or("open");
+    reply!(c.list_pulls(&owner, &repo, state, q.limit()).await)
+}
+
+async fn get_pull(
+    headers: HeaderMap,
+    Path((owner, repo, index)): Path<(String, String, u64)>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.get_pull(&owner, &repo, index).await)
+}
+
+async fn issue_comments(
+    headers: HeaderMap,
+    Path((owner, repo, index)): Path<(String, String, u64)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_issue_comments(&owner, &repo, index, q.limit()).await)
+}
+
+async fn labels(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_labels(&owner, &repo, q.limit()).await)
+}
+
+async fn milestones(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    let state = q.state.as_deref().unwrap_or("open");
+    reply!(c.list_milestones(&owner, &repo, state, q.limit()).await)
+}
+
+async fn user_keys(
+    headers: HeaderMap,
+    Path(login): Path<String>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_user_keys(&login, q.limit()).await)
+}
+
 // ── Org / team reads ─────────────────────────────────────────────────
 
 async fn org_members(
@@ -677,6 +732,154 @@ async fn unlock_issue(
     reply!(c.unlock_issue(&owner, &repo, index).await)
 }
 
+// ── Pull request / ticket writes ─────────────────────────────────────
+
+async fn create_pull(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_pull(&owner, &repo, &body).await)
+}
+
+async fn edit_pull(
+    headers: HeaderMap,
+    Path((owner, repo, index)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_pull(&owner, &repo, index, &body).await)
+}
+
+async fn merge_pull(
+    headers: HeaderMap,
+    Path((owner, repo, index)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.merge_pull(&owner, &repo, index, &body).await)
+}
+
+async fn create_issue_comment(
+    headers: HeaderMap,
+    Path((owner, repo, index)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_issue_comment(&owner, &repo, index, &body).await)
+}
+
+async fn edit_issue_comment(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_issue_comment(&owner, &repo, id, &body).await)
+}
+
+async fn delete_issue_comment(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_issue_comment(&owner, &repo, id).await)
+}
+
+async fn create_label(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_label(&owner, &repo, &body).await)
+}
+
+async fn edit_label(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_label(&owner, &repo, id, &body).await)
+}
+
+async fn delete_label(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_label(&owner, &repo, id).await)
+}
+
+async fn set_issue_labels(
+    headers: HeaderMap,
+    Path((owner, repo, index)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.set_issue_labels(&owner, &repo, index, &body).await)
+}
+
+async fn create_milestone(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_milestone(&owner, &repo, &body).await)
+}
+
+async fn edit_milestone(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_milestone(&owner, &repo, id, &body).await)
+}
+
+async fn delete_milestone(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_milestone(&owner, &repo, id).await)
+}
+
+async fn edit_hook(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_hook(&owner, &repo, id, &body).await)
+}
+
+async fn edit_release(
+    headers: HeaderMap,
+    Path((owner, repo, id)): Path<(String, String, u64)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_release(&owner, &repo, id, &body).await)
+}
+
+async fn create_user_key(
+    headers: HeaderMap,
+    Path(login): Path<String>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_user_key(&login, &body).await)
+}
+
+async fn delete_user_key(headers: HeaderMap, Path((login, id)): Path<(String, u64)>) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_user_key(&login, id).await)
+}
+
 async fn run_cron(headers: HeaderMap, Path(task): Path<String>) -> Response {
     let c = mc!(headers);
     reply!(c.run_cron(&task).await)
@@ -721,6 +924,11 @@ pub fn routes() -> Router {
         .route(&p("/users"), get(users).post(create_user))
         .route(&p("/users/{login}"), patch(edit_user).delete(delete_user))
         .route(&p("/users/{user}/repos"), post(create_repo_for_user))
+        .route(
+            &p("/users/{login}/keys"),
+            get(user_keys).post(create_user_key),
+        )
+        .route(&p("/users/{login}/keys/{id}"), delete(delete_user_key))
         // orgs & teams
         .route(&p("/orgs"), get(orgs).post(create_org))
         .route(&p("/orgs/{org}"), patch(edit_org).delete(delete_org))
@@ -764,13 +972,16 @@ pub fn routes() -> Router {
         )
         .route(
             &p("/repos/{owner}/{repo}/releases/{id}"),
-            delete(delete_release),
+            patch(edit_release).delete(delete_release),
         )
         .route(
             &p("/repos/{owner}/{repo}/hooks"),
             get(hooks).post(create_hook),
         )
-        .route(&p("/repos/{owner}/{repo}/hooks/{id}"), delete(delete_hook))
+        .route(
+            &p("/repos/{owner}/{repo}/hooks/{id}"),
+            patch(edit_hook).delete(delete_hook),
+        )
         .route(
             &p("/repos/{owner}/{repo}/hooks/{id}/tests"),
             post(test_hook),
@@ -801,6 +1012,46 @@ pub fn routes() -> Router {
         .route(
             &p("/repos/{owner}/{repo}/issues/{index}/lock"),
             put(lock_issue).delete(unlock_issue),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/issues/{index}/comments"),
+            get(issue_comments).post(create_issue_comment),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/issues/comments/{id}"),
+            patch(edit_issue_comment).delete(delete_issue_comment),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/issues/{index}/labels"),
+            put(set_issue_labels),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/labels"),
+            get(labels).post(create_label),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/labels/{id}"),
+            patch(edit_label).delete(delete_label),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/milestones"),
+            get(milestones).post(create_milestone),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/milestones/{id}"),
+            patch(edit_milestone).delete(delete_milestone),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/pulls"),
+            get(pulls).post(create_pull),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/pulls/{index}"),
+            get(get_pull).patch(edit_pull),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/pulls/{index}/merge"),
+            post(merge_pull),
         )
         .route(&p("/repos/{owner}/{repo}/runners"), get(repo_runners))
         .route(

--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -493,6 +493,22 @@ impl ForgejoClient {
         .await
     }
 
+    pub async fn edit_hook(
+        &self,
+        owner: &str,
+        repo: &str,
+        id: u64,
+        body: &Value,
+    ) -> Result<ForgejoHook, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/hooks/{id}"),
+            Some(body),
+        )
+        .await
+    }
+
     pub async fn delete_hook(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
         self.policy.check_owner(owner)?;
         self.write_empty(
@@ -538,6 +554,22 @@ impl ForgejoClient {
         self.write(
             Method::POST,
             &format!("/api/v1/repos/{owner}/{repo}/releases"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn edit_release(
+        &self,
+        owner: &str,
+        repo: &str,
+        id: u64,
+        body: &Value,
+    ) -> Result<ForgejoRelease, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/releases/{id}"),
             Some(body),
         )
         .await
@@ -745,6 +777,312 @@ impl ForgejoClient {
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/lock"),
+            None,
+        )
+        .await
+    }
+
+    // ── Pull requests ────────────────────────────────────────────────
+
+    pub async fn list_pulls(
+        &self,
+        owner: &str,
+        repo: &str,
+        state: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoPull>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/pulls"),
+            &[("state", state.to_string()), ("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn get_pull(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+    ) -> Result<ForgejoPull, JediError> {
+        self.get(&format!("/api/v1/repos/{owner}/{repo}/pulls/{index}"), &[])
+            .await
+    }
+
+    pub async fn create_pull(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoPull, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/pulls"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn edit_pull(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+        body: &Value,
+    ) -> Result<ForgejoPull, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/pulls/{index}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn merge_pull(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+        body: &Value,
+    ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/pulls/{index}/merge"),
+            Some(body),
+        )
+        .await
+    }
+
+    // ── Issue comments ───────────────────────────────────────────────
+
+    pub async fn list_issue_comments(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+        limit: u32,
+    ) -> Result<Vec<ForgejoComment>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/comments"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+        body: &Value,
+    ) -> Result<ForgejoComment, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/comments"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn edit_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        id: u64,
+        body: &Value,
+    ) -> Result<ForgejoComment, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/issues/comments/{id}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_issue_comment(
+        &self,
+        owner: &str,
+        repo: &str,
+        id: u64,
+    ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/issues/comments/{id}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Labels ───────────────────────────────────────────────────────
+
+    pub async fn list_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoLabel>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/labels"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoLabel, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/labels"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn edit_label(
+        &self,
+        owner: &str,
+        repo: &str,
+        id: u64,
+        body: &Value,
+    ) -> Result<ForgejoLabel, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/labels/{id}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_label(&self, owner: &str, repo: &str, id: u64) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/labels/{id}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn set_issue_labels(
+        &self,
+        owner: &str,
+        repo: &str,
+        index: u64,
+        body: &Value,
+    ) -> Result<Vec<ForgejoLabel>, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PUT,
+            &format!("/api/v1/repos/{owner}/{repo}/issues/{index}/labels"),
+            Some(body),
+        )
+        .await
+    }
+
+    // ── Milestones ───────────────────────────────────────────────────
+
+    pub async fn list_milestones(
+        &self,
+        owner: &str,
+        repo: &str,
+        state: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoMilestone>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/milestones"),
+            &[("state", state.to_string()), ("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_milestone(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoMilestone, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/milestones"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn edit_milestone(
+        &self,
+        owner: &str,
+        repo: &str,
+        id: u64,
+        body: &Value,
+    ) -> Result<ForgejoMilestone, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/milestones/{id}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_milestone(
+        &self,
+        owner: &str,
+        repo: &str,
+        id: u64,
+    ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/milestones/{id}"),
+            None,
+        )
+        .await
+    }
+
+    // ── User SSH keys (onboarding) ───────────────────────────────────
+
+    pub async fn list_user_keys(
+        &self,
+        login: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoPublicKey>, JediError> {
+        self.get(
+            &format!("/api/v1/users/{login}/keys"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_user_key(
+        &self,
+        login: &str,
+        body: &Value,
+    ) -> Result<ForgejoPublicKey, JediError> {
+        self.write(
+            Method::POST,
+            &format!("/api/v1/admin/users/{login}/keys"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_user_key(&self, login: &str, id: u64) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/admin/users/{login}/keys/{id}"),
             None,
         )
         .await

--- a/packages/rust/jedi/src/entity/forgejo/types.rs
+++ b/packages/rust/jedi/src/entity/forgejo/types.rs
@@ -268,6 +268,110 @@ pub struct ForgejoIssue {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoPull {
+    pub id: u64,
+    pub number: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub merged: bool,
+    #[serde(default)]
+    pub mergeable: bool,
+    #[serde(default)]
+    pub is_locked: bool,
+    #[serde(default)]
+    pub comments: u64,
+    #[serde(default)]
+    pub base: Option<ForgejoPullBranch>,
+    #[serde(default)]
+    pub head: Option<ForgejoPullBranch>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+    #[serde(default)]
+    pub html_url: String,
+    #[serde(default)]
+    pub user: Option<ForgejoOwner>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoPullBranch {
+    #[serde(default)]
+    pub label: String,
+    #[serde(default, rename = "ref")]
+    pub ref_name: String,
+    #[serde(default)]
+    pub sha: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoComment {
+    pub id: u64,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub html_url: String,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+    #[serde(default)]
+    pub user: Option<ForgejoOwner>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoLabel {
+    pub id: u64,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub color: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub exclusive: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoMilestone {
+    pub id: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub open_issues: u64,
+    #[serde(default)]
+    pub closed_issues: u64,
+    #[serde(default)]
+    pub due_on: Option<String>,
+    #[serde(default)]
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoPublicKey {
+    pub id: u64,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub fingerprint: String,
+    #[serde(default)]
+    pub key: String,
+    #[serde(default)]
+    pub read_only: bool,
+    #[serde(default)]
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForgejoCronTask {
     pub name: String,
     #[serde(default)]


### PR DESCRIPTION
Fills the Forgejo API gaps **not** surfaced on the dashboard — the backend surface the future Forgejo runners will drive for issue/PR ticket management, plus the SSH-key endpoints onboarding needs (#9789 Phase 2). Pure backend (jedi + axum-kbve typed routes); no dashboard UI change.

## jedi client (`packages/rust/jedi/src/entity/forgejo`)
- **Pull requests** — list / get / create / edit / merge
- **Issue comments** — list / create / edit / delete
- **Labels** — list / create / edit / delete + set-on-issue
- **Milestones** — list / create / edit / delete
- **User SSH keys** — list (`/users/{u}/keys`), admin create/delete (`/admin/users/{u}/keys`)
- Fills asymmetric CRUD that only had create+delete: `edit_hook`, `edit_release` (PATCH)
- New types: `ForgejoPull` (+`ForgejoPullBranch`), `ForgejoComment`, `ForgejoLabel`, `ForgejoMilestone`, `ForgejoPublicKey`

## axum-kbve typed routes (`transport/forgejo_api.rs`)
- Reads `DASHBOARD_VIEW`-gated, writes `DASHBOARD_MANAGE`-gated
- Owner-scoped writes honour the `FORGEJO_ALLOWED_OWNERS` policy (admin user-key ops are global, same as the existing user-CRUD ops)
- Routes: `/repos/{o}/{r}/pulls[/{index}[/merge]]`, `/issues/{index}/comments`, `/issues/comments/{id}`, `/issues/{index}/labels`, `/labels[/{id}]`, `/milestones[/{id}]`, `/users/{login}/keys[/{id}]`

## Verify
- `./kbve.sh -nx axum-kbve:build` ✓ (compiles jedi `forgejo` feature end-to-end, 8m21s)

## Follow-ups (not in scope)
Branch get/create/delete + protection edit, tags + release assets, team get/edit + team-repo grants, GPG keys, repo contents/files, packages. Can layer on the same pattern.