### PR TITLE
feat(jobboard): SEO/metadata — social embeds, JSON-LD, sitemap, OG SVG, a11y

### DIFF
--- a/apps/jobboard/src/rest/mod.rs
+++ b/apps/jobboard/src/rest/mod.rs
@@ -1,5 +1,6 @@
 mod auth;
 mod proxy;
+mod seo;
 mod spa;
 mod system;
 mod verticals;
@@ -16,6 +17,7 @@ pub fn router(app: Arc<AppState>) -> Router {
 
     Router::new()
         .merge(system::routes())
+        .merge(seo::routes())
         .nest("/api", api)
         .route("/supabase/{*rest}", any(proxy::supabase))
         .route("/kbveapi/{*rest}", any(proxy::kbve_api))

--- a/apps/jobboard/src/rest/seo.rs
+++ b/apps/jobboard/src/rest/seo.rs
@@ -1,0 +1,97 @@
+use crate::error::{ApiError, pg_err};
+use crate::state::AppState;
+use axum::Router;
+use axum::extract::{Path, State};
+use axum::http::header;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use std::sync::Arc;
+
+const SITE: &str = "https://jobs.kbve.com";
+
+pub fn routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/sitemap.xml", get(sitemap))
+        .route("/og/{kind}/{name}", get(og_svg))
+}
+
+fn xml_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+async fn sitemap(State(app): State<Arc<AppState>>) -> Result<Response, ApiError> {
+    let conn = app.db.read().await?;
+    let rows = conn
+        .query(
+            "SELECT slug FROM jobboard.verticals WHERE status > 0 ORDER BY sort_order, label",
+            &[],
+        )
+        .await
+        .map_err(pg_err)?;
+
+    let mut urls: Vec<String> = vec!["/".into(), "/gigs".into(), "/talent".into(), "/post".into()];
+    for r in &rows {
+        let slug: String = r.get(0);
+        urls.push(format!("/gigs?discipline={}", slug));
+    }
+
+    let mut body = String::from(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n",
+    );
+    for u in urls {
+        body.push_str(&format!(
+            "  <url><loc>{}{}</loc></url>\n",
+            SITE,
+            xml_escape(&u)
+        ));
+    }
+    body.push_str("</urlset>\n");
+
+    Ok((
+        [(header::CONTENT_TYPE, "application/xml; charset=utf-8")],
+        body,
+    )
+        .into_response())
+}
+
+// Branded OG card (1200x630 SVG). Per-item titles will come once gigs/talent
+// are served by Axum; for now it renders the section kind on the brand card.
+async fn og_svg(Path((kind, name)): Path<(String, String)>) -> Response {
+    let slug = name.strip_suffix(".svg").unwrap_or(&name);
+    let label = match kind.as_str() {
+        "gig" => "Gig",
+        "talent" => "Talent",
+        _ => "Jobs",
+    };
+    let svg = format!(
+        r##"<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7c5cf0"/>
+      <stop offset="100%" stop-color="#d946ef"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="#181a20"/>
+  <rect x="40" y="40" width="1120" height="550" rx="28" fill="#20232b" stroke="#2c303b"/>
+  <circle cx="150" cy="150" r="46" fill="url(#g)"/>
+  <text x="220" y="165" font-family="system-ui,sans-serif" font-size="44" font-weight="700" fill="#e9eaf0">KBVE Jobs</text>
+  <text x="100" y="360" font-family="system-ui,sans-serif" font-size="72" font-weight="800" fill="#ffffff">{label}</text>
+  <text x="100" y="430" font-family="system-ui,sans-serif" font-size="34" fill="#a6acbb">{slug}</text>
+  <text x="100" y="540" font-family="system-ui,sans-serif" font-size="28" fill="#6b7080">jobs.kbve.com</text>
+</svg>"##,
+        label = label,
+        slug = xml_escape(slug),
+    );
+    (
+        [
+            (header::CONTENT_TYPE, "image/svg+xml; charset=utf-8"),
+            (header::CACHE_CONTROL, "public, max-age=3600"),
+        ],
+        svg,
+    )
+        .into_response()
+}

--- a/apps/jobboard/web/index.html
+++ b/apps/jobboard/web/index.html
@@ -3,7 +3,10 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<meta name="robots" content="noindex" />
+		<meta
+			name="description"
+			content="A curated, both-sides-vetted job board for game development. Hire vetted talent, or get hired."
+		/>
 		<title>KBVE Jobs</title>
 	</head>
 	<body>

