### PR TITLE
fix(sql): tracker.find_claim_identity_by_discord_id OWNER postgres (Discord session 500)

### DIFF
--- a/packages/data/sql/dbmate/migrations/20260615130000_tracker_discord_identity_owner_postgres.sql
+++ b/packages/data/sql/dbmate/migrations/20260615130000_tracker_discord_identity_owner_postgres.sql
@@ -1,0 +1,13 @@
+-- migrate:up
+
+-- find_claim_identity_by_discord_id is SECURITY DEFINER and reads auth.identities,
+-- so its body runs as the owner. Owned by service_role it throws 42501 (service_role
+-- has no SELECT on auth.*); reassign to postgres. Same trap fixed for profile_discord
+-- and discordsh_vault.
+ALTER FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) OWNER TO postgres;
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+ALTER FUNCTION tracker.find_claim_identity_by_discord_id(TEXT) OWNER TO service_role;


### PR DESCRIPTION
## Problem
Discord Activity: **`session exchange failed (500)`**. Backend path is `discord.rs` → `tracker.find_claim_identity_by_discord_id` → returns 500 "profile lookup failed".

Root cause: that function is `SECURITY DEFINER` and reads `auth.identities`, but the migration set `OWNER TO service_role`. A definer fn runs its body as the **owner**, and `service_role` has no SELECT on `auth.*` → **42501**. (PgCluster is fine — it connects as `postgres`; a connection failure would be 503, not 500.)

This is the exact trap already fixed twice — see `20260608014906_profile_discord_provider_id_owner` and `20260608183000_discordsh_vault_functions_owner`.

## Fix
New migration `20260615130000`: `ALTER FUNCTION ... OWNER TO postgres` (EXECUTE grant to service_role unchanged). Forward-fix — works whether the original `20260523033932` is already applied (reassigns owner) or applied fresh in the same deploy (runs after it).

## Deploy
Needs the gated prod dbmate deploy (`ci-dbmate-deploy.yml` + kilobase-prod approval) — I won't run dbmate against prod. After it applies, the session exchange should resolve the Discord→KBVE profile and return {jwt, username}.

## Note
If the user's Discord isn't linked to a KBVE profile, the handler correctly returns **403** ("not linked"), not 500 — so a 403 after this is expected/working, not a regression.