### PR TITLE
fix(astro-kbve): clear 5 astro check type errors (Phaser plugin types + Scalar global)

### DIFF
--- a/apps/kbve/astro-kbve/src/arcade/towerdefense/TowerDefenseScene.ts
+++ b/apps/kbve/astro-kbve/src/arcade/towerdefense/TowerDefenseScene.ts
@@ -294,6 +294,13 @@ function refundForBuilding(b: Building): number {
 	return Math.floor(value * 0.5);
 }
 
+type NexusAuraObject = Phaser.GameObjects.GameObject & {
+	setDepth(depth: number): NexusAuraObject;
+	setBlendMode(mode: number): NexusAuraObject;
+	setAlpha(alpha: number): NexusAuraObject;
+	offset: number;
+};
+
 export class TowerDefenseScene extends Phaser.Scene {
 	private path!: GeneratedPath;
 	private world!: World;
@@ -637,12 +644,7 @@ export class TowerDefenseScene extends Phaser.Scene {
 	private placementRange!: Phaser.GameObjects.Arc;
 	private placementCoverage!: Phaser.GameObjects.Graphics;
 	private grassController: GrassController | null = null;
-	private nexusAura:
-		| (Phaser.GameObjects.GameObject & {
-				setAlpha(alpha: number): unknown;
-				offset: number;
-		  })
-		| null = null;
+	private nexusAura: NexusAuraObject | null = null;
 	private cameraPauseBlur: unknown = null;
 	private hoverRangeIndicator: Phaser.GameObjects.Arc | null = null;
 	private hoverRangeOwner: Building | null = null;
@@ -1139,12 +1141,7 @@ export class TowerDefenseScene extends Phaser.Scene {
 				y: number,
 				width: number,
 				height: number,
-			) => Phaser.GameObjects.GameObject & {
-				setDepth(depth: number): unknown;
-				setAlpha(alpha: number): unknown;
-				setBlendMode(mode: number): unknown;
-				offset: number;
-			};
+			) => unknown;
 		};
 		if (typeof factory.gradient !== 'function') return;
 		const size = TILE * 5;
@@ -1177,7 +1174,7 @@ export class TowerDefenseScene extends Phaser.Scene {
 			cy,
 			size,
 			size,
-		);
+		) as unknown as NexusAuraObject;
 		aura.setDepth(baseDepth - 1)
 			.setBlendMode(Phaser.BlendModes.ADD)
 			.setAlpha(0.85);

--- a/apps/kbve/astro-kbve/src/arcade/towerdefense/environment/grass.ts
+++ b/apps/kbve/astro-kbve/src/arcade/towerdefense/environment/grass.ts
@@ -42,7 +42,7 @@ export function drawGrass(scene: Phaser.Scene): GrassController | null {
 		BASE_WIDTH,
 		BASE_HEIGHT,
 	);
-	noise.setAlpha(0.55);
+	(noise as unknown as { setAlpha(alpha: number): void }).setAlpha(0.55);
 
 	return {
 		update(time: number) {

--- a/apps/kbve/astro-kbve/src/components/api/scalar-auth-bridge.ts
+++ b/apps/kbve/astro-kbve/src/components/api/scalar-auth-bridge.ts
@@ -2,6 +2,7 @@ import { initSupa, getSupa } from '@/lib/supa';
 
 type ScalarInstance = {
 	updateConfiguration?: (cfg: Record<string, unknown>) => void;
+	destroy?: () => void;
 };
 
 declare global {


### PR DESCRIPTION
## Problem

`astro-kbve:check` reported 5 pre-existing type errors (surfaced while diagnosing #12645):

- `TowerDefenseScene.ts:1183/1184` — `Gradient` has no `setAlpha`; `Gradient` not assignable to the `nexusAura` field
- `environment/grass.ts:45` — `NoiseSimplex2D` has no `setAlpha`
- `AstroApiDashboard.astro:109` — `Window.__scalarRef` redeclared with a mismatched `ScalarInstance` (ts2717)
- `AstroApiDashboard.astro:142` — `destroy` missing on `ScalarInstance` (ts2339)

Causes:
1. A Phaser plugin update added ambient types for the `gradient` / `noisesimplex2d` factories whose return types (`Gradient` / `NoiseSimplex2D`) omit `setAlpha` — which exists at runtime since both are GameObjects. The previous defensive inline casts no longer won against the ambient types.
2. `AstroApiDashboard.astro` and `scalar-auth-bridge.ts` each `declare global Window.__scalarRef`, but the bridge's `ScalarInstance` lacked `destroy?`, so the two global declarations disagreed and the bridge's shape (no `destroy`) won at the call site.

## Fix

- Add a `NexusAuraObject` alias with chainable `setDepth/setBlendMode/setAlpha` + `offset`; cast the `gradient` factory result to it. Field typed `NexusAuraObject | null`.
- Cast the `noisesimplex2d` result for the `setAlpha` call only, leaving `noiseFlow` on the real type.
- Add `destroy?: () => void` to the bridge's `ScalarInstance` so both global declarations agree.

Runtime behavior unchanged — types only.

## Test

`astro-kbve:check` — **0 errors** (was 5). Remaining output is pre-existing `ts(6385)` zod deprecation warnings, untouched.