### PR TITLE
feat(cryptothrone): polish Discord Activity boot UX (#12520)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
+++ b/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
@@ -20,12 +20,88 @@
 				width: 100vw;
 				height: 100vh;
 			}
+			.ct-boot {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				height: 100%;
+				gap: 1rem;
+				padding: 1.5rem;
+				text-align: center;
+				box-sizing: border-box;
+			}
+			.ct-spinner {
+				width: 2rem;
+				height: 2rem;
+				border-radius: 9999px;
+				border: 2px solid rgba(251, 191, 36, 0.2);
+				border-top-color: #fbbf24;
+				animation: ct-spin 0.8s linear infinite;
+			}
+			@keyframes ct-spin {
+				to {
+					transform: rotate(360deg);
+				}
+			}
+			.ct-boot-status {
+				margin: 0;
+				font-size: 0.875rem;
+				font-weight: 600;
+				color: #fde68a;
+			}
+			.ct-boot-sub {
+				margin: 0;
+				max-width: 22rem;
+				font-size: 0.75rem;
+				color: #a8a29e;
+			}
+			.ct-error-icon {
+				color: #f87171;
+			}
+			.ct-error-title {
+				margin: 0;
+				font-size: 0.875rem;
+				font-weight: 600;
+				color: #fca5a5;
+			}
+			.ct-error-msg {
+				margin: 0;
+				max-width: 22rem;
+				font-size: 0.75rem;
+				color: #a8a29e;
+				word-break: break-word;
+			}
+			.ct-retry {
+				margin-top: 0.5rem;
+				border: none;
+				border-radius: 0.5rem;
+				background: rgba(245, 158, 11, 0.9);
+				color: #000;
+				font-size: 0.875rem;
+				font-weight: 600;
+				padding: 0.5rem 1.25rem;
+				cursor: pointer;
+				transition: background 0.15s ease;
+			}
+			.ct-retry:hover {
+				background: #fbbf24;
+			}
 		</style>
 	</head>
 	<body>
 		<!-- Discord Activity root. discord.js runs the OAuth handshake, bridges
