### PR TITLE
fix(cryptothrone): drop redirect_uri from Discord Activity OAuth (revert #12510)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -15,12 +15,6 @@ const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
 	| string
 	| undefined;
 
-// Discord's OAuth2 authorize rejects (code 5000) without a redirect_uri. It
-// must be registered under the app's OAuth2 → Redirects AND match the value the
-// backend sends on the code→token exchange (DISCORD_REDIRECT_URI). The Activity
-// uses the code grant, so this URI is never navigated — it only has to match.
-const REDIRECT_URI = 'https://cryptothrone.com';
-
 // Backend bridge (P3b): exchanges the Discord OAuth code for a Discord
 // access_token AND a game-server session {jwt, username}, linking the Discord
 // user to a KBVE profile. The Activity iframe runs on *.discordsays.com, so
@@ -107,7 +101,6 @@ async function boot(): Promise<void> {
 			state: '',
 			prompt: 'none',
 			scope: ['identify'],
-			redirect_uri: REDIRECT_URI,
 		}),
 	);
 

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.35"
+version: "0.1.36"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
+++ b/apps/kube/cryptothrone/manifest/cryptothrone-deployment.yaml
@@ -73,11 +73,6 @@ spec:
                       # arrive via the supabase-shared envFrom below).
                       - name: KBVE_PG_APPLICATION_NAME
                         value: 'axum-cryptothrone'
-                      # Discord OAuth2 code→token exchange. Must match the
-                      # redirect_uri the Activity client sends on authorize and
-                      # a URI registered under the app's OAuth2 → Redirects.
-                      - name: DISCORD_REDIRECT_URI
-                        value: 'https://cryptothrone.com'
                   envFrom:
                       # Optional so the pod still boots before the
                       # ExternalSecret has rendered or the kilobase


### PR DESCRIPTION
## Problem
After #12510 the Activity failed at **`Discord authorize: Redirect URI cannot be used in the RPC OAuth2 Authorization flow (code 5000)`**.

The embedded/RPC `authorize` flow does **not** accept an explicit `redirect_uri`. Verified against Discord's [Activity docs](https://docs.discord.com/developers/activities/building-an-activity) and the [official embedded-app-sdk-examples starter](https://github.com/discord/embedded-app-sdk-examples) — neither `authorize()` nor the code→token exchange pass `redirect_uri`; the SDK handles the redirect internally.

The original `Missing redirect_uri` error (pre-#12510) just meant the app had **zero** redirect URIs registered in the portal. The fix was to register one — not to send it in the request.

## Fix (reverts #12510)
- client `discord.tsx`: drop `redirect_uri` from `authorize`.
- `cryptothrone-deployment.yaml`: drop `DISCORD_REDIRECT_URI` (`discord.rs` already omits it from the token exchange when unset — matching the canonical flow).
- bump 0.1.36.

## Portal (still required, unchanged)
OAuth2 → Redirects must have **≥1 URI registered** (e.g. `https://cryptothrone.com`). It's never sent in the request — Discord just requires one to exist.

## Verified
build-discord clean; `redirect_uri` no longer in the bundle.