### PR TITLE
feat(mc-lot): live player positions on the world map via RCON

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMap.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMap.astro
@@ -232,6 +232,7 @@ const blockMax = (MAX + 1) * 16 - 1;
 			}
 
 			<g data-mcworld-live-lots></g>
+			<g data-mcworld-live-players></g>
 
 			{
 				pois

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
@@ -7,9 +7,23 @@ type McServerStatus = {
 	reachable: boolean;
 };
 
+type McPosition = {
+	x: number;
+	y: number;
+	z: number;
+	dimension: string;
+};
+
+type McPlayer = {
+	name: string;
+	server: string;
+	position?: McPosition;
+};
+
 type McPlayerList = {
 	online: number;
 	max: number;
+	players: McPlayer[];
 	servers: McServerStatus[];
 };
 
@@ -48,6 +62,7 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 	// Cache the static-side SVG + injection-point lookup once on mount so
 	// dbLots updates don't re-walk the DOM every refresh.
 	const liveLayerRef = useRef<SVGGElement | null>(null);
+	const playerLayerRef = useRef<SVGGElement | null>(null);
 	const svgRef = useRef<SVGSVGElement | null>(null);
 
 	const cancel = useCallback(() => {
@@ -104,6 +119,9 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 		liveLayerRef.current =
 			wrap?.querySelector<SVGGElement>('[data-mcworld-live-lots]') ??
 			null;
+		playerLayerRef.current =
+			wrap?.querySelector<SVGGElement>('[data-mcworld-live-players]') ??
+			null;
 
 		document
 			.querySelectorAll('[data-mcworld-live-skeleton]')
@@ -138,7 +156,11 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 			if (liveLayerRef.current) {
 				liveLayerRef.current.replaceChildren();
 			}
+			if (playerLayerRef.current) {
+				playerLayerRef.current.replaceChildren();
+			}
 			liveLayerRef.current = null;
+			playerLayerRef.current = null;
 			svgRef.current = null;
 		};
 	}, [refresh, cancel, world]);
@@ -182,8 +204,72 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 		}
 	}, [dbLots, minChunk, maxChunk]);
 
+	// Project live player positions into the dedicated SVG layer. Block
+	// coords / 16 = chunk coords; players outside the visible window are
+	// dropped so the dot stays inside the panel.
+	useEffect(() => {
+		const layer = playerLayerRef.current;
+		const svg = svgRef.current;
+		if (!layer || !svg) return;
+		const SIZE = svg.viewBox.baseVal.width;
+		const span = maxChunk - minChunk + 1;
+		const cell = SIZE / span;
+		layer.replaceChildren();
+
+		const players = (status?.players ?? []).filter(
+			(p) => p.position && p.position.dimension === world,
+		);
+
+		for (const p of players) {
+			const pos = p.position!;
+			const cx = (pos.x / 16 - minChunk) * cell;
+			const cz = (pos.z / 16 - minChunk) * cell;
+			if (cx < 0 || cx > SIZE || cz < 0 || cz > SIZE) continue;
+
+			const g = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'g',
+			);
+			const halo = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'circle',
+			);
+			halo.setAttribute('cx', String(cx));
+			halo.setAttribute('cy', String(cz));
+			halo.setAttribute('r', '8');
+			halo.setAttribute('fill', 'rgba(74, 222, 128, 0.18)');
+			halo.setAttribute('stroke', 'rgba(74, 222, 128, 0.55)');
+			halo.setAttribute('stroke-width', '0.8');
+
+			const dot = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'circle',
+			);
+			dot.setAttribute('cx', String(cx));
+			dot.setAttribute('cy', String(cz));
+			dot.setAttribute('r', '3.5');
+			dot.setAttribute('fill', '#4ade80');
+			dot.setAttribute('stroke', '#0a0d12');
+			dot.setAttribute('stroke-width', '1');
+
+			const title = document.createElementNS(
+				'http://www.w3.org/2000/svg',
+				'title',
+			);
+			title.textContent = `${p.name} · ${Math.round(pos.x)}, ${Math.round(pos.y)}, ${Math.round(pos.z)} · ${pos.dimension}`;
+			dot.appendChild(title);
+
+			g.appendChild(halo);
+			g.appendChild(dot);
+			layer.appendChild(g);
+		}
+	}, [status, world, minChunk, maxChunk]);
+
 	const total = status?.online ?? 0;
 	const max = status?.max ?? 0;
