### PR TITLE
test(axum-cryptothrone): 81% LoC coverage + asset-presence e2e

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/assets.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/assets.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Critical bundled assets must actually ship and serve with the right MIME —
+ * the Discord Activity client (`/discord/discord.js`), the standalone embed
+ * (`/embed/embed.js`), and the LLM/robots/sitemap descriptors. These are
+ * produced by separate vite builds copied through `public/` into the Astro
+ * `dist/`; a broken build step yields a silent 404 (or an HTML 404 body served
+ * as a script, which `nosniff` then refuses to execute). Docker-only — the
+ * axum binary is what serves them.
+ */
+test.describe('bundled assets', () => {
+	test.beforeEach(() => {
+		test.skip(
+			test.info().project.name !== 'docker',
+			'assets are served by the axum build, not astro dev',
+		);
+	});
+
+	test('Discord Activity bundle serves as executable JS', async ({
+		request,
+	}) => {
+		const res = await request.get('/discord/discord.js');
+		expect(res.status(), 'discord.js must not 404').toBe(200);
+		expect(res.headers()['content-type']).toMatch(/javascript|ecmascript/);
+		// nosniff would block a non-JS body; a real bundle is non-trivial.
+		expect((await res.body()).length).toBeGreaterThan(1000);
+	});
+
+	test('Discord Activity index loads its script relatively', async ({
+		request,
+	}) => {
+		const res = await request.get('/discord/');
+		expect(res.status()).toBe(200);
+		expect(res.headers()['content-type']).toMatch(/html/);
+		const html = await res.text();
+		// Relative src so the Discord `/` -> `/discord/` mapping resolves it.
+		expect(html).toMatch(/src=["']discord\.js["']/);
+	});
+
+	test('standalone embed bundle serves as executable JS', async ({
+		request,
+	}) => {
+		const res = await request.get('/embed/embed.js');
+		expect(res.status(), 'embed.js must not 404').toBe(200);
+		expect(res.headers()['content-type']).toMatch(/javascript|ecmascript/);
+		expect((await res.body()).length).toBeGreaterThan(1000);
+	});
+
+	test('llms.txt descriptor is present', async ({ request }) => {
+		const res = await request.get('/llms.txt');
+		expect(res.status()).toBe(200);
+		expect(res.headers()['content-type']).toMatch(/text\/plain/);
+		expect(await res.text()).toContain('KBVE');
+	});
+
+	test('robots.txt points at the sitemap', async ({ request }) => {
+		const res = await request.get('/robots.txt');
+		expect(res.status()).toBe(200);
+		expect(await res.text()).toMatch(/Sitemap:/i);
+	});
+
+	test('sitemap.xml resolves to the generated index', async ({ request }) => {
+		const res = await request.get('/sitemap.xml');
+		expect(res.status()).toBe(200);
+		expect(await res.text()).toMatch(/sitemapindex|sitemap-index|urlset/);
+	});
+
+	test('a missing nested asset returns a real 404, not a script', async ({
+		request,
+	}) => {
+		const res = await request.get('/discord/does-not-exist.js');
+		expect(res.status()).toBe(404);
+	});
+});

--- a/apps/cryptothrone/axum-cryptothrone/project.json
+++ b/apps/cryptothrone/axum-cryptothrone/project.json
@@ -38,6 +38,15 @@
 				}
 			}
 		},
