### PR TITLE
feat(astro): social/{twitter,youtube,tiktok} components + wire MDX

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/tiktok.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/tiktok.mdx
@@ -13,69 +13,12 @@ tableOfContents: false
 ---
 
 import Adsense from '@/components/astropad/adsense/Adsense.astro';
+import TiktokSocialComponent from '@kbve/astro/components/social/tiktok/TiktokSocialComponent.astro';
 
 ## Follow on TikTok
 
 Short-form clips: gamedev highlights, devlog snippets, quick demos.
 
-<div class="tt-page">
-  <a
-    class="tt-cta"
-    href="https://www.tiktok.com/@kbve"
-    target="_blank"
-    rel="noopener noreferrer">
-    <span class="tt-cta__icon" aria-hidden="true">♪</span>
-    <span class="tt-cta__label">Follow @kbve on TikTok</span>
-  </a>
-
-  <div class="tt-embed">
-    <blockquote
-      class="tiktok-embed"
-      cite="https://www.tiktok.com/@kbve"
-      data-unique-id="kbve"
-      data-embed-type="creator"
-      style="max-width: 720px; min-width: 288px;">
-      <section>
-        <a target="_blank" href="https://www.tiktok.com/@kbve">@kbve</a>
-      </section>
-    </blockquote>
-    <script async src="https://www.tiktok.com/embed.js"></script>
-  </div>
-</div>
+<TiktokSocialComponent handle="kbve" />
 
 <Adsense />
-
-<style is:global>{`
-  .tt-page {
-    max-width: 720px;
-    margin: 1.5rem auto;
-    display: grid;
-    gap: 1rem;
-  }
-  .tt-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.75rem 1.25rem;
-    border-radius: 10px;
-    background: #000;
-    color: #fff;
-    font-weight: 600;
-    text-decoration: none;
-    width: fit-content;
-    border: 1px solid var(--sl-color-gray-5, #2a2a33);
-    transition: transform 0.12s ease, border-color 0.12s ease;
-  }
-  .tt-cta:hover {
-    transform: translateY(-1px);
-    border-color: #ff0050;
-  }
-  .tt-cta__icon { font-size: 1.1rem; line-height: 1; }
-  .tt-embed {
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid var(--sl-color-gray-5, #2a2a33);
-    background: var(--sl-color-bg-nav, #131318);
-    padding: 0.5rem;
-  }
-`}</style>

--- a/apps/kbve/astro-kbve/src/content/docs/twitter.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/twitter.mdx
@@ -13,69 +13,12 @@ tableOfContents: false
 ---
 
 import Adsense from '@/components/astropad/adsense/Adsense.astro';
+import TwitterSocialComponent from '@kbve/astro/components/social/twitter/TwitterSocialComponent.astro';
 
 ## Follow on X (Twitter)
 
 Project updates, dev snippets, release pings, and community highlights.
 
-<div class="tw-page">
-  <a
-    class="tw-cta"
-    href="https://x.com/kbve"
-    target="_blank"
-    rel="noopener noreferrer">
-    <span class="tw-cta__icon" aria-hidden="true">𝕏</span>
-    <span class="tw-cta__label">Follow @kbve on X</span>
-  </a>
-
-  <div class="tw-embed">
-    <a
-      class="twitter-timeline"
-      data-height="600"
-      data-theme="dark"
-      href="https://twitter.com/kbve?ref_src=twsrc%5Etfw">
-      Tweets by @kbve
-    </a>
-    <script
-      async
-      src="https://platform.twitter.com/widgets.js"
-      charset="utf-8"></script>
-  </div>
-</div>
+<TwitterSocialComponent handle="kbve" />
 
 <Adsense />
-
-<style is:global>{`
-  .tw-page {
-    max-width: 720px;
-    margin: 1.5rem auto;
-    display: grid;
-    gap: 1rem;
-  }
-  .tw-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.75rem 1.25rem;
-    border-radius: 10px;
-    background: #000;
-    color: #fff;
-    font-weight: 600;
-    text-decoration: none;
-    width: fit-content;
-    border: 1px solid var(--sl-color-gray-5, #2a2a33);
-    transition: transform 0.12s ease, border-color 0.12s ease;
-  }
-  .tw-cta:hover {
-    transform: translateY(-1px);
-    border-color: #1d9bf0;
-  }
-  .tw-cta__icon { font-size: 1.1rem; line-height: 1; }
-  .tw-embed {
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid var(--sl-color-gray-5, #2a2a33);
-    background: var(--sl-color-bg-nav, #131318);
-    padding: 0.5rem;
-  }
-`}</style>

--- a/apps/kbve/astro-kbve/src/content/docs/youtube.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/youtube.mdx
@@ -13,71 +13,12 @@ tableOfContents: false
 ---
 
 import Adsense from '@/components/astropad/adsense/Adsense.astro';
+import YoutubeSocialComponent from '@kbve/astro/components/social/youtube/YoutubeSocialComponent.astro';
 
 ## Subscribe on YouTube
 
 Devlogs, tutorials, music mixes, and project showcases — full archive on our channel.
 
