### PR TITLE
fix(kbve): trust CNPG cluster CA so PgCluster TLS verify stops 408ing wallet routes

### DIFF
--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -234,6 +234,18 @@ spec:
                             secretKeyRef:
                                 name: supabase-shared
                                 key: db-url-any
+                      # CNPG cluster CA (internal-ca) that signs the
+                      # supabase-cluster server + pooler certs. PgCluster's
+                      # rustls connector only trusts the webpki public roots
+                      # by default, so without this it can't verify the
+                      # internal-ca-signed cert and every acquire times out
+                      # (→ /api/v1/wallet/* 408). Synced into supabase-shared
+                      # from the kilobase supabase-cluster-ca secret by
+                      # kbve-externalsecret.yaml; ESO's 1h refresh + the
+                      # supabase-shared reloader watch roll the pod on CA
+                      # rotation.
+                      - name: KBVE_PG_CA_PEM_FILE
+                        value: '/etc/ssl/pgca/ca.crt'
                       # KvCache (jedi::state::kv) L2 backing. valkey-auth
                       # is cloned into the kbve namespace by Kyverno
                       # (apps/kube/valkey/manifests/valkey-auth-sync-policy.yaml).
@@ -261,6 +273,9 @@ spec:
                                 key: hash-secret
                                 optional: true
                   volumeMounts:
+                      - name: pg-ca
+                        mountPath: /etc/ssl/pgca
+                        readOnly: true
                       - name: argocd-ca
                         mountPath: /etc/ssl/argocd
                         readOnly: true
@@ -278,6 +293,12 @@ spec:
                           memory: '1024Mi'
                           cpu: '2000m'
             volumes:
+                - name: pg-ca
+                  secret:
+                      secretName: supabase-shared
+                      items:
+                          - key: db-ca-crt
+                            path: ca.crt
                 - name: argocd-ca
                   secret:
                       secretName: kbve-internal-ca-tls

--- a/apps/kube/kbve/manifest/kbve-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/kbve-externalsecret.yaml
@@ -41,6 +41,7 @@ spec:
                 db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
                 db-url-ro: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-pooler-ro.kilobase.svc.cluster.local:5432/supabase'
                 db-url-any: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-r.kilobase.svc.cluster.local:5432/supabase'
+                db-ca-crt: '{{ .dbcacrt }}'
                 twitch-client-id: '{{ .twitchclientid }}'
                 twitch-client-secret: '{{ .twitchclientsecret }}'
     data:
@@ -60,6 +61,10 @@ spec:
           remoteRef:
               key: supabase-postgres
               property: password
+        - secretKey: dbcacrt
+          remoteRef:
+              key: supabase-cluster-ca
+              property: ca.crt
         - secretKey: twitchclientid
           remoteRef:
               key: twitch-oauth-config

--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -20,6 +20,7 @@ rules:
               'supabase-jwt',
               'supabase-postgres',
               'supabase-db',
+              'supabase-cluster-ca',
               'twitch-oauth-config',
               'ows-db-password',
               'referral-hash',


### PR DESCRIPTION
## Problem

`GET /api/v1/wallet/me/balance` (and every other PgCluster-backed wallet/ledger route) returns **408** in prod. Logs show the request reaching JWT verification, then silence — no error, no completion.

## Root cause

`PgCluster` (`jedi::state::pg`) connects **directly** to `supabase-cluster` over TLS (`use_pooler=false`), but `make_rustls_connector()` only trusts the **webpki public roots** unless `KBVE_PG_CA_PEM_FILE` is set. The supabase-cluster server + pooler certs are signed by the CNPG **`internal-ca`** (secret `kilobase/supabase-cluster-ca`), so:

1. rustls cert verification fails →
2. bb8 can't establish a connection → every `acquire` hits `connection_timeout` →
3. `JediError::Timeout` → `jedi_error_response` maps it to `StatusCode::REQUEST_TIMEOUT` (**408**) on a code path that **does not log** → the silent stall after JWT verify.

`/health/pg` confirmed it: all three pools (`rw`/`ro`/`any`) probe-timeout after 1s. The forum/PostgREST routes are unaffected because they go through Kong inside kilobase, not the direct PgCluster TLS path.

Valkey/fred were ruled out — `KvCache` bounds every L2 op (250ms + fred 750ms) and swallows errors, and `pool.init()` succeeded at startup.

## Fix

Trust the CNPG cluster CA instead of disabling TLS:

- **ExternalSecret**: pull `supabase-cluster-ca` / `ca.crt` into the kbve-namespace `supabase-shared` secret as `db-ca-crt`.
- **Deployment**: mount it at `/etc/ssl/pgca/ca.crt` and set `KBVE_PG_CA_PEM_FILE` so the rustls root store trusts `internal-ca`.
- **RBAC**: whitelist `supabase-cluster-ca` on the cross-namespace reader Role used by `kbve-external-secrets`.

CA rotation is handled by ESO's 1h refresh + the existing `supabase-shared` reloader watch (rolls the pod automatically).

## Deploy note

ArgoCD tracks `main`; this lands on `dev` and reaches the cluster on the next dev→main release. After rollout, verify with `/health/pg` (`all_ok: true`) before re-testing the wallet route.