### PR TITLE
fix(jobboard): runtime version in /health (sccache-proof)

### DIFF
--- a/apps/jobboard/Dockerfile
+++ b/apps/jobboard/Dockerfile
@@ -68,9 +68,15 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p jobboard && \
     strip target/release/jobboard
 
+# Version read at runtime by /health (see src/rest/system.rs): grep from
+# Cargo.toml (NOT the sccache-cached compile) so the reported version always
+# matches the source, even on a version-only bump.
+RUN awk -F'"' '/^version/{print $2; exit}' apps/jobboard/Cargo.toml > /app/version.txt
+
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/jobboard /app/jobboard
+COPY --from=builder --chown=10001:10001 /app/version.txt /app/version.txt
 
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=5400

--- a/apps/jobboard/src/rest/system.rs
+++ b/apps/jobboard/src/rest/system.rs
@@ -4,9 +4,30 @@ use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
-const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Resolve the reported version at RUNTIME, not compile time. `env!` bakes the
+/// value into the binary, but the Docker build's sccache mount doesn't key on
+/// CARGO_PKG_VERSION — so a version-only bump gets a cache hit and the baked
+/// string goes stale (image tag advances, /health stays behind). Reading at
+/// runtime sidesteps that: APP_VERSION env, else the version.txt the Dockerfile
+/// writes from Cargo.toml, else the compile-time fallback (fine for local cargo).
+fn version() -> &'static str {
+    static VERSION: OnceLock<String> = OnceLock::new();
+    VERSION.get_or_init(|| {
+        std::env::var("APP_VERSION")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .or_else(|| {
+                std::fs::read_to_string("/app/version.txt")
+                    .ok()
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+            })
+            .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
+    })
+}
 
 pub fn routes() -> Router<Arc<AppState>> {
     Router::new()
@@ -18,7 +39,7 @@ async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "status": "healthy",
         "service": "jobboard",
-        "version": VERSION,
+        "version": version(),
     }))
 }
 
@@ -33,7 +54,7 @@ async fn readiness(State(app): State<Arc<AppState>>) -> impl IntoResponse {
     let body = serde_json::json!({
         "status": if ready { "ready" } else { "degraded" },
         "service": "jobboard",
-        "version": VERSION,
+        "version": version(),
         "uptime_seconds": app.started_at.elapsed().as_secs(),
         "database": {
             "rw": health.rw.ok,


### PR DESCRIPTION
## Problem
`/health` reported a stale version: the image tag advanced to `0.1.3` (version.toml/MDX/Cargo.toml all 0.1.3) but `/health` returned `0.0.1` — on **both prod and local**.

Root cause: `system.rs` baked the version via `env!("CARGO_PKG_VERSION")` at compile time, and the Docker build's **sccache** mount doesn't key its cache on `CARGO_PKG_VERSION`. A version-only bump leaves the source unchanged, so sccache returns a cache hit and serves the object compiled when the version was still the `0.0.1` sentinel.

## Fix
Resolve the version at **runtime**, not compile time:
1. `APP_VERSION` env (lets the k8s deployment set it explicitly), else
2. `/app/version.txt` — written by the Dockerfile via `grep` from `Cargo.toml` (not the sccache-cached compile), else
3. `env!("CARGO_PKG_VERSION")` fallback (fine for local `cargo run`).

`/health` now tracks the source version regardless of sccache. Verified `cargo check` green.