### PR TITLE
chore(chuck): gate beta auto-dispatch (MDX 0.3.20 → 0.3.19 == version.toml)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.199",
+			"version": "1.0.200",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.28",
+			"version": "0.1.30",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -120,7 +120,7 @@
 		{
 			"key": "cryptothrone_server",
 			"app_name": "cryptothrone-server",
-			"version": "0.0.16",
+			"version": "0.0.17",
 			"version_toml": "apps/agones/cryptothrone/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
 			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",
@@ -259,7 +259,7 @@
 		{
 			"key": "irc_gateway",
 			"app_name": "irc-gateway",
-			"version": "0.1.25",
+			"version": "0.1.26",
 			"version_toml": "apps/irc/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/irc-gateway.mdx",
 			"version_target": "apps/irc/irc-gateway/Cargo.toml",
@@ -1094,7 +1094,7 @@
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
-			"version": "0.3.20",
+			"version": "0.3.19",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",
 			"runner": "arc-runner-ue",

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -15,7 +15,7 @@ pipeline: unreal_game
 app_name: chuck
 source_path: apps/chuckrpg/unreal-chuck
 version_toml: apps/chuckrpg/unreal-chuck/version.toml
-version: "0.3.20"
+version: "0.3.19"
 runner: arc-runner-ue
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
## Why

Stop the every-main-push re-dispatch loop while we sort the Linux cook errors (UE plugin compile issues surfacing now that the pipeline reaches BuildCookRun).

## What

Set beta MDX `version: 0.3.20 → 0.3.19` so it **equals** the published `version.toml` (0.3.19). The version gate then reads "already published" → **no auto-dispatch** on main pushes. Manifest regenerated (beta `version: 0.3.19`).

## Notes

- **Manual deploy still works**: `gh workflow run ci-unreal.yml --field task=server/game ...` for testing the cook without the loop.
- **Re-arm later**: bump beta MDX `version:` back to `0.3.20` once the Linux plugin compile is green → resumes auto-dispatch + the actual release/publish.
- dev + rentearth already gated; this makes beta quiet too.