### PR TITLE
feat(simgrid): timed status effects (Poison/Regen/Haste) + protocol v6

### DIFF
--- a/apps/agones/cryptothrone/server/src/game.rs
+++ b/apps/agones/cryptothrone/server/src/game.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
 use bevy::prelude::{Commands, Local, Res};
-use simgrid::proto::Tile;
+use simgrid::proto::{StatusKind, Tile};
 use simgrid::{
-    AggroSpec, ConsumableEffects, EquipBonus, EquipmentEffects, KindRegistry, NpcDb, NpcSpec,
-    SIM_TICK_HZ, SimConfig, WalkableMap, ground_item_bundle, spawn_npc_from_spec,
+    AggroSpec, BuffEffects, BuffSpec, ConsumableEffects, EquipBonus, EquipmentEffects,
+    KindRegistry, NpcDb, NpcSpec, SIM_TICK_HZ, SimConfig, WalkableMap, ground_item_bundle,
+    spawn_npc_from_spec,
 };
 
 pub const MAP_WIDTH: i32 = 50;
@@ -64,12 +65,37 @@ pub const IRON_SHIELD_DEFENSE: i32 = 3;
 
 pub const POTION_HEAL: i32 = 25;
 
+// Buff consumables: the elixir regenerates HP over time, the swift tonic grants
+// a burst of movement haste. Both are timed status effects, not instant heals.
+pub const ELIXIR_REF: &str = "elixir";
+pub const ELIXIR_REGEN: i32 = 4;
+pub const ELIXIR_PERIOD_TICKS: u32 = SIM_TICK_HZ;
+pub const SWIFT_TONIC_REF: &str = "swift-tonic";
+pub const SWIFT_TONIC_HASTE: i32 = 1;
+pub const BUFF_DURATION_TICKS: u32 = SIM_TICK_HZ * 10;
+
+// Goblins and the boss carry venom — landing a hit poisons the player.
+pub const GOBLIN_POISON_DMG: i32 = 2;
+pub const POISON_PERIOD_TICKS: u32 = SIM_TICK_HZ;
+pub const POISON_DURATION_TICKS: u32 = SIM_TICK_HZ * 6;
+
 pub const GROUND_ITEMS: &[(&str, u32, Tile)] = &[
     ("potion", 1, Tile::new(8, 12)),
     ("coin", 5, Tile::new(12, 9)),
     ("iron-sword", 1, Tile::new(6, 15)),
     ("iron-shield", 1, Tile::new(10, 16)),
+    (ELIXIR_REF, 1, Tile::new(9, 11)),
+    (SWIFT_TONIC_REF, 1, Tile::new(11, 13)),
 ];
