### PR TITLE
feat(cryptothrone): typed npcdb integration

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcdb.test.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcdb.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+	getAllNpcEntries,
+	getNpcEntry,
+	getNpcStats,
+	isHostileRef,
+} from './npcdb';
+
+describe('npcdb adapter', () => {
+	it('loads a non-empty, deduped registry of valid entries', () => {
+		const all = getAllNpcEntries();
+		expect(all.length).toBeGreaterThan(0);
+		// Every entry is well-formed.
+		for (const n of all) {
+			expect(n.ref).toBeTruthy();
+			expect(n.name).toBeTruthy();
+			expect(n.id).toBeTruthy();
+		}
+		// refs are unique.
+		const refs = all.map((n) => n.ref);
+		expect(new Set(refs).size).toBe(refs.length);
+	});
+
+	it('normalizes the archer fixture from the prefixed enums', () => {
+		const archer = getNpcEntry('archer');
+		expect(archer).toBeDefined();
+		expect(archer!.name).toBe('Archer');
+		// NPC_RARITY_COMMON -> common, MOVEMENT_TYPE_PATROL -> patrol.
+		expect(archer!.rarity).toBe('common');
+		expect(archer!.movement).toBe('patrol');
+		expect(archer!.family).toBe('humanoid');
+		expect(archer!.firstStrike).toBe(true);
+		expect(archer!.stats.maxHp).toBe(50);
+		expect(archer!.abilities[0]).toMatchObject({ id: 'attack', damage: 6 });
+	});
+
+	it('exposes canonical stats by ref', () => {
+		const stats = getNpcStats('archer');
+		expect(stats).toEqual({
+			hp: 50,
+			maxHp: 50,
+			attack: 6,
+			defense: 1,
+			speed: 4,
+			armor: 1,
+		});
+	});
+
+	it('every normalized enum resolves to a known union member', () => {
+		const families = new Set([
+			'humanoid',
+			'undead',
+			'beast',
+			'construct',
+			'elemental',
+			'demon',
+			'plant',
+			'aberration',
+			'spirit',
+			'unknown',
+		]);
+		const movements = new Set([
+			'stationary',
+			'random_wander',
+			'patrol',
+			'scripted',
+			'aggressive',
+		]);
+		const rarities = new Set([
+			'common',
+			'uncommon',
+			'rare',
+			'epic',
+			'legendary',
+			'mythic',
+		]);
+		for (const n of getAllNpcEntries()) {
+			expect(families.has(n.family)).toBe(true);
+			expect(movements.has(n.movement)).toBe(true);
+			expect(rarities.has(n.rarity)).toBe(true);
+			// Prefixes are fully stripped.
+			expect(n.rarity).not.toMatch(/NPC_RARITY_/);
+			expect(n.movement).not.toMatch(/MOVEMENT_TYPE_/);
+		}
+	});
+
+	it('returns undefined for unknown refs and false for hostility', () => {
+		expect(getNpcEntry('does-not-exist')).toBeUndefined();
+		expect(getNpcStats('does-not-exist')).toBeUndefined();
+		expect(isHostileRef('does-not-exist')).toBe(false);
+	});
+
+	it('marks hostile faction entries as hostile', () => {
+		const hostiles = getAllNpcEntries().filter((n) => n.hostile);
+		for (const h of hostiles) {
+			expect(h.factionId).toBe('hostile');
+			expect(isHostileRef(h.ref)).toBe(true);
+		}
+	});
+});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcdb.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcdb.ts
@@ -1,0 +1,158 @@
+import npcdbRaw from '@kbve/npcdb-data';
+import type {
+	NpcEntry,
+	NpcStats,
+	NpcAbility,
+	NpcFamily,
+	NpcMovement,
+	NpcRarity,
+} from '../types';
+
+// Typed adapter over the shared @kbve/npcdb-data pool. Mirrors the itemdb
+// adapter: the codegen JSON is camelCase with prefixed enum values
+// (NPC_RARITY_COMMON, MOVEMENT_TYPE_PATROL, …); we normalize each entry into a
+// flat, game-ready NpcEntry once at module load and index it by ref + id.
+
+interface RawNpcStats {
+	hp?: number;
+	maxHp?: number;
+	attack?: number;
+	defense?: number;
+	speed?: number;
+	armor?: number;
+}
+
+interface RawNpcAbility {
+	id?: string;
+	name?: string;
+	damage?: number;
+}
+
+interface RawNpc {
+	ref: string;
+	id: string;
+	name: string;
+	description?: string;
+	typeFlags?: number;
+	rarity?: string;
+	personality?: string;
+	rank?: string;
+	family?: string;
+	level?: number;
+	stats?: RawNpcStats;
+	behavior?: { movementType?: string; firstStrike?: boolean };
+	abilities?: RawNpcAbility[];
+	faction?: { factionId?: string };
+}
+
+const FAMILIES: readonly NpcFamily[] = [
+	'humanoid',
+	'undead',
+	'beast',
+	'construct',
+	'elemental',
+	'demon',
+	'plant',
+	'aberration',
+	'spirit',
+];
+
+const MOVEMENTS: readonly NpcMovement[] = [
+	'stationary',
+	'random_wander',
+	'patrol',
+	'scripted',
+	'aggressive',
+];
+
+const RARITIES: readonly NpcRarity[] = [
+	'common',
+	'uncommon',
+	'rare',
+	'epic',
+	'legendary',
+	'mythic',
+];
+
+/** Strip a `PREFIX_` enum prefix and lowercase, e.g. `NPC_RARITY_EPIC` → `epic`. */
+function unprefix(raw: string | undefined, prefix: string): string {
+	return (raw ?? '').replace(prefix, '').toLowerCase();
+}
+
+function resolveRarity(raw?: string): NpcRarity {
+	const r = unprefix(raw, 'NPC_RARITY_') as NpcRarity;
+	return RARITIES.includes(r) ? r : 'common';
+}
+
+function resolveFamily(raw?: string): NpcFamily {
+	const f = (raw ?? '').toLowerCase() as NpcFamily;
+	return FAMILIES.includes(f) ? f : 'unknown';
+}
+
+function resolveMovement(raw?: string): NpcMovement {
+	const m = unprefix(raw, 'MOVEMENT_TYPE_') as NpcMovement;
+	return MOVEMENTS.includes(m) ? m : 'stationary';
+}
+
+function resolveStats(raw?: RawNpcStats): NpcStats {
+	const hp = raw?.hp ?? 30;
+	return {
+		hp,
+		maxHp: raw?.maxHp ?? hp,
+		attack: raw?.attack ?? 1,
+		defense: raw?.defense ?? 0,
+		speed: raw?.speed ?? 1,
+		armor: raw?.armor ?? 0,
+	};
+}
+
+function resolveAbilities(raw?: RawNpcAbility[]): NpcAbility[] {
+	return (raw ?? [])
+		.filter((a) => a && a.id)
+		.map((a) => ({
+			id: a.id as string,
+			name: a.name ?? (a.id as string),
+			damage: a.damage ?? 0,
+		}));
+}
+
+function adapt(raw: RawNpc): NpcEntry {
+	const factionId = raw.faction?.factionId ?? 'neutral';
+	return {
+		ref: raw.ref,
+		id: raw.id,
+		name: raw.name,
+		description: (raw.description ?? '').trim(),
+		family: resolveFamily(raw.family),
+		rarity: resolveRarity(raw.rarity),
+		rank: unprefix(raw.rank, 'NPC_RANK_') || 'normal',
+		level: raw.level ?? 1,
+		movement: resolveMovement(raw.behavior?.movementType),
+		firstStrike: raw.behavior?.firstStrike ?? false,
+		stats: resolveStats(raw.stats),
+		abilities: resolveAbilities(raw.abilities),
+		factionId,
+		hostile: factionId === 'hostile',
+	};
+}
+
+const pool = (npcdbRaw as { npcs?: RawNpc[] }).npcs ?? [];
+const npcs: NpcEntry[] = pool.filter((r) => r && r.ref && r.name).map(adapt);
+
+const byRef = new Map(npcs.map((n) => [n.ref, n]));
+
+export function getNpcEntry(ref: string): NpcEntry | undefined {
+	return byRef.get(ref);
+}
+
+export function getAllNpcEntries(): NpcEntry[] {
+	return npcs;
+}
+
+export function getNpcStats(ref: string): NpcStats | undefined {
+	return byRef.get(ref)?.stats;
+}
+
+export function isHostileRef(ref: string): boolean {
+	return byRef.get(ref)?.hostile ?? false;
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcs.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/npcs.ts
@@ -1,16 +1,8 @@
-import npcdbRaw from '@kbve/npcdb-data';
-import type { NPCData, DialogueNode } from '../types';
+import type { NPCData, DialogueNode, NpcEntry } from '../types';
+import { getNpcEntry, isHostileRef } from './npcdb';
 
-interface NpcDbEntry {
-	ref: string;
-	name: string;
-	description?: string;
-	faction?: { factionId?: string };
-	stats?: { hp?: number; maxHp?: number; attack?: number };
-}
-
-const NPCDB: NpcDbEntry[] = (npcdbRaw as { npcs: NpcDbEntry[] }).npcs ?? [];
-const npcDbByRef = new Map(NPCDB.map((n) => [n.ref, n]));
+// Re-exported so existing scene code keeps importing it from `./npcs`.
+export { isHostileRef };
 
 const REF_AVATARS: Record<string, string> = {
 	cleric: '/assets/entity/monks.png',
@@ -42,16 +34,12 @@ export function npcIdForRef(ref: string): string {
 	return `npc_${ref}`;
 }
 
-export function getNpcDbEntry(ref: string): NpcDbEntry | undefined {
-	return npcDbByRef.get(ref);
-}
-
-export function isHostileRef(ref: string): boolean {
-	return npcDbByRef.get(ref)?.faction?.factionId === 'hostile';
+export function getNpcDbEntry(ref: string): NpcEntry | undefined {
+	return getNpcEntry(ref);
 }
 
 function buildNpcFromDb(ref: string): NPCData | undefined {
-	const entry = npcDbByRef.get(ref);
+	const entry = getNpcEntry(ref);
 	if (!entry) return undefined;
 	const npc: NPCData = {
 		id: npcIdForRef(ref),
@@ -133,7 +121,7 @@ const DIALOGUES: Record<string, DialogueNode> = {
 };
 
 function buildDialogueFromDb(ref: string): DialogueNode | undefined {
-	const entry = npcDbByRef.get(ref);
+	const entry = getNpcEntry(ref);
 	if (!entry) return undefined;
 	const id = `dlg_${ref}_greeting`;
 	const dialogue: DialogueNode = {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/world.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ecs/world.ts
@@ -8,6 +8,7 @@ import {
 	NpcTag,
 	MonsterTag,
 } from './components';
+import { getNpcStats } from '../data/npcdb';
 
 export type GameWorld = World;
 
@@ -39,8 +40,16 @@ export function spawnPlayer(world: GameWorld, x: number, y: number): number {
 	return spawn(world, PlayerTag, x, y, 100);
 }
 
-export function spawnNpc(world: GameWorld, x: number, y: number): number {
-	return spawn(world, NpcTag, x, y, 30);
+export function spawnNpc(
+	world: GameWorld,
+	x: number,
+	y: number,
+	ref?: string,
+): number {
+	// When an npcdb ref is supplied, seed Health from its canonical stats;
+	// otherwise fall back to the generic NPC baseline.
+	const hp = (ref && getNpcStats(ref)?.maxHp) || 30;
+	return spawn(world, NpcTag, x, y, hp);
 }
 
 export function spawnMonster(world: GameWorld, x: number, y: number): number {

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/types.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/types.ts
@@ -62,6 +62,64 @@ export interface NPCData {
 
 export type NPCAction = 'talk' | 'trade' | 'steal' | 'inspect';
 
+// --- npcdb (typed view of @kbve/npcdb-data) ---------------------------------
+// Game-facing, normalized projection of an npcdb entry. The raw JSON ships
+// snake-free camelCase fields with prefixed enums (NPC_RARITY_*, MOVEMENT_TYPE_*);
+// `npcdb.ts` strips the prefixes into these tidy unions for gameplay use.
+
+export type NpcRarity = ItemRarity;
+
+export type NpcFamily =
+	| 'humanoid'
+	| 'undead'
+	| 'beast'
+	| 'construct'
+	| 'elemental'
+	| 'demon'
+	| 'plant'
+	| 'aberration'
+	| 'spirit'
+	| 'unknown';
+
+export type NpcMovement =
+	| 'stationary'
+	| 'random_wander'
+	| 'patrol'
+	| 'scripted'
+	| 'aggressive';
+
+export interface NpcStats {
+	hp: number;
+	maxHp: number;
+	attack: number;
+	defense: number;
+	speed: number;
+	armor: number;
+}
+
+export interface NpcAbility {
+	id: string;
+	name: string;
+	damage: number;
+}
+
+export interface NpcEntry {
+	ref: string;
+	id: string;
+	name: string;
+	description: string;
+	family: NpcFamily;
+	rarity: NpcRarity;
+	rank: string;
+	level: number;
+	movement: NpcMovement;
+	firstStrike: boolean;
+	stats: NpcStats;
+	abilities: NpcAbility[];
+	factionId: string;
+	hostile: boolean;
+}
+
 export interface DialogueNode {
 	id: string;
 	title: string;

--- a/apps/cryptothrone/astro-cryptothrone/vitest.config.ts
+++ b/apps/cryptothrone/astro-cryptothrone/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
 				'src/components/game/store/GameStoreContext.tsx',
 				'src/components/game/data/items.ts',
 				'src/components/game/data/itemdb.ts',
+				'src/components/game/data/npcdb.ts',
 				'src/components/game/data/npcs.ts',
 				'src/components/game/ui/ToggleButton.tsx',
 				'src/components/game/ui/StatsSection.tsx',


### PR DESCRIPTION
## Summary
Full **npcdb integration with TypeScript types** for cryptothrone, mirroring the existing itemdb adapter.

The shared `@kbve/npcdb-data` pool was already aliased into cryptothrone but consumed as an `any` cast. This adds a typed data layer.

## What
- **`data/npcdb.ts`** (new) — typed adapter over `@kbve/npcdb-data`. Normalizes each raw entry once at load into a flat, game-ready `NpcEntry`, indexed by ref. Getters: `getNpcEntry`, `getAllNpcEntries`, `getNpcStats`, `isHostileRef`.
- **`types.ts`** — game-facing unions/interfaces: `NpcEntry`, `NpcStats`, `NpcAbility`, `NpcFamily`, `NpcMovement`, `NpcRarity`.
- **`data/npcs.ts`** — drops the inline `any`-cast `NpcDbEntry`; consumes the typed adapter (re-exports `isHostileRef` for scene code).
- **`ecs/world.ts`** — `spawnNpc(world, x, y, ref?)` seeds `Health` from canonical npcdb stats.
- **6 unit tests** — registry load/dedup, enum-prefix normalization, stats, hostility, unknown-ref safety. All green; full data suite 36/36.

## Enum/JSON note
The generated `npcdb-schema.ts` (Zod) is **snake_case + bare enums** (`type_flags`, `cunning`) while the emitted `npcdb-data.json` is **camelCase + prefixed enums** (`typeFlags`, `PERSONALITY_CUNNING`). They don't match, so types are hand-rolled to the actual JSON shape (same as itemdb). Flagging as a codegen inconsistency worth a separate look.

## Not included
No MDX version bump — cryptothrone 0.1.30 is mid-flight (#12458 gates its publish). Bump to be decided once that lands.