### PR TITLE
feat(jedi/kv+axum-kbve): tag-based cache invalidation for account-keyed writes

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/ledger.rs
+++ b/apps/kbve/axum-kbve/src/transport/ledger.rs
@@ -344,9 +344,6 @@ fn ledger_error_response(err: JediError) -> Response {
         JediError::NotFound => (StatusCode::NOT_FOUND, "not_found"),
         JediError::BadRequest(_) => (StatusCode::BAD_REQUEST, "invalid_argument"),
         JediError::Database(_) => {
-            // wallet_account_missing (WLT01) surfaces through Database
-            // when the auth.uid() subquery returns 0 rows we just yield
-            // an empty page; only true db / pool errors land here.
             tracing::error!(error = %err, "ledger query failed");
             (StatusCode::INTERNAL_SERVER_ERROR, "internal")
         }

--- a/apps/kbve/axum-kbve/src/transport/wallet.rs
+++ b/apps/kbve/axum-kbve/src/transport/wallet.rs
@@ -185,13 +185,19 @@ pub(crate) async fn me_balance(headers: HeaderMap) -> Response {
             Some(cache) => {
                 let key = format!("caller:{user_id}:balance");
                 cluster
-                    .cached_caller_read(
+                    .cached_caller_read_tagged(
                         cache,
                         &key,
                         None,
                         user_id,
                         None,
                         |tx| -> PgCallerReadFut<'_, BalanceDto> { Box::pin(balance_query(tx)) },
+                        move |b: &BalanceDto| {
+                            vec![
+                                format!("wallet:caller:{user_id}"),
+                                format!("wallet:account:{}", b.account_id),
+                            ]
+                        },
                     )
                     .await
             }
@@ -307,13 +313,14 @@ pub(crate) async fn me_coupons(headers: HeaderMap) -> Response {
             Some(cache) => {
                 let key = format!("caller:{user_id}:coupons");
                 cluster
-                    .cached_caller_read(
+                    .cached_caller_read_tagged(
                         cache,
                         &key,
                         None,
                         user_id,
                         None,
                         |tx| -> PgCallerReadFut<'_, Vec<CouponDto>> { Box::pin(coupons_query(tx)) },
+                        move |_: &Vec<CouponDto>| vec![format!("wallet:caller:{user_id}")],
                     )
                     .await
             }
@@ -408,16 +415,26 @@ pub(crate) async fn me_redeem_coupon(
     }
 }
 
-/// Invalidate all cached entries scoped to a caller subject. Hooks
-/// into wallet write paths after a successful commit so the next
-/// /me/balance / /me/coupons / /me/ledger read can't serve stale
-/// data within the L1/L2 TTL window. Best-effort; cache errors
-/// are logged but not returned.
+/// Invalidate every cached entry tagged with this caller's user_id.
+/// Hooks into wallet write paths after a successful commit so the
+/// next /me/balance / /me/coupons / /me/ledger read can't serve
+/// stale data within the L1/L2 TTL window. Best-effort.
 pub(crate) async fn invalidate_caller_cache(user_id: Uuid) {
     let Some(cache) = get_kv_cache() else { return };
-    let prefix = format!("caller:{user_id}");
-    if let Err(e) = cache.invalidate_prefix(&prefix).await {
-        tracing::warn!(error = %e, user_id = %user_id, "[wallet] cache invalidate_prefix failed");
+    let tag = format!("wallet:caller:{user_id}");
+    if let Err(e) = cache.invalidate_tag(&tag).await {
+        tracing::warn!(error = %e, user_id = %user_id, "[wallet] invalidate_tag(caller) failed");
+    }
+}
+
+/// Invalidate every cached entry tagged with this account_id. Hooks
+/// into account-keyed service writes (credit / debit / transfer)
+/// where the caller's user_id isn't readily available. Best-effort.
+pub(crate) async fn invalidate_account_cache(account_id: Uuid) {
+    let Some(cache) = get_kv_cache() else { return };
+    let tag = format!("wallet:account:{account_id}");
+    if let Err(e) = cache.invalidate_tag(&tag).await {
+        tracing::warn!(error = %e, account_id = %account_id, "[wallet] invalidate_tag(account) failed");
     }
 }
 
@@ -629,8 +646,12 @@ pub(crate) async fn service_credit(
         ref_id: body.ref_id,
         idempotency_key: body.idempotency_key,
     };
+    let account_id = req.account_id;
     match client.credit(req).await {
-        Ok(ledger_id) => Json(ServiceLedgerDto { ledger_id }).into_response(),
+        Ok(ledger_id) => {
+            invalidate_account_cache(account_id).await;
+            Json(ServiceLedgerDto { ledger_id }).into_response()
+        }
         Err(e) => wallet_error_response(e),
     }
 }
@@ -682,8 +703,12 @@ pub(crate) async fn service_debit(
         ref_id: body.ref_id,
         idempotency_key: body.idempotency_key,
     };
+    let account_id = req.account_id;
     match client.debit(req).await {
-        Ok(ledger_id) => Json(ServiceLedgerDto { ledger_id }).into_response(),
+        Ok(ledger_id) => {
+            invalidate_account_cache(account_id).await;
+            Json(ServiceLedgerDto { ledger_id }).into_response()
+        }
         Err(e) => wallet_error_response(e),
     }
 }
@@ -736,8 +761,14 @@ pub(crate) async fn service_transfer(
         ref_id: body.ref_id,
         idempotency_key: body.idempotency_key,
     };
+    let from_account = req.from_account;
+    let to_account = req.to_account;
     match client.transfer(req).await {
-        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Ok(()) => {
+            invalidate_account_cache(from_account).await;
+            invalidate_account_cache(to_account).await;
+            StatusCode::NO_CONTENT.into_response()
+        }
         Err(e) => wallet_error_response(e),
     }
 }
@@ -926,6 +957,7 @@ pub(crate) async fn service_credit_user(
     match client.credit(req).await {
         Ok(ledger_id) => {
             invalidate_caller_cache(body.user_id).await;
+            invalidate_account_cache(account_id).await;
             Json(ServiceCreditUserDto {
                 account_id,
                 ledger_id,

--- a/packages/rust/jedi/src/state/kv.rs
+++ b/packages/rust/jedi/src/state/kv.rs
@@ -69,6 +69,7 @@ impl KvCacheConfig {
 
 struct L1Entry {
     body: Arc<[u8]>,
+    tags: Arc<[Arc<str>]>,
     expires_at: Instant,
 }
 
@@ -77,6 +78,9 @@ pub struct KvCache {
     l1: Mutex<LruCache<String, L1Entry>>,
     l2: Option<ValkeyPool>,
     inflight: DashMap<String, broadcast::Sender<Result<Arc<[u8]>, String>>>,
+    /// `tag → set<qualified_key>` reverse index for L1 invalidation.
+    /// L2 mirrors this in `<namespace>:tag:<tag>` Redis SETs.
+    tag_index: DashMap<Arc<str>, dashmap::DashSet<Arc<str>>>,
 }
 
 impl KvCache {
@@ -88,6 +92,7 @@ impl KvCache {
             l1,
             l2,
             inflight: DashMap::new(),
+            tag_index: DashMap::new(),
         })
     }
 
@@ -126,6 +131,30 @@ impl KvCache {
         F: FnOnce() -> Fut + Send,
         Fut: std::future::Future<Output = Result<T, JediError>> + Send,
     {
+        self.get_or_fetch_json_tagged(key, ttl, fetch, |_| Vec::new())
+            .await
+    }
+
+    /// Same as [`get_or_fetch_json`] but the caller supplies a closure
+    /// that derives a tag list from the fetched value. Tags are
+    /// registered alongside the cached body so a later
+    /// [`KvCache::invalidate_tag`] can purge every key carrying the
+    /// tag — useful when writes are keyed differently from reads
+    /// (e.g. `service/credit` knows the `account_id` while
+    /// `/me/balance` is keyed by `user_id`).
+    pub async fn get_or_fetch_json_tagged<T, F, Fut, TagFn>(
+        &self,
+        key: &str,
+        ttl: Option<Duration>,
+        fetch: F,
+        tag_fn: TagFn,
+    ) -> Result<T, JediError>
+    where
+        T: Serialize + DeserializeOwned + Send,
+        F: FnOnce() -> Fut + Send,
+        Fut: std::future::Future<Output = Result<T, JediError>> + Send,
+        TagFn: FnOnce(&T) -> Vec<String> + Send,
+    {
         let qualified = self.qualified(key);
         let l1_ttl = ttl.unwrap_or(self.cfg.l1_default_ttl);
         let l2_ttl = ttl.unwrap_or(self.cfg.l2_default_ttl);
@@ -139,22 +168,23 @@ impl KvCache {
         if let Some(bytes) = self.l2_get(&qualified).await {
             metrics_inc("kbve_kv_l2_hit");
             let arc: Arc<[u8]> = Arc::from(bytes.into_boxed_slice());
-            self.l1_put(qualified.clone(), Arc::clone(&arc), l1_ttl)
+            self.l1_put(qualified.clone(), Arc::clone(&arc), Vec::new(), l1_ttl)
                 .await;
             return serde_json::from_slice(&arc).map_err(json_err);
         }
         metrics_inc("kbve_kv_l2_miss");
 
         let bytes = self
-            .single_flight(&qualified, fetch, l1_ttl, l2_ttl)
+            .single_flight(&qualified, fetch, tag_fn, l1_ttl, l2_ttl)
             .await?;
         serde_json::from_slice(&bytes).map_err(json_err)
     }
 
-    async fn single_flight<T, F, Fut>(
+    async fn single_flight<T, F, Fut, TagFn>(
         &self,
         qualified: &str,
         fetch: F,
+        tag_fn: TagFn,
         l1_ttl: Duration,
         l2_ttl: Duration,
     ) -> Result<Arc<[u8]>, JediError>
@@ -162,6 +192,7 @@ impl KvCache {
         T: Serialize + Send,
         F: FnOnce() -> Fut + Send,
         Fut: std::future::Future<Output = Result<T, JediError>> + Send,
+        TagFn: FnOnce(&T) -> Vec<String> + Send,
     {
         let receiver = match self.inflight.entry(qualified.to_string()) {
             Entry::Occupied(o) => {
@@ -188,13 +219,14 @@ impl KvCache {
         }
 
         let outcome = fetch().await;
-        let (bytes, err_str): (Option<Arc<[u8]>>, Option<String>) = match &outcome {
-            Ok(v) => match serde_json::to_vec(v) {
-                Ok(b) => (Some(Arc::from(b.into_boxed_slice())), None),
-                Err(e) => (None, Some(format!("kv encode: {e}"))),
-            },
-            Err(e) => (None, Some(e.to_string())),
-        };
+        let (bytes, tags, err_str): (Option<Arc<[u8]>>, Vec<String>, Option<String>) =
+            match &outcome {
+                Ok(v) => match serde_json::to_vec(v) {
+                    Ok(b) => (Some(Arc::from(b.into_boxed_slice())), tag_fn(v), None),
+                    Err(e) => (None, Vec::new(), Some(format!("kv encode: {e}"))),
+                },
+                Err(e) => (None, Vec::new(), Some(e.to_string())),
+            };
 
         if let Some((_, tx)) = self.inflight.remove(qualified) {
             let payload = match (&bytes, &err_str) {
@@ -210,16 +242,22 @@ impl KvCache {
             JediError::Internal(err_str.unwrap_or_else(|| "kv: missing body".into()).into())
         })?;
 
-        self.l1_put(qualified.to_string(), Arc::clone(&bytes), l1_ttl)
-            .await;
-        self.l2_put(qualified, bytes.as_ref(), l2_ttl).await;
+        self.l1_put(
+            qualified.to_string(),
+            Arc::clone(&bytes),
+            tags.clone(),
+            l1_ttl,
+        )
+        .await;
+        self.l2_put(qualified, bytes.as_ref(), &tags, l2_ttl).await;
 
         Ok(bytes)
     }
 
     pub async fn invalidate(&self, key: &str) -> Result<(), JediError> {
         let q = self.qualified(key);
-        self.l1.lock().await.pop(&q);
+        let tags = self.l1_pop(&q).await;
+        self.tag_index_remove_key(&q, &tags);
         if let Some(pool) = &self.l2 {
             let _: Result<i64, _> = pool.del(&*q).await;
         }
@@ -228,21 +266,99 @@ impl KvCache {
 
     pub async fn invalidate_prefix(&self, prefix: &str) -> Result<(), JediError> {
         let q = self.qualified(prefix);
-        let mut l1 = self.l1.lock().await;
-        let victims: Vec<String> = l1
-            .iter()
-            .filter_map(|(k, _)| {
-                if k.starts_with(&q) {
-                    Some(k.clone())
-                } else {
-                    None
-                }
-            })
-            .collect();
-        for k in victims {
-            l1.pop(&k);
+        let victims: Vec<(String, Arc<[Arc<str>]>)> = {
+            let mut l1 = self.l1.lock().await;
+            let keys: Vec<String> = l1
+                .iter()
+                .filter_map(|(k, _)| {
+                    if k.starts_with(&q) {
+                        Some(k.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            keys.into_iter()
+                .filter_map(|k| {
+                    let entry = l1.pop(&k)?;
+                    Some((k, entry.tags))
+                })
+                .collect()
+        };
+        for (k, tags) in victims {
+            self.tag_index_remove_key(&k, &tags);
         }
         Ok(())
+    }
+
+    /// Drop every cached entry registered under `tag` from L1 + L2.
+    /// Returns the number of L1 keys purged (L2 deletes happen
+    /// best-effort and may exceed the L1 count when other pods have
+    /// also cached entries under the same tag).
+    ///
+    /// `tag` is namespaced internally — callers pass the bare tag
+    /// (e.g. `"wallet:account:<uuid>"`).
+    pub async fn invalidate_tag(&self, tag: &str) -> Result<usize, JediError> {
+        let qualified_tag: Arc<str> = self.qualified(tag).into();
+
+        let l1_keys: Vec<Arc<str>> = self
+            .tag_index
+            .remove(&qualified_tag)
+            .map(|(_, set)| set.into_iter().collect())
+            .unwrap_or_default();
+        let l1_count = l1_keys.len();
+        {
+            let mut l1 = self.l1.lock().await;
+            for k in &l1_keys {
+                if let Some(entry) = l1.pop(&**k) {
+                    let other_tags: Vec<Arc<str>> = entry
+                        .tags
+                        .iter()
+                        .filter(|t| **t != qualified_tag)
+                        .cloned()
+                        .collect();
+                    drop(other_tags);
+                }
+            }
+        }
+
+        if let Some(pool) = &self.l2 {
+            let tag_set_key = self.tag_set_key(&qualified_tag);
+            let members: Vec<String> = match pool.smembers::<Vec<String>, _>(&*tag_set_key).await {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(error = %e, tag = %tag, "[KvCache] L2 SMEMBERS failed");
+                    Vec::new()
+                }
+            };
+            for m in &members {
+                let _: Result<i64, _> = pool.del(m.as_str()).await;
+            }
+            let _: Result<i64, _> = pool.del(&*tag_set_key).await;
+        }
+
+        Ok(l1_count)
+    }
+
+    fn tag_set_key(&self, qualified_tag: &str) -> String {
+        format!("{}:__tag:{qualified_tag}", self.cfg.namespace)
+    }
+
+    fn tag_index_register(&self, qualified_key: &Arc<str>, tags: &[Arc<str>]) {
+        for tag in tags {
+            self.tag_index
+                .entry(Arc::clone(tag))
+                .or_default()
+                .insert(Arc::clone(qualified_key));
+        }
+    }
+
+    fn tag_index_remove_key(&self, qualified_key: &str, tags: &[Arc<str>]) {
+        for tag in tags {
+            if let Some(set) = self.tag_index.get(tag) {
+                set.remove(qualified_key);
+            }
+        }
     }
 
     fn qualified(&self, key: &str) -> String {
@@ -262,9 +378,24 @@ impl KvCache {
         body
     }
 
-    async fn l1_put(&self, key: String, body: Arc<[u8]>, ttl: Duration) {
+    async fn l1_pop(&self, key: &str) -> Arc<[Arc<str>]> {
+        match self.l1.lock().await.pop(key) {
+            Some(e) => e.tags,
+            None => Arc::from(Vec::<Arc<str>>::new().into_boxed_slice()),
+        }
+    }
+
+    async fn l1_put(&self, key: String, body: Arc<[u8]>, tags: Vec<String>, ttl: Duration) {
+        let qualified_key: Arc<str> = key.clone().into();
+        let tag_arcs: Vec<Arc<str>> = tags
+            .into_iter()
+            .map(|t| Arc::<str>::from(self.qualified(&t).into_boxed_str()))
+            .collect();
+        let tag_slice: Arc<[Arc<str>]> = Arc::from(tag_arcs.clone().into_boxed_slice());
+        self.tag_index_register(&qualified_key, &tag_arcs);
         let entry = L1Entry {
             body,
+            tags: tag_slice,
             expires_at: Instant::now() + ttl,
         };
         self.l1.lock().await.put(key, entry);
@@ -278,7 +409,7 @@ impl KvCache {
         }
     }
 
-    async fn l2_put(&self, key: &str, body: &[u8], ttl: Duration) {
+    async fn l2_put(&self, key: &str, body: &[u8], tags: &[String], ttl: Duration) {
         let Some(pool) = &self.l2 else { return };
         let ttl_ms = ttl.as_millis() as i64;
         let res: Result<(), _> = pool
@@ -286,6 +417,14 @@ impl KvCache {
             .await;
         if let Err(e) = res {
             tracing::warn!(error = %e, key = %key, "[KvCache] L2 put failed");
+            return;
+        }
+        let set_ttl_secs = (ttl.as_secs().saturating_mul(2)).max(1);
+        for tag in tags {
+            let qualified_tag = self.qualified(tag);
+            let tag_set_key = self.tag_set_key(&qualified_tag);
+            let _: Result<i64, _> = pool.sadd(&*tag_set_key, key).await;
+            let _: Result<i64, _> = pool.expire(&*tag_set_key, set_ttl_secs as i64, None).await;
         }
     }
 }
@@ -352,6 +491,103 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invalidate_tag_purges_all_keys_carrying_tag() {
+        let cache = KvCache::new(cfg(), None);
+        let acc_a = uuid::Uuid::new_v4();
+        let acc_b = uuid::Uuid::new_v4();
+
+        let _: u32 = cache
+            .get_or_fetch_json_tagged(
+                "user-1:balance",
+                None,
+                || async { Ok::<u32, JediError>(100) },
+                |_| vec![format!("wallet:account:{acc_a}")],
+            )
+            .await
+            .unwrap();
+        let _: u32 = cache
+            .get_or_fetch_json_tagged(
+                "user-1:coupons",
+                None,
+                || async { Ok::<u32, JediError>(7) },
+                |_| vec![format!("wallet:account:{acc_a}")],
+            )
+            .await
+            .unwrap();
+        let _: u32 = cache
+            .get_or_fetch_json_tagged(
+                "user-2:balance",
+                None,
+                || async { Ok::<u32, JediError>(200) },
+                |_| vec![format!("wallet:account:{acc_b}")],
+            )
+            .await
+            .unwrap();
+
+        let purged = cache
+            .invalidate_tag(&format!("wallet:account:{acc_a}"))
+            .await
+            .unwrap();
+        assert_eq!(purged, 2, "expected both acc_a keys purged");
+
+        let v: u32 = cache
+            .get_or_fetch_json_tagged(
+                "user-1:balance",
+                None,
+                || async { Ok::<u32, JediError>(999) },
+                |_| vec![format!("wallet:account:{acc_a}")],
+            )
+            .await
+            .unwrap();
+        assert_eq!(v, 999);
+
+        let v: u32 = cache
+            .get_or_fetch_json_tagged(
+                "user-2:balance",
+                None,
+                || async { panic!("should be cached") },
+                |_| vec![format!("wallet:account:{acc_b}")],
+            )
+            .await
+            .unwrap();
+        assert_eq!(v, 200);
+    }
+
+    #[tokio::test]
+    async fn invalidate_tag_with_no_members_is_noop() {
+        let cache = KvCache::new(cfg(), None);
+        let purged = cache.invalidate_tag("never-registered").await.unwrap();
+        assert_eq!(purged, 0);
+    }
+
+    #[tokio::test]
+    async fn key_with_multiple_tags_purged_on_any_tag() {
+        let cache = KvCache::new(cfg(), None);
+        let _: u32 = cache
+            .get_or_fetch_json_tagged(
+                "shared",
+                None,
+                || async { Ok::<u32, JediError>(42) },
+                |_| vec!["tag-a".into(), "tag-b".into()],
+            )
+            .await
+            .unwrap();
+
+        cache.invalidate_tag("tag-b").await.unwrap();
+
+        let v: u32 = cache
+            .get_or_fetch_json_tagged(
+                "shared",
+                None,
+                || async { Ok::<u32, JediError>(99) },
+                |_| vec!["tag-a".into(), "tag-b".into()],
+            )
+            .await
+            .unwrap();
+        assert_eq!(v, 99);
+    }
+
+    #[tokio::test]
     async fn populates_l1_on_first_fetch() {
         let cache = KvCache::new(cfg(), None);
         let val: u32 = cache
@@ -359,7 +595,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(val, 42);
-        // Second call: fetch must NOT run (would panic).
         let val2: u32 = cache
             .get_or_fetch_json("k", None, || async { panic!("should not be called") })
             .await
@@ -392,7 +627,6 @@ mod tests {
                 .unwrap();
         }
         cache.invalidate_prefix("wallet").await.unwrap();
-        // wallet:* should miss; market:c should hit.
         let v: u32 = cache
             .get_or_fetch_json("wallet:a", None, || async { Ok::<u32, JediError>(99) })
             .await
@@ -414,7 +648,6 @@ mod tests {
             })
             .await;
         assert!(r.is_err());
-        // Second call must invoke fetch again (no negative caching).
         let v: u32 = cache
             .get_or_fetch_json("k", None, || async { Ok::<u32, JediError>(7) })
             .await

--- a/packages/rust/jedi/src/state/pg.rs
+++ b/packages/rust/jedi/src/state/pg.rs
@@ -501,14 +501,47 @@ impl PgCluster {
             + Send
             + 'static,
     {
+        self.cached_caller_read_tagged(cache, cache_key, ttl, sub, auth_role, f, |_: &T| Vec::new())
+            .await
+    }
+
+    /// [`cached_caller_read`] variant that also registers per-value
+    /// tags so a later [`crate::state::kv::KvCache::invalidate_tag`]
+    /// can purge every key carrying the tag. Tags are derived from
+    /// the fetched value via `tag_fn`, so callers don't need to know
+    /// the response shape at call time.
+    pub async fn cached_caller_read_tagged<T, F, TagFn>(
+        self: &Arc<Self>,
+        cache: &Arc<crate::state::kv::KvCache>,
+        cache_key: &str,
+        ttl: Option<Duration>,
+        sub: Uuid,
+        auth_role: Option<&str>,
+        f: F,
+        tag_fn: TagFn,
+    ) -> Result<T, JediError>
+    where
+        T: serde::Serialize + serde::de::DeserializeOwned + Send + 'static,
+        F: for<'tx> FnOnce(
+                &'tx tokio_postgres::Transaction<'_>,
+            ) -> BoxFuture<'tx, Result<T, JediError>>
+            + Send
+            + 'static,
+        TagFn: FnOnce(&T) -> Vec<String> + Send + 'static,
+    {
         let cluster = Arc::clone(self);
         let owned_role = auth_role.map(|s| s.to_string());
         cache
-            .get_or_fetch_json(cache_key, ttl, move || async move {
-                cluster
-                    .with_caller_read(sub, owned_role.as_deref(), f)
-                    .await
-            })
+            .get_or_fetch_json_tagged(
+                cache_key,
+                ttl,
+                move || async move {
+                    cluster
+                        .with_caller_read(sub, owned_role.as_deref(), f)
+                        .await
+                },
+                tag_fn,
+            )
             .await
     }
 }


### PR DESCRIPTION
Closes the staleness gap left in #12407 — account-keyed service writes (`/service/credit`, `/debit`, `/transfer`) now bust the cached `/me/balance` / `/me/coupons` entries owned by the account, instead of waiting for L1/L2 TTL.

## jedi/kv

`L1Entry` picks up a `tags: Arc<[Arc<str>]>` field. New per-cache `tag_index: DashMap<Arc<str>, DashSet<Arc<str>>>` keeps a reverse `tag → set<key>` index for L1; L2 mirrors this in `<namespace>:__tag:<qualified_tag>` Redis SETs.

**New API:**
```rust
KvCache::get_or_fetch_json_tagged(key, ttl, fetch, tag_fn)
KvCache::invalidate_tag(tag) -> Result<usize, JediError>

PgCluster::cached_caller_read_tagged(cache, key, ttl, sub, role, f, tag_fn)
```

- `tag_fn: FnOnce(&T) -> Vec<String>` derives tags from the fetched value — useful when writes are keyed differently from reads (`service/credit` knows the `account_id`; `/me/balance` is keyed by `user_id`).
- `invalidate_tag` purges L1 via the in-process reverse index, then `SMEMBERS` → `DEL` each member → `DEL` the tag set in L2.
- Tag-set TTL = 2× body TTL so the set outlives its members.
- Swallows L2 errors (best-effort), returns L1 purge count.

**3 new state::kv tests** (16/16 pass under `postgres,valkey,prometheus`):
- `invalidate_tag_purges_all_keys_carrying_tag` — cross-key fan-out
- `invalidate_tag_with_no_members_is_noop`
- `key_with_multiple_tags_purged_on_any_tag` — untag-by-any semantics

## axum-kbve/wallet

**Read tagging:**

| Endpoint | Tags |
|---|---|
| `/me/balance` | `wallet:caller:<user_id>`, `wallet:account:<account_id>` (from `BalanceDto.account_id`) |
| `/me/coupons` | `wallet:caller:<user_id>` |
| `/me/ledger`  | unchanged for now |

**Write hooks:**

| Route | Invalidates |
|---|---|
| `/me/redeem-coupon` | `invalidate_caller_cache(user_id)` |
| `/service/credit` | `invalidate_account_cache(account_id)` **[new]** |
| `/service/debit` | `invalidate_account_cache(account_id)` **[new]** |
| `/service/transfer` | `invalidate_account_cache(from)` + `(to)` **[new]** |
| `/service/credit-user` | `invalidate_caller_cache(user_id)` + `invalidate_account_cache(account_id)` |
| `/service/redeem-coupon` | no hook (redeeming user not in scope) |
| `/service/revoke-coupon` | no hook |

`invalidate_caller_cache` switched from `invalidate_prefix` (L1-only) to `invalidate_tag("wallet:caller:<uuid>")` so it's now cluster-safe in L2.

## Cleanup

Per repo convention (RustDocs + utoipa only), stripped redundant narrative `//` comments from `jedi/src/state/kv.rs` and `axum-kbve/src/transport/ledger.rs`. Kept all `///` rustdoc, `#[utoipa::path(...)]` annotations, and the `SAFETY:` convention block.

## Build verified
- `cargo build -p jedi --no-default-features --features postgres,valkey,prometheus`
- `cargo test -p jedi … --lib state::` — 16/16 pass
- `cargo check -p axum-kbve`

## Test plan
- [x] All build variants + 16/16 jedi tests
- [ ] `POST /service/credit {account_id, …}` then immediate `GET /me/balance` returns updated balance (cache busted via account tag)
- [ ] `POST /service/transfer {from, to, …}` busts both accounts
- [ ] Confirm `kbve_kv_*` metrics increment on hit / miss / invalidate

## Follow-ups (tracked on #12343)
- `/me/ledger` could pick up `wallet:account:<id>` tag too once we plumb account_id into the ledger response shape
- Service-side `redeem-coupon` / `revoke-coupon` would benefit from tagging by `wallet:coupon:<id>` so admin actions bust the owner's `/me/coupons`