### PR TITLE
test(cryptothrone-e2e): fix asset suite (drop kbve.com-only checks)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/assets.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/assets.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '@playwright/test';
 /**
  * Critical bundled assets must actually ship and serve with the right MIME —
  * the Discord Activity client (`/discord/discord.js`), the standalone embed
- * (`/embed/embed.js`), and the LLM/robots/sitemap descriptors. These are
+ * (`/embed/embed.js`), and the generated sitemap index. The JS bundles are
  * produced by separate vite builds copied through `public/` into the Astro
  * `dist/`; a broken build step yields a silent 404 (or an HTML 404 body served
  * as a script, which `nosniff` then refuses to execute). Docker-only — the
@@ -47,23 +47,13 @@ test.describe('bundled assets', () => {
 		expect((await res.body()).length).toBeGreaterThan(1000);
 	});
 
-	test('llms.txt descriptor is present', async ({ request }) => {
-		const res = await request.get('/llms.txt');
+	test('@astrojs/sitemap index is generated', async ({ request }) => {
+		// cryptothrone.com ships the sitemap as `sitemap-index.xml` (no static
+		// `/sitemap.xml` redirect — that is a kbve.com-only convenience). It has
+		// no robots.txt / llms.txt; those are kbve.com descriptors.
+		const res = await request.get('/sitemap-index.xml');
 		expect(res.status()).toBe(200);
-		expect(res.headers()['content-type']).toMatch(/text\/plain/);
-		expect(await res.text()).toContain('KBVE');
-	});
-
-	test('robots.txt points at the sitemap', async ({ request }) => {
-		const res = await request.get('/robots.txt');
-		expect(res.status()).toBe(200);
-		expect(await res.text()).toMatch(/Sitemap:/i);
-	});
-
-	test('sitemap.xml resolves to the generated index', async ({ request }) => {
-		const res = await request.get('/sitemap.xml');
-		expect(res.status()).toBe(200);
-		expect(await res.text()).toMatch(/sitemapindex|sitemap-index|urlset/);
+		expect(await res.text()).toMatch(/sitemapindex|urlset/);
 	});
 
 	test('a missing nested asset returns a real 404, not a script', async ({


### PR DESCRIPTION
Follow-up to #12453 (merged with a red e2e). The asset-presence suite asserted three descriptors that belong to **kbve.com**, not cryptothrone.com:

- `/llms.txt`, `/robots.txt` — cryptothrone has neither.
- `/sitemap.xml` — cryptothrone serves `sitemap-index.xml` (no static redirect).

Dropped those three; kept the real bundled-asset guards (`/discord/discord.js`, `/embed/embed.js`, the `/discord/` index, nested-404) and switched the sitemap check to `/sitemap-index.xml` (the path the existing `server.spec.ts` already validates).

Rides the pending 0.1.30 release (never shipped — #12453's publish was gated by this failure), so no version re-bump.