+		"coverage": {
+			"executor": "nx:run-commands",
+			"options": {
+				"commands": [
+					"cargo llvm-cov -p axum-cryptothrone --ignore-filename-regex 'main\\.rs' --fail-under-lines 80 --summary-only"
+				],
+				"parallel": false
+			}
+		},
 		"lint": {
 			"executor": "@monodon/rust:lint",
 			"outputs": ["{options.target-dir}"],

--- a/apps/cryptothrone/axum-cryptothrone/src/agones.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/agones.rs
@@ -10,6 +10,7 @@ pub struct AgonesAllocator {
     fleet: String,
 }
 
+#[derive(Debug)]
 pub struct Allocation {
     pub game_server_name: String,
     pub address: String,
@@ -59,37 +60,116 @@ impl AgonesAllocator {
                 .await
                 .map_err(|_| anyhow!("allocation request timed out"))??;
 
-        let status = resp
-            .get("status")
-            .ok_or_else(|| anyhow!("no status in allocation response"))?;
-        let state = status.get("state").and_then(|v| v.as_str()).unwrap_or("");
-        if state != "Allocated" {
-            return Err(anyhow!("allocation not granted (state={state})"));
-        }
-        let address = status
-            .get("address")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        let port = status
-            .get("ports")
-            .and_then(|v| v.as_array())
-            .and_then(|a| a.first())
-            .and_then(|p| p.get("port"))
-            .and_then(|v| v.as_i64())
-            .unwrap_or(0) as i32;
-        let game_server_name = status
-            .get("gameServerName")
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
-        if address.is_empty() || port <= 0 {
-            return Err(anyhow!("allocation returned empty address/port"));
-        }
-        Ok(Allocation {
-            game_server_name,
-            address,
-            port,
-        })
+        parse_allocation(&resp)
+    }
+}
+
+/// Extract a usable [`Allocation`] from an Agones `GameServerAllocation`
+/// response. Pure (no IO) so the brittle field-plucking + validation is unit
+/// tested against the real shapes Agones returns.
+fn parse_allocation(resp: &serde_json::Value) -> Result<Allocation> {
+    let status = resp
+        .get("status")
+        .ok_or_else(|| anyhow!("no status in allocation response"))?;
+    let state = status.get("state").and_then(|v| v.as_str()).unwrap_or("");
+    if state != "Allocated" {
+        return Err(anyhow!("allocation not granted (state={state})"));
+    }
+    let address = status
+        .get("address")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let port = status
+        .get("ports")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .and_then(|p| p.get("port"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0) as i32;
+    let game_server_name = status
+        .get("gameServerName")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    if address.is_empty() || port <= 0 {
+        return Err(anyhow!("allocation returned empty address/port"));
+    }
+    Ok(Allocation {
+        game_server_name,
+        address,
+        port,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_allocation_success() {
+        let resp = json!({
+            "status": {
+                "state": "Allocated",
+                "address": "10.0.0.5",
+                "ports": [{ "name": "default", "port": 7777 }],
+                "gameServerName": "cryptothrone-server-abc12"
+            }
+        });
+        let a = parse_allocation(&resp).unwrap();
+        assert_eq!(a.address, "10.0.0.5");
+        assert_eq!(a.port, 7777);
+        assert_eq!(a.game_server_name, "cryptothrone-server-abc12");
+    }
+
+    #[test]
+    fn parse_allocation_unallocated_state_errors() {
+        let resp = json!({ "status": { "state": "UnAllocated" } });
+        let err = parse_allocation(&resp).unwrap_err().to_string();
+        assert!(err.contains("not granted"), "got: {err}");
+        assert!(err.contains("UnAllocated"), "state echoed: {err}");
+    }
+
+    #[test]
+    fn parse_allocation_missing_status_errors() {
+        let resp = json!({});
+        assert!(
+            parse_allocation(&resp)
+                .unwrap_err()
+                .to_string()
+                .contains("no status")
+        );
+    }
+
+    #[test]
+    fn parse_allocation_empty_address_errors() {
+        let resp = json!({
+            "status": { "state": "Allocated", "ports": [{ "port": 7777 }] }
+        });
+        assert!(
+            parse_allocation(&resp)
+                .unwrap_err()
+                .to_string()
+                .contains("empty address/port")
+        );
+    }
+
+    #[test]
+    fn parse_allocation_zero_port_errors() {
+        let resp = json!({
+            "status": { "state": "Allocated", "address": "1.2.3.4", "ports": [] }
+        });
+        assert!(parse_allocation(&resp).is_err());
+    }
+
+    #[tokio::test]
+    async fn try_new_resolves_without_panicking() {
+        // Exercises env-default resolution + the kube client branch. Outside a
+        // cluster (CI/local) this returns None; in-cluster it would be Some.
+        // Either way the constructor must not panic. The kube client builds a
+        // rustls stack, so install the provider main() normally sets up.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = AgonesAllocator::try_new().await;
     }
 }

--- a/apps/cryptothrone/axum-cryptothrone/src/auth.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/auth.rs
@@ -73,4 +73,61 @@ mod tests {
         assert!(verify_supabase_jwt("garbage", secret).is_err());
         assert!(verify_supabase_jwt(&token, b"").is_err());
     }
+
+    #[test]
+    fn expired_token_rejected() {
+        let secret = b"test-secret";
+        let claims = TestClaims {
+            sub: "u1".into(),
+            exp: 1, // 1970 — long expired
+            kbve_username: "h0lybyte".into(),
+        };
+        let token = encode(
+            &Header::new(jsonwebtoken::Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(secret),
+        )
+        .unwrap();
+        assert!(verify_supabase_jwt(&token, secret).is_err());
+    }
+
+    #[test]
+    fn missing_username_defaults_to_empty() {
+        #[derive(Serialize)]
+        struct NoName {
+            sub: String,
+            exp: i64,
+        }
+        let secret = b"test-secret";
+        let token = encode(
+            &Header::new(jsonwebtoken::Algorithm::HS256),
+            &NoName {
+                sub: "u1".into(),
+                exp: 9_999_999_999,
+            },
+            &EncodingKey::from_secret(secret),
+        )
+        .unwrap();
+        assert_eq!(
+            verify_supabase_jwt(&token, secret).unwrap().kbve_username,
+            ""
+        );
+    }
+
+    #[test]
+    fn bearer_rejects_malformed() {
+        let mk = |v: &str| {
+            let mut h = axum::http::HeaderMap::new();
+            h.insert(axum::http::header::AUTHORIZATION, v.parse().unwrap());
+            h
+        };
+        // Missing "Bearer " scheme prefix.
+        assert_eq!(bearer_token(&mk("token-without-scheme")), None);
+        // Lowercase scheme is not accepted (strip_prefix is case-sensitive).
+        assert_eq!(bearer_token(&mk("bearer abc")), None);
+        // Empty token after the scheme.
+        assert_eq!(bearer_token(&mk("Bearer    ")), None);
+        // Surrounding whitespace is trimmed.
+        assert_eq!(bearer_token(&mk("Bearer  tok ")), Some("tok"));
+    }
 }

--- a/apps/cryptothrone/axum-cryptothrone/src/db/kv_cache.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/db/kv_cache.rs
@@ -15,3 +15,17 @@ pub async fn init_kv_cache() -> bool {
 pub fn get_kv_cache() -> Option<&'static Arc<KvCache>> {
     KV_CACHE.get()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn init_populates_l1_and_get_reflects_it() {
+        // KvCache always builds (L1 LRU works without Valkey), so init succeeds
+        // and the getter then resolves the shared handle.
+        let ok = init_kv_cache().await;
+        assert!(ok, "KvCache L1 should always initialize");
+        assert!(get_kv_cache().is_some());
+    }
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/db/pg_cluster.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/db/pg_cluster.rs
@@ -29,3 +29,17 @@ pub async fn init_pg_cluster() -> bool {
 pub fn get_pg_cluster() -> Option<&'static Arc<PgCluster>> {
     PG_CLUSTER.get().and_then(|c| c.as_ref())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn init_is_idempotent_and_getter_tracks_state() {
+        // No KBVE_PG_* in the test env -> pools fail to build -> disabled. The
+        // getter must agree with init, and a second init is a no-op (OnceCell).
+        let enabled = init_pg_cluster().await;
+        assert_eq!(get_pg_cluster().is_some(), enabled);
+        assert_eq!(init_pg_cluster().await, enabled, "init is idempotent");
+    }
+}

--- a/apps/cryptothrone/axum-cryptothrone/src/discord.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/discord.rs
@@ -165,18 +165,7 @@ pub async fn session(
 
     // 4. Mint the Supabase-valid HS256 JWT the game server accepts.
     let exp = now_secs().saturating_add(JWT_TTL_SECS) as i64;
-    let claims = MintedClaims {
-        sub: user_id,
-        exp,
-        kbve_username: kbve_username.clone(),
-        role: "authenticated".into(),
-        aud: "authenticated".into(),
-    };
-    let jwt = match encode(
-        &Header::new(Algorithm::HS256),
-        &claims,
-        &EncodingKey::from_secret(jwt_secret.as_bytes()),
-    ) {
+    let jwt = match mint_session_jwt(&user_id, &kbve_username, jwt_secret.as_bytes(), exp) {
         Ok(t) => t,
         Err(e) => {
             tracing::error!(error = %e, "jwt mint failed");
@@ -197,4 +186,123 @@ fn now_secs() -> u64 {
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+/// Mint the Supabase-compatible HS256 JWT the game server accepts. Mirrors the
+/// claim set the GoTrue custom-access-token hook injects (`sub`, `exp`,
+/// `kbve_username`, `role`, `aud`). Pure — no env/IO — so it is unit tested.
+fn mint_session_jwt(
+    sub: &str,
+    kbve_username: &str,
+    secret: &[u8],
+    exp: i64,
+) -> Result<String, jsonwebtoken::errors::Error> {
+    let claims = MintedClaims {
+        sub: sub.to_string(),
+        exp,
+        kbve_username: kbve_username.to_string(),
+        role: "authenticated".into(),
+        aud: "authenticated".into(),
+    };
+    encode(
+        &Header::new(Algorithm::HS256),
+        &claims,
+        &EncodingKey::from_secret(secret),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+    use serial_test::serial;
+
+    /// Decode-side mirror of the minted claims so the round-trip can assert
+    /// every field the game server relies on.
+    #[derive(Deserialize)]
+    struct DecodedClaims {
+        sub: String,
+        exp: i64,
+        kbve_username: String,
+        role: String,
+        aud: String,
+    }
+
+    fn decode_minted(token: &str, secret: &[u8]) -> DecodedClaims {
+        use jsonwebtoken::{DecodingKey, Validation, decode};
+        let mut v = Validation::new(Algorithm::HS256);
+        v.validate_aud = false;
+        decode::<DecodedClaims>(token, &DecodingKey::from_secret(secret), &v)
+            .unwrap()
+            .claims
+    }
+
+    #[test]
+    fn mint_jwt_round_trip_carries_supabase_claims() {
+        let secret = b"super-secret-key";
+        let exp = now_secs() as i64 + 3600;
+        let token = mint_session_jwt("user-123", "h0lybyte", secret, exp).unwrap();
+
+        // Verifiable by the same path the game server uses.
+        assert_eq!(
+            crate::auth::verify_supabase_jwt(&token, secret)
+                .unwrap()
+                .kbve_username,
+            "h0lybyte"
+        );
+
+        let c = decode_minted(&token, secret);
+        assert_eq!(c.sub, "user-123");
+        assert_eq!(c.kbve_username, "h0lybyte");
+        assert_eq!(c.role, "authenticated");
+        assert_eq!(c.aud, "authenticated");
+        assert_eq!(c.exp, exp);
+    }
+
+    #[test]
+    fn mint_jwt_rejects_wrong_secret() {
+        let token = mint_session_jwt("u", "name", b"right", now_secs() as i64 + 60).unwrap();
+        assert!(crate::auth::verify_supabase_jwt(&token, b"wrong").is_err());
+    }
+
+    #[test]
+    fn now_secs_is_monotonic_and_positive() {
+        assert!(now_secs() > 1_700_000_000);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn session_returns_500_when_unconfigured() {
+        for k in [
+            "DISCORD_CLIENT_ID",
+            "DISCORD_CLIENT_SECRET",
+            "SUPABASE_JWT_SECRET",
+        ] {
+            std::env::remove_var(k);
+        }
+        let resp = session(Extension(None), Json(SessionRequest { code: "abc".into() }))
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn session_returns_503_when_db_offline() {
+        std::env::set_var("DISCORD_CLIENT_ID", "id");
+        std::env::set_var("DISCORD_CLIENT_SECRET", "secret");
+        std::env::set_var("SUPABASE_JWT_SECRET", "jwt-secret");
+        let resp = session(Extension(None), Json(SessionRequest { code: "abc".into() }))
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+        for k in [
+            "DISCORD_CLIENT_ID",
+            "DISCORD_CLIENT_SECRET",
+            "SUPABASE_JWT_SECRET",
+        ] {
+            std::env::remove_var(k);
+        }
+    }
 }

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -259,6 +259,7 @@ mod tests {
     use crate::astro::{StaticConfig, build_static_router};
     use axum::{body::Body, http::StatusCode};
     use http_body_util::BodyExt;
+    use serial_test::serial;
     use std::path::PathBuf;
     use tower::ServiceExt;
 
@@ -508,5 +509,119 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let speed: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert!(speed["time_ms"].as_u64().unwrap() > 0);
+    }
+
+    #[tokio::test]
+    async fn test_fix_ts_mime_passes_non_ts_through() {
+        let app = Router::new()
+            .route(
+                "/script.js",
+                get(|| async { ([(header::CONTENT_TYPE, "text/plain")], "code") }),
+            )
+            .layer(axum::middleware::from_fn(fix_ts_mime));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/script.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Non-.ts content type is left untouched.
+        assert_eq!(
+            response.headers().get(header::CONTENT_TYPE).unwrap(),
+            "text/plain"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_discord_frame_headers_relax_csp_for_activity() {
+        let app = Router::new()
+            .route("/discord/x", get(|| async { "x" }))
+            .route("/other", get(|| async { "o" }))
+            .layer(SetResponseHeaderLayer::overriding(
+                header::X_FRAME_OPTIONS,
+                HeaderValue::from_static("DENY"),
+            ))
+            .layer(axum::middleware::from_fn(discord_frame_headers));
+
+        let discord = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/discord/x")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            discord.headers().get(header::X_FRAME_OPTIONS).is_none(),
+            "X-Frame-Options must be dropped for /discord/*"
+        );
+        let csp = discord
+            .headers()
+            .get(header::CONTENT_SECURITY_POLICY)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(csp.contains("frame-ancestors"));
+        assert!(csp.contains("discord.com"));
+
+        let other = app
+            .oneshot(
+                Request::builder()
+                    .uri("/other")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            other.headers().get(header::X_FRAME_OPTIONS).unwrap(),
+            "DENY",
+            "non-discord routes keep the global DENY"
+        );
+        assert!(
+            other
+                .headers()
+                .get(header::CONTENT_SECURITY_POLICY)
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tuned_listener_binds_ephemeral_port() {
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let listener = tuned_listener(addr).expect("bind ephemeral port");
+        let local = listener.local_addr().unwrap();
+        assert!(local.port() > 0, "OS assigned a real port");
+        assert!(local.ip().is_loopback());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_join_unauthorized_without_bearer() {
+        std::env::set_var("SUPABASE_JWT_SECRET", "secret");
+        let allocator = Arc::new(None::<AgonesAllocator>);
+        let resp = join(Extension(allocator), axum::http::HeaderMap::new())
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        std::env::remove_var("SUPABASE_JWT_SECRET");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_join_allocator_offline_returns_503() {
+        // No JWT secret -> auth gate is skipped -> reaches the allocator check.
+        std::env::remove_var("SUPABASE_JWT_SECRET");
+        let allocator = Arc::new(None::<AgonesAllocator>);
+        let resp = join(Extension(allocator), axum::http::HeaderMap::new())
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.16"
+version: "0.0.17"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.29"
+version: "0.1.30"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## Summary
Raise **axum-cryptothrone** test coverage from ~75% → **81.28% lines** (10 → 31 tests; excludes the `main.rs` entrypoint) and add an asset-presence e2e suite. Motivated by the recent `/discord/discord.js` 404 — now guarded end-to-end.

## Coverage
| file | lines |
|---|---|
| auth.rs | 100% |
| db/kv_cache.rs | 100% |
| db/pg_cluster.rs | 89% |
| transport/https.rs | 85% |
| agones.rs | 81% |
| discord.rs | 60% (Discord OAuth + PG path needs a mock server/DB) |
| **TOTAL** | **81.28%** |

New nx target `coverage` enforces `--fail-under-lines 80`.

## Changes
- Extracted pure, testable helpers from IO paths: `mint_session_jwt` (discord), `parse_allocation` (agones).
- Unit/integration tests: JWT round-trip + session guard branches, allocation parsing (5 shapes) + `try_new`, auth expiry/default/bearer edges, db init/getter, `/api/join` 401/503, `discord_frame_headers`, mime passthrough, `tuned_listener` bind.
- **assets.spec.ts** e2e: `/discord/discord.js`, `/embed/embed.js` serve as real JS (>1KB, correct MIME); `/discord/` index; `llms.txt`; `robots.txt`; `sitemap.xml`; nested-404.
- Bump `cryptothrone` (0.1.29→0.1.30) + `cryptothrone-server` (0.0.16→0.0.17) MDX versions to publish.

## Test
`nx run axum-cryptothrone:coverage` → 31 passed, 81.28% lines, gate passes.