### PR TITLE
chore(rows): retire legacy single-tenant backend (replicas 0) — free ows connections

### DIFF
--- a/apps/kube/rows/manifest/rows-deployment.yaml
+++ b/apps/kube/rows/manifest/rows-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
         app: rows
         app.kubernetes.io/part-of: ows
 spec:
-    replicas: 1
+    replicas: 0
     strategy:
         type: RollingUpdate
         rollingUpdate:


### PR DESCRIPTION
## Why

The legacy `rows`-ns deployment is **unrouted** (api.chuckrpg.com cut over to the chuckrpg-dev tenant) but its pod held ~50 connections on the shared `ows` Postgres role. That exhausted the role and starved the per-tenant backends — `rows-chuckrpg-beta` crashlooped on `pool timed out`, api-beta 503.

A `kubectl scale 0` freed enough for api-beta to return 200, but ArgoCD selfHeal reverted it back to 1.

## What

Set the legacy deployment `replicas: 1 → 0` in git so selfHeal honors it. Frees the `ows` connections permanently → the capped (`DB_MAX_CONNECTIONS=10`) tenant rollouts complete and the role has headroom. Manifests kept for a clean full removal later (the app's standalone, not in app-of-apps).

## After sync
Legacy pod gone → dev + beta rows run their 10-cap pods cleanly → api-beta stays 200, gameserver reaches a healthy ROWS.