### PR TITLE
fix(jobboard): /health real version — cargo-chef Cargo.toml normalization

### DIFF
--- a/apps/jobboard/Dockerfile
+++ b/apps/jobboard/Dockerfile
@@ -57,6 +57,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 
 FROM cook AS builder
 
+# cargo-chef normalizes the package version to 0.0.1 in the cook skeleton so a
+# version bump doesn't bust the dependency cache. Re-copy the REAL Cargo.toml
+# here so cargo build bakes the true CARGO_PKG_VERSION and the version.txt grep
+# below reads the real version (otherwise /health is forever 0.0.1).
+COPY apps/jobboard/Cargo.toml apps/jobboard/Cargo.toml
 COPY packages/rust/jedi/ packages/rust/jedi/
 COPY packages/rust/holy/ packages/rust/holy/
 COPY packages/rust/kbve/ packages/rust/kbve/


### PR DESCRIPTION
## The actual root cause
`/health` reported `0.0.1` everywhere (prod + local) regardless of the real version (0.1.3) or image tag. Earlier fixes (#12590 runtime version.txt, #12592 APP_VERSION) didn't help because they read the **wrong Cargo.toml**.

**cargo-chef** normalizes the package version to `0.0.1` in the `cook` skeleton — intentional, so a version bump doesn't invalidate the cached dependency build. The `builder` stage does `FROM cook` and inherits that skeleton Cargo.toml. So:
- `cargo build` baked `CARGO_PKG_VERSION = 0.0.1`, and
- the `version.txt` grep read `0.0.1` too.

It was never sccache.

## Fix
Re-copy the real `apps/jobboard/Cargo.toml` in the `builder` stage before the build, overwriting chef's skeleton. Now `cargo build` + the grep both see the true version.

Verified locally: `docker compose build` → `/health` reports **0.1.3** (was 0.0.1). Combined with #12590/#12592 the version now flows MDX → Cargo.toml → /health correctly.