### PR TITLE
fix(jobboard): readiness probe -> /health (fixes jobs.kbve.com 503)

### DIFF
--- a/apps/kube/jobboard/manifest/jobboard-deployment.yaml
+++ b/apps/kube/jobboard/manifest/jobboard-deployment.yaml
@@ -69,7 +69,7 @@ spec:
                       timeoutSeconds: 3
                   readinessProbe:
                       httpGet:
-                          path: /ready
+                          path: /health
                           port: 5400
                       initialDelaySeconds: 5
                       periodSeconds: 10


### PR DESCRIPTION
## Symptom
jobs.kbve.com → 503. Pod **Running, 0/1 Ready** → empty endpoints → gateway 503.

## Diagnosis (kubectl)
- `pg_isready` from kbve ns → DB up + reachable (not network).
- Pod boots fine (`PgCluster connected`, listening) but `/ready` reports **all PgCluster pools false** (rw/ro/any) → DB-gated readiness fails every cycle.
- **`axum-kbve` uses the same `supabase-shared/db-url` and is `1/1 Ready`** — because its `readinessProbe` is **`/health`** (process-up), not DB-gated. That's the house pattern.
- The DB-gated probe also hammers all 3 pools every 10s on a never-ready pod (6h+), adding connection pressure to `supabase-cluster-rw`.

## Fix
Point jobboard `readinessProbe` at **`/health`** (matches axum-kbve). Pod goes Ready → endpoints populate → gateway serves. `/ready` stays as a DB diagnostic (reports rw/ro/any + version). Removing the hammering should also relieve the connection pressure.

## Follow-up (separate)
Why jedi PgCluster can't complete the in-cluster connect while `pg_isready` works (all pools false) — prime suspect: `supabase-shared/db-url` lacks `?sslmode=disable` (the dbmate runner uses it for in-cluster), or connection exhaustion / password rotation. Masked everywhere else by /health-readiness; needs the cred test (blocked by the prod-secret boundary) to confirm auth-vs-TLS. Tracking separately.