### PR TITLE
fix(ci): scope Nx daemon-off to cryptothrone only (narrow #12543/#12544)

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -44,11 +44,13 @@ jobs:
         timeout-minutes: 180
         env:
             NX_NO_CLOUD: true
-            # The Nx daemon intermittently crashes during graph processing on
-            # one-shot CI runners ("Failed to process project graph"). It adds
-            # no value for a single invocation; force it off for every nx call
-            # in this job (direct `pnpm nx e2e` + nested kbve.sh -nx builds).
-            NX_DAEMON: false
+            # cryptothrone-only: its docker test intermittently hits the Nx
+            # daemon crashing during graph processing ("Failed to process
+            # project graph"). Scope the daemon-off to that project so other
+            # (working) pipelines keep their default. The job env is inherited
+            # by both the direct `pnpm nx e2e` and the nested kbve.sh -nx
+            # container-prep build.
+            NX_DAEMON: ${{ inputs.project == 'cryptothrone' && 'false' || '' }}
         permissions:
             contents: read
             packages: write

--- a/kbve.sh
+++ b/kbve.sh
@@ -871,12 +871,6 @@ _load_env_local() {
         . .env.local
         set +a
     fi
-    # Force the Nx daemon off for every -nx invocation. Worktrees get this via
-    # .env.local, but the main checkout (CI/Docker container-prep) has none, so
-    # the daemon ran there and intermittently crashed mid `nx exec`
-    # ("Failed to process project graph"). It's pure overhead for one-shot
-    # builds; disabling it makes graph processing deterministic everywhere.
-    export NX_DAEMON=false
 }
 
 # Function to run pnpm nx with additional arguments under the cloud.


### PR DESCRIPTION
## Why
#12543 (kbve.sh `-nx` wrapper) and #12544 (docker-test-app job env) disabled the Nx daemon **workspace-wide** — affecting every project's builds and docker tests, not just the one that flakes. Those other pipelines were working; don't change them.

## Change
- **Revert** the blanket `export NX_DAEMON=false` from `kbve.sh`'s `_load_env_local` (it touched every `-nx` build).
- **Gate** the docker-test-app job env: `NX_DAEMON: ${{ inputs.project == 'cryptothrone' && 'false' || '' }}`.

The job `env` is inherited by child processes, so for cryptothrone it covers **both** the direct `pnpm nx e2e cryptothrone` and the nested `./kbve.sh -nx astro-cryptothrone:build` container-prep — the whole job runs daemon-off. Every other project gets an empty `NX_DAEMON` (nx default = daemon on, unchanged).

## Context
The graph is structurally valid (verbose daemon-off `nx graph` = exit 0); the failures were transient daemon crashes on cryptothrone's run only. No version bump (CI config).