-		     to a game-server session, then mounts the game into #app. -->
-		<div id="app">Loading CryptoThrone…</div>
+		     to a game-server session, then mounts the game into #app. The boot
+		     card below is the pre-React loading state; discord.js updates its
+		     status text per stage and swaps it for an error card with a retry
+		     button on failure. -->
+		<div id="app">
+			<div class="ct-boot">
+				<span class="ct-spinner" aria-hidden="true"></span>
+				<p class="ct-boot-status">Linking to Cloud City…</p>
+				<p class="ct-boot-sub">Starting CryptoThrone.</p>
+			</div>
+		</div>
 		<!-- Relative src: under the Discord root mapping (/ -> .../discord/) an
 		     absolute /discord/discord.js would double to /discord/discord/…. -->
 		<script src="discord.js" defer></script>

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -1,4 +1,8 @@
-import { DiscordSDK, patchUrlMappings } from '@discord/embedded-app-sdk';
+import {
+	DiscordSDK,
+	patchUrlMappings,
+	type Types,
+} from '@discord/embedded-app-sdk';
 import { mount } from './index';
 
 /**
@@ -37,6 +41,8 @@ const URL_MAPPINGS: { prefix: string; target: string }[] = [
 	{ prefix: '/cryptothrone-chat', target: 'chat.kbve.com' },
 ];
 
+const AUTHORIZE_SCOPE: Types.OAuthScopes[] = ['identify', 'email'];
+
 interface DiscordSession {
 	access_token: string;
 	jwt: string;
@@ -65,15 +71,60 @@ function errMsg(err: unknown): string {
 	return String(err);
 }
 
-function fail(msg: string, ...extra: unknown[]): void {
-	console.error(`[Cryptothrone/Discord] ${msg}`, ...extra);
-	const root = document.getElementById('app');
-	if (root) {
-		root.textContent = `Could not start the Activity: ${msg}`;
-	}
+function root(): HTMLElement | null {
+	return document.getElementById('app');
 }
 
-/** Run a boot step, re-throwing with a labelled message so the on-screen text
+/** Update the boot card's status line (and optional sub-line) in place so each
+ * stage names itself instead of a frozen "Loading…". */
+function setStatus(status: string, sub?: string): void {
+	const el = root();
+	if (!el) return;
+	const statusEl = el.querySelector<HTMLElement>('.ct-boot-status');
+	const subEl = el.querySelector<HTMLElement>('.ct-boot-sub');
+	if (statusEl) {
+		statusEl.textContent = status;
+	} else {
+		// Boot card was replaced (e.g. by an error) — rebuild it.
+		el.innerHTML = `
+			<div class="ct-boot">
+				<span class="ct-spinner" aria-hidden="true"></span>
+				<p class="ct-boot-status">${status}</p>
+				<p class="ct-boot-sub">${sub ?? ''}</p>
+			</div>`;
+		return;
+	}
+	if (subEl && sub !== undefined) subEl.textContent = sub;
+}
+
+/** Swap the boot card for a legible error with a retry button. Retry reloads
+ * the Activity iframe — the cleanest reset for the SDK/OAuth handshake, same
+ * pattern the in-game ConnectionOverlay uses. */
+function fail(msg: string, ...extra: unknown[]): void {
+	console.error(`[Cryptothrone/Discord] ${msg}`, ...extra);
+	const el = root();
+	if (!el) return;
+	el.innerHTML = `
+		<div class="ct-boot">
+			<svg class="ct-error-icon" width="32" height="32" viewBox="0 0 24 24"
+				fill="none" stroke="currentColor" stroke-width="1.75"
+				stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<path d="M10.3 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.7 3.86a2 2 0 0 0-3.4 0z" />
+				<line x1="12" y1="9" x2="12" y2="13" />
+				<line x1="12" y1="17" x2="12.01" y2="17" />
+			</svg>
+			<p class="ct-error-title">Could not start the Activity</p>
+			<p class="ct-error-msg"></p>
+			<button type="button" class="ct-retry">Try again</button>
+		</div>`;
+	// Set message via textContent so error strings can't inject markup.
+	const msgEl = el.querySelector<HTMLElement>('.ct-error-msg');
+	if (msgEl) msgEl.textContent = msg;
+	const retry = el.querySelector<HTMLButtonElement>('.ct-retry');
+	retry?.addEventListener('click', () => window.location.reload());
+}
+
+/** Run a boot step, re-throwing with a labelled message so the error card
  * names which stage failed instead of a generic "boot failed". */
 async function step<T>(label: string, run: () => Promise<T>): Promise<T> {
 	try {
@@ -83,27 +134,58 @@ async function step<T>(label: string, run: () => Promise<T>): Promise<T> {
 	}
 }
 
+/** Discord authorize with a silent-first strategy. `prompt:'none'` skips the
+ * consent screen for users who already authorized the app, but Discord rejects
+ * it for never-authorized users — fall back to authorize *without* `prompt`,
+ * which opens the OAuth consent modal, so a first-time player isn't left at a
+ * dead end. */
+async function authorize(clientId: string, sdk: DiscordSDK): Promise<string> {
+	try {
+		const { code } = await sdk.commands.authorize({
+			client_id: clientId,
+			response_type: 'code',
+			state: '',
+			prompt: 'none',
+			scope: AUTHORIZE_SCOPE,
+		});
+		return code;
+	} catch (err) {
+		console.warn(
+			'[Cryptothrone/Discord] silent authorize failed, prompting for consent',
+			errMsg(err),
+		);
+		setStatus(
+			'Waiting for you to authorize…',
+			'Approve access in Discord.',
+		);
+		const { code } = await step('Discord authorize', () =>
+			sdk.commands.authorize({
+				client_id: clientId,
+				response_type: 'code',
+				state: '',
+				scope: AUTHORIZE_SCOPE,
+			}),
+		);
+		return code;
+	}
+}
+
 async function boot(): Promise<void> {
 	if (!CLIENT_ID) {
-		fail('missing PUBLIC_DISCORD_CLIENT_ID at build time');
+		fail('Missing PUBLIC_DISCORD_CLIENT_ID at build time.');
 		return;
 	}
 
 	patchUrlMappings(URL_MAPPINGS);
 
+	setStatus('Linking to Cloud City…', 'Connecting to Discord.');
 	const sdk = new DiscordSDK(CLIENT_ID);
 	await step('Discord SDK ready', () => sdk.ready());
 
-	const { code } = await step('Discord authorize', () =>
-		sdk.commands.authorize({
-			client_id: CLIENT_ID,
-			response_type: 'code',
-			state: '',
-			prompt: 'none',
-			scope: ['identify', 'email'],
-		}),
-	);
+	setStatus('Linking to Cloud City…', 'Authorizing your Discord account.');
+	const code = await authorize(CLIENT_ID, sdk);
 
+	setStatus('Linking to Cloud City…', 'Setting up your game session.');
 	const res = await step('session request', () =>
 		fetch(SESSION_ENDPOINT, {
 			method: 'POST',
@@ -112,18 +194,19 @@ async function boot(): Promise<void> {
 		}),
 	);
 	if (!res.ok) {
-		fail(`session exchange failed (${res.status})`);
+		fail(`Session exchange failed (${res.status}).`);
 		return;
 	}
 	const session = (await step('session parse', () =>
 		res.json(),
 	)) as DiscordSession;
 
+	setStatus('Linking to Cloud City…', 'Entering the world.');
 	await step('Discord authenticate', () =>
 		sdk.commands.authenticate({ access_token: session.access_token }),
 	);
 
-	const el = document.getElementById('app') ?? document.body;
+	const el = root() ?? document.body;
 	mount({
 		el,
 		jwt: session.jwt,
@@ -132,4 +215,4 @@ async function boot(): Promise<void> {
 	});
 }
 
-void boot().catch((err) => fail(`boot failed — ${errMsg(err)}`, err));
+void boot().catch((err) => fail(`Boot failed — ${errMsg(err)}`, err));


### PR DESCRIPTION
Polish pass on the isolated Discord Activity boot path. Closes the **Polish** items in #12520.

## Changes
- **Loading spinner + per-stage status** — `public/discord/index.html` now renders a spinner boot card (amber theme, matches in-game `ConnectionOverlay`) instead of bare "Loading…" text. `discord.tsx` updates the status sub-line per stage (Connecting to Discord → Authorizing → Setting up session → Entering the world).
- **Legible error + retry button** — `fail()` swaps the boot card for an error card (warning icon, message, **Try again** button) instead of dead-ending with replaced `textContent`. Retry reloads the iframe — cleanest reset for the SDK/OAuth handshake, same pattern the in-game overlay uses. Error text set via `textContent` (no markup injection).
- **`prompt:'none'` consent fallback** — `authorize()` tries silent (`prompt:'none'`) first, then falls back to authorize *without* `prompt` (opens the OAuth consent modal) for never-authorized users who'd otherwise hit a dead end. (`AuthorizeInput.prompt` only types `'none'`, so consent = omit it.)

## Not changed
- **WS reconnect mid-session** — already handled: laser's `ReconnectingWebSocket` (backoff + attempt cap) drives `net:status` → `ConnectionOverlay`, which shows the reconnecting spinner and a retry button. No change needed.

## Verify (manual, post-deploy)
The issue's **Verify** section needs a real Discord client + registered portal `redirect_uri` + deploy — can't be exercised locally. Launch the Activity in Discord and confirm `SDK ready → authorize → /.proxy/api/discord/session → authenticate → mount` and that game/chat WS reach through the proxy mappings.

Built via `nx run astro-cryptothrone:build-discord`; scoped `tsc --noEmit` on `discord.tsx` clean. (`astro check` OOMs locally on whole-project content collections — pre-existing env issue.)