### PR TITLE
feat(cryptothrone): fast-register Discord users + fix chat WS jwt (iat)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -100,7 +100,7 @@ async function boot(): Promise<void> {
 			response_type: 'code',
 			state: '',
 			prompt: 'none',
-			scope: ['identify'],
+			scope: ['identify', 'email'],
 		}),
 	);
 

--- a/apps/cryptothrone/axum-cryptothrone/src/discord.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/discord.rs
@@ -67,6 +67,7 @@ struct GoTrueUser {
 #[derive(Serialize)]
 struct MintedClaims {
     sub: String,
+    iat: i64,
     exp: i64,
     kbve_username: String,
     role: String,
@@ -333,6 +334,7 @@ fn mint_session_jwt(
 ) -> Result<String, jsonwebtoken::errors::Error> {
     let claims = MintedClaims {
         sub: sub.to_string(),
+        iat: now_secs() as i64,
         exp,
         kbve_username: kbve_username.to_string(),
         role: "authenticated".into(),

--- a/apps/cryptothrone/axum-cryptothrone/src/discord.rs
+++ b/apps/cryptothrone/axum-cryptothrone/src/discord.rs
@@ -17,7 +17,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use jedi::state::pg::{PgCluster, tokio_postgres::Row};
+use jedi::state::pg::{PgCluster, PgConn};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use serde::{Deserialize, Serialize};
 
@@ -48,6 +48,19 @@ struct DiscordToken {
 
 #[derive(Deserialize)]
 struct DiscordUser {
+    id: String,
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    verified: Option<bool>,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    global_name: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GoTrueUser {
     id: String,
 }
 
@@ -128,15 +141,16 @@ pub async fn session(
         }
     };
 
-    // 3. Discord id -> linked KBVE profile (user_id + kbve_username).
-    let conn = match pg.read().await {
+    // 3. Discord id -> linked KBVE profile, or fast-register one. write() pool
+    // because the register path sets profile.username.
+    let conn = match pg.write().await {
         Ok(c) => c,
         Err(e) => {
             tracing::error!(error = %e, "pg acquire failed");
             return (StatusCode::SERVICE_UNAVAILABLE, "database unavailable").into_response();
         }
     };
-    let row: Row = match conn
+    let linked: Option<(String, Option<String>)> = match conn
         .query_opt(
             "SELECT user_id::text, kbve_username \
              FROM tracker.find_claim_identity_by_discord_id($1)",
@@ -144,23 +158,23 @@ pub async fn session(
         )
         .await
     {
-        Ok(Some(row)) => row,
-        Ok(None) => {
-            return (
-                StatusCode::FORBIDDEN,
-                "Discord account is not linked to a KBVE profile",
-            )
-                .into_response();
-        }
+        Ok(Some(row)) => Some((row.get(0), row.get(1))),
+        Ok(None) => None,
         Err(e) => {
             tracing::error!(error = %e, "discord profile lookup failed");
             return (StatusCode::INTERNAL_SERVER_ERROR, "profile lookup failed").into_response();
         }
     };
-    let user_id: String = row.get(0);
-    let kbve_username: Option<String> = row.get(1);
-    let Some(kbve_username) = kbve_username.filter(|u| !u.is_empty()) else {
-        return (StatusCode::FORBIDDEN, "linked KBVE profile has no username").into_response();
+
+    let (user_id, kbve_username) = match linked {
+        Some((uid, Some(name))) if !name.is_empty() => (uid, name),
+        other => {
+            let existing = other.map(|(uid, _)| uid);
+            match provision_user(&http, &conn, &user, existing).await {
+                Ok(pair) => pair,
+                Err((code, msg)) => return (code, msg).into_response(),
+            }
+        }
     };
 
     // 4. Mint the Supabase-valid HS256 JWT the game server accepts.
@@ -179,6 +193,126 @@ pub async fn session(
         username: kbve_username,
     })
     .into_response()
+}
+
+/// Email key for a Discord user: their verified Discord email, else a stable
+/// synthetic address derived from the snowflake so the GoTrue create-or-get is
+/// still idempotent for users who didn't grant email or whose email is unverified.
+fn discord_email(user: &DiscordUser) -> String {
+    match (&user.email, user.verified) {
+        (Some(e), Some(true)) if !e.is_empty() => e.to_lowercase(),
+        _ => format!("discord_{}@users.cryptothrone.com", user.id),
+    }
+}
+
+/// Resolve the KBVE user for a Discord identity that isn't fully linked yet:
+/// reuse an existing user_id (linked but no username) or fast-register via
+/// GoTrue create-or-get on the email key, then ensure a profile.username.
+async fn provision_user(
+    http: &reqwest::Client,
+    conn: &PgConn<'_>,
+    user: &DiscordUser,
+    existing_uid: Option<String>,
+) -> Result<(String, String), (StatusCode, &'static str)> {
+    let user_id = match existing_uid {
+        Some(uid) => uid,
+        None => gotrue_create_or_get(http, conn, &discord_email(user), &user.id).await?,
+    };
+
+    let base = user
+        .global_name
+        .clone()
+        .or_else(|| user.username.clone())
+        .unwrap_or_default();
+    let username: String = match conn
+        .query_one(
+            "SELECT tracker.ensure_discord_username($1::uuid, $2, $3)",
+            &[&user_id, &base, &user.id],
+        )
+        .await
+    {
+        Ok(row) => row.get(0),
+        Err(e) => {
+            tracing::error!(error = %e, "ensure_discord_username failed");
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "username provisioning failed",
+            ));
+        }
+    };
+    Ok((user_id, username))
+}
+
+/// GoTrue admin create-or-get keyed on email. GoTrue owns auth.users, so we
+/// never hand-craft it; on "already registered" we resolve the existing user.
+async fn gotrue_create_or_get(
+    http: &reqwest::Client,
+    conn: &PgConn<'_>,
+    email: &str,
+    discord_id: &str,
+) -> Result<String, (StatusCode, &'static str)> {
+    let base = std::env::var("SUPABASE_URL").unwrap_or_default();
+    let key = std::env::var("SUPABASE_SERVICE_ROLE_KEY").unwrap_or_default();
+    if base.is_empty() || key.is_empty() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "supabase admin not configured",
+        ));
+    }
+    let body = serde_json::json!({
+        "email": email,
+        "email_confirm": true,
+        "user_metadata": { "provider": "discord", "discord_id": discord_id },
+    });
+    match http
+        .post(format!("{base}/auth/v1/admin/users"))
+        .header("apikey", key.as_str())
+        .bearer_auth(&key)
+        .json(&body)
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => match r.json::<GoTrueUser>().await {
+            Ok(u) => Ok(u.id),
+            Err(_) => Err((StatusCode::BAD_GATEWAY, "bad gotrue response")),
+        },
+        Ok(r)
+            if r.status() == StatusCode::UNPROCESSABLE_ENTITY
+                || r.status() == StatusCode::CONFLICT =>
+        {
+            find_user_id_by_email(conn, email).await
+        }
+        Ok(r) => {
+            tracing::error!(status = %r.status(), "gotrue admin create failed");
+            Err((StatusCode::BAD_GATEWAY, "gotrue admin create failed"))
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "gotrue admin request failed");
+            Err((StatusCode::BAD_GATEWAY, "gotrue admin request failed"))
+        }
+    }
+}
+
+async fn find_user_id_by_email(
+    conn: &PgConn<'_>,
+    email: &str,
+) -> Result<String, (StatusCode, &'static str)> {
+    match conn
+        .query_opt(
+            "SELECT tracker.find_user_id_by_email($1)::text",
+            &[&email.to_lowercase()],
+        )
+        .await
+    {
+        Ok(Some(row)) => row
+            .get::<_, Option<String>>(0)
+            .ok_or((StatusCode::INTERNAL_SERVER_ERROR, "user not found by email")),
+        Ok(None) => Err((StatusCode::INTERNAL_SERVER_ERROR, "user not found by email")),
+        Err(e) => {
+            tracing::error!(error = %e, "find_user_id_by_email failed");
+            Err((StatusCode::INTERNAL_SERVER_ERROR, "user lookup failed"))
+        }
+    }
 }
 
 fn now_secs() -> u64 {

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.36"
+version: "0.1.37"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml

--- a/packages/data/sql/dbmate/migrations/20260616000000_tracker_provision_discord_user.sql
+++ b/packages/data/sql/dbmate/migrations/20260616000000_tracker_provision_discord_user.sql
@@ -1,0 +1,97 @@
+-- migrate:up
+
+-- Fast-register helpers for the Discord Activity session bridge. auth.users is
+-- created by GoTrue (admin API) so these never INSERT into auth.*; they only
+-- read auth.users (link-by-email) and set profile.username. SECURITY DEFINER
+-- owned by postgres because auth.users is owned by supabase_auth_admin and a
+-- service_role-owned definer fn would throw 42501.
+
+CREATE OR REPLACE FUNCTION tracker.find_user_id_by_email(p_email TEXT)
+RETURNS UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+    SELECT u.id
+    FROM auth.users u
+    WHERE u.email = lower(p_email)
+    ORDER BY u.created_at DESC NULLS LAST, u.id DESC
+    LIMIT 1;
+$$;
+
+ALTER FUNCTION tracker.find_user_id_by_email(TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION tracker.find_user_id_by_email(TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION tracker.find_user_id_by_email(TEXT) TO service_role;
+
+-- Idempotently give a freshly-provisioned user a profile.username. Returns the
+-- existing username if one is already set, otherwise derives a candidate from
+-- the Discord display name (sanitized to the profile charset) and retries with a
+-- snowflake-derived suffix on collision/banlist rejection.
+CREATE OR REPLACE FUNCTION tracker.ensure_discord_username(
+    p_user_id    UUID,
+    p_base       TEXT,
+    p_discord_id TEXT
+)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+    v_existing  TEXT;
+    v_base      TEXT;
+    v_candidate TEXT;
+    v_suffix    TEXT;
+    v_attempt   INT := 0;
+BEGIN
+    SELECT username INTO v_existing FROM profile.username WHERE user_id = p_user_id;
+    IF v_existing IS NOT NULL THEN
+        RETURN v_existing;
+    END IF;
+
+    v_base := lower(coalesce(p_base, ''));
+    v_base := regexp_replace(v_base, '[^a-z0-9_-]', '', 'g');
+    IF char_length(v_base) < 3 THEN
+        v_base := 'chip' || right(regexp_replace(coalesce(p_discord_id, ''), '[^0-9]', '', 'g'), 6);
+    END IF;
+    v_base := left(v_base, 24);
+
+    LOOP
+        v_attempt := v_attempt + 1;
+        IF v_attempt = 1 THEN
+            v_candidate := v_base;
+        ELSE
+            v_suffix := right(regexp_replace(coalesce(p_discord_id, ''), '[^0-9]', '', 'g'), v_attempt + 1);
+            v_candidate := left(v_base, 60 - char_length(v_suffix)) || '-' || v_suffix;
+        END IF;
+
+        BEGIN
+            PERFORM profile.service_add_username(p_user_id, v_candidate);
+            RETURN v_candidate;
+        EXCEPTION
+            WHEN unique_violation THEN
+                IF v_attempt >= 6 THEN
+                    RAISE;
+                END IF;
+            WHEN OTHERS THEN
+                -- banlist/format rejection on the derived candidate; fall through
+                -- to a snowflake-suffixed retry rather than failing the register.
+                IF v_attempt >= 6 THEN
+                    RAISE;
+                END IF;
+        END;
+    END LOOP;
+END;
+$$;
+
+ALTER FUNCTION tracker.ensure_discord_username(UUID, TEXT, TEXT) OWNER TO postgres;
+REVOKE ALL ON FUNCTION tracker.ensure_discord_username(UUID, TEXT, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION tracker.ensure_discord_username(UUID, TEXT, TEXT) TO service_role;
+
+NOTIFY pgrst, 'reload schema';
+
+-- migrate:down
+
+DROP FUNCTION IF EXISTS tracker.ensure_discord_username(UUID, TEXT, TEXT);
+DROP FUNCTION IF EXISTS tracker.find_user_id_by_email(TEXT);


### PR DESCRIPTION
## What
The Discord Activity hands the backend a verified Discord user, so `discord.rs` now **provisions a KBVE account** instead of returning 403 when there's no linked profile.

## Flow
1. `find_claim_identity_by_discord_id` hit → existing path (unchanged).
2. Else **GoTrue admin create-or-get** keyed on email: the verified Discord email, or a stable synthetic `discord_<snowflake>@users.cryptothrone.com` when email is absent/unverified (keeps it idempotent + lets a verified email link to an existing KBVE account). GoTrue owns `auth.users` — **no hand-crafted auth rows**; on "already registered" we resolve via `tracker.find_user_id_by_email`.
3. `tracker.ensure_discord_username` sets `profile.username` (derived from the Discord display name, collision-suffixed via the existing `profile.service_add_username`).
4. Mint the session JWT (unchanged).

## Pieces
- **client** (`discord.tsx`): `scope: ['identify','email']`.
- **SQL** migration `20260616000000`: `tracker.find_user_id_by_email` + `tracker.ensure_discord_username`, both `SECURITY DEFINER` **OWNER postgres** (read-only on `auth.*`; 42501 rule), EXECUTE to service_role.
- **backend** (`discord.rs`): GoTrue admin create-or-get + provision orchestration; uses existing `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY` env.
- bump **0.1.37**.

## Validation
axum-cryptothrone lint ✓, build-discord ✓ (`scope:["identify","email"]` in bundle). The SQL migration + the GoTrue admin call can only be fully exercised against real Supabase — needs the gated dbmate prod deploy (the two new fns) **and** validation in prod after the image ships. Hand-crafted auth rows were deliberately avoided to de-risk.

## Security
- Link-by-email only via the email key; synthetic email for unverified/no-email so an unverified address never collides onto a real account.
- New SQL fns never write `auth.*` (only GoTrue does); they read auth.users + set profile.username.

Closes #12555.