### PR TITLE
polish(forgejo dashboard): render side-effect, owner guards, memo, empty state

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoPanel.tsx
@@ -86,6 +86,10 @@ function CreateRepoModal({ onClose }: { onClose: () => void }) {
 	});
 	const submit = async () => {
 		const [kind, owner] = state.owner.split(':');
+		if (!owner) {
+			forgejoService.showToast('error', 'Pick an owner');
+			return;
+		}
 		const ok = await forgejoService.createRepo({
 			owner,
 			ownerIsOrg: kind === 'org',
@@ -165,6 +169,10 @@ function MigrateRepoModal({ onClose }: { onClose: () => void }) {
 	});
 	const submit = async () => {
 		const [, owner] = state.owner.split(':');
+		if (!owner) {
+			forgejoService.showToast('error', 'Pick an owner');
+			return;
+		}
 		const ok = await forgejoService.migrateRepo({
 			clone_addr: state.clone_addr,
 			repo_name: state.repo_name,
@@ -356,7 +364,10 @@ function CollaboratorsModal({
 	const collabs = collabMap[repo.full_name];
 	const [user, setUser] = useState('');
 	const [perm, setPerm] = useState('write');
-	if (collabs === undefined) forgejoService.loadCollaborators(repo.full_name);
+	useEffect(() => {
+		if (collabs === undefined)
+			forgejoService.loadCollaborators(repo.full_name);
+	}, [repo.full_name, collabs === undefined]);
 	return (
 		<Modal
 			title={`Collaborators · ${repo.full_name}`}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
@@ -585,11 +585,38 @@ function RepoRow({
 export default function ReactForgejoRepoTable() {
 	const active = useTabActive('overview');
 	const repos = useStore(forgejoService.$repos);
+	const loading = useStore(forgejoService.$loading);
 	const expandedRepo = useStore(forgejoService.$expandedRepo);
 	const repoDetails = useStore(forgejoService.$repoDetails);
 
 	if (!active) return null;
-	if (repos.length === 0) return null;
+	if (repos.length === 0) {
+		return (
+			<div
+				className="not-content"
+				style={{
+					display: 'flex',
+					justifyContent: 'center',
+					alignItems: 'center',
+					gap: 8,
+					padding: '2rem',
+					color: 'var(--sl-color-gray-3, #8b949e)',
+					fontSize: '0.85rem',
+				}}>
+				{loading ? (
+					<>
+						<Loader2
+							size={16}
+							style={{ animation: 'spin 1s linear infinite' }}
+						/>
+						Loading repositories…
+					</>
+				) : (
+					'No repositories found'
+				)}
+			</div>
+		);
+	}
 
 	return (
 		<div className="not-content">

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	forgejoService,
@@ -84,11 +85,15 @@ function StatCard({
 function StorageBreakdown() {
 	const repos = useStore(forgejoService.$repos);
 
-	if (repos.length === 0) return null;
+	const { totalSize, top } = useMemo(() => {
+		const sorted = [...repos].sort((a, b) => b.size - a.size);
+		return {
+			totalSize: sorted.reduce((s, r) => s + r.size, 0),
+			top: sorted.slice(0, 8),
+		};
+	}, [repos]);
 
-	const sorted = [...repos].sort((a, b) => b.size - a.size);
-	const totalSize = sorted.reduce((s, r) => s + r.size, 0);
-	const top = sorted.slice(0, 8);
+	if (repos.length === 0) return null;
 
 	return (
 		<div style={{ marginBottom: '1.5rem' }}>


### PR DESCRIPTION
Frontend polish batch from the dashboard audit (verified — discarded the audit's false/overstated items).

- **Render side-effect** — `CollaboratorsModal` called `loadCollaborators()` *during render* (a store write in the render path → can re-fire every render until the data lands). Moved into a `useEffect` keyed on the repo.
- **Owner guard** — the create-repo & migrate modals did `owner.split(':')`, which yields `undefined` when nothing is selected, and silently posted `owner: undefined`. Added a guard + "Pick an owner" toast.
- **Memo** — `StorageBreakdown` sorted the full repo array on every render; wrapped in `useMemo([repos])`.
- **Empty/loading state** — the repo table `return null`-ed when empty, so both initial load and a genuinely-empty instance showed a blank tab. Now renders a spinner while loading and "No repositories found" otherwise.

Issues tab already had its empty state (audit overstated) — left alone.

## Verify
- `./kbve.sh -nx astro-kbve:build` ✓