### PR TITLE
test(simgrid): axum WS + sim integration tests; unblock cryptothrone-server lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,6 +1417,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
+ "serde_urlencoded",
  "sha1",
  "sync_wrapper 1.0.2",
  "tokio",
@@ -1424,6 +1425,7 @@ dependencies = [
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1496,6 +1498,7 @@ dependencies = [
  "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -15136,6 +15139,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tracing",
 ]
 

--- a/apps/agones/cryptothrone/server/src/db/kv_cache.rs
+++ b/apps/agones/cryptothrone/server/src/db/kv_cache.rs
@@ -12,6 +12,7 @@ pub async fn init_kv_cache() -> bool {
     KV_CACHE.set(cache).is_ok()
 }
 
+#[allow(dead_code)]
 pub fn get_kv_cache() -> Option<&'static Arc<KvCache>> {
     KV_CACHE.get()
 }

--- a/apps/agones/cryptothrone/server/src/db/pg_cluster.rs
+++ b/apps/agones/cryptothrone/server/src/db/pg_cluster.rs
@@ -26,6 +26,7 @@ pub async fn init_pg_cluster() -> bool {
         .is_some()
 }
 
+#[allow(dead_code)]
 pub fn get_pg_cluster() -> Option<&'static Arc<PgCluster>> {
     PG_CLUSTER.get().and_then(|c| c.as_ref())
 }

