### PR TITLE
fix(cryptothrone): never CDN-cache non-2xx (sticky /discord/discord.js 404)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
@@ -35,6 +35,12 @@ export default defineConfig({
 	publicDir: false,
 	define: {
 		'process.env.NODE_ENV': JSON.stringify('production'),
+		// Raw `vite build` (not Astro) does not surface PUBLIC_* from process.env
+		// into import.meta.env, so bake the Discord client id in explicitly from
+		// the Docker build ENV. Public value — safe to inline client-side.
+		'import.meta.env.PUBLIC_DISCORD_CLIENT_ID': JSON.stringify(
+			process.env.PUBLIC_DISCORD_CLIENT_ID ?? '',
+		),
 	},
 	build: {
 		outDir: 'public/discord',

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -195,13 +195,24 @@ async fn cache_headers(request: Request, next: Next) -> Response {
     let path = request.uri().path().to_owned();
     let mut response = next.run(request).await;
 
-    // Never let a CDN cache a non-2xx: a 404 for an asset that didn't exist yet
-    // would otherwise stick for max-age (Cloudflare served stale /discord/*.js
-    // 404s for a day while the bundle rolled out).
+    let is_html = response
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|ct| ct.starts_with("text/html"));
+    // The Discord/embed entry bundles keep a stable filename across releases, so
+    // a long max-age would pin last deploy's bytes; force them to revalidate.
+    let is_entry_bundle = path == "/discord/discord.js" || path == "/embed/embed.js";
+
+    // /_astro/ assets are content-hashed → immutable. HTML and the unhashed entry
+    // bundles must revalidate (ETag/304) so a redeploy is seen at once. A non-2xx
+    // is never cached — a transient 404 once stuck in Cloudflare for a full day.
     let cache_value = if !response.status().is_success() {
         "no-store"
     } else if path.starts_with("/_astro/") {
         "public, max-age=31536000, immutable"
+    } else if is_html || is_entry_bundle {
+        "no-cache"
     } else {
         "public, max-age=86400"
     };
@@ -474,6 +485,58 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(cc.contains("86400"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_html_revalidates() {
+        let app = Router::new()
+            .route(
+                "/discord/",
+                get(|| async {
+                    (
+                        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+                        "<html>",
+                    )
+                }),
+            )
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/discord/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_entry_bundle_revalidates() {
+        let app = Router::new()
+            .route("/discord/discord.js", get(|| async { "bundle" }))
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/discord/discord.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "no-cache"
+        );
     }
 
     #[tokio::test]

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -195,7 +195,12 @@ async fn cache_headers(request: Request, next: Next) -> Response {
     let path = request.uri().path().to_owned();
     let mut response = next.run(request).await;
 
-    let cache_value = if path.starts_with("/_astro/") {
+    // Never let a CDN cache a non-2xx: a 404 for an asset that didn't exist yet
+    // would otherwise stick for max-age (Cloudflare served stale /discord/*.js
+    // 404s for a day while the bundle rolled out).
+    let cache_value = if !response.status().is_success() {
+        "no-store"
+    } else if path.starts_with("/_astro/") {
         "public, max-age=31536000, immutable"
     } else {
         "public, max-age=86400"
@@ -469,6 +474,35 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(cc.contains("86400"));
+    }
+
+    #[tokio::test]
+    async fn test_cache_headers_404_not_cached() {
+        let app = Router::new()
+            .route(
+                "/missing.js",
+                get(|| async { (StatusCode::NOT_FOUND, "nope") }),
+            )
+            .layer(axum::middleware::from_fn(cache_headers));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/missing.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let cc = response
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert_eq!(cc, "no-store");
     }
 
     #[tokio::test]

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.30"
+version: "0.1.31"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## Symptom

`https://cryptothrone.com/discord/discord.js` 404s, so the Discord Activity can't boot — even though the deployed 0.1.30 image **contains** the file (verified by extracting `/app/templates/dist/discord/discord.js`, 3.9MB, from the published image).

## Root cause

Cloudflare cached the 404:

| request | result |
|---|---|
| `/discord/discord.js` | 404, `cf-cache-status: HIT`, `age: 46295` (~12.8h) |
| `/discord/discord.js?v=<ts>` | **200** (cache-bust → origin serves the real file) |
| `/discord/` | 200, `cf-cache-status: DYNAMIC` |

The rust `cache_headers` middleware stamped `public, max-age=86400` on **every** static response, including the 404 fallback. So when the bundle was requested before it rolled out, Cloudflare cached that 404 with a 24h TTL and kept serving it.

## Fix

Gate the long `cache-control` on a 2xx status; non-2xx gets `no-store` so a CDN never pins a transient error. Adds a regression unit test (`cargo test -p axum-cryptothrone` → 32 passed). Bumps to 0.1.31 to ship.

## Manual step (needs CF access)

The already-cached 404 won't clear until its max-age expires (~11h left). **Purge Cloudflare cache for `/discord/discord.js`** (and `/embed/embed.js` if cached) to fix it immediately.