### PR TITLE
fix(cryptothrone): copy codegen root .ts into astro Docker build (npcdb ENOENT)

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -23,6 +23,7 @@ COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
 
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
+COPY packages/data/codegen/*.ts packages/data/codegen/
 
 COPY apps/cryptothrone/astro-cryptothrone/ apps/cryptothrone/astro-cryptothrone/
 


### PR DESCRIPTION
## Problem
`CI - Docker / cryptothrone` failed ([run 27520780331](https://github.com/KBVE/kbve/actions/runs/27520780331)). The in-container astro/embed/discord build errored:

```
[vite:load-fallback] Could not load /app/packages/data/codegen/npcdb.ts
  (imported by src/components/game/data/npcdb.ts): ENOENT
```

`@kbve/npcdb` resolves to `packages/data/codegen/npcdb.ts` (added by the npcdb unify). The Dockerfile only copied `codegen/generated/`, so the source file was absent in the image → vite ENOENT → build exit 1. (The "Entry docs → 404" line in the log is a harmless Starlight 404 message, not the failure.)

## Fix
`COPY packages/data/codegen/*.ts` into the astro-builder stage alongside `generated/`. Picks up `npcdb.ts` (the only codegen-root `.ts` consumed via a `@kbve/*` alias) and future root-TS API files; the heavy gen scripts + map/tile assets stay out of the image.

## Notes
- Local `astro-cryptothrone:build` already passed (file present on disk) — this was Docker-context-only.
- Rides the pending cryptothrone 0.1.32 (the version this run was trying to publish); no bump.