### PR TITLE
revert(ci-unreal-build): drop monorepo plugin overlay — chuck owns its plugins

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -460,24 +460,6 @@ jobs:
                   mkdir -p /tmp/game-project
                   cp -r "${SRC}/." /tmp/game-project/
 
-            - name: Fetch monorepo plugins (source of truth)
-              uses: actions/checkout@v6
-              with:
-                  path: _kbve_mono
-                  sparse-checkout: packages/unreal
-                  sparse-checkout-cone-mode: true
-            - name: Overlay KBVE plugins onto project
-              run: |
-                  PLUGINS_DIR=/tmp/game-project/Plugins
-                  mkdir -p "${PLUGINS_DIR}"
-                  for p in "${GITHUB_WORKSPACE}/_kbve_mono/packages/unreal/"KBVE*; do
-                    [ -d "$p" ] || continue
-                    n=$(basename "$p")
-                    echo "::notice::overlay plugin ${n} from monorepo (source of truth)"
-                    rm -rf "${PLUGINS_DIR}/${n}"
-                    cp -r "$p" "${PLUGINS_DIR}/${n}"
-                  done
-
             - name: Build dedicated server
               env:
                   SERVER_TARGET: ${{ needs.server_config.outputs.server_target }}
@@ -790,24 +772,6 @@ jobs:
                   fi
                   mkdir -p /tmp/game-project
                   cp -r "${SRC}/." /tmp/game-project/
-
-            - name: Fetch monorepo plugins (source of truth)
-              uses: actions/checkout@v6
-              with:
-                  path: _kbve_mono
-                  sparse-checkout: packages/unreal
-                  sparse-checkout-cone-mode: true
-            - name: Overlay KBVE plugins onto project
-              run: |
-                  PLUGINS_DIR=/tmp/game-project/Plugins
-                  mkdir -p "${PLUGINS_DIR}"
-                  for p in "${GITHUB_WORKSPACE}/_kbve_mono/packages/unreal/"KBVE*; do
-                    [ -d "$p" ] || continue
-                    n=$(basename "$p")
-                    echo "::notice::overlay plugin ${n} from monorepo (source of truth)"
-                    rm -rf "${PLUGINS_DIR}/${n}"
-                    cp -r "$p" "${PLUGINS_DIR}/${n}"
-                  done
 
             - name: Build Linux client
               run: |


### PR DESCRIPTION
## Why

The overlay (#12460) forced `packages/unreal/KBVE*` onto the cloned project, **clobbering ChuckRPG's own customized plugin copies**. chuck has custom plugin changes the monorepo lacks (e.g. extra `KBVEWorld` virtuals `ChuckWorldGen` overrides, #12565) — so the monorepo version broke the cook.

## What

Remove the overlay (both server + Linux-client steps). chuck builds its **committed plugins as-is**. The monorepo `packages/unreal` stays the source for *new installs* via `KBVEPluginRegistry`, not a forced overlay onto game repos.

## Follow-on
- chuck owns + maintains its plugin copies — incl. the UE 5.7 fixes (`SetStaticMesh` → `GetStaticMesh`, etc.) on the **chuck side**. (Reverting the overlay re-exposes those if chuck's committed copies are still pre-5.7 — the friend handles that in `KBVE/chuck`.)
- #12567 (adding the hooks to the monorepo base) is moot for the build now — closing it.