### PR TITLE
refactor(mc-lot): typed collection helpers + independent fetch errors + a11y

### DIFF
--- a/apps/kbve/astro-kbve/src/components/mcdb/MCLotPanel.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCLotPanel.astro
@@ -1,6 +1,6 @@
 ---
-import { getCollection } from 'astro:content';
 import { MCLotFrontmatterSchema } from '@/data/schema';
+import { getLotEntries } from './mc-collections';
 
 const { data } = Astro.props;
 const lot = MCLotFrontmatterSchema.parse(data);
@@ -24,20 +24,7 @@ const stateAccent: Record<string, string> = {
 };
 const accent = stateAccent[lot.state] ?? '#cbd5e1';
 
-// Pull every lot in the same world so the panel can render an overview
-// SVG marking THIS lot inside the broader plaza.
-const allLots = await getCollection('docs', (entry) => {
-	const m = (entry.data as { mc_lot?: unknown }).mc_lot;
-	if (!m) return false;
-	try {
-		const parsed = MCLotFrontmatterSchema.parse(m);
-		return parsed.world === lot.world;
-	} catch {
-		return false;
-	}
-});
-
-const peers = allLots.map((e) => MCLotFrontmatterSchema.parse(e.data.mc_lot));
+const peers = await getLotEntries(lot.world);
 const minX = Math.min(...peers.map((p) => p.chunk_x_min), lot.chunk_x_min) - 1;
 const maxX = Math.max(...peers.map((p) => p.chunk_x_max), lot.chunk_x_max) + 1;
 const minZ = Math.min(...peers.map((p) => p.chunk_z_min), lot.chunk_z_min) - 1;

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCPlazaOverview.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCPlazaOverview.astro
@@ -1,38 +1,12 @@
 ---
-import { getCollection } from 'astro:content';
-import { MCLotFrontmatterSchema } from '@/data/schema';
+import { getLotEntries } from './mc-collections';
 
 interface Props {
 	world?: string;
 }
 const world = Astro.props.world ?? 'minecraft:overworld';
 
-const entries = await getCollection('docs', (entry) => {
-	const m = (entry.data as { mc_lot?: unknown }).mc_lot;
-	if (!m) return false;
-	try {
-		const parsed = MCLotFrontmatterSchema.parse(m);
-		return parsed.world === world;
-	} catch {
-		return false;
-	}
-});
-
-type LotRow = ReturnType<typeof MCLotFrontmatterSchema.parse> & {
-	slug: string;
-	title: string;
-};
-
-const lots: LotRow[] = entries.map((e) => {
-	const m = MCLotFrontmatterSchema.parse(
-		(e.data as { mc_lot: unknown }).mc_lot,
-	);
-	return {
-		...m,
-		slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
-		title: (e.data as { title?: string }).title ?? m.lot_id,
-	};
-});
+const lots = await getLotEntries(world);
 
 const minX = Math.min(...lots.map((l) => l.chunk_x_min)) - 1;
 const maxX = Math.max(...lots.map((l) => l.chunk_x_max)) + 1;
@@ -209,8 +183,20 @@ const stateAccent: Record<string, string> = {
 		border-radius: 0.4rem;
 	}
 
