### PR TITLE
fix(astro-kbve): no-data state for stale/non-running pods in Argo Grafana panel

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
@@ -186,6 +186,18 @@ export default function ReactArgoGrafanaPanel({
 	const ns = sel.namespace;
 	const name = sel.name;
 
+	const noData =
+		!!metrics &&
+		metrics.snapshot.cpuCores == null &&
+		metrics.snapshot.memoryBytes == null &&
+		metrics.snapshot.memoryLimitBytes == null &&
+		metrics.snapshot.netRxBytesPerSec == null &&
+		metrics.snapshot.netTxBytesPerSec == null &&
+		metrics.snapshot.fsBytes == null &&
+		metrics.snapshot.running == null &&
+		metrics.cpuMemSeries.length === 0 &&
+		metrics.netSeries.length === 0;
+
 	useEffect(() => {
 		if (!isPod || !userId || !ns || !name) return;
 
@@ -492,7 +504,40 @@ export default function ReactArgoGrafanaPanel({
 				</div>
 			)}
 
-			{metrics && (
+			{metrics && noData && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'flex-start',
+						gap: 8,
+						padding: '0.75rem 0.9rem',
+						borderRadius: 8,
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						background: 'var(--sl-color-bg-nav, #111)',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.82rem',
+						lineHeight: 1.5,
+					}}>
+					<Activity
+						size={15}
+						style={{ marginTop: 2, flexShrink: 0 }}
+					/>
+					<span>
+						No Prometheus series for{' '}
+						<strong
+							style={{ color: 'var(--sl-color-text, #e6edf3)' }}>
+							{ns}/{name}
+						</strong>
+						. The pod is likely not running — replaced by a newer
+						rollout, completed (Job/init), or stopped. cAdvisor only
+						keeps metrics for live pods. Confirm the pod is{' '}
+						<strong>Running</strong>, or hard-refresh the ArgoCD
+						tree if it still lists a stale pod.
+					</span>
+				</div>
+			)}
+
+			{metrics && !noData && (
 				<>
 					<div
 						style={{


### PR DESCRIPTION
## Problem

The ArgoCD resource drawer's **Grafana** tab showed an empty panel for pods, which read as a Grafana reverse-proxy / datasource failure. It is not.

Diagnosed end-to-end against the live cluster (port-forward to `monitoring-grafana`):

- anonymous `GET /api/datasources` → `200` (RBAC fine)
- datasource proxy query → `200`, data present
- cAdvisor: 531 series, `pod` label present
- `kbve` namespace CPU aggregate → `0.96` cores ✅
- **screenshot pod** `kbve-deployment-6bcf6bdcd7-2dfr5` → `[]` empty
- **live pod** `kbve-deployment-57bcc7ddcd-2j7wl` → `1.0` cores ✅

Root cause: the queried pod was a **stale ReplicaSet hash** (`6bcf6bdcd7`, rolled to `57bcc7ddcd`). cAdvisor only keeps series for live/recent pods, so an exact-name query for a deleted/completed pod returns nothing. The panel then rendered stat cards full of `--` and no charts — visually indistinguishable from a broken proxy.

## Fix

Detect the all-empty result (all-null snapshot + both series empty) and render an explicit notice: the pod is likely rolled away, completed (Job/init), or stopped, with a hint to verify it is `Running` or hard-refresh a stale ArgoCD tree.

No proxy/datasource/infra change — the pipeline is healthy.

## Test

`astro-kbve:check` — `ReactArgoGrafanaPanel.tsx` clean (the 5 repo errors are pre-existing and unrelated).