### PR TITLE
refactor(jobboard): drop version.txt, APP_VERSION env as single version source

### DIFF
--- a/apps/jobboard/Dockerfile
+++ b/apps/jobboard/Dockerfile
@@ -59,8 +59,8 @@ FROM cook AS builder
 
 # cargo-chef normalizes the package version to 0.0.1 in the cook skeleton so a
 # version bump doesn't bust the dependency cache. Re-copy the REAL Cargo.toml
-# here so cargo build bakes the true CARGO_PKG_VERSION and the version.txt grep
-# below reads the real version (otherwise /health is forever 0.0.1).
+# here so cargo build bakes the true CARGO_PKG_VERSION (the /health fallback
+# when APP_VERSION isn't set).
 COPY apps/jobboard/Cargo.toml apps/jobboard/Cargo.toml
 COPY packages/rust/jedi/ packages/rust/jedi/
 COPY packages/rust/holy/ packages/rust/holy/
@@ -73,15 +73,9 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cargo build --release -p jobboard && \
     strip target/release/jobboard
 
-# Version read at runtime by /health (see src/rest/system.rs): grep from
-# Cargo.toml (NOT the sccache-cached compile) so the reported version always
-# matches the source, even on a version-only bump.
-RUN awk -F'"' '/^version/{print $2; exit}' apps/jobboard/Cargo.toml > /app/version.txt
-
 FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
 
 COPY --from=builder --chown=10001:10001 /app/target/release/jobboard /app/jobboard
-COPY --from=builder --chown=10001:10001 /app/version.txt /app/version.txt
 
 ENV HTTP_HOST=0.0.0.0
 ENV HTTP_PORT=5400

--- a/apps/jobboard/docker-compose.yml
+++ b/apps/jobboard/docker-compose.yml
@@ -86,6 +86,11 @@ services:
             context: ../..
             dockerfile: apps/jobboard/Dockerfile
         environment:
+            # Single source of truth for the reported version (matches prod, where
+            # the k8s deployment's APP_VERSION is atom-PR-synced from the MDX bump).
+            # The jobboard:dev nx target exports this from version.toml; empty here
+            # falls back to the compiled CARGO_PKG_VERSION.
+            APP_VERSION: ${APP_VERSION:-}
             HTTP_HOST: 0.0.0.0
             HTTP_PORT: '5400'
             RUST_LOG: jobboard=info,tower_http=info

--- a/apps/jobboard/src/rest/system.rs
+++ b/apps/jobboard/src/rest/system.rs
@@ -6,12 +6,12 @@ use axum::routing::get;
 use axum::{Json, Router};
 use std::sync::{Arc, OnceLock};
 
-/// Resolve the reported version at RUNTIME, not compile time. `env!` bakes the
-/// value into the binary, but the Docker build's sccache mount doesn't key on
-/// CARGO_PKG_VERSION — so a version-only bump gets a cache hit and the baked
-/// string goes stale (image tag advances, /health stays behind). Reading at
-/// runtime sidesteps that: APP_VERSION env, else the version.txt the Dockerfile
-/// writes from Cargo.toml, else the compile-time fallback (fine for local cargo).
+/// Reported version. APP_VERSION env is the single source of truth (set on the
+/// k8s deployment + local compose, kept in sync with the image tag from the MDX
+/// bump by utils-post-publish.yml). Falls back to the compile-time
+/// CARGO_PKG_VERSION for plain `cargo run`. The builder re-copies the real
+/// Cargo.toml (cargo-chef zeroes it in the cook skeleton) so the fallback is
+/// accurate too.
 fn version() -> &'static str {
     static VERSION: OnceLock<String> = OnceLock::new();
     VERSION.get_or_init(|| {
@@ -19,12 +19,6 @@ fn version() -> &'static str {
             .ok()
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
-            .or_else(|| {
-                std::fs::read_to_string("/app/version.txt")
-                    .ok()
-                    .map(|s| s.trim().to_string())
-                    .filter(|s| !s.is_empty())
-            })
             .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string())
     })
 }


### PR DESCRIPTION
Follow-up cleanup. version.txt (added in #12590) is redundant now that:
- the builder re-copies the real Cargo.toml past cargo-chef's 0.0.1 skeleton (#12595), so the compiled `CARGO_PKG_VERSION` is accurate, and
- `APP_VERSION` env (#12592) is set on the k8s deployment and atom-PR-synced from the MDX bump.

`/health` now resolves: **`APP_VERSION` env → `CARGO_PKG_VERSION` fallback**. The runtime image never had Cargo.toml/version.toml anyway, so a baked file added nothing the env + compiled version don't already cover.

Changes:
- `system.rs`: drop the `/app/version.txt` read.
- `Dockerfile`: drop the awk + `version.txt` COPY (keep the chef Cargo.toml re-copy).
- `docker-compose.yml`: pass `APP_VERSION: ${APP_VERSION:-}` (empty → compiled fallback; export it to override locally).

cargo check green; prod stays correct (deployment APP_VERSION), local resolves via the now-accurate CARGO_PKG_VERSION.