### PR TITLE
fix(kube/valkey): generateExisting on sync-valkey-auth to unblock kbve rollout

### DIFF
--- a/apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml
+++ b/apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml
@@ -3,6 +3,7 @@ kind: ClusterPolicy
 metadata:
     name: sync-valkey-auth
 spec:
+    generateExisting: true
     rules:
         - name: clone-valkey-auth-forgejo
           match:


### PR DESCRIPTION
## Problem

`https://kbve.com/health` is pinned at **v1.0.198** while main deploys `ghcr.io/kbve/kbve:1.0.200` (dev: 1.0.201). The kbve namespace shows as degraded.

### Root cause
#12389 added a `VALKEY_PASSWORD` env to the kbve Deployment sourced from a `valkey-auth` Secret:

```yaml
- name: VALKEY_PASSWORD
  valueFrom:
    secretKeyRef: { name: valkey-auth, key: valkey-password }
```

`valkey-auth` is not an ExternalSecret — it's cloned into the kbve namespace by the Kyverno ClusterPolicy `sync-valkey-auth`. That policy's `clone-valkey-auth-kbve` rule matches **Namespace create/update events** for `kbve`, but the policy lacks `generateExisting`. Since the `kbve` namespace already existed when the rule was added, Kyverno never fired the generate → `valkey-auth` was never cloned into `kbve`.

Result: new pods (1.0.199/1.0.200) → `CreateContainerConfigError` → RollingUpdate stalls → the old **1.0.198** pod keeps serving `/health`.

This is not a publish deadlock — images 1.0.199/200/201 all exist in GHCR. It is a missing cloned Secret.

## Fix
Add `generateExisting: true` to the `sync-valkey-auth` ClusterPolicy spec so Kyverno backfills already-existing matched namespaces — cloning `valkey-auth` into `kbve` and unblocking the rollout. `synchronize: true` already keeps it reconciled afterward; backfilling the other (already-populated) namespaces is a harmless no-op.

## Rollout note
ArgoCD tracks `main`; this reaches the cluster after the dev→main release. If kbve must recover sooner, the secret can be cloned manually or the `kbve` Namespace annotated to trigger the existing rule (separate, prod-touching action).