### PR TITLE
chore(chuck): bump beta 0.3.21 -> 0.3.22

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -15,7 +15,7 @@ pipeline: unreal_game
 app_name: chuck
 source_path: apps/chuckrpg/unreal-chuck
 version_toml: apps/chuckrpg/unreal-chuck/version.toml
-version: "0.3.21"
+version: "0.3.22"
 runner: arc-runner-ue
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
Bumps the Chuck beta manifest version to ship a new itch.io build. This build fixes the barren Greenshire zone: baked foliage now persists/cooks, and terrain+water come from the deterministic seeded streamer. Chuck repo main is updated (merge a7d269cb + 80f80413).