--- a/packages/rust/jedi/src/lib.rs
+++ b/packages/rust/jedi/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::doc_overindented_list_items)]
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/packages/rust/jedi/src/state/kv.rs
+++ b/packages/rust/jedi/src/state/kv.rs
@@ -77,6 +77,7 @@ pub struct KvCache {
     cfg: KvCacheConfig,
     l1: Mutex<LruCache<String, L1Entry>>,
     l2: Option<ValkeyPool>,
+    #[allow(clippy::type_complexity)]
     inflight: DashMap<String, broadcast::Sender<Result<Arc<[u8]>, String>>>,
     /// `tag → set<qualified_key>` reverse index for L1 invalidation.
     /// L2 mirrors this in `<namespace>:tag:<tag>` Redis SETs.

--- a/packages/rust/jedi/src/state/pg.rs
+++ b/packages/rust/jedi/src/state/pg.rs
@@ -510,6 +510,7 @@ impl PgCluster {
     /// can purge every key carrying the tag. Tags are derived from
     /// the fetched value via `tag_fn`, so callers don't need to know
     /// the response shape at call time.
+    #[allow(clippy::too_many_arguments)]
     pub async fn cached_caller_read_tagged<T, F, TagFn>(
         self: &Arc<Self>,
         cache: &Arc<crate::state::kv::KvCache>,

--- a/packages/rust/simgrid/Cargo.toml
+++ b/packages/rust/simgrid/Cargo.toml
@@ -28,3 +28,11 @@ tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "sync", "ti
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 jsonwebtoken = { version = "9.3", default-features = false, optional = true }
 tracing = "0.1"
+
+[dev-dependencies]
+# Integration tests spin the real axum WS router + sim loop and drive a client.
+tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "time", "net"] }
+axum = { version = "0.7", features = ["ws", "tokio"] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"
+serde_json = "1.0"

--- a/packages/rust/simgrid/tests/ws_flow.rs
+++ b/packages/rust/simgrid/tests/ws_flow.rs
@@ -1,0 +1,187 @@
+//! Integration tests for the full axum WS + sim loop: a real client joins the
+//! router, the bevy sim spawns/moves the player, snapshots stream back, and the
+//! single-session + capacity rules hold. Spins everything in-process on an
+//! ephemeral port — no network, no auth (empty jwt_secret -> username trusted).
+
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+
+use simgrid::proto::{
+    self, ClientFrame, ClientMessage, Dir, Input, JoinMatch, PROTOCOL_VERSION, ServerEvent,
+};
+use simgrid::{
+    KindRegistry, SNAPSHOT_BROADCAST_CAPACITY, ServerState, SimConfig, WalkableMap, build_app,
+    proto::Tile, router, run_sim_loop,
+};
+use tokio::sync::{broadcast, mpsc};
+
+type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+const SPAWN: Tile = Tile::new(5, 5);
+
+/// Boot a sim + router on an ephemeral port; returns the ws:// URL.
+async fn spawn_server(capacity: usize) -> String {
+    let (snap_tx, _keep) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+    let (input_tx, input_rx) = mpsc::unbounded_channel();
+    let state = ServerState::new(snap_tx.clone(), input_tx, 7, Vec::new(), true, capacity);
+    let roster = state.roster.clone();
+    let config = SimConfig {
+        spawn: SPAWN,
+        ticks_per_tile: 1,
+        ..Default::default()
+    };
+    let map = WalkableMap::open(20, 20);
+    let registry = KindRegistry::new();
+
+    // Sim runs on its own current-thread runtime, like the gameserver binary.
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("sim runtime");
+        let app = build_app(snap_tx, input_rx, roster, 7, config, map, registry);
+        rt.block_on(run_sim_loop(app));
+    });
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, router(state)).await;
+    });
+    format!("ws://{addr}/ws")
+}
+
+fn join(user: &str) -> Message {
+    let jm = ClientMessage::JoinMatch(JoinMatch {
+        protocol: PROTOCOL_VERSION,
+        jwt: String::new(),
+        kbve_username: user.to_string(),
+    });
+    Message::Text(proto::encode_json(&jm).expect("encode join"))
+}
+
+/// Next decoded ServerEvent within a timeout, or None.
+async fn next_event(ws: &mut Ws) -> Option<ServerEvent> {
+    let deadline = Duration::from_secs(5);
+    loop {
+        let msg = tokio::time::timeout(deadline, ws.next())
+            .await
+            .ok()??
+            .ok()?;
+        match msg {
+            Message::Text(t) => {
+                if let Ok(evt) = proto::decode_json::<ServerEvent>(&t) {
+                    return Some(evt);
+                }
+            }
+            Message::Close(_) => return None,
+            _ => {}
+        }
+    }
+}
+
+async fn join_and_welcome(url: &str, user: &str) -> Ws {
+    let (mut ws, _) = connect_async(url).await.expect("connect");
+    ws.send(join(user)).await.expect("send join");
+    match next_event(&mut ws).await {
+        Some(ServerEvent::Welcome { protocol, .. }) => {
+            assert_eq!(protocol, PROTOCOL_VERSION);
+        }
+        other => panic!("expected Welcome, got {other:?}"),
+    }
+    ws
+}
+
+#[tokio::test]
+async fn join_spawns_player_at_spawn_tile() {
+    let url = spawn_server(8).await;
+    let mut ws = join_and_welcome(&url, "ann").await;
+
+    // A snapshot should soon carry our player entity at the spawn tile.
+    for _ in 0..200 {
+        if let Some(ServerEvent::Snapshot(snap)) = next_event(&mut ws).await {
+            if let Some(e) = snap.entities.iter().find(|e| e.tile == SPAWN) {
+                assert_eq!(e.tile, SPAWN);
+                return;
+            }
+        }
+    }
+    panic!("never saw the player spawn at {SPAWN:?}");
+}
+
+#[tokio::test]
+async fn step_input_moves_player() {
+    let url = spawn_server(8).await;
+    let mut ws = join_and_welcome(&url, "mover").await;
+
+    // Wait for the spawn snapshot.
+    let mut start_y = None;
+    for _ in 0..200 {
+        if let Some(ServerEvent::Snapshot(s)) = next_event(&mut ws).await {
+            if let Some(e) = s.entities.iter().find(|e| e.tile.x == SPAWN.x) {
+                start_y = Some(e.tile.y);
+                break;
+            }
+        }
+    }
+    let start_y = start_y.expect("player spawned");
+
+    // Step up a few times; y should decrease.
+    let frame = ClientMessage::Frame(ClientFrame {
+        client_tick: 1,
+        inputs: vec![Input::Step { dir: Dir::Up }],
+    });
+    for _ in 0..5 {
+        ws.send(Message::Text(proto::encode_json(&frame).unwrap()))
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(120)).await;
+    }
+
+    for _ in 0..200 {
+        if let Some(ServerEvent::Snapshot(s)) = next_event(&mut ws).await {
+            if let Some(e) = s.entities.iter().find(|e| e.tile.x == SPAWN.x) {
+                if e.tile.y < start_y {
+                    return;
+                }
+            }
+        }
+    }
+    panic!("player never moved up from y={start_y}");
+}
+
+#[tokio::test]
+async fn second_login_evicts_first() {
+    let url = spawn_server(8).await;
+    let mut first = join_and_welcome(&url, "dup").await;
+    let _second = join_and_welcome(&url, "dup").await;
+
+    // The first session should be disconnected (stream ends) by the newest-wins
+    // eviction once "dup" reconnects.
+    for _ in 0..200 {
+        match next_event(&mut first).await {
+            None => return, // closed/evicted
+            Some(_) => continue,
+        }
+    }
+    panic!("first session for duplicate username was never evicted");
+}
+
+#[tokio::test]
+async fn full_match_rejects_extra_player() {
+    let url = spawn_server(1).await;
+    let _first = join_and_welcome(&url, "one").await;
+
+    let (mut second, _) = connect_async(&url).await.expect("connect");
+    second.send(join("two")).await.expect("send join");
+    match next_event(&mut second).await {
+        Some(ServerEvent::Reject { reason }) => assert!(reason.contains("full")),
+        other => panic!("expected Reject for a full match, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## What

In-process integration tests for simgrid: boot the **real** axum WS router + bevy sim loop on an ephemeral port, drive a `tokio-tungstenite` client end-to-end.

Cases (`packages/rust/simgrid/tests/ws_flow.rs`):
- join -> `Welcome` (protocol match)
- player spawns at the configured spawn tile (snapshot)
- `Step` input moves the player
- second login for same username **evicts** the first session (newest-wins)
- join to a full match -> `Reject`

All 4 pass (`cargo test --test ws_flow`).

## Also

`nx run cryptothrone-server:lint` was red under **clippy 1.94** (new lints on pre-existing code, unrelated to the tests):
- jedi: `doc_overindented_list_items` (crate allow), `too_many_arguments`, `type_complexity` (targeted allows)
- cryptothrone-server: `dead_code` on the not-yet-wired `get_kv_cache`/`get_pg_cluster` getters

Lint now green (exit 0).

No shipped behavior change -> no version bump.