### PR TITLE
fix(ci): force NX_DAEMON=false in kbve.sh -nx wrapper (Failed to process project graph)

### DIFF
--- a/kbve.sh
+++ b/kbve.sh
@@ -871,6 +871,12 @@ _load_env_local() {
         . .env.local
         set +a
     fi
+    # Force the Nx daemon off for every -nx invocation. Worktrees get this via
+    # .env.local, but the main checkout (CI/Docker container-prep) has none, so
+    # the daemon ran there and intermittently crashed mid `nx exec`
+    # ("Failed to process project graph"). It's pure overhead for one-shot
+    # builds; disabling it makes graph processing deterministic everywhere.
+    export NX_DAEMON=false
 }
 
 # Function to run pnpm nx with additional arguments under the cloud.


### PR DESCRIPTION
## Problem
`CI - Docker / cryptothrone` failed ([run 27569577865](https://github.com/KBVE/kbve/actions/runs/27569577865)) with:

```
NX  Failed to process project graph.
> UV_THREADPOOL_SIZE=4 NODE_OPTIONS=... nx exec -- astro build
```

The graph is structurally valid (`nx show projects` + a fresh daemon-off `nx graph` both pass locally), and cryptothrone runs **alternate** pass/fail on the same graph → a transient **Nx daemon crash**, not a config error.

Root cause: `kbve.sh`'s `-nx` wrapper (`run_pnpm_nx`) only gets `NX_DAEMON=false` from `.env.local`, which is generated **only in worktrees**. CI/Docker container-prep runs in the **main checkout** (no `.env.local`), so the daemon was enabled there and intermittently died during the nested `nx exec`. Locally it never reproduces because worktrees disable the daemon.

## Fix
Export `NX_DAEMON=false` unconditionally in `_load_env_local` (the `-nx` path). The daemon is pure overhead for one-shot CI/Docker builds; disabling it makes graph processing deterministic everywhere, matching worktree behavior.

## Notes
- Workspace-wide hardening — fixes the same flake class for every `kbve.sh -nx` build, not just cryptothrone.
- No version bump (build tooling, not a published artifact). Lets the pending cryptothrone 0.1.36 build reliably.