### PR TITLE
fix(cryptothrone): Discord authorize redirect_uri (code 5000)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -15,6 +15,12 @@ const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
 	| string
 	| undefined;
 
+// Discord's OAuth2 authorize rejects (code 5000) without a redirect_uri. It
+// must be registered under the app's OAuth2 → Redirects AND match the value the
+// backend sends on the code→token exchange (DISCORD_REDIRECT_URI). The Activity
+// uses the code grant, so this URI is never navigated — it only has to match.
+const REDIRECT_URI = 'https://cryptothrone.com';
+
 // Backend bridge (P3b): exchanges the Discord OAuth code for a Discord
 // access_token AND a game-server session {jwt, username}, linking the Discord
 // user to a KBVE profile. The Activity iframe runs on *.discordsays.com, so
@@ -101,6 +107,7 @@ async function boot(): Promise<void> {
 			state: '',
 			prompt: 'none',
 			scope: ['identify'],
+			redirect_uri: REDIRECT_URI,
 		}),
 	);
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.33"
+version: "0.1.34"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
@@ -73,6 +73,11 @@ spec:
                       # arrive via the supabase-shared envFrom below).
                       - name: KBVE_PG_APPLICATION_NAME
                         value: 'axum-cryptothrone'
+                      # Discord OAuth2 code→token exchange. Must match the
+                      # redirect_uri the Activity client sends on authorize and
+                      # a URI registered under the app's OAuth2 → Redirects.
+                      - name: DISCORD_REDIRECT_URI
+                        value: 'https://cryptothrone.com'
                   envFrom:
                       # Optional so the pod still boots before the
                       # ExternalSecret has rendered or the kilobase


### PR DESCRIPTION
## Problem
Activity failed at **`Discord authorize: OAuth2 Error: invalid_request: Missing "redirect_uri" (code 5000)`**.

Discord's OAuth2 **code grant** requires a `redirect_uri` that is (a) registered under the app's OAuth2 → Redirects and (b) identical between the `authorize` call and the backend code→token exchange. We sent none.

## Fix
- **Client** (`discord.tsx`): pass `redirect_uri: https://cryptothrone.com` on `authorize`.
- **Backend** (`cryptothrone-deployment.yaml`): set `DISCORD_REDIRECT_URI=https://cryptothrone.com` — `discord.rs` already forwards it on the token exchange when set (it's a public URL, so plain env, not the sealed secret).
- Bump cryptothrone **0.1.34**.

## ⚠️ Manual portal step (required)
Discord Developer Portal → the app → **OAuth2 → Redirects** → add **`https://cryptothrone.com`** → Save. Must match exactly (no trailing slash). The Activity uses the code grant, so this URI is never navigated — it only has to be registered + match.

## Notes
- build-discord verified; bundle emits `redirect_uri:"https://cryptothrone.com"`.
- Bump in the same commit as the code this time (prior follow-up bumps stranded on squash-merge).