### PR TITLE
fix(jedi/forgejo): enforce FORGEJO_ALLOWED_OWNERS on all team writes

### DIFF
--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -428,7 +428,24 @@ impl ForgejoClient {
         .await
     }
 
+    /// Team writes carry only an opaque `team_id`, so the allowlist can't be
+    /// applied directly. When restricted, resolve the team's org and check that
+    /// instead; when open, skip the extra round-trip.
+    async fn check_team_owner(&self, team_id: u64) -> Result<(), JediError> {
+        if !self.policy.is_restricted() {
+            return Ok(());
+        }
+        let org = self
+            .get_team(team_id)
+            .await?
+            .organization
+            .map(|o| o.username)
+            .ok_or(JediError::Forbidden)?;
+        self.policy.check_owner(&org)
+    }
+
     pub async fn delete_team(&self, team_id: u64) -> Result<(), JediError> {
+        self.check_team_owner(team_id).await?;
         self.write_empty(Method::DELETE, &format!("/api/v1/teams/{team_id}"), None)
             .await
     }
@@ -446,6 +463,7 @@ impl ForgejoClient {
     }
 
     pub async fn add_team_member(&self, team_id: u64, user: &str) -> Result<(), JediError> {
+        self.check_team_owner(team_id).await?;
         self.write_empty(
             Method::PUT,
             &format!("/api/v1/teams/{team_id}/members/{user}"),
@@ -455,6 +473,7 @@ impl ForgejoClient {
     }
 
     pub async fn remove_team_member(&self, team_id: u64, user: &str) -> Result<(), JediError> {
+        self.check_team_owner(team_id).await?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/teams/{team_id}/members/{user}"),
@@ -1239,6 +1258,7 @@ impl ForgejoClient {
     }
 
     pub async fn edit_team(&self, team_id: u64, body: &Value) -> Result<ForgejoTeam, JediError> {
+        self.check_team_owner(team_id).await?;
         self.write(
             Method::PATCH,
             &format!("/api/v1/teams/{team_id}"),
@@ -1265,6 +1285,7 @@ impl ForgejoClient {
         org: &str,
         repo: &str,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(org)?;
         self.write_empty(
             Method::PUT,
             &format!("/api/v1/teams/{team_id}/repos/{org}/{repo}"),
@@ -1279,6 +1300,7 @@ impl ForgejoClient {
         org: &str,
         repo: &str,
     ) -> Result<(), JediError> {
+        self.policy.check_owner(org)?;
         self.write_empty(
             Method::DELETE,
             &format!("/api/v1/teams/{team_id}/repos/{org}/{repo}"),

--- a/packages/rust/jedi/src/entity/forgejo/policy.rs
+++ b/packages/rust/jedi/src/entity/forgejo/policy.rs
@@ -37,6 +37,12 @@ impl ForgejoPolicy {
         }
     }
 
+    /// True when an allowlist is set, so callers can skip a team→org lookup
+    /// they only need in order to policy-check.
+    pub fn is_restricted(&self) -> bool {
+        self.allowed_owners.is_some()
+    }
+
     /// Reject before any HTTP call if `owner` is outside the allowlist.
     pub fn check_owner(&self, owner: &str) -> Result<(), JediError> {
         match &self.allowed_owners {

--- a/packages/rust/jedi/src/entity/forgejo/types.rs
+++ b/packages/rust/jedi/src/entity/forgejo/types.rs
@@ -186,6 +186,8 @@ pub struct ForgejoTeam {
     pub includes_all_repositories: bool,
     #[serde(default)]
     pub can_create_org_repo: bool,
+    #[serde(default)]
+    pub organization: Option<ForgejoOrg>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Found in an audit of the Forgejo backend. Team mutations carry only an opaque `team_id`, so they slipped past the owner allowlist (`FORGEJO_ALLOWED_OWNERS`) that guards every other owner-scoped write. Under a restrictive policy a `DASHBOARD_MANAGE` staff member could still alter teams — and therefore repo access — for orgs **outside** the mandate.

## Gaps closed
- `delete_team`, `edit_team`, `add_team_member`, `remove_team_member` — **no policy check at all**
- `add_team_repo`, `remove_team_repo` — ignored the `org` already in scope

## Change
- `check_team_owner(team_id)` resolves the team's org (`GET /teams/{id}` → `organization`) and applies the allowlist; **short-circuits when the policy is open**, so open mode keeps its single round-trip (no extra call when `FORGEJO_ALLOWED_OWNERS` is unset)
- `ForgejoTeam` gains the `organization` field the API already returns
- `ForgejoPolicy::is_restricted()` gates the lookup
- repo-grant ops check the `org` they already receive (no fetch needed)

Defense-in-depth — these are already behind `DASHBOARD_MANAGE`; this makes the allowlist actually cover team writes like it does repo/org/user-scoped ones.

## Verify
- `./kbve.sh -nx axum-kbve:build` ✓