### PR TITLE
chore(kilobase): reusable reseal script for supabase-jwt anon/service keys

### DIFF
--- a/apps/kube/kilobase/reseal-supabase-jwt-keys.sh
+++ b/apps/kube/kilobase/reseal-supabase-jwt-keys.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# reseal-supabase-jwt-keys.sh — re-mint + reseal the Supabase anon + service_role
+# JWTs in the supabase-jwt SealedSecret, signed with the CURRENT JWT secret.
+#
+# Why: the sealed anon-key / service-key were signed with a secret that no longer
+# matches GoTrue's GOTRUE_JWT_SECRET (== supabase-jwt/secret) — GoTrue rejects the
+# service key as not_admin even though its role claim is service_role. Re-minting
+# with the live cluster secret makes them verify again.
+#
+# Surgical: only anon-key + service-key are replaced; secret / automaton-key /
+# expiry are left untouched. The signing secret is read from the cluster and
+# lives only in memory (never disk, history, or git).
+#
+# Prereqs: kubectl (cluster access), kubeseal, openssl, yq.
+# Usage:   ./reseal-supabase-jwt-keys.sh
+#          # overridable: CONTROLLER_NAME, CONTROLLER_NS, EXP_SECONDS
+#
+# After running: review the diff, commit + PR (ArgoCD applies; ExternalSecrets
+# refresh consumers). The anon key is embedded in frontend builds — rebuild +
+# redeploy those (e.g. astro-kbve / cryptothrone) so clients carry the new key.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFEST="${SCRIPT_DIR}/manifests/kilobase-jwt-secret-sealed.yaml"
+NS=kilobase
+NAME=supabase-jwt
+CONTROLLER_NAME="${CONTROLLER_NAME:-sealed-secrets-controller}"
+CONTROLLER_NS="${CONTROLLER_NS:-kube-system}"
+EXP_SECONDS="${EXP_SECONDS:-315360000}" # 10y, matches Supabase key convention
+
+for c in kubectl kubeseal openssl yq; do
+	command -v "$c" >/dev/null || {
+		echo "Error: missing required tool: $c" >&2
+		exit 1
+	}
+done
+kubectl get deployment "$CONTROLLER_NAME" -n "$CONTROLLER_NS" >/dev/null 2>&1 || {
+	echo "Error: sealed-secrets controller not found ($CONTROLLER_NAME/$CONTROLLER_NS)" >&2
+	exit 1
+}
+[ -f "$MANIFEST" ] || {
+	echo "Error: manifest not found: $MANIFEST" >&2
+	exit 1
+}
+
+JWT_SECRET="$(kubectl get secret -n "$NS" "$NAME" -o jsonpath='{.data.secret}' | base64 -d)"
+[ -n "$JWT_SECRET" ] || {
+	echo "Error: could not read $NAME/secret from the cluster" >&2
+	exit 1
+}
+
+b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+mint() { # $1 = role -> prints a signed HS256 JWT
+	local now header payload data sig
+	now="$(date +%s)"
+	header="$(printf '{"alg":"HS256","typ":"JWT"}' | b64url)"
+	payload="$(printf '{"role":"%s","iss":"supabase","iat":%s,"exp":%s}' \
+		"$1" "$now" "$((now + EXP_SECONDS))" | b64url)"
+	data="${header}.${payload}"
+	sig="$(printf '%s' "$data" | openssl dgst -sha256 -hmac "$JWT_SECRET" -binary | b64url)"
+	printf '%s.%s' "$data" "$sig"
+}
+
+seal_raw() { # stdin = plaintext -> prints the strict-scoped sealed blob
+	kubeseal --raw --scope strict --namespace "$NS" --name "$NAME" \
+		--controller-name "$CONTROLLER_NAME" --controller-namespace "$CONTROLLER_NS"
+}
+
+ANON_SEALED="$(mint anon | seal_raw)"
+SERVICE_SEALED="$(mint service_role | seal_raw)"
+
+yq -i ".spec.encryptedData.\"anon-key\" = \"${ANON_SEALED}\"" "$MANIFEST"
+yq -i ".spec.encryptedData.\"service-key\" = \"${SERVICE_SEALED}\"" "$MANIFEST"
+
+echo "Re-sealed anon-key + service-key in:"
+echo "  $MANIFEST"
+echo "Review the diff, commit, and PR. Rebuild/redeploy frontends that embed the anon key."


### PR DESCRIPTION
## Why
The sealed `anon-key`/`service-key` in `supabase-jwt` are **stale-signed** — their signature doesn't match GoTrue's current `GOTRUE_JWT_SECRET` (== `supabase-jwt/secret`), so GoTrue rejects the service key as `not_admin` (the claims are correct: `role: service_role`). Decoded the live key to confirm: valid role/iss/exp, so it's a signature mismatch, not a wrong key.

## What
`apps/kube/kilobase/reseal-supabase-jwt-keys.sh` — re-mints both keys from the **live cluster secret** and reseals them **surgically** (only `anon-key` + `service-key`; `secret`/`automaton-key`/`expiry` untouched) via `kubeseal --raw` + `yq`. Mirrors the existing `seal-*.sh` pattern (controller `sealed-secrets-controller`/`kube-system`); signing secret read from the cluster, in-memory only. Reusable for future rotations.

This PR adds the **tool only** — running it edits `kilobase-jwt-secret-sealed.yaml` (separate commit) since it needs cluster + kubeseal access I don't have.

## Sequence / risk
- Run **after #12599** deploys + confirms fast-register (proves the live secret is the right one — #12599 mints a service_role JWT from it at runtime).
- **Blast radius**: rotates the project-wide anon + service keys. The **anon key is embedded in frontend builds** — rebuild/redeploy astro-kbve / cryptothrone after, or anon-scoped client calls break.

No version bump (ops tooling).