### PR TITLE
fix(kyverno): guarantee admission CPU + relax probes to stop crashloop

### DIFF
--- a/apps/kube/kyverno/application.yaml
+++ b/apps/kube/kyverno/application.yaml
@@ -16,18 +16,34 @@ spec:
                 fullnameOverride: kyverno
                 admissionController:
                     replicas: 2
-                    resources:
-                        limits: { cpu: 1000m, memory: 1Gi }
-                        requests: { cpu: 100m, memory: 256Mi }
+                    container:
+                        resources:
+                            limits: { cpu: 1000m, memory: 1Gi }
+                            requests: { cpu: 500m, memory: 256Mi }
+                    livenessProbe:
+                        timeoutSeconds: 10
+                        failureThreshold: 6
+                    readinessProbe:
+                        timeoutSeconds: 10
+                        failureThreshold: 10
                 backgroundController:
                     replicas: 1
-                    resources:
-                        limits: { cpu: 500m, memory: 512Mi }
-                        requests: { cpu: 50m, memory: 128Mi }
+                    container:
+                        resources:
+                            limits: { cpu: 500m, memory: 512Mi }
+                            requests: { cpu: 100m, memory: 128Mi }
                 cleanupController:
                     replicas: 1
+                    container:
+                        resources:
+                            limits: { cpu: 500m, memory: 256Mi }
+                            requests: { cpu: 100m, memory: 128Mi }
                 reportsController:
                     replicas: 1
+                    container:
+                        resources:
+                            limits: { cpu: 500m, memory: 512Mi }
+                            requests: { cpu: 100m, memory: 128Mi }
                 config:
                     excludeKyvernoNamespace: true
                     resourceFilters:


### PR DESCRIPTION
## Problem
kyverno admission webhook intermittently rejects `kubectl apply` with `validate.kyverno.svc-fail ... connection refused` (hit while applying the dbmate-runner Job in kilobase). Root cause: kyverno pods crashloop ~every 6min and `kyverno-svc` loses ready endpoints during the restart window.

## Cause
- `admissionController.resources` is **not** a key in the kyverno helm chart — it was silently ignored, so the admission container ran on the chart-default **100m CPU request / no CPU limit**.
- Node `talos-4bn-whr` is CPU-overcommitted (limits ~267%). Under contention the admission container is throttled; its port-9443 server (which serves **both** `/health/*` and the admission webhook) can't answer probes in time → liveness `context deadline exceeded` → kubelet SIGKILL → restart loop (218+ restarts over 30d; background/cleanup/reports fully CrashLoopBackOff).

## Fix
- Move resources under `admissionController.container.resources` (the real key) with a guaranteed **500m CPU request**.
- Relax `livenessProbe`/`readinessProbe` `timeoutSeconds` + `failureThreshold` so transient CPU stalls don't trigger a kill.
- Give background/cleanup/reports controllers their resources under `.container` too, with non-trivial CPU requests.

Verified with `helm template kyverno/kyverno --version 3.8.0`: container resources + probe overrides now render into the admission Deployment (previously dropped).

## Note
ArgoCD-managed, tracks main. Reaches the cluster after the dev→main release. Does not by itself relieve the node CPU overcommit (UE build load) — that's a separate ops step.