### PR TITLE
fix(axum-cryptothrone): drop trim_trailing_slash layer (fixes #12440 redirect loop)

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -6,7 +6,6 @@ use std::{
 
 use std::sync::Arc;
 
-use axum::ServiceExt;
 use axum::{
     Extension, Router,
     extract::Request,
@@ -16,8 +15,6 @@ use axum::{
     routing::{get, post},
 };
 use tokio::net::TcpListener;
-use tower::Layer;
-use tower_http::normalize_path::NormalizePathLayer;
 use tower_http::set_header::SetResponseHeaderLayer;
 use tracing::info;
 
@@ -46,10 +43,8 @@ pub async fn serve() -> Result<()> {
         }
     };
     let app = router().layer(Extension(allocator)).layer(Extension(pg));
-    // Trim trailing slashes before routing so `/health/` matches `/health`.
-    let app = NormalizePathLayer::trim_trailing_slash().layer(app);
 
-    axum::serve(listener, ServiceExt::<Request>::into_make_service(app))
+    axum::serve(listener, app.into_make_service())
         .with_graceful_shutdown(shutdown_signal())
         .await?;
 
@@ -284,25 +279,6 @@ mod tests {
             .route("/health", get(health))
             .route("/api/v1/speed", get(speed))
             .layer(middleware)
-    }
-
-    #[tokio::test]
-    async fn test_health_trailing_slash_normalized() {
-        let app = NormalizePathLayer::trim_trailing_slash().layer(test_router());
-        let response = app
-            .oneshot(
-                Request::builder()
-                    .uri("/health/")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let body = response.into_body().collect().await.unwrap().to_bytes();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(json["status"], "ok");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

CI `CI - Docker / cryptothrone` e2e fails (#12440):

```
Error: page.goto: net::ERR_TOO_MANY_REDIRECTS at http://localhost:4321/guides/getting-started/
```

Every astro directory route (`/guides/getting-started/`, `/discord/`, …) redirect-loops.

## Root cause

`NormalizePathLayer::trim_trailing_slash()` (added in the Discord work so `/health/` matched `/health`) wraps the whole app and strips the trailing slash off **every** request before routing.

But astro builds with `trailingSlash: 'always'`, and the shared `ServeDir` uses `append_index_html_on_directories(true)` — so a request to `/x/y` gets a **307 → `/x/y/`** to add the slash back. The normalize layer immediately re-strips it on the redirected request → infinite loop.

## Fix

Remove the global layer (and its unit test). Static SSG serving requires the canonical trailing slash; `ServeDir` already handles the no-slash → slash redirect in a single hop. The only thing the layer bought was `/health/` tolerance, which k8s probes never rely on (they hit `/health` exactly).

- `cargo test -p axum-cryptothrone` → 8 passed
- Unblocks the 0.1.29 release e2e (riding the pending MDX bump, no version change)

Closes #12440