### PR TITLE
feat(cryptothrone): slower + smoother day/night cycle + in-game clock

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/CloudCityScene.ts
@@ -567,7 +567,7 @@ export class CloudCityScene extends Scene {
 		this.checkHostileProximity();
 		this.syncRoster(snap);
 		this.runPendingAction();
-		const DAY_MS = 600000;
+		const DAY_MS = 1800000;
 		laserEvents.emit('world:time', {
 			phase: (snap.server_time_ms % DAY_MS) / DAY_MS,
 		});

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CoordsBar.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/CoordsBar.tsx
@@ -5,7 +5,7 @@ export function CoordsBar() {
 	const [pos, setPos] = useState({ x: 0, y: 0 });
 	const [fps, setFps] = useState(0);
 	const [zone, setZone] = useState('—');
-	const [clock, setClock] = useState('');
+	const [clock, setClock] = useState('--:--');
 
 	useEffect(() => {
 		const offs = [
@@ -18,21 +18,15 @@ export function CoordsBar() {
 			laserEvents.on('zone:enter', (d) =>
 				setZone((d as { name: string }).name),
 			),
+			laserEvents.on('world:time', (d) => {
+				const phase = (((d as { phase: number }).phase % 1) + 1) % 1;
+				const mins = Math.floor(phase * 24 * 60);
+				const hh = String(Math.floor(mins / 60)).padStart(2, '0');
+				const mm = String(mins % 60).padStart(2, '0');
+				setClock(`${hh}:${mm}`);
+			}),
 		];
-		const t = window.setInterval(
-			() =>
-				setClock(
-					new Date().toLocaleTimeString(undefined, {
-						hour: '2-digit',
-						minute: '2-digit',
-					}),
-				),
-			1000,
-		);
-		return () => {
-			offs.forEach((o) => o());
-			window.clearInterval(t);
-		};
+		return () => offs.forEach((o) => o());
 	}, []);
 
 	return (

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DayNight.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DayNight.tsx
@@ -1,12 +1,36 @@
 import { useEffect, useState } from 'react';
 import { laserEvents } from '@kbve/laser';
 
+type Rgba = [number, number, number, number];
+type Stop = [number, Rgba];
+
+const STOPS: Stop[] = [
+	[0.0, [10, 14, 40, 0.45]],
+	[0.1, [10, 14, 40, 0.45]],
+	[0.16, [255, 150, 80, 0.18]],
+	[0.24, [0, 0, 0, 0]],
+	[0.7, [0, 0, 0, 0]],
+	[0.8, [255, 120, 60, 0.2]],
+	[0.88, [20, 20, 60, 0.3]],
+	[0.94, [10, 14, 40, 0.45]],
+	[1.0, [10, 14, 40, 0.45]],
+];
+
 function tint(phase: number): string {
-	if (phase < 0.05 || phase >= 0.92) return 'rgba(10,14,40,0.45)'; // night
-	if (phase < 0.15) return 'rgba(255,150,80,0.18)'; // dawn
-	if (phase < 0.7) return 'rgba(0,0,0,0)'; // day
-	if (phase < 0.85) return 'rgba(255,120,60,0.2)'; // dusk
-	return 'rgba(20,20,60,0.3)'; // evening
+	const p = ((phase % 1) + 1) % 1;
+	let lo = STOPS[0];
+	let hi = STOPS[STOPS.length - 1];
+	for (let i = 0; i < STOPS.length - 1; i++) {
+		if (p >= STOPS[i][0] && p <= STOPS[i + 1][0]) {
+			lo = STOPS[i];
+			hi = STOPS[i + 1];
+			break;
+		}
+	}
+	const span = hi[0] - lo[0];
+	const t = span > 0 ? (p - lo[0]) / span : 0;
+	const c = lo[1].map((v, i) => v + (hi[1][i] - v) * t);
+	return `rgba(${Math.round(c[0])},${Math.round(c[1])},${Math.round(c[2])},${c[3].toFixed(3)})`;
 }
 
 export function DayNight() {
@@ -18,7 +42,7 @@ export function DayNight() {
 	}, []);
 	return (
 		<div
-			className="pointer-events-none absolute inset-0 z-10 transition-colors duration-1000"
+			className="pointer-events-none absolute inset-0 z-10 transition-colors duration-700"
 			style={{ backgroundColor: color }}
 			aria-hidden="true"
 		/>

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.39"
+version: "0.1.41"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
## What
- **Slower cycle**: `DAY_MS` 600000 → 1800000 — a full day/night is now ~30 min instead of ~10, so it stops racing.
- **Smoother colors**: `DayNight` `tint()` now **interpolates RGBA across phase color stops** (night → dawn → day → dusk → evening) instead of 5 hard `if` bands, so dawn/dusk are natural gradients. CSS transition trimmed 1000→700ms to track the continuous values.
- **In-game clock**: `CoordsBar` shows in-game time (HH:MM from the `world:time` phase, 24h) instead of the device wall clock.

## Notes
- Same `world:time` phase event drives the overlay + the clock; `setClock` only re-renders when the minute string changes.
- 109 vitest tests green. bump **0.1.41** (distinct from #12601's pending 0.1.40).