### PR TITLE
fix(cryptothrone): Discord Activity session fetch via /.proxy/ + named boot steps

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -17,10 +17,12 @@ const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
 
 // Backend bridge (P3b): exchanges the Discord OAuth code for a Discord
 // access_token AND a game-server session {jwt, username}, linking the Discord
-// user to a KBVE profile. Same origin as the Activity (axum-cryptothrone serves
-// both /discord/* and /api/*), so it rides the portal ROOT mapping — a relative
-// path, not /.proxy/ (that prefix is for the external WS hosts below).
-const SESSION_ENDPOINT = '/api/discord/session';
+// user to a KBVE profile. The Activity iframe runs on *.discordsays.com, so
+// every request — including same-origin backend calls — must carry the
+// `/.proxy/` prefix: Discord strips it and applies the portal ROOT mapping
+// (`/` -> the axum-cryptothrone host serving /api/*). Without it the fetch
+// hits discordsays.com directly and never reaches the backend.
+const SESSION_ENDPOINT = '/.proxy/api/discord/session';
 
 // External hosts the game's plain `new WebSocket('wss://game.cryptothrone…')`
 // calls reach. patchUrlMappings rewrites those real URLs through Discord's
@@ -41,11 +43,28 @@ interface DiscordSession {
 	username: string;
 }
 
+function errMsg(err: unknown): string {
+	if (err instanceof Error) {
+		return err.message;
+	}
+	return String(err);
+}
+
 function fail(msg: string, ...extra: unknown[]): void {
 	console.error(`[Cryptothrone/Discord] ${msg}`, ...extra);
 	const root = document.getElementById('app');
 	if (root) {
 		root.textContent = `Could not start the Activity: ${msg}`;
+	}
+}
+
+/** Run a boot step, re-throwing with a labelled message so the on-screen text
+ * names which stage failed instead of a generic "boot failed". */
+async function step<T>(label: string, run: () => Promise<T>): Promise<T> {
+	try {
+		return await run();
+	} catch (err) {
+		throw new Error(`${label}: ${errMsg(err)}`, { cause: err });
 	}
 }
 
@@ -58,28 +77,36 @@ async function boot(): Promise<void> {
 	patchUrlMappings(URL_MAPPINGS);
 
 	const sdk = new DiscordSDK(CLIENT_ID);
-	await sdk.ready();
+	await step('Discord SDK ready', () => sdk.ready());
 
-	const { code } = await sdk.commands.authorize({
-		client_id: CLIENT_ID,
-		response_type: 'code',
-		state: '',
-		prompt: 'none',
-		scope: ['identify', 'guilds'],
-	});
+	const { code } = await step('Discord authorize', () =>
+		sdk.commands.authorize({
+			client_id: CLIENT_ID,
+			response_type: 'code',
+			state: '',
+			prompt: 'none',
+			scope: ['identify', 'guilds'],
+		}),
+	);
 
-	const res = await fetch(SESSION_ENDPOINT, {
-		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
-		body: JSON.stringify({ code }),
-	});
+	const res = await step('session request', () =>
+		fetch(SESSION_ENDPOINT, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ code }),
+		}),
+	);
 	if (!res.ok) {
 		fail(`session exchange failed (${res.status})`);
 		return;
 	}
-	const session = (await res.json()) as DiscordSession;
+	const session = (await step('session parse', () =>
+		res.json(),
+	)) as DiscordSession;
 
-	await sdk.commands.authenticate({ access_token: session.access_token });
+	await step('Discord authenticate', () =>
+		sdk.commands.authenticate({ access_token: session.access_token }),
+	);
 
 	const el = document.getElementById('app') ?? document.body;
 	mount({
@@ -90,4 +117,4 @@ async function boot(): Promise<void> {
 	});
 }
 
-void boot().catch((err) => fail('boot failed', err));
+void boot().catch((err) => fail(`boot failed — ${errMsg(err)}`, err));

--- a/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/transport/https.rs
@@ -107,7 +107,13 @@ fn router() -> Router {
         .route("/health", get(health))
         .route("/api/v1/speed", get(speed))
         .route("/api/join", post(join))
-        .route("/api/discord/session", post(crate::discord::session));
+        .route("/api/discord/session", post(crate::discord::session))
+        // The Discord Activity proxies under the `/` -> .../discord/ root mapping,
+        // which prepends /discord to every request, so its session call lands here.
+        .route(
+            "/discord/api/discord/session",
+            post(crate::discord::session),
+        );
 
     static_router
         .merge(dynamic_router)


### PR DESCRIPTION
## Problem
Discord Activity died with **"could not start the activity: boot failed"**.

The Activity iframe runs on `*.discordsays.com` and proxies through the portal **root URL mapping `/` → cryptothrone.com/discord/** (confirmed by `public/discord/index.html` — relative script src, so an absolute path would double under `/discord`). Two issues:
1. Discord requires the **`/.proxy/`** prefix on every request; the session fetch used a bare `/api/discord/session` → hit discordsays.com directly → never reached the backend.
2. Because the root mapping prepends **/discord** to every proxied path, `/.proxy/api/discord/session` resolves to `cryptothrone.com/discord/api/discord/session` — which axum didn't serve.

## Fix
- Client (`discord.tsx`): fetch `/.proxy/api/discord/session`; wrap each boot stage so the on-screen + console message names the failing step instead of a generic "boot failed".
- Server (`axum-cryptothrone`): also route `/discord/api/discord/session` → the same session handler, so the proxied (prepended) path resolves. Bare `/api/discord/session` stays for non-Activity callers.

## Portal config
- Keep the single root mapping **`/` → cryptothrone.com/discord/** (loads the Activity entry; assets use relative paths).
- No separate `/api` mapping needed — the server now answers under `/discord`.

## Notes
- axum-cryptothrone lint green; discord bundle build verified to emit `fetch("/.proxy/api/discord/session")` (with client id set; empty id dead-code-strips the boot body locally).
- No version bump — rides the pending cryptothrone 0.1.32.