### PR TITLE
fix(cryptothrone): Discord Activity authorize — drop unused guilds scope + surface RPC error

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -47,6 +47,21 @@ function errMsg(err: unknown): string {
 	if (err instanceof Error) {
 		return err.message;
 	}
+	// Discord RPC rejects with a plain {code, message} object — surface it
+	// instead of the useless "[object Object]" String() default.
+	if (err && typeof err === 'object') {
+		const o = err as Record<string, unknown>;
+		if (typeof o.message === 'string') {
+			return typeof o.code === 'number' || typeof o.code === 'string'
+				? `${o.message} (code ${o.code})`
+				: o.message;
+		}
+		try {
+			return JSON.stringify(err);
+		} catch {
+			return String(err);
+		}
+	}
 	return String(err);
 }
 
@@ -85,7 +100,7 @@ async function boot(): Promise<void> {
 			response_type: 'code',
 			state: '',
 			prompt: 'none',
-			scope: ['identify', 'guilds'],
+			scope: ['identify'],
 		}),
 	);
 


### PR DESCRIPTION
## Problem
Activity failed at: **`Discord authorize: [object Object]`** (the named-step diag from #12488 working as intended).

`sdk.commands.authorize` rejected. Two issues:
1. It requested `scope: ['identify','guilds']`, but the backend (`discord.rs`) only calls Discord `/users/@me` (identify) — `guilds` is unused and a likely authorize-failure source if the OAuth2 app doesn't grant it.
2. `errMsg` only handled `Error` instances, so the Discord RPC rejection object collapsed to `[object Object]`, hiding `{code, message}`.

## Fix
- Request only `scope: ['identify']`.
- `errMsg` now unwraps RPC objects → shows `message (code N)` (or JSON), so any remaining failure is legible.

## Notes
- build-discord verified; bundle emits `scope:["identify"]`.
- Rides pending cryptothrone 0.1.32; no bump.