### PR TITLE
chore(chuck): bump beta 0.3.21 -> 0.3.22

### DIFF
--- a/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx
@@ -15,7 +15,7 @@ pipeline: unreal_game
 app_name: chuck
 source_path: apps/chuckrpg/unreal-chuck
 version_toml: apps/chuckrpg/unreal-chuck/version.toml
-version: "0.3.21"
+version: "0.3.22"
 runner: arc-runner-ue
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
Bump the Chuck beta manifest to ship a new kbve/chuckrpg build to itch.io. CI's version gate ships once this lands on dev and flows to main.