### PR TITLE
fix(jobboard): web-safe @kbve/rn root barrel (exclude rails)

### DIFF
--- a/apps/jobboard/web/vite.config.ts
+++ b/apps/jobboard/web/vite.config.ts
@@ -55,11 +55,10 @@ export default defineConfig(({ mode }) => ({
 				),
 			},
 			{
+				// extensionless so vite resolves index.web.ts (drops rails, whose
+				// RailItem/Rail pull @expo/vector-icons) before index.ts
 				find: /^@kbve\/rn$/,
-				replacement: path.join(
-					repoRoot,
-					'packages/npm/rn/src/index.ts',
-				),
+				replacement: path.join(repoRoot, 'packages/npm/rn/src/index'),
 			},
 			{
 				find: /^@kbve\/core$/,

--- a/packages/npm/rn/src/index.web.ts
+++ b/packages/npm/rn/src/index.web.ts
@@ -1,0 +1,45 @@
+export const RN_PACKAGE_VERSION = '0.0.1';
+
+export * from '@kbve/core';
+export * from './config';
+
+export * from './agent/ws';
+export * from './agent/useAgent';
+
+export * from './auth/supabase';
+export * from './auth/executor';
+export * from './auth/KbveProvider';
+export * from './auth/useAuth';
+export * from './auth/useApi';
+export * from './auth/useAuthForm';
+export * from './auth/AuthGate';
+export * from './auth/LoginScreen';
+export * from './auth/SetUsernameScreen';
+export * from './auth/useStaff';
+
+export * from './captcha/HCaptcha';
+
+export * from './chat/executor';
+export * from './chat/useChat';
+
+export * from './hooks';
+export * from './offload';
+export * from './platform/openExternal';
+export * from './platform/viewTransition';
+export * from './store';
+export * from './worker';
+export * from './toasts';
+
+export * from './plugin';
+export * from './sandbox';
+export * from './examples/helloPlugin';
+export * from './examples/isometricPlugin';
+export * from './examples/wgpuPlugin';
+export * from './examples/typegpuPlugin';
+
+export * from './screens/HomeScreen';
+export * from './screens/HomeView';
+export * from './screens/DashboardScreen';
+export * from './screens/ChatScreen';
+
+export * from './ui';


### PR DESCRIPTION
## Problem
`jobboard:dev` docker build failed at `vite build`:
```
[vite]: Rollup failed to resolve import "@expo/vector-icons" from "packages/npm/rn/src/rails/RailItem.tsx".
```
#12622 added `export * from './rails'` to the rn root `index.ts`. Rails (`RailItem`/`Rail`/`models`) import `@expo/vector-icons` — native-only, ships untranspiled JSX, never bundles on web. jobboard web pulls bare `@kbve/rn` (`createWorkerPool` in `api/client.ts`), so rollup tried to resolve the rails chain and failed.

## Fix
Same pattern as the existing nav exclusion (`ui/index.web.ts`):
- New `packages/npm/rn/src/index.web.ts` — root barrel minus `./rails`.
- jobboard `vite.config.ts` `@kbve/rn` alias now extensionless so `.web.ts` wins on web. Native (metro) keeps `index.ts` with rails.

Verified locally: `npx vite build` → 2961 modules, no resolve error.

## Note
Rails has no web-safe icon path yet. Rendering rails on the /dashboard web route later needs a platform-split icon (no Ionicons font/SVG set on web).