-<div class="yt-page">
-  <a
-    class="yt-cta"
-    href="https://www.youtube.com/@kbve"
-    target="_blank"
-    rel="noopener noreferrer">
-    <span class="yt-cta__icon" aria-hidden="true">▶</span>
-    <span class="yt-cta__label">Visit @kbve on YouTube</span>
-  </a>
-
-  <div class="yt-embed">
-    <iframe
-      src="https://www.youtube.com/embed?listType=user_uploads&list=kbve"
-      title="KBVE YouTube uploads"
-      frameborder="0"
-      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-      referrerpolicy="strict-origin-when-cross-origin"
-      allowfullscreen></iframe>
-  </div>
-</div>
+<YoutubeSocialComponent handle="kbve" />
 
 <Adsense />
-
-<style is:global>{`
-  .yt-page {
-    max-width: 960px;
-    margin: 1.5rem auto;
-    display: grid;
-    gap: 1rem;
-  }
-  .yt-cta {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    padding: 0.75rem 1.25rem;
-    border-radius: 10px;
-    background: #ff0000;
-    color: #fff;
-    font-weight: 600;
-    text-decoration: none;
-    width: fit-content;
-    box-shadow: 0 6px 20px color-mix(in srgb, #ff0000 30%, transparent);
-    transition: transform 0.12s ease;
-  }
-  .yt-cta:hover { transform: translateY(-1px); }
-  .yt-cta__icon { font-size: 1.1rem; line-height: 1; }
-  .yt-embed {
-    position: relative;
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    border-radius: 12px;
-    overflow: hidden;
-    border: 1px solid var(--sl-color-gray-5, #2a2a33);
-    background: #000;
-  }
-  .yt-embed iframe {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    border: 0;
-  }
-`}</style>

--- a/packages/npm/astro/package.json
+++ b/packages/npm/astro/package.json
@@ -54,7 +54,10 @@
 		"./components/hero/scroll/ScrollZoomHero.astro": "./components/hero/scroll/ScrollZoomHero.astro",
 		"./components/hero/observer/ObserverCollections.astro": "./components/hero/observer/ObserverCollections.astro",
 		"./components/hero/observer/ObserverSelection.astro": "./components/hero/observer/ObserverSelection.astro",
-		"./components/social/bluesky/BlueskySocialComponent.astro": "./components/social/bluesky/BlueskySocialComponent.astro"
+		"./components/social/bluesky/BlueskySocialComponent.astro": "./components/social/bluesky/BlueskySocialComponent.astro",
+		"./components/social/twitter/TwitterSocialComponent.astro": "./components/social/twitter/TwitterSocialComponent.astro",
+		"./components/social/youtube/YoutubeSocialComponent.astro": "./components/social/youtube/YoutubeSocialComponent.astro",
+		"./components/social/tiktok/TiktokSocialComponent.astro": "./components/social/tiktok/TiktokSocialComponent.astro"
 	},
 	"files": [
 		"astro.es.js",

--- a/packages/npm/astro/src/components/social/tiktok/TiktokSocialComponent.astro
+++ b/packages/npm/astro/src/components/social/tiktok/TiktokSocialComponent.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+	handle?: string;
+	label?: string;
+	showEmbed?: boolean;
+	class?: string;
+}
+
+const {
+	handle = 'kbve',
+	label,
+	showEmbed = true,
+	class: className = '',
+} = Astro.props;
+
+const profileUrl = `https://www.tiktok.com/@${handle}`;
+const ctaLabel = label ?? `Follow @${handle} on TikTok`;
+---
+
+<div class:list={['mx-auto my-6 grid w-full max-w-3xl gap-4', className]}>
+	<a
+		class="inline-flex w-fit items-center gap-2 rounded-xl border border-gray-700 bg-black px-5 py-3 font-semibold text-white transition-transform duration-150 hover:-translate-y-px hover:border-[#ff0050] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#ff0050]"
+		href={profileUrl}
+		target="_blank"
+		rel="noopener noreferrer">
+		<span class="text-lg leading-none" aria-hidden="true">♪</span>
+		<span>{ctaLabel}</span>
+	</a>
+
+	{
+		showEmbed && (
+			<div class="overflow-hidden rounded-xl border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-900">
+				<blockquote
+					class="tiktok-embed"
+					cite={profileUrl}
+					data-unique-id={handle}
+					data-embed-type="creator"
+					style="max-width:720px;min-width:288px;">
+					<section>
+						<a target="_blank" href={profileUrl}>
+							@{handle}
+						</a>
+					</section>
+				</blockquote>
+				<script async src="https://www.tiktok.com/embed.js" />
+			</div>
+		)
+	}
+</div>

