### PR TITLE
fix(axum-discordsh): correct jedi PgCluster/JediError paths + lint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,6 +1572,7 @@ dependencies = [
  "axum-extra",
  "dotenvy",
  "http-body-util",
+ "jedi",
  "kbve",
  "num_cpus",
  "reqwest 0.13.2",

--- a/apps/discordsh/axum-discordsh/Cargo.toml
+++ b/apps/discordsh/axum-discordsh/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.13.2", default-features = false, features = ["json", "r
 
 # Workspace path dependencies
 kbve = { path = "../../../packages/rust/kbve", features = ["supabase", "image-gen"] }
+jedi = { path = "../../../packages/rust/jedi", features = ["postgres"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/apps/discordsh/axum-discordsh/src/api/servers.rs
+++ b/apps/discordsh/axum-discordsh/src/api/servers.rs
@@ -1,6 +1,12 @@
 use std::net::IpAddr;
 
-use axum::{Json, Router, extract::{Path, Query, State}, http::StatusCode, response::IntoResponse, routing::{get, post}};
+use axum::{
+    Json, Router,
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+};
 use serde::{Deserialize, Serialize};
 
 use super::validate::{
@@ -266,8 +272,11 @@ async fn list_servers(
 ) -> impl IntoResponse {
     let Some(ref cluster) = state.app.pg_cluster else {
         tracing::warn!("[list_servers] PgCluster not initialized");
-        return err(StatusCode::SERVICE_UNAVAILABLE, "Database temporarily unavailable")
-            .into_response();
+        return err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Database temporarily unavailable",
+        )
+        .into_response();
     };
 
     match query_servers(cluster, &params).await {
@@ -288,11 +297,9 @@ async fn list_servers(
 }
 
 async fn query_servers(
-    cluster: &kbve::jedi::state::pg::PgCluster,
+    cluster: &jedi::state::pg::PgCluster,
     params: &ListServersQuery,
-) -> Result<(Vec<ServerRecord>, i64), kbve::jedi::entity::error::JediError> {
-    use kbve::jedi::state::pg::tokio_postgres;
-
+) -> Result<(Vec<ServerRecord>, i64), jedi::entity::error::JediError> {
     let conn = cluster.read().await?;
 
     // Map category ID to array contains check
@@ -410,8 +417,11 @@ async fn get_server(
 
     let Some(ref cluster) = state.app.pg_cluster else {
         tracing::warn!("[get_server] PgCluster not initialized");
-        return err(StatusCode::SERVICE_UNAVAILABLE, "Database temporarily unavailable")
-            .into_response();
+        return err(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Database temporarily unavailable",
+        )
+        .into_response();
     };
 
     match query_server_by_id(cluster, &server_id).await {
@@ -425,11 +435,9 @@ async fn get_server(
 }
 
 async fn query_server_by_id(
-    cluster: &kbve::jedi::state::pg::PgCluster,
+    cluster: &jedi::state::pg::PgCluster,
     server_id: &str,
-) -> Result<Option<ServerRecord>, kbve::jedi::entity::error::JediError> {
-    use kbve::jedi::state::pg::tokio_postgres;
-
+) -> Result<Option<ServerRecord>, jedi::entity::error::JediError> {
     let conn = cluster.read().await?;
 
     let sql = r#"

--- a/apps/discordsh/axum-discordsh/src/health/mod.rs
+++ b/apps/discordsh/axum-discordsh/src/health/mod.rs
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn round2_precision() {
-        assert_eq!(round2(3.14159), 3.14);
+        assert_eq!(round2(1.23456), 1.23);
         assert_eq!(round2(0.0), 0.0);
         assert_eq!(round2(99.999), 100.0);
     }

--- a/apps/discordsh/axum-discordsh/src/main.rs
+++ b/apps/discordsh/axum-discordsh/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> anyhow::Result<()> {
     health_monitor.spawn_background_task();
 
     // Initialize PgCluster if env configured
-    let pg_cluster = match kbve::jedi::state::pg::PgCluster::from_env().await {
+    let pg_cluster = match jedi::state::pg::PgCluster::from_env().await {
         Ok(cluster) => {
             info!("PgCluster initialized successfully");
             Some(cluster)

--- a/apps/discordsh/axum-discordsh/src/state.rs
+++ b/apps/discordsh/axum-discordsh/src/state.rs
@@ -21,7 +21,7 @@ pub struct AppState {
 
     /// Direct Postgres pool (bypasses Postgrest/edge).
     /// TODO: Make this required (not Option) once PgCluster is stable.
-    pub pg_cluster: Option<Arc<kbve::jedi::state::pg::PgCluster>>,
+    pub pg_cluster: Option<Arc<jedi::state::pg::PgCluster>>,
 }
 
 impl AppState {
@@ -41,7 +41,7 @@ impl AppState {
         }
     }
 
-    pub fn with_pg_cluster(mut self, cluster: Arc<kbve::jedi::state::pg::PgCluster>) -> Self {
+    pub fn with_pg_cluster(mut self, cluster: Arc<jedi::state::pg::PgCluster>) -> Self {
         self.pg_cluster = Some(cluster);
         self
     }


### PR DESCRIPTION
Fixes the `axum-discordsh:lint` CI failure.

## Cause

The recent PgCluster wiring referenced `kbve::jedi::state::pg::PgCluster` and `kbve::jedi::entity::error::JediError` — but `kbve`'s own `jedi` module has no `state`/`entity` submodules; those types live in the **`jedi` crate** (`jedi::state::pg`, `jedi::entity::error`), and axum-discordsh didn't even depend on `jedi`. → `E0433 could not find state/entity in jedi` (×11), cascading into `E0282`/`E0308` (unresolved `cluster`/`conn` types). Plus a deny-by-default `clippy::approx_constant` in the `round2` health test.

## Fix

- Add `jedi = { path = ..., features = ["postgres"] }` as a direct dep (mirrors axum-kbve).
- `kbve::jedi::state::pg` → `jedi::state::pg`, `kbve::jedi::entity::error` → `jedi::entity::error`.
- Drop two unused `tokio_postgres` imports; change the `round2` test literal `3.14159` → `1.23456` (false-positive ≈ PI).

## Verify

`cargo clippy --manifest-path apps/discordsh/axum-discordsh/Cargo.toml --all-targets` → **exit 0** (0 errors; the 5 remaining warn-level lints are pre-existing and don't fail `@monodon/rust:lint`). rustfmt applied.