### PR TITLE
fix(agones): chuck fleets read flattened server dir on PVC

### DIFF
--- a/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-beta/manifests/fleet.yaml
@@ -47,16 +47,16 @@ spec:
                               - |
                                   SERVER_DIR=$(find /server -maxdepth 2 -name "LinuxServer" -type d | sort -V | tail -1)
                                   if [ -z "${SERVER_DIR}" ]; then
-                                    echo "ERROR: LinuxServer directory not found on PVC"
+                                    SERVER_DIR=$(find /server -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -1)
+                                  fi
+                                  if [ -z "${SERVER_DIR}" ]; then
+                                    echo "ERROR: no server build found on PVC"
                                     ls -la /server/ 2>/dev/null
                                     exit 1
                                   fi
                                   SERVER_BIN=$(find "${SERVER_DIR}" -maxdepth 1 -name "*Server.sh" | head -1)
                                   if [ -z "${SERVER_BIN}" ]; then
-                                    SERVER_BIN="${SERVER_DIR}/ChuckServer.sh"
-                                  fi
-                                  if [ ! -f "${SERVER_BIN}" ]; then
-                                    echo "ERROR: Server binary not found at ${SERVER_BIN}"
+                                    echo "ERROR: no *Server.sh found under ${SERVER_DIR}"
                                     ls -la "${SERVER_DIR}/" 2>/dev/null
                                     exit 1
                                   fi

--- a/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
+++ b/apps/kube/agones/rows-tenants/chuckrpg-dev/manifests/fleet.yaml
@@ -47,16 +47,16 @@ spec:
                               - |
                                   SERVER_DIR=$(find /server -maxdepth 2 -name "LinuxServer" -type d | sort -V | tail -1)
                                   if [ -z "${SERVER_DIR}" ]; then
-                                    echo "ERROR: LinuxServer directory not found on PVC"
+                                    SERVER_DIR=$(find /server -maxdepth 1 -type d -name '[0-9]*' | sort -V | tail -1)
+                                  fi
+                                  if [ -z "${SERVER_DIR}" ]; then
+                                    echo "ERROR: no server build found on PVC"
                                     ls -la /server/ 2>/dev/null
                                     exit 1
                                   fi
                                   SERVER_BIN=$(find "${SERVER_DIR}" -maxdepth 1 -name "*Server.sh" | head -1)
                                   if [ -z "${SERVER_BIN}" ]; then
-                                    SERVER_BIN="${SERVER_DIR}/ChuckServer.sh"
-                                  fi
-                                  if [ ! -f "${SERVER_BIN}" ]; then
-                                    echo "ERROR: Server binary not found at ${SERVER_BIN}"
+                                    echo "ERROR: no *Server.sh found under ${SERVER_DIR}"
                                     ls -la "${SERVER_DIR}/" 2>/dev/null
                                     exit 1
                                   fi


### PR DESCRIPTION
## Problem

`ows-chuckrpg-beta` gameservers crash-loop with:

```
ERROR: LinuxServer directory not found on PVC
```

The dedicated-server build (`ci-unreal-build.yml` → *Deploy server to PVC*) flattens the staged build:

```sh
cp -r "${SERVER_DIR}/." "${DEST}/"   # SERVER_DIR = .../StagedBuilds/LinuxServer
```

So the PVC version dir (`chuckServer/0.3.20/`) holds `Engine/`, `chuck/`, `chuckServer.sh` directly — **no `LinuxServer/` subdir**. The fleet container's `find /server -name LinuxServer` matched nothing → `exit 1` → crash-loop. The hardcoded fallback was also wrong-case (`ChuckServer.sh` vs actual `chuckServer.sh`).

## Fix

Both `chuckrpg-beta` + `chuckrpg-dev` fleets:
- keep the `LinuxServer/` lookup (future-proof), then fall back to the newest versioned dir (`/server/<version>/`)
- drop the wrong-case `ChuckServer.sh` fallback — the `*Server.sh` glob already matches `chuckServer.sh`; error clearly if absent

No rebuild needed — the existing `0.3.20` PVC payload works as-is once the fleet resolves the right dir.

## Note

ArgoCD tracks `main`; this reaches the cluster on the next dev→main release. The live beta crash-loop persists until then (or a manual fleet patch).