### PR TITLE
fix(ci-unreal): all UE jobs on self-hosted runners + repair kbve runner

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -210,7 +210,7 @@ env:
 jobs:
     guard:
         name: Fork Guard
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 2
         outputs:
             allowed: ${{ steps.check.outputs.allowed }}
@@ -256,7 +256,7 @@ jobs:
         name: Server Config
         needs: guard
         if: inputs.mode == 'server' && needs.guard.outputs.allowed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 5
         permissions:
             contents: read
@@ -604,7 +604,7 @@ jobs:
         name: Game Version Gate
         needs: guard
         if: inputs.mode == 'game' && needs.guard.outputs.allowed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 5
         permissions:
             contents: read
@@ -1062,7 +1062,7 @@ jobs:
         name: Game Build (Mac client - STUB)
         needs: [guard, game_gate]
         if: inputs.mode == 'game' && needs.guard.outputs.allowed == 'true' && needs.game_gate.outputs.should_build == 'true' && contains(inputs.build_targets, 'Mac')
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 5
         permissions:
             contents: read
@@ -1097,7 +1097,7 @@ jobs:
         name: Engine Version Gate
         needs: guard
         if: inputs.mode == 'engine' && needs.guard.outputs.allowed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 5
         permissions:
             contents: read
@@ -1284,7 +1284,7 @@ jobs:
         name: Engine Build (Mac client - STUB)
         needs: [guard, engine_gate]
         if: inputs.mode == 'engine' && needs.guard.outputs.allowed == 'true' && needs.engine_gate.outputs.should_build == 'true' && contains(inputs.platforms, 'mac')
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 5
         permissions:
             contents: read
@@ -1400,7 +1400,7 @@ jobs:
             (needs.engine_build_mac.result == 'success' || needs.engine_build_mac.result == 'skipped') &&
             (needs.engine_build_linux.result == 'success' || needs.engine_build_linux.result == 'skipped') &&
             (needs.engine_build_mac.result == 'success' || needs.engine_build_linux.result == 'success')
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 15
         permissions:
             contents: read
@@ -1456,7 +1456,7 @@ jobs:
             always() &&
             needs.engine_gate.outputs.should_build == 'true' &&
             needs.engine_release.result == 'success'
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 10
         permissions:
             contents: write
@@ -1503,7 +1503,7 @@ jobs:
         name: Plugin Version Gate
         needs: guard
         if: (inputs.mode == 'plugin' || inputs.mode == 'plugin-win') && needs.guard.outputs.allowed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 5
         permissions:
             contents: read
@@ -1784,7 +1784,7 @@ jobs:
             always() &&
             needs.plugin_check.outputs.should_release == 'true' &&
             (needs.plugin_build_linux.result == 'success' || needs.plugin_build_win.result == 'success')
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 10
         permissions:
             contents: write
@@ -1816,7 +1816,7 @@ jobs:
             (needs.plugin_build_linux.result == 'success' || needs.plugin_build_win.result == 'success') &&
             inputs.deploy_to_itch == true &&
             inputs.itch_game_id != ''
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 15
         permissions:
             contents: read
@@ -2020,7 +2020,7 @@ jobs:
         name: Install on UE5-Mac (STUB)
         needs: guard
         if: inputs.mode == 'mac-setup' && needs.guard.outputs.allowed == 'true'
-        runs-on: ubuntu-latest
+        runs-on: arc-runner-set-kbve
         timeout-minutes: 5
         permissions:
             contents: read

--- a/apps/kube/github/runners/manifests/values-kbve.yaml
+++ b/apps/kube/github/runners/manifests/values-kbve.yaml
@@ -24,10 +24,11 @@ controllerServiceAccount:
     name: arc-controller
     namespace: arc-systems
 
-# Canary capacity — keep low until workflows are migrated. Bump
-# in step with traffic as the upstream arc-runner-set drains.
+# Hosts all lightweight UE workflow jobs (Fork Guard, version gates,
+# releases, version-sync PRs, Win VM boot) so no UE job touches a
+# GitHub-hosted runner. Sized for concurrent game+server dispatch.
 minRunners: 0
-maxRunners: 3
+maxRunners: 6
 
 template:
     metadata:
@@ -52,9 +53,7 @@ template:
         containers:
             - name: runner
               image: ghcr.io/kbve/arc-runner:0.1.5
-              # No `command:` override — the image bakes in the
-              # sudoers entry, so the upstream entrypoint
-              # (/home/runner/run.sh) Just Works.
+              command: ['/home/runner/run.sh']
               env:
                   - name: DOCKER_HOST
                     value: tcp://localhost:2376


### PR DESCRIPTION
## Goal

No UE workflow job touches a GitHub-hosted runner. Hosted-runner freezes (Actions minutes/spending cap) have twice blocked chuck game builds at the `ubuntu-latest` Fork Guard — `updated_at` frozen at creation, never scheduled.

## Changes

**1. `ci-unreal-build.yml` — route all 12 `ubuntu-latest` jobs → `arc-runner-set-kbve`**
Fork Guard, server/game/engine/plugin version gates, engine+plugin releases, version-sync PRs, mac stubs. The kbve runner image (`ghcr.io/kbve/arc-runner:0.1.5`) bakes `gh`, `node`, `git-lfs`, `jq`, `kubectl` — no inline installs needed. Heavy build jobs already run on `arc-runner-ue`/`UE5-Win`.

**2. `values-kbve.yaml` — `command: ['/home/runner/run.sh']` on the runner container**
Root cause of a long-standing canary failure: the base `ghcr.io/actions/actions-runner` image has no default CMD that launches `run.sh`. Without the override the runner container exited `0` ("Completed") in <1s and never ran its job — `jobsCompleted: 0`, runners churned every ~50s. `arc-runner-set-kbve` had **never completed a single job**, which is also why `win_vm_boot` never booted the Windows VM. `arc-runner-ue` works precisely because it sets this command explicitly. Also bump `maxRunners` 3→6 for concurrent game+server dispatch.

## Deployment ordering ⚠️

`ci-unreal-build.yml` runs `@dev` → live on dev-merge. `values-kbve.yaml` is ArgoCD (tracks `main`) → reaches the cluster on the next dev→main release + sync. **The runner fix must reach the cluster before the workflow routing takes effect**, or UE gates hang on the still-broken kbve set. Sequence: land runner fix on-cluster (release/sync), confirm kbve runners complete jobs, then the routing is safe.

## Unblocks
- chuck Linux client + server + Win64 builds (no hosted-runner dependency)
- `win_vm_boot` → Windows VM actually boots (same runner repair)