### PR TITLE
feat(cryptothrone): / to focus chat, Enter sends + closes on empty

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ChatBar.tsx
@@ -66,19 +66,36 @@ export function ChatBar() {
 
 	useEffect(() => {
 		const onKey = (e: KeyboardEvent) => {
+			const active = document.activeElement;
+			const inChat = active === inputRef.current;
+			const inAnyInput =
+				active instanceof HTMLInputElement ||
+				active instanceof HTMLTextAreaElement ||
+				(active as HTMLElement | null)?.isContentEditable === true;
 			if (e.key === 'Escape') {
-				inputRef.current?.blur();
+				if (inChat) inputRef.current?.blur();
 				return;
 			}
-			if (e.key !== 'Enter') return;
-			const active = document.activeElement;
-			if (
-				active instanceof HTMLInputElement ||
-				active instanceof HTMLTextAreaElement
-			)
+			if (e.key === '/') {
+				if (inChat) {
+					if ((inputRef.current?.value ?? '') === '') {
+						e.preventDefault();
+						inputRef.current?.blur();
+					}
+				} else if (!inAnyInput) {
+					e.preventDefault();
+					inputRef.current?.focus();
+				}
 				return;
-			e.preventDefault();
-			inputRef.current?.focus();
+			}
+			if (
+				e.key === 'Enter' &&
+				inChat &&
+				(inputRef.current?.value ?? '').trim() === ''
+			) {
+				e.preventDefault();
+				inputRef.current?.blur();
+			}
 		};
 		window.addEventListener('keydown', onKey);
 		return () => window.removeEventListener('keydown', onKey);
@@ -294,7 +311,7 @@ export function ChatBar() {
 							if (e.key === 'Escape') inputRef.current?.blur();
 						}}
 						placeholder={
-							connected ? 'Press Enter to chat…' : 'Chat offline'
+							connected ? 'Press / to chat…' : 'Chat offline'
 						}
 						aria-label="Chat message"
 						className="min-w-0 flex-1 bg-transparent px-1 py-1 text-xs text-white placeholder-stone-500 outline-none"

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.39"
+version: "0.1.40"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## What
Reworks the chat key UX in `ChatBar`:
- **`/`** focuses the chat box when nothing else is focused; pressing it again while the box is focused **and empty** closes it (so `/` still types literally mid-message).
- **Enter** no longer opens the chat — it **sends** a non-empty draft (form submit), and on an **empty** box it blurs (closes) so the chat never stays stuck open.
- **Escape** still closes.
- Placeholder: `Press / to chat…`.

## Notes
- Emptiness is read from the live input value, so the single window-keydown listener stays correct without re-subscribing.
- `/` only intercepts when not already in another input field; game keys (WASD/arrows/space/E) are untouched, and the scene already skips movement while typing.
- 109 vitest tests green. bump 0.1.40.