### PR TITLE
docs(gdd): spatial/pathfinding page, shader languages, godot gdshader

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/application/godot.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/application/godot.mdx
@@ -90,11 +90,49 @@ Remember to connect the signals for the animations, to create custom effects onc
 
 ## Shaders
 
+Godot ships its own shading language, **GDShader** (`.gdshader` files), a GLSL-derived language wired into Godot's render pipeline. For the engine-agnostic fundamentals (the GPU pipeline, shader stages, lighting models, performance budget), see the [Shaders & Rendering GDD page](/gdd/shaders/); this section covers the Godot-specific layer.
+
+### GDShader language
+
+GDShader looks like GLSL ES 3.0 but adds Godot-provided built-ins and a `shader_type` declaration that tells the engine which render path the shader plugs into.
+
+- **`shader_type`** — the first line; picks the context:
+  - `spatial` — 3D materials (mesh surfaces).
+  - `canvas_item` — 2D materials (sprites, UI, tilemaps).
+  - `particles` — compute-style particle processing.
+  - `sky` and `fog` — environment shading.
+- **Processor functions** — you fill in stage entry points: `vertex()` (per-vertex), `fragment()` (per-pixel surface output), and `light()` (per-light custom lighting).
+- **Built-in I/O** — Godot exposes inputs like `UV`, `NORMAL`, `TIME`, `SCREEN_TEXTURE`, and you write outputs such as `ALBEDO`, `ALPHA`, `EMISSION`, `ROUGHNESS`, `METALLIC` — no manual matrix wiring for the common case.
+- **`uniform`** — parameters exposed to the editor/inspector and settable from GDScript/C# at runtime (`material.set_shader_parameter(...)`).
+
+```glsl
+shader_type canvas_item;
+
+uniform vec4 tint : source_color = vec4(1.0);
+uniform float wave_speed = 2.0;
+
+void fragment() {
+    vec2 uv = UV;
+    uv.x += sin(TIME * wave_speed + UV.y * 10.0) * 0.02;
+    COLOR = texture(TEXTURE, uv) * tint;
+}
+```
+
+<Aside>
+GDShader has two front-ends: write the language directly in a `.gdshader` file, or build it with the **VisualShader** node graph (Godot compiles the graph to the same GDShader under the hood). Use the visual editor to prototype, drop to text for control.
+</Aside>
+
 ### Cel Shaders
 
 This is a quick reference to a couple popular cel shaders for Godot!
 
 [eldskald's complete global cel shader](https://github.com/eldskald/godot4-cel-shader/tree/main?tab=readme-ov-file) provides a comprehensive cel shader designed for Godot 4.
+
+### Further reading
+
+-   Godot [Shading language reference](https://docs.godotengine.org/en/stable/tutorials/shaders/shader_reference/shading_language.html)
+-   Godot [Your first 2D / 3D shader](https://docs.godotengine.org/en/stable/tutorials/shaders/your_first_shader/index.html) tutorials
+-   [Shaders & Rendering](/gdd/shaders/) — engine-agnostic shader and rendering fundamentals
 
 
 ---

--- a/apps/kbve/astro-kbve/src/content/docs/gdd/index.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/gdd/index.mdx
@@ -44,6 +44,7 @@ GDDs are living documents. Update them as the project evolves to keep them usefu
 This page is the core GDD template. Deeper, scoped topics live alongside it:
 
 - [Architecture Patterns](/gdd/patterns/) — decoupling, sequencing, behavioral, and optimization patterns for game code.
+- [Spatial & Pathfinding](/gdd/spatial/) — acceleration structures (grid, quadtree, BVH, R-tree) and pathfinding (A*, flow fields, nav meshes).
 - [Shaders & Rendering](/gdd/shaders/) — the GPU pipeline, shader stages, techniques, and the frame budget.
 - [ECS & Data-Oriented Design](/gdd/ecs/) — entities, components, systems, and why data layout wins at scale.
 - [Netcode & Multiplayer](/gdd/netcode/) — topologies, replication, latency hiding, and authority.

--- a/apps/kbve/astro-kbve/src/content/docs/gdd/patterns.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/gdd/patterns.mdx
@@ -197,6 +197,7 @@ Organize objects by their position (grid, quadtree, BVH, BSP) so spatial queries
 
 - **Use when:** collision, range queries, neighbor finding, culling at scale.
 - **Trade-off:** the structure must be maintained as objects move; choose grid vs tree by density and movement patterns.
+- **Go deeper:** [Spatial & Pathfinding](/gdd/spatial/) covers concrete structures (grid, quadtree, BVH, R-tree, k-d, BSP) and pathfinding (A*, flow fields, nav meshes).
 
 ---
 

--- a/apps/kbve/astro-kbve/src/content/docs/gdd/shaders.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/gdd/shaders.mdx
@@ -50,6 +50,40 @@ The vertex shader runs once per vertex; the fragment shader runs once per covere
 
 ---
 
+## Shader languages
+
+Shaders are written in a GPU language, then compiled to the driver's native format. Which language you use is mostly dictated by your graphics API and engine.
+
+| Language | API / ecosystem | Notes |
+| --- | --- | --- |
+| **GLSL** | OpenGL, Vulkan, WebGL | The long-time cross-platform standard; C-like. Vulkan compiles GLSL to SPIR-V. |
+| **HLSL** | Direct3D, also Vulkan | Microsoft's language; the de-facto AAA standard, usable on Vulkan via SPIR-V. |
+| **WGSL** | WebGPU (wgpu) | The WebGPU Shading Language — the modern web/portable target; what you write against [wgpu](https://wgpu.rs/) (the Rust WebGPU implementation). |
+| **MSL** | Metal (Apple) | Metal Shading Language; C++-based, Apple platforms only. |
+| **SPIR-V** | Vulkan, WebGPU | Not hand-written — a binary *intermediate representation* that GLSL/HLSL/WGSL compile **to**; the driver consumes it. |
+
+<Aside>
+**SPIR-V is the hub.** Modern toolchains author in GLSL/HLSL/WGSL, compile to SPIR-V, then translate to the platform's native format (DXIL, MSL, SPIR-V). Tools like [naga](https://github.com/gfx-rs/wgpu/tree/trunk/naga) (used by wgpu) and SPIRV-Cross translate between these languages.
+</Aside>
+
+### wgpu / WGSL
+
+[wgpu](https://wgpu.rs/) is the Rust implementation of the WebGPU standard — one API that targets Vulkan, Metal, D3D12, and WebGPU-in-the-browser. You write shaders in **WGSL**; wgpu (via naga) compiles them to each backend. For Rust game/graphics work that must run native *and* on the web, this is the portable path.
+
+### Engine-specific shader languages
+
+Most engines wrap a standard language in their own material/shader layer with engine-provided inputs and node graphs:
+
+- **Godot** — [GDShader](/application/godot/#shaders) (`.gdshader`), a GLSL-derived language with Godot's render pipeline built in. Covered in the [Godot application doc](/application/godot/#shaders).
+- **Unity** — ShaderLab wrapping HLSL, plus the node-based Shader Graph.
+- **Unreal** — the node-based Material Editor compiling to HLSL under the hood.
+
+<Aside type="tip">
+This page stays language-agnostic on engine specifics. Application-specific shader languages (GDShader, ShaderLab, Unreal materials) are documented on their engine pages and linked from here, not inlined.
+</Aside>
+
+---
+
 ## Spaces and transforms
 
 Vertices move through a chain of coordinate spaces:

--- a/apps/kbve/astro-kbve/src/content/docs/gdd/spatial.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/gdd/spatial.mdx
@@ -1,0 +1,164 @@
+---
+title: Spatial Partitioning and Pathfinding
+description: |
+    Spatial acceleration structures (grids, quadtrees, BVH, R-trees, k-d trees, BSP) and pathfinding (A*, flow fields, nav meshes) — how games answer "what is near me?" and "how do I get there?" without touching every object.
+    Own-words reference cross-linked to KBVE projects.
+sidebar:
+    label: Spatial & Pathfinding
+    order: 7
+tags:
+    - gdd
+    - spatial
+    - pathfinding
+---
+
+import { Aside, Card, CardGrid } from '@astrojs/starlight/components';
+import { Giscus, Adsense } from '@/components/astropad';
+
+## Introduction
+
+Two questions dominate game simulation at scale: *what is near me?* (spatial queries) and *how do I get there?* (pathfinding). Both become impossibly slow if answered naively — checking every object against every other is O(n²). This page covers the acceleration structures that make spatial queries cheap and the pathfinding algorithms that move agents through a world.
+
+This expands on the [Spatial Partition pattern](/gdd/patterns/) with concrete structures and trade-offs.
+
+<Aside type="tip" title="Source material">
+For depth see [Real-Time Collision Detection](https://realtimecollisiondetection.net/) (Ericson) on acceleration structures, [Amit Patel's Red Blob Games](https://www.redblobgames.com/pathfinding/a-star/introduction.html) on pathfinding, and the [Game Programming Patterns Spatial Partition chapter](https://gameprogrammingpatterns.com/spatial-partition.html). This page summarizes and maps the concepts to KBVE.
+</Aside>
+
+<Adsense />
+
+---
+
+## Why spatial structures
+
+A spatial query — "what's within radius r?", "what does this ray hit?", "which objects overlap?" — naively scans every object: O(n) per query, O(n²) for all-pairs. Acceleration structures organize objects by position so a query only visits nearby candidates, turning O(n) into roughly O(log n) or O(1) per query.
+
+The universal trade-off: **build/update cost vs query speed**. Static geometry can afford an expensive structure built once; objects that move every frame need cheap updates or a structure rebuilt each frame.
+
+---
+
+## Acceleration structures
+
+<CardGrid>
+  <Card title="Uniform grid" icon="seti:grid">
+    Divide space into fixed-size cells; each cell lists the objects in it.
+  </Card>
+  <Card title="Quadtree / Octree" icon="seti:plan">
+    Recursively split space into 4 (2D) or 8 (3D) until each node holds few objects.
+  </Card>
+  <Card title="BVH" icon="seti:default">
+    Tree of nested bounding volumes wrapping the objects themselves.
+  </Card>
+  <Card title="R-tree" icon="seti:db">
+    Balanced tree of bounding rectangles; database-style, disk-friendly.
+  </Card>
+  <Card title="k-d tree" icon="seti:crystal">
+    Binary tree splitting on one axis at a time; great for nearest-neighbor.
+  </Card>
+  <Card title="BSP tree" icon="seti:json">
+    Recursive splits by arbitrary planes; exact front-to-back ordering.
+  </Card>
+</CardGrid>
+
+### Uniform grid
+
+Space is divided into equal cells; each object is bucketed into the cell(s) it overlaps. A range query visits only the cells the query touches.
+
+- **Best for:** objects of similar size, evenly distributed, moving constantly (cheap to update — just move between buckets). The default for 2D particle/agent swarms.
+- **Weak when:** density varies wildly (empty cells waste memory, hot cells degrade to linear scan) or object sizes vary a lot. Spatial hashing (hash cell coords instead of a dense array) fixes the "huge sparse world" memory problem.
+
+### Quadtree / Octree
+
+Start with one node covering the whole space; when a node holds too many objects, subdivide it into 4 (quadtree, 2D) or 8 (octree, 3D) children and redistribute. Recursion adapts depth to local density.
+
+- **Best for:** non-uniform distributions, mixed object sizes, mostly-static or slow-moving worlds.
+- **Weak when:** objects move fast (constant re-insertion) or straddle node boundaries (loose quadtrees relax boundaries to reduce churn).
+
+### BVH (Bounding Volume Hierarchy)
+
+A tree where each node is a bounding volume (usually an AABB) enclosing its children, and leaves wrap actual objects. Unlike quadtrees (which partition *space*), a BVH partitions *objects* — volumes may overlap, but each object lives in exactly one leaf.
+
+- **Best for:** ray casting, collision broad-phase, and rendering — the standard for raytracing acceleration and physics engines. Refittable: when objects move a little, expand parent bounds instead of rebuilding.
+- **Weak when:** objects move so far the tree quality degrades; periodic rebuild or rebalance needed.
+
+### R-tree
+
+A height-balanced tree of minimum bounding rectangles, related to the B-tree. Designed for databases and on-disk spatial indexes (GIS, PostGIS), it keeps the tree balanced under insertion/deletion.
+
+- **Best for:** large, persistent spatial datasets, disk-backed indexes, query-heavy with moderate update rates.
+- **Weak when:** high-churn real-time simulation — the balancing overhead outweighs an in-memory grid/BVH. Rare in the hot frame loop, common in tooling and servers.
+
+### k-d tree
+
+A binary tree that splits on one axis per level (x, then y, then z, cycling). Excellent for nearest-neighbor and k-nearest queries.
+
+- **Best for:** static point clouds, nearest-neighbor search, photon mapping.
+- **Weak when:** dynamic data — k-d trees are painful to rebalance, so they shine on static sets.
+
+### BSP tree
+
+Binary Space Partitioning recursively splits space by arbitrary planes (not axis-aligned). It yields an exact ordering of geometry from any viewpoint — the classic Doom/Quake visibility and sorting structure.
+
+- **Best for:** static level geometry, exact visibility ordering, CSG.
+- **Weak when:** dynamic scenes — BSP trees are expensive to build and assume static geometry.
+
+<Aside>
+Rule of thumb: **grid** for uniform moving swarms, **BVH** for rays/collision, **quadtree/octree** for non-uniform density, **k-d tree** for nearest-neighbor on static points, **R-tree** for persistent/disk indexes, **BSP** for static visibility ordering.
+</Aside>
+
+---
+
+## Pathfinding
+
+Once you can ask "what's near me?", agents still need "how do I get there?"
+
+### A* and graph search
+
+A* searches a graph (grid cells, waypoints, nav-mesh polygons) from start to goal, guided by a heuristic that estimates remaining distance. It's optimal and complete with an admissible heuristic, and the workhorse of single-agent pathfinding.
+
+- **Variants:** Dijkstra (A* with a zero heuristic — uniform-cost), Greedy best-first (heuristic only — fast but non-optimal), JPS (Jump Point Search — A* optimized for uniform grids), Theta* (any-angle paths).
+- **Cost:** per-agent search; expensive when thousands of agents path every frame to the same goal — that's where flow fields win.
+
+### Flow fields (and flow gates)
+
+Instead of pathing each agent individually, compute **one** field over the whole map that, at every cell, stores the direction toward the goal. Every agent just samples its cell and follows the arrow. The cost is amortized: one Dijkstra-style pass from the goal builds a cost (integration) field, then a flow field of directions — then N agents path for free.
+
+- **Build:** a breadth-first / Dijkstra sweep outward from the goal produces an **integration field** (cost-to-goal per cell); the gradient of that field is the **flow field** (direction per cell).
+- **Flow gates:** chokepoints — doors, bridges, narrow passes — that the integration field naturally routes flow through, and where you throttle or meter agent throughput to avoid clumping/deadlock. Gating flow at these cells keeps dense crowds moving instead of jamming the pinch point.
+- **Best for:** RTS/swarm games — hundreds or thousands of units converging on shared goals. One field, any number of followers.
+- **Weak when:** few agents with distinct goals (per-agent A* is cheaper than building a whole field per goal), or highly dynamic costs that force frequent field rebuilds.
+
+<Aside type="caution" title="Crowds, not just paths">
+A path is not movement. Dense crowds need local avoidance (RVO/ORCA, boids steering) layered on top of the field/path so agents don't overlap or oscillate at flow gates. Pathfinding picks the route; steering resolves the traffic.
+</Aside>
+
+### Navigation meshes
+
+A nav mesh represents walkable space as convex polygons instead of a grid. Pathfinding runs over the polygon graph (fewer nodes than a fine grid), then a string-pulling/funnel pass smooths the polygon path into a direct route.
+
+- **Best for:** 3D and continuous worlds, varied geometry, smoother paths than grid A*.
+- **Weak when:** frequently changing geometry (mesh must be regenerated/patched).
+
+### Hierarchical pathfinding
+
+Partition the map into clusters, precompute paths between cluster portals, and search the coarse graph first, refining only within clusters along the route. Trades optimality for huge speedups on large maps (HPA*).
+
+---
+
+## How KBVE applies these
+
+- **rareicon** — uniform-grid / spatial-hash style partitioning suits its DOTS swarms; the [task-offer dispatcher](/gdd/) and job system reason over nearby candidates rather than the full entity set, and HexDB drains feed spatial reads.
+- **Flow-field candidates** — large-unit-count convergence (colony/swarm behavior) is the textbook flow-field + flow-gate case; per-agent A* is reserved for distinct-goal units.
+- **Static vs dynamic split** — level/tilemap geometry favors a built-once structure (quadtree/BSP), while moving units favor a grid rebuilt or updated each frame — the build-vs-query trade-off in practice.
+
+---
+
+## Further reading
+
+- [Red Blob Games — A* and pathfinding](https://www.redblobgames.com/pathfinding/a-star/introduction.html), interactive and definitive.
+- [Red Blob Games — flow fields / vector fields](https://www.redblobgames.com/pathfinding/tower-defense/).
+- *Real-Time Collision Detection* — Christer Ericson (grids, BVH, k-d, BSP).
+- [Game Programming Patterns — Spatial Partition](https://gameprogrammingpatterns.com/spatial-partition.html).
+- [ECS & Data-Oriented Design](/gdd/ecs/) — spatial structures pair with data-oriented layout for cache-friendly queries.
+
+<Giscus />


### PR DESCRIPTION
Follow-up to the GDD split. Deepens the scoped pages.

## What
- **New `gdd/spatial.mdx`** — Spatial & Pathfinding:
  - Acceleration structures: uniform grid/spatial hash, quadtree/octree, BVH, R-tree, k-d tree, BSP — with best-for / weak-when trade-offs.
  - Pathfinding: A* (+ Dijkstra/JPS/Theta*), **flow fields & flow gates** (integration field → flow field, chokepoint metering), nav meshes, hierarchical (HPA*).
  - Crowds note: pathfinding picks the route, steering (RVO/ORCA) resolves traffic.
- **`shaders.mdx`** — new *Shader languages* section: GLSL / HLSL / **WGSL + wgpu** / MSL / SPIR-V (the IR hub). Engine-specific languages link out, not inlined.
- **`application/godot.mdx`** — expanded Shaders section with **GDShader** (`shader_type`, processor fns, built-in I/O, uniforms, VisualShader) + example + docs links.
- **`patterns.mdx` + `index.mdx`** — cross-link the new spatial page.

## Verify
`astro-kbve:build` green in worktree — 7762 pages, spatial page renders, cross-links resolve.