### PR TITLE
feat(rareicon): flat-top hex grid + atlas tile rendering with overlays

### DIFF
--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/SelectionVisualSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/DB/Units/Systems/SelectionVisualSystem.cs
@@ -33,9 +33,9 @@ namespace RareIcon
             }
 
             var selectedHandle   = new MarkSelectedVisualJob   { Target = 1f }.ScheduleParallel(state.Dependency);
-            var unselectedHandle = new MarkUnselectedVisualJob { Target = 0f }.ScheduleParallel(state.Dependency);
+            var unselectedHandle = new MarkUnselectedVisualJob { Target = 0f }.ScheduleParallel(selectedHandle);
 
-            state.Dependency = Unity.Jobs.JobHandle.CombineDependencies(selectedHandle, unselectedHandle);
+            state.Dependency = unselectedHandle;
         }
     }
 

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Hex/HexBiomeAtlas.cs.meta
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Hex/HexBiomeAtlas.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: efe149d53341b48d99dee8815c23e072

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/HexMeshUtil.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/HexMeshUtil.cs
@@ -21,7 +21,7 @@ namespace RareIcon
 
             for (int i = 0; i < 6; i++)
             {
-                float angle = 60f * i - 30f;
+                float angle = 60f * i;
                 float rad = angle * Mathf.Deg2Rad;
                 vertices[i + 1] = new Vector3(
                     outerRadius * Mathf.Cos(rad),
@@ -57,14 +57,48 @@ namespace RareIcon
             return mesh;
         }
 
+        /// <summary>Upright quad for 2.5D atlas tiles: width × height with the cap centered on the hex and the skirt hanging below by yOffset. UV 0..1 maps the full atlas tile (cap+skirt). Double-sided to match the hex mesh Cull Off.</summary>
+        public static Mesh CreateQuadMesh(float width, float height, float yOffset)
+        {
+            float hw = width * 0.5f;
+            float bottom = yOffset;
+            float top = yOffset + height;
+
+            var vertices = new Vector3[4]
+            {
+                new Vector3(-hw, bottom, 0f),
+                new Vector3( hw, bottom, 0f),
+                new Vector3( hw, top,    0f),
+                new Vector3(-hw, top,    0f),
+            };
+            var uv = new Vector2[4]
+            {
+                new Vector2(0f, 0f),
+                new Vector2(1f, 0f),
+                new Vector2(1f, 1f),
+                new Vector2(0f, 1f),
+            };
+            var triangles = new int[] { 0, 1, 2, 0, 2, 3 };
+
+            var mesh = new Mesh
+            {
+                vertices = vertices,
+                uv = uv,
+                triangles = triangles,
+            };
+            mesh.RecalculateNormals();
+            mesh.RecalculateBounds();
+            return mesh;
+        }
+
         /// <summary>
         /// Convert axial hex coords (q, r) to world position (x, y).
-        /// Pointy-top layout.
+        /// Flat-top layout.
         /// </summary>
         public static float3 HexToWorld(int q, int r, float size)
         {
-            float x = size * (math.sqrt(3f) * q + math.sqrt(3f) / 2f * r);
-            float y = size * (3f / 2f * r);
+            float x = size * (3f / 2f * q);
+            float y = size * (math.sqrt(3f) * (r + q / 2f));
             return new float3(x, y, 0f);
         }
 
@@ -73,8 +107,8 @@ namespace RareIcon
         /// </summary>
         public static int2 WorldToHex(float worldX, float worldY, float size)
         {
-            float q = (math.sqrt(3f) / 3f * worldX - 1f / 3f * worldY) / size;
-            float r = (2f / 3f * worldY) / size;
+            float q = (2f / 3f * worldX) / size;
+            float r = (-1f / 3f * worldX + math.sqrt(3f) / 3f * worldY) / size;
 
             float3 cube = new float3(q, -q - r, r);
             float3 rounded = math.round(cube);

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/HexSpawnSystem.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/ECS/Systems/HexSpawnSystem.cs
@@ -26,6 +26,13 @@ namespace RareIcon
         const int BaseLoadRadius = 5;
         const int MaxSpawnsPerFrame = 3;
 
+        const float QuadWidth   = 0.5f;
+        const float QuadHeight  = 0.65625f;
+        const float QuadYOffset = -0.281f;
+        const float DepthPerY   = 0.02f;
+        const int   MeshHex     = 0;
+        const int   MeshQuad    = 1;
+
         readonly Dictionary<int2, NativeList<Entity>> _loadedChunks = new();
         readonly HashSet<int2> _pendingChunks = new();
 
@@ -59,6 +66,7 @@ namespace RareIcon
         bool _initialLoad;
 
         Mesh _hexMesh;
+        Mesh _quadMesh;
         Material[] _biomeMaterials;
         RenderMeshDescription _renderMeshDesc;
         RenderMeshArray _renderMeshArray;
@@ -97,7 +105,10 @@ namespace RareIcon
         void InitRendering()
         {
             _hexMesh = HexMeshUtil.CreateHexMesh(HexSize);
+            _quadMesh = HexMeshUtil.CreateQuadMesh(QuadWidth, QuadHeight, QuadYOffset);
             _biomeMaterials = new Material[BiomeGenerator.BIOME_COUNT];
+
+            var atlasTex = LoadHexAtlas();
 
             var hexShader = Shader.Find("RareIcon/HexTile");
             if (hexShader == null) hexShader = Shader.Find("Universal Render Pipeline/Unlit");
@@ -109,6 +120,14 @@ namespace RareIcon
                 bool isRiver = i == BiomeGenerator.BIOME_RIVER && riverTileShader != null;
                 _biomeMaterials[i] = new Material(isRiver ? riverTileShader : hexShader);
                 _biomeMaterials[i].enableInstancing = true;
+
+                if (atlasTex != null)
+                {
+                    _biomeMaterials[i].SetTexture("_Atlas", atlasTex);
+                    _biomeMaterials[i].SetFloat("_AtlasCols", HexTileAtlas.Columns);
+                    _biomeMaterials[i].SetFloat("_AtlasTileU", HexTileAtlas.TileU);
+                    _biomeMaterials[i].SetFloat("_AtlasTileV", HexTileAtlas.TileV);
+                }
 
                 var c = HexMeshUtil.BiomeColor((byte)i);
                 var primary = new Color(c.x, c.y, c.z, c.w);
@@ -158,7 +177,33 @@ namespace RareIcon
                 shadowCastingMode: ShadowCastingMode.Off,
                 receiveShadows: false
             );
-            _renderMeshArray = new RenderMeshArray(_biomeMaterials, new[] { _hexMesh });
+            _renderMeshArray = new RenderMeshArray(_biomeMaterials, new[] { _hexMesh, _quadMesh });
+        }
+
+        static Texture2D LoadHexAtlas()
+        {
+            string path = System.IO.Path.Combine(Application.streamingAssetsPath, "hextile-atlas.png");
+            if (!System.IO.File.Exists(path))
+            {
+                Debug.LogError($"[HexChunkSystem] hextile-atlas.png missing at {path}. Run `npx nx run astro-kbve:sync:hextile-atlas`.");
+                return null;
+            }
+            var raw = System.IO.File.ReadAllBytes(path);
+            var tex = new Texture2D(HexTileAtlas.AtlasWidth, HexTileAtlas.AtlasHeight, TextureFormat.RGBA32, mipChain: false, linear: false)
+            {
+                name       = "HexTile Atlas",
+                wrapMode   = TextureWrapMode.Clamp,
+                filterMode = FilterMode.Point,
+                anisoLevel = 0,
+            };
+            if (!tex.LoadImage(raw, markNonReadable: false))
+            {
+                Debug.LogError("[HexChunkSystem] hextile-atlas LoadImage rejected the PNG bytes.");
+                Object.Destroy(tex);
+                return null;
+            }
+            tex.Apply(updateMipmaps: false, makeNoLongerReadable: true);
+            return tex;
         }
 
         protected override void OnUpdate()
@@ -301,6 +346,8 @@ namespace RareIcon
                     int gx = startX + lx;
                     int gy = startY + ly;
                     float3 worldPos = HexMeshUtil.HexToWorld(gx, gy, HexSize);
+                    bool isAtlas = HexBiomeAtlas.TileIdForBiome(biome) >= 0;
+                    if (isAtlas) worldPos.z = worldPos.y * DepthPerY;
 
                     var entity = batchEntities[idx++];
                     em.SetComponentData(entity, LocalTransform.FromPosition(worldPos));
@@ -340,9 +387,10 @@ namespace RareIcon
                         Value = HexResourceTable.ComputeCactusAmount(in res)
                     });
 
