### PR TITLE
fix(ci): NX_DAEMON=false job-wide in docker-test-app (graph flake)

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -44,6 +44,11 @@ jobs:
         timeout-minutes: 180
         env:
             NX_NO_CLOUD: true
+            # The Nx daemon intermittently crashes during graph processing on
+            # one-shot CI runners ("Failed to process project graph"). It adds
+            # no value for a single invocation; force it off for every nx call
+            # in this job (direct `pnpm nx e2e` + nested kbve.sh -nx builds).
+            NX_DAEMON: false
         permissions:
             contents: read
             packages: write


### PR DESCRIPTION
## Problem
`CI - Docker / cryptothrone` intermittently fails with `NX Failed to process project graph` ([run 27569577865](https://github.com/KBVE/kbve/actions/runs/27569577865)). The graph is **structurally valid** — `nx show projects` and a verbose daemon-off `nx graph` both exit 0 with no errors locally; runs alternate pass/fail on the same graph. It's a transient **Nx daemon crash** on the one-shot runner.

## Why #12543 wasn't enough
#12543 forced `NX_DAEMON=false` in `kbve.sh`'s `-nx` wrapper, covering the **nested** container-prep builds (`./kbve.sh -nx astro-cryptothrone:build`). But `docker-test-app.yml` runs the **outer** command directly:
```
pnpm nx e2e ${{ inputs.project }} --configuration=ci --no-cloud ...
```
That invocation has no `.env.local` and isn't routed through kbve.sh, so the daemon was still on for it → it could crash graph processing.

## Fix
Set `NX_DAEMON: false` at the **job env** in `docker-test-app.yml`, so every nx call in the job — the direct `pnpm nx e2e` and all nested kbve.sh builds — runs daemon-off. Combined with #12543, no daemon-on path remains in the docker app test pipeline.

## Notes
- ci-main.yml has no direct nx calls (checked) — not affected.
- No daemon = pure win for one-shot CI (the daemon only helps repeated local invocations).
- No version bump (CI config).