### PR TITLE
fix(chuck): beta server_target → chuckServer (real target in external repo)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.196",
+			"version": "1.0.199",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.18",
+			"version": "0.1.28",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -120,7 +120,7 @@
 		{
 			"key": "cryptothrone_server",
 			"app_name": "cryptothrone-server",
-			"version": "0.0.10",
+			"version": "0.0.16",
 			"version_toml": "apps/agones/cryptothrone/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
 			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",
@@ -161,7 +161,7 @@
 		{
 			"key": "edge",
 			"app_name": "edge",
-			"version": "0.1.42",
+			"version": "0.1.43",
 			"version_toml": "apps/kbve/edge/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/edge.mdx",
 			"version_target": "apps/kbve/edge/deno.json",
@@ -259,7 +259,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.22",
+			"version": "0.1.25",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",
@@ -1083,7 +1083,7 @@
 					"Linux"
 				],
 				"external_repo_url": "https://github.com/kbve/chuck",
-				"server_target": "chuckServerBeta",
+				"server_target": "chuckServer",
 				"server_config": "Shipping",
 				"client_config": "Shipping",
 				"maps": [

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -29,7 +29,7 @@ engine:
         - Win64
         - Linux
     client_config: Shipping
-    server_target: chuckServerBeta
+    server_target: chuckServer
     server_config: Shipping
     game_mode: /Script/Chuck.ChuckGameMode
     maps:

--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
@@ -108,7 +108,7 @@ spec:
                           volumeMounts:
                               - name: server-binary
                                 mountPath: /server
-                                subPath: chuckServerBeta
+                                subPath: chuckServer
                     volumes:
                         - name: server-binary
                           persistentVolumeClaim:


### PR DESCRIPTION
## What the cook exposed (after #12418 fixed the mount)

```
Setting up ProjectParams for /project/chuck.uproject
Unable to find target 'chuckServerBeta'
```

`chuckServerBeta` only ever existed in the **monorepo** `Source/`. The external `KBVE/chuck` repo we now build from has: `chuck`, `chuckEditor`, **`chuckServer`** — no per-channel server targets.

## Fix (our side)

- beta `engine.server_target`: `chuckServerBeta` → **`chuckServer`** (the real target; `server_config: Shipping` unchanged — that's what makes it the beta channel).
- `ows-chuckrpg-beta` fleet PVC subPath: `chuckServerBeta` → `chuckServer`, so it finds the deployed binary at `/mnt/longhorn/ows-server/chuckServer/<version>`.
- Manifest regenerated (build + sync), confirmed `server_target: chuckServer`.

## Note (future)

Per-channel server *targets* are gone (external repo has one `chuckServer`). When dev's server build comes online it'll also be `chuckServer` → same PVC subPath as beta. Distinguish channels by the deploy path (tenant/key) then, not the target name. Fine for beta-only now.

After merge → dev: the cook resolves `chuckServer` → builds → archives → deploys to the PVC subPath the beta fleet mounts.