+                    int meshIndex = isAtlas ? MeshQuad : MeshHex;
                     RenderMeshUtility.AddComponents(
                         entity, em, _renderMeshDesc, _renderMeshArray,
-                        MaterialMeshInfo.FromRenderMeshArrayIndices(biome, 0)
+                        MaterialMeshInfo.FromRenderMeshArrayIndices(biome, meshIndex)
                     );
 
                     HexHoverSystem.AddHex(new int2(gx, gy), entity);

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Services/MouseStateSource.cs
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Scripts/Services/MouseStateSource.cs
@@ -100,24 +100,7 @@ namespace RareIcon
                 _pressScreenPos, _pressWorldPos);
         }
 
-        static int2 WorldToHex(float2 wp)
-        {
-            float q = (math.sqrt(3f) / 3f * wp.x - 1f / 3f * wp.y) / HexSize;
-            float r = (2f / 3f * wp.y) / HexSize;
-
-            float3 cube = new float3(q, -q - r, r);
-            float3 rounded = math.round(cube);
-            float3 diff = math.abs(rounded - cube);
-
-            if (diff.x > diff.y && diff.x > diff.z)
-                rounded.x = -rounded.y - rounded.z;
-            else if (diff.y > diff.z)
-                rounded.y = -rounded.x - rounded.z;
-            else
-                rounded.z = -rounded.x - rounded.y;
-
-            return new int2((int)rounded.x, (int)rounded.z);
-        }
+        static int2 WorldToHex(float2 wp) => HexMeshUtil.WorldToHex(wp.x, wp.y, HexSize);
 
         public void Dispose()
         {

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexBuildPreview.shader
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexBuildPreview.shader
@@ -69,8 +69,8 @@ Shader "RareIcon/HexBuildPreview"
             float hexSDF(float2 p, float size)
             {
                 p = abs(p);
-                float d = dot(p, normalize(float2(1.0, 1.732)));
-                return max(d, p.x) - size;
+                float d = dot(p, normalize(float2(1.732, 1.0)));
+                return max(d, p.y) - size;
             }
 
             Varyings vert(Attributes input)

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexHoverOverlay.shader
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexHoverOverlay.shader
@@ -55,8 +55,8 @@ Shader "RareIcon/HexHoverOverlay"
             float hexSDF(float2 p, float size)
             {
                 p = abs(p);
-                float d = dot(p, normalize(float2(1.0, 1.732)));
-                return max(d, p.x) - size;
+                float d = dot(p, normalize(float2(1.732, 1.0)));
+                return max(d, p.y) - size;
             }
 
             Varyings vert(Attributes input)

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexRiverTile.shader
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexRiverTile.shader
@@ -85,8 +85,8 @@ Shader "RareIcon/HexRiverTile"
             float hexSDF(float2 p, float size)
             {
                 p = abs(p);
-                float d = dot(p, normalize(float2(1.0, 1.732)));
-                return max(d, p.x) - size;
+                float d = dot(p, normalize(float2(1.732, 1.0)));
+                return max(d, p.y) - size;
             }
 
             Varyings vert(Attributes input)

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexTile.shader
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/HexTile.shader
@@ -60,6 +60,12 @@ Shader "RareIcon/HexTile"
         _FogExploredColor  ("Fog Color (Explored)",     Color) = (0.20, 0.22, 0.28, 1)
         _FogNoiseDensity   ("Fog Noise Density",        Float) = 6.0
         _FogNoiseSpeed     ("Fog Noise Speed",          Float) = 0.05
+
+        _Atlas      ("Tile Atlas (base biomes)", 2D) = "white" {}
+        _AtlasCols  ("Atlas Columns", Float)    = 5
+        _AtlasTileU ("Atlas Tile U size", Float) = 0.2
+        _AtlasTileV ("Atlas Tile V size", Float) = 0.25
+        _AtlasHexSize ("Atlas overlay hex SDF size", Float) = 0.2165
     }
 
     SubShader
