### PR TITLE
fix(jobboard): readiness gates on rw pool only + version in health (fixes jobs.kbve.com 503)

### DIFF
--- a/apps/jobboard/Dockerfile
+++ b/apps/jobboard/Dockerfile
@@ -16,6 +16,7 @@ RUN npm ci
 COPY tsconfig.base.json tsconfig.base.json
 COPY packages/npm/rn packages/npm/rn
 COPY packages/npm/core packages/npm/core
+COPY packages/npm/fx packages/npm/fx
 COPY apps/jobboard/web apps/jobboard/web
 RUN cd apps/jobboard/web && npx vite build
 

--- a/apps/jobboard/src/rest/system.rs
+++ b/apps/jobboard/src/rest/system.rs
@@ -6,6 +6,8 @@ use axum::routing::get;
 use axum::{Json, Router};
 use std::sync::Arc;
 
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/health", get(health))
@@ -13,22 +15,31 @@ pub fn routes() -> Router<Arc<AppState>> {
 }
 
 async fn health() -> Json<serde_json::Value> {
-    Json(serde_json::json!({ "status": "healthy", "service": "jobboard" }))
+    Json(serde_json::json!({
+        "status": "healthy",
+        "service": "jobboard",
+        "version": VERSION,
+    }))
 }
 
 async fn readiness(State(app): State<Arc<AppState>>) -> impl IntoResponse {
     let health = app.db.health().await;
-    let db_ok = health.all_ok();
-    let status = if db_ok {
+    let ready = health.rw.ok;
+    let status = if ready {
         StatusCode::OK
     } else {
         StatusCode::SERVICE_UNAVAILABLE
     };
     let body = serde_json::json!({
-        "status": if db_ok { "ready" } else { "degraded" },
+        "status": if ready { "ready" } else { "degraded" },
         "service": "jobboard",
-        "database": db_ok,
+        "version": VERSION,
         "uptime_seconds": app.started_at.elapsed().as_secs(),
+        "database": {
+            "rw": health.rw.ok,
+            "ro": health.ro.ok,
+            "any": health.any.ok,
+        },
     });
     (status, Json(body))
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx
@@ -24,7 +24,7 @@ tags:
 key: jobboard
 pipeline: docker
 app_name: jobboard
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/jobboard
 version_toml: apps/jobboard/version.toml
 version_target: apps/jobboard/Cargo.toml


### PR DESCRIPTION
## Symptom
jobs.kbve.com → **503**. Pod is **Running, 0 restarts, app healthy** (direct `/verticals` = 200, `/ready` = 200 on a one-off curl) but kubelet readiness probe fails **every cycle** → `0/1 Ready` → empty endpoints → gateway 503.

## Cause
`/ready` gated on `PgCluster.health().all_ok()` = **rw && ro && any**. The RO pooler (`supabase-cluster-pooler-ro`) is borderline against jedi's 1s health deadline, so the aggregate flaps — kubelet (every 10s) catches the slow path → 503; my manual curls caught the fast path → 200. The **rw** pool (what the service actually uses) is fine.

## Fix
- Readiness gates on **`health.rw.ok` only**; `ro`/`any` are reported in the body but don't gate the pod out of the gateway.
- Add build **`version`** (`CARGO_PKG_VERSION`) to `/health` and `/ready` (per request).
- Bump MDX `version: 0.1.0 → 0.1.1` to publish.

Verified: `cargo build -p jobboard` ok.

## Note
Ships after publish + dev→main release. The running pod is genuinely healthy — if you want jobs.kbve.com up **immediately**, I can (with your OK) live-patch the readiness probe to `/health` as a stopgap, or you can `kubectl -n kbve patch` it; the proper fix here supersedes it.