### PR TITLE
feat(cryptothrone): Discord rich presence via setActivity (#12530)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord-presence.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord-presence.ts
@@ -1,0 +1,149 @@
+import type { DiscordSDK } from '@discord/embedded-app-sdk';
+import { laserEvents } from '@kbve/laser';
+
+/**
+ * Discord rich presence for the isolated Activity path. Subscribes to the
+ * laser event bus (the same bus the React HUD reads) and pushes meaningful
+ * game-state changes — zone, party size, combat — to the player's Discord
+ * profile via `setActivity`. Lives outside React because discord.tsx owns the
+ * DiscordSDK instance; the game mounts into a shadow root and never sees it.
+ *
+ * Requires the `rpc.activities.write` OAuth scope on `authorize`.
+ */
+
+const DEFAULT_ZONE = 'Cloud City';
+/** Keep the in-combat badge up this long after the last combat event so it
+ * doesn't flicker off between swings. */
+const COMBAT_LINGER_MS = 8_000;
+/** Discord rate-limits setActivity (~5 updates / 20s). Coalesce bursts to one
+ * update per window, leading + trailing. */
+const THROTTLE_MS = 4_000;
+
+/** Max party size for the `[current, max]` badge. Mirrors the game server
+ * roster capacity; env-overridable so it tracks the deployed cap without a
+ * code change. */
+function resolvePartyMax(): number {
+	const env = import.meta.env.PUBLIC_CT_PARTY_MAX as string | undefined;
+	const n = env ? Number.parseInt(env, 10) : Number.NaN;
+	return Number.isFinite(n) && n > 0 ? n : 64;
+}
+
+/** Large presence art. Defaults to a Rich Presence asset key (`cryptothrone`)
+ * uploaded in the Discord developer portal — no URL mapping needed. An external
+ * image URL also works (CSP exempts presence assets) via the env override. */
+function resolvePresenceImage(): string {
+	const env = import.meta.env.PUBLIC_CT_PRESENCE_IMAGE as string | undefined;
+	return env && env.length > 0 ? env : 'cryptothrone';
+}
+
+interface PresenceState {
+	zone: string;
+	party: number;
+	inCombat: boolean;
+}
+
+/** Start pushing rich presence. Returns a stop() that unsubscribes, cancels
+ * pending updates, and clears the presence. */
+export function startPresence(sdk: DiscordSDK): () => void {
+	const partyMax = resolvePartyMax();
+	const largeImage = resolvePresenceImage();
+	const startTs = Date.now();
+
+	const presence: PresenceState = {
+		zone: DEFAULT_ZONE,
+		party: 1,
+		inCombat: false,
+	};
+
+	let dirty = false;
+	let throttle = 0;
+	let combatTimer = 0;
+	let lastSent = 0;
+	let stopped = false;
+
+	function build() {
+		const current = Math.max(1, presence.party);
+		return {
+			type: 0,
+			details: presence.inCombat
+				? `In combat — ${presence.zone}`
+				: `Exploring ${presence.zone}`,
+			// `state` only renders alongside `party`, so always send both.
+			state:
+				current > 1 ? `In a party of ${current}` : 'Adventuring solo',
+			party: {
+				id: 'cryptothrone-realm',
+				size: [current, Math.max(current, partyMax)],
+			},
+			assets: { large_image: largeImage, large_text: 'CryptoThrone' },
+			timestamps: { start: startTs },
+		};
+	}
+
+	function flush() {
+		dirty = false;
+		lastSent = Date.now();
+		void sdk.commands.setActivity({ activity: build() }).catch((err) => {
+			console.warn('[Cryptothrone/Discord] setActivity failed', err);
+		});
+	}
+
+	function schedule() {
+		if (stopped) return;
+		dirty = true;
+		if (throttle) return;
+		const elapsed = Date.now() - lastSent;
+		if (elapsed >= THROTTLE_MS) {
+			flush();
+			return;
+		}
+		throttle = window.setTimeout(() => {
+			throttle = 0;
+			if (dirty) flush();
+		}, THROTTLE_MS - elapsed);
+	}
+
+	const unsubs: (() => void)[] = [
+		laserEvents.on('net:status', (data) => {
+			// First presence push once the game is live in the world.
+			if ((data as { status?: string }).status === 'ready') schedule();
+		}),
+		laserEvents.on('zone:enter', (data) => {
+			const name = (data as { name?: string }).name;
+			if (name && name !== presence.zone) {
+				presence.zone = name;
+				schedule();
+			}
+		}),
+		laserEvents.on('players:sync', (data) => {
+			const players = (data as { players?: unknown[] }).players ?? [];
+			const next = Math.max(1, players.length);
+			if (next !== presence.party) {
+				presence.party = next;
+				schedule();
+			}
+		}),
+		laserEvents.on('combat:event', () => {
+			if (!presence.inCombat) {
+				presence.inCombat = true;
+				schedule();
+			}
+			window.clearTimeout(combatTimer);
+			combatTimer = window.setTimeout(() => {
+				presence.inCombat = false;
+				schedule();
+			}, COMBAT_LINGER_MS);
+		}),
+	];
+
+	// Show presence immediately on entry; net:status 'ready' refreshes it.
+	schedule();
+
+	return () => {
+		stopped = true;
+		unsubs.forEach((fn) => fn());
+		window.clearTimeout(throttle);
+		window.clearTimeout(combatTimer);
+		void sdk.commands.setActivity({ activity: null }).catch(() => {});
+	};
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -4,6 +4,7 @@ import {
 	type Types,
 } from '@discord/embedded-app-sdk';
 import { mount } from './index';
+import { startPresence } from './discord-presence';
 
 /**
  * Discord Activity entry — the isolated Discord path. Runs entirely on the main
@@ -41,7 +42,13 @@ const URL_MAPPINGS: { prefix: string; target: string }[] = [
 	{ prefix: '/cryptothrone-chat', target: 'chat.kbve.com' },
 ];
 
-const AUTHORIZE_SCOPE: Types.OAuthScopes[] = ['identify', 'email'];
+// `rpc.activities.write` is required for setActivity (rich presence). Only
+// widen the scope because the Activity adopts presence — see discord-presence.
+const AUTHORIZE_SCOPE: Types.OAuthScopes[] = [
+	'identify',
+	'email',
+	'rpc.activities.write',
+];
 
 interface DiscordSession {
 	access_token: string;
@@ -213,6 +220,10 @@ async function boot(): Promise<void> {
 		username: session.username,
 		height: '100vh',
 	});
+
+	// Surface live game state on the player's Discord profile. Subscribes to
+	// the laser bus; lives for the lifetime of the Activity iframe.
+	startPresence(sdk);
 }
 
 void boot().catch((err) => fail(`Boot failed — ${errMsg(err)}`, err));


### PR DESCRIPTION
Surface live game state on the player's Discord profile while in the Activity. Closes #12530.

## Changes
- **`src/embed/discord-presence.ts`** (new) — `startPresence(sdk)` subscribes to the laser event bus (same bus the React HUD reads) and pushes `setActivity`:
  - `details` — `Exploring {zone}` / `In combat — {zone}`
  - `state` + `party.size [current, max]` — party count from `players:sync` (state only renders with party set, so both always sent)
  - `assets.large_image` / `large_text` — presence art + "CryptoThrone"
  - `timestamps.start` — session start (elapsed timer)
- **Update triggers** — `zone:enter` (zone), `players:sync` (party), `combat:event` (in-combat, 8s linger so the badge doesn't flicker between swings), `net:status: ready` (first push). Throttled to one update / 4s to stay under Discord's setActivity rate limit (leading + trailing).
- **`discord.tsx`** — adds the **`rpc.activities.write`** scope (required for setActivity) and calls `startPresence(sdk)` after the game mounts.
- **Config** — `PUBLIC_CT_PARTY_MAX` (default 64, mirrors server roster capacity) and `PUBLIC_CT_PRESENCE_IMAGE` (default Rich Presence asset key `cryptothrone`; external URL also works — CSP exempts presence assets) are env-overridable.

## Notes
- `large_image` defaults to a portal-uploaded Rich Presence asset key (`cryptothrone`) — no URL mapping needed. Upload that art in the Discord developer portal, or set `PUBLIC_CT_PRESENCE_IMAGE` to an external URL, for the image to render.
- Game server capacity isn't visible to the client (separate host); `PUBLIC_CT_PARTY_MAX` carries the display cap.

## Verify (manual, in a real Discord client)
Profile shows details + state + party size, updating on zone change / party join / combat. Built via `nx run astro-cryptothrone:build-discord`; scoped `tsc --noEmit` on the touched files clean.