### PR TITLE
test(cryptothrone): allow discord.js ?v= cache-bust in e2e assertion

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/assets.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/assets.spec.ts
@@ -35,7 +35,8 @@ test.describe('bundled assets', () => {
 		expect(res.headers()['content-type']).toMatch(/html/);
 		const html = await res.text();
 		// Relative src so the Discord `/` -> `/discord/` mapping resolves it.
-		expect(html).toMatch(/src=["']discord\.js["']/);
+		// The build stamps a ?v=<hash> cache-bust query, so allow it.
+		expect(html).toMatch(/src=["']discord\.js(\?v=[0-9a-f]+)?["']/);
 	});
 
 	test('standalone embed bundle serves as executable JS', async ({


### PR DESCRIPTION
## Problem
`CI - Docker / cryptothrone` e2e failed ([run 27558059288](https://github.com/KBVE/kbve/actions/runs/27558059288)):

```
assets.spec.ts:38 › Discord Activity index loads its script relatively
Expected pattern: /src=["']discord\.js["']/
Received:         <script src="discord.js?v=725ff326" defer></script>
```

The cache-bust stamp (#12514) added `?v=<hash>`, which the old regex (quote immediately after `.js`) rejected. Image built fine — assertion was just stale.

## Fix
Regex now accepts the optional `?v=<hex>` query (still matches the unstamped form).

## Notes
- No version bump — 0.1.35 failed at e2e so it never published; this rides it (re-run publishes 0.1.35).