+	const visiblePlayers = (status?.players ?? []).filter(
+		(p) => p.position && p.position.dimension === world,
+	).length;
 
 	return (
 		<aside className="mcworldlive">
@@ -220,6 +306,13 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 					{dbLots.length === 1 ? '' : 's'} from
 					<code> /api/v1/mc/lots/viewport</code>. Refreshes every 30
 					s; lots you own render in deep blue.
+				</p>
+			)}
+			{status && (
+				<p className="mcworldlive__hint">
+					Live positions: {visiblePlayers} player
+					{visiblePlayers === 1 ? '' : 's'} in <code>{world}</code>{' '}
+					from RCON. Off-map players are dropped from the overlay.
 				</p>
 			)}
 			{error && <p className="mcworldlive__error">{error}</p>}

--- a/apps/kbve/axum-kbve/src/db/mc.rs
+++ b/apps/kbve/axum-kbve/src/db/mc.rs
@@ -21,6 +21,18 @@ const MOJANG_SESSION: &str = "https://sessionserver.mojang.com/session/minecraft
 /// / `_PASSWORD`.
 const KNOWN_SERVERS: &[&str] = &["LOBBY", "SURVIVAL"];
 
+/// Block-space coordinates + dimension pulled per-poll from
+/// `/data get entity <name> Pos` and `... Dimension`. None when the
+/// backend is a proxy (LOBBY) or the RCON sub-call failed.
+#[derive(Clone, Debug, Serialize)]
+pub struct McPosition {
+    pub x: f64,
+    pub y: f64,
+    pub z: f64,
+    /// Namespaced dimension id like `minecraft:overworld`.
+    pub dimension: String,
+}
+
 /// API response model — serialized to JSON for `/api/v1/mc/players`.
 #[derive(Clone, Debug, Serialize)]
 pub struct McPlayer {
@@ -29,6 +41,10 @@ pub struct McPlayer {
     pub skin_url: Option<String>,
     /// Backend server the player is connected to ("lobby", "survival").
     pub server: String,
+    /// Live block-space coordinates pulled via RCON. Missing on proxies
+    /// (lobby) and when the per-player data lookup failed this poll.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub position: Option<McPosition>,
 }
 
 /// Per-server status for API clients that want a breakdown by backend.
@@ -274,13 +290,30 @@ impl McService {
                         max,
                         reachable: true,
                     });
+                    let endpoint = self
+                        .endpoints
+                        .iter()
+                        .find(|e| e.name == server_name)
+                        .cloned();
+                    let positions = match endpoint.as_ref() {
+                        Some(ep) if server_name == "survival" => {
+                            Self::rcon_positions(ep, &names).await
+                        }
+                        _ => Vec::new(),
+                    };
+
                     for name in names {
                         let cached = self.resolve_player(&name).await;
+                        let position = positions
+                            .iter()
+                            .find(|(n, _)| n.eq_ignore_ascii_case(&name))
+                            .map(|(_, p)| p.clone());
                         all_players.push(McPlayer {
                             name,
                             uuid: cached.as_ref().map(|c| c.uuid.clone()),
                             skin_url: cached.and_then(|c| c.skin_url),
                             server: server_name.clone(),
+                            position,
                         });
                     }
                 }
@@ -387,6 +420,38 @@ impl McService {
         let mut client = RconClient::connect(&ep.conn, RCON_TIMEOUT).await?;
         let body = client.exec("list").await?;
         parse_list_response(&body)
+    }
+
+    /// For each named player, issue `/data get entity <name> Pos` and
+    /// `/data get entity <name> Dimension`, parse, and return the pairs
+    /// that succeeded. Re-uses one RCON connection for the whole batch.
+    /// Per-player failures are skipped silently so a single offline /
+    /// AFK-out-of-bounds player can't black-hole the entire poll.
+    async fn rcon_positions(ep: &RconEndpoint, names: &[String]) -> Vec<(String, McPosition)> {
+        let mut client = match RconClient::connect(&ep.conn, RCON_TIMEOUT).await {
+            Ok(c) => c,
+            Err(e) => {
+                warn!(server = %ep.name, error = %e, "RCON connect for positions failed");
+                return Vec::new();
+            }
+        };
+        let mut out = Vec::with_capacity(names.len());
+        for name in names {
+            let pos_cmd = format!("data get entity {name} Pos");
+            let dim_cmd = format!("data get entity {name} Dimension");
+            let pos = match client.exec(&pos_cmd).await {
+                Ok(body) => parse_pos_response(&body),
+                Err(_) => None,
+            };
+            let dim = match client.exec(&dim_cmd).await {
+                Ok(body) => parse_dimension_response(&body),
+                Err(_) => None,
+            };
+            if let (Some((x, y, z)), Some(dimension)) = (pos, dim) {
+                out.push((name.clone(), McPosition { x, y, z, dimension }));
+            }
+        }
+        out
     }
 }
 
