### PR TITLE
feat(cryptothrone): P2 — NetSync system + headless sim tests (#12422)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -30,6 +30,12 @@ import {
 	type Interactable,
 } from '../data/interactables';
 import { EntityStore, type EntityCat } from '../ecs/store';
+import {
+	applyEntitySync,
+	type SyncBridge,
+	type SyncResolvers,
+	type SyncState,
+} from '../systems/netSync';
 
 interface EntityRefs {
 	sprite: Phaser.GameObjects.Sprite;
@@ -102,6 +108,8 @@ export class CloudCityScene extends Scene {
 	private slotUsername = new Map<number, string>();
 	private myEid = -1;
 	private store = new EntityStore<EntityRefs>();
+	private syncBridge!: SyncBridge<EntityRefs>;
+	private syncResolvers!: SyncResolvers;
 	private kindRegistry = new Map<number, KindEntry>();
 	private cursors!: Phaser.Types.Input.Keyboard.CursorKeys;
 	private wasd!: {
@@ -225,6 +233,7 @@ export class CloudCityScene extends Scene {
 		this.attackKey = this.input.keyboard!.addKey(Codes.SPACE, false);
 		this.interactKey = this.input.keyboard!.addKey(Codes.E, false);
 		this.interactables = getZoneInteractables(this.zone.key);
+		this.initSyncSystems();
 
 		const cfg = getCtNetConfig();
 		if (!cfg) {
@@ -485,25 +494,9 @@ export class CloudCityScene extends Scene {
 		);
 	}
 
-	private applySnapshot(snap: Snapshot) {
-		const seen = new Set<number>();
-		for (const pv of snap.players) {
-			this.slotUsername.set(pv.slot, pv.kbve_username);
-		}
-
-		for (const e of snap.entities) {
-			if (
-				e.eid === this.myEid &&
-				(e.hp !== this.myHp || e.max_hp !== this.myMaxHp)
-			) {
-				this.myHp = e.hp;
-				this.myMaxHp = e.max_hp;
-				laserEvents.emit('player:stats', {
-					stats: { hp: e.hp, maxHp: e.max_hp },
-				});
-			}
-			seen.add(e.eid);
-			if (!this.store.has(e.eid)) {
+	private initSyncSystems() {
+		this.syncBridge = {
+			create: (e, label) => {
 				const { sprite, mapping } = this.makeSprite(e.kind, e.owner);
 				const charId = `e${e.eid}`;
 				const conf: Record<string, unknown> = {
@@ -518,14 +511,6 @@ export class CloudCityScene extends Scene {
 				}
 				this.gridEngine.addCharacter(conf);
 				const refs: EntityRefs = { sprite, charId };
-				const ref = this.kindRef(e.kind);
-				const cat = this.catName(e.kind);
-				let label: string | undefined;
-				if (cat === 'player') {
-					label = this.slotUsername.get(e.owner);
-				} else if (cat === 'npc') {
-					label = ref ? (getNPCByRef(ref)?.name ?? ref) : undefined;
-				}
 				if (label) {
 					const top = sprite.getTopCenter();
 					refs.nameplate = this.add
@@ -539,81 +524,71 @@ export class CloudCityScene extends Scene {
 						.setOrigin(0.5, 1)
 						.setDepth(this.entityDepth + 2);
 				}
-				this.store.spawn(
-					e.eid,
-					{
-						tile: { x: e.tile.x, y: e.tile.y },
-						kind: e.kind,
-						cat,
-						owner: e.owner,
-						hostile: !!(ref && isHostileRef(ref)),
-						hp: e.hp,
-						maxHp: e.max_hp,
-					},
-					refs,
-				);
-				if (
-					cat === 'player' &&
-					e.owner === this.mySlot &&
-					this.myEid < 0
-				) {
-					this.myEid = e.eid;
-					this.cameras.main.startFollow(sprite, true);
-					this.predicted = { x: e.tile.x, y: e.tile.y };
-					this.predictSeeded = true;
+				return refs;
+			},
+			move: (refs, tile) => this.gridEngine.moveTo(refs.charId, tile),
+			setPos: (refs, tile) =>
+				this.gridEngine.setPosition(refs.charId, tile),
+			follow: (refs) => this.cameras.main.startFollow(refs.sprite, true),
+			remove: (refs) => {
+				if (this.gridEngine.hasCharacter(refs.charId)) {
+					this.gridEngine.removeCharacter(refs.charId);
 				}
-			} else if (e.eid === this.myEid) {
-				// Reconcile prediction: trust the local position unless it
-				// drifts too far from authority (rejected move / lag spike),
-				// then snap back to the server.
-				const drift = Math.max(
-					Math.abs(e.tile.x - this.predicted.x),
-					Math.abs(e.tile.y - this.predicted.y),
-				);
-				if (drift > 2) {
-					this.predicted = { x: e.tile.x, y: e.tile.y };
-					const refs = this.store.refs(e.eid);
-					if (refs) {
-						this.gridEngine.setPosition(refs.charId, {
-							x: e.tile.x,
-							y: e.tile.y,
-						});
-					}
+				refs.hpBar?.destroy();
+				refs.nameplate?.destroy();
+				refs.sprite.destroy();
+			},
+		};
+		this.syncResolvers = {
+			cat: (kind) => this.catName(kind),
+			hostile: (kind) => {
+				const ref = this.kindRef(kind);
+				return !!(ref && isHostileRef(ref));
+			},
+			label: (e, cat) => {
+				if (cat === 'player') return this.slotUsername.get(e.owner);
+				if (cat === 'npc') {
+					const ref = this.kindRef(e.kind);
+					return ref ? (getNPCByRef(ref)?.name ?? ref) : undefined;
 				}
-				this.store.update(e.eid, {
-					tile: { ...this.predicted },
-					hp: e.hp,
-					maxHp: e.max_hp,
-				});
-			} else {
-				const cur = this.store.tile(e.eid);
-				const refs = this.store.refs(e.eid);
-				if (cur && refs && (cur.x !== e.tile.x || cur.y !== e.tile.y)) {
-					this.gridEngine.moveTo(refs.charId, {
-						x: e.tile.x,
-						y: e.tile.y,
-					});
-				}
-				this.store.update(e.eid, {
-					tile: { x: e.tile.x, y: e.tile.y },
-					hp: e.hp,
-					maxHp: e.max_hp,
-				});
-			}
+				return undefined;
+			},
+		};
+	}
+
+	private applySnapshot(snap: Snapshot) {
+		for (const pv of snap.players) {
+			this.slotUsername.set(pv.slot, pv.kbve_username);
 		}
 
-		for (const [serverEid, , refs] of [...this.store.entries()]) {
-			if (seen.has(serverEid)) continue;
-			if (this.gridEngine.hasCharacter(refs.charId)) {
-				this.gridEngine.removeCharacter(refs.charId);
+		const state: SyncState = {
+			myEid: this.myEid,
+			mySlot: this.mySlot,
+			predicted: this.predicted,
+			predictSeeded: this.predictSeeded,
+		};
+		const despawned = applyEntitySync(
+			snap.entities,
+			this.store,
+			this.syncBridge,
+			this.syncResolvers,
+			state,
+		);
+		this.myEid = state.myEid;
+		this.predicted = state.predicted;
+		this.predictSeeded = state.predictSeeded;
+		for (const eid of despawned) {
+			if (this.pendingAction?.eid === eid) this.pendingAction = null;
+		}
+
+		if (this.myEid >= 0) {
+			const hp = this.store.hp(this.myEid);
+			const maxHp = this.store.maxHp(this.myEid);
+			if (hp !== this.myHp || maxHp !== this.myMaxHp) {
+				this.myHp = hp;
+				this.myMaxHp = maxHp;
+				laserEvents.emit('player:stats', { stats: { hp, maxHp } });
 			}
-			refs.hpBar?.destroy();
-			refs.nameplate?.destroy();
-			refs.sprite.destroy();
-			this.store.despawn(serverEid);
-			if (serverEid === this.myEid) this.myEid = -1;
-			if (this.pendingAction?.eid === serverEid)
-				this.pendingAction = null;
 		}
 
 		this.checkHostileProximity();

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/netSync.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/netSync.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import type { EntityDelta } from '@kbve/laser';
+import { EntityStore, type EntityCat } from '../ecs/store';
+import {
+	applyEntitySync,
+	type SyncBridge,
+	type SyncResolvers,
+	type SyncState,
+} from './netSync';
+
+interface Ref {
+	id: number;
+}
+
+// Kind convention for the stubs: 1 = player, 2 = npc, 3 = item; 9 = hostile npc.
+function delta(p: {
+	eid: number;
+	kind: number;
+	owner?: number;
+	x: number;
+	y: number;
+	hp?: number;
+	maxHp?: number;
+}): EntityDelta {
+	return {
+		eid: p.eid,
+		kind: p.kind,
+		owner: p.owner ?? 0xffff,
+		tile: { x: p.x, y: p.y },
+		hp: p.hp ?? 10,
+		max_hp: p.maxHp ?? 10,
+	} as unknown as EntityDelta;
+}
+
+function harness(mySlot = 7) {
+	const store = new EntityStore<Ref>();
+	const calls: string[] = [];
+	const bridge: SyncBridge<Ref> = {
+		create: (e) => {
+			calls.push(`create:${e.eid}`);
+			return { id: e.eid };
+		},
+		move: (r, t) => calls.push(`move:${r.id}->${t.x},${t.y}`),
+		setPos: (r, t) => calls.push(`setPos:${r.id}->${t.x},${t.y}`),
+		follow: (r) => calls.push(`follow:${r.id}`),
+		remove: (r) => calls.push(`remove:${r.id}`),
+	};
+	const resolve: SyncResolvers = {
+		cat: (k): EntityCat => (k === 1 ? 'player' : k === 3 ? 'item' : 'npc'),
+		hostile: (k) => k === 9,
+		label: (e, cat) => `${cat}:${e.eid}`,
+	};
+	const state: SyncState = {
+		myEid: -1,
+		mySlot,
+		predicted: { x: 0, y: 0 },
+		predictSeeded: false,
+	};
+	return { store, calls, bridge, resolve, state };
+}
+
+describe('applyEntitySync', () => {
+	it('spawns new entities and stores their data', () => {
+		const h = harness();
+		applyEntitySync(
+			[delta({ eid: 2, kind: 2, x: 3, y: 4, hp: 6 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		expect(h.store.has(2)).toBe(true);
+		expect(h.store.tile(2)).toEqual({ x: 3, y: 4 });
+		expect(h.store.hp(2)).toBe(6);
+		expect(h.calls).toContain('create:2');
+	});
+
+	it('seeds myEid + prediction on the local player and follows it', () => {
+		const h = harness(7);
+		applyEntitySync(
+			[delta({ eid: 1, kind: 1, owner: 7, x: 5, y: 5 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		expect(h.state.myEid).toBe(1);
+		expect(h.state.predictSeeded).toBe(true);
+		expect(h.state.predicted).toEqual({ x: 5, y: 5 });
+		expect(h.calls).toContain('follow:1');
+	});
+
+	it('does NOT claim a player owned by another slot', () => {
+		const h = harness(7);
+		applyEntitySync(
+			[delta({ eid: 1, kind: 1, owner: 99, x: 5, y: 5 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		expect(h.state.myEid).toBe(-1);
+	});
+
+	it('reconciles the local player: keeps prediction within drift, snaps past it', () => {
+		const h = harness(7);
+		applyEntitySync(
+			[delta({ eid: 1, kind: 1, owner: 7, x: 5, y: 5 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		h.state.predicted = { x: 6, y: 5 }; // client predicted one step
+		// server still at 5,5 → drift 1 ≤ 2 → keep prediction, no setPos
+		applyEntitySync(
+			[delta({ eid: 1, kind: 1, owner: 7, x: 5, y: 5 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		expect(h.state.predicted).toEqual({ x: 6, y: 5 });
+		expect(h.calls.filter((c) => c.startsWith('setPos'))).toHaveLength(0);
+
+		// server jumps to 10,10 → drift 4 > 2 → snap back
+		applyEntitySync(
+			[delta({ eid: 1, kind: 1, owner: 7, x: 10, y: 10 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		expect(h.state.predicted).toEqual({ x: 10, y: 10 });
+		expect(h.calls).toContain('setPos:1->10,10');
+	});
+
+	it('interpolates other entities toward the authoritative tile', () => {
+		const h = harness();
+		applyEntitySync(
+			[delta({ eid: 2, kind: 2, x: 1, y: 1 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		applyEntitySync(
+			[delta({ eid: 2, kind: 2, x: 2, y: 1 })],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		expect(h.calls).toContain('move:2->2,1');
+		expect(h.store.tile(2)).toEqual({ x: 2, y: 1 });
+	});
+
+	it('despawns entities absent from the snapshot and returns their ids', () => {
+		const h = harness(7);
+		applyEntitySync(
+			[
+				delta({ eid: 1, kind: 1, owner: 7, x: 5, y: 5 }),
+				delta({ eid: 2, kind: 2, x: 3, y: 3 }),
+			],
+			h.store,
+			h.bridge,
+			h.resolve,
+			h.state,
+		);
+		// next snapshot drops both 2 and the local player
+		const gone = applyEntitySync([], h.store, h.bridge, h.resolve, h.state);
+		expect(gone.sort()).toEqual([1, 2]);
+		expect(h.store.has(2)).toBe(false);
+		expect(h.state.myEid).toBe(-1);
+		expect(h.calls).toContain('remove:2');
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/netSync.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/netSync.ts
@@ -1,0 +1,123 @@
+import type { EntityDelta } from '@kbve/laser';
+import type { EntityCat, EntityStore } from '../ecs/store';
+
+export interface TileXY {
+	x: number;
+	y: number;
+}
+
+/**
+ * Phaser/gridEngine effects, behind an interface so the sync dispatch is
+ * headlessly testable (stub it in jsdom). `create` builds the managed refs
+ * (sprite + grid character + nameplate); the rest mutate/tear them down.
+ */
+export interface SyncBridge<R> {
+	create(e: EntityDelta, label: string | undefined): R;
+	move(refs: R, tile: TileXY): void;
+	setPos(refs: R, tile: TileXY): void;
+	follow(refs: R): void;
+	remove(refs: R): void;
+}
+
+export interface SyncResolvers {
+	cat(kind: number): EntityCat;
+	hostile(kind: number): boolean;
+	label(e: EntityDelta, cat: EntityCat): string | undefined;
+}
+
+/** Mutable local-player + prediction state the sync reads and advances. */
+export interface SyncState {
+	myEid: number;
+	mySlot: number;
+	predicted: TileXY;
+	predictSeeded: boolean;
+}
+
+/**
+ * Reconcile a snapshot's entity list into the store + bridge:
+ *   - spawn entities new this frame
+ *   - the local player reconciles against client prediction (snap back only on
+ *     drift > 2)
+ *   - everyone else interpolates toward the authoritative tile
+ *   - entities absent from the snapshot despawn
+ * Pure dispatch — all rendering/gridEngine lives behind `bridge`. Mutates
+ * `state` (seeds myEid + prediction on the local player's first appearance,
+ * clears myEid on despawn) and returns the despawned server eids so the caller
+ * can drop dependent state (e.g. a pending action).
+ */
+export function applyEntitySync<R>(
+	entities: readonly EntityDelta[],
+	store: EntityStore<R>,
+	bridge: SyncBridge<R>,
+	resolve: SyncResolvers,
+	state: SyncState,
+): number[] {
+	const seen = new Set<number>();
+	for (const e of entities) {
+		seen.add(e.eid);
+		const cat = resolve.cat(e.kind);
+		if (!store.has(e.eid)) {
+			const label = resolve.label(e, cat);
+			const refs = bridge.create(e, label);
+			store.spawn(
+				e.eid,
+				{
+					tile: { x: e.tile.x, y: e.tile.y },
+					kind: e.kind,
+					cat,
+					owner: e.owner,
+					hostile: resolve.hostile(e.kind),
+					hp: e.hp,
+					maxHp: e.max_hp,
+				},
+				refs,
+			);
+			if (
+				cat === 'player' &&
+				e.owner === state.mySlot &&
+				state.myEid < 0
+			) {
+				state.myEid = e.eid;
+				bridge.follow(refs);
+				state.predicted = { x: e.tile.x, y: e.tile.y };
+				state.predictSeeded = true;
+			}
+		} else if (e.eid === state.myEid) {
+			const drift = Math.max(
+				Math.abs(e.tile.x - state.predicted.x),
+				Math.abs(e.tile.y - state.predicted.y),
+			);
+			if (drift > 2) {
+				state.predicted = { x: e.tile.x, y: e.tile.y };
+				const refs = store.refs(e.eid);
+				if (refs) bridge.setPos(refs, e.tile);
+			}
+			store.update(e.eid, {
+				tile: { ...state.predicted },
+				hp: e.hp,
+				maxHp: e.max_hp,
+			});
+		} else {
+			const cur = store.tile(e.eid);
+			const refs = store.refs(e.eid);
+			if (cur && refs && (cur.x !== e.tile.x || cur.y !== e.tile.y)) {
+				bridge.move(refs, e.tile);
+			}
+			store.update(e.eid, {
+				tile: { x: e.tile.x, y: e.tile.y },
+				hp: e.hp,
+				maxHp: e.max_hp,
+			});
+		}
+	}
+
+	const despawned: number[] = [];
+	for (const [serverEid, , refs] of [...store.entries()]) {
+		if (seen.has(serverEid)) continue;
+		bridge.remove(refs);
+		store.despawn(serverEid);
+		despawned.push(serverEid);
+		if (serverEid === state.myEid) state.myEid = -1;
+	}
+	return despawned;
+}


### PR DESCRIPTION
**Phase 2** of #12422 — and the verification milestone you flagged.

The entity-sync dispatch (spawn / local-player reconcile / interpolate / despawn) moves out of `CloudCityScene.applySnapshot` into a pure, testable `applyEntitySync()`:
- all Phaser + gridEngine effects behind a **`SyncBridge`** (create/move/setPos/follow/remove)
- local-player + prediction state behind **`SyncState`**
- **type-only imports** — neither the system nor its test pulls the Phaser barrel

## Closes the P1 verification gap
The exact logic I *couldn't* check headlessly in P1 is now covered by **6 sim tests** over synthetic snapshot streams (jsdom, no Phaser, no server):
- spawn → store data + `create` called
- local-player seeding (myEid/predicted/follow) + ownership (won't claim another slot)
- **drift reconcile**: keep prediction when drift ≤ 2, snap (`setPos`) when > 2
- interpolation (`move`) toward authoritative tile
- despawn cleanup + returned ids

The scene builds the bridge/resolvers in `initSyncSystems()` and delegates; `player:stats` / roster / proximity / `world:time` orchestration stays in the scene. Behaviour-preserving.

## Verified
scoped `tsc` 0 new errors · **61 cryptothrone tests** (10 files, +6 sim) · build-discord resolves (204 modules).

Stacked on #12431 (P1). Next: P3 extracts Interaction + Prediction systems (now sim-testable the same way), then P4 the thin scene shell.