### PR TITLE
feat(jobboard): APP_VERSION auto-sync (stranded follow-up to #12590)

### DIFF
--- a/.github/workflows/utils-post-publish.yml
+++ b/.github/workflows/utils-post-publish.yml
@@ -252,6 +252,11 @@ jobs:
                     if [ "$OLD_TAG" != "unknown" ]; then
                       sed -i "s|version: \"${OLD_TAG}\"|version: \"${VERSION}\"|g" "$FILE"
                     fi
+                    # Keep an APP_VERSION env (apps that surface a runtime version
+                    # via /health) in sync with the image tag. No-op if absent.
+                    if grep -q "name: APP_VERSION" "$FILE"; then
+                      sed -i "/name: APP_VERSION/{n;s|value:.*|value: '${VERSION}'|}" "$FILE"
+                    fi
                     sed -i "s|rollout-restart: \".*\"|rollout-restart: \"${TIMESTAMP}\"|g" "$FILE"
 
                     echo "Updated $FILE: $OLD_TAG → $VERSION"

--- a/apps/kube/jobboard/manifest/jobboard-deployment.yaml
+++ b/apps/kube/jobboard/manifest/jobboard-deployment.yaml
@@ -39,6 +39,10 @@ spec:
                       - containerPort: 5400
                         protocol: TCP
                   env:
+                      # Kept in sync with the image tag by utils-post-publish.yml
+                      # (the MDX version bump flows here). /health reads it first.
+                      - name: APP_VERSION
+                        value: '0.1.3'
                       - name: HTTP_HOST
                         value: '0.0.0.0'
                       - name: HTTP_PORT


### PR DESCRIPTION
The runtime-version fix (#12590) merged, but its **second commit stranded** on the squash-merge — the `APP_VERSION` env + post-publish sync never landed on dev.

This re-applies that part off fresh dev:
- `jobboard-deployment.yaml`: `APP_VERSION` env (read first by /health).
- `utils-post-publish.yml`: keep `APP_VERSION` in sync with the image tag (generic, no-op if a manifest lacks the env).

So the MDX `version:` bump flows: MDX → atom PR → image tag + `APP_VERSION` → /health, fully automatic. The version.txt fallback from #12590 already covers builds without the env.