### PR TITLE
ci(failure-tracker): record version on issues + close on success

### DIFF
--- a/.github/workflows/ci-bevy.yml
+++ b/.github/workflows/ci-bevy.yml
@@ -257,22 +257,37 @@ jobs:
 
     # ---------------------------------------------------------------------------
     # Failure tracker — surfaces build failures as GitHub issues (#8186).
-    # Runs on any failure so async failures are not silently dropped.
+    # One call per job so each issue title auto-closes on its own success.
     # ---------------------------------------------------------------------------
-    track_failure:
-        name: Track Failures
-        if: always() && (needs.build_wasm.result == 'failure' || needs.deploy_wasm.result == 'failure')
-        needs: [build_wasm, deploy_wasm]
+    track_build_wasm:
+        name: Track build_wasm
+        if: always() && needs.build_wasm.result != 'cancelled' && needs.build_wasm.result != 'skipped'
+        needs: [build_wasm]
         permissions:
             issues: write
             contents: read
         uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
         with:
             workflow_name: 'CI - Bevy'
-            job_name: ${{ needs.build_wasm.result == 'failure' && 'build_wasm' || 'deploy_wasm' }}
+            job_name: 'build_wasm'
             run_id: ${{ github.run_id }}
             run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            status: 'failure'
+            status: ${{ needs.build_wasm.result }}
+
+    track_deploy_wasm:
+        name: Track deploy_wasm
+        if: always() && needs.deploy_wasm.result != 'cancelled' && needs.deploy_wasm.result != 'skipped'
+        needs: [deploy_wasm]
+        permissions:
+            issues: write
+            contents: read
+        uses: KBVE/kbve/.github/workflows/utils-ci-failure-tracker.yml@main
+        with:
+            workflow_name: 'CI - Bevy'
+            job_name: 'deploy_wasm'
+            run_id: ${{ github.run_id }}
+            run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            status: ${{ needs.deploy_wasm.result }}
 
     # ---------------------------------------------------------------------------
     # Future build targets — disabled, scaffolded for when native builds land.

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -301,7 +301,7 @@ jobs:
 
     track_failure:
         name: Track Failures
-        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        if: ${{ always() && !contains(needs.*.result, 'cancelled') }}
         needs: [version_gate, test, publish, post_publish, external_publish]
         permissions:
             issues: write
@@ -312,4 +312,5 @@ jobs:
             job_name: ${{ inputs.app_name }}
             run_id: ${{ github.run_id }}
             run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            status: 'failure'
+            status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+            version: ${{ needs.version_gate.outputs.local_version }}

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -467,7 +467,7 @@ jobs:
     # ---------------------------------------------------------------------------
     track_failure:
         name: Track Failures
