### PR TITLE
chore(cryptothrone): bump 0.1.33 to ship Discord authorize fix

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.32"
+version: "0.1.33"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
#12501 (Discord authorize fix — drop guilds scope + surface RPC error) merged under cryptothrone 0.1.32, but 0.1.32 had already published (via the #12493 docs-404 fix), so the publish gate skipped and the image never rebuilt with the fix.

Bump cryptothrone 0.1.32 → 0.1.33 to trigger a republish carrying the merged authorize fix. No code change.