-	.mcplaza__svg a:hover rect {
+	.mcplaza__svg a:hover rect,
+	.mcplaza__svg a:focus-visible rect {
 		fill-opacity: 0.9;
+	}
+
+	.mcplaza__svg a:focus-visible {
+		outline: 2px solid var(--sl-color-accent);
+		outline-offset: 1px;
+		border-radius: 0.2rem;
+	}
+
+	.mcplaza__svg a:focus-visible rect {
+		stroke: var(--sl-color-white);
+		stroke-width: 2;
 	}
 
 	.mcplaza__hint {

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCSchematicCatalog.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCSchematicCatalog.astro
@@ -1,38 +1,9 @@
 ---
-import { getCollection } from 'astro:content';
-import { MCSchematicFrontmatterSchema } from '@/data/schema';
+import { getSchematicEntries } from './mc-collections';
 
-const entries = await getCollection('docs', (entry) => {
-	const m = (entry.data as { mc_schematic?: unknown }).mc_schematic;
-	if (!m) return false;
-	try {
-		MCSchematicFrontmatterSchema.parse(m);
-		return true;
-	} catch {
-		return false;
-	}
-});
-
-type Row = ReturnType<typeof MCSchematicFrontmatterSchema.parse> & {
-	slug: string;
-	title: string;
-};
-
-const rows: Row[] = entries
-	.map((e) => {
-		const m = MCSchematicFrontmatterSchema.parse(
-			(e.data as { mc_schematic: unknown }).mc_schematic,
-		);
-		return {
-			...m,
-			slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
-			title: (e.data as { title?: string }).title ?? m.display_name,
-		};
-	})
-	.sort(
-		(a, b) =>
-			a.tier - b.tier || a.display_name.localeCompare(b.display_name),
-	);
+const rows = (await getSchematicEntries()).sort(
+	(a, b) => a.tier - b.tier || a.display_name.localeCompare(b.display_name),
+);
 
 const categoryAccent: Record<string, string> = {
 	house: '#86efac',

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMap.astro
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMap.astro
@@ -1,6 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
-import { MCLotFrontmatterSchema, MCPoiFrontmatterSchema } from '@/data/schema';
+import { getLotEntries, getPoiEntries } from './mc-collections';
 
 interface Props {
 	world?: string;
@@ -14,43 +13,8 @@ const span = MAX - MIN + 1;
 const SIZE = 640;
 const cell = SIZE / span;
 
-const lotEntries = await getCollection('docs', (entry) => {
-	const m = (entry.data as { mc_lot?: unknown }).mc_lot;
-	if (!m) return false;
-	try {
-		const parsed = MCLotFrontmatterSchema.parse(m);
-		return parsed.world === world;
-	} catch {
-		return false;
-	}
-});
-
-type LotRow = ReturnType<typeof MCLotFrontmatterSchema.parse> & {
-	slug: string;
-};
-const lots: LotRow[] = lotEntries.map((e) => ({
-	...MCLotFrontmatterSchema.parse((e.data as { mc_lot: unknown }).mc_lot),
-	slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
-}));
-
-const poiEntries = await getCollection('docs', (entry) => {
-	const m = (entry.data as { mc_poi?: unknown }).mc_poi;
-	if (!m) return false;
-	try {
-		const parsed = MCPoiFrontmatterSchema.parse(m);
-		return parsed.world === world;
-	} catch {
-		return false;
-	}
-});
-
-type PoiRow = ReturnType<typeof MCPoiFrontmatterSchema.parse> & {
-	slug: string;
-};
-const pois: PoiRow[] = poiEntries.map((e) => ({
-	...MCPoiFrontmatterSchema.parse((e.data as { mc_poi: unknown }).mc_poi),
-	slug: e.id.replace(/\.mdx?$/, '').replace(/^mc\//, ''),
-}));
+const lots = await getLotEntries(world);
+const pois = await getPoiEntries(world);
 
 const kindAccent: Record<string, string> = {
 	spawn: '#fde68a',
@@ -347,12 +311,25 @@ const blockMax = (MAX + 1) * 16 - 1;
 		display: block;
 	}
 
-	.mcworld__svg a:hover rect {
+	.mcworld__svg a:hover rect,
+	.mcworld__svg a:focus-visible rect {
 		fill-opacity: 0.85;
 	}
 
-	.mcworld__svg a:hover circle {
+	.mcworld__svg a:hover circle,
+	.mcworld__svg a:focus-visible circle {
 		stroke: var(--sl-color-white);
+	}
+
+	.mcworld__svg a:focus-visible {
+		outline: 2px solid var(--sl-color-accent);
+		outline-offset: 1px;
+		border-radius: 0.2rem;
+	}
+
+	.mcworld__svg a:focus-visible rect {
+		stroke: var(--sl-color-white);
+		stroke-width: 2;
 	}
 
 	.mcworld__hint {

--- a/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
+++ b/apps/kbve/astro-kbve/src/components/mcdb/MCWorldMapLive.tsx
@@ -56,11 +56,12 @@ interface Props {
 export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 	const [status, setStatus] = useState<McPlayerList | null>(null);
 	const [dbLots, setDbLots] = useState<Lot[] | null>(null);
-	const [error, setError] = useState<string | null>(null);
+	// Track player + lot fetch failures independently so a flaky RCON
+	// bridge doesn't blank the DB lot overlay (and vice versa).
+	const [statusError, setStatusError] = useState<string | null>(null);
+	const [lotsError, setLotsError] = useState<string | null>(null);
 	const mountedRef = useRef(false);
 	const abortRef = useRef<AbortController | null>(null);
-	// Cache the static-side SVG + injection-point lookup once on mount so
-	// dbLots updates don't re-walk the DOM every refresh.
 	const liveLayerRef = useRef<SVGGElement | null>(null);
 	const playerLayerRef = useRef<SVGGElement | null>(null);
 	const svgRef = useRef<SVGSVGElement | null>(null);
@@ -76,32 +77,61 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 		cancel();
 		const ctrl = new AbortController();
 		abortRef.current = ctrl;
+
+		const errMessage = (e: unknown, fallback: string): string =>
+			e instanceof Error ? e.message : fallback;
+
+		const isAbort = (e: unknown): boolean =>
+			(e as Error | undefined)?.name === 'AbortError';
+
+		const statusPromise = fetch('/api/v1/mc/players', {
+			signal: ctrl.signal,
+		})
+			.then((r) =>
+				r.ok
+					? (r.json() as Promise<McPlayerList>)
+					: Promise.reject(new Error(`HTTP ${r.status}`)),
+			)
+			.then((res) => {
+				if (ctrl.signal.aborted || !mountedRef.current) return;
+				setStatus(res);
+				setStatusError(null);
+			})
+			.catch((e) => {
+				if (isAbort(e) || !mountedRef.current) return;
+				setStatusError(errMessage(e, 'failed to load player status'));
+			});
+
+		const lotsPromise = fetch(
+			`/api/v1/mc/lots/viewport?${new URLSearchParams({
+				world,
+				min_chunk_x: String(minChunk),
+				max_chunk_x: String(maxChunk),
+				min_chunk_z: String(minChunk),
+				max_chunk_z: String(maxChunk),
+				limit: '1024',
+			})}`,
+			{ signal: ctrl.signal },
+		)
+			.then((r) =>
+				r.ok
+					? (r.json() as Promise<Lot[]>)
+					: Promise.reject(new Error(`HTTP ${r.status}`)),
+			)
+			.then((res) => {
+				if (ctrl.signal.aborted || !mountedRef.current) return;
+				if (Array.isArray(res)) {
+					setDbLots(res);
+					setLotsError(null);
+				}
+			})
+			.catch((e) => {
+				if (isAbort(e) || !mountedRef.current) return;
+				setLotsError(errMessage(e, 'failed to load lot overlay'));
+			});
+
 		try {
-			const [statusRes, lotsRes] = await Promise.all([
-				fetch('/api/v1/mc/players', { signal: ctrl.signal }).then(
-					(r) => (r.ok ? r.json() : null),
-				),
-				fetch(
-					`/api/v1/mc/lots/viewport?${new URLSearchParams({
-						world,
-						min_chunk_x: String(minChunk),
-						max_chunk_x: String(maxChunk),
-						min_chunk_z: String(minChunk),
-						max_chunk_z: String(maxChunk),
-						limit: '1024',
-					})}`,
-					{ signal: ctrl.signal },
-				).then((r) => (r.ok ? r.json() : null)),
-			]);
-			if (ctrl.signal.aborted || !mountedRef.current) return;
-			if (statusRes) setStatus(statusRes);
-			if (Array.isArray(lotsRes)) setDbLots(lotsRes);
-		} catch (e) {
-			if ((e as Error)?.name === 'AbortError') return;
-			if (!mountedRef.current) return;
-			setError(
-				e instanceof Error ? e.message : 'failed to load live data',
-			);
+			await Promise.all([statusPromise, lotsPromise]);
 		} finally {
 			if (abortRef.current === ctrl) abortRef.current = null;
 		}
@@ -315,7 +345,16 @@ export function MCWorldMapLive({ world, minChunk, maxChunk }: Props) {
 					from RCON. Off-map players are dropped from the overlay.
 				</p>
 			)}
-			{error && <p className="mcworldlive__error">{error}</p>}
+			{statusError && (
+				<p className="mcworldlive__error">
+					Player status unavailable: {statusError}
+				</p>
+			)}
+			{lotsError && (
+				<p className="mcworldlive__error">
+					Lot overlay unavailable: {lotsError}
+				</p>
+			)}
 		</aside>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/mcdb/mc-collections.ts
+++ b/apps/kbve/astro-kbve/src/components/mcdb/mc-collections.ts
@@ -1,0 +1,80 @@
+import { getCollection } from 'astro:content';
+import {
+	MCLotFrontmatterSchema,
+	MCPoiFrontmatterSchema,
+	MCSchematicFrontmatterSchema,
+	type MCLotFrontmatter,
+	type MCPoiFrontmatter,
+	type MCSchematicFrontmatter,
+} from '@/data/schema';
+
+type DocEntry = Awaited<ReturnType<typeof getCollection<'docs'>>>[number];
+
+export type LotRow = MCLotFrontmatter & { slug: string; title: string };
+export type PoiRow = MCPoiFrontmatter & { slug: string; title: string };
+export type SchematicRow = MCSchematicFrontmatter & {
+	slug: string;
+	title: string;
+};
+
+function entrySlug(entry: DocEntry): string {
+	return entry.id.replace(/\.mdx?$/, '').replace(/^mc\//, '');
+}
+
+function entryTitle(entry: DocEntry, fallback: string): string {
+	const data = entry.data as { title?: unknown };
+	return typeof data.title === 'string' ? data.title : fallback;
+}
+
+export async function getLotEntries(world?: string): Promise<LotRow[]> {
+	const entries = await getCollection('docs');
+	const out: LotRow[] = [];
+	for (const entry of entries) {
+		const raw = (entry.data as { mc_lot?: unknown }).mc_lot;
+		if (raw === undefined) continue;
+		const parsed = MCLotFrontmatterSchema.safeParse(raw);
+		if (!parsed.success) continue;
+		if (world !== undefined && parsed.data.world !== world) continue;
+		out.push({
+			...parsed.data,
+			slug: entrySlug(entry),
+			title: entryTitle(entry, parsed.data.lot_id),
+		});
+	}
+	return out;
+}
+
+export async function getPoiEntries(world?: string): Promise<PoiRow[]> {
+	const entries = await getCollection('docs');
+	const out: PoiRow[] = [];
+	for (const entry of entries) {
+		const raw = (entry.data as { mc_poi?: unknown }).mc_poi;
+		if (raw === undefined) continue;
+		const parsed = MCPoiFrontmatterSchema.safeParse(raw);
+		if (!parsed.success) continue;
+		if (world !== undefined && parsed.data.world !== world) continue;
+		out.push({
+			...parsed.data,
+			slug: entrySlug(entry),
+			title: entryTitle(entry, parsed.data.display_name),
+		});
+	}
+	return out;
+}
+
+export async function getSchematicEntries(): Promise<SchematicRow[]> {
+	const entries = await getCollection('docs');
+	const out: SchematicRow[] = [];
+	for (const entry of entries) {
+		const raw = (entry.data as { mc_schematic?: unknown }).mc_schematic;
+		if (raw === undefined) continue;
+		const parsed = MCSchematicFrontmatterSchema.safeParse(raw);
+		if (!parsed.success) continue;
+		out.push({
+			...parsed.data,
+			slug: entrySlug(entry),
+			title: entryTitle(entry, parsed.data.display_name),
+		});
+	}
+	return out;
+}

--- a/apps/kbve/axum-kbve/src/db/mc_lot.rs
+++ b/apps/kbve/axum-kbve/src/db/mc_lot.rs
@@ -12,16 +12,26 @@ pub async fn init_lot_client() -> bool {
         .get_or_init(|| async {
             match get_wallet_client() {
                 Some(wallet) => {
-                    tracing::info!("LotClient initialized (sharing WalletClient pool)");
+                    tracing::info!(
+                        source = "shared_wallet_pool",
+                        "LotClient initialized"
+                    );
                     Some(LotClient::new(wallet.clone()))
                 }
                 None => match WalletClient::from_env().await {
                     Ok(wallet) => {
-                        tracing::info!("LotClient initialized (standalone wallet pool)");
+                        tracing::info!(
+                            source = "standalone_pool",
+                            "LotClient initialized; wallet client wasn't ready so we bootstrapped a private pool — check init order if this is unexpected"
+                        );
                         Some(LotClient::new(wallet))
                     }
                     Err(e) => {
-                        tracing::warn!(error = %e, "LotClient disabled: no wallet pool available");
+                        tracing::warn!(
+                            error = %e,
+                            error.kind = std::any::type_name_of_val(&e),
+                            "LotClient disabled: WalletClient::from_env failed; /api/v1/mc/lots/* will return 503 until wallet env is configured"
+                        );
                         None
                     }
                 },


### PR DESCRIPTION
## Summary

Sweep pass through the MC lot codebase addressing the highest-impact items from a system-wide audit. Four buckets: shared helpers, fetch resilience, a11y, structured logging.

### 1. Shared typed collection helpers
New \`apps/kbve/astro-kbve/src/components/mcdb/mc-collections.ts\` exports \`getLotEntries\` / \`getPoiEntries\` / \`getSchematicEntries\`. Each one wraps \`getCollection('docs')\`, runs the matching \`safeParse\`, and returns a typed \`{ ...row, slug, title }\` row.

Four components dropped the \`(entry.data as { mc_lot?: unknown }).mc_lot\` cast pattern in favor of the helpers:
- \`MCWorldMap.astro\`
- \`MCPlazaOverview.astro\`
- \`MCSchematicCatalog.astro\`
- \`MCLotPanel.astro\`

Removes ~130 lines of duplicated parsing + the implicit-any filter callbacks the previous code carried. Frontmatter-key drift now breaks in one place.

### 2. MCWorldMapLive — independent fetch failure tracking
Replaces the single \`error\` state with \`statusError\` + \`lotsError\`. \`/api/v1/mc/players\` and \`/api/v1/mc/lots/viewport\` fail independently; a flaky RCON bridge no longer blanks the DB lot overlay (and vice versa).

- HTTP non-2xx surfaces as a typed \`HTTP <status>\` error instead of silently returning \`null\` and looking like an empty payload.
- Each fetch sets its own banner on rejection and clears it on success — the next clean poll heals the UI automatically.
- AbortError + unmount checks still short-circuit before any \`setState\`; no double-paint or post-teardown writes.

### 3. SVG map accessibility
\`MCWorldMap.astro\` and \`MCPlazaOverview.astro\` add \`:focus-visible\` styling on every \`<a>\` cell: outline + accent stroke + opacity bump matching the hover state. Keyboard users now get a discoverable focus indicator on every clickable rect.

### 4. axum init logging
\`init_lot_client\` surfaces structured fields (\`source = shared_wallet_pool | standalone_pool\`) plus an explanatory message when \`WalletClient::from_env\` fails. The error type name lands as \`error.kind\` via \`std::any::type_name_of_val\` so ops can grep Grafana logs by failure class without parsing free text.

### Audit items deferred to follow-up PRs
From the same sweep but out of scope for this PR:
- Price-field non-negative constraint in generated Zod (codegen config tweak).
- Discriminated union for \`MCBuildActionKind\` ↔ \`schematic_id\` presence.
- CSS state-class refactor to keyed map instead of string interpolation.
- Client-side \`world\` regex validation in the dashboard.

## Test plan
- [x] \`cargo check --manifest-path apps/kbve/axum-kbve/Cargo.toml\` is clean (0 errors, 6 pre-existing warnings).
- [x] \`./kbve.sh -nx astro-kbve:build\` ships \`/mc/world/\`, \`/mc/lots/\`, \`/mc/schematics/\` index pages with the refactored helpers.
- [ ] On a deployed instance, kill the RCON bridge; the \`Player status unavailable: ...\` banner appears while DB lots keep rendering.
- [ ] Tab-key through \`/mc/world/\` and \`/mc/lots/\` — every map cell shows a visible focus ring.