### PR TITLE
fix(jobboard): has_test=false to unblock the docker publish gate

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -388,7 +388,7 @@
 			"image": "kbve/jobboard",
 			"e2e_name": "jobboard",
 			"deployment_yaml": "apps/kube/jobboard/manifest/jobboard-deployment.yaml",
-			"has_test": true
+			"has_test": false
 		},
 		{
 			"key": "nd_server",

--- a/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
@@ -32,7 +32,7 @@ runner: ubuntu-latest
 image: kbve/jobboard
 e2e_name: jobboard
 deployment_yaml: apps/kube/jobboard/manifest/jobboard-deployment.yaml
-has_test: true
+has_test: false
 author: h0lybyte
 license: KBVE
 status: active


### PR DESCRIPTION
Clean redo of closed #12553 (that branch was stale and would've reverted ~9.6k lines of newer dev work).

**Net change: 2 lines.** Flip `has_test` true→false in `jobboard.mdx` frontmatter + the jobboard `.github/ci-dispatch-manifest.json` entry.

**Why:** in `ci-docker.yml`, `has_test=true` makes the `test` job a required gate before `publish`. jobboard has no e2e target (verified on dev), so that gate would fail and block the `ghcr.io/kbve/jobboard` push. With `has_test=false`, publish proceeds (full rebuild + push). Cargo unit tests still run in the Validate Dev→Main CI.

Flip back to `true` once a boot+/health docker e2e (needs a throwaway PG) is wired.