--- a/packages/npm/astro/src/components/social/twitter/TwitterSocialComponent.astro
+++ b/packages/npm/astro/src/components/social/twitter/TwitterSocialComponent.astro
@@ -1,0 +1,53 @@
+---
+interface Props {
+	handle?: string;
+	label?: string;
+	theme?: 'dark' | 'light';
+	embedHeight?: number;
+	showEmbed?: boolean;
+	class?: string;
+}
+
+const {
+	handle = 'kbve',
+	label,
+	theme = 'dark',
+	embedHeight = 600,
+	showEmbed = true,
+	class: className = '',
+} = Astro.props;
+
+const profileUrl = `https://x.com/${handle}`;
+const timelineUrl = `https://twitter.com/${handle}?ref_src=twsrc%5Etfw`;
+const ctaLabel = label ?? `Follow @${handle} on X`;
+---
+
+<div class:list={['mx-auto my-6 grid w-full max-w-3xl gap-4', className]}>
+	<a
+		class="inline-flex w-fit items-center gap-2 rounded-xl border border-gray-700 bg-black px-5 py-3 font-semibold text-white transition-transform duration-150 hover:-translate-y-px hover:border-sky-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-400"
+		href={profileUrl}
+		target="_blank"
+		rel="noopener noreferrer">
+		<span class="text-lg leading-none" aria-hidden="true">𝕏</span>
+		<span>{ctaLabel}</span>
+	</a>
+
+	{
+		showEmbed && (
+			<div class="overflow-hidden rounded-xl border border-gray-200 bg-white p-2 dark:border-gray-700 dark:bg-gray-900">
+				<a
+					class="twitter-timeline"
+					data-height={embedHeight}
+					data-theme={theme}
+					href={timelineUrl}>
+					Tweets by @{handle}
+				</a>
+				<script
+					async
+					src="https://platform.twitter.com/widgets.js"
+					charset="utf-8"
+				/>
+			</div>
+		)
+	}
+</div>

--- a/packages/npm/astro/src/components/social/youtube/YoutubeSocialComponent.astro
+++ b/packages/npm/astro/src/components/social/youtube/YoutubeSocialComponent.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+	handle?: string;
+	channelId?: string;
+	label?: string;
+	showEmbed?: boolean;
+	class?: string;
+}
+
+const {
+	handle = 'kbve',
+	channelId,
+	label,
+	showEmbed = true,
+	class: className = '',
+} = Astro.props;
+
+const profileUrl = `https://www.youtube.com/@${handle}`;
+const embedUrl = channelId
+	? `https://www.youtube.com/embed/videoseries?list=UU${channelId.replace(/^UC/, '')}`
+	: `https://www.youtube.com/embed?listType=user_uploads&list=${handle}`;
+const ctaLabel = label ?? `Visit @${handle} on YouTube`;
+---
+
+<div class:list={['mx-auto my-6 grid w-full max-w-5xl gap-4', className]}>
+	<a
+		class="inline-flex w-fit items-center gap-2 rounded-xl bg-red-600 px-5 py-3 font-semibold text-white shadow-lg shadow-red-500/30 transition-transform duration-150 hover:-translate-y-px focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-300"
+		href={profileUrl}
+		target="_blank"
+		rel="noopener noreferrer">
+		<span class="text-lg leading-none" aria-hidden="true">▶</span>
+		<span>{ctaLabel}</span>
+	</a>
+
+	{
+		showEmbed && (
+			<div class="relative w-full overflow-hidden rounded-xl border border-gray-200 bg-black aspect-video dark:border-gray-700">
+				<iframe
+					src={embedUrl}
+					title={`${handle} YouTube uploads`}
+					class="absolute inset-0 h-full w-full border-0"
+					allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+					referrerpolicy="strict-origin-when-cross-origin"
+					allowfullscreen
+				/>
+			</div>
+		)
+	}
+</div>


### PR DESCRIPTION
## Summary

Extends the per-platform `social/<platform>/` layout under `@kbve/astro/components/` with three more platforms (follow-up to #12400 which landed `social/bluesky/`).

- `social/twitter/TwitterSocialComponent.astro` — CTA + widgets.js timeline embed
- `social/youtube/YoutubeSocialComponent.astro` — CTA + uploads iframe (16:9 aspect)
- `social/tiktok/TiktokSocialComponent.astro` — CTA + embed.js creator blockquote

All three mirror the `BlueskySocialComponent` shape: `handle`, optional `label`, `showEmbed`, `class`. Tailwind utilities inline (no scoped `<style>` block).

`twitter.mdx`, `youtube.mdx`, `tiktok.mdx` drop their inline CTA + embed + `<style is:global>` blocks and consume the components instead:

```mdx
import TwitterSocialComponent from '@kbve/astro/components/social/twitter/TwitterSocialComponent.astro';

<TwitterSocialComponent handle="kbve" />
```

## Not in scope

Twitch and GitHub stay app-internal:
- Twitch pulls React (`ReactTwitchEmbed`, `ReactTwitchChat`), `ServiceTwitch.ts`, and `@kbve/astro/utils/clientRouter` — needs a multi-file extraction.
- GitHub pages embed live in-app data fetches (`AstroGithubActivity`, `AstroGithubProjectBoard`, etc.) — tightly coupled to app state, not a pure social embed.

Both reasonable as their own follow-up PRs once the simple CTA pattern is settled.

## Test plan

- [x] `nx run astro-kbve:sync` — schema validation
- [x] `nx run astro-kbve:build` — 7,758 pages built, 0 errors