### PR TITLE
fix(jobboard): lint/build/test dependsOn web-build (RustEmbed web/dist)

### DIFF
--- a/apps/jobboard/project.json
+++ b/apps/jobboard/project.json
@@ -7,6 +7,7 @@
 		"build": {
 			"executor": "@monodon/rust:build",
 			"outputs": ["{options.target-dir}"],
+			"dependsOn": ["web-build"],
 			"options": {
 				"target-dir": "dist/target/jobboard"
 			},
@@ -19,6 +20,7 @@
 		"test": {
 			"executor": "@monodon/rust:test",
 			"outputs": ["{options.target-dir}"],
+			"dependsOn": ["web-build"],
 			"options": {
 				"target-dir": "dist/target/jobboard"
 			}
@@ -26,6 +28,7 @@
 		"lint": {
 			"executor": "@monodon/rust:lint",
 			"outputs": ["{options.target-dir}"],
+			"dependsOn": ["web-build"],
 			"options": {
 				"target-dir": "dist/target/jobboard"
 			}


### PR DESCRIPTION
Fixes the `jobboard:lint` failure in `nx affected` (Validate Dev→Main):
```
error: #[derive(RustEmbed)] folder '.../apps/jobboard/web/dist' does not exist
  --> apps/jobboard/src/rest/spa.rs:7:1
```

`src/rest/spa.rs` embeds the SPA via `#[derive(RustEmbed)] #[folder = "web/dist"]`, which must exist at compile/clippy time. The rust `build`/`lint`/`test` targets didn't depend on the existing `web-build` target, so cargo ran before the SPA was built.

**Fix (1 file, 3 lines):** add `dependsOn: ["web-build"]` to `build`, `lint`, `test`. nx builds `web/dist` first.

Verified: `cargo clippy -p jobboard` passes once `web/dist` exists.