### PR TITLE
feat(jedi/forgejo): branches, tags, release assets, team repos, contents, packages, GPG

### DIFF
--- a/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
+++ b/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
@@ -101,6 +101,8 @@ pub struct ListQuery {
     #[serde(rename = "type")]
     kind: Option<String>,
     purge: Option<bool>,
+    #[serde(rename = "ref")]
+    git_ref: Option<String>,
 }
 
 impl ListQuery {
@@ -880,6 +882,186 @@ async fn delete_user_key(headers: HeaderMap, Path((login, id)): Path<(String, u6
     reply!(c.delete_user_key(&login, id).await)
 }
 
+async fn user_gpg_keys(
+    headers: HeaderMap,
+    Path(login): Path<String>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_user_gpg_keys(&login, q.limit()).await)
+}
+
+// ── Branches / tags / assets ─────────────────────────────────────────
+
+async fn get_branch(
+    headers: HeaderMap,
+    Path((owner, repo, branch)): Path<(String, String, String)>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.get_branch(&owner, &repo, &branch).await)
+}
+
+async fn create_branch(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_branch(&owner, &repo, &body).await)
+}
+
+async fn delete_branch(
+    headers: HeaderMap,
+    Path((owner, repo, branch)): Path<(String, String, String)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_branch(&owner, &repo, &branch).await)
+}
+
+async fn edit_protection(
+    headers: HeaderMap,
+    Path((owner, repo, name)): Path<(String, String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_branch_protection(&owner, &repo, &name, &body).await)
+}
+
+async fn tags(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_tags(&owner, &repo, q.limit()).await)
+}
+
+async fn create_tag(
+    headers: HeaderMap,
+    Path((owner, repo)): Path<(String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_tag(&owner, &repo, &body).await)
+}
+
+async fn delete_tag(
+    headers: HeaderMap,
+    Path((owner, repo, tag)): Path<(String, String, String)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_tag(&owner, &repo, &tag).await)
+}
+
+async fn release_assets(
+    headers: HeaderMap,
+    Path((owner, repo, release_id)): Path<(String, String, u64)>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_release_assets(&owner, &repo, release_id).await)
+}
+
+async fn delete_release_asset(
+    headers: HeaderMap,
+    Path((owner, repo, release_id, asset_id)): Path<(String, String, u64, u64)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(
+        c.delete_release_asset(&owner, &repo, release_id, asset_id)
+            .await
+    )
+}
+
+// ── Teams (extended) ─────────────────────────────────────────────────
+
+async fn get_team(headers: HeaderMap, Path(team_id): Path<u64>) -> Response {
+    let c = vc!(headers);
+    reply!(c.get_team(team_id).await)
+}
+
+async fn edit_team(
+    headers: HeaderMap,
+    Path(team_id): Path<u64>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.edit_team(team_id, &body).await)
+}
+
+async fn team_repos(
+    headers: HeaderMap,
+    Path(team_id): Path<u64>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_team_repos(team_id, q.limit()).await)
+}
+
+async fn add_team_repo(
+    headers: HeaderMap,
+    Path((team_id, org, repo)): Path<(u64, String, String)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.add_team_repo(team_id, &org, &repo).await)
+}
+
+async fn remove_team_repo(
+    headers: HeaderMap,
+    Path((team_id, org, repo)): Path<(u64, String, String)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.remove_team_repo(team_id, &org, &repo).await)
+}
+
+// ── Repository contents / packages ───────────────────────────────────
+
+async fn contents(
+    headers: HeaderMap,
+    Path((owner, repo, path)): Path<(String, String, String)>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(
+        c.list_contents(&owner, &repo, &path, q.git_ref.as_deref())
+            .await
+    )
+}
+
+async fn put_file(
+    headers: HeaderMap,
+    Path((owner, repo, path)): Path<(String, String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.create_or_update_file(&owner, &repo, &path, &body).await)
+}
+
+async fn delete_file(
+    headers: HeaderMap,
+    Path((owner, repo, path)): Path<(String, String, String)>,
+    Json(body): Json<Value>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_file(&owner, &repo, &path, &body).await)
+}
+
+async fn packages(
+    headers: HeaderMap,
+    Path(owner): Path<String>,
+    q: axum::extract::Query<ListQuery>,
+) -> Response {
+    let c = vc!(headers);
+    reply!(c.list_packages(&owner, q.page(), q.limit()).await)
+}
+
+async fn delete_package(
+    headers: HeaderMap,
+    Path((owner, kind, name, version)): Path<(String, String, String, String)>,
+) -> Response {
+    let c = mc!(headers);
+    reply!(c.delete_package(&owner, &kind, &name, &version).await)
+}
+
 async fn run_cron(headers: HeaderMap, Path(task): Path<String>) -> Response {
     let c = mc!(headers);
     reply!(c.run_cron(&task).await)
@@ -929,6 +1111,7 @@ pub fn routes() -> Router {
             get(user_keys).post(create_user_key),
         )
         .route(&p("/users/{login}/keys/{id}"), delete(delete_user_key))
+        .route(&p("/users/{login}/gpg_keys"), get(user_gpg_keys))
         // orgs & teams
         .route(&p("/orgs"), get(orgs).post(create_org))
         .route(&p("/orgs/{org}"), patch(edit_org).delete(delete_org))
@@ -941,11 +1124,19 @@ pub fn routes() -> Router {
             &p("/orgs/{org}/runners/registration-token"),
             post(org_runner_token),
         )
-        .route(&p("/teams/{team_id}"), delete(delete_team))
+        .route(
+            &p("/teams/{team_id}"),
+            get(get_team).patch(edit_team).delete(delete_team),
+        )
         .route(&p("/teams/{team_id}/members"), get(team_members))
         .route(
             &p("/teams/{team_id}/members/{user}"),
             put(add_team_member).delete(remove_team_member),
+        )
+        .route(&p("/teams/{team_id}/repos"), get(team_repos))
+        .route(
+            &p("/teams/{team_id}/repos/{org}/{repo}"),
+            put(add_team_repo).delete(remove_team_repo),
         )
         // repos
         .route(&p("/repos/search"), get(repos_search))
@@ -955,7 +1146,14 @@ pub fn routes() -> Router {
             get(repo).patch(edit_repo).delete(delete_repo),
         )
         .route(&p("/repos/{owner}/{repo}/transfer"), post(transfer_repo))
-        .route(&p("/repos/{owner}/{repo}/branches"), get(branches))
+        .route(
+            &p("/repos/{owner}/{repo}/branches"),
+            get(branches).post(create_branch),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/branches/{branch}"),
+            get(get_branch).delete(delete_branch),
+        )
         .route(&p("/repos/{owner}/{repo}/commits"), get(commits))
         .route(&p("/repos/{owner}/{repo}/languages"), get(languages))
         .route(
@@ -975,6 +1173,16 @@ pub fn routes() -> Router {
             patch(edit_release).delete(delete_release),
         )
         .route(
+            &p("/repos/{owner}/{repo}/releases/{id}/assets"),
+            get(release_assets),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/releases/{id}/assets/{asset_id}"),
+            delete(delete_release_asset),
+        )
+        .route(&p("/repos/{owner}/{repo}/tags"), get(tags).post(create_tag))
+        .route(&p("/repos/{owner}/{repo}/tags/{tag}"), delete(delete_tag))
+        .route(
             &p("/repos/{owner}/{repo}/hooks"),
             get(hooks).post(create_hook),
         )
@@ -992,7 +1200,7 @@ pub fn routes() -> Router {
         )
         .route(
             &p("/repos/{owner}/{repo}/protections/{name}"),
-            delete(delete_protection),
+            patch(edit_protection).delete(delete_protection),
         )
         .route(&p("/repos/{owner}/{repo}/secrets"), get(secrets))
         .route(
@@ -1052,6 +1260,18 @@ pub fn routes() -> Router {
         .route(
             &p("/repos/{owner}/{repo}/pulls/{index}/merge"),
             post(merge_pull),
+        )
+        .route(
+            &p("/repos/{owner}/{repo}/contents/{*path}"),
+            get(contents)
+                .post(put_file)
+                .put(put_file)
+                .delete(delete_file),
+        )
+        .route(&p("/packages/{owner}"), get(packages))
+        .route(
+            &p("/packages/{owner}/{kind}/{name}/{version}"),
+            delete(delete_package),
         )
         .route(&p("/repos/{owner}/{repo}/runners"), get(repo_runners))
         .route(

--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -1088,6 +1088,290 @@ impl ForgejoClient {
         .await
     }
 
+    pub async fn list_user_gpg_keys(
+        &self,
+        login: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoGpgKey>, JediError> {
+        self.get(
+            &format!("/api/v1/users/{login}/gpg_keys"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    // ── Branches ─────────────────────────────────────────────────────
+
+    pub async fn get_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Result<ForgejoBranch, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/branches/{branch}"),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn create_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoBranch, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/branches"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_branch(
+        &self,
+        owner: &str,
+        repo: &str,
+        branch: &str,
+    ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/branches/{branch}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn edit_branch_protection(
+        &self,
+        owner: &str,
+        repo: &str,
+        name: &str,
+        body: &Value,
+    ) -> Result<ForgejoBranchProtection, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/repos/{owner}/{repo}/branch_protections/{name}"),
+            Some(body),
+        )
+        .await
+    }
+
+    // ── Tags ─────────────────────────────────────────────────────────
+
+    pub async fn list_tags(
+        &self,
+        owner: &str,
+        repo: &str,
+        limit: u32,
+    ) -> Result<Vec<ForgejoTag>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/tags"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn create_tag(
+        &self,
+        owner: &str,
+        repo: &str,
+        body: &Value,
+    ) -> Result<ForgejoTag, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::POST,
+            &format!("/api/v1/repos/{owner}/{repo}/tags"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_tag(&self, owner: &str, repo: &str, tag: &str) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/tags/{tag}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Release assets ───────────────────────────────────────────────
+
+    pub async fn list_release_assets(
+        &self,
+        owner: &str,
+        repo: &str,
+        release_id: u64,
+    ) -> Result<Vec<ForgejoReleaseAsset>, JediError> {
+        self.get(
+            &format!("/api/v1/repos/{owner}/{repo}/releases/{release_id}/assets"),
+            &[],
+        )
+        .await
+    }
+
+    pub async fn delete_release_asset(
+        &self,
+        owner: &str,
+        repo: &str,
+        release_id: u64,
+        asset_id: u64,
+    ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/releases/{release_id}/assets/{asset_id}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Teams (extended) ─────────────────────────────────────────────
+
+    pub async fn get_team(&self, team_id: u64) -> Result<ForgejoTeam, JediError> {
+        self.get(&format!("/api/v1/teams/{team_id}"), &[]).await
+    }
+
+    pub async fn edit_team(&self, team_id: u64, body: &Value) -> Result<ForgejoTeam, JediError> {
+        self.write(
+            Method::PATCH,
+            &format!("/api/v1/teams/{team_id}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn list_team_repos(
+        &self,
+        team_id: u64,
+        limit: u32,
+    ) -> Result<Vec<ForgejoRepo>, JediError> {
+        self.get(
+            &format!("/api/v1/teams/{team_id}/repos"),
+            &[("limit", limit.to_string())],
+        )
+        .await
+    }
+
+    pub async fn add_team_repo(
+        &self,
+        team_id: u64,
+        org: &str,
+        repo: &str,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::PUT,
+            &format!("/api/v1/teams/{team_id}/repos/{org}/{repo}"),
+            None,
+        )
+        .await
+    }
+
+    pub async fn remove_team_repo(
+        &self,
+        team_id: u64,
+        org: &str,
+        repo: &str,
+    ) -> Result<(), JediError> {
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/teams/{team_id}/repos/{org}/{repo}"),
+            None,
+        )
+        .await
+    }
+
+    // ── Repository contents ──────────────────────────────────────────
+
+    pub async fn list_contents(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        git_ref: Option<&str>,
+    ) -> Result<Value, JediError> {
+        let q: Vec<(&str, String)> = git_ref
+            .filter(|s| !s.is_empty())
+            .map(|r| vec![("ref", r.to_string())])
+            .unwrap_or_default();
+        self.get(&format!("/api/v1/repos/{owner}/{repo}/contents/{path}"), &q)
+            .await
+    }
+
+    pub async fn create_or_update_file(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        body: &Value,
+    ) -> Result<Value, JediError> {
+        self.policy.check_owner(owner)?;
+        let method = if body.get("sha").is_some() {
+            Method::PUT
+        } else {
+            Method::POST
+        };
+        self.write(
+            method,
+            &format!("/api/v1/repos/{owner}/{repo}/contents/{path}"),
+            Some(body),
+        )
+        .await
+    }
+
+    pub async fn delete_file(
+        &self,
+        owner: &str,
+        repo: &str,
+        path: &str,
+        body: &Value,
+    ) -> Result<Value, JediError> {
+        self.policy.check_owner(owner)?;
+        self.write(
+            Method::DELETE,
+            &format!("/api/v1/repos/{owner}/{repo}/contents/{path}"),
+            Some(body),
+        )
+        .await
+    }
+
+    // ── Packages ─────────────────────────────────────────────────────
+
+    pub async fn list_packages(
+        &self,
+        owner: &str,
+        page: u32,
+        limit: u32,
+    ) -> Result<Vec<ForgejoPackage>, JediError> {
+        self.get(
+            &format!("/api/v1/packages/{owner}"),
+            &Self::page_query(page, limit),
+        )
+        .await
+    }
+
+    pub async fn delete_package(
+        &self,
+        owner: &str,
+        kind: &str,
+        name: &str,
+        version: &str,
+    ) -> Result<(), JediError> {
+        self.policy.check_owner(owner)?;
+        self.write_empty(
+            Method::DELETE,
+            &format!("/api/v1/packages/{owner}/{kind}/{name}/{version}"),
+            None,
+        )
+        .await
+    }
+
     // ── System / admin ───────────────────────────────────────────────
 
     pub async fn version(&self) -> Result<ForgejoVersion, JediError> {

--- a/packages/rust/jedi/src/entity/forgejo/types.rs
+++ b/packages/rust/jedi/src/entity/forgejo/types.rs
@@ -372,6 +372,62 @@ pub struct ForgejoPublicKey {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoGpgKey {
+    pub id: u64,
+    #[serde(default)]
+    pub key_id: String,
+    #[serde(default)]
+    pub public_key: String,
+    #[serde(default)]
+    pub can_sign: bool,
+    #[serde(default)]
+    pub can_certify: bool,
+    #[serde(default)]
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoTagCommit {
+    #[serde(default)]
+    pub sha: String,
+    #[serde(default)]
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoTag {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub commit: Option<ForgejoTagCommit>,
+    #[serde(default)]
+    pub zipball_url: String,
+    #[serde(default)]
+    pub tarball_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ForgejoPackage {
+    pub id: u64,
+    #[serde(rename = "type", default)]
+    pub package_type: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub owner: Option<ForgejoOwner>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub html_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForgejoCronTask {
     pub name: String,
     #[serde(default)]


### PR DESCRIPTION
Second backend sweep over the Forgejo API surface not yet wired — the follow-ups flagged in #12428. Backend only (jedi + axum-kbve typed routes); no dashboard UI. Same VIEW/MANAGE gating + `FORGEJO_ALLOWED_OWNERS` policy on owner-scoped writes.

## jedi client (`packages/rust/jedi/src/entity/forgejo`)
- **Branches** — get / create / delete + branch-protection **edit** (PATCH)
- **Tags** — list / create / delete
- **Release assets** — list / delete
- **Teams (extended)** — get / edit + team-repo grants (list / add / remove)
- **Repository contents** — list, create-or-update file (POST vs PUT auto-selected by `sha` presence), delete file
- **Packages** — list per owner, delete by type/name/version
- **GPG keys** — list per user (read)
- New types: `ForgejoGpgKey`, `ForgejoTag` (+`ForgejoTagCommit`), `ForgejoPackage`

## axum-kbve typed routes (`transport/forgejo_api.rs`)
- `ListQuery` gains a `ref` param (contents at a given branch/sha)
- Routes: `/repos/{o}/{r}/branches[/{branch}]`, `/tags[/{tag}]`, `/releases/{id}/assets[/{asset_id}]`, `/protections/{name}` PATCH, `/contents/{*path}` (GET/POST/PUT/DELETE), `/teams/{id}` GET/PATCH, `/teams/{id}/repos[/{org}/{repo}]`, `/packages/{owner}[/{kind}/{name}/{version}]`, `/users/{login}/gpg_keys`

## Verify
- `./kbve.sh -nx axum-kbve:build` ✓ (compiles jedi `forgejo` feature end-to-end, 2m41s incremental)

## Remaining follow-ups (not in scope)
Release-asset **upload** (multipart, needs a non-JSON write path), admin GPG-key creation for other users (no Forgejo endpoint), repo topics, forks/stargazers, mirror-sync, notifications. Most need either multipart support or have no admin API.