### PR TITLE
fix(KBVEWorld): add SampleVertexColor/FoliageDensity/RoadInfluence base virtuals (#12565)

### DIFF
--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldChunkActor.h
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/Public/KBVEWorldChunkActor.h
@@ -38,6 +38,9 @@ public:
 	void   MarkUsed(uint64 TickNow) { LastUsedTick = TickNow; }
 
 	virtual float SampleHeight(float Wx, float Wy, uint32 InSeed) const { return 0.f; }
+	virtual FColor SampleVertexColor(float Wx, float Wy) const { return FColor::White; }
+	virtual float SampleFoliageDensity(float Wx, float Wy) const { return 0.f; }
+	virtual float SampleRoadInfluence(float Wx, float Wy) const { return 0.f; }
 
 protected:
 	virtual void BeginPlay() override;


### PR DESCRIPTION
## Root cause (#12565)

After the plugin overlay (#12460) made the monorepo `KBVEWorld` the source of truth, the `chuckServer` Linux cook failed (exit 6):

```
ChuckWorldChunk.h: 'SampleVertexColor'    marked 'override' but does not override any member function
ChuckWorldChunk.h: 'SampleFoliageDensity' marked 'override' but does not override any member function
ChuckWorldChunk.h: 'SampleRoadInfluence'  marked 'override' but does not override any member function
```

`ChuckWorldGen::AChuckWorldChunk` overrides **four** sample hooks; the monorepo `KBVEWorldChunkActor` base only declared `SampleHeight`. The other three were chuck-side custom additions never reconciled into the monorepo — so the overrides have no base to bind to.

## Fix

Add the three hooks to the base as virtuals with neutral defaults (matching ChuckWorldGen's signatures):
```cpp
virtual FColor SampleVertexColor(float Wx, float Wy) const { return FColor::White; }
virtual float  SampleFoliageDensity(float Wx, float Wy) const { return 0.f; }
virtual float  SampleRoadInfluence(float Wx, float Wy) const { return 0.f; }
```
Pure extension points; base behavior unchanged. This reconciles the chuck-side custom API into the source of truth, so the overlayed plugin + `ChuckWorldGen` compile together.

## Note
Needs to reach the dispatched ref (main for auto) so the overlay picks it up. Closes #12565.