### PR TITLE
chore(chuck): re-arm beta auto-dispatch (MDX 0.3.19 → 0.3.20)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.30",
+			"version": "0.1.31",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -1094,7 +1094,7 @@
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
-			"version": "0.3.19",
+			"version": "0.3.20",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",
 			"runner": "arc-runner-ue",

--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -15,7 +15,7 @@ pipeline: unreal_game
 app_name: chuck
 source_path: apps/chuckrpg/unreal-chuck
 version_toml: apps/chuckrpg/unreal-chuck/version.toml
-version: "0.3.19"
+version: "0.3.20"
 runner: arc-runner-ue
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
Reverses the temporary gate (#12456). beta MDX `0.3.20` > `version.toml` 0.3.19 → the version gate fires each main push again (rotation back on), now that the plugin overlay (#12460) + LFS/target/mount cook fixes are in. Manifest regenerated. A successful publish bumps version.toml → the loop self-terminates once a build ships.