### PR TITLE
feat(ci-unreal-build): overlay monorepo KBVE plugins onto the cook (source of truth)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -460,6 +460,24 @@ jobs:
                   mkdir -p /tmp/game-project
                   cp -r "${SRC}/." /tmp/game-project/
 
+            - name: Fetch monorepo plugins (source of truth)
+              uses: actions/checkout@v6
+              with:
+                  path: _kbve_mono
+                  sparse-checkout: packages/unreal
+                  sparse-checkout-cone-mode: true
+            - name: Overlay KBVE plugins onto project
+              run: |
+                  PLUGINS_DIR=/tmp/game-project/Plugins
+                  mkdir -p "${PLUGINS_DIR}"
+                  for p in "${GITHUB_WORKSPACE}/_kbve_mono/packages/unreal/"KBVE*; do
+                    [ -d "$p" ] || continue
+                    n=$(basename "$p")
+                    echo "::notice::overlay plugin ${n} from monorepo (source of truth)"
+                    rm -rf "${PLUGINS_DIR}/${n}"
+                    cp -r "$p" "${PLUGINS_DIR}/${n}"
+                  done
+
             - name: Build dedicated server
               env:
                   SERVER_TARGET: ${{ needs.server_config.outputs.server_target }}
@@ -772,6 +790,24 @@ jobs:
                   fi
                   mkdir -p /tmp/game-project
                   cp -r "${SRC}/." /tmp/game-project/
+
+            - name: Fetch monorepo plugins (source of truth)
+              uses: actions/checkout@v6
+              with:
+                  path: _kbve_mono
+                  sparse-checkout: packages/unreal
+                  sparse-checkout-cone-mode: true
+            - name: Overlay KBVE plugins onto project
+              run: |
+                  PLUGINS_DIR=/tmp/game-project/Plugins
+                  mkdir -p "${PLUGINS_DIR}"
+                  for p in "${GITHUB_WORKSPACE}/_kbve_mono/packages/unreal/"KBVE*; do
+                    [ -d "$p" ] || continue
+                    n=$(basename "$p")
+                    echo "::notice::overlay plugin ${n} from monorepo (source of truth)"
+                    rm -rf "${PLUGINS_DIR}/${n}"
+                    cp -r "$p" "${PLUGINS_DIR}/${n}"
+                  done
 
             - name: Build Linux client
               run: |


### PR DESCRIPTION
## Why

The cloned `KBVE/chuck` repo commits its own snapshot of the KBVE plugins, which drifts **stale** vs `packages/unreal`. The dedicated-server cook failed on chuck's old `KBVEWorld` (`SetStaticMesh`, incomplete `FMassEntityQuery`) — both **already fixed** in the monorepo source. So the build was compiling stale ghosts.

## What

Make `packages/unreal` the source of truth at build time. After materializing the project, both the **server** and **Linux-client** steps now:
1. `actions/checkout` (sparse `packages/unreal`) → `_kbve_mono`
2. overlay every `packages/unreal/KBVE*` onto `<project>/Plugins/`, replacing the committed copies.

So monorepo plugin fixes reach the cook directly, and the next failures are **real current-source** errors, not stale ones — exactly what we need to drive the per-plugin agnostic (Win/Linux/server) pass.

## Notes
- `KBVEWorld` source is already 5.7-clean + `UnrealEd` is editor-guarded; the overlay is what lets that reach the build.
- Win64-client overlay is a follow-up (it builds on the VM).
- Overlay uses the run's ref — plugin fixes need to be on that ref (main for auto-dispatch) to apply.