### PR TITLE
refactor(cryptothrone): consume the canonical itemdb Item type (one type system)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/itemdb.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/itemdb.ts
@@ -1,5 +1,13 @@
 import rawItemdb from '@kbve/itemdb-data';
-import type { ItemData, ItemAction, ItemRarity } from '../types';
+import type { Item } from '@kbve/itemdb-schema';
+import type { ItemData, ItemAction } from '../types';
+
+// `bonuses` is a freeform top-level MDX field not modeled in the proto `Item`
+// (proto only carries bonuses nested under equipment/enchantment), so layer it
+// onto the canonical type rather than re-describing the whole shape.
+type ItemRecord = Item & {
+	bonuses?: Record<string, number | boolean | string>;
+};
 
 // Inline SVG placeholder for item icons whose sprite is missing (the default
 // /assets/icons/<ref>.png path has no backing file for many items). A data URI
@@ -27,22 +35,6 @@ const BONUS_ALIAS: Record<string, string> = {
 	energy: 'ep',
 };
 
-interface RawItem {
-	ref: string;
-	name: string;
-	key?: number;
-	description?: string;
-	lore?: string;
-	typeFlags?: number;
-	rarity?: string;
-	img?: string;
-	hasImg?: boolean;
-	weight?: number;
-	durability?: number;
-	consumable?: boolean;
-	bonuses?: Record<string, number>;
-}
-
 function resolveType(flags: number): ItemData['type'] {
 	if (flags & FLAG_WEAPON) return 'weapon';
 	if (flags & FLAG_ARMOR) return 'armor';
@@ -58,32 +50,19 @@ function resolveActions(type: ItemData['type']): ItemAction[] {
 	return ['drop', 'inspect'];
 }
 
-function resolveRarity(raw?: string): ItemRarity {
-	const r = (raw ?? '').replace(/^ITEM_RARITY_/, '').toLowerCase();
-	switch (r) {
-		case 'uncommon':
-		case 'rare':
-		case 'epic':
-		case 'legendary':
-		case 'mythic':
-			return r;
-		default:
-			return 'common';
-	}
-}
-
-function normalizeBonuses(
-	raw?: Record<string, number>,
-): Record<string, number> {
+// Bonuses are freeform in the MDX (ItemBonusesSchema is .passthrough()), so the
+// values can be numbers, booleans, or nested — keep only the numeric ones the
+// UI shows.
+function normalizeBonuses(raw: ItemRecord['bonuses']): Record<string, number> {
 	const out: Record<string, number> = {};
 	for (const [k, v] of Object.entries(raw ?? {})) {
-		out[BONUS_ALIAS[k] ?? k] = v;
+		if (typeof v === 'number') out[BONUS_ALIAS[k] ?? k] = v;
 	}
 	return out;
 }
 
-function adapt(raw: RawItem): ItemData {
-	const flags = raw.typeFlags ?? 0;
+function adapt(raw: ItemRecord): ItemData {
+	const flags = raw.type_flags ?? 0;
 	const type = resolveType(flags);
 	return {
 		id: raw.ref,
@@ -96,12 +75,12 @@ function adapt(raw: RawItem): ItemData {
 		durability: raw.durability ?? (type === 'consumable' ? 1 : 100),
 		weight: raw.weight ?? 1,
 		actions: resolveActions(type),
-		rarity: resolveRarity(raw.rarity),
+		rarity: raw.rarity,
 		lore: raw.lore?.trim() || undefined,
 	};
 }
 
-const pool = (rawItemdb as { items?: RawItem[] }).items ?? [];
+const pool = (rawItemdb as { items?: ItemRecord[] }).items ?? [];
 const items: ItemData[] = pool.filter((r) => r && r.ref && r.name).map(adapt);
 
 const itemMap = new Map(items.map((i) => [i.id, i]));

--- a/apps/cryptothrone/astro-cryptothrone/tsconfig.json
+++ b/apps/cryptothrone/astro-cryptothrone/tsconfig.json
@@ -17,7 +17,10 @@
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
 			"@kbve/laser/ecs": ["../../../packages/npm/laser/src/ecs.ts"],
 			"@kbve/itemdb-data": [
-				"../../../packages/data/codegen/generated/itemdb-data.json"
+				"../../../packages/data/codegen/generated/itemdb.json"
+			],
+			"@kbve/itemdb-schema": [
+				"../../../packages/data/codegen/generated/itemdb-schema.ts"
 			],
 			"@kbve/npcdb-data": [
 				"../../../packages/data/codegen/generated/npcdb-data.json"

--- a/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
@@ -24,7 +24,7 @@ export default defineConfig({
 			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
 			{
 				find: '@kbve/itemdb-data',
-				replacement: pkg('data/codegen/generated/itemdb-data.json'),
+				replacement: pkg('data/codegen/generated/itemdb.json'),
 			},
 			{
 				find: '@kbve/npcdb-data',

--- a/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
@@ -30,7 +30,7 @@ export default defineConfig({
 			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
 			{
 				find: '@kbve/itemdb-data',
-				replacement: pkg('data/codegen/generated/itemdb-data.json'),
+				replacement: pkg('data/codegen/generated/itemdb.json'),
 			},
 			{
 				find: '@kbve/npcdb-data',

--- a/apps/kbve/astro-kbve/project.json
+++ b/apps/kbve/astro-kbve/project.json
@@ -285,6 +285,7 @@
 			"outputs": [
 				"{workspaceRoot}/packages/data/codegen/generated/itemdb-data.json",
 				"{workspaceRoot}/packages/data/codegen/generated/itemdb-data.binpb",
+				"{workspaceRoot}/packages/data/codegen/generated/itemdb.json",
 				"{workspaceRoot}/apps/rareicon/unity-rareicon/Assets/StreamingAssets/itemdb.json",
 				"{workspaceRoot}/apps/rareicon/unity-rareicon/Assets/StreamingAssets/itemdb.binpb"
 			],

--- a/packages/data/codegen/gen-itemdb-data.mjs
+++ b/packages/data/codegen/gen-itemdb-data.mjs
@@ -53,6 +53,11 @@ const DESCRIPTOR_PATH = resolve(__dirname, 'descriptors/itemdb.binpb');
 const GENERATED_DIR = resolve(__dirname, 'generated');
 const CENTRAL_JSON = resolve(GENERATED_DIR, 'itemdb-data.json');
 const CENTRAL_BINPB = resolve(GENERATED_DIR, 'itemdb-data.binpb');
+// Web bundle: snake_case + bare enums, shaped { items: [...] } to match the
+// generated zod ItemRegistry/Item types verbatim. Lets TS consumers (cryptothrone)
+// import the canonical `Item` type instead of hand-rolling a second shape. The
+// camelCase CENTRAL_JSON stays the proto-canonical artifact for Unreal/binpb.
+const WEB_JSON = resolve(GENERATED_DIR, 'itemdb.json');
 
 // Per-game sync targets — each Unity game mirrors both formats into its
 // StreamingAssets so the runtime loader finds them at boot, and gets
@@ -312,6 +317,12 @@ function main() {
 	writeFileSync(CENTRAL_BINPB, wire);
 	console.log(`Wrote ${CENTRAL_JSON}`);
 	console.log(`Wrote ${CENTRAL_BINPB} (${wire.length} bytes)`);
+
+	writeFileSync(
+		WEB_JSON,
+		JSON.stringify({ items: unityEntries }, null, 2) + '\n',
+	);
+	console.log(`Wrote ${WEB_JSON}`);
 
 	// 5. Build ItemId enum + ref map from mdx + legacy holdouts.
 	const members = buildEnumMembers(records);

--- a/packages/data/codegen/generated/itemdb.json
+++ b/packages/data/codegen/generated/itemdb.json
@@ -1,0 +1,5303 @@
+{
+  "items": [
+    {
+      "description": "A faint silver powder that weighs almost nothing and refuses to settle in still air. Light passing through it arrives a half-second late, and the grains align themselves toward whichever celestial object happens to be directly overhead, regardless of what the ceiling says.\n",
+      "lore": "Collected by the DeepCore Alchemy Arrays from the event horizons of collapsing stars, where matter gives up some of its stubbornness about which moment it belongs to. A single gram finishes a transmutation that would otherwise require a lifetime of failed attempts. Alchemists who handle it carelessly report remembering things in the wrong order for the rest of the year, and occasionally for the rest of the previous one.\n",
+      "ref": "alchemist-stardust",
+      "key": 9,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRSD",
+      "name": "Alchemist Stardust",
+      "type_flags": 397,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "mythic",
+      "weight": 0.1,
+      "buy_price": 10000,
+      "durability": 999,
+      "level_requirement": 10,
+      "cooldown": 0,
+      "action": "transmute",
+      "bonuses": {
+        "quantumFlux": true,
+        "elementAffinity": 1,
+        "timeHarmonics": 0.85
+      },
+      "scripts": [
+        {
+          "guid": "fc721e1beaa145c8aab2ebde8121e173",
+          "vars": {
+            "quantumFlux": true,
+            "affinityBoost": 1,
+            "harmonicSync": 0.85,
+            "dimensionalEnergy": "5D"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A stout purple bloom the size of a fist, carried on a hollow stalk that squeaks when bent. The scent is faintly oniony, pleasant at distance and less so up close.\n",
+      "lore": "Cultivated by hedge-border witches for reasons they never wrote down, and later adopted by kitchen gardeners who found it kept deer honest about their appetites. The bulbs are edible in modest quantities, which is how most cooks learn the word modest.\n",
+      "ref": "allium",
+      "key": 113,
+      "id": "01KMVPV9ZJ37XD5AAAP211W0XM",
+      "name": "Allium",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 4,
+      "sell_price": 2,
+      "emoji": "🟣",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 5,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-allium"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "A full-length comfort pillow printed with a vaguely familiar animated figure. One side is smiling. The other is not, and it watches the room with an expression that could charitably be called patient.\n",
+      "lore": "Pressed in a midnight run at a convention print shop that closed before its lease was up, using a reference sheet the artist swore was public domain. Owners report dreaming in subtitles for the first week, and gaining a small but persistent tolerance for criticism after that.\n",
+      "ref": "anime-body-pillow",
+      "key": 30,
+      "id": "01JWFA5N2C1SFDP1S7331YF4A6",
+      "name": "Anime Body Pillow",
+      "type_flags": 418,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 3.4,
+      "buy_price": 160,
+      "durability": 999,
+      "level_requirement": 0,
+      "cooldown": 69,
+      "action": "snuggle",
+      "bonuses": {
+        "moraleBoost": 2,
+        "sleepQuality": 1,
+        "dreamInfluence": true
+      },
+      "scripts": [
+        {
+          "guid": "dd838b8d3a9442e0a4b0dc3ddcfa71d5",
+          "vars": {
+            "sleepModifier": 1,
+            "comfortAura": true,
+            "dreamFlag": "anime"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A cloudy tonic in a brown glass vial, stoppered with a cork that has absorbed its color over time. It tastes strongly of pine, iron, and the faint chalk aftertaste of a decent apology.\n",
+      "lore": "Brewed to a shared guild recipe that every apothecary insists they have personally improved. Effective against most common venoms, several uncommon ones, and the particular despair that arrives halfway through a hard winter. The recipe lives in a single copied book, kept at the Pharmacists' Union hall behind a door that does not lock.\n",
+      "ref": "antidote",
+      "key": 75,
+      "id": "01KKR7QNRC81EVK4PF70V5E3FR",
+      "name": "Antidote",
+      "type_flags": 544,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 2,
+      "rarity": "uncommon",
+      "buy_price": 45,
+      "emoji": "🧴",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "remove_all_negative"
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "alchemy",
+          "skill_level": 5,
+          "xp_reward": 25,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "lavender",
+              "amount": 2
+            },
+            {
+              "item_ref": "chanterelle",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A single fletched arrow with a steel bodkin head and goose feathers trimmed straight. The shaft is pale ash, balanced a finger's width forward of center.\n",
+      "lore": "Produced in bundles of twenty by village fletchers working off winter contracts, which means every batch carries the private grudges of whichever household lost the bidding. Quartermasters are expected to sort them by straightness before issue, and most do not. The ones they skip tend to find the quietest archers in the line.\n",
+      "ref": "arrow",
+      "key": 517,
+      "id": "01KPTSDW05RW20S2D1HT5YVRXM",
+      "name": "Arrow",
+      "type_flags": 576,
+      "rarity": "common",
+      "emoji": "🏹",
+      "stackable": true,
+      "max_stack": 50,
+      "buy_price": 1,
+      "compress": {
+        "target_ref": "quiver",
+        "ratio": 100
+      },
+      "recipes": [
+        {
+          "skill": "fletching",
+          "skill_level": 1,
+          "xp_reward": 4,
+          "output_quantity": 10,
+          "ingredients": [
+            {
+              "item_ref": "log",
+              "amount": 1
+            },
+            {
+              "item_ref": "cacti-needle",
+              "amount": 1
+            },
+            {
+              "item_ref": "stone",
+              "amount": 1
+            }
+          ]
+        },
+        {
+          "skill": "fletching",
+          "skill_level": 1,
+          "xp_reward": 6,
+          "output_quantity": 10,
+          "ingredients": [
+            {
+              "item_ref": "bone",
+              "amount": 1
+            },
+            {
+              "item_ref": "log",
+              "amount": 1
+            }
+          ]
+        },
+        {
+          "skill": "fletching",
+          "skill_level": 3,
+          "xp_reward": 80,
+          "output_quantity": 500,
+          "ingredients": [
+            {
+              "item_ref": "timber",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A fine grey powder, still warm enough at the center of a scoop to remind you what it came from. Tastes alkaline, clings to fingers, settles into the weave of any cloth you set it near.\n",
+      "lore": "Swept from hearths and kilns across the lower valleys, then traded up the river by children young enough to not yet be angry about it. Gardeners mix it into sour soil to sweeten a beet patch, and dyers use it to set indigo. Alchemists reserve a small portion for work they prefer not to itemize.\n",
+      "ref": "ash",
+      "key": 513,
+      "id": "01KPTSDW04QVW5F1VNTKEF8NHB",
+      "name": "Ash",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 1
+    },
+    {
+      "description": "A countertop appliance in polished enamel with a single dial labelled SURPRISE and a door that never quite closes on the same side twice. It hums with culinary ambition whether or not it has been switched on.\n",
+      "lore": "Final flagship product of DomeTech Home Labs, released at a press event that ended with an evacuation order and a spokeswoman going quietly off-roster. Units still in the field produce meals that taste correct but arrive with ingredients nobody in the kitchen put in, a quirk that the manual refers to in passing as \"enthusiasm\". Firmware updates are no longer available.\n",
+      "ref": "auto-cooker-9000",
+      "key": 55,
+      "id": "01JWN7TN1P44J963328VP0YNFF",
+      "name": "Auto Cooker 9000",
+      "type_flags": 4096,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 12.5,
+      "buy_price": 850,
+      "durability": 500,
+      "level_requirement": 6,
+      "cooldown": 120,
+      "action": "deploy",
+      "bonuses": {
+        "cookingSpeed": 2,
+        "foodQuality": 1,
+        "recipeDiscovery": true
+      },
+      "scripts": [
+        {
+          "guid": "acf8fd9f713247ea99cde9a43b6781ab",
+          "vars": {
+            "deployableType": "cooker",
+            "speedMultiplier": 2,
+            "foodQualityBonus": 1,
+            "traits": "cooker"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A canvas shoulder bag with leather straps softened by long use and an interior liner stitched back in by an unidentified repair. Big enough for a full day of foraging without leaning you sideways on the return walk.\n",
+      "lore": "Mass-produced during the Third Caravan Revival by a cooperative of tentmakers who agreed, in writing, to never press their logo on the outside. A well-kept bag lasts longer than the person carrying it, and the stitching tends to outlive two generations of contents. The last owner's initials are usually visible inside the lip if you know where to look.\n",
+      "ref": "bag",
+      "key": 531,
+      "id": "01KPTSDW068ASJCC6BEK23CPDA",
+      "name": "Bag",
+      "type_flags": 8196,
+      "rarity": "uncommon",
+      "emoji": "🎒",
+      "stackable": true,
+      "max_stack": 2,
+      "buy_price": 60,
+      "container": {
+        "added_slots": 4
+      }
+    },
+    {
+      "description": "A strip of clean linen wound tight and folded into a palm-sized square, pinned with a sliver of bone. It smells faintly of lye and the sheep it came from.\n",
+      "lore": "Cut from rolls stocked in every caravan chest, barracks locker, and village kitchen from here to the coast, because bleeding does not pause for negotiation. Seasoned campaigners keep one in the same pocket as their field ration, since hunger and injury rarely arrive on separate days. The pin is the expensive part, and you get it back.\n",
+      "ref": "bandage",
+      "key": 68,
+      "id": "01KKR7QNRCPH4QEYXHHXV2301B",
+      "name": "Bandage",
+      "type_flags": 544,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 5,
+      "rarity": "common",
+      "buy_price": 10,
+      "emoji": "🧷",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "heal",
+          "amount": 5
+        },
+        {
+          "type": "remove_effect",
+          "status_effect": "bleed"
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 1,
+          "xp_reward": 8,
+          "output_quantity": 2,
+          "ingredients": [
+            {
+              "item_ref": "wildflower",
+              "amount": 1
+            },
+            {
+              "item_ref": "log",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A wooden tankard of golden-brown ale, foam thinning fast, carrying the warmth of a taproom that has been breathing on it since noon. First sip is grain, second is bitter, third is whatever you came to the inn to say.\n",
+      "lore": "Brewed in long cellars under every roadside inn worth stopping at, using grain bought off the same three farms and hops that nobody quite remembers agreeing on. The recipe drifts year to year, always by a little, never enough to argue with the landlord. A pint will not make you braver, but it makes the next decision feel cheaper.\n",
+      "ref": "beer",
+      "key": 50,
+      "id": "01JWJAVCGHH345RKABKR1D04XF",
+      "name": "Beer",
+      "type_flags": 400,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.75,
+      "buy_price": 35,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 30,
+      "action": "consume",
+      "bonuses": {
+        "strength": 1,
+        "charisma": -1,
+        "buzzed": true
+      },
+      "scripts": [
+        {
+          "guid": "cd2023aa19234f07bbf31fbc7265eb1c",
+          "vars": {
+            "buffDuration": 90,
+            "traits": "buzzed"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A cluster of pale blue bells nodding on a single thin stem, the petals so light that the shape is mostly suggestion. Found in shaded groves where the moss has been left alone.\n",
+      "lore": "Protected under the old forest compacts, which means nobody picks them without first apologizing to whoever is listening. The flower closes at dusk and reopens at first light, a habit that kitchen gardeners have tried to exploit for clock-making with universally disappointing results. Pressed between the pages of a heavy book, the petals dry to a color exactly matching bruises.\n",
+      "ref": "bellflower",
+      "key": 108,
+      "id": "01KMVPV9ZHMZNVQDYGK8F47P5D",
+      "name": "Bellflower",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 4,
+      "sell_price": 2,
+      "emoji": "🔔",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 5,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-bell"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "A handful of deep-purple berries, skins tight enough to split under a thumb, fingers stained within a step of the bush. Sweet at the top, sharp underneath, with a seed that tastes faintly of cedar.\n",
+      "lore": "Foraged off low thornbushes that line every goat path worth walking, and tolerated by the farms that pretend they do not notice children emptying the hedgerows. A decent forager learns early which patch belongs to which grandmother, and whose grudge is worth the shortcut. The season is short, always shorter than anyone planned for.\n",
+      "ref": "berry",
+      "key": 500,
+      "id": "01KPTSDW02MJBNHGJN2QDM05X5",
+      "name": "Berry",
+      "type_flags": 72,
+      "rarity": "common",
+      "emoji": "🫐",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 2,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 10,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-food"
+      },
+      "skilling": {
+        "skill": "foraging"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A slender blue orchid with three curled petals the color of pond ice, resting on a stem so thin it bends under the weight of its own bloom. The scent arrives only after dusk, and only if you are not expecting it.\n",
+      "lore": "Grown in pocket glades where a spring runs shallow over granite, and tended informally by the small number of hedge-keepers who still remember the orchid's full proper name. Collectors pay well for a fresh cutting, which is why most patches have been stripped at least once in living memory. The surviving stands are the ones somebody has chosen to protect quietly, and those keepers are not taking new apprentices.\n",
+      "ref": "blue-orchid",
+      "key": 114,
+      "id": "01KMVPV9ZJCX2MW8DR54AV33JS",
+      "name": "Blue Orchid",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 7,
+      "sell_price": 3,
+      "emoji": "🏵️",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 8,
+        "gather_time": 0.5,
+        "respawn_time": 25,
+        "resource_node": "flower-blue-orchid"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "A heavy deep-water shark, slate blue along the back and fading to silver under the belly, stiff with cold from the hold. The flesh cuts white and firm, and the blood dries an unexpectedly bright crimson against the gut walls.\n",
+      "lore": "Caught on the long lines run out of the northern harbor by crews who do not advertise their routes, because the grounds shift with the tide and the shark is worth the secrecy. Cooks along the coast use it sparingly in broths intended to settle both the body and the mind, since a stew made from it keeps its heat longer than the fire that made it. Old fishermen drink a cup of the same broth before any voyage they expect to come home from.\n",
+      "ref": "blue-shark",
+      "key": 2,
+      "id": "01J263S362R0Q3TV8T4DFMR8Z5",
+      "name": "Blue Shark",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "common",
+      "weight": 10,
+      "buy_price": 500,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 120,
+      "action": "consume",
+      "bonuses": {
+        "health": 50,
+        "mana": 25
+      },
+      "scripts": [
+        {
+          "guid": "dd238a91353c4a1991cf275041730ab0",
+          "vars": {
+            "health": 50,
+            "mana": 25,
+            "duration": 600,
+            "tickRate": 5
+          }
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 86400,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "A palm-sized cast-iron sphere with a short oiled fuse and a seam of poured lead running around its middle. Heavy enough to remind you what it is every time you shift your belt.\n",
+      "lore": "Built to a shared military pattern that has been printed in field manuals since the last long war, and copied faithfully by every backroom smith who ever lost a cousin to the same. The fuse is the mercy of the thing, and the smiths who sell them will tell you exactly how many heartbeats it gives you, never one more. A full crate should always be unpacked in daylight, away from anyone who is in a hurry.\n",
+      "ref": "bomb",
+      "key": 69,
+      "id": "01KKR7QNRCXEWSCSYHRKEVJ20N",
+      "name": "Bomb",
+      "type_flags": 8704,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 3,
+      "rarity": "uncommon",
+      "buy_price": 50,
+      "emoji": "💣",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "damage_enemy",
+          "amount": 10
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 5,
+          "xp_reward": 20,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "copper-ore",
+              "amount": 1
+            },
+            {
+              "item_ref": "fly-agaric",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A sun-bleached length of bone, dry to the touch and surprisingly light for its size. The marrow cavity whistles faintly when the wind passes it at the right angle.\n",
+      "lore": "Picked clean by scavengers long before anyone worth naming came along to collect them, which is why the best specimens turn up in places nobody wanted to camp. Alchemists prize them for reagent preparation, dogs for reasons entirely their own, and spirits for the shape of the sound they make when disturbed. A household with one on the mantelpiece is understood to have opinions about funerary etiquette, and guests do not usually ask.\n",
+      "ref": "bone",
+      "key": 13,
+      "id": "01JW9Z6VRWVN2RXGWNEVVG9RTJ",
+      "name": "Bone",
+      "type_flags": 401,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.5,
+      "buy_price": 30,
+      "durability": 120,
+      "level_requirement": 1,
+      "cooldown": 0,
+      "action": "toss",
+      "bonuses": {
+        "chewValue": true,
+        "alchemyUse": true,
+        "spiritualEcho": 0.05
+      },
+      "scripts": [
+        {
+          "guid": "dd319f2f47ab4f0faaba2917ee7832af",
+          "vars": {
+            "useCase": "alchemy",
+            "chewChance": 1,
+            "spiritEchoChance": 0.05
+          }
+        }
+      ],
+      "stacking": {
+        "pack_max": 30
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Heavy brass key the length of two fingers, ward cut in a pattern unlike any in the locksmith's standard book, bow stamped with a pictogram that reads the same from either side. Warm to the touch in a way that has stopped surprising its current bearer.\n",
+      "lore": "Falls out of pockets that did not have it a moment earlier, at the end of fights that did not seem survivable, in rooms where nobody has had time to check for ambient magic. The key fits exactly one door in its lifetime, and everybody involved tends to agree on which door without having to discuss it. Retired adventurers keep their old ones strung on a cord by the hearth, as a small defense against the assumption that the work is ever fully finished.\n",
+      "ref": "boss-key",
+      "key": 555,
+      "id": "01KTVTRAB1B0SSKEY0000000010",
+      "name": "Boss Key",
+      "type_flags": 4096,
+      "rarity": "rare",
+      "stackable": true,
+      "max_stack": 10,
+      "buy_price": 0,
+      "tradeable": false
+    },
+    {
+      "description": "Salvage-grade notebook with fan noise that sounds like a dying moth. The plastic smells faintly of oxidized capacitors and old caffeine, and the boot sequence drops into a desktop where every icon leads somewhere you did not click.\n",
+      "lore": "Recovered from a landfill in the Inland Valley after the 2038 Cloud Purge. The previous owner left behind seventeen tabs of legally actionable forum history and a bookmark folder titled \"final form\". Powering it on appears to reopen the session exactly where she left it, which is concerning, because she has been missing since the second wave of AI layoffs.\n",
+      "ref": "brainrot-laptop",
+      "key": 61,
+      "id": "01JX4H5YJKEBYQT4QZ2PHTYMY5",
+      "name": "Brainrot Laptop",
+      "type_flags": 411,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 3.2,
+      "buy_price": 550,
+      "durability": 250,
+      "level_requirement": 3,
+      "cooldown": 60,
+      "action": "boot",
+      "bonuses": {
+        "confusion": 5,
+        "memeticInfection": true
+      },
+      "scripts": [
+        {
+          "guid": "b0c0ffee0c0ffee0deadbeef12345678",
+          "vars": {
+            "glitchChance": 0.3,
+            "confusionRate": 5,
+            "runtime": 300
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A loose bundle of wrist-thick branches, still flexible enough at the tips to bow under their own weight, snapped off cleanly at the base. Bark is green-grey, catching the light where the breaks are fresh.\n",
+      "lore": "Gathered off the forest floor by the woodcutters' apprentices, who are told that anything too thin for the saw is theirs to sell if they can bundle it. Villages that run out of them in late winter pay a surprising amount to anyone willing to walk out and fill a cart. The kindling burns fast and clean, and a good armful will outrun the first hour of a cold morning.\n",
+      "ref": "branches",
+      "key": 508,
+      "id": "01KPTSDW0424E0BGSQW0MJR2NJ",
+      "name": "Branches",
+      "type_flags": 384,
+      "rarity": "common",
+      "emoji": "🪵",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 1,
+      "skilling": {
+        "skill": "woodcutting"
+      }
+    },
+    {
+      "description": "A deep brown sauce the color of wet earth, glossy with fat, cooked long enough that the spices have settled into their second or third conversation with each other. The smell carries through two rooms and one closed door.\n",
+      "lore": "Built from a roux that every cook insists is theirs alone, thickened over a day that nobody sane would spend on a single pot unless it was this one. The recipe passes between households on stained paper, never printed, never taught to anyone in a hurry. Eaten over rice at the end of a long week, it is widely considered a decent substitute for being understood.\n",
+      "ref": "brown-curry-sauce",
+      "key": 44,
+      "id": "01JWG7MYCBHXK5WP2WS6AQYMSC",
+      "name": "Brown Curry Sauce",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.85,
+      "buy_price": 90,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 45,
+      "action": "consume",
+      "bonuses": {
+        "stamina": 20,
+        "focus": 2,
+        "nostalgia": true
+      },
+      "scripts": [
+        {
+          "guid": "cc12495f03df489fb2e94a967f7a7981",
+          "vars": {
+            "buffDuration": 120
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Small round wood-and-leather hand shield, gripped centrally rather than strapped. Light enough that a militia goblin can swing it on a club arm without slowing the swing. Stops a glancing arrow; nothing more ambitious.\n",
+      "lore": "The starting shield of every village watch from here to the river. Carpenters press them out by the dozen between the spring weapons-tax and the autumn harvest stand-down, and the watch sergeants accept them because losses to weather and woodworm always run ahead of replacements. A buckler that lasts past its second autumn is generally good for another five.\n",
+      "ref": "buckler",
+      "key": 557,
+      "id": "01KTVTRAB1BUCKLER0000000557",
+      "name": "Buckler",
+      "type_flags": 514,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 8
+    },
+    {
+      "description": "A hand-sized block of pale gold butter wrapped in waxed cloth, the surface printed with the farmhouse's maker-stamp in low relief. Soft at the corners, firm at the middle, carrying the clean smell of cultured cream.\n",
+      "lore": "Churned at dawn in kitchens where the first person up is the one who draws the butter duty, and the last person to bed is the one who scolds them about it. A block keeps a week in a cellar, a day in a pack, and roughly an hour on the counter in summer. Cooks use it for richness; apothecaries for carrier fat; the old hedge-circle for oiling whatever they do not want seen turning.\n",
+      "ref": "butter",
+      "key": 49,
+      "id": "01JWJ9XF2P7MFM2W96T55XTGA7",
+      "name": "Butter",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.5,
+      "buy_price": 25,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 15,
+      "action": "consume",
+      "bonuses": {
+        "flavorBoost": 1,
+        "speed": 0.5
+      },
+      "scripts": [
+        {
+          "guid": "ab1f253d95ac4db2b774eb3ce18e42d1",
+          "vars": {
+            "effectContext": "cooking",
+            "flavorBoost": 1,
+            "mobilityBonus": 0.5
+          }
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 1209600,
+        "spoils_into_ref": "rotten-food"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "A single glossy black needle, finger-length and stiff, tapering from a pale base to a point that catches light from surprising angles. Sharper dry than wet, and unforgiving of careless pockets.\n",
+      "lore": "Pulled from the old barrel cacti out on the southern flats, where the plants grow slow and the needles come off cleanly if you thank them first. Tanners use them for leather awls, seamstresses for anything they do not want bending mid-stitch, and healers for a specific kind of bloodletting that the guild has stopped printing in its handbooks. A bundle trades at the border for a day's ration, sometimes two if the caravan has just come up from the dunes.\n",
+      "ref": "cacti-needle",
+      "key": 504,
+      "id": "01KPTSDW04YJ5V18QD68VXG168",
+      "name": "Cacti Needle",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 3,
+      "skilling": {
+        "skill": "foraging"
+      }
+    },
+    {
+      "description": "A pinch of small black seeds tucked into a folded paper twist, each one hard enough to rattle when shaken. They smell faintly of the inside of a dry melon.\n",
+      "lore": "Collected from the fruiting bodies of the flats-cacti by seed-keepers who walk a route older than the road beside it, and who are generally unwilling to explain which seeds are this year's and which are the slow stock. Planted in sand-poor soil they sprout in a week; planted anywhere wetter they rot quietly and leave the grower with an opinion about drainage. A well-stored twist will germinate reliably for a decade, which is longer than most growers stay in one place.\n",
+      "ref": "cacti-seeds",
+      "key": 507,
+      "id": "01KPTSDW04JBK3QHKP6BK28Z2C",
+      "name": "Cacti Seeds",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 50,
+      "buy_price": 4,
+      "skilling": {
+        "skill": "foraging"
+      }
+    },
+    {
+      "description": "A rolled canvas bundle holding a flint striker, a folded iron grate, and a stack of resin-soaked tinder sticks tied with waxed twine. Heavy enough to notice on a full pack, light enough that no one takes it out at the planning stage.\n",
+      "lore": "Issued to scouting parties by the quartermasters at the eastern forts, using a packing list that has not changed in four generations because nothing in the list has ever failed in the field. A well-made kit will light a camp in the rain, dry socks by the second hour, and outlast the careers of most of its users. Losing one is the kind of mistake that gets remembered at promotion boards decades later.\n",
+      "ref": "campfire-kit",
+      "key": 77,
+      "id": "01KKR7QNRCDVADFBQ4TTESGDQA",
+      "name": "Campfire Kit",
+      "type_flags": 8704,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 1,
+      "rarity": "rare",
+      "buy_price": 150,
+      "emoji": "🔥",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "campfire_rest",
+          "percent": 50
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 1,
+          "xp_reward": 10,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "log",
+              "amount": 3
+            },
+            {
+              "item_ref": "stone",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Folded vellum the size of a small book, sealed in red wax with the capital's three-tower pressing and tied with ribbon in the palace's registered colors. Heavier than vellum has any right to be, and warm along the fold where the seal was most recently pressed.\n",
+      "lore": "Issued by the Office of Settlements on behalf of the crown, conferring on the bearer the right to claim and improve one parcel of unallocated land within the territories currently open for settlement. The grant is countersigned by three officials the office prefers not to list publicly, because the list has become a shorthand for a factional dispute the office claims it is not involved in. Rare enough that most town halls have not seen one in two generations, and the mayor who receives one is expected, by tradition, to bow before reading it.\n",
+      "ref": "capital-land-grant",
+      "key": 556,
+      "id": "01KTVTRAB1C4P1T4LGR4NT00011",
+      "name": "Capital Land Grant",
+      "type_flags": 4096,
+      "rarity": "mythic",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 0,
+      "tradeable": false
+    },
+    {
+      "description": "A long orange carrot with the green tops still attached, dirt clinging to the taproot in the shape of the soil it came out of. Snaps cleanly when broken, releasing a sharp sweet smell.\n",
+      "lore": "Grown in every market-garden plot worth tending, on the strength of a crop that keeps paying through the cold months and tolerates being ignored for weeks at a time. Children are set on weeding duty as soon as they can tell the plant from the grass, which takes most of them longer than anyone likes to admit. A good carrot will outlast the cook who bought it, provided the cellar stays dry and the mice lose interest.\n",
+      "ref": "carrot",
+      "key": 516,
+      "id": "01KPTSDW05ZP05TV92F9F5F7R5",
+      "name": "Carrot",
+      "type_flags": 72,
+      "rarity": "common",
+      "emoji": "🥕",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 4,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 9,
+        "perishable": true,
+        "shelf_life_seconds": 1209600,
+        "spoils_into_ref": "rotten-food"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A heavy shirt of interlocking iron rings, each one hand-closed with a rivet that catches fingernails if you run a hand the wrong way across it. Hangs from the shoulders with the weight of a decent meal and rings softly against itself on the walk.\n",
+      "lore": "Built in the armorer's quarter by journeymen who earn their master's stamp on the day their first finished shirt turns a serious blow. Standard issue in every organized company, and the first piece of gear that separates soldiers from people who happen to be holding swords. A well-maintained shirt passes through three or four owners before the rings begin to give, which is usually the same moment its final owner decides to retire.\n",
+      "ref": "chain-mail",
+      "key": 93,
+      "id": "01KKR7QNRCHKCKBSFQW8Z8DC7G",
+      "name": "Chain Mail",
+      "type_flags": 514,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "buy_price": 80,
+      "emoji": "⛓️",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "chest",
+        "bonuses": {
+          "armor": 4,
+          "health": 5
+        }
+      },
+      "recipes": [
+        {
+          "skill": "smithing",
+          "skill_level": 15,
+          "xp_reward": 45,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "iron-ore",
+              "amount": 4
+            },
+            {
+              "item_ref": "copper-ore",
+              "amount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "A small funnel-shaped mushroom the color of fresh butter, with false gills that run down the stem in soft ridges. The scent is apricot at first and pepper on the second breath.\n",
+      "lore": "Pushed up after a summer rain on the shady side of older woodlots, where the oaks and the pines have agreed on an uneasy border. Cooks pay well for a handful, and experienced foragers know that the patch is worth walking past twice rather than stripping clean. Mistaken for two similar-looking mushrooms that are considerably less friendly, which is why every forager carries a whittled key-guide that their grandmother signed off on.\n",
+      "ref": "chanterelle",
+      "key": 116,
+      "id": "01KMVPV9ZJF97SBP3WTVTPV93C",
+      "name": "Chanterelle",
+      "type_flags": 136,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 10,
+      "sell_price": 5,
+      "emoji": "🍄",
+      "weight": 0.15,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 10,
+        "gather_time": 0.5,
+        "respawn_time": 25,
+        "resource_node": "mushroom-chanterelle"
+      },
+      "food": {
+        "heals": 4,
+        "doses": 1,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-food"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "A dense wedge of aged cheddar, deep yellow at the rind and paling toward the heart, firm enough to crack cleanly under a thumb. Sharp on the first bite, smooth on the second, carrying the specific stubbornness of a long cellar.\n",
+      "lore": "Pressed and aged by a handful of dairy cooperatives that operate under a shared mark, which each of them insists their own rind-stamp quietly improves upon. The wheels turn in their cellars for a year and a season, while the cheesemongers argue privately about which cave wall gives the best crystalline bite. Sold by the wedge at any market worth the walk, and cut larger than necessary for anyone the cutter considers a friend.\n",
+      "ref": "cheddar-cheese",
+      "key": 38,
+      "id": "01JWG4CAABY3EHB65EBTG77J5A",
+      "name": "Cheddar Cheese",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.6,
+      "buy_price": 60,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 35,
+      "action": "consume",
+      "bonuses": {
+        "health": 25,
+        "stamina": 8,
+        "charm": 1
+      },
+      "scripts": [
+        {
+          "guid": "cf3d881412c44a50a87ff7382f8ad552",
+          "vars": {
+            "healAmount": 25,
+            "staminaBoost": 8,
+            "charmModifier": 1,
+            "duration": 120
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A modest wedge of cheese wrapped in a square of waxed linen, pale cream at the center and smudged with cellar dust along the rind. Tastes of milk first, grass second, and a distant memory of the barn it came from.\n",
+      "lore": "Made by the same farms that keep a cow or two beyond what the household actually drinks, and pressed in cloths that never quite get clean between batches, because that is part of the flavor by the third turn of the year. Sold off the back of carts at roadside markets, cut with a knife that everybody recognizes even if they cannot remember whose it is. A wedge keeps a week on the road and considerably longer in the right cellar.\n",
+      "ref": "cheese",
+      "key": 529,
+      "id": "01KPTSDW065HD5K0FP6QWA0GX0",
+      "name": "Cheese",
+      "type_flags": 8,
+      "rarity": "common",
+      "emoji": "🧀",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 15,
+      "consumable": true,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 22,
+        "perishable": true,
+        "shelf_life_seconds": 1814400,
+        "spoils_into_ref": "rotten-food"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A fist-sized chunk of black coal, cold to the touch and oddly lighter than it looks, marking everything it brushes with a dark streak that will not come off a working glove. The surface splits along glossy conchoidal faces when dropped.\n",
+      "lore": "Cut out of the upland seams by crews who spend more of their year underground than anybody would willingly admit, and hauled out in carts drawn by ponies bred for exactly that kind of narrow work. Smelters burn it for the long steady heat that charcoal cannot hold, and the best hearths will run through a cart of it a day without blinking. The smoke is dirty enough that every major foundry has a clause in its lease about the neighbors.\n",
+      "ref": "coal",
+      "key": 512,
+      "id": "01KPTSDW044DXKPC8E59TQ77GT",
+      "name": "Coal",
+      "type_flags": 384,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 4
+    },
+    {
+      "description": "A small copper coin, worn smooth by every hand it has passed through, the stamped profile on the face softened to a suggestion of a profile. Weighs less than you think, and more than it should.\n",
+      "lore": "Struck in the basement mint beneath the treasury, on dies that are renewed every third year and never quite match the coin before them. Used everywhere in the lower markets and respected nowhere in the upper ones, which is a distinction most people only learn by trying. A handful will feed a traveler through a long day on the road, and a heavy pouch will do very little to get you past a competent gatekeeper.\n",
+      "ref": "coin",
+      "key": 533,
+      "id": "01KPTSDW07M5HSJ2E0W1K6KYKF",
+      "name": "Coin",
+      "type_flags": 262208,
+      "rarity": "common",
+      "emoji": "🪙",
+      "stackable": true,
+      "max_stack": 50,
+      "buy_price": 1,
+      "compress": {
+        "target_ref": "gold-bar",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A shovelful of dark, crumbly soil-matter rich with the smell of an autumn forest floor, pocked with the last stubborn fragments of what it used to be. Warm in the middle of the pile, cool at the edges, alive with the patient work of worms.\n",
+      "lore": "Turned in layered heaps behind every farmstead and kitchen garden, where every household keeps its own private theory about what makes the heap cook properly. A well-tended pile returns more to the soil than the seed ever asked for, which is the quiet compromise that keeps a farm in the family beyond a generation. Neighbors judge each other on the state of their heap, and almost never say so out loud.\n",
+      "ref": "compost",
+      "key": 515,
+      "id": "01KPTSDW056NCW1M774M05VMQK",
+      "name": "Compost",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 2
+    },
+    {
+      "description": "A thick seared steak resting on a square of butcher-paper, juices pooling brown and patient underneath. Dark crust on the outside, pink at the heart, seasoned with whatever the cook at the fire had to hand.\n",
+      "lore": "Prepared by field cooks who learned the craft under older cooks who learned it under older ones, all of them working from the same short list of rules about heat, rest, and knowing when the fire is lying to you. A steak done right is the quiet marker of a company that respects its supply lines, and a steak done wrong is the loudest complaint in any camp after weather. Leftovers never last the night, regardless of how carefully they are wrapped.\n",
+      "ref": "cooked-beef",
+      "key": 526,
+      "id": "01KPTSDW06VFDEQZXX9YD0QDET",
+      "name": "Cooked Beef",
+      "type_flags": 8,
+      "rarity": "uncommon",
+      "emoji": "🥩",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 36,
+      "consumable": true,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 50,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A whole roasted chicken with a thin glossed crust and herb-rubbed skin crackling faintly as it cools. The legs fall off the bone at a glance, the thigh juice runs clear, and the breast carries the quiet suggestion of the butter it was basted with.\n",
+      "lore": "Turned over the spits at roadside inns, at harvest dinners, and at the end of any market day that went better than the butcher expected. A bird cooked well is a private argument won between the cook and the fire, one that neither of them bothers to explain afterwards. The wishbone is pulled by whichever two people are willing to be seen doing it, and the luck is split honestly, which is more than can be said for most things at that table.\n",
+      "ref": "cooked-chicken",
+      "key": 524,
+      "id": "01KPTSDW06FBW33WZW4G3K7EJ6",
+      "name": "Cooked Chicken",
+      "type_flags": 8,
+      "rarity": "common",
+      "emoji": "🍗",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 12,
+      "consumable": true,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 20,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A hard-boiled egg still warm in its shell, peel starting to lift at one end where the cook tapped it against the pan. Yolk a firm pale yellow, white smooth enough to carry the salt cleanly.\n",
+      "lore": "Boiled at every inn kitchen and field cook-post from here to the border, because nothing else on the menu keeps longer or travels better. A good cook can tell readiness by the sound the water makes when the egg settles against the bottom of the pan, which is the sort of knowledge that does not transfer well to apprentices in a hurry. Two in a pocket is a decent meal, three is generous, and four is the start of a story about somebody oversleeping breakfast.\n",
+      "ref": "cooked-egg",
+      "key": 528,
+      "id": "01KPTSDW06HW10Z3RFW1K6XSW0",
+      "name": "Cooked Egg",
+      "type_flags": 8,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 8,
+      "consumable": true,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 14,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A thick cut of roasted mutton, dark brown at the edges and softly pink at the center, glistening with the slow-rendered fat that pooled around it in the pan. The smell fills a room before anyone sets a plate down.\n",
+      "lore": "Prepared from the older sheep that the flockmaster has decided will not see another winter, which is a practical arrangement that keeps the meat on the table and the wool on the spindle. Mutton done right takes most of an afternoon and a patient cook, and done wrong takes almost as long and a less patient one. Every serious inn has a private rub for it, and none of them agree on the rosemary question.\n",
+      "ref": "cooked-mutton",
+      "key": 525,
+      "id": "01KPTSDW06FXJVV2E59FQ3BAP1",
+      "name": "Cooked Mutton",
+      "type_flags": 8,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 24,
+      "consumable": true,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 35,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A fist-sized chunk of copper ore, dull grey rock streaked with veins of greenish malachite and the occasional hairline of bright native metal. Heavier than expected, the way most honest stones are.\n",
+      "lore": "Pulled from the shallow shafts out on the eastern ridges, where the veins run close enough to the surface that a careful hand can work a face with a short hammer. Smelters render the green streaks out as copper and flux, and reserve the cleanest ore for the bells and the cookware the masters are willing to put their own stamp on. The trade runs old, predictable, and unromantic, which is exactly why every city still has a copper quarter.\n",
+      "ref": "copper-ore",
+      "key": 102,
+      "id": "01KMVPV9ZHV1GFHM1MPDN4FV70",
+      "name": "Copper Ore",
+      "type_flags": 384,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 12,
+      "sell_price": 6,
+      "emoji": "🟤",
+      "weight": 4,
+      "skilling": {
+        "skill": "mining",
+        "skill_level": 1,
+        "xp_reward": 18,
+        "gather_time": 3,
+        "respawn_time": 40,
+        "resource_node": "ore-copper",
+        "tool_required": "pickaxe"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "A thin stem topped with a starburst of deep blue petals, narrow and ragged at the edges, the color so saturated it looks wet even on a dry afternoon. Leaves a fine blue powder on fingers that press it.\n",
+      "lore": "Grows wild along the fenceposts at the edges of wheat fields, which suits the farmers because it keeps the pollinators loyal to the hedgerow through the season. Dyers will pay for bundles if the blooms come in before the heat has taken the edge off their color, and herbalists take the heads for eye-rinses they prefer not to have written down. Old tradition holds that carrying a dried bloom on the first day of a long walk keeps certain kinds of trouble behind you, which is the kind of faith that does not require proof to persist.\n",
+      "ref": "cornflower",
+      "key": 112,
+      "id": "01KMVPV9ZJHTX417X4HV0DY663",
+      "name": "Cornflower",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 5,
+      "sell_price": 2,
+      "emoji": "🔵",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 5,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-cornflower"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "A breastplate built from plates of clear-blue crystal bound to a leather underlayer with twisted silver wire. Light passes through it in shifting bands, and a good strike rings it like a struck glass before the plate decides how much of the blow to keep.\n",
+      "lore": "Forged in the foothill workshops of a smith's guild that stopped training outsiders two generations ago, after a pair of apprentices walked off with techniques they were not entitled to carry. The crystal is cut from ore that refuses polishing by any tool younger than the piece itself, which is the quiet reason the guild's commissions are counted in years, not weeks. Owners are expected to return the suit for recutting after a serious hit, whether or not they plan to wear it again.\n",
+      "ref": "crystal-armor",
+      "key": 95,
+      "id": "01KKR7QNRC18GWKPEPKM2VDYWM",
+      "name": "Crystal Armor",
+      "type_flags": 514,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "epic",
+      "buy_price": 400,
+      "emoji": "💎",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "chest",
+        "bonuses": {
+          "armor": 6,
+          "health": 10
+        }
+      }
+    },
+    {
+      "description": "Pale blue shards run through a lump of host rock the weight of a good hammer, refracting lamplight in slow bands that never quite land where you expect. Hold it long enough and the palm goes warm, not hot, the way a cat warms a lap.\n",
+      "lore": "Pulled from the frost-shafts east of the ridge, where miners measure their week by how many shifts the ore allowed before the vein went quiet. Crystal cutters bid on each crate at the pit-head, then argue for the rest of the season about which stone came from which face. Royal houses and a handful of guild-masters keep standing orders, which is the polite way of saying that very little of it ever reaches a market the rest of us can see.\n",
+      "ref": "crystal-ore",
+      "key": 104,
+      "id": "01KMVPV9ZHRQSBQJDRNEAJN368",
+      "name": "Crystal Ore",
+      "type_flags": 384,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 16,
+      "rarity": "rare",
+      "buy_price": 75,
+      "sell_price": 35,
+      "emoji": "💎",
+      "weight": 3.5,
+      "skilling": {
+        "skill": "mining",
+        "skill_level": 30,
+        "xp_reward": 65,
+        "gather_time": 5,
+        "respawn_time": 90,
+        "resource_node": "ore-crystal",
+        "tool_required": "pickaxe"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Five white petals ring a yolk of gold pollen, the whole bloom no wider than a coin, riding on a stem that bends without breaking. Smells faintly of dry grass and the inside of an old jar.\n",
+      "lore": "Open fields produce them by the handful every summer, which is why children learn early that pulling daisies is never seriously scolded. Hedge-witches bundle the petals to dry for the small rituals that do not warrant the expensive flowers, and pressmakers use the heads to calibrate the lighter shades of yellow ink. The saying that a daisy means neither yes nor no is usually repeated by people who already know the answer.\n",
+      "ref": "daisy",
+      "key": 106,
+      "id": "01KMVPV9ZH852GF5HWAQJQD0G1",
+      "name": "Daisy",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 4,
+      "sell_price": 2,
+      "emoji": "🌼",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 5,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-daisy"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Under a desk lamp the disc looks ordinary, iridescent on the read side and matte black on the label. Tilt it at the right angle and the reflection resolves into text that is not printed on the surface.\n",
+      "lore": "Produced in a three-month window at a fabrication plant that shut down before the line had been fully signed off, which is the reason every disc still bears the provisional serial in hex along the inner rim. Each one holds roughly the archival output of a mid-sized university, encoded in layers that most available drives cannot read past the second. Collectors pass them around at private shows, and nobody has been able to explain, satisfactorily, why the contents differ between readings.\n",
+      "ref": "data-cd",
+      "key": 27,
+      "id": "01JWCWVCGTZRJQ3FD5Z0MVS5XH",
+      "name": "Data CD",
+      "type_flags": 415,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 0.1,
+      "buy_price": 777,
+      "durability": 999,
+      "level_requirement": 1,
+      "cooldown": 0,
+      "action": "read",
+      "bonuses": {
+        "infiniteStorage": true,
+        "quantumCompatible": true,
+        "memoryPressure": 0.6
+      },
+      "scripts": [
+        {
+          "guid": "eebc1d58adf84d0e913f9c63c7f7d9be",
+          "vars": {
+            "storageLayers": "infinite",
+            "readSignal": "quantum-optical",
+            "emotionalLeakChance": 0.1
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Overlapping plates the size of a child's hand, each one ridged along its spine and scored at the leading edge by whatever the dragon last disagreed with. Heavier than the leather they are sewn to, cool against the skin even in direct sun.\n",
+      "lore": "Gathered during the slow molts of the highland wyrms, when a full rosette can be cleared off a cliffshelf in a single careful climb, or never. Armorers who know how to work them have never been many, because the scale resists every standard trick of the trade and rewards exactly one. Whoever commissions a full suit is understood to have opinions about being noticed, and those opinions will be remembered for longer than the armor.\n",
+      "ref": "dragon-scale",
+      "key": 98,
+      "id": "01KKR7QNRCD9Z8VG601R379C71",
+      "name": "Dragon Scale",
+      "type_flags": 514,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "legendary",
+      "buy_price": 1500,
+      "emoji": "🐉",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "chest",
+        "bonuses": {
+          "armor": 8,
+          "health": 15
+        },
+        "special": "damage_reduction",
+        "special_value": 0.1
+      }
+    },
+    {
+      "description": "Pink skin flares outward in soft scales that tear easily once you start, revealing flesh the color of old snow studded with black seeds. The taste is mild, almost reluctant, closer to a cold melon than anything the outside would suggest.\n",
+      "lore": "Climbing cactus-vines along the dry southern cliffs put these out on a two-week cycle through the late summer, and the fruit is best eaten within a day of coming off the plant. Caravan cooks buy them cheap at the border and sell them twice over in the capital, where the novelty is still worth more than the flavor. Old pickers carry small whittled scoops for opening them, because the scales stain anything pale and no one wants to explain the evidence.\n",
+      "ref": "dragonfruit",
+      "key": 506,
+      "id": "01KPTSDW04P1KQ7FC0RYTFV4PC",
+      "name": "Dragonfruit",
+      "type_flags": 72,
+      "rarity": "uncommon",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 20,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 22,
+        "perishable": true,
+        "shelf_life_seconds": 345600,
+        "spoils_into_ref": "rotten-food"
+      },
+      "skilling": {
+        "skill": "foraging"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A neon-green beverage in a dented aluminum can that sweats even when cold, wrapped in a label that has been recalled in four jurisdictions. It tastes like citrus, copper, and something your memory insists you have tried before but cannot place.\n",
+      "lore": "Produced in 1995 by a short-lived ghost-themed marketing campaign that was cancelled after three focus-group members reported mild haunting. The remaining cans were warehoused, forgotten, and later rediscovered by a night-shift custodian who has been restocking corner stores with them quietly for almost thirty years. Every can is still somehow in date, which no one at the bottler has been able to explain to auditors.\n",
+      "ref": "ecto-cooler-drank-type-95",
+      "key": 3,
+      "id": "01J27QABD2GPFNRVK69S51HSGB",
+      "name": "Ecto Cooler Drank Type 95",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 0.5,
+      "buy_price": 50,
+      "durability": 1,
+      "level_requirement": 5,
+      "cooldown": 60,
+      "action": "consume",
+      "bonuses": {
+        "health": 20,
+        "energy": 10
+      },
+      "scripts": [
+        {
+          "guid": "dd238a91353c4a1991cf275041730ab0",
+          "vars": {
+            "health": 20,
+            "energy": 10,
+            "duration": 600,
+            "tickRate": 5
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Thick purple preserves shake loose from the jar with an audible thunk, carrying the sugary weight of a recipe nobody has bothered to standardize. Smells like the inside of a grape arbor in late heat, with a faint undercurrent that might be pepper.\n",
+      "lore": "Cooked in a second-floor kitchen above a corner store by Ed, who has never once explained where the grapes come from and answers any direct question with a shrug. Jars move through the neighborhood at a steady enough clip that the store keeps them behind the counter rather than on the shelf. Children rate each batch against the last, and the adults pretend not to care about the ranking until the batch is gone.\n",
+      "ref": "eds-jelly-jam",
+      "key": 41,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRJJ",
+      "name": "Ed's Jelly Jam",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.5,
+      "buy_price": 88,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 30,
+      "action": "consume",
+      "bonuses": {
+        "energy": 30,
+        "speed": 2,
+        "sugarSync": true
+      },
+      "scripts": [
+        {
+          "guid": "3af2a457d47b42ba845f3e9f5ff23192",
+          "vars": {
+            "energyBoost": 30,
+            "speedModifier": 2,
+            "sugarBuff": true,
+            "duration": 90
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Warm to the touch, a little speckled at one end, weight of it settling into the palm the way a stone never quite does. The shell takes a pencil-tap to crack cleanly, anything heavier and you lose the yolk.\n",
+      "lore": "Pulled from straw nests every morning before the hens work out that the day has other plans for them. Counted into the basket, then counted again on arrival at the kitchen, because the children who run the errand learn subtraction faster than most schoolmasters manage to teach it. A cook who can judge an egg by its weight on the palm is a cook worth keeping, and nobody on the household staff ever asks her how she does it.\n",
+      "ref": "egg",
+      "key": 527,
+      "id": "01KPTSDW060QAV532JXYHG2JTC",
+      "name": "Egg",
+      "type_flags": 72,
+      "rarity": "common",
+      "emoji": "🥚",
+      "stackable": true,
+      "max_stack": 50,
+      "buy_price": 3,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 6,
+        "perishable": true,
+        "shelf_life_seconds": 1209600,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "Clear as spring-water at the top of the vial, darker toward the bottom, the liquid refuses to settle into a single color for longer than a glance. Drinking it tastes like nothing at all, which is the first surprise of several.\n",
+      "lore": "Distilled by the senior members of the apothecaries' college, in small batches, against commissions that nobody below a certain rank of patron will ever see. The recipe is not secret so much as impossible to repeat outside one specific room on the northeast corner of the third floor, and the college is not keen to explain why. A single vial is understood to buy a second chance at one circumstance of the drinker's choosing, provided the circumstance has not yet become inevitable.\n",
+      "ref": "elixir",
+      "key": 73,
+      "id": "01KKR7QNRCNNPNQD46DYT110R9",
+      "name": "Elixir",
+      "type_flags": 33312,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 1,
+      "rarity": "legendary",
+      "buy_price": 500,
+      "emoji": "✨",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "full_heal"
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "alchemy",
+          "skill_level": 30,
+          "xp_reward": 80,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "crystal-ore",
+              "amount": 1
+            },
+            {
+              "item_ref": "rose",
+              "amount": 3
+            },
+            {
+              "item_ref": "chanterelle",
+              "amount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Four feet of pattern-welded steel with a hilt of silver-wrapped bone, balanced a hand's width above the guard, edge so fine it whistles when drawn through a still room. Every notch along the blade has a date scratched beside it in a hand that is not the owner's.\n",
+      "lore": "Forged in a week that the chroniclers pretend to agree on, by smiths whose names appear on nothing younger than a funeral stone, for a king whose reign ended so cleanly that nobody remembers where the tomb actually sits. Carried in succession through a dozen contested inheritances, and lost from the written record at least three times, each reappearance a little harder to explain than the last. Nobody has ever been able to unbend a wielder's grip on it, which is usually the detail that convinces the skeptics.\n",
+      "ref": "excalibur",
+      "key": 90,
+      "id": "01KKR7QNRCNZ64AGRD8M3H09YP",
+      "name": "Excalibur",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "legendary",
+      "buy_price": 1000,
+      "emoji": "⚔️",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 6,
+          "health": 5,
+          "crit_chance": 0.1
+        },
+        "special": "crit_bonus",
+        "special_value": 0.1
+      }
+    },
+    {
+      "description": "Nearly weightless between two fingers, vane striped brown and cream, the spine straight enough that it barely rolls when laid on a plank. Catches the light along the barbs in a way that suggests it was preened, not shed.\n",
+      "lore": "Collected from the molting grounds where the large meat-birds shelter out the hottest weeks of the year, then sorted for straightness by the fletchers' apprentices before anybody else gets to see the pile. The ones that do not make the cut end up in inkpots, pillows, and the hatbands of people who cannot afford better birds than that. A fletcher who insists on matched pairs for every arrow is a fletcher whose work you can trust not to wander off-line over distance.\n",
+      "ref": "feather",
+      "key": 519,
+      "id": "01KPTSDW05C6249E1CD6KF3MRB",
+      "name": "Feather",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 1
+    },
+    {
+      "description": "Heavy blown glass the color of weak tea, corked tight and sealed with a ring of wax that has been softened by the heat of a pocket. Held up to a lamp, the liquid inside moves slowly and keeps its own opinions about which way is down.\n",
+      "lore": "Compounded by the same alchemists who supply the siege companies, in batches small enough that a stray lantern in the workshop never takes out more than one wall. Field manuals put the throwing radius at twelve paces, the cooks put the pan-range at six, and the veterans put the comfortable distance at something larger than either. A flask that has been carried for a full season is considered lucky, because the alternative is that it was used at some point in that season.\n",
+      "ref": "fire-flask",
+      "key": 80,
+      "id": "01KKR7QNRC7V62X0C8J3ZX22DA",
+      "name": "Fire Flask",
+      "type_flags": 8704,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 3,
+      "rarity": "uncommon",
+      "buy_price": 65,
+      "emoji": "🔥",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "damage_and_apply",
+          "amount": 8,
+          "status_effect": "burning",
+          "stacks": 2,
+          "turns": 3
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 10,
+          "xp_reward": 25,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "copper-ore",
+              "amount": 1
+            },
+            {
+              "item_ref": "sunflower",
+              "amount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Blackened steel head with a dull red glow banked along the inner curve, haft wrapped in leather that has been replaced at least twice. Held at rest, it gives off the same heat as a closed oven at the other side of a room.\n",
+      "lore": "Commissioned in the last years of the Forge-Quarter Agreement, when the volcanic smiths were still accepting outside orders and their apprentices could not yet tell which commissions they were permitted to finish. Every axe out of that workshop was marked with the same hexagonal stamp on the cheek and the same oath on the underside, and every one of them eventually comes back for rebanking. The old smiths will not confirm whether the ember will ever actually go out, and nobody has yet outlived an axe long enough to find out.\n",
+      "ref": "flame-axe",
+      "key": 86,
+      "id": "01KKR7QNRC0XKBPFD6BNWV57SR",
+      "name": "Flame Axe",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "buy_price": 150,
+      "emoji": "🪓",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 4
+        }
+      }
+    },
+    {
+      "description": "Deep red cap dotted with flaking white spots the shape of drying paint, set over a short cream-colored stalk and the faintest ring of skirt below the gills. Raw, the smell is earthy and wrong enough that most people put it down again without being told.\n",
+      "lore": "Pushes up under birch and pine on cool wet mornings, reliable as a calendar once the season has turned. The cap is outright poisonous at any worthwhile dose, but the apothecaries have learned to extract a narrow range of alkaloids from the trimmed skin, and the dyers have learned to extract a hard-earned red that nobody else can match. Children in the forest villages grow up with two rules about the mushroom, and the one their grandmothers repeat loudest is: do not touch it before breakfast.\n",
+      "ref": "fly-agaric",
+      "key": 117,
+      "id": "01KMVPV9ZJTK4QB8KGBH5XAEW4",
+      "name": "Fly Agaric",
+      "type_flags": 160,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "uncommon",
+      "buy_price": 15,
+      "sell_price": 8,
+      "emoji": "🍄",
+      "weight": 0.2,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 12,
+        "gather_time": 0.5,
+        "respawn_time": 30,
+        "resource_node": "mushroom-fly-agaric"
+      },
+      "tags": [
+        "isometric"
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-food"
+      }
+    },
+    {
+      "description": "Heavy glass bottle sweating faintly in the hand, cap pressed on by a household pressure-seal older than most of the household, liquid inside pale enough to be mistaken for diluted cream. Tastes first of grass, then of the bottle, then of whichever morning it was pulled.\n",
+      "lore": "Delivered before dawn by a cooperative of dairymen who still run the lower routes on foot, on the theory that anybody who oversleeps loses their spot in the order. The milk is pooled from three or four farms at the sorting-shed and only rarely from one, which is why the flavor shifts a little week to week and nobody respectable complains about it. A bottle kept cool in a shaded cellar will last the better part of two days, which is the longest anyone in the household is willing to wait for their tea.\n",
+      "ref": "fresh-milk",
+      "key": 35,
+      "id": "01JWG25PJN79DJP822GGKN8B1R",
+      "name": "Fresh Milk",
+      "type_flags": 393,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.6,
+      "buy_price": 45,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 45,
+      "action": "consume",
+      "bonuses": {
+        "health": 15,
+        "boneBoost": 3,
+        "calm": true
+      },
+      "scripts": [
+        {
+          "guid": "d4f83b9d9c384db78aefea39000e17c3",
+          "vars": {
+            "healAmount": 15,
+            "calciumInfusion": 3,
+            "calmEffect": true,
+            "duration": 90
+          }
+        }
+      ],
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 10,
+        "perishable": true,
+        "shelf_life_seconds": 172800,
+        "spoils_into_ref": "rotten-milk"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      },
+      "stacking": {
+        "pack_max": 50
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Folded in a warm flour tortilla, fried whitefish showing through pale stripes of slaw and a line of pink sauce the cook refused to name. The oil has soaked halfway up the wrap by the time you get it to a table, which is how you know it was made for walking.\n",
+      "lore": "Sold off steel carts parked in the shade of harbor warehouses, run by cooks whose families have worked the same corner through three redrafts of the city plan. The batter recipe drifts a little between stalls and a lot between cities, and regulars rank the results quietly, in rankings the carts themselves never ask about. Eating one while it is still spitting from the fryer is a rite of passage that most travelers only realize they have passed in retrospect.\n",
+      "ref": "fried-fish-taco",
+      "key": 31,
+      "id": "01JWFY6R3G5BQ7FZ7Q3KPKHY2C",
+      "name": "Fish Taco",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "common",
+      "weight": 0.4,
+      "buy_price": 90,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 60,
+      "action": "consume",
+      "bonuses": {
+        "health": 25,
+        "agility": 5,
+        "reflex": 3
+      },
+      "scripts": [
+        {
+          "guid": "eef4995c21cb4e7a812aa5e5ec2f449b",
+          "vars": {
+            "healAmount": 25,
+            "dexterityBoost": 5,
+            "duration": 180
+          }
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "cooking",
+          "skill_level": 15,
+          "xp_reward": 40,
+          "output_quantity": 2,
+          "ingredients": [
+            {
+              "item_ref": "salmon",
+              "amount": 2
+            },
+            {
+              "item_ref": "butter",
+              "amount": 1
+            }
+          ]
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 43200,
+        "spoils_into_ref": "rotten-food"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Paper bag still wearing frost around the seam, rattling faintly with a pound or so of bite-sized pastry pockets stuffed with marinara, processed cheese, and pepperoni that knows what it is. Heated correctly they arrive molten; heated incorrectly they arrive punitively molten.\n",
+      "lore": "Produced in the middle shift at a plant that has not accepted visitors since the labor dispute of 2039, using a recipe whose ingredient list reads like the first half of a disclaimer. Households buy them in bulk for the freezer drawer that nobody bothers to defrost, and teenagers treat them as the reliable meal that nobody old enough to disapprove can actually disapprove of on paper. The first one you bite into always burns the roof of the mouth, and the second never does.\n",
+      "ref": "frozen-pizza-rolls",
+      "key": 21,
+      "id": "01JWAXYK9QWKYVTDG21614F3KT",
+      "name": "Frozen Pizza Rolls",
+      "type_flags": 409,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.8,
+      "buy_price": 95,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 30,
+      "action": "consume",
+      "bonuses": {
+        "health": 15,
+        "stamina": 10,
+        "tasteTempVariance": true
+      },
+      "scripts": [
+        {
+          "guid": "a912c38f3f514b76afcce028b1c09cb2",
+          "vars": {
+            "healthRestore": 15,
+            "staminaRestore": 10,
+            "burnChance": 0.1,
+            "cookable": true
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Split loaf pulled from under the broiler, butter still pooling along the cut, garlic browned to just shy of bitter at the crust. Steam comes up the moment you lift a piece, and the first bite is warmer on the way down than any stew will be all evening.\n",
+      "lore": "Baked in the back ovens of every roadside inn that believes in earning repeat custom, on bread that was meant for the next morning and has been redirected toward tonight's regulars instead. The garlic is crushed by hand on a small block in the kitchen, never by a press, because the press leaves the flavor sharp in a way the older cooks disapprove of. A basket on the table does more for morale than any pep talk the captain can manage.\n",
+      "ref": "garlic-bread",
+      "key": 59,
+      "id": "01JX11B4TZ6BN2WB3DBVETSZYW",
+      "name": "Garlic Bread",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.3,
+      "buy_price": 40,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 20,
+      "action": "consume",
+      "bonuses": {
+        "health": 10,
+        "morale": 2
+      },
+      "scripts": [
+        {
+          "guid": "22cc8a2063a2a58b99190df93f083d07",
+          "vars": {
+            "healAmount": 10,
+            "moraleBoost": 2,
+            "aroma": "garlic"
+          }
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "cooking",
+          "skill_level": 5,
+          "xp_reward": 20,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "allium",
+              "amount": 2
+            },
+            {
+              "item_ref": "butter",
+              "amount": 1
+            }
+          ]
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Held against a window the spirit reads clear as rainwater, and the only clue to what it actually is comes up from the rim of the glass as juniper, lemon peel, and something slightly medicinal. Drinks cold, bites warm, finishes on a note that the distiller refuses to commit to in writing.\n",
+      "lore": "Run out of copper stills in a distillery that sits behind the linen-cleaner on the north side of the market, using botanicals that the distiller sources from farms he refuses to name even to his own bookkeeper. The first batch of any season is sold under a slightly different label than the rest, which the regulars know and the tourists do not. A bottle kept on a shelf out of sunlight will age for years in a direction the distiller considers interesting and most drinkers cannot be trained to notice.\n",
+      "ref": "gin",
+      "key": 43,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRGN",
+      "name": "Gin",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.75,
+      "buy_price": 140,
+      "durability": 1,
+      "level_requirement": 2,
+      "cooldown": 60,
+      "action": "consume",
+      "bonuses": {
+        "charm": 2,
+        "perception": 1,
+        "hallucinationChance": true
+      },
+      "scripts": [
+        {
+          "guid": "fd49c54d37de48cb8703e8b63e832a12",
+          "vars": {
+            "buffDuration": 90,
+            "effectRisk": "hallucination"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Ten inches of smoked glass drawn to a needle at the point, set into a hilt of black-oiled wood without a guard to speak of. Sounds softly of sand when carried against cloth, and the edge will score steel if pressed slowly enough.\n",
+      "lore": "Drawn from the glassblowers' quarter by a handful of masters who are willing to work the longer kilns in the back sheds, and who finish each piece alone in rooms the apprentices are not permitted to enter. A blade shatters exactly once in the wielder's hands, usually on the blow that most needed it to hold. Buyers who understand the trade order in pairs, and carry the second sheathed against the ribs, because the replacement turnaround at the workshop is measured in seasons, not days.\n",
+      "ref": "glass-stiletto",
+      "key": 89,
+      "id": "01KKR7QNRC6837QFCM9K0BD1N9",
+      "name": "Glass Stiletto",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "buy_price": 180,
+      "emoji": "🔪",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 3,
+          "crit_chance": 0.15
+        },
+        "special": "crit_bonus",
+        "special_value": 0.15
+      }
+    },
+    {
+      "description": "Ingot the length of a forearm and the width of two fingers, surface still marked by the ripple of the mould it cooled in, heavy enough that you adjust your stance the moment someone hands it to you. The color is warmer than any paint can manage.\n",
+      "lore": "Cast at the treasury's lower foundry from the coin-melt that the counting houses deliver under escort every fiscal quarter, stamped twice on each face with the assayer's mark and once along the edge with the year. Merchants trade the bar itself rarely and the certificate of weight against it constantly, which is the whole point of keeping the gold in a vault nobody is permitted to tour. A bar missing one of its stamps is worth precisely its weight in suspicion.\n",
+      "ref": "gold-bar",
+      "key": 538,
+      "id": "01KPTSDW07WDKCS7JAHW71XZJD",
+      "name": "Gold Bar",
+      "type_flags": 262208,
+      "rarity": "uncommon",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 150
+    },
+    {
+      "description": "Ceremonial round shield, hammered iron core sheathed in a thin layer of beaten gold and chased with the bearer's house mark. Stops a blow as well as the iron underneath, and looks like a king's ransom doing it.\n",
+      "lore": "Awarded — never sold — to heroes who have already proven they don't need it. The plating is too soft to take a direct sword stroke without scarring, which is rather the point: a gold-plated shield with deep score marks tells a story the bearer no longer has to. A clean one suggests its owner has either retired well or hasn't earned the gift yet.\n",
+      "ref": "gold-plated-shield",
+      "key": 560,
+      "id": "01KTVTRAB1GOLDPLATED00000560",
+      "name": "Gold-Plated Shield",
+      "type_flags": 514,
+      "rarity": "rare",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 250
+    },
+    {
+      "description": "Steel shin-cuffs clasp over mid-calf boots of scuffed grey leather, each sole housing a ring of microthrusters around a central electromagnetic coil. They hum faintly when powered on, and the footsteps they leave dent the floor instead of marking it.\n",
+      "lore": "Produced as working prototypes by a defense-contract subsidiary that was shuttered inside eighteen months, and leaked into circulation when the assets auction went ahead without the inventory register. Pilots describe the activation surge as a short drop followed by a longer rise, which is apparently easier to learn than it sounds and considerably easier to unlearn. The charge reserve burns through in four jumps, and the replacement cell is made by a supplier the original contractor is no longer speaking to.\n",
+      "ref": "gravity-boots",
+      "key": 62,
+      "id": "01JX55ZPSYC91ERYPHP47FPQAN",
+      "name": "Gravity Boots",
+      "type_flags": 419,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "epic",
+      "weight": 4.2,
+      "buy_price": 1800,
+      "durability": 600,
+      "level_requirement": 6,
+      "cooldown": 60,
+      "action": "leap",
+      "bonuses": {
+        "mobility": 2,
+        "fallDamageReduction": true,
+        "zeroG": true
+      },
+      "scripts": [
+        {
+          "guid": "6bb9f15edc0e49679ec3d4fb01fc1caa",
+          "vars": {
+            "leapBoost": 10,
+            "duration": 5,
+            "zeroGControl": true
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Emerald-green, glossy enough to catch the overhead light, loosened with oil and studded with almond fragments that settle to the bottom of the jar while you are not looking. Smells sharply of basil and a second herb the supplier will not disclose.\n",
+      "lore": "Pressed in the cold back-room of a cooperative that bought up the last shipment of greenhouse basil before the strain was pulled from certification, and has not agreed on a replacement since. The jars go out in wooden crates, labeled with the week of pressing, and regulars know to reserve a case the moment the notice goes up. A spoonful on hot pasta fogs mildly in the steam, a trait the cooperative considers a feature and the health inspector considers a conversation.\n",
+      "ref": "green-pasta-sauce",
+      "key": 45,
+      "id": "01JWG89BEEKCWWYQ9XVAM53CJ6",
+      "name": "Green Pasta Sauce",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.8,
+      "buy_price": 85,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 40,
+      "action": "consume",
+      "bonuses": {
+        "stamina": 24,
+        "regenRate": 1.5,
+        "plantAffinity": true
+      },
+      "scripts": [
+        {
+          "guid": "6bb9f15edc0e49679ec3d4fb01fc1caa",
+          "vars": {
+            "buffDuration": 100,
+            "traits": "photosynthetic-resonance"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Foil-wrapped cylinder the weight of a small brick, unwrapped to reveal a tortilla packed with grilled whitefish, yellow rice, black beans, and a line of salsa that runs the full length of the roll. First bite is warm and second is warmer, because the heat is coming from the center on a delay.\n",
+      "lore": "Built at a walk-up window on the east pier by a cook who has refused expansion offers from three separate restaurant groups, on the straightforward grounds that the line would get longer and he does not care to see further down it. The fish is caught the same morning, cleaned in a back room nobody is shown, and grilled over a pan whose seasoning has never been stripped since the stall opened. Locals eat standing; visitors sit down, and regret it.\n",
+      "ref": "grilled-fish-burrito",
+      "key": 32,
+      "id": "01JWFZBV4K5T7KNFYKY7Q5YF29",
+      "name": "Grilled Fish Burrito",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 0.9,
+      "buy_price": 120,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 90,
+      "action": "consume",
+      "bonuses": {
+        "health": 40,
+        "strength": 6,
+        "resistance": 4
+      },
+      "scripts": [
+        {
+          "guid": "ba39cbfaabfc4a2ba1d3ed6a5aefeecc",
+          "vars": {
+            "healAmount": 40,
+            "strengthBoost": 6,
+            "resistanceBoost": 4,
+            "duration": 240
+          }
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 43200,
+        "spoils_into_ref": "rotten-food"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Tied with brown twine, the bundle hangs upside down from a rafter long enough to dry without shedding color, each stem a different grey-green tone of the same family. The scent clings to hands for the rest of the afternoon.\n",
+      "lore": "Cut from the hedge-rows behind kitchen gardens at first light, when the oils are still carrying the water of the morning and before the sun starts pulling them off. Cooks and alchemists buy from the same growers and argue, politely, over which bundles are worth the higher price. A well-dried bundle keeps flavor for six months and memory for considerably longer, which is why the jar of old herbs at the back of the shelf is the one the family never quite finishes.\n",
+      "ref": "herb",
+      "key": 502,
+      "id": "01KPTSDW0349260PX485Z4YD29",
+      "name": "Herb",
+      "type_flags": 64,
+      "rarity": "common",
+      "emoji": "🌿",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 5,
+      "skilling": {
+        "skill": "foraging"
+      },
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 604800,
+        "spoils_into_ref": "rotten-food"
+      }
+    },
+    {
+      "description": "Rolled strip of unbleached linen packed with crushed mint, comfrey, and a resinous oil the apothecary prefers not to name in front of visitors. Peels away in a single pass once the wound has closed, leaving the skin faintly green for a day or two.\n",
+      "lore": "Made up in batches of thirty by a small cooperative of field-medics who trained together at the old southern academy, and who still use the same recipe despite ongoing arguments about the balance of comfrey to arnica. The wraps travel in sealed tin cylinders that keep the oils active for about a season, and the regulars trade empty tins back for a partial refund. A squad captain who runs out of them before the week is up is understood to have had an interesting week.\n",
+      "ref": "herbal-medi-wrap",
+      "key": 18,
+      "id": "01JWAPWQT370ZK76K32JGVBZWV",
+      "name": "Herbal Medi-Wrap",
+      "type_flags": 406,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.4,
+      "buy_price": 210,
+      "durability": 1,
+      "level_requirement": 2,
+      "cooldown": 60,
+      "action": "apply",
+      "bonuses": {
+        "healingOverTime": 35,
+        "bleedingReduction": true,
+        "aromaEffect": "calming"
+      },
+      "scripts": [
+        {
+          "guid": "dd2931f8821244c9bfaebfef1182d93a",
+          "vars": {
+            "healPerTick": 7,
+            "ticks": 5,
+            "reduceBleed": true,
+            "aroma": "calming",
+            "cooldown": 60
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Translucent polymer, coin-sized, shot through with a refracting layer that cycles from magenta to cyan depending on the angle of the light. The edge reads HF-21 in raised script on one side and nothing at all on the other.\n",
+      "lore": "Issued as loyalty rewards by a chain of arcades that closed during the Neon Recession, in quantities the accountants were never able to reconcile against the official run. Cabinets that read the token recognize it as a second-tier operator key, and respond by unlocking menus the cabinet's own maintenance crew never knew existed. A handful of collectors have worked out that not all tokens unlock the same hidden modes, and none of them have explained this finding to the rest.\n",
+      "ref": "holographic-arcade-token",
+      "key": 65,
+      "id": "01JX5617TYSVQC68T3R8ZA91ND",
+      "name": "Holographic Arcade Token",
+      "type_flags": 420,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 0.1,
+      "buy_price": 120,
+      "durability": 100,
+      "level_requirement": 1,
+      "cooldown": 0,
+      "action": "use",
+      "bonuses": {
+        "nostalgia": true,
+        "highScoreBoost": 5
+      },
+      "scripts": [
+        {
+          "guid": "dd2931f8821244c9bfaebfef1182d93a",
+          "vars": {
+            "secretModes": true,
+            "scoreMultiplier": 1.05
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Plain wool hood in a weather-darkened grey, cut long enough at the shoulders to pass for a scarf in poor light. The inside lining has been re-stitched at the crown at least once, by someone who cared more about function than craft.\n",
+      "lore": "Standard issue to couriers, scouts, and anybody whose work goes easier when their face is not immediately available for comment. The cloth comes off a cooperative loom three valleys over and the dye off a vat nobody in town formally acknowledges. A hood in good repair keeps the rain honest; a hood with the lining coming loose keeps secrets better, which is the version experienced travelers preferentially buy.\n",
+      "ref": "hood",
+      "key": 550,
+      "id": "01KTVTRAB1H00DGARB0N000000005",
+      "name": "Hood",
+      "type_flags": 514,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 15
+    },
+    {
+      "description": "Jet-black, almost greasy at the surface, the sauce coats whatever it touches in a single uniform pass and refuses to wash out of the first three cloths the cook reaches for. Tastes like brine at the front, iron in the middle, and something the ocean might have meant to keep at the end.\n",
+      "lore": "Blended in the back of the cooperative kitchen on the harbor road, from squid ink that arrives in sealed jars and deep-salt crystals the supplier insists are mined rather than evaporated. The emulsifiers are proprietary, meaning the two cooks who share the recipe also share a deadlock on whether to ever write it down. Served once a week, by reservation, and the regulars have learned to wear black to dinner as a matter of practical respect.\n",
+      "ref": "ink-pasta-sauce",
+      "key": 46,
+      "id": "01JWG8KEBJPJ3WRW8RDMD3066S",
+      "name": "Ink Pasta Sauce",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 0.9,
+      "buy_price": 120,
+      "durability": 1,
+      "level_requirement": 3,
+      "cooldown": 60,
+      "action": "consume",
+      "bonuses": {
+        "stealth": 3,
+        "darkVision": true,
+        "entityAttractionChance": true
+      },
+      "scripts": [
+        {
+          "guid": "74fadb2721794f4eab189d3f813b29fb",
+          "vars": {
+            "buffDuration": 150,
+            "traits": "dark-vision'"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Full plate of overlapping iron lames held together by leather straps and a modest quantity of honest faith, the surface buffed to a dull sheen that refuses to catch daylight. Moves with the wearer once the straps have been fitted by somebody who has done it before.\n",
+      "lore": "Commissioned by the provincial garrisons under a supply contract that rotates between three workshops on a five-year cycle, so that no single master ever becomes indispensable. The plates ship unfinished and the garrison's own armorer fits them to each sergeant, on the old principle that an ill-fitting suit is worse than a well-fitted mail shirt. A suit lasts two careers if maintained, one if not, and the maintenance is the quiet difference between a garrison that wins engagements and one that merely attends them.\n",
+      "ref": "iron-armor",
+      "key": 553,
+      "id": "01KTVTRAB11R0N4RM0R00000008",
+      "name": "Iron Armor",
+      "type_flags": 514,
+      "rarity": "uncommon",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 80
+    },
+    {
+      "description": "Solid iron head the size of a clenched fist, flanged into six ridges for the kind of impact that cares less about edges than arithmetic, mounted on an oak haft wrapped in rawhide. Settles heavily into the palm the moment you stop thinking about it.\n",
+      "lore": "Hammered out in bulk at the provincial forges on contracts that rotate between the garrison and the militia depending on which one has the budget that month. A good mace will outlast three hafts, and most quartermasters keep a small supply of spare shafts on the shelf next to the stockroom beer. Nobody has ever named one, which is how you know it is an honest weapon.\n",
+      "ref": "iron-mace",
+      "key": 88,
+      "id": "01KKR7QNRCCDST7FEYK9CFPX26",
+      "name": "Iron Mace",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "buy_price": 70,
+      "emoji": "🔨",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 3
+        }
+      },
+      "recipes": [
+        {
+          "skill": "smithing",
+          "skill_level": 15,
+          "xp_reward": 40,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "iron-ore",
+              "amount": 3
+            },
+            {
+              "item_ref": "log",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Rust-red streaks run through the grey host rock, heavier in the hand than any equivalent volume of stone has any right to be.\n",
+      "lore": "Comes out of the deep shafts east of the ridge, where the seams run broad enough to keep a crew fed through a long winter. The sorters at the pit-head pick out the high-grade by a test the older hands can pass blind, which the younger hands still refuse to believe is not guesswork.\n",
+      "ref": "iron-ore",
+      "key": 103,
+      "id": "01KMVPV9ZHGWG5M1Q4R3YPYSG7",
+      "name": "Iron Ore",
+      "type_flags": 384,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "uncommon",
+      "buy_price": 25,
+      "sell_price": 12,
+      "emoji": "⛏️",
+      "weight": 5,
+      "skilling": {
+        "skill": "mining",
+        "skill_level": 15,
+        "xp_reward": 35,
+        "gather_time": 4,
+        "respawn_time": 60,
+        "resource_node": "ore-iron",
+        "tool_required": "pickaxe"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Round iron-banded oak shield a hand's breadth wider than the shoulder it rests against, with a central boss hammered from one piece and a leather arm-strap softened by long use. Rings softly when struck across the boss and dully when struck along the rim.\n",
+      "lore": "Built to a militia specification that the guild has tried to modernize twice and the militias have rejected twice, on the reasonable grounds that the current shield stops arrows adequately and the modernizations would require retraining every sergeant from the rim out. Apprentices earn their journeyman stamp on the day their first finished shield passes the drop test from second-floor height without splitting the boards. A shield that has been refaced twice belongs to its carrier in a way a fresh one does not.\n",
+      "ref": "iron-shield",
+      "key": 552,
+      "id": "01KTVTRAB11R0NSH1ELD00000007",
+      "name": "Iron Shield",
+      "type_flags": 514,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 30
+    },
+    {
+      "description": "Dark grey liquid with a dull metallic sheen, thick enough that it clings to the inside of the vial for a moment after you tilt it. The taste is the taste of licking a cast-iron pan, which nobody recommends as a preview.\n",
+      "lore": "Compounded in a workshop above the old armorer's guild hall, by two brothers who disagree about everything except the recipe. The potion sets a thin temper in the skin for the better part of an afternoon, and a heavy blow during that window will ring rather than land. Over-reliance leaves the drinker feeling vaguely bruised for a week afterward, which the brothers will not sell to anybody who has not admitted that out loud.\n",
+      "ref": "iron-skin-potion",
+      "key": 81,
+      "id": "01KKR7QNRCWS11606Z2MJC11QA",
+      "name": "Iron Skin Potion",
+      "type_flags": 544,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 2,
+      "rarity": "uncommon",
+      "buy_price": 55,
+      "emoji": "🛡️",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "apply_effect",
+          "status_effect": "shielded",
+          "stacks": 1,
+          "turns": 3
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "alchemy",
+          "skill_level": 15,
+          "xp_reward": 45,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "allium",
+              "amount": 2
+            },
+            {
+              "item_ref": "iron-ore",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Straight double-edged blade the length of a forearm, forged from mid-grade iron with a shallow fuller running along both faces. Hilt wrapped in oiled cord, pommel weighted just enough to keep the draw honest.\n",
+      "lore": "Produced in bulk by the provincial forges under a pattern the guild has not revised in a decade, on the grounds that the pattern works and the guild is busy with more interesting commissions. Every militia recruit receives one, every other recruit loses theirs within a season, and the forge's records have stopped tracking which. A blade sharpened on a proper stone will hold its edge through a long afternoon, which is the standard the guild designed for and the standard most fights conclude within.\n",
+      "ref": "iron-sword",
+      "key": 551,
+      "id": "01KTVTRAB11R0NSW0RD000000006",
+      "name": "Iron Sword",
+      "type_flags": 513,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 40
+    },
+    {
+      "description": "Glass jar full to the shoulder with honey the color of late afternoon, thick enough that a spoon pulled straight out leaves a slow column draining back in. Smells of wildflowers for the first breath, and of something older the moment you lean closer.\n",
+      "lore": "Drawn from the same hillside apiary that has been passed mother-to-daughter since the old road was widened, through a filter that has never once been boiled. The beekeepers claim the hive's year is etched faintly in the color, and that a liar cannot swallow a full spoon of it without hesitating. Younger members of the household usually agree with the first claim and pretend to disbelieve the second until asked directly.\n",
+      "ref": "jar-of-honey",
+      "key": 17,
+      "id": "01JWAB140RVZX5C7M8622AZXGA",
+      "name": "Jar of Honey",
+      "type_flags": 405,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.9,
+      "buy_price": 150,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 45,
+      "action": "consume",
+      "bonuses": {
+        "health": 20,
+        "stamina": 10,
+        "sweetnessRating": 100
+      },
+      "scripts": [
+        {
+          "guid": "c2a993bc552a4982b54d08ae2191a34e",
+          "vars": {
+            "healthRestore": 20,
+            "staminaBoost": 10,
+            "sweetness": 100,
+            "alchemyBase": true
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A ziplock bag packed tight with yellowed newspaper and closed with two layers of tape. A smiling face is drawn on the outside in permanent marker, slightly off-center. It crinkles in a way that feels like it is answering you.\n",
+      "lore": "Assembled one late night in a Palo Alto kitchen as a placeholder gift, never meant to leave the apartment. It has since followed its owner through three cities and one federal subpoena, always ending up at the top of the moving box whether it was packed that way or not. The newspaper inside reports events that have not yet happened, although only in the classifieds section.\n",
+      "ref": "jareds-teddy-bear",
+      "key": 20,
+      "id": "01JWAWYPGZHJW1Q103D8M2Q29W",
+      "name": "Jared's Teddy Bear",
+      "type_flags": 408,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "mythic",
+      "weight": 0.3,
+      "buy_price": 2,
+      "durability": 999,
+      "level_requirement": 0,
+      "cooldown": 5,
+      "action": "hug",
+      "bonuses": {
+        "moraleBoost": 1,
+        "npcReactionModifier": true,
+        "crinkleSound": true
+      },
+      "scripts": [
+        {
+          "guid": "ffa910eb43c34711b928f22dd1cf2001",
+          "vars": {
+            "moraleBonus": 1,
+            "reactionFlags": "emotional",
+            "soundEffect": "crinkle"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Tall teardrop-shaped iron-faced shield strapped along the forearm and shoulder, covering the body from chin to knee when the bearer crouches. Heavy; favoured by armoured cavalry and front-line spearmen who can afford to plant rather than skirmish.\n",
+      "lore": "A pattern brought back from the southern border and copied every year by a different armourer who insists his rivet spacing is the correct one. The point pattern bullies a lance off line where a round shield would just split. Cavalry recruits learn its weight by holding it level until their arm gives out; sergeants count the seconds.\n",
+      "ref": "kite-shield",
+      "key": 559,
+      "id": "01KTVTRAB1KITESHIELD00000559",
+      "name": "Kite Shield",
+      "type_flags": 514,
+      "rarity": "uncommon",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 55
+    },
+    {
+      "description": "Taxidermy kiwi bird fixed at the crown of a cracked ceramic mask, its small glass eyes set slightly closer together than nature managed. Equal parts gift-shop curio and cautionary artifact, and impossible to face directly for more than a minute at a stretch.\n",
+      "lore": "Assembled in the back room of a natural history auction that lost its license in the year of the big audit, from surplus specimens and a shelf of unsold festival masks. The joining is clean but not kind, and the earliest owners report the piece rearranging its posture between photographs without anyone admitting to having moved it. It has been bequeathed rather than sold in every documented transfer since 2034.\n",
+      "ref": "kiwi-jigsaw",
+      "key": 23,
+      "id": "01JWB04MV4JB6P79G5ZF3XQ122",
+      "name": "Kiwi Jigsaw",
+      "type_flags": 411,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "mythic",
+      "weight": 1.4,
+      "buy_price": 666,
+      "durability": 999,
+      "level_requirement": 0,
+      "cooldown": 42069,
+      "action": "stare",
+      "bonuses": {
+        "uncannyEffect": true,
+        "npcEmotionRoll": true,
+        "cursedPresence": 0.3
+      },
+      "scripts": [
+        {
+          "guid": "ccbbac00277c46f4b109e8ba3cfa05e2",
+          "vars": {
+            "rollEmotions": "fear",
+            "auraTrigger": "visual",
+            "curseChance": 0.3
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A steel countertop appliance with a cracked digital readout that only displays the word NEARLY. The interior smells like every meal it has ever cooked, layered in the order they were served, with the unmistakable top note of something no one asked for.\n",
+      "lore": "Final production run from KrispeeTech Culinary Systems, shipped in the months before the Great Banquet Collapse of 2042 rendered mass catering uninsurable. The heating element is calibrated against a reference meal that nobody at the company is willing to describe on record. Used regularly, the unit develops opinions about seasoning that are difficult to argue with and harder to override.\n",
+      "ref": "krispee-air-fryer",
+      "key": 12,
+      "id": "01JW9Y29NQCWSS8B2ET09YZ6T7",
+      "name": "Krispee Air Fryer",
+      "type_flags": 400,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 4.2,
+      "buy_price": 1250,
+      "durability": 500,
+      "level_requirement": 5,
+      "cooldown": 60,
+      "action": "cook",
+      "bonuses": {
+        "cookTimeReduction": 0.25,
+        "buffChance": 0.15,
+        "tasteScore": 9.5
+      },
+      "scripts": [
+        {
+          "guid": "aa1487bc20484d91adbbd913fd7aefbb",
+          "vars": {
+            "reduceCookTime": 0.25,
+            "applyFoodBuffChance": 0.15,
+            "tasteAmplifier": 9.5,
+            "usableTags": "cooking"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Leather-bound, cover worn black at the corners, the spine stamped with a title that has been partly scraped off by a previous reader. Inside, the printed text alternates between what reads as scripture and what reads as tactical debriefing, with margin notes in at least four different hands.\n",
+      "lore": "Traces through the private libraries of a shipping family that lost most of its fortune in the same decade the book first enters the record, which is usually how these things go. Each owner has added a chapter-length annotation in a closing flyleaf, and none of them sign their names. The current custodian lives in a cottage on a coastline he refuses to name and does not answer letters, which is the polite version of an indefinite hold.\n",
+      "ref": "kryptonite-book",
+      "key": 29,
+      "id": "01JWCXER3NRHA3J4DNCJN250MX",
+      "name": "Kryptonite Book",
+      "type_flags": 417,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "mythic",
+      "weight": 1.3,
+      "buy_price": 1337,
+      "durability": 999,
+      "level_requirement": 10,
+      "cooldown": 2,
+      "action": "read",
+      "bonuses": {
+        "divineAnalysis": true,
+        "vulnerabilityTheories": 5,
+        "forbiddenKnowledge": 1
+      },
+      "scripts": [
+        {
+          "guid": "dede93bbd7fc4b999b1e289187d3eeb9",
+          "vars": {
+            "mythResistance": true,
+            "spiritualParadox": true,
+            "contentRating": "unstable"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Narrow grey-green leaves carry a spike of tight purple florets that release their scent at the faintest touch. One stem is enough to scent a small room for a day.\n",
+      "lore": "Grows along the sun-baked banks above the lower river, where somebody's great-grandmother planted the first cutting and the colony has been widening its own borders ever since. Herbalists cut at the edge of bloom, dry in bundles in a dark closet, and sell to both the sleep-doctors and the moth-preventers without picking a side. A pillow stuffed with the bracts will outlast the pillow it was stuffed into.\n",
+      "ref": "lavender",
+      "key": 107,
+      "id": "01KMVPV9ZH2X5XSMVAE90D21YM",
+      "name": "Lavender",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 6,
+      "sell_price": 3,
+      "emoji": "💜",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 7,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-lavender"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Sleeveless vest of boiled calf leather, dark with use along the shoulders and pale where the lacing has kept the dye from setting. Softens to the wearer's shape within a week of steady use, and remembers that shape for years after.\n",
+      "lore": "Made up in a dozen small leather-shops off the river road, each of them insisting, quietly, that their pattern is the one the militia actually adopted. A vest that has been re-laced three times belongs to its wearer in a way a newer one does not, which is the short version of why veterans refuse to trade up.\n",
+      "ref": "leather-vest",
+      "key": 92,
+      "id": "01KKR7QNRC3B4Y2629KQY1YDB6",
+      "name": "Leather Vest",
+      "type_flags": 514,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "common",
+      "buy_price": 25,
+      "emoji": "🥋",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "chest",
+        "bonuses": {
+          "armor": 2
+        }
+      },
+      "recipes": [
+        {
+          "skill": "smithing",
+          "skill_level": 1,
+          "xp_reward": 15,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "bone",
+              "amount": 2
+            },
+            {
+              "item_ref": "log",
+              "amount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Folded sheet of tanned hide, the grain still showing faintly across the surface, edges trimmed straight and corners rounded by the cutter's block. Smells of oak bark and the long weeks in the tannery's pits.\n",
+      "lore": "Every town large enough to have a market has a tanner at the edge of it, for reasons that become obvious downwind. The finished leather travels further than any of the animals it came from, which is the quiet arithmetic of the trade.\n",
+      "ref": "leather",
+      "key": 523,
+      "id": "01KPTSDW063N64TP0XTER3WAZ7",
+      "name": "Leather",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 8
+    },
+    {
+      "description": "Armful of dry leaves rustling softly against each other, the colors staggered through every shade between copper and rust. Crumbles to a papery powder if squeezed with any conviction.\n",
+      "lore": "Raked from the kitchen-yards and orchard lanes by children who are promised a small payment in sweets. Composters prize the first turn of leaves, because those are the ones that have not yet surrendered their tannins to the weather. The roof-thatchers take the rest for patching work, and nobody involved finds this division of labor worth arguing over.\n",
+      "ref": "leaves",
+      "key": 509,
+      "id": "01KPTSDW04VCJBRQVTRQS1SNRW",
+      "name": "Leaves",
+      "type_flags": 384,
+      "rarity": "common",
+      "emoji": "🍃",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 1,
+      "skilling": {
+        "skill": "woodcutting"
+      }
+    },
+    {
+      "description": "Pale coral-colored broth hides chunks of lobster tail and root vegetable under a slow-rising film of butter, the whole bowl served so hot that the spoon fogs briefly against the rim. First taste is sweet, second taste is briny, third is whichever memory the cook accidentally filed into the stock.\n",
+      "lore": "Simmered overnight in the back of the harbor-road inn by a cook who has never once allowed a visitor into her kitchen, over a stock that has been refreshed rather than restarted for the better part of a decade. The rare roots come up from the tidal flats at the lowest spring tides, and the inn's regular forager will not disclose which bed she harvests. Bowls are served with a slice of dark bread and the explicit understanding that refills will be considered, not promised.\n",
+      "ref": "lobster-soup",
+      "key": 48,
+      "id": "01JWG9ZCRB9JW5F4DHMRXQ2VM8",
+      "name": "Lobster Soup",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 2.5,
+      "buy_price": 520,
+      "durability": 1,
+      "level_requirement": 6,
+      "cooldown": 120,
+      "action": "consume",
+      "bonuses": {
+        "health": 90,
+        "regenRate": 2,
+        "seaAffinity": true
+      },
+      "scripts": [
+        {
+          "guid": "e5cba389843f4d8f973c82459ef10551",
+          "vars": {
+            "buffDuration": 180,
+            "traits": "sea-affinity"
+          }
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "cooking",
+          "skill_level": 20,
+          "xp_reward": 50,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "lobster",
+              "amount": 1
+            },
+            {
+              "item_ref": "butter",
+              "amount": 1
+            },
+            {
+              "item_ref": "allium",
+              "amount": 1
+            }
+          ]
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 86400,
+        "spoils_into_ref": "rotten-food"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Deep-blue shell shades to bronze where the joints catch the light, claws banded closed with twine the fisherman will ask for back. Still wet from the pot, still holding an opinion about the matter.\n",
+      "lore": "Trapped off the continental shelf by crews whose pot-lines run miles along the sea floor, marked by painted floats that everybody on the dock can read at a glance. The market in the capital prices them by weight and by cunning, the latter measured informally at the unloading and never written on the tag. A lobster that reaches a cookpot without fighting is suspected of having arranged something the diner is not yet aware of.\n",
+      "ref": "lobster",
+      "key": 47,
+      "id": "01JWG9JF11KYG4DAXF1VTKYZWS",
+      "name": "Lobster",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 5.2,
+      "buy_price": 400,
+      "durability": 1,
+      "level_requirement": 5,
+      "cooldown": 90,
+      "action": "consume",
+      "bonuses": {
+        "health": 75,
+        "armor": 2,
+        "seaAffinity": true
+      },
+      "scripts": [
+        {
+          "guid": "83a1f3fd6c12406aa8ef9cdd54aacf99",
+          "vars": {
+            "traits": "shell-hardened"
+          }
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 43200,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Freshly-split length of oak, sapwood pale and heartwood dark, the cut faces still bleeding a little sap where the axe landed. Heavy enough that you think twice about carrying a second.\n",
+      "lore": "Worked out of the slow-rotation coppice that the forestry wardens maintain against a calendar nobody in living memory has successfully argued against. Woodcutters deliver by the cart, builders measure by the cord, and the village children make a minor sport of stealing splinters off the pile for kindling of their own. A single log rough-squared on two sides becomes a respectable beam in an afternoon, which is why carpenters never pass an unclaimed pile without checking.\n",
+      "ref": "log",
+      "key": 99,
+      "id": "01KMVPV9ZG6TPG7BVB5Q9QV69M",
+      "name": "Log",
+      "type_flags": 384,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 64,
+      "rarity": "common",
+      "buy_price": 5,
+      "sell_price": 2,
+      "emoji": "🪵",
+      "weight": 2.5,
+      "skilling": {
+        "skill": "woodcutting",
+        "xp_reward": 10,
+        "gather_time": 2.5,
+        "respawn_time": 30,
+        "resource_node": "tree"
+      },
+      "tags": [
+        "isometric"
+      ],
+      "compress": {
+        "target_ref": "timber",
+        "ratio": 100
+      },
+      "stacking": {
+        "pack_max": 12
+      }
+    },
+    {
+      "description": "Iron frame holds four panes of milky moonstone-glass around a wick that draws only under direct moonlight, casting a soft cold light no larger than the lantern itself. The hinge creaks softly when the lamp is turned toward something it does not want to show you.\n",
+      "lore": "Built to the specifications of an astronomer-priest who is cited twice in the temple's margin notes and never by her proper name. A charged lantern will outline the edges of minor illusions and mark the paths that have been deliberately scrubbed from daylight maps. Travelers who borrow one from the temple sign a short promise that does not use the word return.\n",
+      "ref": "lunar-lantern",
+      "key": 66,
+      "id": "01JX727N5R6EKJ61NME0QD08RW",
+      "name": "Lunar Lantern",
+      "type_flags": 402,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 1.2,
+      "buy_price": 850,
+      "durability": 300,
+      "level_requirement": 4,
+      "cooldown": 30,
+      "action": "illuminate",
+      "bonuses": {
+        "lightRadius": 6,
+        "revealIllusions": true,
+        "nightVision": 2
+      },
+      "scripts": [
+        {
+          "guid": "3e4071deb6e4448982bca27c7302c1c8",
+          "vars": {
+            "lightRadius": 6,
+            "reveals": true,
+            "nightVision": 2,
+            "cooldown": 30
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Orange-and-white striped fish suspended in a small glass sphere of seawater that never warms to the room around it. It regards observers with an entirely unchildlike composure, and it blinks exactly once per minute.\n",
+      "lore": "Handed down through the apprenticeship of a line of mages who refuse to be photographed and issue written statements only through a third party. The fish does not age, does not feed, and does not answer questions, though a mage in its presence reports noticeably sharper recall for the duration. The current holder is a ten-year-old named Harriet who has already asked to be addressed as the Pot-Aware.\n",
+      "ref": "magic-nemo",
+      "key": 56,
+      "id": "01J269PK47V1DWX2S1251DEASD",
+      "name": "Magic Nemo",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "common",
+      "weight": 1,
+      "buy_price": 500,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 120,
+      "action": "consume",
+      "bonuses": {
+        "health": 10,
+        "mana": 100
+      },
+      "scripts": [
+        {
+          "guid": "b1e9402b4e560b693c348283c7a72859",
+          "vars": {
+            "health": 10,
+            "mana": 100,
+            "duration": 120
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Cobalt-blue liquid in a narrow hexagonal vial, stoppered with a sliver of tin wrapped in waxed silk. Cold to the touch even when left in the sun, and the surface ripples when a spell is cast within arm's reach.\n",
+      "lore": "Distilled by the apothecaries' college on the same schedule as their red counterparts, from a base that travels in unlabeled barrels from a supplier the college refuses to name. Mages who carry one describe the drink as unnervingly flavorless, which the college considers a feature and most drinkers consider the hardest part. A vial restores enough focus to bridge the gap between a failed first casting and a successful second, which is usually the gap that matters.\n",
+      "ref": "mana-potion",
+      "key": 546,
+      "id": "01KTVTRAB1MANAPOTI0NN000001",
+      "name": "Mana Potion",
+      "type_flags": 544,
+      "rarity": "common",
+      "emoji": "🧪",
+      "stackable": true,
+      "max_stack": 16,
+      "buy_price": 25,
+      "consumable": true,
+      "cooldown": 15,
+      "action": "consume",
+      "food": {
+        "restore_mana": 25,
+        "duration": 8,
+        "buff_effects": [
+          {
+            "type": "apply_effect",
+            "status_effect": "regen",
+            "stacks": 1,
+            "turns": 8
+          }
+        ]
+      }
+    },
+    {
+      "description": "Covered wooden tray holds bread, roast, greens, and a small cup of whatever the cook was willing to declare finished. The cover is hot enough at the edges to remind you whose kitchen you left it in.\n",
+      "lore": "Assembled at the back of every serious commissary from whatever the pot has been working on since sundown. Companies that eat together mark the meal as sacred in a quietly practical way, because the meal is the interval during which nobody is expected to be useful. Refusing a seat at the long table is considered rude, and eating too fast is considered worse.\n",
+      "ref": "meal",
+      "key": 537,
+      "id": "01KPTSDW07364SY50ZZ1Y6QZT3",
+      "name": "Meal",
+      "type_flags": 8,
+      "rarity": "uncommon",
+      "emoji": "🍱",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 500,
+      "consumable": true,
+      "action": "consume",
+      "food": {
+        "heals": 100,
+        "restore_energy": 100,
+        "restore_mana": 100,
+        "perishable": true,
+        "shelf_life_seconds": 86400,
+        "spoils_into_ref": "rotten-food"
+      }
+    },
+    {
+      "description": "Dark red cut of game meat, dense and faintly gamy through the paper it was wrapped in, edges already darkening toward brown within the first hour off the spit. Heavier in the hand than farm-raised cuts, and noticeably warmer to the touch when fresh.\n",
+      "lore": "Taken off whatever the hunters brought back that day, from deer on the north slopes to boar in the lower thickets and occasionally something the hunters will not name at the butcher's counter. Quartered and traded before sundown because nobody trusts the next morning's weather, and the village cook assigns cuts on a rotation everybody privately disputes. Eaten the same evening it arrives, because anything else is a disagreement with the cook, and the cook wins those.\n",
+      "ref": "meat",
+      "key": 549,
+      "id": "01KTVTRAB1ME4T000000000000004",
+      "name": "Meat",
+      "type_flags": 72,
+      "rarity": "common",
+      "emoji": "🥩",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 4,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 12,
+        "regen_per_second": 3,
+        "regen_duration": 6,
+        "perishable": true,
+        "shelf_life_seconds": 86400,
+        "spoils_into_ref": "rotten-meat"
+      }
+    },
+    {
+      "description": "Flat tin box painted field-green, the hinge stiff with corrosion, contents laid out on a folded cotton wrap that serves as the first bandage and the final splint. Inside: three dressings, a short suture kit, a stim-vial, and the field manual's one-page flowchart for deciding in what order to use them.\n",
+      "lore": "Stocked to a regulation that was last revised in the second year of the Border War and has not been seriously updated since, on the principle that the contents still fail rarely enough to justify nobody owning the revision. Every unit that pulls a shift in the field keeps one per squad and a spare behind the captain's seat. The stim-vial is expensive, the suture kit is painful, and the manual is barely readable in the dark, which is why the younger medics memorize it before anyone asks.\n",
+      "ref": "medkit",
+      "key": 542,
+      "id": "01KPTSDW07DFVC7FKABJ2VX3Y8",
+      "name": "MedKit",
+      "type_flags": 32,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 10,
+      "buy_price": 80,
+      "consumable": true,
+      "action": "consume",
+      "food": {
+        "heals": 25,
+        "regen_per_second": 2,
+        "regen_duration": 15
+      }
+    },
+    {
+      "description": "A green-lacquered board the size of a paperback, dense with solder joints that still look factory-fresh despite the date etched on the underside. Each trace catches the light like a river viewed from a plane at dusk.\n",
+      "lore": "Salvaged from a decommissioned fabrication line that was running designs nobody filed patents on, most likely because the engineers who drew them preferred not to be found. The chips respond to instructions the documentation does not cover, and they run cooler than their silicon budget allows. Sensitive to heat, not because of thermal failure, but because it makes them talkative.\n",
+      "ref": "microchip-motherboard",
+      "key": 19,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRMM",
+      "name": "Microchip Motherboard",
+      "type_flags": 407,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 0.7,
+      "buy_price": 650,
+      "durability": 300,
+      "level_requirement": 4,
+      "cooldown": 2,
+      "action": "install",
+      "bonuses": {
+        "processingPower": 12,
+        "systemCompat": "technology",
+        "heatSensitivity": true
+      },
+      "scripts": [
+        {
+          "guid": "bfc81da8f92e4b8bbd46e2385b28dc33",
+          "vars": {
+            "coreLogicBoost": 12,
+            "compatTags": "technology",
+            "overheatRisk": 0.2
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Palm-sized stone wearing a thick cap of emerald moss, damp to the touch at the underside and cool long after it has been brought indoors. Smells of forest floor and the kind of quiet a rainstorm leaves behind.\n",
+      "lore": "Collectors pay a small premium for the good ones, because the moss dies quickly in hands that are not used to keeping things alive. Garden designers use them as stepping stones in the private shade-gardens that never make the guild catalogues, which is how you can tell which gardens are actually private.\n",
+      "ref": "mossy-stone",
+      "key": 101,
+      "id": "01KMVPV9ZHNPTTYJPWD3RD00Y2",
+      "name": "Mossy Stone",
+      "type_flags": 384,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 64,
+      "rarity": "uncommon",
+      "buy_price": 8,
+      "sell_price": 4,
+      "emoji": "🪨",
+      "weight": 3,
+      "skilling": {
+        "skill": "mining",
+        "xp_reward": 15,
+        "gather_time": 2.5,
+        "respawn_time": 35,
+        "resource_node": "mossy-rock"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Off-white cap the size of a silver piece, edges starting to roll upward, stem still carrying a smudge of leaf-litter where the forager twisted it loose. Smells of damp and faint pepper.\n",
+      "lore": "Comes up in clusters along the woodpath between the village and the coppice, on the week after the first heavy autumn rain. Children who learn the safe species from their grandmothers are paid in sweets for a full basket, and children who learn them from each other are paid with long lectures from the apothecary.\n",
+      "ref": "mushroom",
+      "key": 501,
+      "id": "01KPTSDW036BJPP1KXZKQ4GA90",
+      "name": "Mushroom",
+      "type_flags": 72,
+      "rarity": "common",
+      "emoji": "🍄",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 3,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 7,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-food"
+      },
+      "skilling": {
+        "skill": "foraging"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "Disc of soft gold wax warmed just enough by the hand to yield to a thumbprint, the surface still carrying the honeycomb lattice that shaped it. Smells faintly of pollen and the wood of the hive it was scraped from.\n",
+      "lore": "Pressed from the capping wax of the hillside apiaries after the honey has been pulled, and aged in wooden boxes until it passes the smell test that every beekeeper performs alone. Chandlers take the cleanest blocks for altar candles, apothecaries take the next grade for salves, and the alchemists take the seconds for seals they insist behave better than anyone else's wax.\n",
+      "ref": "natural-beeswax",
+      "key": 16,
+      "id": "01JWA62X4JRK6MMNJBFEZENK0V",
+      "name": "Natural Beeswax",
+      "type_flags": 404,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.2,
+      "buy_price": 80,
+      "durability": 100,
+      "level_requirement": 1,
+      "cooldown": 0,
+      "action": "craft",
+      "bonuses": {
+        "candleCrafting": true,
+        "potionBinding": true,
+        "scentSoothing": 0.3
+      },
+      "scripts": [
+        {
+          "guid": "bbee1f99a3bb4e59be3f91ee1253f010",
+          "vars": {
+            "craftingTags": "wax",
+            "potionStabilityBonus": 0.1,
+            "aromaValue": 0.3
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Pale silica grains so fine they run between fingers like slow water, leaving a thin residue on the skin and a thinner one on the air. Collected in heavy cloth sacks that sweat dry around the seams.\n",
+      "lore": "Drawn from the dune-chains east of the trade road by crews working short shifts under cover, because the summer sun bakes the exposed flats past the point of tolerable labor by the third hour. Glassblowers grade it by handful and by ear, which is a technique they refuse to explain to anyone who has not already figured most of it out on their own.\n",
+      "ref": "natural-sand",
+      "key": 510,
+      "id": "01KPTSDW04YKBHCEPY4YYSZ3BK",
+      "name": "Natural Sand",
+      "type_flags": 384,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 1
+    },
+    {
+      "description": "Ash-shafted arrow tipped with a hardened cacti needle bound in resin. The needle's natural taper drives through cloth and light leather where a wooden head would skip — quartermasters issue them when the line expects unarmoured raiders.\n",
+      "lore": "Desert frontier fletchers learned to harvest spent cacti needles from foragers' yields long before the central guild caught on. The recipe travelled north with a single retired sergeant who could not stop talking about it. Within a season every militia bowyer was bidding for needle stock at twice the cactus harvester's asking price.\n",
+      "ref": "needle-arrow",
+      "key": 561,
+      "id": "01KTVTRAB1NEEDLEARROW000561",
+      "name": "Needle Arrow",
+      "type_flags": 576,
+      "rarity": "uncommon",
+      "emoji": "🏹",
+      "stackable": true,
+      "max_stack": 50,
+      "buy_price": 3
+    },
+    {
+      "description": "A thick, slow-moving liquid that coats the inside of the vial like wet paint. It hums when you bring it near metal, and the label warns against operating heavy machinery, prayer, or romance for twelve hours after consumption.\n",
+      "lore": "Formulated by NoodlesTech out of a rented lab above a laundromat, using precursor chemicals that the regulator has not yet invented categories for. The company pivoted to wellness branding in 2039 and stopped answering returns. Users report the same three dreams in rotation, always in this order: a staircase, a boardroom, and a meal they almost finished.\n",
+      "ref": "noodles-girthy-pharma-potion",
+      "key": 4,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRJW",
+      "name": "Noodles Girthy Pharma Potion",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 0.6,
+      "buy_price": 75,
+      "durability": 1,
+      "level_requirement": 4,
+      "cooldown": 45,
+      "action": "consume",
+      "bonuses": {
+        "health": 15,
+        "mana": 25,
+        "energy": 25,
+        "strength": 5
+      },
+      "scripts": [
+        {
+          "guid": "dd238a91353c4a1991cf275041730ab0",
+          "vars": {
+            "health": 15,
+            "mana": 25,
+            "energy": 25,
+            "strength": 5,
+            "duration": 300,
+            "tickRate": 3
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Stoppered clay flask, the surface darkened at the neck from decades of pouring, contents clear gold against a candle and black against a cloth. Smells heavy enough to remind you why the flask is sealed.\n",
+      "lore": "Rendered at the coastal tryworks from the last of the migratory pods, in the short season each year that the harbor-masters permit the boats out past the reef. A careful flask will light a lantern for forty nights and keep a forge banked through a cold one, which is the arithmetic on which the whole trade still depends.\n",
+      "ref": "oil",
+      "key": 514,
+      "id": "01KPTSDW04M84CTCD27SRZBWA0",
+      "name": "Oil",
+      "type_flags": 64,
+      "rarity": "uncommon",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 12
+    },
+    {
+      "description": "Tall canvas pack on an ash-wood frame, shoulder straps padded with hair-stuffed leather pads, the top flap buckling down across an oilskin lining. Weighs enough empty to remind you what a fair full weight should feel like.\n",
+      "lore": "Adopted in the mountain caravans first, then everywhere else that regularly walks out further than a day, because the frame keeps the load off the spine and the oilskin keeps the contents off the rain. Old quartermasters refit the straps once a year, and the owners who skip that step find out why at the worst possible pass. A pack with its frame still straight after ten seasons is the pack worth inheriting.\n",
+      "ref": "pack",
+      "key": 532,
+      "id": "01KPTSDW06EQ5FZETRGGW0YNMH",
+      "name": "Pack",
+      "type_flags": 8196,
+      "rarity": "rare",
+      "stackable": true,
+      "max_stack": 2,
+      "buy_price": 150,
+      "container": {
+        "added_slots": 8
+      }
+    },
+    {
+      "description": "Burlap sack tied off at the neck with twine, weight resting heavier at some corners than others for reasons geometry does not entirely support. Held against the chest, the sack hums at a pitch too low for most voices to reach.\n",
+      "lore": "Delivered each autumn to the same corner of the same root cellar by nobody who has ever been seen delivering it, which is the root fact of the household's long truce with whatever arranges the sack. Counted once by a visiting accountant who left with a different count than the one she arrived to verify, and who politely declined to discuss it afterward. Eaten singly, the potatoes taste like potatoes; eaten in any group of four or more, the eaters report the faint, brief sensation of having already finished the meal.\n",
+      "ref": "paradox-sack-of-potatoes",
+      "key": 5,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRPX",
+      "name": "Paradox Sack of Potatoes",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 3.5,
+      "buy_price": 120,
+      "durability": 1,
+      "level_requirement": 2,
+      "cooldown": 30,
+      "action": "consume",
+      "bonuses": {
+        "health": 35,
+        "mana": 10,
+        "timeBend": true
+      },
+      "scripts": [
+        {
+          "guid": "bb384b99932c4874bafd29170d2e9ed5",
+          "vars": {
+            "health": 35,
+            "mana": 10,
+            "realityBend": true,
+            "duration": 120,
+            "tickRate": 6
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Long feather running from cold bronze at the tip to a living ember red at the quill, warm enough to hold comfortably and bright enough to read by. Leaves a thin pale afterglow in the air for a breath after it is set down.\n",
+      "lore": "Falls once from each phoenix's molt, which is recorded as a rare enough event that the priory keeps its own registry with the master copy sealed in wax. A single feather, pressed to the chest of the recently fallen, is sufficient to bring them back as far as the body will still permit. The feather does not survive the use, and the returned rarely speak of the interval.\n",
+      "ref": "phoenix-feather",
+      "key": 83,
+      "id": "01KKR7QNRCKPV43AZDEN3GMME7",
+      "name": "Phoenix Feather",
+      "type_flags": 10784,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 1,
+      "rarity": "epic",
+      "buy_price": 300,
+      "emoji": "🔥",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "revive_ally",
+          "percent": 30
+        }
+      ]
+    },
+    {
+      "description": "Patchwork coat in every color the dyer could not sell plainly, the seams running in a pattern that almost resolves into music if you stop looking for it. Whistles faintly along the inside of the collar whenever the room goes quiet.\n",
+      "lore": "Tailored in the back of a theater-costumer's shop by a journeyman who left town the week after delivery, using bolt-ends from a shipment of dyed silks that arrived without a manifest. Wearers report that small animals arrange themselves in a slow line behind them within a block of stepping outside, which the original owner considered a feature and the second owner considered grounds for returning the coat. No third owner has yet come forward.\n",
+      "ref": "pied-piper-jacket",
+      "key": 22,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRPP",
+      "name": "Pied Piper Jacket",
+      "type_flags": 410,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "epic",
+      "weight": 2.1,
+      "buy_price": 2200,
+      "durability": 850,
+      "level_requirement": 6,
+      "cooldown": 90,
+      "action": "command",
+      "bonuses": {
+        "charm": 3,
+        "creatureInfluence": 0.25,
+        "passiveWhistle": true
+      },
+      "scripts": [
+        {
+          "guid": "bbf29ce88a4c445fbbc210efbde2188b",
+          "vars": {
+            "charmBoost": 3,
+            "tameChance": 0.25,
+            "whistleTrigger": "ambient",
+            "cooldown": 90
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "A palm-sized idol carved from black-market bullion and whatever material was binding the vault walls in the subprime years. It is warmer than it should be, and the eye sockets track the nearest screen whenever a number turns red.\n",
+      "lore": "Reputedly forged under Wall Street in the fourth quarter of 2007, during the long weekend when the lights never came back up. The original custodian was a CFO who signed two resignation letters before his own, neither of them his, and he has not aged since. Holding the idol long enough grants clear forecasts of near-future markets; letting go becomes measurably harder each time.\n",
+      "ref": "pocket-prophet-of-profit",
+      "key": 6,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRZZ",
+      "name": "Pocket Prophet of Profit",
+      "type_flags": 393,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "legendary",
+      "weight": 0.3,
+      "buy_price": 9999,
+      "durability": 999,
+      "level_requirement": 9,
+      "cooldown": 666,
+      "action": "activate",
+      "bonuses": {
+        "foresight": true,
+        "profitBoost": "7%",
+        "dreadAura": true
+      },
+      "scripts": [
+        {
+          "guid": "cc498b99932c4874bafd29170d2e9edf",
+          "vars": {
+            "foresight": true,
+            "marketSurgeChance": 0.2,
+            "profitBoost": 0.07,
+            "dreadAura": true,
+            "duration": 300,
+            "tickRate": 12
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Heavy brown cap set over a bulbous cream-colored stalk, the flesh firm under a careful thumb and smelling faintly of walnuts before you have even cut into it. Dried, the scent deepens into something closer to old wood and warm butter.\n",
+      "lore": "Comes up along the root-line of the older oaks in the hill forests, and the foragers who know the spots do not generally share them before the third cup of wine. Restaurants pay twice for fresh and thrice for dried, and the best dried caps are aged through a dry winter before they reach any serious kitchen. An unfamiliar basket at the market is worth approaching slowly, on the theory that the picker is either very generous or very new.\n",
+      "ref": "porcini",
+      "key": 115,
+      "id": "01KMVPV9ZJB35BQJ3SNZ4W9GDA",
+      "name": "Porcini",
+      "type_flags": 136,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 8,
+      "sell_price": 4,
+      "emoji": "🍄",
+      "weight": 0.2,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 8,
+        "gather_time": 0.5,
+        "respawn_time": 25,
+        "resource_node": "mushroom-porcini"
+      },
+      "food": {
+        "heals": 3,
+        "doses": 1,
+        "perishable": true,
+        "shelf_life_seconds": 259200,
+        "spoils_into_ref": "rotten-food"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Hand-sized brick of brushed aluminum housing, three status LEDs across the face, braided cable coiled into a side pocket that never quite wants to close. Buzzes faintly when shaken, in a way that the manufacturer describes as expected behavior.\n",
+      "lore": "Last design signed off by Voltwell Systems before the firm was absorbed in the post-collapse consolidation, and the only one in that product line that used the heavier-grade cells. The units have outlasted the warranty paperwork, the fulfillment center, and three attempts at brand revival, which is why secondhand pricing has drifted upward since. A powerbank that clicks once on the hour is in working order; one that clicks twice is asking to be retired.\n",
+      "ref": "portable-powerbank",
+      "key": 25,
+      "id": "01JWCKTE3TC42CNP3X24TM0BA1",
+      "name": "Portable Powerbank",
+      "type_flags": 413,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 1.9,
+      "buy_price": 440,
+      "durability": 400,
+      "level_requirement": 2,
+      "cooldown": 60,
+      "action": "recharge",
+      "bonuses": {
+        "energyRestore": 25,
+        "overloadChance": 0.05,
+        "chargeSlots": 2
+      },
+      "scripts": [
+        {
+          "guid": "af148fdc10d842f08bb29a10d38cdabb",
+          "vars": {
+            "chargeAmount": 25,
+            "chargeTargets": "tools",
+            "overheatChance": 0.05,
+            "maxConnections": 2
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Red liquid in a stubby glass vial, stoppered with a cork half the size of a thumb, a single label-ring tied on with waxed thread. Warm going down, followed by a tingle at the edges of recent injuries.\n",
+      "lore": "Brewed to the most widely adopted apothecaries' recipe, which drifted into the public register two generations back when the original guild disbanded over a royalty argument. Every apothecary below the capital will tell you their own version is slightly better, and most of them are correct in the narrowest possible sense. A belt of three is standard issue, a belt of five is a confession that the day has already gone poorly.\n",
+      "ref": "potion",
+      "key": 67,
+      "id": "01KKR7QNRATCW9JB66FKPMYB65",
+      "name": "Potion",
+      "type_flags": 544,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 5,
+      "rarity": "common",
+      "buy_price": 25,
+      "emoji": "🧪",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "heal",
+          "amount": 15
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "alchemy",
+          "skill_level": 1,
+          "xp_reward": 15,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "wildflower",
+              "amount": 2
+            },
+            {
+              "item_ref": "porcini",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Drawstring pouch of oiled deerhide the size of a clenched fist, darkened along the belt-loop from a season on the road. The cord is braided from a finer leather, ends burned rather than knotted.\n",
+      "lore": "Turned out by leatherworkers in the same shops that supply the military, as the first gear an apprentice is allowed to sell for their own account. Most go to travelers, couriers, and children running errands long enough to warrant carrying more than a fist of coin. A good pouch takes its shape from the owner inside a month, and gives nothing back to a thief who wears it after.\n",
+      "ref": "pouch",
+      "key": 530,
+      "id": "01KPTSDW06GQCSDZJT7JK1CQQ6",
+      "name": "Pouch",
+      "type_flags": 8196,
+      "rarity": "common",
+      "emoji": "👝",
+      "stackable": true,
+      "max_stack": 2,
+      "buy_price": 20,
+      "container": {
+        "added_slots": 2
+      }
+    },
+    {
+      "description": "Waxy magenta fruit shaped like a small egg, studded with hair-fine spines that embed in fingers almost invisibly. Peeled properly, the flesh inside is pale green, wet, and aggressively sweet.\n",
+      "lore": "Gathered off the flats-cacti through the dry end of summer by pickers wearing leather gauntlets that have done nothing else for a decade. The pear is scored at the poles, rolled between two cloths to break the spines free, then peeled while still wrapped. Travelers who skip the cloth trick carry the spines home with them and learn not to skip the cloth trick again.\n",
+      "ref": "prickly-pear",
+      "key": 505,
+      "id": "01KPTSDW04C5M7YQTPAE99GHR3",
+      "name": "Prickly Pear",
+      "type_flags": 72,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 8,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 15,
+        "perishable": true,
+        "shelf_life_seconds": 432000,
+        "spoils_into_ref": "rotten-food"
+      },
+      "skilling": {
+        "skill": "foraging"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "A battered laptop that runs its fan at full speed whenever you type something untrue. The spacebar is worn flat, the screen carries ghost burn-in of a talking head, and the stickers have been scraped off so thoroughly that the glue still remembers them.\n",
+      "lore": "Issued to contract operators during the Algorithmic Spring, when the line between marketing and intelligence work stopped being a line. The machine boots into a clean desktop regardless of the previous session, which is reassuring until you realize the disk has no visible storage and the network indicator never stops blinking. Whoever owned it last did not turn it in, and their name never appears twice in the same article.\n",
+      "ref": "propagandist-laptop",
+      "key": 7,
+      "id": "01JW8GK1Z1DYXTB7KB8RRKP87B",
+      "name": "Propagandist Laptop",
+      "type_flags": 395,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "epic",
+      "weight": 2.7,
+      "buy_price": 3750,
+      "durability": 450,
+      "level_requirement": 6,
+      "cooldown": 90,
+      "action": "deploy",
+      "bonuses": {
+        "influence": 12,
+        "hackPower": 8,
+        "stealthScripts": true
+      },
+      "scripts": [
+        {
+          "guid": "dd912f1e871c4a3e8a8fbcacafee205c",
+          "vars": {
+            "influenceBoost": 12,
+            "hackPower": 8,
+            "stealthEnabled": true,
+            "duration": 600,
+            "tickRate": 15
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Hardwood deck repaired with duct tape along both rails, trucks loosened past the point most shops will certify, wheels painted over three times in colors that did not belong to the original owner. Rattles on gravel, sings on smooth pavement, refuses to roll the direction you bought it pointing.\n",
+      "lore": "Built in a garage by a rotating cast of teenagers who have been swapping parts on the same deck since the first owner left for college without it. The bearings are from a disassembled laundromat dryer, the grip tape was stolen from a rival shop, and the stickers cover a dented inscription nobody currently claims to have written. A board in this tradition is not bought, it is joined, and a board that has stopped being joined is just a board.\n",
+      "ref": "punk-skateboard",
+      "key": 53,
+      "id": "01JWJGBXT7E6VSVV6E6D6N2AT5",
+      "name": "Punk Skateboard",
+      "type_flags": 4096,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 4.2,
+      "buy_price": 180,
+      "durability": 150,
+      "level_requirement": 3,
+      "cooldown": 10,
+      "action": "equip",
+      "bonuses": {
+        "speed": 1.25,
+        "evasion": 5,
+        "stylePoints": true
+      },
+      "scripts": [
+        {
+          "guid": "e78ccfd540b445f78f137a21a0f77e5c",
+          "vars": {
+            "speedMultiplier": 1.25,
+            "evasionBonus": 5,
+            "traits": "grind-ready"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Paper cup with a corrugated sleeve, lid pressed on too hard, the coffee inside at a temperature the barista has declined to guarantee to within a second or two. The surface ripples in a way that does not quite match the motion of the cup.\n",
+      "lore": "Brewed from beans harvested in a microclimate on the leeward side of a mountain the cartographers have stopped updating. The roaster operates one pilot unit and sells the beans through a single cafe that rotates location every month, posted the night before on a board nobody in particular maintains. Drinkers report clarity on unrelated problems for the following afternoon, and a faint sense of having just hung up from a phone call that never happened.\n",
+      "ref": "quantum-coffee",
+      "key": 58,
+      "id": "01JX0YM8XTR59QQ83STSSM0P93",
+      "name": "Quantum Coffee",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 0.6,
+      "buy_price": 150,
+      "durability": 1,
+      "level_requirement": 2,
+      "cooldown": 45,
+      "action": "consume",
+      "bonuses": {
+        "energy": 5,
+        "intelligence": 1,
+        "timeWarp": true
+      },
+      "scripts": [
+        {
+          "guid": "1234567890abcdef1234567890abcdef",
+          "vars": {
+            "hasteDuration": 60,
+            "slowChance": 0.1
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Slender aluminum can in an ugly neon gradient that looks printed on two passes through the same machine, tab seated flush, liquid inside fizzing with a sound a half-second ahead of the shake. First sip is grapefruit and solder, second is apology.\n",
+      "lore": "Produced under license by a beverage conglomerate that acquired the formula from a physics lab that should not have been running a beverage project in the first place. Each can is coded to the specific batch, and drinkers who scan the code too fast are redirected to a helpline whose operators know the questions and not the answers. Half a can is enough to short-circuit a slow meeting; a full can leaves the drinker faintly convinced they have already solved the problem the meeting was about.\n",
+      "ref": "quantum-energy-drink",
+      "key": 60,
+      "id": "01JX4H2NVFGJ1F74KGHYQFTN6M",
+      "name": "Quantum Energy Drink",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 0.4,
+      "buy_price": 180,
+      "durability": 1,
+      "level_requirement": 2,
+      "cooldown": 30,
+      "action": "consume",
+      "bonuses": {
+        "stamina": 20,
+        "speed": 5
+      },
+      "scripts": [
+        {
+          "guid": "abcdef1234567890abcdef1234567890",
+          "vars": {
+            "staminaBoost": 20,
+            "speedBoost": 5,
+            "duration": 45
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Rolled parchment held by a blue cord and a disc of wax stamped with the guild-house seal, the edges of the paper yellowed by however many hands it has passed through. Opens with a small resistance, as if it has decided who should be reading it today.\n",
+      "lore": "Issued from the guild-house as the formal record of a contract a member has agreed to fulfill, countersigned by the guild steward and the patron in separate inks that are known to have fought each other once before. The scroll is the contract, and a member who returns without it is understood to have failed at the paperwork stage of an engagement, which is taken as seriously as the engagement itself. Completed scrolls are filed in the back archive, where the humidity is apparently important and visitors are apparently not.\n",
+      "ref": "quest-scroll",
+      "key": 554,
+      "id": "01KTVTRAB1QUESTSCR0LL000009",
+      "name": "Quest Scroll",
+      "type_flags": 4096,
+      "rarity": "uncommon",
+      "stackable": true,
+      "max_stack": 10,
+      "buy_price": 0,
+      "tradeable": false
+    },
+    {
+      "description": "Two-loop leather belt wound with a folded kit of pliers, spanner, driver, and three wrapped blades that the wearer has clearly chosen for reasons of their own. The buckle is dented on one corner from a long-ago fall that the wearer still tells the story of.\n",
+      "lore": "Standard issue for the field-repair crews at the shipyard and the print-shop and the greenhouse, which is to say anyone whose job is to keep something going long enough for the real fix to arrive by post. A well-kept belt outlives the trade that issued it, which is usually how it ends up on the hips of whichever relative takes it down from the hook after the wearer retires. The one missing tool in any toolbelt is the one its wearer never admits they lost.\n",
+      "ref": "quick-toolbelt",
+      "key": 11,
+      "id": "01JW9MMAPMYMX7F6C1XYMNT9BN",
+      "name": "Quick Toolbelt",
+      "type_flags": 398,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "common",
+      "weight": 1.6,
+      "buy_price": 450,
+      "durability": 300,
+      "level_requirement": 2,
+      "cooldown": 15,
+      "action": "repair",
+      "bonuses": {
+        "repairBoost": 0.01,
+        "multiTargetCompat": true,
+        "toolGrade": "Class-B"
+      },
+      "scripts": [
+        {
+          "guid": "ee541e1cf4214c4cbbb4e1fa99d7fbbb",
+          "vars": {
+            "repairModifier": 0.01,
+            "usableOn": "technocraft",
+            "toolQuality": "Class-B",
+            "cooldown": 15
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Leather tube the length of a forearm, stitched along one seam and capped at the base with a hardwood plug, thirty arrow-ends showing in neat rings at the mouth. Rides over the shoulder on a strap that has been adjusted by every owner in its history.\n",
+      "lore": "Carried by any archer who takes the work seriously, because counting your arrows by twenties rather than by feel is the difference between a long day and a very short one. The quartermaster restocks through a weekly rotation, and the fletchers downstream learn fast which archers are rough with their gear. A quiver that rattles has been packed by someone in a hurry.\n",
+      "ref": "quiver",
+      "key": 536,
+      "id": "01KPTSDW07VNS0CD7MK0ADEZX7",
+      "name": "Quiver",
+      "type_flags": 576,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 100
+    },
+    {
+      "description": "Copper-colored liquid in a vial barely wider than a thumb, still hot at the sides when the cork comes loose, the smell layered with clove and black pepper and something underneath it the apothecary will not identify. The drinker's pulse picks up before the second mouthful is swallowed.\n",
+      "lore": "Compounded on commission by a small set of apothecaries who keep the ingredients under lock and the paperwork off their own desks, because the draught's reputation outpaces its legal standing in three jurisdictions. The effects run sharp and narrow for a quarter of an hour, then hand the drinker a cold, hollow afternoon as a receipt. Seasoned fighters rate it a tool for the last engagement of a day, never the first.\n",
+      "ref": "rage-draught",
+      "key": 82,
+      "id": "01KKR7QNRC4PXBN13CNS1YR9HY",
+      "name": "Rage Draught",
+      "type_flags": 544,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 2,
+      "rarity": "rare",
+      "buy_price": 100,
+      "emoji": "🧪",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "apply_effect",
+          "status_effect": "sharpened",
+          "stacks": 2,
+          "turns": 4
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "alchemy",
+          "skill_level": 20,
+          "xp_reward": 55,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "fly-agaric",
+              "amount": 2
+            },
+            {
+              "item_ref": "sunflower",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Waxed cloth bundle wrapping hardtack, salt beef, a twist of dried fruit, and a square of pressed seed-bar that can break a tooth if approached without patience. Keeps forever, tastes like it intends to.\n",
+      "lore": "Packed at the quartermasters' warehouse according to a list that was settled in arbitration two generations ago and has held up on its own practicality ever since. Every army that tried to improve the ration ended up returning to it within a campaign, because the point of the ration is not to feed a soldier, it is to keep a soldier moving.\n",
+      "ref": "rations",
+      "key": 71,
+      "id": "01KKR7QNRCTKXB470J4ENW4KCK",
+      "name": "Rations",
+      "type_flags": 520,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 3,
+      "rarity": "common",
+      "buy_price": 15,
+      "emoji": "🍞",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "heal",
+          "amount": 8
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "cooking",
+          "skill_level": 1,
+          "xp_reward": 10,
+          "output_quantity": 2,
+          "ingredients": [
+            {
+              "item_ref": "porcini",
+              "amount": 2
+            },
+            {
+              "item_ref": "wildflower",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Cut of dark red beef sitting on a butcher-paper square, fat marbled in fine white lines that catch the lamp-light, the edges still wet where the knife left them. Weight of a small meal in a single hand.\n",
+      "lore": "Sold off the back counter of the village butcher, whose wall chart of cuts has not been updated since the last occupation and whose loyalty to that chart has become its own kind of reputation. The serious cooks arrive before the counter opens, and the rest of us arrive later and learn to be patient about it.\n",
+      "ref": "raw-beef",
+      "key": 522,
+      "id": "01KPTSDW056ZG78N01E5NACTZ0",
+      "name": "Raw Beef",
+      "type_flags": 72,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 18,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 25,
+        "perishable": true,
+        "shelf_life_seconds": 86400,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "Pale green slab of cactus flesh still weeping clear sap at the edges, the skin trimmed off on one face and left intact on the other. Smells faintly of cucumber and turned soil.\n",
+      "lore": "Harvested in narrow slices from the older barrel cacti, because a slab that large will regrow within a season if the cut is clean. Kitchens use it boiled or pickled, apothecaries use it drained and reduced, and nobody reputable eats it raw unless they are already in an argument with someone.\n",
+      "ref": "raw-cacti",
+      "key": 503,
+      "id": "01KPTSDW03Z16QMG7DG4JXG7JB",
+      "name": "Raw Cacti",
+      "type_flags": 64,
+      "rarity": "common",
+      "emoji": "🌵",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 2,
+      "skilling": {
+        "skill": "foraging"
+      }
+    },
+    {
+      "description": "Whole plucked chicken hanging by the feet from a butcher's hook, pale yellow skin bunched around the ankles, a single pinfeather the plucker missed still clinging to a wing. Wet to the touch and cool against the palm.\n",
+      "lore": "Raised in the yards behind most households that can spare the grain, and sold on the mornings when the rooster stopped counting correctly. A fresh chicken is expected to be on the fire by dusk, and a chicken that has been on the hook overnight is used for stock and not for roasting.\n",
+      "ref": "raw-chicken",
+      "key": 518,
+      "id": "01KPTSDW05751DV6FHW7P5BBHX",
+      "name": "Raw Chicken",
+      "type_flags": 72,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 6,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 9,
+        "perishable": true,
+        "shelf_life_seconds": 86400,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "Cloudy lump of unshaped glass that still remembers the kiln, surface pitted in spots where the heat finished unevenly, edges sharp enough to draw a line along soft leather. Cool to the touch after a day, colder than expected.\n",
+      "lore": "Pulled from the first crucible of the morning, when the glassblowers are still calibrating the heat against the outside weather. The good rough stock goes straight into the stenciling shop, the middling grade is reworked, and the worst of it is bought by the alchemists, who have their own opinions about what the bubbles mean.\n",
+      "ref": "raw-glass",
+      "key": 511,
+      "id": "01KPTSDW04CCSPT2QTZ1PF363P",
+      "name": "Raw Glass",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 24,
+      "buy_price": 8
+    },
+    {
+      "description": "Bone-in shoulder of mutton wrapped in muslin, the fat coating the outside of the cut a creamy yellow, a light smoke still clinging to the wrapping from the butcher's cellar. The smell is heavier than beef's and less patient about it.\n",
+      "lore": "Hung for four days in a cellar whose temperature the butcher refuses to discuss with visitors, on the principle that half his reputation rests in the cellar and the other half in the aging. Older cuts cook down into something the younger cuts cannot, which is why the cellar list outlives the meat list in the back of the book.\n",
+      "ref": "raw-mutton",
+      "key": 520,
+      "id": "01KPTSDW056MAY4EB3J1J7QKZN",
+      "name": "Raw Mutton",
+      "type_flags": 72,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 12,
+      "pool_group": "food",
+      "food": {
+        "restore_energy": 17,
+        "perishable": true,
+        "shelf_life_seconds": 172800,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "compress": {
+        "target_ref": "meal",
+        "ratio": 100
+      }
+    },
+    {
+      "description": "Handheld transceiver cobbled together from the guts of three different radios, the casing held shut with electrical tape and a small prayer, the antenna made from a repurposed car whip. Crackles softly even when switched off, which the owner will tell you is a feature.\n",
+      "lore": "Built in the back rooms of printers and bike shops and the occasional sympathetic bakery, using boards scavenged from state-surplus auctions that nobody quite remembers how to track. The frequency schedule is printed on rolling papers, memorized, and burned, because nothing routed through the device survives a thorough search. Units in the field change hands every few weeks on principle, and the serial numbers have all been filed to different guesses.\n",
+      "ref": "rebel-radio",
+      "key": 28,
+      "id": "01JWCX61HFPET0VWXTZFDG4D06",
+      "name": "Rebel Radio",
+      "type_flags": 416,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 1.2,
+      "buy_price": 975,
+      "durability": 800,
+      "level_requirement": 5,
+      "cooldown": 180,
+      "action": "transmit",
+      "bonuses": {
+        "signalAccess": "encrypted",
+        "supportChance": 0.2,
+        "jamBoost": true
+      },
+      "scripts": [
+        {
+          "guid": "c3aa918a7f244a0c83d2e9d552e61aad",
+          "vars": {
+            "contactChannels": "encrypted",
+            "backupChance": 0.2,
+            "jammingField": true,
+            "cooldownSeconds": 180
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Beige plastic shell around a curved glass tube the size of a small kitchen sink, warming-up with a soft electrical smell and a faint coil-whine that settles into a comfortable pitch within a minute. The image comes up in four passes, and the geometry never quite aligns until the second or third minute.\n",
+      "lore": "Produced in runs of a few thousand by a factory that retooled for something else in the middle of the decade, which is why matched pairs are considered notable. Collectors prize the units for the phosphor mix, which ages in a way modern panels cannot reproduce, and for the small number of firmware revisions that included text rendering at half a scan-line. A monitor that has outlasted its user is often still running in the corner of the room they left it in.\n",
+      "ref": "retro-crt-monitor",
+      "key": 36,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRRC",
+      "name": "Retro CRT Monitor",
+      "type_flags": 410,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 4.8,
+      "buy_price": 200,
+      "durability": 750,
+      "level_requirement": 3,
+      "cooldown": 0,
+      "action": "access",
+      "bonuses": {
+        "terminalAccess": true,
+        "retroInterface": true,
+        "glitchImmunity": 1
+      },
+      "scripts": [
+        {
+          "guid": "fc0c8a95eb5f4e06ae0875c3b6e0c9cc",
+          "vars": {
+            "enableShell": true,
+            "displayMode": "8-bit",
+            "resolution": "320x240"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Single deep-red bloom on a long thorned stem, petals tight at the center and loosening outward, the scent rising softest on the second breath. Draws blood from a careless hand inside the first minute.\n",
+      "lore": "Cultivated in the walled gardens that the great houses keep for reasons nobody currently alive has had to justify out loud. Hedge-alchemists pay well for rose-hip and rose-oil, and the gardeners sell to them quietly, on the theory that the great houses have more roses than they actually look at. The thorn, like most old traditions, exists mainly to remind people which parts of the arrangement were not optional.\n",
+      "ref": "rose",
+      "key": 111,
+      "id": "01KMVPV9ZHZ93N2B6DB35FDJAM",
+      "name": "Rose",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 6,
+      "sell_price": 3,
+      "emoji": "🌹",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 6,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-rose"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Grey-brown mass of something that used to be food, texture somewhere between wet paper and old clay, smell at the outer edge of smells you can name without wincing. Nobody lifts the lid twice.\n",
+      "lore": "Terminal state of most perishables that sat too long in a pack, a cellar, or the forgotten corner of a supply shed. Can still be eaten in desperation, and the desperate eater learns why that clause sits on the last page of every field manual. Most households bury it, most armies compost it, and the apothecaries who collect it for study refuse to explain what they do with it afterwards.\n",
+      "ref": "rotten-food",
+      "key": 543,
+      "id": "01KTVTRAB100R0TTENF00D0001",
+      "name": "Rotten Food",
+      "type_flags": 8,
+      "rarity": "common",
+      "emoji": "🤢",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 0,
+      "sell_price": 0,
+      "tradeable": false,
+      "consumable": true,
+      "cooldown": 10,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "heals": -5,
+        "restore_energy": -10,
+        "perishable": false
+      }
+    },
+    {
+      "description": "Grey-green flesh that has given up its firmness in patches, the surface shiny in a way no fresh cut ever manages. The smell fills a tent before anyone has unwrapped the parcel, and stays in the cloth afterwards.\n",
+      "lore": "End-state of raw and cooked meat that missed its cook-by schedule, whether through forgetting, bad weather, or somebody's optimistic opinion about how long a pack would keep in the sun. Eating it is technically possible and universally regretted, and the field manuals that do not condemn it outright are written for situations the manuals would rather not describe. Most camps deal with it by pitching it into the fire, on the general principle that anything burned is no longer a problem.\n",
+      "ref": "rotten-meat",
+      "key": 545,
+      "id": "01KTVTRAB100R0TTENME4T0003",
+      "name": "Rotten Meat",
+      "type_flags": 8,
+      "rarity": "common",
+      "emoji": "🍖",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 0,
+      "sell_price": 0,
+      "tradeable": false,
+      "consumable": true,
+      "cooldown": 10,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "heals": -10,
+        "restore_energy": -20,
+        "perishable": false
+      }
+    },
+    {
+      "description": "Chunks of pale yellow curd suspended in a separated liquid the color of weak tea, stopper pushed partway out of the bottle by whatever is still fermenting inside. The smell announces itself through a closed pantry door.\n",
+      "lore": "What [fresh milk](/itemdb/fresh-milk/) becomes when the cellar runs warmer than the dairy intended or the delivery is forgotten on a hot afternoon. Cheesemakers find the very earliest stage of it interesting. Everybody further along the timeline finds it a disposal problem, and a bottle once past the curd stage is poured into the compost heap, which the compost heap will spend a week recovering from.\n",
+      "ref": "rotten-milk",
+      "key": 544,
+      "id": "01KTVTRAB100R0TTENM1KK0002",
+      "name": "Rotten Milk",
+      "type_flags": 8,
+      "rarity": "common",
+      "emoji": "🥛",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 0,
+      "sell_price": 0,
+      "tradeable": false,
+      "consumable": true,
+      "cooldown": 10,
+      "action": "consume",
+      "pool_group": "food",
+      "food": {
+        "heals": -8,
+        "restore_energy": -15,
+        "perishable": false
+      }
+    },
+    {
+      "description": "Cracked vulcanized rubber flexes stiffly under a boot, tread worn uneven on the inside shoulder the way tires go when the alignment was off for longer than anyone admitted. Smells of cold garage and the last summer that car actually ran.\n",
+      "lore": "Pulled off a sedan in the back lot of the salvage yard by a mechanic who keeps a running list of which tires came off which cars, in a notebook nobody else is allowed to touch. Useful as ballast, as swing support, as the base of a weight-rack for somebody's unfinished home gym, and in the late stages of neighborhood disputes nobody officially wants to own. A tire this old should not go back on a road, which is why the yard will not sell it with an axle.\n",
+      "ref": "rubber-tire",
+      "key": 24,
+      "id": "01JWCCEP0B8M6NPSXCW8XQPW6G",
+      "name": "Rubber Tire",
+      "type_flags": 412,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 7.2,
+      "buy_price": 90,
+      "durability": 600,
+      "level_requirement": 1,
+      "cooldown": 2,
+      "action": "salvage",
+      "bonuses": {
+        "tractionMaterial": true,
+        "bounceFactor": 0.2,
+        "burnable": true
+      },
+      "scripts": [
+        {
+          "guid": "afe31a1e0a7344b98b56a4e0c09b9ea1",
+          "vars": {
+            "usableIn": "vehicle",
+            "materialTags": "rubber",
+            "bouncePhysics": 0.2
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Full plate in tarnished steel, every surface carrying the shallow tracery of a rune-pattern that reads the same whether you face it or view it reflected. Cool against the inside of the padding, and slightly cooler against the outside of an incoming blade.\n",
+      "lore": "Forged to a discontinued ceremonial pattern in the last years of the Order of the Second Circle, before the Order's charter was split among three smaller guilds that have argued ever since over which one is the rightful heir. The runes are cut along the grain of the steel at the forge, not etched after, which is the detail that authenticates a piece to anyone who has handled one. Nobody has successfully scavenged a suit from a battlefield, and every attempted forgery has failed within the first serious engagement.\n",
+      "ref": "runeguard-plate",
+      "key": 97,
+      "id": "01KKR7QNRC5MQGKPW28R7FR2X6",
+      "name": "Runeguard Plate",
+      "type_flags": 514,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "buy_price": 220,
+      "emoji": "🛡️",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "chest",
+        "bonuses": {
+          "armor": 5,
+          "health": 5
+        },
+        "special": "thorns",
+        "special_value": 2
+      }
+    },
+    {
+      "description": "Short blade patchy with orange rust along the flat, edge ground thin by the last owner who cared, grip wrapped in brittle leather that has not been replaced this decade. Still takes an honest swing.\n",
+      "lore": "Came out of a trench sale at the eastern garrison's clearance week, priced below the value of the steel on the argument that the paperwork was missing. A careful afternoon with a stone and a rag will return it to service, and the smith down the lane will sharpen it for half the price of a new one. The scabbard is not original, which you can tell because the scabbard fits.\n",
+      "ref": "rusty-sword",
+      "key": 84,
+      "id": "01KKR7QNRCH0N5SPC9X86XRC96",
+      "name": "Rusty Sword",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "common",
+      "buy_price": 30,
+      "emoji": "⚔️",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 2
+        }
+      },
+      "recipes": [
+        {
+          "skill": "smithing",
+          "skill_level": 1,
+          "xp_reward": 20,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "copper-ore",
+              "amount": 3
+            },
+            {
+              "item_ref": "log",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Thick-bodied salmon with a slate-blue back and silver underside, scales still catching light like mail in the late afternoon. The flesh under the skin is coral-pink and cuts cleanly once the fish has rested.\n",
+      "lore": "Runs up the coast-rivers on a calendar the fishing families memorize before they learn to read. The nets go out at dawn and again at dusk, and the haul is sorted on the dock by size and condition, with the largest fish reserved for the smokehouse and the rest set for the evening markets. Arguing with a river-master over the quota is considered a short path to a long season in the cannery.\n",
+      "ref": "salmon",
+      "key": 1,
+      "id": "01JW0R6C62QK3WVJHR05XZ5K1T",
+      "name": "Salmon",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.4,
+      "buy_price": 6,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 5,
+      "action": "consume",
+      "bonuses": {
+        "health": 15
+      },
+      "scripts": [
+        {
+          "guid": "dd238a91353c4a1991cf275041730ab0",
+          "vars": {
+            "health": 15,
+            "duration": 5,
+            "tickRate": 1
+          }
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 86400,
+        "spoils_into_ref": "rotten-meat"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Long cloak in a black so deep it seems to absorb light, the weave refusing to show a clear pattern under any angle. Hems and lining run cool even on a warm evening, and the cloak does not rustle when it should.\n",
+      "lore": "Spun on a loom in the upper rooms of the weavers' guild by members who pay a small fee to the guild and a larger fee to somebody else. The thread is finished at night, outside, under whichever sky agrees to cooperate, and no two cloaks are alike in the small details that matter. Owners are advised to keep one lantern lit in the house at all times, on the theory that the cloak will otherwise extend its opinions into the room it was hung in.\n",
+      "ref": "shadow-cloak",
+      "key": 96,
+      "id": "01KKR7QNRC1W3SZRYP385BX2ST",
+      "name": "Shadow Cloak",
+      "type_flags": 514,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "buy_price": 85,
+      "emoji": "🧥",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "chest",
+        "bonuses": {
+          "armor": 3,
+          "attack": 1
+        }
+      }
+    },
+    {
+      "description": "Blade the color of wet slate, edges ground to a harder line than standard steel will take, hilt wrapped in black silk that has worn smooth at the grip points. Draws from the sheath with no sound worth mentioning.\n",
+      "lore": "Smithed in forges that work cold for the final temper, using a carbon source nobody in the profession seems willing to identify under oath. The dagger holds an edge through most of its owner's career and is passed, unregistered, to whoever cleans the owner's tools on the day they stop needing tools. Certain guilds will not permit the dagger at their tables, which is usually enough confirmation of the blade's reputation for anyone paying attention.\n",
+      "ref": "shadow-dagger",
+      "key": 85,
+      "id": "01KKR7QNRCCGPJS1BY1R6NEN8B",
+      "name": "Shadow Dagger",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "buy_price": 75,
+      "emoji": "🗡️",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 3,
+          "crit_chance": 0.05
+        },
+        "special": "crit_bonus",
+        "special_value": 0.05
+      }
+    },
+    {
+      "description": "Paper-wrapped ball the size of a tangerine, fuse trimmed short and dipped in wax, contents rattling faintly when shaken. Thrown hard enough to break the shell, it produces a dense grey cloud that refuses to clear on any breeze smaller than a gale.\n",
+      "lore": "Produced by the same guild of compounders that supplies stage-magicians, because the distinction between illusion and escape has always been more commercial than technical. The recipe calls for dry resin, iron filings, and a binder the guild will not print in the visitor's handbook. Keep the fuses dry; keep the bombs in separate pockets from the matches; do not run toward anyone immediately after throwing one, because the cloud looks identical on both sides.\n",
+      "ref": "smoke-bomb",
+      "key": 72,
+      "id": "01KKR7QNRCN8GS74B9NMC7DDDW",
+      "name": "Smoke Bomb",
+      "type_flags": 8704,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 1,
+      "rarity": "rare",
+      "buy_price": 120,
+      "emoji": "💨",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "guaranteed_flee"
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 20,
+          "xp_reward": 40,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "fly-agaric",
+              "amount": 2
+            },
+            {
+              "item_ref": "copper-ore",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Paper tray bent under the weight of corn chips buried in bright orange cheese sauce, scattered jalapeños, diced tomato, and a band of sour cream the cook added without asking. The first layer is warm; the deeper layers are hot enough to punish anyone who waits.\n",
+      "lore": "Built to order at a corner stand that posts its hours in grease-pencil on the front glass and keeps a hand-written hall of fame of the regulars who have finished a full tray in one sitting. The chili mix is ground twice a week in the back room, and the cook refuses to discuss the blend with anybody who asks twice. Eating standing is traditional; eating in a hurry is punished; eating in silence is respected.\n",
+      "ref": "spicy-nacho-supreme",
+      "key": 57,
+      "id": "01JX0YKWS3482FA3MBZ9EZQD31",
+      "name": "Spicy Nacho Supreme",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 0.6,
+      "buy_price": 125,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 70,
+      "action": "consume",
+      "bonuses": {
+        "health": 20,
+        "agility": 4,
+        "spiceTolerance": 2
+      },
+      "scripts": [
+        {
+          "guid": "e8c51214a153466b814a7e947d95323b",
+          "vars": {
+            "healAmount": 20,
+            "agilityBoost": 4,
+            "duration": 120
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Deep black bowl full of curly noodles in a broth so dark the underside of the soup-spoon comes up stained red. Chili oil collects at the surface in an inner ring, pickled bamboo leans against one wall, and the soft-boiled egg waits under a slice of pork that the cook cut thicker than usual tonight.\n",
+      "lore": "Served out of a single ramen-ya on a side alley that the cab drivers will drop you at without asking the address. The broth is kept going across days, refreshed with bones and fresh aromatics, never restarted, and the chili has been compounded to a level most visitors are not ready to commit to. First-timers are advised to finish the noodles before drinking the broth; regulars are advised to do whatever the cook nods at, because the cook is not in the habit of nodding at strangers.\n",
+      "ref": "spicy-ramen",
+      "key": 64,
+      "id": "01FC6AB642E4FA4FF6A771F20D",
+      "name": "Spicy Ramen",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "rare",
+      "weight": 0.8,
+      "buy_price": 150,
+      "durability": 1,
+      "level_requirement": 5,
+      "cooldown": 80,
+      "action": "consume",
+      "bonuses": {
+        "health": 25,
+        "fireResist": 5,
+        "bravery": 3
+      },
+      "scripts": [
+        {
+          "guid": "d6732c3b0f2e4bb6a8e0c6f47c77a7aa",
+          "vars": {
+            "healAmount": 25,
+            "fireResist": 5,
+            "braveryBoost": 3,
+            "duration": 150
+          }
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "cooking",
+          "skill_level": 10,
+          "xp_reward": 30,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "salmon",
+              "amount": 1
+            },
+            {
+              "item_ref": "allium",
+              "amount": 1
+            }
+          ]
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Heavy plate worn over padded gambeson, the outer face studded with iron spikes set a hand apart in a grid that refuses to soften for the wearer's silhouette. Moving the arms shifts the spikes in a way nobody nearby is allowed to forget.\n",
+      "lore": "A pattern out of the northern fortress-tradition, worn by the sergeants who fight the front of a shield-line because a backing rank pressed too close will learn why the spikes are there. The plates are forged as a set, and a matched suit is accompanied by a small bundle of spare spikes, since anything driven hard enough into an enemy tends not to come back with the owner. Tailors refuse the commissions for travel cloaks that go over the suit, on the reasonable grounds that tailoring is not supposed to be a contact sport.\n",
+      "ref": "spiked-plate",
+      "key": 94,
+      "id": "01KKR7QNRCF2PAF55RNCVZ5H5S",
+      "name": "Spiked Plate",
+      "type_flags": 514,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "rare",
+      "buy_price": 200,
+      "emoji": "🛡️",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "chest",
+        "bonuses": {
+          "armor": 5
+        },
+        "special": "thorns",
+        "special_value": 3
+      }
+    },
+    {
+      "description": "Human-proportioned skull recast in pale wax around a wick set down through the cranial vault, the teeth standing individually from the jaw on small ivory pegs that the sculptor would rather you did not ask about. Flame sits low in the mouth and throws the orbital shadows upward.\n",
+      "lore": "Cast in a studio above a flower shop by a chandler who trained under a funeral-director and eventually lost her nerve for arrangements. Lit candles are said to flicker in the presence of strong feelings, which the chandler describes as a feature of the wick-blend and which her customers describe as something else entirely. Buyers are advised to keep a mirror out of the candle's direct line, on general principles and also on the specific principle that returns are not accepted.\n",
+      "ref": "spooky-skull-candle",
+      "key": 14,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRSC",
+      "name": "Spooky Skull Candle",
+      "type_flags": 402,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 1.1,
+      "buy_price": 275,
+      "durability": 240,
+      "level_requirement": 3,
+      "cooldown": 30,
+      "action": "illuminate",
+      "bonuses": {
+        "lightRadius": 4,
+        "detectSpirits": true,
+        "warningFlicker": true
+      },
+      "scripts": [
+        {
+          "guid": "caa98fef44bc41e49ae2399823fcb077",
+          "vars": {
+            "lightRadius": 4,
+            "spiritDetection": "minor",
+            "flickerOnPresence": true,
+            "cooldown": 30
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Stacked steel-plate hive body on a galvanized base, each super finished in matte enamel and numbered along the back plate. Buzzes softly at a pitch no carpenter would accept in a wooden hive, which the beekeepers find reassuring.\n",
+      "lore": "Designed at the agricultural station on the northern campus, by engineers who wanted a hive the moths would stop ruining and the beekeepers would stop having to rebuild every third year. The steel warms slower than wood, which changes the bees' daily schedule by about twenty minutes, which in turn changes the flavor of the honey in ways that the beekeepers argue over at conference. Every hive ships with a small, unexplained bell that is permitted to rattle inside the top super and must never be removed.\n",
+      "ref": "steel-beehive",
+      "key": 15,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRBH",
+      "name": "Steel Beehive",
+      "type_flags": 403,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "common",
+      "weight": 6.8,
+      "buy_price": 700,
+      "durability": 1200,
+      "level_requirement": 4,
+      "cooldown": 300,
+      "action": "deploy",
+      "bonuses": {
+        "honeyYield": 3,
+        "waxYield": 2,
+        "harvestInterval": 300
+      },
+      "scripts": [
+        {
+          "guid": "eec189cc32a249bcbcb23bdee61a889d",
+          "vars": {
+            "honeyOutput": 3,
+            "waxOutput": 2,
+            "cooldownSeconds": 300,
+            "tag": "harvestable"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Rectangular block of dressed limestone, all six faces squared with a chisel and dusted pale from the finishing pass, corners sharp enough to mark a pencil drawn across them. Heavy in a way that forearms learn before they argue about it.\n",
+      "lore": "Quarried out of the shelf above the river road by crews who rotate between wet-blasting and dry-cutting depending on the week's rainfall. The blocks move downriver on barges under a schedule the quarrymaster publishes nowhere, because the upstream yards would buy out the summer's output in a morning if the schedule leaked. Masons grade the stock by ring, and the old masters can tell which bed a block came from by the way the chisel answers.\n",
+      "ref": "stone-block",
+      "key": 535,
+      "id": "01KPTSDW07P99SD1Z3550Z6SA6",
+      "name": "Stone Block",
+      "type_flags": 1088,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 200
+    },
+    {
+      "description": "Fist-sized lump of grey stone with fresh hammer-marks along the edges, cold in the hand, dense in a way that makes the first carry shorter than you planned. Smells faintly of the dust the break produced.\n",
+      "lore": "Broken from the tumble-slopes below the quarries by scavenger crews paid by the load, and sold to the village smiths and masons who cannot justify a full quarry delivery for their weekly work. A single good stone does the job of half a wall-brick, which is the quiet arithmetic on which every backyard outbuilding has ever been assembled.\n",
+      "ref": "stone",
+      "key": 100,
+      "id": "01KMVPV9ZHPBRJZZEN7C0Q9R4Q",
+      "name": "Stone",
+      "type_flags": 384,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 64,
+      "rarity": "common",
+      "buy_price": 3,
+      "sell_price": 1,
+      "emoji": "🪨",
+      "weight": 3,
+      "skilling": {
+        "skill": "mining",
+        "xp_reward": 8,
+        "gather_time": 2,
+        "respawn_time": 25,
+        "resource_node": "boulder"
+      },
+      "tags": [
+        "isometric"
+      ],
+      "compress": {
+        "target_ref": "stone-block",
+        "ratio": 100
+      },
+      "stacking": {
+        "pack_max": 6
+      }
+    },
+    {
+      "description": "Heavier ash shaft with a chipped flint or sharpened stone head lashed to it with sinew. Slow off the string but it punches through plank shields and rattles teeth behind a chestplate. Fletchers grumble about the weight; sergeants order them anyway.\n",
+      "lore": "The oldest arrow pattern in the kingdom. Predates ironworking; survives because nothing else in the militia kit puts a heavy man on his back at thirty paces for the cost of a knapped pebble. Apprentice quarrymen knap broken-tile heads on slow shifts and trade them for bowstring — an unofficial economy the guild has tried and failed to tax three times.\n",
+      "ref": "stonehead-arrow",
+      "key": 562,
+      "id": "01KTVTRAB1STONEHEAD0000000562",
+      "name": "Stonehead Arrow",
+      "type_flags": 576,
+      "rarity": "common",
+      "emoji": "🏹",
+      "stackable": true,
+      "max_stack": 50,
+      "buy_price": 2
+    },
+    {
+      "description": "Head the diameter of a saucepan riding on a stem taller than most children, petals golden at the outer ring and fading to rust where the seed-pack begins. Leans visibly toward the afternoon sun in a way that makes the whole field look like it is listening to the same story.\n",
+      "lore": "Farmed as a border crop and a seed crop and occasionally an excuse crop, because a field of sunflowers is the one thing the tax assessor will not inspect too closely. Seed-pressers take the heads at the end of summer and render oil in quantities the village can actually afford. The old saying that a sunflower always faces the sun gets tested twice a generation by contrarians, who fail to produce one that does otherwise without noticeable intervention.\n",
+      "ref": "sunflower",
+      "key": 110,
+      "id": "01KMVPV9ZHQSEG1JXEWWJY2WKV",
+      "name": "Sunflower",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 5,
+      "sell_price": 2,
+      "emoji": "🌻",
+      "weight": 0.15,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 6,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-sunflower"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Eight-foot plank of pale laminated wood, nose rounded and tail squared, deck faintly waxed and slightly tacky under a bare foot. Runs quiet on smooth boardwalk, hums on sand, and chatters on anything metal.\n",
+      "lore": "Shaped in a garage at the end of the coast road by a retired fisherman who started the hobby to keep his hands busy and discovered, three boards in, that he was better at shaping than at fishing. Each board carries a small date on the underside and a initial he changes depending on which ocean he was thinking about that week. The shop takes no commissions, keeps no inventory, and sells through a hand-painted sign that reads IF IT IS HERE IT IS FOR SALE.\n",
+      "ref": "surfer-longboard",
+      "key": 54,
+      "id": "01JWJGC4NYQ7K4MW6YBVD6GYQ5",
+      "name": "Surfer Longboard",
+      "type_flags": 4096,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 4,
+      "buy_price": 220,
+      "durability": 180,
+      "level_requirement": 3,
+      "cooldown": 8,
+      "action": "equip",
+      "bonuses": {
+        "speed": 1.15,
+        "waterAffinity": true,
+        "stylePoints": true
+      },
+      "scripts": [
+        {
+          "guid": "bdf9fa9a29c94492a409c6a3abf0833f",
+          "vars": {
+            "speedMultiplier": 1.15,
+            "buffDuration": 120,
+            "traits": "tidal-grace"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Pale cream wedge cut from a wheel large enough to have its own address, shot through with round eyes from pinhole-small to knuckle-wide. Smells mild on the draw, stays on the palate longer than any of the sharper cheeses on the same board.\n",
+      "lore": "Made in the mountain dairies where the cows spend summers on the high pasture and winters in the long sheds below the snow-line, to a recipe the dairymaster guards with a smile that dares anybody to ask again. The eyes are produced by a specific culture that the dairymaster will confirm, and a specific pause in the press that he will not. Every cave in the dairy has its own numbering system, and every wheel that comes out has a story that only the cave-master can explain.\n",
+      "ref": "swiss-cheese",
+      "key": 37,
+      "id": "01JWG6FTDT249H8AGN439GEXQQ",
+      "name": "Swiss Cheese",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.5,
+      "buy_price": 55,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 30,
+      "action": "consume",
+      "bonuses": {
+        "health": 20,
+        "focus": 2,
+        "rodentAffinity": true
+      },
+      "scripts": [
+        {
+          "guid": "dc19274fa1914cc69a5c7b3dbb5e12f1",
+          "vars": {
+            "healAmount": 20,
+            "focusBoost": 2,
+            "npcAffinity": "rodent",
+            "duration": 120
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Paper bag printed with a gridded sunset and a chrome logo that faded the moment the bag left the fryer, contents still warm and faintly oil-spotted at the corners. The flavor profile is butter, then salt, then something the packager calls proprietary citrus finish.\n",
+      "lore": "Popped in commercial volume at a converted laundromat on the west side, using a kettle the owner bought from a liquidation auction and an oil blend that one assistant quietly reformulates every season. Sold almost exclusively at arcades, skating rinks, and any venue whose marquee is unironically neon, in the polite understanding that anywhere else the bag looks wrong. Every third bag comes with a sticker nobody has ever scanned and everybody has kept.\n",
+      "ref": "synthwave-popcorn",
+      "key": 63,
+      "id": "01JX5620BTQ558YAXW4704SRG5",
+      "name": "Synthwave Popcorn",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.5,
+      "buy_price": 75,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 30,
+      "action": "consume",
+      "bonuses": {
+        "stamina": 15,
+        "morale": 3
+      },
+      "scripts": [
+        {
+          "guid": "baf123abc7890defbaf123abc7890def",
+          "vars": {
+            "staminaGain": 15,
+            "moraleBoost": 3,
+            "duration": 60
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Palm-sized disc of dark schist inscribed with a single concentric pattern that reads the same rotated any quarter-turn, faintly warm at the center and cold along the edge. Breaking the disc sends the holder and everything in contact home by the shortest path the magic can justify.\n",
+      "lore": "Cut and carved by the travel-cartel that rotates through the southern temples on a schedule nobody outside the cartel has ever reliably predicted. Each rune is keyed at the time of purchase to a specific city gate, using a procedure the cartel describes as administrative and the buyer describes as uncomfortable. Used runes shatter rather than discharge, and the shards are collected and turned in, because the cartel has opinions about shards in the wrong hands.\n",
+      "ref": "teleport-rune",
+      "key": 78,
+      "id": "01KKR7QNRC3336DJ0D3SJA8SA7",
+      "name": "Teleport Rune",
+      "type_flags": 10752,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 1,
+      "rarity": "rare",
+      "buy_price": 200,
+      "emoji": "🌀",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "teleport_city"
+        }
+      ]
+    },
+    {
+      "description": "Crisp flatbread base bowing under a full top layer of refried beans, chili-flecked ground beef, jalapeños, shredded cheese, and a parting handful of cilantro the cook flung from too far away. The whole pizza arrives at the table still spitting oil in two visible places.\n",
+      "lore": "Invented by argument at a crossroads diner where the line cook for the Mexican side and the line cook for the Italian side got tired of telling customers to pick one, and it has settled into the menu at every diner downstream ever since. Traditionalists from either tradition walk out when it is ordered, which is how most regulars know who the tourists are. Served only at late hours, on the theory that nothing about the pizza belongs to anybody sober enough to be offended by it.\n",
+      "ref": "tex-mex-pizza",
+      "key": 33,
+      "id": "01JWFZW7DF410GYBT5202S753D",
+      "name": "Tex-Mex Pizza",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "uncommon",
+      "weight": 0.7,
+      "buy_price": 110,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 75,
+      "action": "consume",
+      "bonuses": {
+        "health": 30,
+        "speed": 6
+      },
+      "scripts": [
+        {
+          "guid": "a7b459f6f19149f0b1d3a4c50e4e9981",
+          "vars": {
+            "healAmount": 30,
+            "speedBoost": 6,
+            "duration": 150
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Pink-smoke ring deep as a finger around the outside of the cut, bark the color of old leather, fat rendered clear enough to pool along one edge of the slicing-board. Pulls apart under a fork without needing a knife to ask twice.\n",
+      "lore": "Smoked in an offset pit the cook built from a steel drum and half a trailer axle, fired with a mix of oak and pecan that his father did not approve of and his uncle did. The brisket goes on the pit at two in the morning and comes off when the cook says it comes off, which is never earlier than four in the afternoon. The sauce is served on the side, always, because the cook takes the view that putting sauce on the meat before the eater has tasted the meat is an insult to every hour of the smoke.\n",
+      "ref": "texas-bbq-brisket",
+      "key": 34,
+      "id": "01JWG0HJSK6K77SAKSRC31VH4T",
+      "name": "Texas BBQ Brisket",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "rare",
+      "weight": 1.3,
+      "buy_price": 160,
+      "durability": 1,
+      "level_requirement": 2,
+      "cooldown": 90,
+      "action": "consume",
+      "bonuses": {
+        "health": 60,
+        "strength": 8,
+        "morale": 5
+      },
+      "scripts": [
+        {
+          "guid": "c34bcb0f22164804b930fa4cd9e9cfeb",
+          "vars": {
+            "healAmount": 60,
+            "strengthBoost": 8,
+            "moraleBoost": 5,
+            "duration": 180
+          }
+        }
+      ],
+      "food": {
+        "perishable": true,
+        "shelf_life_seconds": 172800,
+        "spoils_into_ref": "rotten-food"
+      },
+      "hasImg": true
+    },
+    {
+      "description": "Bundle of planed boards the length of an oar, banded in two places with iron strapping, end-grain stamped with the mill's mark in red ink that has half-faded under the rain. Smells of resin and the saw-shed it left.\n",
+      "lore": "Cut and kiln-dried at the river mill in runs of a hundred boards each, under a grading system the old mill-master refuses to change because it was his father's. Every board that passes is matched to a second board of similar character, and only sold in pairs, on the theory that a single board rarely solves a problem on its own.\n",
+      "ref": "timber",
+      "key": 534,
+      "id": "01KPTSDW07B9QT3E497K5D97A6",
+      "name": "Timber",
+      "type_flags": 1088,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 300
+    },
+    {
+      "description": "Deep red sauce slow-reduced to the thickness that coats a wooden spoon without running off the back, flecked with the fine chop of garlic and oregano that the cook added in three passes across an afternoon. Smells the entire house into the kitchen whether the kitchen is ready or not.\n",
+      "lore": "Put up every August in glass jars by a family that processes more tomatoes in a single weekend than the rest of the block uses in a year, then traded through the winter at a discount rate that is never written down. The recipe uses no sugar, and the matriarch will tell you so twice if you ask about it once. Pasta night at that household seats ten, and the tenth chair is reserved for whoever turns up without being asked, which is considered a quiet kind of compliment.\n",
+      "ref": "tomato-pasta-sauce",
+      "key": 39,
+      "id": "01JWG51QXSF2QB8G743A60W5TV",
+      "name": "Tomato Pasta Sauce",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "common",
+      "weight": 0.9,
+      "buy_price": 70,
+      "durability": 1,
+      "level_requirement": 0,
+      "cooldown": 40,
+      "action": "consume",
+      "bonuses": {
+        "health": 22,
+        "crafting": true,
+        "warmth": 1
+      },
+      "scripts": [
+        {
+          "guid": "fba1237c9b3e423f930fcb84e9e82314",
+          "vars": {
+            "healAmount": 22,
+            "warmthBoost": 1
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Flat wooden case the size of a small book, interior fitted out with a single serrated jaw, a spring under enough tension that the case warns the user with a small paper label. Opens only with a specific pin that comes attached to the outside of the case by a short cord.\n",
+      "lore": "Built up in lots of thirty by the same workshop that stocks the hunters' guild, in two grades that the guild politely pretends are not actually the same trap painted different colors. Field-deployed correctly, the kit will take the weight of the heaviest pursuer without moving the stake, and a surprising number of first-deployment failures are the result of hobbyists skipping the anchor line. Veterans buy them in twos and deploy them in pairs, always.\n",
+      "ref": "trap-kit",
+      "key": 76,
+      "id": "01KKR7QNRCECPB1TANAW22C8B2",
+      "name": "Trap Kit",
+      "type_flags": 8704,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 2,
+      "rarity": "uncommon",
+      "buy_price": 55,
+      "emoji": "🪤",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "apply_effect",
+          "status_effect": "thorns",
+          "stacks": 5,
+          "turns": 2
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 10,
+          "xp_reward": 25,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "iron-ore",
+              "amount": 2
+            },
+            {
+              "item_ref": "log",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Cup-shaped bloom on a straight green stem, petals closed tight before the sun and opening wider than expected once the light is on them. Carries no scent worth describing, which every tulip-grower insists is the point.\n",
+      "lore": "Cultivated in long rows across the lowland fields east of the market town, where the bulb-families have been trading cultivars since a speculative bubble centuries back that the historians still argue was either a ruinous mania or a useful one. Every household knows at least one variety by name, and nobody will tell you whose garden it came from without a preamble. The cut flowers keep a week in clean water and a decade in the tax records of whoever bought the bulbs.\n",
+      "ref": "tulip",
+      "key": 105,
+      "id": "01KMVPV9ZHDT45T6PYS5PH82F7",
+      "name": "Tulip",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 4,
+      "sell_price": 2,
+      "emoji": "🌷",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 5,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-tulip"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Bone faintly yellowed at the eye sockets, teeth still seated in the jaw, a single crack running up the parietal that has closed again in a way bone is not supposed to close. Stays warm at the temples even after an hour on a cold shelf.\n",
+      "lore": "Gathered from the boneyards outside the temple of reclamation, in the small number each season that the priests decline to burn because the bone has not yet finished whatever it was still doing. Scholars pay for them by the piece, against paperwork that is easy for the scholar and deliberately awkward for the seller. A skull that rattles quietly when set down is considered desirable by exactly one buyer, and that buyer does not take appointments.\n",
+      "ref": "undead-humanoid-skull",
+      "key": 10,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRSK",
+      "name": "Undead Humanoid Skull",
+      "type_flags": 398,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 2.3,
+      "buy_price": 220,
+      "durability": 666,
+      "level_requirement": 3,
+      "cooldown": 0,
+      "action": "ritual",
+      "bonuses": {
+        "necroAffinity": true,
+        "boneDustYield": 5,
+        "ritualPower": 0.4
+      },
+      "scripts": [
+        {
+          "guid": "ae331c1f28b94be2afdabf3e5b82d992",
+          "vars": {
+            "yieldType": "bone_dust",
+            "yieldAmount": 5,
+            "ritualPower": 0.4,
+            "necroTrigger": true
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Small brass key with an unfamiliar ward cut at the tip, bow engraved with a glyph that matches no registry in the locksmith's current book. Warm to the fingertip, a little heavier than the brass should allow.\n",
+      "lore": "Found in the accepted places keys turn up, namely inside coat pockets the owner does not remember putting anything in, and at the bottom of drawers the owner does not remember opening. The locksmith on the main street keeps a slim folder of rubbings against which new keys are compared, and this pattern has never matched. Carrying one is not discouraged by the guild; returning one to the guild, however, is.\n",
+      "ref": "unknown-key",
+      "key": 539,
+      "id": "01KPTSDW07T9QKWJESCF5ZTQP4",
+      "name": "Unknown Key",
+      "type_flags": 4096,
+      "rarity": "rare",
+      "emoji": "🗝️",
+      "stackable": true,
+      "max_stack": 10,
+      "buy_price": 0
+    },
+    {
+      "description": "Rolled vellum held by a cord and a disc of wax the color of dried blood, seal pressed with a glyph that does not appear in the current registry. Dry along the outside, faintly damp along the inside edge where the cord has stayed in contact.\n",
+      "lore": "Turned in to the guildhall on a steady, quiet basis by clerics who find them in the estates of recently-departed patrons and prefer to send them somewhere official before the family starts asking questions. Reading one requires breaking the seal, and breaking the seal on an unidentified scroll is considered an act of self-interested optimism by everybody except the scholar conducting it.\n",
+      "ref": "unknown-scroll",
+      "key": 540,
+      "id": "01KPTSDW07JFD82CPTS4EB40NW",
+      "name": "Unknown Scroll",
+      "type_flags": 2048,
+      "rarity": "rare",
+      "emoji": "📜",
+      "stackable": true,
+      "max_stack": 10,
+      "buy_price": 0
+    },
+    {
+      "description": "Thick book bound in a dark grey cloth that does not quite match any of the known binderies' stock, pages edged with a faint silver that catches the light only from the book's own angle. Opens with a stiffness that seems to test the reader's intent.\n",
+      "lore": "Kept under restricted circulation at the library of the northern academy, on the strength of a ruling that the book's contents are considered researchable only by members who have held full tenure for at least a decade. The librarians rotate the shelf it sits on every season, on the quiet theory that the tome prefers company. Nobody currently on staff will confirm having read the full volume, and the visiting scholars have stopped politely asking.\n",
+      "ref": "unknown-tome",
+      "key": 541,
+      "id": "01KPTSDW078WM7JFEZSPE2MNRH",
+      "name": "Unknown Tome",
+      "type_flags": 2048,
+      "rarity": "epic",
+      "emoji": "📖",
+      "stackable": true,
+      "max_stack": 5,
+      "buy_price": 0
+    },
+    {
+      "description": "Dark crimson sparkling wine in a heavy glass bottle the vintner's family has been reusing for three generations, foil blackened at the neck, cork scored with a single hidden mark along the underside. Bubbles hold considerably longer in the flute than any mundane champagne has any business managing.\n",
+      "lore": "Produced in a basement cellar off a private drive where the grapes are pressed at night, on the public claim that the cellar's temperature cycle is steadier after dark. A single drop of something the vintner will not disclose goes into each cask at bottling, from a small green vial that is refilled by someone the vintner's staff have never been permitted to see directly. The wine ages well, pairs unfortunately with silver, and is best served to guests whose family histories the host has already researched.\n",
+      "ref": "vampire-blood-champagne",
+      "key": 51,
+      "id": "01JWJC0PYN7P81PD279GGNVYA4",
+      "name": "Vampire Blood Champagne",
+      "type_flags": 400,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "epic",
+      "weight": 1,
+      "buy_price": 1000,
+      "durability": 1,
+      "level_requirement": 10,
+      "cooldown": 180,
+      "action": "consume",
+      "bonuses": {
+        "health": 100,
+        "charisma": 3,
+        "haltAging": true
+      },
+      "scripts": [
+        {
+          "guid": "8dc2aa7c8f1f4dd6b95f28a61db5123e",
+          "vars": {
+            "buffDuration": 240,
+            "traits": "blood-euphoric'"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Deep red gelato scooped into a small black cup, topped with a single candied berry that the shop positions at the exact center every time, spoon resting at an angle the shop-owner prefers. Stays colder in the hand than the glass can justify.\n",
+      "lore": "Churned in small batches at a storefront that opens only in the evening and posts no menu, from a base the proprietor calls her own blend and the regulars have stopped asking about. The candied topping is made in-house on a marble slab, turned with a thin wooden paddle that has a single name carved into the handle. Nobody has complained about the flavor in eleven years of operation, which the proprietor considers a manageable kind of reputation.\n",
+      "ref": "vampire-blood-gelato",
+      "key": 52,
+      "id": "01JWJCC6PEH1BFGXGTD6ETW0TV",
+      "name": "Vampire Blood Gelato",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": false,
+      "rarity": "epic",
+      "weight": 0.8,
+      "buy_price": 600,
+      "durability": 1,
+      "level_requirement": 7,
+      "cooldown": 90,
+      "action": "consume",
+      "bonuses": {
+        "health": 50,
+        "mana": 40,
+        "darkResist": 15
+      },
+      "scripts": [
+        {
+          "guid": "ea539c07b0cb43da9fa5f6db3fbc7db1",
+          "vars": {
+            "buffDuration": 120,
+            "traits": "blood-infused"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Slim longsword the color of cold iron, blade scored with a hairline groove that runs the whole length of the edge and carries a thin, dark residue no solvent has yet dried off. Grip wrapped in silk that has darkened along one side from something more than sweat.\n",
+      "lore": "Forged in a brief window during the reign of a monarch whose name was struck from the public registers, by a smith whose apprentices either did not outlive their terms or did not choose to keep the trade. Every serious scholar of cursed weaponry agrees on the first fact about the blade and disagrees about the rest. The current holder is required, by the private codicil of whoever sold them the sword, to pass it on before their hair grays entirely, and nobody has yet tested the consequences of refusing.\n",
+      "ref": "vampiric-blade",
+      "key": 87,
+      "id": "01KKR7QNRCAJDADA45HXS0KGWF",
+      "name": "Vampiric Blade",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "epic",
+      "buy_price": 350,
+      "emoji": "🩸",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 3
+        },
+        "special": "life_steal",
+        "special_value": 0.2
+      }
+    },
+    {
+      "description": "Black plastic cassette with the reels wound tight and the tabs both still intact, the front label scraped off by a fingernail a long time before it came into your hands. Shake it gently and the tape shifts at a pitch just off true, which is the one note of warning the object offers.\n",
+      "lore": "Traded through the remaining resale shops in the neighborhoods that kept their shelves stocked past the fashionable years, usually in unlabeled lots of five or six. Playing the tape requires an honest deck, an honest deck is difficult to find, and the tape has a way of making the deck sound worse afterward for anything else you play. Collectors who own more than one copy have learned not to store them on the same shelf.\n",
+      "ref": "vhs-tape",
+      "key": 26,
+      "id": "01JWCWCH9FEJXHMW48JYJ94Q8F",
+      "name": "VHS Tape",
+      "type_flags": 414,
+      "consumable": false,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.5,
+      "buy_price": 30,
+      "durability": 150,
+      "level_requirement": 1,
+      "cooldown": 0,
+      "action": "play",
+      "bonuses": {
+        "memoryArtifact": true,
+        "analogSignal": true,
+        "distortionEffect": 0.2
+      },
+      "scripts": [
+        {
+          "guid": "cc910ee42e5a4a5c9f7e1e5a8d309ba7",
+          "vars": {
+            "contentTags": "signal",
+            "staticDistortion": 0.2,
+            "playbackTriggers": "signal"
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Deeper red than the basic potion and thicker on the pour, the vial sealed with wax and pressed with a small fleur that marks the apothecary who bottled it. Takes longer to go down and longer to work, and the work is noticeably more honest.\n",
+      "lore": "Brewed in the back of a handful of apothecaries who are certified for the heavier recipes, under inspections that the guild conducts unannounced and the apothecaries pretend not to schedule around. A full vial will close a wound a basic potion would have scarred, which makes the premium worth it to anyone planning a second engagement in the same week. Carrying more than two is considered bad luck by the veterans, for reasons the veterans have stopped explaining to recruits.\n",
+      "ref": "vitality-potion",
+      "key": 79,
+      "id": "01KKR7QNRCYBZP4ZZ0WCCBBKA4",
+      "name": "Vitality Potion",
+      "type_flags": 544,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 3,
+      "rarity": "uncommon",
+      "buy_price": 60,
+      "emoji": "💊",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "heal",
+          "amount": 25
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "alchemy",
+          "skill_level": 10,
+          "xp_reward": 35,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "rose",
+              "amount": 2
+            },
+            {
+              "item_ref": "porcini",
+              "amount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Pink-orange sauce with an even gloss, the cream visibly mixed but not quite disappeared, the faint heat of alcohol still present on the second breath over the pan. Coats pasta like it was designed for the job, because the cook who invented it was a pasta cook first.\n",
+      "lore": "Codified at a trattoria that closed during the city-center renovations of the previous decade, at which point the chef retired rather than reopen at higher rent. The vodka is burned off imperfectly on purpose, because the point is the texture change, not the alcohol, and every serious cook in the neighborhood can tell whose kitchen skipped that step. A pan of it is the quiet way of apologizing to somebody you have inconvenienced without explicitly admitting to it.\n",
+      "ref": "vodka-sauce",
+      "key": 40,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRVK",
+      "name": "Vodka Sauce",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 1,
+      "buy_price": 95,
+      "durability": 1,
+      "level_requirement": 1,
+      "cooldown": 50,
+      "action": "consume",
+      "bonuses": {
+        "health": 28,
+        "fireBuff": true,
+        "cookingBoost": 2
+      },
+      "scripts": [
+        {
+          "guid": "ebf7925d2ce24b06b4b9a2232b7349c7",
+          "vars": {
+            "healAmount": 28,
+            "elementalFlavor": "fire",
+            "unlockRecipeTags": "pasta",
+            "duration": 150
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Clear as window glass in a squat bottle with a waxed paper label, the seal intact, the cap threaded tight enough that it breaks the pour on the first half-turn. Colder in the hand than the room it was brought in from, which the bar regulars take as confirmation of the distiller's claim.\n",
+      "lore": "Run out of a small distillery behind the granary, using grain that fails the baker's standard and would otherwise go to feed. The master's single rule is that nothing flavored leaves the still under his name, which has held across two sons and a difficult nephew. A bottle on the shelf above the bar is the house's quiet vote of confidence in the bartender, and a bottle in the private drawer is the bartender's vote of confidence in a regular.\n",
+      "ref": "vodka",
+      "key": 42,
+      "id": "01JWG6H44RKRK9TKTHNGRNMA2N",
+      "name": "Vodka",
+      "type_flags": 392,
+      "consumable": true,
+      "stackable": true,
+      "rarity": "uncommon",
+      "weight": 0.8,
+      "buy_price": 120,
+      "durability": 1,
+      "level_requirement": 2,
+      "cooldown": 60,
+      "action": "consume",
+      "bonuses": {
+        "strength": 3,
+        "health": 15,
+        "damageResistance": 2,
+        "focus": -1
+      },
+      "scripts": [
+        {
+          "guid": "a238f44a1e8c4d54b21c42a6c4f78b66",
+          "vars": {
+            "buffDuration": 120
+          }
+        }
+      ],
+      "hasImg": true
+    },
+    {
+      "description": "Long curved blade set on a shaft of iron-bound black wood, the metal of the head drinking light at any angle you care to hold it and refusing to shine. Rests across the shoulder with a weight distribution that never quite settles into a comfortable carry.\n",
+      "lore": "Neither forged nor smelted in any recorded workshop, the scythe first enters the registry in the inventory of a baron who refused to say how he had come by it and refused, also, to let it out of his sight. The blade has passed through six named owners since, five of whom retired to quiet livings that excluded visitors. The sixth is still active, and the academy of weaponry would prefer the sixth to stop writing them letters about it.\n",
+      "ref": "void-scythe",
+      "key": 91,
+      "id": "01KKR7QNRCF2G0B210XXC8HSVA",
+      "name": "Void Scythe",
+      "type_flags": 513,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "legendary",
+      "buy_price": 1200,
+      "emoji": "🌀",
+      "action": "equip",
+      "tags": [
+        "discordsh"
+      ],
+      "equipment": {
+        "slot": "main_hand",
+        "bonuses": {
+          "attack": 7
+        },
+        "special": "life_steal",
+        "special_value": 0.15
+      }
+    },
+    {
+      "description": "Pendant of cold silver braided through three short hairs the charm-maker will not identify, hung on a plain leather thong. Warms on the skin the moment a strong intent is directed at the wearer, and cools again the moment it passes.\n",
+      "lore": "Braided in small batches by a handful of practitioners who trained at the old southern cloister and maintain their own informal registry of who is permitted to sell which tier of charm. A ward of this grade will turn one serious attempt and leave the wearer's skin prickly for an hour afterward, at which point the charm is considered spent. Secondhand wards are treated with suspicion, because the registry of consumed pendants is not quite as complete as the registry of consumed charms.\n",
+      "ref": "ward",
+      "key": 70,
+      "id": "01KKR7QNRCT4AA6ZG8P0Z37NM0",
+      "name": "Ward",
+      "type_flags": 2592,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 2,
+      "rarity": "rare",
+      "buy_price": 80,
+      "emoji": "🧿",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "apply_effect",
+          "status_effect": "shielded",
+          "stacks": 1,
+          "turns": 2
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 15,
+          "xp_reward": 35,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "crystal-ore",
+              "amount": 1
+            },
+            {
+              "item_ref": "lavender",
+              "amount": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Palm-sized rectangle of fine grey stone, one face wet and one face dry, the wet face already carrying the slurry of a morning's work. Sings softly under a blade held at the correct angle, and refuses to sing under one that is not.\n",
+      "lore": "Cut from a specific shelf of quarry stock that the sharpening-trade has claimed since before the current guild was chartered, in sizes that the trade considers non-negotiable. A veteran's stone is identifiable by the wear along its center, and the wear tells you what the veteran's primary weapon has been. A fresh stone gifted to a younger fighter is, by tradition, signed on the underside by the giver, because a stone with a signature tends to travel better than a stone without.\n",
+      "ref": "whetstone",
+      "key": 74,
+      "id": "01KKR7QNRCB0P53ECK35DY6AZQ",
+      "name": "Whetstone",
+      "type_flags": 8704,
+      "consumable": true,
+      "stackable": true,
+      "max_stack": 2,
+      "rarity": "uncommon",
+      "buy_price": 40,
+      "emoji": "🪨",
+      "action": "consume",
+      "tags": [
+        "discordsh"
+      ],
+      "use_effects": [
+        {
+          "type": "apply_effect",
+          "status_effect": "sharpened",
+          "stacks": 1,
+          "turns": 3
+        }
+      ],
+      "recipes": [
+        {
+          "skill": "crafting",
+          "skill_level": 5,
+          "xp_reward": 15,
+          "output_quantity": 1,
+          "ingredients": [
+            {
+              "item_ref": "stone",
+              "amount": 2
+            },
+            {
+              "item_ref": "copper-ore",
+              "amount": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "description": "Small multi-petaled bloom on a thin stem, color varying through every lot the forager brings in, root-clump still carrying a pinch of the meadow it came out of. Smells vaguely green, vaguely sweet, entirely unremarkable in the best possible way.\n",
+      "lore": "Foraged from whichever stretch of untended ground is currently producing, with the understanding that the definition of untended ground shifts every summer. Herbalists buy them in bulk, sort them by hand, and then insist to outsiders that sorting by hand is not a practical use of a herbalist's time, which is the first lesson any apprentice learns to ignore.\n",
+      "ref": "wildflower",
+      "key": 109,
+      "id": "01KMVPV9ZHCFW48C0G9S0CZA2J",
+      "name": "Wildflower",
+      "type_flags": 128,
+      "consumable": false,
+      "stackable": true,
+      "max_stack": 32,
+      "rarity": "common",
+      "buy_price": 3,
+      "sell_price": 1,
+      "emoji": "🌸",
+      "weight": 0.1,
+      "skilling": {
+        "skill": "foraging",
+        "xp_reward": 4,
+        "gather_time": 0.5,
+        "respawn_time": 20,
+        "resource_node": "flower-wildflower"
+      },
+      "tags": [
+        "isometric"
+      ]
+    },
+    {
+      "description": "Curved canine tooth the length of a thumb, ivory at the root and stained tea-brown at the tip from a lifetime's use. Lighter than it looks, with a hairline stress-line running along the inside curve.\n",
+      "lore": "Pulled one at a time from the jaws of grey wolves at the skinner's bench, and sold in small paper twists of six or eight. Bone-carvers use them for knife handles, amulet-makers use them for the kind of charms the temple frowns on, and duelists' lanyards run the best ones as counting tokens on a waxed cord. The fang keeps its edge better than most smiths would like to admit.\n",
+      "ref": "wolf-fang",
+      "key": 548,
+      "id": "01KTVTRAB1W0LFF4NG000000003",
+      "name": "Wolf Fang",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 3
+    },
+    {
+      "description": "Long grey-and-russet pelt with the guard hairs still oiled, stitched edges clean enough to suggest the skinner knew the animal by reputation. Heavier on one shoulder where the winter coat thickened.\n",
+      "lore": "Taken off the grey wolves that work the upland passes in winter, by hunters who do not advertise their methods and do not answer follow-up questions. Tanners along the river road bid on the better pelts in sealed envelopes, and the worst of them end up as saddle blankets for couriers who have opinions about quiet travel. A full pelt trims into one coat, two hoods, and a small bag of scraps the apothecaries will buy without asking where it came from.\n",
+      "ref": "wolf-pelt",
+      "key": 547,
+      "id": "01KTVTRAB1W0LFPELT0000000002",
+      "name": "Wolf Pelt",
+      "type_flags": 64,
+      "rarity": "uncommon",
+      "stackable": true,
+      "max_stack": 20,
+      "buy_price": 6
+    },
+    {
+      "description": "Plank-built oak shield with iron rim banding. A step up from the buckler — large enough to cover the body when crouched, but the heart-pine boards split if a kite-rider lands the charge straight on the boss.\n",
+      "lore": "What every militia outfit issues to its line goblins once they survive a season on the buckler. The carpenters' guild bickers annually with the smiths over rim thickness; the smiths win every time the magister returns from a frontier patrol short two shields and a finger.\n",
+      "ref": "wooden-shield",
+      "key": 558,
+      "id": "01KTVTRAB1WOODENSHIELD000558",
+      "name": "Wooden Shield",
+      "type_flags": 514,
+      "rarity": "common",
+      "stackable": false,
+      "max_stack": 1,
+      "buy_price": 18
+    },
+    {
+      "description": "Loose bundle of cream-colored wool still holding the curl of the fleece, lanolin-rich to the touch and smelling faintly of the sheep and the shear-shed. A handful carded between the fingers comes apart into a soft cloud that wants to stay in the air.\n",
+      "lore": "Sheared in the spring rotation by the flock-masters' cooperative that runs the lower pastures, then graded against a framework that has survived three attempted reforms and one outright revolt. Spinners, weavers, and dyers each buy their own grade, and the remaining seconds go into the felting barrels that the hatters run at the end of the season. A bale of wool in the right cellar keeps its fiber for years; a bale in the wrong one learns what moths are for.\n",
+      "ref": "wool",
+      "key": 521,
+      "id": "01KPTSDW05G0M9KFK1D4Q7H5WZ",
+      "name": "Wool",
+      "type_flags": 64,
+      "rarity": "common",
+      "stackable": true,
+      "max_stack": 30,
+      "buy_price": 4
+    },
+    {
+      "description": "A pocket-sized murder console with a glitched smile stamped into the faceplate. Booting it releases a swarm of drones, and you cannot reliably tell the helpful ones from the rest until one of them picks a side.\n",
+      "lore": "The Z90 line was built in the last profitable year of Ziggy Industries, when the shareholder meeting still clapped at words like \"disruptive\". BlackCell keeps a fabrication cell running in defiance of the 2031 Safety Accords, which means spare units turn up in weapons lockers that no one remembers stocking. The smile on the faceplate is not a logo. It is the last thing the firmware prints before it decides what to do.\n",
+      "ref": "z90-murderbot",
+      "key": 8,
+      "id": "01J2GHZQ9CXY89NB7NS5Q2DRMB",
+      "name": "Z90 MurderBot",
+      "type_flags": 396,
+      "consumable": false,
+      "stackable": false,
+      "rarity": "legendary",
+      "weight": 1.2,
+      "buy_price": 6400,
+      "durability": 900,
+      "level_requirement": 8,
+      "cooldown": 300,
+      "action": "deploy",
+      "bonuses": {
+        "chaosSwarm": true,
+        "allyChance": 0.4,
+        "foeChance": 0.5,
+        "glitchFactor": 0.9
+      },
+      "scripts": [
+        {
+          "guid": "fe991e2232444ee3a0b55ff347ec774d",
+          "vars": {
+            "deploySwarm": true,
+            "swarmSize": "3-8",
+            "chaosLevel": 99,
+            "friendlyChance": 0.4,
+            "hostileChance": 0.5,
+            "duration": 45
+          }
+        }
+      ],
+      "hasImg": true
+    }
+  ]
+}


### PR DESCRIPTION
## Why

cryptothrone hand-maintained a `RawItem` interface re-describing a subset of the item schema. Every time the game needs another field (weapon, food, equipment, …) it'd have to re-add it. The block: cryptothrone read the **camelCase + enum-prefixed** central `itemdb-data.json`, which disagrees (casing *and* enum values) with the generated zod `Item` type — so the canonical type couldn't be used directly. And that central json is also consumed by Unreal C++, so its shape can't change.

## What

Emit a **snake_case + bare-enum web bundle** from the same pipeline (`generated/itemdb.json`, shaped `{ items: [...] }` to match `ItemRegistry`/`Item` verbatim) and point cryptothrone's `@kbve/itemdb-data` at it. `itemdb.ts` now imports the canonical `Item` type from `@kbve/itemdb-schema` and adapts from it — **one type system**.

- `gen-itemdb-data.mjs` emits `generated/itemdb.json`; `sync:itemdb` output added
- `@kbve/itemdb-data` → `itemdb.json`; new `@kbve/itemdb-schema` alias (type-only import)
- `RawItem` deleted; `bonuses` (a freeform top-level MDX field **not modeled in the proto** — proto carries bonuses only nested under equipment/enchantment) layered on as `ItemRecord = Item & { bonuses }` and numeric-filtered in the adapter
- camelCase `itemdb-data.json` + `.binpb` **untouched** (still proto-canonical for Unreal); rareicon unaffected

## Result

Future itemdb fields are already typed — no second shape to maintain. 91 vitest pass, scoped `tsc` clean, no runtime behavior change. Rides the next release (no bump).