### PR TITLE
fix(ci): unbreak ci-manifest-guard on flaky nx project graph

### DIFF
--- a/.github/workflows/ci-manifest-guard.yml
+++ b/.github/workflows/ci-manifest-guard.yml
@@ -51,7 +51,22 @@ jobs:
 
             - run: pnpm install --frozen-lockfile
 
-            - run: npx nx run astro-kbve:build
+            # nx 22 occasionally hits a flaky "Failed to process project graph" race
+            # on the first cold attempt (apps/jobboard/web mixes pnpm + standalone
+            # npm lockfile, which confuses the project-graph merge). Retry once before
+            # surfacing as a real failure.
+            - name: Build astro-kbve (retry on flaky graph)
+              run: |
+                  for attempt in 1 2 3; do
+                      if npx nx run astro-kbve:build; then
+                          echo "Build succeeded on attempt $attempt"
+                          exit 0
+                      fi
+                      echo "::warning::astro-kbve:build attempt $attempt failed, retrying..."
+                      npx nx reset || true
+                  done
+                  echo "::error::astro-kbve:build failed after 3 attempts"
+                  exit 1
 
             - run: npx nx run astro-kbve:sync:ci-manifest
 

--- a/.nxignore
+++ b/.nxignore
@@ -3,3 +3,4 @@
 
 # Directories with their own Cargo.toml/package.json that break NX project graph
 apps/kbve/edge/edge-runtime/
+apps/jobboard/web/

--- a/nx.json
+++ b/nx.json
@@ -97,7 +97,8 @@
 				"apps/kbve/isometric/**",
 				"apps/kbve/desktop-kbve/**",
 				"apps/rows/**",
-				"apps/rows-e2e/**"
+				"apps/rows-e2e/**",
+				"apps/jobboard/web/**"
 			],
 			"options": {
 				"buildTargetName": "build",
@@ -112,7 +113,8 @@
 				"apps/kbve/isometric/**",
 				"apps/kbve/desktop-kbve/**",
 				"apps/rows/**",
-				"apps/rows-e2e/**"
+				"apps/rows-e2e/**",
+				"apps/jobboard/web/**"
 			],
 			"options": {
 				"testTargetName": "test"


### PR DESCRIPTION
## Summary

Fixes the failing `Verify ci-dispatch-manifest is up to date` check on PR #12525 (and any other PR that triggers manifest-guard against current dev).

## Root cause

`apps/jobboard/web/` (introduced in #12492) is a standalone npm project nested inside the pnpm workspace — its own `package-lock.json`, its own `vite.config.ts`. The nx graph parser sees `vite.config.ts` and the `@nx/vite/plugin` auto-creates a project node **without a name**. The `package-json` plugin separately creates a node **with** name `@kbve/jobboard-web`. The merge of these two nodes intermittently produces a node with no name, which trips `validateAndNormalizeProjectRootMap` with `ProjectsWithNoNameError`.

The crash is timing-dependent and only surfaces on the first cold graph parse:

- `nx run astro-kbve:build` from workspace root sometimes succeeds (nx auto-detects flaky and retries).
- `nx exec --` from `apps/kbve/astro-kbve/` (which is what the build target's `cwd: apps/kbve/astro-kbve` + `nx exec -- astro build` does internally) **always** crashes on cold parse locally.
- CI does NOT auto-retry without Nx Cloud, so even one cold-parse crash fails the job.

PR #12509 → #12510 → #12514 → #12526 all passed manifest-guard because they happened to land on a warm cache. #12525 (release rollup) lands on a cold runner and trips it.

## Fix

Three layers of defense:

1. `.nxignore` — adds `apps/jobboard/web/` alongside the existing `apps/kbve/edge/edge-runtime/` line.
2. `nx.json` — `apps/jobboard/web/**` added to `@nx/vite/plugin` and `@nx/vitest` excludes, matching the pattern already used for isometric/desktop-kbve/rows (which all also have vite.config.ts inside their roots).
3. `.github/workflows/ci-manifest-guard.yml` — wraps `nx run astro-kbve:build` in a 3-try retry loop with `nx reset` between attempts. Belt-and-suspenders against any remaining cold-parse race.

## Why not a "real" fix

A proper structural fix probably means moving `apps/jobboard/web/` behind its own pnpm sub-workspace or dropping the npm-style lockfile entirely. That's a bigger refactor. This PR unblocks the release pipeline today so PR #12525 can land.

## Test plan

- [x] Local repro of the crash with `cd apps/kbve/astro-kbve && nx exec -- echo hello` — confirms `ProjectsWithNoNameError`
- [x] Retry loop verified locally (first attempt fails, second succeeds)
- [x] Workflow yaml validates