### PR TITLE
feat(cryptothrone): route pixel panel variants into HUD

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DeathScreen.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DeathScreen.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { laserEvents } from '@kbve/laser';
 import { useGameSelector } from '../store/GameStoreContext';
+import { PixelPanel } from './PixelPanel';
 
 export function DeathScreen() {
 	const hp = useGameSelector((s) => s.player.stats.hp);
@@ -25,14 +26,14 @@ export function DeathScreen() {
 	if (!dead) return null;
 	return (
 		<div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center bg-red-950/40 backdrop-blur-sm">
-			<div className="text-center">
+			<PixelPanel variant="ruby" className="px-10 py-8 text-center">
 				<p className="text-4xl font-black tracking-widest text-red-400 drop-shadow-[0_2px_8px_rgba(0,0,0,0.9)]">
 					YOU DIED
 				</p>
 				<p className="mt-2 text-sm text-stone-300">
 					The well pulls you back to the plaza…
 				</p>
-			</div>
+			</PixelPanel>
 		</div>
 	);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/InventoryGrid.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { laserEvents } from '@kbve/laser';
 import { getItemById } from '../data/items';
 import { ItemIcon } from './ItemIcon';
+import { PixelPanel } from './PixelPanel';
 
 const RARITY_BORDER: Record<string, string> = {
 	common: 'border-stone-400/50',
@@ -97,12 +98,13 @@ export function InventoryGrid({ backpack }: InventoryGridProps) {
 					const item = getItemById(tooltipItem.id);
 					if (!item) return null;
 					return (
-						<div
+						<PixelPanel
+							variant="iron"
 							style={{
 								top: tooltipItem.y,
 								left: tooltipItem.x,
 							}}
-							className="fixed bg-gray-700 text-white p-2 rounded shadow-lg z-50 pointer-events-none">
+							className="fixed text-white p-2 z-50 pointer-events-none">
 							<p className="text-sm font-semibold">{item.name}</p>
 							<p className="text-xs">Type: {item.type}</p>
 							<p className="text-xs">{item.description}</p>
@@ -114,7 +116,7 @@ export function InventoryGrid({ backpack }: InventoryGridProps) {
 										.join(', ')}
 								</p>
 							)}
-						</div>
+						</PixelPanel>
 					);
 				})()}
 		</div>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/QuestTracker.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/QuestTracker.tsx
@@ -1,4 +1,5 @@
 import { useGameSelector } from '../store/GameStoreContext';
+import { PixelPanel } from './PixelPanel';
 
 const GOAL = 10;
 
@@ -6,7 +7,9 @@ export function QuestTracker() {
 	const kills = useGameSelector((s) => s.player.stats.kills ?? 0);
 	const done = Math.min(kills, GOAL);
 	return (
-		<div className="pointer-events-none absolute left-3 top-16 z-30 w-44 rounded-lg border border-white/10 bg-black/55 px-3 py-2 backdrop-blur-md">
+		<PixelPanel
+			variant="wood"
+			className="pointer-events-none absolute left-3 top-16 z-30 w-44 px-3 py-2">
 			<p className="text-[0.6rem] font-semibold uppercase tracking-widest text-amber-300/80">
 				Bounty
 			</p>
@@ -20,6 +23,6 @@ export function QuestTracker() {
 			<p className="mt-0.5 text-right font-mono text-[0.6rem] text-stone-400">
 				{done}/{GOAL}
 			</p>
-		</div>
+		</PixelPanel>
 	);
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/TargetFrame.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/TargetFrame.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { laserEvents } from '@kbve/laser';
+import { PixelPanel } from './PixelPanel';
 
 interface Target {
 	name: string;
@@ -21,7 +22,7 @@ export function TargetFrame() {
 	const pct = Math.max(0, Math.min(100, (target.hp / target.maxHp) * 100));
 	return (
 		<div className="pointer-events-none absolute left-1/2 top-12 z-30 w-44 -translate-x-1/2">
-			<div className="rounded-lg border border-white/10 bg-black/60 px-3 py-1.5 backdrop-blur-md">
+			<PixelPanel variant="ruby" className="px-3 py-1.5">
 				<p className="truncate text-center text-xs font-semibold text-stone-200">
 					{target.name}
 				</p>
@@ -34,7 +35,7 @@ export function TargetFrame() {
 				<p className="mt-0.5 text-center font-mono text-[0.6rem] text-stone-400">
 					{target.hp}/{target.maxHp}
 				</p>
-			</div>
+			</PixelPanel>
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx
@@ -15,7 +15,7 @@ tags:
 key: cryptothrone
 pipeline: docker
 app_name: cryptothrone
-version: "0.1.42"
+version: "0.1.44"
 source_path: apps/cryptothrone
 version_toml: apps/cryptothrone/version.toml
 version_target: apps/cryptothrone/axum-cryptothrone/Cargo.toml


### PR DESCRIPTION
Routes the generated 9-slice panel family (from #12614) into game HUD surfaces:

- QuestTracker -> `wood`
- TargetFrame (enemy) -> `ruby`
- DeathScreen -> `ruby`
- InventoryGrid item tooltip -> `iron`

FloatingWindow-chrome panels (Dialogue, Chat, DiceRoll, Sidebar, etc.) left alone — they already have a frame; double-framing would look wrong.

astro check clean (only 3 pre-existing CloudCityScene/vitest.config errors). bump 0.1.44.