### PR TITLE
feat(cryptothrone): P3b — extract interaction decision system + sim tests (#12422)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -43,6 +43,15 @@ import {
 	type PredictState,
 	type IsBlocked,
 } from '../systems/prediction';
+import {
+	chebyshev,
+	resolveClick,
+	resolvePending,
+	nearestAdjacentNpc,
+	adjacentFreeTile,
+	type ClickHit,
+	type NpcEntry,
+} from '../systems/interaction';
 
 interface EntityRefs {
 	sprite: Phaser.GameObjects.Sprite;
@@ -607,13 +616,11 @@ export class CloudCityScene extends Scene {
 		if (!pending || !this.client) return;
 		const me = this.myTile();
 		const targetTile = this.store.tile(pending.eid);
-		if (!me || !targetTile) {
-			this.pendingAction = null;
-			return;
-		}
-		if (this.chebyshev(me, targetTile) > 1) return;
+		const outcome = resolvePending(pending.kind, me, targetTile ?? null);
+		if (outcome === 'wait') return;
 		this.pendingAction = null;
-		if (pending.kind === 'pickup') {
+		if (outcome === 'cancel') return;
+		if (outcome === 'pickup') {
 			this.client.action(ACTION_PICKUP, pending.eid);
 			return;
 		}
@@ -685,7 +692,7 @@ export class CloudCityScene extends Scene {
 			const ref = this.kindRef(this.store.kind(serverEid));
 			if (!ref || !isHostileRef(ref)) continue;
 			const t = this.store.tile(serverEid);
-			if (t && this.chebyshev(me, t) <= 3) count += 1;
+			if (t && chebyshev(me, t) <= 3) count += 1;
 		}
 		if (count > 0 && this.nearbyHostiles === 0) {
 			laserEvents.emit('monster:nearby', { count });
@@ -698,54 +705,9 @@ export class CloudCityScene extends Scene {
 		return this.store.tile(this.myEid);
 	}
 
-	private chebyshev(
-		a: { x: number; y: number },
-		b: { x: number; y: number },
-	): number {
-		return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
-	}
-
 	private entityAt(tile: { x: number; y: number }): number | null {
 		const hit = this.store.at(tile.x, tile.y, this.myEid);
 		return hit ? hit.serverEid : null;
-	}
-
-	/**
-	 * Nearest walkable tile next to `target` (NPCs occupy a solid tile, so you
-	 * can't path onto it). Picks the neighbour closest to `from` so the player
-	 * stops beside the NPC and the pending interaction can fire. Falls back to
-	 * the target tile when fully boxed in.
-	 */
-	private adjacentFreeTile(
-		target: { x: number; y: number },
-		from: { x: number; y: number },
-	): { x: number; y: number } {
-		const deltas = [
-			[0, -1],
-			[0, 1],
-			[-1, 0],
-			[1, 0],
-			[-1, -1],
-			[1, -1],
-			[-1, 1],
-			[1, 1],
-		];
-		const free = deltas
-			.map(([dx, dy]) => ({ x: target.x + dx, y: target.y + dy }))
-			.filter(
-				(c) =>
-					!this.blocked.has(`${c.x},${c.y}`) &&
-					this.entityAt(c) === null,
-			);
-		if (free.length === 0) return target;
-		free.sort(
-			(a, b) =>
-				this.chebyshev(a, from) - this.chebyshev(b, from) ||
-				Math.abs(a.x - from.x) +
-					Math.abs(a.y - from.y) -
-					(Math.abs(b.x - from.x) + Math.abs(b.y - from.y)),
-		);
-		return free[0];
 	}
 
 	private onPointerDown(pointer: Phaser.Input.Pointer) {
@@ -757,32 +719,42 @@ export class CloudCityScene extends Scene {
 		};
 
 		this.pendingAction = null;
+		const me = this.myTile();
+		const inRange = me !== null && chebyshev(me, tile) <= 1;
 		const hitEid = this.entityAt(tile);
+		let hit: ClickHit | null = null;
 		if (hitEid !== null) {
 			const kind = this.store.kind(hitEid);
 			const ref = this.kindRef(kind);
 			const npc = ref ? getNPCByRef(ref) : undefined;
-			const cat = this.kindCat(kind);
+			hit = {
+				eid: hitEid,
+				cat: this.catName(kind),
+				hasRef: ref !== null,
+			};
 			laserEvents.emit('target:set', {
 				eid: hitEid,
 				name: npc?.name ?? ref ?? 'Unknown',
 				hp: this.store.hp(hitEid),
 				maxHp: this.store.maxHp(hitEid),
-				cat,
+				cat: this.kindCat(kind),
 			});
-			const me = this.myTile();
-			if (cat === KIND_CAT_ITEM) {
-				if (me && this.chebyshev(me, tile) <= 1) {
-					this.client.action(ACTION_PICKUP, hitEid);
-				} else {
-					this.pendingAction = { kind: 'pickup', eid: hitEid };
-					this.startMoveTo(tile);
-				}
+		}
+
+		const intent = resolveClick(hit, inRange);
+		switch (intent.kind) {
+			case 'pickup':
+				this.client.action(ACTION_PICKUP, intent.eid);
 				return;
-			}
-			if (cat === KIND_CAT_NPC) {
-				if (ref && me && this.chebyshev(me, tile) <= 1) {
-					const ev = pointer.event as MouseEvent | undefined;
+			case 'pickup-move':
+				this.pendingAction = { kind: 'pickup', eid: intent.eid };
+				this.startMoveTo(tile);
+				return;
+			case 'interact': {
+				const ref = this.kindRef(this.store.kind(intent.eid));
+				const npc = ref ? getNPCByRef(ref) : undefined;
+				const ev = pointer.event as MouseEvent | undefined;
+				if (ref) {
 					laserEvents.emit('npc:interact', {
 						npcId: npcIdForRef(ref),
 						npcName: npc?.name ?? ref,
@@ -792,18 +764,27 @@ export class CloudCityScene extends Scene {
 							y: ev?.clientY ?? pointer.y,
 						},
 					});
-				} else {
-					this.pendingAction = { kind: 'interact', eid: hitEid };
-					this.startMoveTo(
-						me ? this.adjacentFreeTile(tile, me) : tile,
-					);
 				}
 				return;
 			}
+			case 'interact-move':
+				this.pendingAction = { kind: 'interact', eid: intent.eid };
+				this.startMoveTo(
+					me
+						? adjacentFreeTile(
+								tile,
+								me,
+								this.isBlocked,
+								(c) => this.entityAt(c) !== null,
+							)
+						: tile,
+				);
+				return;
+			case 'move':
+				laserEvents.emit('target:clear', {});
+				this.startMoveTo(tile);
+				return;
 		}
-
-		laserEvents.emit('target:clear', {});
-		this.startMoveTo(tile);
 	}
 
 	/**
@@ -835,20 +816,17 @@ export class CloudCityScene extends Scene {
 		if (!this.client) return;
 		const me = this.myTile();
 		if (!me) return;
-		let best: { eid: number; dist: number } | null = null;
+		const npcs: NpcEntry[] = [];
 		for (const [serverEid] of this.store.entries()) {
 			if (serverEid === this.myEid) continue;
 			if (this.kindCat(this.store.kind(serverEid)) !== KIND_CAT_NPC)
 				continue;
 			const t = this.store.tile(serverEid);
-			if (!t) continue;
-			const dist = this.chebyshev(me, t);
-			if (dist <= 1 && (!best || dist < best.dist)) {
-				best = { eid: serverEid, dist };
-			}
+			if (t) npcs.push({ eid: serverEid, tile: t });
 		}
-		if (best) {
-			this.client.action(ACTION_ATTACK, best.eid);
+		const target = nearestAdjacentNpc(me, npcs);
+		if (target !== null) {
+			this.client.action(ACTION_ATTACK, target);
 		} else {
 			this.showFloatingText(this.myEid, 'no target', '#9ca3af');
 		}
@@ -935,7 +913,7 @@ export class CloudCityScene extends Scene {
 			if (this.kindCat(this.store.kind(serverEid)) !== KIND_CAT_ITEM)
 				continue;
 			const t = this.store.tile(serverEid);
-			if (t && this.chebyshev(me, t) <= 1) {
+			if (t && chebyshev(me, t) <= 1) {
 				this.lastAutoPickup = time;
 				this.client.action(ACTION_PICKUP, serverEid);
 				return;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/interaction.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/interaction.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from 'vitest';
+import {
+	chebyshev,
+	resolveClick,
+	resolvePending,
+	nearestAdjacentNpc,
+	adjacentFreeTile,
+	type ClickHit,
+} from './interaction';
+
+const item = (eid: number): ClickHit => ({ eid, cat: 'item', hasRef: true });
+const npc = (eid: number, hasRef = true): ClickHit => ({
+	eid,
+	cat: 'npc',
+	hasRef,
+});
+const player = (eid: number): ClickHit => ({
+	eid,
+	cat: 'player',
+	hasRef: false,
+});
+
+describe('chebyshev', () => {
+	it('is the king-move distance', () => {
+		expect(chebyshev({ x: 0, y: 0 }, { x: 0, y: 0 })).toBe(0);
+		expect(chebyshev({ x: 0, y: 0 }, { x: 1, y: 1 })).toBe(1);
+		expect(chebyshev({ x: 0, y: 0 }, { x: 3, y: 1 })).toBe(3);
+	});
+});
+
+describe('resolveClick', () => {
+	it('empty tile → move', () => {
+		expect(resolveClick(null, false)).toEqual({ kind: 'move' });
+	});
+
+	it('item: pickup when adjacent, pickup-move when far', () => {
+		expect(resolveClick(item(2), true)).toEqual({ kind: 'pickup', eid: 2 });
+		expect(resolveClick(item(2), false)).toEqual({
+			kind: 'pickup-move',
+			eid: 2,
+		});
+	});
+
+	it('npc: interact when adjacent with a ref, interact-move otherwise', () => {
+		expect(resolveClick(npc(5), true)).toEqual({
+			kind: 'interact',
+			eid: 5,
+		});
+		expect(resolveClick(npc(5), false)).toEqual({
+			kind: 'interact-move',
+			eid: 5,
+		});
+	});
+
+	it('npc adjacent but ref-less → interact-move (walk, resolve on arrival)', () => {
+		expect(resolveClick(npc(5, false), true)).toEqual({
+			kind: 'interact-move',
+			eid: 5,
+		});
+	});
+
+	it('another player → plain move', () => {
+		expect(resolveClick(player(9), true)).toEqual({ kind: 'move' });
+	});
+});
+
+describe('resolvePending', () => {
+	const me = { x: 5, y: 5 };
+	it('cancels when the target is gone', () => {
+		expect(resolvePending('pickup', me, null)).toBe('cancel');
+		expect(resolvePending('interact', null, { x: 5, y: 5 })).toBe('cancel');
+	});
+	it('waits while out of range', () => {
+		expect(resolvePending('pickup', me, { x: 9, y: 9 })).toBe('wait');
+	});
+	it('fires the queued kind once adjacent', () => {
+		expect(resolvePending('pickup', me, { x: 6, y: 5 })).toBe('pickup');
+		expect(resolvePending('interact', me, { x: 4, y: 4 })).toBe('interact');
+	});
+});
+
+describe('nearestAdjacentNpc', () => {
+	const me = { x: 5, y: 5 };
+	it('returns null when nothing is adjacent', () => {
+		expect(
+			nearestAdjacentNpc(me, [{ eid: 1, tile: { x: 8, y: 8 } }]),
+		).toBeNull();
+	});
+	it('picks the closest in-range npc', () => {
+		const got = nearestAdjacentNpc(me, [
+			{ eid: 1, tile: { x: 4, y: 4 } }, // dist 1
+			{ eid: 2, tile: { x: 5, y: 6 } }, // dist 1 (first wins on tie)
+			{ eid: 3, tile: { x: 9, y: 9 } }, // out of range
+		]);
+		expect(got).toBe(1);
+	});
+});
+
+describe('adjacentFreeTile', () => {
+	const open = () => false;
+	const noneOccupied = () => false;
+
+	it('returns the neighbour closest to `from`', () => {
+		// target at 5,5; from at 3,5 → the tile at 4,5 (west) is closest.
+		const got = adjacentFreeTile(
+			{ x: 5, y: 5 },
+			{ x: 3, y: 5 },
+			open,
+			noneOccupied,
+		);
+		expect(got).toEqual({ x: 4, y: 5 });
+	});
+
+	it('skips blocked and occupied neighbours', () => {
+		const blocked = (x: number, y: number) => x === 4 && y === 5;
+		const occupied = (t: { x: number; y: number }) =>
+			t.x === 4 && t.y === 4;
+		const got = adjacentFreeTile(
+			{ x: 5, y: 5 },
+			{ x: 3, y: 5 },
+			blocked,
+			occupied,
+		);
+		expect(got).not.toEqual({ x: 4, y: 5 });
+		expect(got).not.toEqual({ x: 4, y: 4 });
+	});
+
+	it('falls back to the target when fully boxed in', () => {
+		const got = adjacentFreeTile(
+			{ x: 5, y: 5 },
+			{ x: 3, y: 5 },
+			() => true,
+			noneOccupied,
+		);
+		expect(got).toEqual({ x: 5, y: 5 });
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/interaction.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/systems/interaction.ts
@@ -1,0 +1,121 @@
+import type { EntityCat } from '../ecs/store';
+import type { TileXY } from './netSync';
+
+/** Chebyshev (king-move) distance — adjacency is `<= 1`. */
+export function chebyshev(a: TileXY, b: TileXY): number {
+	return Math.max(Math.abs(a.x - b.x), Math.abs(a.y - b.y));
+}
+
+/** The entity under a click, reduced to what the decision needs. */
+export interface ClickHit {
+	eid: number;
+	cat: EntityCat;
+	/** An NPC with a resolvable ref can be interacted with; without one it can
+	 * only be walked toward. */
+	hasRef: boolean;
+}
+
+export type ClickIntent =
+	| { kind: 'pickup'; eid: number }
+	| { kind: 'pickup-move'; eid: number }
+	| { kind: 'interact'; eid: number }
+	| { kind: 'interact-move'; eid: number }
+	| { kind: 'move' };
+
+/**
+ * Decide what a click does given the entity under the cursor (or null for an
+ * empty tile) and whether the player is already adjacent. Pure — the scene maps
+ * the intent onto events, client actions, prediction and pending state. Items
+ * and NPCs out of range resolve to a `-move` intent (walk there, act on
+ * arrival); a click on another player or empty ground is a plain move.
+ */
+export function resolveClick(
+	hit: ClickHit | null,
+	inRange: boolean,
+): ClickIntent {
+	if (!hit) return { kind: 'move' };
+	if (hit.cat === 'item') {
+		return inRange
+			? { kind: 'pickup', eid: hit.eid }
+			: { kind: 'pickup-move', eid: hit.eid };
+	}
+	if (hit.cat === 'npc') {
+		return inRange && hit.hasRef
+			? { kind: 'interact', eid: hit.eid }
+			: { kind: 'interact-move', eid: hit.eid };
+	}
+	return { kind: 'move' };
+}
+
+export type PendingKind = 'pickup' | 'interact';
+export type PendingOutcome = PendingKind | 'wait' | 'cancel';
+
+/**
+ * Resolve a queued action once the player has (maybe) reached the target:
+ * `cancel` if the target vanished, `wait` while still out of range, else fire
+ * the queued kind.
+ */
+export function resolvePending(
+	kind: PendingKind,
+	me: TileXY | null,
+	target: TileXY | null,
+): PendingOutcome {
+	if (!me || !target) return 'cancel';
+	if (chebyshev(me, target) > 1) return 'wait';
+	return kind;
+}
+
+export interface NpcEntry {
+	eid: number;
+	tile: TileXY;
+}
+
+/** Nearest NPC within melee range (`<= 1`), or null when none are adjacent. */
+export function nearestAdjacentNpc(
+	me: TileXY,
+	npcs: NpcEntry[],
+): number | null {
+	let best: { eid: number; dist: number } | null = null;
+	for (const n of npcs) {
+		const dist = chebyshev(me, n.tile);
+		if (dist <= 1 && (!best || dist < best.dist)) {
+			best = { eid: n.eid, dist };
+		}
+	}
+	return best ? best.eid : null;
+}
+
+/**
+ * Nearest walkable tile beside `target`, preferring the one closest to `from`
+ * (so the player stops adjacent and the queued interaction can fire). Falls back
+ * to `target` when fully boxed in.
+ */
+export function adjacentFreeTile(
+	target: TileXY,
+	from: TileXY,
+	isBlocked: (x: number, y: number) => boolean,
+	isOccupied: (tile: TileXY) => boolean,
+): TileXY {
+	const deltas = [
+		[0, -1],
+		[0, 1],
+		[-1, 0],
+		[1, 0],
+		[-1, -1],
+		[1, -1],
+		[-1, 1],
+		[1, 1],
+	];
+	const free = deltas
+		.map(([dx, dy]) => ({ x: target.x + dx, y: target.y + dy }))
+		.filter((c) => !isBlocked(c.x, c.y) && !isOccupied(c));
+	if (free.length === 0) return target;
+	free.sort(
+		(a, b) =>
+			chebyshev(a, from) - chebyshev(b, from) ||
+			Math.abs(a.x - from.x) +
+				Math.abs(a.y - from.y) -
+				(Math.abs(b.x - from.x) + Math.abs(b.y - from.y)),
+	);
+	return free[0];
+}


### PR DESCRIPTION
Phase 3b of the CloudCityScene decomposition (#12422). Branches off dev (P1/P2/P3 already merged) — no stacking.

## What

Pulls the click / pending-action / attack decision logic out of `CloudCityScene` into a pure `systems/interaction.ts`:

- `resolveClick(hit, inRange)` → `pickup` / `pickup-move` / `interact` / `interact-move` / `move` — what a click does given the entity under the cursor and whether the player is adjacent
- `resolvePending(kind, me, target)` → `pickup` | `interact` | `wait` | `cancel` — gate a queued action on arrival / target-still-there
- `nearestAdjacentNpc(me, npcs)` — melee target pick
- `adjacentFreeTile(target, from, isBlocked, isOccupied)` — stop-beside-NPC tile
- `chebyshev` — shared king-move distance (was a private scene method)

The scene maps the returned intents onto `laserEvents`, client actions, prediction and pending state; all entity/registry lookups (`entityAt`, `kindRef`, `getNPCByRef`) stay scene-side as the effect bridge. Drops the scene's private `chebyshev` + `adjacentFreeTile`.

## Tests

14 headless sim tests (click resolution incl. ref-less NPC + other-player, pending gate, nearest-attack ties, adjacent-tile blocked/occupied/boxed-in). Suite **71 → 85**, scoped `tsc` clean.

Next: P4 — thin scene shell orchestrator.