### PR TITLE
test(cryptothrone): fix e2e cache assertions for revalidation policy

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/server.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/server.spec.ts
@@ -22,12 +22,16 @@ test.describe('axum server integration', () => {
 		);
 	});
 
-	test('serves the homepage with a cache-control header', async ({
+	test('homepage HTML revalidates (no-cache, not long-lived)', async ({
 		request,
 	}) => {
 		const res = await request.get('/');
 		expect(res.status()).toBe(200);
-		expect(res.headers()['cache-control']).toContain('max-age');
+		// HTML must revalidate so a redeploy is picked up immediately; only the
+		// content-hashed /_astro/ assets are long-cached.
+		const cc = res.headers()['cache-control'] ?? '';
+		expect(cc).toContain('no-cache');
+		expect(cc).not.toContain('max-age');
 	});
 
 	test('immutable cache for hashed _astro assets', async ({
@@ -51,6 +55,8 @@ test.describe('axum server integration', () => {
 	test('serves a 404 page for unknown routes', async ({ request }) => {
 		const res = await request.get('/definitely-not-a-real-page');
 		expect(res.status()).toBe(404);
+		// A 404 must never be CDN-cached, or a not-yet-deployed asset 404 sticks.
+		expect(res.headers()['cache-control'] ?? '').toContain('no-store');
 		const body = await res.text();
 		expect(body).toMatch(/404|not found/i);
 	});


### PR DESCRIPTION
## Why

The cryptothrone docker e2e failed ([run 27514167152](https://github.com/KBVE/kbve/actions/runs/27514167152)):

```
expect(received).toContain(expected)
Expected substring: "max-age"
```

#12467 changed the cache policy — HTML + the unhashed entry bundles now serve `no-cache` (revalidate) and non-2xx serves `no-store` — but `server.spec.ts` still asserted the old `max-age` on the homepage.

## Fix

- Homepage HTML test now expects `no-cache` (and asserts *not* `max-age`) — documents that HTML revalidates so a redeploy is seen at once.
- 404 test now also asserts `no-store`, covering the sticky-404 fix at the integration layer.
- `/_astro/` immutable test unchanged (still valid).

Test-only; rides the pending 0.1.31 (no version bump).