+
+fn goblin_venom() -> BuffSpec {
+    BuffSpec {
+        kind: StatusKind::Poison,
+        magnitude: GOBLIN_POISON_DMG,
+        period_ticks: POISON_PERIOD_TICKS,
+        duration_ticks: POISON_DURATION_TICKS,
+    }
+}
 
 pub fn npc_db() -> NpcDb {
     NpcDb::from_json(NPCDB_JSON).expect("npcdb-data.json parses")
@@ -109,6 +135,29 @@ pub fn consumables() -> ConsumableEffects {
     ConsumableEffects(HashMap::from([("potion".to_string(), POTION_HEAL)]))
 }
 
+pub fn buffs() -> BuffEffects {
+    BuffEffects(HashMap::from([
+        (
+            ELIXIR_REF.to_string(),
+            BuffSpec {
+                kind: StatusKind::Regen,
+                magnitude: ELIXIR_REGEN,
+                period_ticks: ELIXIR_PERIOD_TICKS,
+                duration_ticks: BUFF_DURATION_TICKS,
+            },
+        ),
+        (
+            SWIFT_TONIC_REF.to_string(),
+            BuffSpec {
+                kind: StatusKind::Haste,
+                magnitude: SWIFT_TONIC_HASTE,
+                period_ticks: 0,
+                duration_ticks: BUFF_DURATION_TICKS,
+            },
+        ),
+    ]))
+}
+
 pub fn equipment() -> EquipmentEffects {
     EquipmentEffects(HashMap::from([
         (
@@ -137,6 +186,7 @@ fn ticks_per_tile_for_speed(speed: i32) -> u8 {
     (20 / speed.clamp(2, 10)).clamp(2, 10) as u8
 }
 
+#[allow(clippy::too_many_arguments)]
 fn npc_spec(
     db: &NpcDb,
     registry: &KindRegistry,
@@ -144,6 +194,7 @@ fn npc_spec(
     origin: Tile,
     wander: Option<(i32, u32)>,
     loot: Option<&str>,
+    poison: Option<BuffSpec>,
 ) -> Option<NpcSpec> {
     let def = db.get(ref_id)?;
     let kind = registry.kind_of(ref_id)?;
@@ -160,6 +211,7 @@ fn npc_spec(
             range: HOSTILE_AGGRO_RANGE,
             damage: def.stats.attack.max(1),
             period_ticks: SIM_TICK_HZ,
+            poison,
         }),
         loot: loot.map(str::to_string),
         respawn_ticks: NPC_RESPAWN_TICKS,
@@ -181,6 +233,7 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
         CLERIC_SPAWN,
         Some((3, 30)),
         None,
+        None,
     ) {
         spawn_npc_from_spec(&mut commands, &spec);
     }
@@ -194,6 +247,7 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
             origin,
             Some((6, 20)),
             Some(BAT_LOOT_REF),
+            None,
         ) {
             spawn_npc_from_spec(&mut commands, &spec);
         }
@@ -208,6 +262,7 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
             origin,
             Some((8, 25)),
             Some(GOBLIN_LOOT_REF),
+            Some(goblin_venom()),
         ) {
             spawn_npc_from_spec(&mut commands, &spec);
         }
@@ -218,7 +273,7 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
         (SOLDIER_REF, SOLDIER_SPAWN),
         (KING_REF, KING_SPAWN),
     ] {
-        if let Some(spec) = npc_spec(&db, &registry, ref_id, tile, Some((2, 40)), None) {
+        if let Some(spec) = npc_spec(&db, &registry, ref_id, tile, Some((2, 40)), None, None) {
             spawn_npc_from_spec(&mut commands, &spec);
         }
     }
@@ -230,6 +285,7 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
         BOSS_SPAWN,
         Some((4, 30)),
         Some(BOSS_LOOT_REF),
+        Some(goblin_venom()),
     ) {
         spawn_npc_from_spec(&mut commands, &spec);
     }
@@ -243,6 +299,7 @@ pub fn spawn_world(mut done: Local<bool>, registry: Res<KindRegistry>, mut comma
             origin,
             Some((10, 22)),
             Some(WOLF_LOOT_REF),
+            None,
         ) {
             spawn_npc_from_spec(&mut commands, &spec);
         }

--- a/apps/agones/cryptothrone/server/src/main.rs
+++ b/apps/agones/cryptothrone/server/src/main.rs
@@ -75,6 +75,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("sim runtime");
         let mut app = build_app(snap_tx, input_rx, roster, seed, config, map, registry);
         app.insert_resource(game::consumables());
+        app.insert_resource(game::buffs());
         app.insert_resource(game::equipment());
         app.add_systems(
             bevy::prelude::Update,

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx
@@ -13,7 +13,7 @@ tags:
 key: cryptothrone_server
 pipeline: docker
 app_name: cryptothrone-server
-version: "0.0.17"
+version: "0.0.18"
 source_path: apps/agones/cryptothrone/server
 version_toml: apps/agones/cryptothrone/server/version.toml
 version_target: apps/agones/cryptothrone/server/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.31"
+version: "0.1.32"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/laser.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/laser.mdx
@@ -10,7 +10,7 @@ tags:
 key: laser
 pipeline: npm
 package_name: laser
-version: "0.1.0"
+version: "0.1.1"
 source_path: packages/npm/laser
 version_toml: packages/npm/laser/version.toml
 author: h0lybyte

--- a/packages/npm/laser/src/index.ts
+++ b/packages/npm/laser/src/index.ts
@@ -96,6 +96,7 @@ export {
 	EPHEMERAL_ITEM_USED,
 	EPHEMERAL_EQUIPPED,
 	EPHEMERAL_STATS,
+	EPHEMERAL_STATUS,
 	KIND_CAT_PLAYER,
 	KIND_CAT_NPC,
 	KIND_CAT_ITEM,
@@ -112,6 +113,8 @@ export type {
 	ServerEvent,
 	Snapshot,
 	EntityDelta,
+	StatusKind,
+	StatusView,
 	PlayerView,
 	Welcome,
 	JoinMatch,
@@ -125,4 +128,5 @@ export type {
 	ItemUsedEvent,
 	EquippedEvent,
 	StatsEvent,
+	StatusEvent,
 } from './lib/net/protocol';

--- a/packages/npm/laser/src/lib/net/protocol.ts
+++ b/packages/npm/laser/src/lib/net/protocol.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = 5;
+export const PROTOCOL_VERSION = 6;
 
 export const ACTION_ATTACK = 1;
 export const ACTION_PICKUP = 2;
@@ -9,6 +9,7 @@ export const EPHEMERAL_PICKUP = 3;
 export const EPHEMERAL_ITEM_USED = 5;
 export const EPHEMERAL_EQUIPPED = 6;
 export const EPHEMERAL_STATS = 7;
+export const EPHEMERAL_STATUS = 8;
 
 export const KIND_CAT_PLAYER = 0;
 export const KIND_CAT_NPC = 1;
@@ -51,6 +52,13 @@ export interface PlayerView {
 	connected: boolean;
 }
 
+export type StatusKind = 'Poison' | 'Regen' | 'Haste';
+
+export interface StatusView {
+	kind: StatusKind;
+	remaining: number;
+}
+
 export interface EntityDelta {
 	eid: number;
 	kind: number;
@@ -61,6 +69,7 @@ export interface EntityDelta {
 	hp: number;
 	max_hp: number;
 	destroyed: boolean;
+	effects?: StatusView[];
 }
 
 export interface Snapshot {
@@ -133,6 +142,12 @@ export interface StatsEvent {
 	max_hp: number;
 	attack: number;
 	kills?: number;
+}
+
+export interface StatusEvent {
+	kind: number;
+	magnitude: number;
+	remaining: number;
 }
 
 export type ServerEvent =

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -12,9 +12,9 @@ pub use data::{ItemDb, KindRegistry, NpcDb, NpcDef};
 pub use grid::{GridPos, MoveSpeed, MoveTarget, WalkableMap};
 pub use net::{Roster, ServerState, SlotInput, router};
 pub use sim::{
-    Aggro, AggroSpec, CombatStats, ConsumableEffects, Defense, EntityKind, EquipBonus,
-    EquipmentEffects, Equipped, Health, Inventory, Loot, NpcLevel, NpcSpec, Path, PlayerSlotTag,
-    PlayerStore, RespawnOnDeath, SIM_TICK_HZ, SNAPSHOT_BROADCAST_CAPACITY, SimConfig, SimSet,
-    StepBuffer, Wander, XpState, build_app, ground_item_bundle, level_attack, level_max_hp,
-    run_sim_loop, spawn_npc_from_spec, xp_to_next,
+    Aggro, AggroSpec, BuffEffects, BuffSpec, CombatStats, ConsumableEffects, Defense, EntityKind,
+    EquipBonus, EquipmentEffects, Equipped, Health, Inventory, Loot, NpcLevel, NpcSpec, Path,
+    PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, SNAPSHOT_BROADCAST_CAPACITY,
+    SimConfig, SimSet, StatusEffect, StatusEffects, StepBuffer, Wander, XpState, build_app,
+    ground_item_bundle, level_attack, level_max_hp, run_sim_loop, spawn_npc_from_spec, xp_to_next,
 };

--- a/packages/rust/simgrid/src/proto.rs
+++ b/packages/rust/simgrid/src/proto.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;
 pub const DEFAULT_MAX_PLAYERS: usize = 64;
 
 pub const ACTION_ATTACK: u16 = 1;
@@ -12,6 +12,7 @@ pub const EPHEMERAL_PICKUP: u16 = 3;
 pub const EPHEMERAL_ITEM_USED: u16 = 5;
 pub const EPHEMERAL_EQUIPPED: u16 = 6;
 pub const EPHEMERAL_STATS: u16 = 7;
+pub const EPHEMERAL_STATUS: u16 = 8;
 
 pub const KIND_CAT_PLAYER: u8 = 0;
 pub const KIND_CAT_NPC: u8 = 1;
@@ -122,6 +123,20 @@ pub struct PlayerView {
     pub connected: bool,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[repr(u8)]
+pub enum StatusKind {
+    Poison = 0,
+    Regen = 1,
+    Haste = 2,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StatusView {
+    pub kind: StatusKind,
+    pub remaining: u16,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct EntityDelta {
     pub eid: EntityId,
@@ -133,6 +148,8 @@ pub struct EntityDelta {
     pub hp: i32,
     pub max_hp: i32,
     pub destroyed: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub effects: Vec<StatusView>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -187,10 +187,62 @@ pub const TOWN_REGEN_AMOUNT: i32 = 6;
 pub const CRIT_CHANCE_PCT: u64 = 15;
 
 #[derive(Clone, Copy)]
+pub struct StatusEffect {
+    pub kind: proto::StatusKind,
+    pub magnitude: i32,
+    pub period_ticks: u32,
+    pub next_tick: u32,
+    pub expires_tick: u32,
+}
+
+#[derive(Component, Default)]
+pub struct StatusEffects(pub Vec<StatusEffect>);
+
+impl StatusEffects {
+    /// Add or refresh an effect. Same-kind effects never stack: the stronger
+    /// magnitude and later expiry win, so re-applying just tops it up.
+    pub fn apply(&mut self, e: StatusEffect) {
+        if let Some(existing) = self.0.iter_mut().find(|x| x.kind == e.kind) {
+            existing.magnitude = existing.magnitude.max(e.magnitude);
+            existing.expires_tick = existing.expires_tick.max(e.expires_tick);
+            existing.period_ticks = e.period_ticks.max(1);
+            existing.next_tick = existing.next_tick.min(e.next_tick);
+        } else {
+            self.0.push(e);
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct BuffSpec {
+    pub kind: proto::StatusKind,
+    pub magnitude: i32,
+    pub period_ticks: u32,
+    pub duration_ticks: u32,
+}
+
+impl BuffSpec {
+    pub fn at(&self, now: u32) -> StatusEffect {
+        let period = self.period_ticks.max(1);
+        StatusEffect {
+            kind: self.kind,
+            magnitude: self.magnitude,
+            period_ticks: period,
+            next_tick: now.saturating_add(period),
+            expires_tick: now.saturating_add(self.duration_ticks),
+        }
+    }
+}
+
+#[derive(Resource, Default, Clone)]
+pub struct BuffEffects(pub HashMap<String, BuffSpec>);
+
+#[derive(Clone, Copy)]
 pub struct AggroSpec {
     pub range: i32,
     pub damage: i32,
     pub period_ticks: u32,
+    pub poison: Option<BuffSpec>,
 }
 
 #[derive(Clone)]
@@ -213,6 +265,7 @@ pub struct Aggro {
     pub damage: i32,
     pub period_ticks: u32,
     pub next_tick: u32,
+    pub poison: Option<BuffSpec>,
 }
 
 #[derive(Component, Clone)]
@@ -340,6 +393,7 @@ pub fn spawn_npc_from_spec(commands: &mut Commands, spec: &NpcSpec) {
             damage: a.damage,
             period_ticks: a.period_ticks,
             next_tick: 0,
+            poison: a.poison,
         });
     }
     if spec.respawn_ticks > 0 {
@@ -369,6 +423,7 @@ pub fn build_app(
         .insert_resource(PendingActions::default())
         .insert_resource(PlayerStore::default())
         .insert_resource(ConsumableEffects::default())
+        .insert_resource(BuffEffects::default())
         .insert_resource(EquipmentEffects::default())
         .insert_resource(RespawnQueue::default())
         .insert_resource(KillCounts::default())
@@ -409,6 +464,7 @@ pub fn build_app(
             (
                 advance_movement,
                 chain_steps,
+                tick_status_effects,
                 respawn_players,
                 regen_players,
             )
@@ -507,6 +563,7 @@ fn sync_roster(
                 Equipped { weapon, armor },
                 Path::default(),
                 StepBuffer::default(),
+                StatusEffects::default(),
             ))
             .id();
         spawned.by_slot.insert(slot.0, (entity, username.clone()));
@@ -558,8 +615,10 @@ fn drain_inputs(
     queue: Res<InputQueue>,
     map: Res<WalkableMap>,
     effects: Res<ConsumableEffects>,
+    buffs: Res<BuffEffects>,
     equipment: Res<EquipmentEffects>,
     config: Res<SimConfig>,
+    clock: Res<SimClock>,
     bcast: Res<SnapshotBroadcast>,
     mut actions: ResMut<PendingActions>,
     mut q: Query<(
@@ -575,6 +634,7 @@ fn drain_inputs(
         &mut CombatStats,
         &mut Defense,
         &XpState,
+        &mut StatusEffects,
     )>,
 ) {
     let mut pending: HashMap<u16, Vec<Input>> = HashMap::new();
@@ -608,6 +668,7 @@ fn drain_inputs(
         mut stats,
         mut defense,
         xp,
+        mut status,
     ) in q.iter_mut()
     {
         let Some(inputs) = pending.get(&slot.0.0) else {
@@ -636,7 +697,17 @@ fn drain_inputs(
                     pos.facing = *facing;
                 }
                 Input::UseItem { item_ref } => {
-                    use_item(&effects, &bcast, slot.0, item_ref, &mut hp, &mut inv);
+                    use_item(
+                        &effects,
+                        &buffs,
+                        &bcast,
+                        slot.0,
+                        item_ref,
+                        clock.tick,
+                        &mut hp,
+                        &mut inv,
+                        &mut status,
+                    );
                 }
                 Input::EquipItem { item_ref } => {
                     let Some(&bonus) = equipment.0.get(item_ref.as_str()) else {
@@ -689,17 +760,23 @@ fn drain_inputs(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn use_item(
     effects: &ConsumableEffects,
+    buffs: &BuffEffects,
     bcast: &SnapshotBroadcast,
     slot: proto::PlayerSlot,
     item_ref: &str,
+    now: u32,
     hp: &mut Health,
     inv: &mut Inventory,
+    status: &mut StatusEffects,
 ) {
-    let Some(&heal) = effects.0.get(item_ref) else {
+    let heal = effects.0.get(item_ref).copied();
+    let buff = buffs.0.get(item_ref).copied();
+    if heal.is_none() && buff.is_none() {
         return;
-    };
+    }
     let Some(idx) = inv.slots.iter().position(|(r, c)| r == item_ref && *c > 0) else {
         return;
     };
@@ -707,8 +784,15 @@ fn use_item(
     if inv.slots[idx].1 == 0 {
         inv.slots.remove(idx);
     }
-    hp.hp = (hp.hp + heal).min(hp.max_hp);
-    let payload = json!({ "item_ref": item_ref, "heal": heal })
+    let heal_amt = heal.unwrap_or(0);
+    if heal_amt != 0 {
+        hp.hp = (hp.hp + heal_amt).min(hp.max_hp);
+    }
+    if let Some(b) = buff {
+        status.apply(b.at(now));
+        send_status(bcast, slot, b.kind, b.magnitude, b.duration_ticks);
+    }
+    let payload = json!({ "item_ref": item_ref, "heal": heal_amt })
         .to_string()
         .into_bytes();
     let _ = bcast.tx.send(ServerEvent::Ephemeral {
@@ -1011,11 +1095,21 @@ fn hostile_ai(
     map: Res<WalkableMap>,
     bcast: Res<SnapshotBroadcast>,
     mut q_mobs: Query<(Entity, &mut GridPos, &mut MoveTarget, &mut Aggro), Without<PlayerSlotTag>>,
-    mut q_players: Query<(Entity, &GridPos, &mut Health, &Defense), With<PlayerSlotTag>>,
+    mut q_players: Query<
+        (
+            Entity,
+            &GridPos,
+            &mut Health,
+            &Defense,
+            &PlayerSlotTag,
+            &mut StatusEffects,
+        ),
+        With<PlayerSlotTag>,
+    >,
 ) {
     for (mob, mut pos, mut mv, mut aggro) in q_mobs.iter_mut() {
         let mut nearest: Option<(Entity, Tile, i32)> = None;
-        for (pe, ppos, hp, _) in q_players.iter() {
+        for (pe, ppos, hp, _, _, _) in q_players.iter() {
             if hp.hp <= 0 {
                 continue;
             }
@@ -1041,12 +1135,17 @@ fn hostile_ai(
                 continue;
             }
             aggro.next_tick = clock.tick.saturating_add(aggro.period_ticks);
-            let Ok((_, _, mut hp, defense)) = q_players.get_mut(player_entity) else {
+            let Ok((_, _, mut hp, defense, slot, mut status)) = q_players.get_mut(player_entity)
+            else {
                 continue;
             };
             let dmg = (aggro.damage - defense.0).max(1);
             hp.hp -= dmg;
             let died = hp.hp <= 0;
+            if !died && let Some(p) = aggro.poison {
+                status.apply(p.at(clock.tick));
+                send_status(&bcast, slot.0, p.kind, p.magnitude, p.duration_ticks);
+            }
             let payload = json!({
                 "attacker": mob.index_u32(),
                 "target": player_entity.index_u32(),
@@ -1083,6 +1182,66 @@ fn hostile_ai(
     }
 }
 
+fn send_status(
+    bcast: &SnapshotBroadcast,
+    slot: proto::PlayerSlot,
+    kind: proto::StatusKind,
+    magnitude: i32,
+    remaining: u32,
+) {
+    let payload = json!({
+        "kind": kind as u8,
+        "magnitude": magnitude,
+        "remaining": remaining,
+    })
+    .to_string()
+    .into_bytes();
+    let _ = bcast.tx.send(ServerEvent::Ephemeral {
+        kind: proto::EPHEMERAL_STATUS,
+        to: slot,
+        payload,
+    });
+}
+
+/// Drive timed status effects: periodic Poison damage / Regen healing, expiry,
+/// and the Haste movement-speed modifier. Runs before respawn so a poison kill
+/// resolves to a respawn on the same tick. Players only — town regen and combat
+/// stay independent of this.
+fn tick_status_effects(
+    clock: Res<SimClock>,
+    config: Res<SimConfig>,
+    mut q: Query<(&mut StatusEffects, &mut Health, &mut MoveSpeed), With<PlayerSlotTag>>,
+) {
+    let now = clock.tick;
+    for (mut status, mut hp, mut speed) in q.iter_mut() {
+        if status.0.is_empty() {
+            continue;
+        }
+        for e in status.0.iter_mut() {
+            if e.period_ticks == 0 {
+                continue;
+            }
+            while now >= e.next_tick && e.next_tick <= e.expires_tick {
+                match e.kind {
+                    proto::StatusKind::Poison => hp.hp -= e.magnitude,
+                    proto::StatusKind::Regen => hp.hp = (hp.hp + e.magnitude).min(hp.max_hp),
+                    proto::StatusKind::Haste => {}
+                }
+                e.next_tick = e.next_tick.saturating_add(e.period_ticks);
+            }
+        }
+        status.0.retain(|e| now < e.expires_tick);
+        let haste = status
+            .0
+            .iter()
+            .filter(|e| e.kind == proto::StatusKind::Haste)
+            .map(|e| e.magnitude)
+            .max()
+            .unwrap_or(0);
+        speed.ticks_per_tile = (config.ticks_per_tile as i32 - haste).max(1) as u8;
+    }
+}
+
 #[allow(clippy::type_complexity)]
 fn regen_players(
     clock: Res<SimClock>,
@@ -1108,6 +1267,7 @@ fn regen_players(
     }
 }
 
+#[allow(clippy::type_complexity)]
 fn respawn_players(
     config: Res<SimConfig>,
     mut q: Query<
@@ -1117,11 +1277,13 @@ fn respawn_players(
             &mut Path,
             &mut StepBuffer,
             &mut Health,
+            &mut StatusEffects,
+            &mut MoveSpeed,
         ),
         With<PlayerSlotTag>,
     >,
 ) {
-    for (mut pos, mut mv, mut path, mut buffer, mut hp) in q.iter_mut() {
+    for (mut pos, mut mv, mut path, mut buffer, mut hp, mut status, mut speed) in q.iter_mut() {
         if hp.hp > 0 {
             continue;
         }
@@ -1131,6 +1293,8 @@ fn respawn_players(
         path.steps.clear();
         buffer.dir = None;
         hp.hp = hp.max_hp;
+        status.0.clear();
+        speed.ticks_per_tile = config.ticks_per_tile;
     }
 }
 
@@ -1259,15 +1423,17 @@ fn emit_snapshot(
         &MoveTarget,
         Option<&MoveSpeed>,
         Option<&Health>,
+        Option<&StatusEffects>,
     )>,
 ) {
     if !clock.tick.is_multiple_of(SNAPSHOT_EVERY_N_TICKS) {
         return;
     }
 
+    let now = clock.tick;
     let entities: Vec<proto::EntityDelta> = q
         .iter()
-        .map(|(entity, kind, slot, pos, mv, speed, hp)| {
+        .map(|(entity, kind, slot, pos, mv, speed, hp, status)| {
             let sub = mv
                 .target
                 .map(|_| {
@@ -1275,6 +1441,17 @@ fn emit_snapshot(
                     ((mv.progress as u32 * 255) / span).min(255) as u8
                 })
                 .unwrap_or(0);
+            let effects = status
+                .map(|s| {
+                    s.0.iter()
+                        .map(|e| proto::StatusView {
+                            kind: e.kind,
+                            remaining: e.expires_tick.saturating_sub(now).min(u16::MAX as u32)
+                                as u16,
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
             proto::EntityDelta {
                 eid: proto::EntityId(entity.index_u32()),
                 kind: kind.0,
@@ -1285,6 +1462,7 @@ fn emit_snapshot(
                 hp: hp.map(|h| h.hp).unwrap_or(0),
                 max_hp: hp.map(|h| h.max_hp).unwrap_or(0),
                 destroyed: false,
+                effects,
             }
         })
         .collect();
@@ -1556,6 +1734,7 @@ mod tests {
                 range: 8,
                 damage: 60,
                 period_ticks: 1,
+                poison: None,
             }),
             loot: None,
             respawn_ticks: 4,
@@ -1919,6 +2098,7 @@ mod tests {
             range: 8,
             damage: 5,
             period_ticks: 1,
+            poison: None,
         });
         {
             let mut commands_queue = bevy::ecs::world::CommandQueue::default();
@@ -2150,5 +2330,190 @@ mod tests {
         let payload = inventory_payload.expect("no inventory sync");
         assert!(payload.contains("potion"), "payload: {payload}");
         assert!(payload.contains("2"), "payload: {payload}");
+    }
+
+    #[test]
+    fn poison_damages_over_time_then_expires() {
+        let (mut app, _rx, _tx, roster) = harness(61);
+        let _slot = join(&roster, "envenomed");
+        app.update();
+        let player = player_entity(&mut app);
+        let now = app.world().resource::<SimClock>().tick;
+        {
+            let mut se = app.world_mut().get_mut::<StatusEffects>(player).unwrap();
+            se.apply(StatusEffect {
+                kind: proto::StatusKind::Poison,
+                magnitude: 5,
+                period_ticks: 2,
+                next_tick: now + 2,
+                expires_tick: now + 8,
+            });
+        }
+        for _ in 0..10 {
+            app.update();
+        }
+        let hp_after = app.world().get::<Health>(player).unwrap().hp;
+        assert!(hp_after < 100, "poison dealt no damage (hp={hp_after})");
+        assert!(
+            app.world()
+                .get::<StatusEffects>(player)
+                .unwrap()
+                .0
+                .is_empty(),
+            "poison never expired"
+        );
+        for _ in 0..6 {
+            app.update();
+        }
+        let hp_settled = app.world().get::<Health>(player).unwrap().hp;
+        assert_eq!(hp_settled, hp_after, "poison kept ticking after expiry");
+    }
+
+    #[test]
+    fn regen_buff_heals_and_shows_in_snapshot() {
+        let (mut app, mut rx, input_tx, roster) = harness(62);
+        let slot = join(&roster, "mender");
+        app.update();
+        app.world_mut().insert_resource(BuffEffects(HashMap::from([(
+            "elixir".to_string(),
+            BuffSpec {
+                kind: proto::StatusKind::Regen,
+                magnitude: 4,
+                period_ticks: 2,
+                duration_ticks: 8,
+            },
+        )])));
+        let player = player_entity(&mut app);
+        {
+            let mut inv = app.world_mut().get_mut::<Inventory>(player).unwrap();
+            inv.add("elixir", 1);
+        }
+        {
+            let mut hp = app.world_mut().get_mut::<Health>(player).unwrap();
+            hp.hp = 50;
+        }
+        input_tx
+            .send((
+                slot,
+                Input::UseItem {
+                    item_ref: "elixir".into(),
+                },
+            ))
+            .unwrap();
+        for _ in 0..10 {
+            app.update();
+        }
+        let hp = app.world().get::<Health>(player).unwrap().hp;
+        assert!(hp > 50, "regen buff did not heal (hp={hp})");
+
+        let mut saw_effect = false;
+        let mut saw_status_ephemeral = false;
+        while let Ok(evt) = rx.try_recv() {
+            match evt {
+                ServerEvent::Snapshot(snap) => {
+                    for e in snap.entities {
+                        if e.effects.iter().any(|s| s.kind == proto::StatusKind::Regen) {
+                            saw_effect = true;
+                        }
+                    }
+                }
+                ServerEvent::Ephemeral { kind, .. } if kind == proto::EPHEMERAL_STATUS => {
+                    saw_status_ephemeral = true;
+                }
+                _ => {}
+            }
+        }
+        assert!(saw_effect, "regen effect missing from snapshot");
+        assert!(saw_status_ephemeral, "no status ephemeral emitted");
+    }
+
+    #[test]
+    fn haste_buff_speeds_movement_then_restores() {
+        let (mut app, _rx, input_tx, roster) = harness(63);
+        let slot = join(&roster, "sprinter");
+        app.update();
+        app.world_mut().insert_resource(BuffEffects(HashMap::from([(
+            "swift-tonic".to_string(),
+            BuffSpec {
+                kind: proto::StatusKind::Haste,
+                magnitude: 1,
+                period_ticks: 0,
+                duration_ticks: 5,
+            },
+        )])));
+        let player = player_entity(&mut app);
+        let base = app.world().get::<MoveSpeed>(player).unwrap().ticks_per_tile;
+        {
+            let mut inv = app.world_mut().get_mut::<Inventory>(player).unwrap();
+            inv.add("swift-tonic", 1);
+        }
+        input_tx
+            .send((
+                slot,
+                Input::UseItem {
+                    item_ref: "swift-tonic".into(),
+                },
+            ))
+            .unwrap();
+        for _ in 0..2 {
+            app.update();
+        }
+        let hasted = app.world().get::<MoveSpeed>(player).unwrap().ticks_per_tile;
+        assert_eq!(hasted, base - 1, "haste did not speed movement");
+        for _ in 0..8 {
+            app.update();
+        }
+        let restored = app.world().get::<MoveSpeed>(player).unwrap().ticks_per_tile;
+        assert_eq!(restored, base, "speed not restored after haste expired");
+    }
+
+    #[test]
+    fn venomous_mob_poisons_player_on_hit() {
+        let (mut app, mut rx, _tx, roster) = harness(64);
+        let _slot = join(&roster, "bitten");
+        app.update();
+        let registry = app.world().resource::<KindRegistry>().clone();
+        let kind = registry.kind_of("training-dummy").unwrap();
+        let mut spec = hostile_spec(kind, Tile::new(9, 8));
+        spec.aggro = Some(AggroSpec {
+            range: 8,
+            damage: 3,
+            period_ticks: 2,
+            poison: Some(BuffSpec {
+                kind: proto::StatusKind::Poison,
+                magnitude: 2,
+                period_ticks: 1,
+                duration_ticks: 6,
+            }),
+        });
+        {
+            let mut q = bevy::ecs::world::CommandQueue::default();
+            let mut commands = Commands::new(&mut q, app.world());
+            spawn_npc_from_spec(&mut commands, &spec);
+            q.apply(app.world_mut());
+        }
+        let player = player_entity(&mut app);
+        for _ in 0..30 {
+            app.update();
+        }
+        let poisoned = app
+            .world()
+            .get::<StatusEffects>(player)
+            .unwrap()
+            .0
+            .iter()
+            .any(|e| e.kind == proto::StatusKind::Poison);
+        let mut saw_status = false;
+        while let Ok(evt) = rx.try_recv() {
+            if let ServerEvent::Ephemeral { kind, .. } = evt
+                && kind == proto::EPHEMERAL_STATUS
+            {
+                saw_status = true;
+            }
+        }
+        assert!(
+            poisoned || saw_status,
+            "venomous mob never poisoned the player"
+        );
     }
 }


### PR DESCRIPTION
## What

Adds a **timed status-effect system** to the simgrid sim core — the next gameplay-engine upgrade for cryptothrone.

### Engine (`packages/rust/simgrid`)
- `StatusKind` { Poison, Regen, Haste } + `StatusEffect` component (`StatusEffects` buffer) with **refresh-not-stack** semantics (stronger magnitude + later expiry win).
- `tick_status_effects` system (Movement set, before respawn): periodic **Poison DoT** / **Regen HoT**, expiry pruning, and **Haste** movement-speed modifier. Runs before respawn so a poison kill resolves to a respawn on the same tick; respawn clears effects and restores base speed.
- Effects ride in the snapshot `EntityDelta.effects`; an `EPHEMERAL_STATUS` event fires on apply.
- Data-driven sources: `BuffEffects` map (consumables grant effects) + `Aggro.poison` (venomous mobs apply Poison on hit).

### Cryptothrone wiring (`apps/agones/cryptothrone/server`)
- Buff consumables: **elixir** → Regen, **swift-tonic** → Haste (both as ground items).
- **Goblins + the boss general** are venomous (Poison on hit).

### Protocol (`@kbve/laser`)
- `PROTOCOL_VERSION` **5 → 6** (server hard-rejects mismatched clients).
- Adds `StatusKind` / `StatusView` / `StatusEvent` types, `EntityDelta.effects`, `EPHEMERAL_STATUS`.

## Tests
- 4 new simgrid unit tests: poison DoT + expiry, regen buff heal + snapshot exposure, haste speed change + restore, venom-on-hit. **40 lib + 4 ws_flow pass.**
- `cryptothrone-server:lint` green; `laser:build` green.

## Release
Coordinated republish — server + client + laser bump together so the deployed client speaks v6. Old cached browsers get the existing "refresh your browser" reject until they reload.
- cryptothrone-server 0.0.17 → 0.0.18
- cryptothrone 0.1.31 → 0.1.32
- laser 0.1.0 → 0.1.1