### PR TITLE
fix(forgejo dashboard): invalidate IndexedDB cache on mutation + hard refresh

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -1,7 +1,7 @@
 import { atom, computed } from 'nanostores';
 import { persistentAtom } from '@nanostores/persistent';
 import { initSupa, getSupa } from '@/lib/supa';
-import { cacheGet, cacheSet } from '@/lib/idb-cache';
+import { cacheGet, cacheSet, cacheDel } from '@/lib/idb-cache';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -509,6 +509,8 @@ async function apiMutate<T>(
 		);
 	}
 
+	await invalidateDataCache();
+
 	const text = await resp.text();
 	if (!text || text.trim().length === 0) return {} as T;
 	try {
@@ -656,6 +658,19 @@ async function fetchRepoLanguages(
 // ---------------------------------------------------------------------------
 // Cache helpers
 // ---------------------------------------------------------------------------
+
+// Every IndexedDB key this service writes (the aggregate plus each per-resource
+// list). Tracked so a mutation can wipe the exact set of stale entries instead
+// of waiting out their TTL or guessing at a key prefix (UI prefs share the
+// `forgejo:` namespace and must survive).
+const dataCacheKeys = new Set<string>([CACHE_KEY]);
+
+// Drop every cached read so the next load refetches from upstream. Awaited at
+// the mutation chokepoint, so the reload that follows a write sees an empty
+// cache and shows fresh data with no stale flash.
+async function invalidateDataCache(): Promise<void> {
+	await Promise.all([...dataCacheKeys].map((k) => cacheDel(k)));
+}
 
 function loadCache(): Promise<CachedData | null> {
 	return cacheGet<CachedData>(CACHE_KEY, CACHE_TTL_MS);
@@ -1071,7 +1086,7 @@ class ForgejoService {
 		const token = this.$accessToken.get();
 		if (token) {
 			this.$loading.set(true);
-			this.fetchData();
+			void invalidateDataCache().then(() => this.fetchData());
 		}
 	}
 
@@ -1252,6 +1267,7 @@ class ForgejoService {
 	): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
+		dataCacheKeys.add(cacheKey);
 		const cached = await cacheGet<T>(cacheKey, ttl);
 		if (cached !== null) apply(cached);
 		try {


### PR DESCRIPTION
The per-resource lists (hooks, secrets, releases, branch protections, collaborators, org members, teams, team members, variables) are cached in IndexedDB with a 60s TTL but were **never busted on write**. After creating/deleting one, the next load served the stale list first (the live fetch then overwrote it), and a reload within the TTL showed pre-mutation data. The aggregate repos/users/orgs cache already refreshed via `fetchData()`, but the detail caches had no cleanup path.

## Change (`forgejoService.ts`, frontend-only)
- **`dataCacheKeys`** — a registry of every IDB key the service writes (the aggregate + each per-resource key, recorded in `_loadResource`). Lets invalidation wipe the *exact* set instead of guessing a prefix — important because the UI-pref keys (`forgejo:activeTab`, `forgejo:expandedRepo`) share the `forgejo:` namespace and must survive.
- **`invalidateDataCache()`** `cacheDel`s them all; **awaited inside `apiMutate` on success** so the reload every mutation already triggers sees an empty cache → fresh data, no stale flash.
- **`refresh()`** (manual Refresh button) now clears the cache before refetching — an explicit "clean up + pull new data" path. The 30s background poll still calls `fetchData()` directly (cheap; server-side TTL-cached).

No `idb-cache` facade or worker-protocol change — reuses the existing `cacheDel`, which already works across the shared-worker / dexie / localStorage / memory backends.

## Verify
- `./kbve.sh -nx astro-kbve:build` ✓