### PR TITLE
fix(kbve): use internal-ca for PgCluster TLS + point RO at direct replica

### DIFF
--- a/apps/kube/kbve/manifest/kbve-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/kbve-externalsecret.yaml
@@ -39,7 +39,7 @@ spec:
                 anon-key: '{{ .anonkey }}'
                 service-role-key: '{{ .servicekey }}'
                 db-url: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-rw.kilobase.svc.cluster.local:5432/supabase'
-                db-url-ro: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-pooler-ro.kilobase.svc.cluster.local:5432/supabase'
+                db-url-ro: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-ro.kilobase.svc.cluster.local:5432/supabase'
                 db-url-any: 'postgres://postgres:{{ .dbpassword }}@supabase-cluster-r.kilobase.svc.cluster.local:5432/supabase'
                 db-ca-crt: '{{ .dbcacrt }}'
                 twitch-client-id: '{{ .twitchclientid }}'
@@ -63,7 +63,7 @@ spec:
               property: password
         - secretKey: dbcacrt
           remoteRef:
-              key: supabase-cluster-ca
+              key: supabase-server-tls
               property: ca.crt
         - secretKey: twitchclientid
           remoteRef:

--- a/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
+++ b/apps/kube/kilobase/manifests/cross-namespace-rbac.yaml
@@ -20,7 +20,7 @@ rules:
               'supabase-jwt',
               'supabase-postgres',
               'supabase-db',
-              'supabase-cluster-ca',
+              'supabase-server-tls',
               'twitch-oauth-config',
               'ows-db-password',
               'referral-hash',


### PR DESCRIPTION
Follow-up to #12636 — wallet routes were **still 408ing** after that merged. Two corrections, both verified out-of-band before this PR.

## 1. Wrong CA mounted

The supabase-cluster serving cert is `CN=supabase-cluster-rw`, **issued by `CN=internal-ca`**, and the server sends only the leaf in the TLS handshake (chain depth 0). #12636 mounted `supabase-cluster-ca`, which is a *different* self-signed root (`CN=supabase-cluster`), so rustls could never build a valid chain → every bb8 acquire kept timing out → 408 unchanged.

Pull the CA from **`supabase-server-tls`/`ca.crt`** instead — the cert-manager-managed `internal-ca` bundle that actually issued the serving cert (and rotates with it).

## 2. RO pool hostname-SAN gap

The serving cert SAN covers the **direct** services (`supabase-cluster-rw` / `-ro` / `-r` `.svc.cluster.local`) but **not** `supabase-cluster-pooler-ro`. So `KBVE_PG_RO_URL` (→ pooler-ro) failed rustls hostname verification even with the correct CA. Point `db-url-ro` at the direct **`supabase-cluster-ro`** service (which is in the SAN). PgCluster already pools via bb8, so dropping the PgBouncer hop on reads is fine.

RBAC: swap the cross-namespace reader whitelist `supabase-cluster-ca` → `supabase-server-tls`.

## Verification

```
openssl s_client -starttls postgres -CAfile <supabase-server-tls/ca.crt> -verify_hostname <fqdn>
supabase-cluster-rw -> Verify return code: 0 (ok)
supabase-cluster-ro -> Verify return code: 0 (ok)
supabase-cluster-r  -> Verify return code: 0 (ok)
```

## Deploy note

Lands on `dev`, reaches cluster on next dev→main release. After rollout confirm `https://kbve.com/health/pg` shows `all_ok:true` before re-testing the wallet route. The deployment YAML is unchanged from #12636 (still mounts `db-ca-crt` → `/etc/ssl/pgca/ca.crt`).