--- a/apps/jobboard/web/src/lib/seo.tsx
+++ b/apps/jobboard/web/src/lib/seo.tsx
@@ -1,0 +1,95 @@
+import { useEffect } from 'react';
+import {
+	buildSeo,
+	graph,
+	organization,
+	website,
+	type SchemaNode,
+	type SeoInput,
+} from '@kbve/core';
+
+export const SITE_URL = 'https://jobs.kbve.com';
+export const SITE_NAME = 'KBVE Jobs';
+
+const ORG_ID = `${SITE_URL}/#org`;
+const SITE_ID = `${SITE_URL}/#website`;
+
+export const abs = (path: string): string =>
+	path.startsWith('http') ? path : `${SITE_URL}${path}`;
+
+/** OG image served by the Axum /og route (dynamic SVG). */
+export const ogImage = (type: string, id: string): string =>
+	`${SITE_URL}/og/${type}/${encodeURIComponent(id)}.svg`;
+
+const siteNodes = (): SchemaNode[] => [
+	organization({
+		id: ORG_ID,
+		name: SITE_NAME,
+		url: SITE_URL,
+		logo: `${SITE_URL}/icon.svg`,
+		sameAs: ['https://kbve.com', 'https://github.com/KBVE'],
+	}),
+	website({ id: SITE_ID, name: SITE_NAME, url: SITE_URL, publisher: ORG_ID }),
+];
+
+// Tiny CSR head manager — no react-helmet (peers react 18; app is react 19).
+// Each render clears prior [data-seo] tags and writes fresh ones, so route
+// changes swap meta cleanly. Crawlers that run JS (Google, Discord, Slack,
+// Twitter) pick these up; for JS-less crawlers, pair with server-side
+// injection later.
+function applyHead(
+	title: string,
+	canonical: string,
+	metas: { name?: string; property?: string; content: string }[],
+	jsonLd: SchemaNode,
+) {
+	document.title = title;
+	document.querySelectorAll('[data-seo]').forEach((el) => el.remove());
+	const head = document.head;
+
+	const link = document.createElement('link');
+	link.rel = 'canonical';
+	link.href = canonical;
+	link.setAttribute('data-seo', '');
+	head.appendChild(link);
+
+	for (const m of metas) {
+		const el = document.createElement('meta');
+		if (m.property) el.setAttribute('property', m.property);
+		else if (m.name) el.setAttribute('name', m.name);
+		el.setAttribute('content', m.content);
+		el.setAttribute('data-seo', '');
+		head.appendChild(el);
+	}
+
+	const script = document.createElement('script');
+	script.type = 'application/ld+json';
+	script.textContent = JSON.stringify(jsonLd);
+	script.setAttribute('data-seo', '');
+	head.appendChild(script);
+}
+
+export function Seo({
+	seo,
+	jsonLd,
+}: {
+	seo: Omit<SeoInput, 'url'> & { path: string };
+	jsonLd?: SchemaNode[];
+}) {
+	const { path, ...rest } = seo;
+	const result = buildSeo({
+		...rest,
+		url: abs(path),
+		siteName: SITE_NAME,
+		twitterSite: '@kbve',
+	});
+	const doc = graph([...siteNodes(), ...(jsonLd ?? [])]);
+
+	useEffect(() => {
+		applyHead(result.title, result.canonical, result.meta, doc);
+		// re-run when the page identity changes
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [result.title, result.canonical, JSON.stringify(doc)]);
+
+	return null;
+}

--- a/apps/jobboard/web/src/main.tsx
+++ b/apps/jobboard/web/src/main.tsx
@@ -29,8 +29,8 @@ createRoot(document.getElementById('root')!).render(
 				<PersistQueryClientProvider
 					client={queryClient}
 					persistOptions={{ persister }}>
-					{/* Public marketplace — browsing needs no auth. Login lives
-					    at the /login route; KbveProvider supplies the session. */}
+					{/* Public marketplace — browsing needs no auth. Login
+					    lives at /login; KbveProvider supplies the session. */}
 					<RouterProvider router={router} />
 				</PersistQueryClientProvider>
 				<OverlayHost />

--- a/apps/jobboard/web/src/routes/gig-detail.tsx
+++ b/apps/jobboard/web/src/routes/gig-detail.tsx
@@ -1,17 +1,30 @@
 import { Fragment, type ReactNode, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRouteApi, Link } from '@tanstack/react-router';
+import { jobPosting, breadcrumbList } from '@kbve/core';
 import { applyToGig, fetchGig } from '../api/client';
 import type { ApplyInput, Gig } from '../api/types';
 import { Avatar, Button, ErrorNote, Spinner, TagRow } from '../components/ui';
 import { formatBudget, LOCATION_LABELS, relativeTime } from '../lib/format';
 import { useAuth } from '../lib/auth';
+import { Seo, abs, ogImage } from '../lib/seo';
 
 const routeApi = getRouteApi('/gigs/$gigId');
 
+const plainText = (md: string, max = 160): string =>
+	md
+		.replace(/[#*_`>[\]()!]/g, '')
+		.replace(/\s+/g, ' ')
+		.trim()
+		.slice(0, max);
+
 export function GigDetailPage() {
 	const { gigId } = routeApi.useParams();
-	const { data: gig, isLoading, error } = useQuery({
+	const {
+		data: gig,
+		isLoading,
+		error,
+	} = useQuery({
 		queryKey: ['gig', gigId],
 		queryFn: () => fetchGig(gigId),
 	});
@@ -27,8 +40,38 @@ export function GigDetailPage() {
 			)
 		: 'Flexible';
 
+	const path = `/gigs/${gig.slug ?? gig.id}`;
+	const desc = plainText(gig.description);
+
 	return (
 		<div className="mx-auto max-w-5xl">
+			<Seo
+				seo={{
+					title: `${gig.title} · KBVE Jobs`,
+					description: desc,
+					path,
+					image: ogImage('gig', gig.slug ?? gig.id),
+					type: 'article',
+				}}
+				jsonLd={[
+					jobPosting({
+						title: gig.title,
+						description: desc,
+						url: abs(path),
+						datePosted: gig.created_at,
+						validThrough: gig.deadline ?? undefined,
+						salaryMin: gig.budget_min || undefined,
+						salaryMax: gig.budget_max || undefined,
+						currency: gig.currency,
+						remote: gig.location_pref === 0,
+						location: LOCATION_LABELS[gig.location_pref],
+					}),
+					breadcrumbList([
+						['Gigs', abs('/gigs')],
+						[gig.title, abs(path)],
+					]),
+				]}
+			/>
 			<Link
 				to="/gigs"
 				className="text-sm text-zinc-400 hover:text-quest-300">
@@ -80,9 +123,15 @@ export function GigDetailPage() {
 								{formatBudget(gig)}
 							</div>
 						</div>
-						<Meta label="Location" value={LOCATION_LABELS[gig.location_pref]} />
+						<Meta
+							label="Location"
+							value={LOCATION_LABELS[gig.location_pref]}
+						/>
 						<Meta label="Deadline" value={deadline} />
-						<Meta label="Applicants" value={String(gig.applicant_count)} />
+						<Meta
+							label="Applicants"
+							value={String(gig.applicant_count)}
+						/>
 
 						<ApplyBox gig={gig} />
 					</div>

--- a/apps/jobboard/web/src/routes/home.tsx
+++ b/apps/jobboard/web/src/routes/home.tsx
@@ -7,8 +7,14 @@ import { TalentCard } from '../components/TalentCard';
 import { DisciplineGrid } from '../components/DisciplineGrid';
 import { HowItWorks } from '../components/HowItWorks';
 import { Button } from '../components/ui';
+import { Seo, ogImage } from '../lib/seo';
 
-const TRUST = ['Both sides vetted', 'Game-dev only', 'Portfolio-first', 'No bidding wars'];
+const TRUST = [
+	'Both sides vetted',
+	'Game-dev only',
+	'Portfolio-first',
+	'No bidding wars',
+];
 
 export function HomePage() {
 	const navigate = useNavigate();
@@ -31,6 +37,15 @@ export function HomePage() {
 
 	return (
 		<div className="mx-auto max-w-6xl">
+			<Seo
+				seo={{
+					title: 'KBVE Jobs — the quest board for game developers',
+					description:
+						'A curated, both-sides-vetted job board for game development. Hire vetted talent, or get hired.',
+					path: '/',
+					image: ogImage('site', 'home'),
+				}}
+			/>
 			{/* Hero — search-first (Fiverr/Upwork), editorial spacing (Toptal) */}
 			<section className="py-14 text-center sm:py-20">
 				<span className="inline-flex items-center gap-2 rounded-full border border-quest-700/60 bg-quest-500/10 px-3 py-1 text-xs font-medium text-quest-200">
@@ -41,8 +56,8 @@ export function HomePage() {
 					<span className="text-quest-400">Or get hired.</span>
 				</h1>
 				<p className="mx-auto mt-5 max-w-xl text-lg text-zinc-400">
-					A curated, both-sides-vetted job board for game development. Quality is
-					the product — not volume.
+					A curated, both-sides-vetted job board for game development.
+					Quality is the product — not volume.
 				</p>
 
 				<form
@@ -120,7 +135,8 @@ export function HomePage() {
 						Running a studio?
 					</h2>
 					<p className="mt-1 text-zinc-400">
-						Post a gig and reach vetted, portfolio-backed game-dev talent.
+						Post a gig and reach vetted, portfolio-backed game-dev
+						talent.
 					</p>
 				</div>
 				<Link to="/post">

--- a/apps/jobboard/web/src/routes/talent-profile.tsx
+++ b/apps/jobboard/web/src/routes/talent-profile.tsx
@@ -11,12 +11,14 @@ import {
 	TagRow,
 } from '../components/ui';
 import { Stars } from '@kbve/rn/ui';
+import { person, breadcrumbList } from '@kbve/core';
 import {
 	AVAILABILITY_LABELS,
 	AVAILABILITY_TONE,
 	formatRate,
 	rankProgress,
 } from '../lib/format';
+import { Seo, abs, ogImage } from '../lib/seo';
 
 const routeApi = getRouteApi('/talent/$handle');
 
@@ -88,9 +90,32 @@ export function TalentProfilePage() {
 	if (!t) return null;
 
 	const progress = rankProgress(t.reputation, t.rank);
+	const path = `/talent/${t.handle}`;
 
 	return (
 		<div className="mx-auto max-w-5xl">
+			<Seo
+				seo={{
+					title: `${t.display_name} — ${t.headline} · KBVE Jobs`,
+					description: t.headline,
+					path,
+					image: ogImage('talent', t.handle),
+					type: 'profile',
+				}}
+				jsonLd={[
+					person({
+						id: abs(path) + '#person',
+						name: t.display_name,
+						url: abs(path),
+						image: t.avatar_url || undefined,
+						jobTitle: t.headline,
+					}),
+					breadcrumbList([
+						['Talent', abs('/talent')],
+						[t.display_name, abs(path)],
+					]),
+				]}
+			/>
 			<Link
 				to="/talent"
 				className="text-sm text-zinc-400 hover:text-quest-300">

--- a/packages/npm/core/src/index.ts
+++ b/packages/npm/core/src/index.ts
@@ -9,3 +9,4 @@ export * from './net';
 export * from './auth';
 export * from './chat';
 export * from './api';
+export * from './seo';

--- a/packages/npm/core/src/seo/index.ts
+++ b/packages/npm/core/src/seo/index.ts
@@ -1,0 +1,2 @@
+export * from './schema';
+export * from './meta';

--- a/packages/npm/core/src/seo/meta.ts
+++ b/packages/npm/core/src/seo/meta.ts
@@ -1,0 +1,58 @@
+// Framework-agnostic social-embed / <meta> builder. Returns a flat list of tag
+// descriptors; a renderer (web <Seo> via react-helmet, or an SSR template)
+// turns them into <meta>/<title>/<link> elements.
+
+export interface MetaTag {
+	/** <meta name="..."> */
+	name?: string;
+	/** <meta property="..."> (Open Graph) */
+	property?: string;
+	content: string;
+}
+
+export interface SeoInput {
+	title: string;
+	description: string;
+	/** Canonical absolute URL. */
+	url: string;
+	/** Absolute OG image URL (e.g. the axum /og/*.svg route). */
+	image?: string;
+	siteName?: string;
+	type?: 'website' | 'article' | 'profile';
+	twitterCard?: 'summary' | 'summary_large_image';
+	twitterSite?: string;
+	noindex?: boolean;
+}
+
+export interface SeoResult {
+	title: string;
+	canonical: string;
+	meta: MetaTag[];
+}
+
+export function buildSeo(i: SeoInput): SeoResult {
+	const meta: MetaTag[] = [
+		{ name: 'description', content: i.description },
+		{ property: 'og:title', content: i.title },
+		{ property: 'og:description', content: i.description },
+		{ property: 'og:url', content: i.url },
+		{ property: 'og:type', content: i.type ?? 'website' },
+		...(i.siteName
+			? [{ property: 'og:site_name', content: i.siteName }]
+			: []),
+		...(i.image ? [{ property: 'og:image', content: i.image }] : []),
+		{
+			name: 'twitter:card',
+			content:
+				i.twitterCard ?? (i.image ? 'summary_large_image' : 'summary'),
+		},
+		{ name: 'twitter:title', content: i.title },
+		{ name: 'twitter:description', content: i.description },
+		...(i.image ? [{ name: 'twitter:image', content: i.image }] : []),
+		...(i.twitterSite
+			? [{ name: 'twitter:site', content: i.twitterSite }]
+			: []),
+		...(i.noindex ? [{ name: 'robots', content: 'noindex' }] : []),
+	];
+	return { title: i.title, canonical: i.url, meta };
+}

--- a/packages/npm/core/src/seo/schema.ts
+++ b/packages/npm/core/src/seo/schema.ts
@@ -1,0 +1,164 @@
+// Framework-agnostic schema.org / JSON-LD builders (pure data, no deps).
+// Mirrors the shapes used by @kbve/astro/seo so web (jobboard) + astro stay
+// consistent. Builders return plain objects; render them as
+// <script type="application/ld+json"> (see the web <JsonLd> wrapper).
+
+export type SchemaNode = Record<string, unknown>;
+
+export const ref = (id: string): SchemaNode => ({ '@id': id });
+
+export interface OrgInput {
+	id: string;
+	name: string;
+	url: string;
+	logo?: string;
+	sameAs?: string[];
+}
+
+export const organization = (i: OrgInput): SchemaNode => ({
+	'@type': 'Organization',
+	'@id': i.id,
+	name: i.name,
+	url: i.url,
+	...(i.logo ? { logo: i.logo } : {}),
+	...(i.sameAs?.length ? { sameAs: i.sameAs } : {}),
+});
+
+export interface WebSiteInput {
+	id: string;
+	name: string;
+	url: string;
+	publisher?: string;
+}
+
+export const website = (i: WebSiteInput): SchemaNode => ({
+	'@type': 'WebSite',
+	'@id': i.id,
+	name: i.name,
+	url: i.url,
+	...(i.publisher ? { publisher: ref(i.publisher) } : {}),
+});
+
+export type Crumb = [name: string, url: string];
+
+export const breadcrumbList = (crumbs: Crumb[]): SchemaNode => ({
+	'@type': 'BreadcrumbList',
+	itemListElement: crumbs.map(([name, url], idx) => ({
+		'@type': 'ListItem',
+		position: idx + 1,
+		name,
+		item: url,
+	})),
+});
+
+export interface PersonInput {
+	id?: string;
+	name: string;
+	url?: string;
+	image?: string;
+	jobTitle?: string;
+	sameAs?: string[];
+}
+
+export const person = (i: PersonInput): SchemaNode => ({
+	'@type': 'Person',
+	...(i.id ? { '@id': i.id } : {}),
+	name: i.name,
+	...(i.url ? { url: i.url } : {}),
+	...(i.image ? { image: i.image } : {}),
+	...(i.jobTitle ? { jobTitle: i.jobTitle } : {}),
+	...(i.sameAs?.length ? { sameAs: i.sameAs } : {}),
+});
+
+export interface JobPostingInput {
+	title: string;
+	description: string;
+	url: string;
+	datePosted?: string;
+	validThrough?: string;
+	employmentType?: string;
+	hiringOrganization?: { name: string; url?: string };
+	/** Minor units (e.g. cents). Omit for "undisclosed". */
+	salaryMin?: number;
+	salaryMax?: number;
+	currency?: string;
+	remote?: boolean;
+	location?: string;
+}
+
+export const jobPosting = (i: JobPostingInput): SchemaNode => ({
+	'@type': 'JobPosting',
+	title: i.title,
+	description: i.description,
+	url: i.url,
+	...(i.datePosted ? { datePosted: i.datePosted } : {}),
+	...(i.validThrough ? { validThrough: i.validThrough } : {}),
+	...(i.employmentType ? { employmentType: i.employmentType } : {}),
+	...(i.hiringOrganization
+		? {
+				hiringOrganization: {
+					'@type': 'Organization',
+					name: i.hiringOrganization.name,
+					...(i.hiringOrganization.url
+						? { sameAs: i.hiringOrganization.url }
+						: {}),
+				},
+			}
+		: {}),
+	...(i.salaryMin !== undefined && i.currency
+		? {
+				baseSalary: {
+					'@type': 'MonetaryAmount',
+					currency: i.currency,
+					value: {
+						'@type': 'QuantitativeValue',
+						minValue: i.salaryMin,
+						...(i.salaryMax !== undefined
+							? { maxValue: i.salaryMax }
+							: {}),
+						unitText: 'MONTH',
+					},
+				},
+			}
+		: {}),
+	...(i.remote
+		? { jobLocationType: 'TELECOMMUTE' }
+		: i.location
+			? {
+					jobLocation: {
+						'@type': 'Place',
+						address: i.location,
+					},
+				}
+			: {}),
+});
+
+export interface ListItemRef {
+	name: string;
+	url: string;
+}
+
+export const itemList = (items: ListItemRef[]): SchemaNode => ({
+	'@type': 'ItemList',
+	itemListElement: items.map((it, idx) => ({
+		'@type': 'ListItem',
+		position: idx + 1,
+		name: it.name,
+		url: it.url,
+	})),
+});
+
+/** Wrap nodes into a single @graph document, de-duplicated by @id. */
+export const graph = (nodes: SchemaNode[]): SchemaNode => {
+	const seen = new Map<string, SchemaNode>();
+	const out: SchemaNode[] = [];
+	for (const n of nodes) {
+		const id = n['@id'] as string | undefined;
+		if (id) {
+			if (seen.has(id)) continue;
+			seen.set(id, n);
+		}
+		out.push(n);
+	}
+	return { '@context': 'https://schema.org', '@graph': out };
+};

--- a/packages/npm/rn/src/ui/primitives/Button.tsx
+++ b/packages/npm/rn/src/ui/primitives/Button.tsx
@@ -28,6 +28,9 @@ export interface ButtonProps {
 	disabled?: boolean;
 	loading?: boolean;
 	style?: StyleProp<ViewStyle>;
+	/** Accessible name (maps to aria-label on web). Required for icon-only buttons. */
+	accessibilityLabel?: string;
+	accessibilityHint?: string;
 }
 
 export const Button = memo(function Button({
@@ -38,6 +41,8 @@ export const Button = memo(function Button({
 	disabled = false,
 	loading = false,
 	style,
+	accessibilityLabel,
+	accessibilityHint,
 }: ButtonProps) {
 	const t = useTheme();
 	const inactive = disabled || loading;
@@ -84,6 +89,13 @@ export const Button = memo(function Button({
 				style,
 			]}
 			disabled={inactive}
+			accessibilityRole="button"
+			accessibilityLabel={
+				accessibilityLabel ??
+				(typeof title === 'string' ? title : undefined)
+			}
+			accessibilityHint={accessibilityHint}
+			accessibilityState={{ disabled: inactive }}
 			onPressIn={() => {
 				scale.value = withSpring(0.95, { damping: 18, stiffness: 320 });
 			}}


### PR DESCRIPTION
Adds the SEO/metadata layer (A–E), leaning on @kbve/core as the agnostic home.

**A) Social embeds + C) JSON-LD** — new framework-agnostic `@kbve/core/seo` (pure, no deps): schema.org builders (organization/website/jobPosting/person/breadcrumbList/itemList + graph dedup) + `buildSeo` (OG/Twitter/description meta). jobboard/web gets a tiny CSR head manager (`lib/seo.tsx`, no react-helmet — peers react 18, app is react 19) writing title/canonical/og:*/twitter:* + `<script ld+json>` per route, swapping cleanly on nav. Wired: home (WebSite/Org), gig-detail (JobPosting + breadcrumbs), talent-profile (Person + breadcrumbs). Dropped the SPA-wide `noindex`.

**B) OG image via Axum** — `GET /og/{kind}/{name}.svg` returns a branded 1200×630 SVG (image/svg+xml, cached). The SPA's `og:image` points here. (Per-item titles once gigs/talent are served by Axum; today it renders the section kind on the brand card.)

**D) Sitemap via Axum** — `GET /sitemap.xml`: static routes + per-vertical gig URLs from the DB.

**E) Aria** — `@kbve/rn` Button gains `accessibilityLabel`/`Hint` + `accessibilityRole=button`/state (RNW maps to aria-*); defaults the label from `title`. `PressableSurface` already forwards a11y.

Verified: headless smoke shows og:*, canonical, and the JSON-LD graph (Organization/WebSite) render with 0 errors; cargo check + web build green.

Note: 'via @kbve/rn' in the ask → the agnostic builders live in @kbve/core (truly framework-free); @kbve/rn is React Native. The web `<Seo>` wrapper is jobboard-local (DOM head).