@@ -93,6 +99,7 @@ Shader "RareIcon/HexTile"
                 float2 localPos  : TEXCOORD0;
                 float2 worldPos  : TEXCOORD1;
                 float2 hexCenter : TEXCOORD2;
+                float2 uv        : TEXCOORD3;
                 UNITY_VERTEX_INPUT_INSTANCE_ID
             };
 
@@ -143,7 +150,14 @@ Shader "RareIcon/HexTile"
                 float  _AuraHighlight;
                 float4 _AuraHighlightColor;
                 float  _TileId;
+                float  _AtlasCols;
+                float  _AtlasTileU;
+                float  _AtlasTileV;
+                float  _AtlasHexSize;
             CBUFFER_END
+
+            TEXTURE2D(_Atlas);
+            SAMPLER(sampler_Atlas);
 
             #ifdef DOTS_INSTANCING_ON
             UNITY_DOTS_INSTANCING_START(MaterialPropertyMetadata)
@@ -205,12 +219,36 @@ Shader "RareIcon/HexTile"
                 float3 wp = TransformObjectToWorld(input.positionOS.xyz);
                 output.worldPos = wp.xy;
                 output.hexCenter = TransformObjectToWorld(float3(0,0,0)).xy;
+                output.uv = input.uv;
                 return output;
             }
 
             float4 frag(Varyings input) : SV_Target
             {
                 UNITY_SETUP_INSTANCE_ID(input);
+
+                if (_TileId >= 0.0)
+                {
+                    int tid = (int)(_TileId + 0.5);
+                    float ac = fmod((float)tid, _AtlasCols);
+                    float ar = floor((float)tid / _AtlasCols);
+                    float2 auv = float2((ac + input.uv.x) * _AtlasTileU,
+                                        1.0 - (ar + 1.0 - input.uv.y) * _AtlasTileV);
+                    float4 tex = SAMPLE_TEXTURE2D(_Atlas, sampler_Atlas, auv);
+                    clip(tex.a - 0.5);
+
+                    float dCap = hexSDF(input.localPos, _AtlasHexSize);
+                    float3 c = tex.rgb;
+                    c = ApplyTerritory(c, dCap, _Territory);
+                    c = ApplyFog(c, input.worldPos, dCap, _Fog);
+                    if (_AuraHighlight > 0.5)
+                    {
+                        c = lerp(c, _AuraHighlightColor.rgb, 0.18);
+                        float rim = smoothstep(0.090, 0.020, -dCap);
+                        c = lerp(c, _AuraHighlightColor.rgb, rim * _AuraHighlightColor.a * 0.85);
+                    }
+                    return float4(ApplyWorldAmbient(c), 1.0);
+                }
 
                 float d = hexSDF(input.localPos, 0.45);
 

--- a/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexShared.hlsl
+++ b/apps/rareicon/unity-rareicon/Assets/_RareIcon/Shaders/Includes/HexShared.hlsl
@@ -10,8 +10,8 @@
 float hexSDF(float2 p, float size)
 {
     p = abs(p);
-    float d = dot(p, normalize(float2(1.0, 1.732)));
-    return max(d, p.x) - size;
+    float d = dot(p, normalize(float2(1.732, 1.0)));
+    return max(d, p.y) - size;
 }
 
 // Cheap deterministic 2D hash → [0, 1].


### PR DESCRIPTION
Phase 2 render layer for the hex tilemap — base biome tiles now render from the `hextile-atlas` PNGs, and the grid is flat-top to match the art.

### Rendering
- **HexMeshUtil** — `HexToWorld`/`WorldToHex` switched to **flat-top axial** (keeps the `(q,r)` identity, so hex-coord gameplay is unchanged; only world orientation flips). `CreateHexMesh` → flat-top vertices. New `CreateQuadMesh` for the 64×84 2.5D tile.
- **HexChunkSystem** — loads `hextile-atlas.png` from StreamingAssets (Point/Clamp, mirrors the item-atlas loader), adds the quad as a second mesh; atlas biomes (grass/sand/snow, `tileId >= 0`) render on the quad, procedural biomes (forest/dirt/stone/river) stay on the hex mesh. Y-depth sort (`z = worldY · k`) so lower rows draw over upper rows' skirts.
- **HexTile.shader** — `tileId >= 0` samples the atlas cell (V-flipped) and layers **territory / fog / aura** on top of the sprite via a cap-sized flat-top SDF (`_AtlasHexSize`, tunable).
- **hexSDF → flat-top** in HexShared, HexRiverTile, HexHoverOverlay (cursor), HexBuildPreview so borders/cursor/preview match the new mesh.

### Fixes surfaced during bring-up
- **SelectionVisualSystem** — `MarkUnselectedVisualJob` now chains on `MarkSelectedVisualJob` (both write `UnitSelectedVisual`; the parallel schedule raced).
- **MouseStateSource** — had its own pointy-top `WorldToHex` copy → mouse picking was offset after the flip. Now delegates to `HexMeshUtil.WorldToHex` (single source of truth).

Plus `HexBiomeAtlas.cs.meta`.

### Known follow-up (not in this PR)
`HexCapital.hlsl` draws the capital building as a 7-hex cluster with hardcoded pointy-top pixel offsets — needs flipping to flat-top.

### Verification
No Unity compiler locally; verified in-editor during pairing (tiles tessellate, picking aligns, overlays render). Tuning knobs: `QuadYOffset`, `DepthPerY` sign, `_AtlasHexSize`.