-        if: ${{ always() && contains(needs.*.result, 'failure') }}
+        if: ${{ always() && !contains(needs.*.result, 'cancelled') }}
         needs:
             [
                 version_gate,
@@ -489,4 +489,5 @@ jobs:
             job_name: '${{ inputs.package_type }}/${{ inputs.package_name }}'
             run_id: ${{ github.run_id }}
             run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-            status: 'failure'
+            status: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+            version: ${{ needs.version_gate.outputs.local_version }}

--- a/.github/workflows/utils-ci-failure-tracker.yml
+++ b/.github/workflows/utils-ci-failure-tracker.yml
@@ -18,6 +18,10 @@ on:
             status:
                 required: true
                 type: string # "failure", "success", "cancelled", "skipped"
+            version:
+                required: false
+                type: string
+                default: ''
 
 jobs:
     track:
@@ -94,16 +98,25 @@ jobs:
                   RUN_ID: ${{ inputs.run_id }}
                   RUN_URL: ${{ inputs.run_url }}
                   FAILED_STEP: ${{ steps.logs.outputs.failed_step }}
+                  VERSION: ${{ inputs.version }}
               run: |
                   set -euo pipefail
                   TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                   LOG_SNIPPET=$(cat /tmp/log_snippet.txt 2>/dev/null || echo "Logs unavailable")
+                  VERSION_LINE=""
+                  VERSION_MARKER=""
+                  if [ -n "${VERSION:-}" ]; then
+                    VERSION_LINE="**Version:** ${VERSION}"
+                    VERSION_MARKER="<!-- ci-tracker:version=${VERSION} -->"
+                  fi
 
                   cat > /tmp/issue-body.md << ISSUEEOF
                   ## ${TITLE}
+                  ${VERSION_MARKER}
 
                   **Workflow:** ${WORKFLOW_NAME}
                   **Job:** ${JOB_NAME}
+                  ${VERSION_LINE}
                   **Failed step:** ${FAILED_STEP}
                   **Status:** Failing since ${TIMESTAMP}
                   **Consecutive failures:** 1
@@ -145,16 +158,22 @@ jobs:
                   RUN_ID: ${{ inputs.run_id }}
                   RUN_URL: ${{ inputs.run_url }}
                   FAILED_STEP: ${{ steps.logs.outputs.failed_step }}
+                  VERSION: ${{ inputs.version }}
               run: |
                   set -euo pipefail
                   TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
                   LOG_SNIPPET=$(cat /tmp/log_snippet.txt 2>/dev/null || echo "Logs unavailable")
+                  VERSION_LINE=""
+                  if [ -n "${VERSION:-}" ]; then
+                    VERSION_LINE="- **Version:** ${VERSION}"
+                  fi
 
                   cat > /tmp/comment-body.md << COMMENTEOF
                   ## Failure — ${TIMESTAMP}
 
                   - **Run:** [#${RUN_ID}](${RUN_URL})
                   - **Failed step:** ${FAILED_STEP}
+                  ${VERSION_LINE}
                   - **Ref:** ${{ github.ref }}
                   - **Trigger:** ${{ github.event_name }}
 
@@ -176,12 +195,17 @@ jobs:
                   ISSUE_NUMBER: ${{ steps.search.outputs.issue_number }}
                   RUN_ID: ${{ inputs.run_id }}
                   RUN_URL: ${{ inputs.run_url }}
+                  VERSION: ${{ inputs.version }}
               run: |
                   set -euo pipefail
                   TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                  RESOLVE_TITLE="## Resolved — ${TIMESTAMP}"
+                  if [ -n "${VERSION:-}" ]; then
+                    RESOLVE_TITLE="## Resolved — shipped v${VERSION} — ${TIMESTAMP}"
+                  fi
 
                   cat > /tmp/resolve-body.md << RESOLVEEOF
-                  ## Resolved — ${TIMESTAMP}
+                  ${RESOLVE_TITLE}
 
                   - **Run:** [#${RUN_ID}](${RUN_URL})
                   - **Ref:** ${{ github.ref }}


### PR DESCRIPTION
## What

Improvements to the auto-generated CI failure issue system (#8186), prompted by #12440 lingering open.

### 1. Version on tickets
`utils-ci-failure-tracker.yml` gains an optional `version` input:
- `**Version:** X` line + hidden `<!-- ci-tracker:version=X -->` marker in the issue body
- version in each failure comment
- close comment reads "Resolved — shipped vX"

### 2. Auto-close failure issues
`ci-docker` and `ci-publish` only ever called the tracker with `status: 'failure'`, so the tracker's close-on-success path never ran — failure issues like #12440 could never auto-close. Both now pass a dynamic status (`failure`/`success`) and `version_gate.local_version`. A green run closes the matching open issue.

`ci-bevy` had a single call covering two jobs (build_wasm, deploy_wasm); a success could only ever close one of the two possible titles. Split into one call per job so each title self-closes.

## Notes
- `version` input is optional/back-compat; other callers unchanged.
- Tracker's job-level guard already ignores any status other than `failure`/`success`, so skipped/cancelled passthrough is a no-op.
- Tracker pinned `@main` by these callers — close behavior goes live once this reaches main via the dev→main release.

## Audit
All tracker callers checked: only ci-docker, ci-publish, ci-bevy were failure-only. The rest already pair failure+success calls or pass dynamic status.