@@ -498,6 +563,38 @@ fn parse_list_response(response: &str) -> anyhow::Result<(Vec<String>, usize)> {
     };
 
     Ok((names, max))
+}
+
+/// Parse the response from `/data get entity <name> Pos`. Vanilla format:
+/// `KbveCEO has the following entity data: [-12.5d, 64.0d, 8.2d]`. The
+/// `d` suffix tags doubles. Returns None on any deviation so callers can
+/// silently drop the player from this poll.
+fn parse_pos_response(response: &str) -> Option<(f64, f64, f64)> {
+    // splitn(2) so a dimension-style suffix with a namespace colon
+    // doesn't truncate the captured body.
+    let body = response.splitn(2, ':').nth(1)?.trim();
+    let inner = body.strip_prefix('[').and_then(|s| s.strip_suffix(']'))?;
+    let mut parts = inner.split(',').map(|p| {
+        p.trim()
+            .trim_end_matches(|c: char| c == 'd' || c == 'D' || c == 'f' || c == 'F')
+            .parse::<f64>()
+            .ok()
+    });
+    Some((parts.next()??, parts.next()??, parts.next()??))
+}
+
+/// Parse the response from `/data get entity <name> Dimension`. Vanilla
+/// format: `KbveCEO has the following entity data: "minecraft:overworld"`.
+/// Trims the surrounding quotes; returns None if the format drifts.
+fn parse_dimension_response(response: &str) -> Option<String> {
+    // splitn(2) so the namespaced dimension id (which contains its own
+    // colon, e.g. `"minecraft:overworld"`) survives intact.
+    let body = response.splitn(2, ':').nth(1)?.trim();
+    let unquoted = body.strip_prefix('"').and_then(|s| s.strip_suffix('"'))?;
+    if unquoted.is_empty() {
+        return None;
+    }
+    Some(unquoted.to_string())
 }
 
 /// Extract the 60-64 char hex texture hash from a textures.minecraft.net URL.


### PR DESCRIPTION
## Summary

Replace dummy-only world map with real player positions polled from the live Minecraft server.

### axum-kbve (\`db/mc.rs\`)
- New \`McPosition\` (\`x\` / \`y\` / \`z\` / \`dimension\`) attached optionally to every \`McPlayer\`.
- \`rcon_positions\` opens **one** RCON connection per poll against the SURVIVAL endpoint, issues \`data get entity <name> Pos\` + \`... Dimension\` per online player, and pairs the parsed result back to the listing. Per-player errors are swallowed silently — one bad lookup can't poison the whole snapshot. LOBBY is a Velocity proxy with no world; positions there stay \`None\` and the field is \`serde(skip_serializing_if)\`'d out of JSON.
- \`parse_pos_response\` / \`parse_dimension_response\` use \`splitn(2, ':')\` so the namespaced dimension id (which contains its own colon) survives intact.

### astro-kbve world map
- \`MCWorldMap.astro\` adds a second SSG injection point: \`<g data-mcworld-live-players />\` next to the existing lots layer.
- \`MCWorldMapLive.tsx\` caches both layers in \`useRef\`, projects each player's block coords to chunk coords (\`x / 16\`) and renders a green halo + dot inside the visible window. Off-map players are dropped so the overlay stays inside the SVG bounds.
- Mount-effect cleanup empties the player layer on React unmount; the existing ClientRouter teardown still owns the swap-away path.
- Live aside grows a second hint line summarizing visible-player count for the active world.

### Verification
- \`cargo check --manifest-path apps/kbve/axum-kbve/Cargo.toml\` is clean (6 pre-existing warnings, 0 errors).
- \`./kbve.sh -nx astro-kbve:build\` ships \`/mc/world/index.html\` with both \`data-mcworld-live-lots\` and \`data-mcworld-live-players\` baked in, plus the existing skeleton hook.

## Test plan
- [ ] On a deployed instance, log into the SURVIVAL backend and confirm a green halo + dot appears at the right chunk coordinates within ~30 s.
- [ ] Cross a dimension boundary (e.g. nether portal). The dot should disappear when \`dimension != 'minecraft:overworld'\` until the player returns.
- [ ] LOBBY players continue to appear in the player count badge but never paint a position dot.
- [ ] Swap-navigate away mid-poll; injected dots vanish with the page, fresh dots appear on swap-back.