### PR TITLE
feat(cryptothrone): P3 — extract client-prediction system + sim tests (#12422)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -36,6 +36,13 @@ import {
 	type SyncResolvers,
 	type SyncState,
 } from '../systems/netSync';
+import {
+	stepDir,
+	followPath,
+	commitPredicted,
+	type PredictState,
+	type IsBlocked,
+} from '../systems/prediction';
 
 interface EntityRefs {
 	sprite: Phaser.GameObjects.Sprite;
@@ -48,13 +55,6 @@ const MAP_SCALE = 3;
 const STEP_THROTTLE_MS = 60;
 const SLOT_NONE = 0xffff;
 const PLAYER_SPRITE_VARIANTS = 8;
-
-const DIR_DELTA: Record<string, { x: number; y: number }> = {
-	Up: { x: 0, y: -1 },
-	Down: { x: 0, y: 1 },
-	Left: { x: -1, y: 0 },
-	Right: { x: 1, y: 0 },
-};
 
 function spriteVariantForName(name: string): number {
 	let h = 2166136261;
@@ -144,6 +144,8 @@ export class CloudCityScene extends Scene {
 	private hoverThrottle = 0;
 	private laserUnsubs: (() => void)[] = [];
 	private blocked = new Set<string>();
+	private readonly isBlocked: IsBlocked = (x, y) =>
+		this.blocked.has(`${x},${y}`);
 	private predicted = { x: 0, y: 0 };
 	private predictedPath: { x: number; y: number }[] = [];
 	private predictSeeded = false;
@@ -812,9 +814,7 @@ export class CloudCityScene extends Scene {
 	 */
 	private startMoveTo(tile: { x: number; y: number }) {
 		if (!this.client) return;
-		this.predictedPath = findTilePath(this.predicted, tile, (x, y) =>
-			this.blocked.has(`${x},${y}`),
-		);
+		this.predictedPath = findTilePath(this.predicted, tile, this.isBlocked);
 		this.client.moveTo(tile);
 	}
 
@@ -967,6 +967,12 @@ export class CloudCityScene extends Scene {
 		// prediction tracks the server's tile rate instead of outrunning it.
 		if (this.gridEngine.isMoving(myChar)) return;
 
+		const pstate: PredictState = {
+			predicted: this.predicted,
+			path: this.predictedPath,
+			seeded: this.predictSeeded,
+		};
+
 		let dir: Dir | null = null;
 		if (this.cursors.up.isDown || this.wasd.up.isDown) dir = 'Up';
 		else if (this.cursors.down.isDown || this.wasd.down.isDown)
@@ -977,35 +983,26 @@ export class CloudCityScene extends Scene {
 			dir = 'Right';
 
 		if (dir) {
-			// Keyboard interrupts any click-path and predicts a single step.
-			this.predictedPath = [];
-			const delta = DIR_DELTA[dir];
-			const cand = {
-				x: this.predicted.x + delta.x,
-				y: this.predicted.y + delta.y,
-			};
-			if (!this.blocked.has(`${cand.x},${cand.y}`)) {
-				this.advancePredicted(myChar, cand);
-			}
+			const cand = stepDir(pstate, dir, this.isBlocked);
+			if (cand) this.advancePredicted(pstate, myChar, cand);
+			this.predictedPath = pstate.path;
 			this.client.step(dir);
 			this.lastStepAt = time;
 			return;
 		}
 
-		// Follow a predicted click-path one tile at a time (the server walks
-		// its own authoritative MoveTo in parallel).
-		if (this.predictedPath.length > 0) {
-			const next = this.predictedPath.shift()!;
-			if (!this.blocked.has(`${next.x},${next.y}`)) {
-				this.advancePredicted(myChar, next);
-			} else {
-				this.predictedPath = [];
-			}
-		}
+		const next = followPath(pstate, this.isBlocked);
+		this.predictedPath = pstate.path;
+		if (next) this.advancePredicted(pstate, myChar, next);
 	}
 
-	private advancePredicted(myChar: string, tile: { x: number; y: number }) {
-		this.predicted = { ...tile };
+	private advancePredicted(
+		state: PredictState,
+		myChar: string,
+		tile: { x: number; y: number },
+	) {
+		commitPredicted(state, tile);
+		this.predicted = state.predicted;
 		this.gridEngine.moveTo(myChar, tile);
 		this.store.update(this.myEid, { tile: { ...tile } });
 	}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/prediction.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/prediction.spec.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+	stepDir,
+	followPath,
+	commitPredicted,
+	DIR_DELTA,
+	type PredictState,
+	type IsBlocked,
+} from './prediction';
+
+const OPEN: IsBlocked = () => false;
+const wall =
+	(...tiles: [number, number][]): IsBlocked =>
+	(x, y) =>
+		tiles.some(([tx, ty]) => tx === x && ty === y);
+
+function state(p: Partial<PredictState> = {}): PredictState {
+	return {
+		predicted: { x: 5, y: 5 },
+		path: [],
+		seeded: true,
+		...p,
+	};
+}
+
+describe('DIR_DELTA', () => {
+	it('maps the four cardinals to unit steps', () => {
+		expect(DIR_DELTA.Up).toEqual({ x: 0, y: -1 });
+		expect(DIR_DELTA.Down).toEqual({ x: 0, y: 1 });
+		expect(DIR_DELTA.Left).toEqual({ x: -1, y: 0 });
+		expect(DIR_DELTA.Right).toEqual({ x: 1, y: 0 });
+	});
+});
+
+describe('stepDir', () => {
+	it('returns the adjacent tile in the pressed direction', () => {
+		expect(stepDir(state(), 'Right', OPEN)).toEqual({ x: 6, y: 5 });
+		expect(stepDir(state(), 'Up', OPEN)).toEqual({ x: 5, y: 4 });
+	});
+
+	it('returns null when unseeded', () => {
+		expect(stepDir(state({ seeded: false }), 'Right', OPEN)).toBeNull();
+	});
+
+	it('returns null when the candidate tile is blocked', () => {
+		expect(stepDir(state(), 'Right', wall([6, 5]))).toBeNull();
+	});
+
+	it('clears an active click-path even when blocked (keyboard interrupts)', () => {
+		const s = state({
+			path: [
+				{ x: 6, y: 5 },
+				{ x: 7, y: 5 },
+			],
+		});
+		stepDir(s, 'Right', wall([6, 5]));
+		expect(s.path).toEqual([]);
+	});
+});
+
+describe('followPath', () => {
+	it('shifts and returns the next path tile', () => {
+		const s = state({
+			path: [
+				{ x: 6, y: 5 },
+				{ x: 7, y: 5 },
+			],
+		});
+		expect(followPath(s, OPEN)).toEqual({ x: 6, y: 5 });
+		expect(s.path).toEqual([{ x: 7, y: 5 }]);
+	});
+
+	it('returns null on an empty path', () => {
+		expect(followPath(state(), OPEN)).toBeNull();
+	});
+
+	it('drops the whole path when the next tile is blocked', () => {
+		const s = state({
+			path: [
+				{ x: 6, y: 5 },
+				{ x: 7, y: 5 },
+			],
+		});
+		expect(followPath(s, wall([6, 5]))).toBeNull();
+		expect(s.path).toEqual([]);
+	});
+});
+
+describe('commitPredicted', () => {
+	it('moves the cursor and copies (no aliasing)', () => {
+		const s = state();
+		const tile = { x: 9, y: 2 };
+		commitPredicted(s, tile);
+		expect(s.predicted).toEqual({ x: 9, y: 2 });
+		tile.x = 0;
+		expect(s.predicted.x).toBe(9);
+	});
+
+	it('walks a click-path tile by tile to its destination', () => {
+		const s = state({
+			predicted: { x: 0, y: 0 },
+			path: [
+				{ x: 1, y: 0 },
+				{ x: 2, y: 0 },
+				{ x: 2, y: 1 },
+			],
+		});
+		let next: ReturnType<typeof followPath>;
+		while ((next = followPath(s, OPEN))) commitPredicted(s, next);
+		expect(s.predicted).toEqual({ x: 2, y: 1 });
+		expect(s.path).toEqual([]);
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/prediction.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/prediction.ts
@@ -1,0 +1,67 @@
+import type { Dir } from '@kbve/laser';
+import type { TileXY } from './netSync';
+
+export type IsBlocked = (x: number, y: number) => boolean;
+
+export const DIR_DELTA: Record<Dir, TileXY> = {
+	Up: { x: 0, y: -1 },
+	Down: { x: 0, y: 1 },
+	Left: { x: -1, y: 0 },
+	Right: { x: 1, y: 0 },
+};
+
+/**
+ * Client-side movement prediction: a predicted cursor that walks one tile per
+ * tick while the server runs its own authoritative move. `path` is the queued
+ * click-route; `seeded` gates prediction until the local player first appears
+ * in a snapshot (see netSync). Pure state — Phaser/gridEngine effects stay in
+ * the scene, which mirrors `predicted` after each commit.
+ */
+export interface PredictState {
+	predicted: TileXY;
+	path: TileXY[];
+	seeded: boolean;
+}
+
+/**
+ * Resolve a keyboard step. Keyboard always interrupts an active click-path, so
+ * `path` is cleared regardless. Returns the tile to advance onto, or null when
+ * unseeded or the candidate is blocked (the caller still steps the server).
+ */
+export function stepDir(
+	state: PredictState,
+	dir: Dir,
+	isBlocked: IsBlocked,
+): TileXY | null {
+	state.path = [];
+	if (!state.seeded) return null;
+	const delta = DIR_DELTA[dir];
+	const cand = {
+		x: state.predicted.x + delta.x,
+		y: state.predicted.y + delta.y,
+	};
+	return isBlocked(cand.x, cand.y) ? null : cand;
+}
+
+/**
+ * Advance one tile along the active click-path. Returns the next tile, or null
+ * when the path is empty or its next tile became blocked — in which case the
+ * stale path is dropped so prediction doesn't push into a wall.
+ */
+export function followPath(
+	state: PredictState,
+	isBlocked: IsBlocked,
+): TileXY | null {
+	if (state.path.length === 0) return null;
+	const next = state.path.shift()!;
+	if (isBlocked(next.x, next.y)) {
+		state.path = [];
+		return null;
+	}
+	return next;
+}
+
+/** Move the predicted cursor onto a committed tile. */
+export function commitPredicted(state: PredictState, tile: TileXY): void {
+	state.predicted = { x: tile.x, y: tile.y };
+}


### PR DESCRIPTION
Phase 3 of the CloudCityScene decomposition (#12422). **Stacks on #12434 (P2)** — review/merge that first; rebases onto dev after it lands.

## What

Pulls the movement-prediction state machine out of `CloudCityScene` into a pure `systems/prediction.ts`:

- `stepDir` — keyboard single-step; always interrupts an active click-path; null when unseeded or blocked
- `followPath` — walk a click-route one tile per tick; drops the path on a blocked tile
- `commitPredicted` — advance the predicted cursor (copies, no aliasing)
- `DIR_DELTA` — the cardinal delta table (moved off the scene)

All decisions are pure over an injected `IsBlocked` predicate + a `PredictState` the scene wraps around its `predicted`/`predictedPath`/`predictSeeded` fields — the same wrap pattern P2's netSync uses for `SyncState`. `findTilePath` and gridEngine stay in the scene as the effect bridge; `advancePredicted` now commits via the system and mirrors into gridEngine + the store.

## Tests

10 headless sim tests (blocked handling, keyboard-interrupts-path, walk-to-destination, no aliasing). Suite **61 → 71**, scoped `tsc` clean.

Next: P4 — thin scene shell orchestrator.