### PR TITLE
fix(cryptothrone): content-hash cache-bust on discord.js

### DIFF
--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -40,6 +40,11 @@ WORKDIR /app/apps/cryptothrone/astro-cryptothrone
 RUN rm -rf .astro && npx astro sync && \
     NODE_OPTIONS="--max-old-space-size=4096" npx vite build --config vite.embed.config.mts && \
     NODE_OPTIONS="--max-old-space-size=4096" npx vite build --config vite.discord.config.mts && \
+    # Cache-bust the fixed-name discord.js: stamp its content hash as a query so
+    # Discord's asset proxy can't serve last deploy's bytes. Done before astro
+    # build so the rewritten index.html is what gets copied into dist.
+    DJS_V=$(sha1sum public/discord/discord.js | cut -c1-8) && \
+    sed -i "s#src=\"discord.js\"#src=\"discord.js?v=$DJS_V\"#" public/discord/index.html && \
     UV_THREADPOOL_SIZE=4 NODE_OPTIONS="--max-old-space-size=4096" npx astro build && \
     # Fail loud if the embed/discord bundles didn't make it into dist (a stale
     # cached astro-builder layer once shipped without them -> silent 404s).

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.34"
+version: "0.1.35"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## What
The Discord Activity loads a fixed-name `/discord/discord.js`. Discord's asset proxy can serve last deploy's bytes (it doesn't necessarily honor the `cache_headers` revalidation, which only helps direct clients). Stamp the bundle's sha1 hash as a `?v=` query in `public/discord/index.html` during the Docker astro build (before `astro build` copies it into dist), so a changed bundle always gets a fresh URL / cache key.

## Notes
- Content hash, not version → busts precisely when the bundle changes.
- ServeDir ignores the query (still serves discord.js); `cache_headers` `is_entry_bundle` still matches (uses path, not query).
- Verified: built astro-builder stage emits `src="discord.js?v=725ff326"` in dist index.html.
- Bump 0.1.35 (in the same commit).