### PR TITLE
feat(kbve-gate): auth reverse-proxy sidecar fronting n8n

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.201",
+			"version": "1.0.202",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.37",
+			"version": "0.1.44",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -120,7 +120,7 @@
 		{
 			"key": "cryptothrone_server",
 			"app_name": "cryptothrone-server",
-			"version": "0.0.18",
+			"version": "0.0.19",
 			"version_toml": "apps/agones/cryptothrone/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
 			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",
@@ -273,7 +273,7 @@
 		{
 			"key": "jobboard",
 			"app_name": "jobboard",
-			"version": "0.1.2",
+			"version": "0.1.5",
 			"version_toml": "apps/jobboard/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/jobboard.mdx",
 			"version_target": "apps/jobboard/Cargo.toml",
@@ -294,6 +294,19 @@
 			"runner": "ubuntu-latest",
 			"image": "kbve/kasm-void",
 			"deployment_yaml": "apps/kube/kasm/manifest/deployment.yaml",
+			"has_test": false
+		},
+		{
+			"key": "kbve_gate",
+			"app_name": "kbve-gate",
+			"version": "0.1.0",
+			"version_toml": "apps/kbve/kbve-gate/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx",
+			"version_target": "apps/kbve/kbve-gate/Cargo.toml",
+			"source_path": "apps/kbve/kbve-gate",
+			"runner": "ubuntu-latest",
+			"image": "kbve/kbve-gate",
+			"deployment_yaml": "apps/kube/n8n/manifest/n8n-deployment.yaml",
 			"has_test": false
 		},
 		{
@@ -1108,7 +1121,7 @@
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
-			"version": "0.3.20",
+			"version": "0.3.21",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",
 			"runner": "arc-runner-ue",
@@ -1174,7 +1187,7 @@
 	],
 	"bevy_game": [],
 	"summary": {
-		"docker": 31,
+		"docker": 32,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -1184,6 +1197,6 @@
 		"godot": 1,
 		"unreal_game": 3,
 		"bevy_game": 0,
-		"total": 94
+		"total": 95
 	}
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9071,6 +9071,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-tungstenite 0.24.0",
  "tower 0.5.3",
  "tower-http",
  "tracing",
@@ -9093,6 +9094,17 @@ dependencies = [
  "tauri-plugin-store",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "kbve-gate"
+version = "0.1.0"
+dependencies = [
+ "dotenvy",
+ "kbve",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
 	'apps/discordsh/axum-discordsh',
 	'apps/discordsh/discordsh-bot',
 	'apps/kbve/axum-kbve',
+	'apps/kbve/kbve-gate',
 	'apps/chuckrpg/axum-chuckrpg',
 	'apps/rareicon/axum-rareicon',
 	'apps/cryptothrone/axum-cryptothrone',

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -1,0 +1,65 @@
+---
+title: KBVE Gate
+description: |
+    Reusable auth reverse-proxy sidecar. Validates a Supabase JWT and an
+    authz policy (jwt-only or is_staff), then proxies HTTP and WebSocket
+    traffic to an internal upstream. First deployment fronts n8n.
+sidebar:
+    label: KBVE Gate
+    order: 52
+tags:
+    - docker
+    - networking
+    - auth
+key: kbve_gate
+pipeline: docker
+app_name: kbve-gate
+version: "0.1.0"
+source_path: apps/kbve/kbve-gate
+version_toml: apps/kbve/kbve-gate/version.toml
+version_target: apps/kbve/kbve-gate/Cargo.toml
+runner: ubuntu-latest
+image: kbve/kbve-gate
+deployment_yaml: apps/kube/n8n/manifest/n8n-deployment.yaml
+has_test: false
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+import { Aside, Steps } from '@astrojs/starlight/components';
+
+## KBVE Gate
+
+`kbve-gate` is a thin authentication reverse-proxy built on the `kbve` crate's
+feature-gated `gate` module. It runs as a sidecar in front of an internal
+service so the upstream binds localhost and only the gate is exposed.
+
+### Auth
+
+The gate accepts a Supabase JWT from an `Authorization: Bearer` header, an
+`sb-access-token` / `kbve_gate` cookie, or an `?access_token=` query param.
+After the JWT validates it applies an authz policy:
+
+- `jwt-only` — any valid Supabase JWT passes.
+- `is_staff` — `forum.is_staff(sub)` must return true. The gate mints a
+  short-lived `service_role` JWT from `SUPABASE_JWT_SECRET` to call PostgREST,
+  so the stale stored service-key is never used.
+
+### Configuration
+
+| Env | Default | Purpose |
+| --- | --- | --- |
+| `GATE_LISTEN` | `0.0.0.0:5678` | bind address |
+| `GATE_UPSTREAM` | `http://127.0.0.1:5679` | upstream base URL |
+| `GATE_AUTHZ` | `is_staff` | `is_staff` or `jwt-only` |
+| `GATE_UPSTREAM_BASIC` | — | `Basic <b64>` injected downstream |
+| `GATE_LOGIN_REDIRECT` | — | 302 target for unauthed browser navigations |
+| `SUPABASE_JWT_SECRET` | — | required |
+| `SUPABASE_URL` | — | required for `is_staff` (direct PostgREST) |
+
+### n8n deployment
+
+The first consumer fronts n8n: n8n moves to `127.0.0.1:5681`, the gate owns the
+Service port `5678`, and `n8n.kbve.com` routes through it so the panel stays
+staff-only.

--- a/apps/kbve/kbve-gate/Cargo.toml
+++ b/apps/kbve/kbve-gate/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "kbve-gate"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "kbve-gate"
+path = "src/main.rs"
+
+[dependencies]
+kbve = { path = "../../../packages/rust/kbve", features = ["gate"] }
+tokio = { version = "1.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+dotenvy = "0.15"

--- a/apps/kbve/kbve-gate/Cargo.workspace.toml
+++ b/apps/kbve/kbve-gate/Cargo.workspace.toml
@@ -1,0 +1,15 @@
+[workspace]
+resolver = "2"
+members = [
+    "apps/kbve/kbve-gate",
+    "packages/rust/holy",
+    "packages/rust/jedi",
+    "packages/rust/kbve",
+]
+
+[profile.release]
+opt-level = 3
+lto = true
+strip = true
+codegen-units = 1
+panic = "abort"

--- a/apps/kbve/kbve-gate/Dockerfile
+++ b/apps/kbve/kbve-gate/Dockerfile
@@ -1,0 +1,94 @@
+# ============================================================================
+# kbve-gate — auth reverse-proxy sidecar. Multi-stage cargo-chef build.
+#
+# Shared chisel base images:
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder  (Rust + cargo-chef + sccache)
+#   ghcr.io/kbve/chisel-ubuntu-axum:24.04.3         (chiseled Ubuntu runtime)
+# ============================================================================
+
+# [STAGE A] - Cargo Chef Planner
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
+
+COPY apps/kbve/kbve-gate/Cargo.workspace.toml Cargo.toml
+COPY Cargo.lock ./
+
+COPY apps/kbve/kbve-gate/Cargo.toml apps/kbve/kbve-gate/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
+
+COPY packages/data/proto packages/data/proto
+
+RUN mkdir -p apps/kbve/kbve-gate/src && echo "fn main() {}" > apps/kbve/kbve-gate/src/main.rs && \
+    mkdir -p packages/rust/jedi/src && echo "" > packages/rust/jedi/src/lib.rs && \
+    mkdir -p packages/rust/kbve/src && echo "" > packages/rust/kbve/src/lib.rs && \
+    mkdir -p packages/rust/holy/src && echo "" > packages/rust/holy/src/lib.rs
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+# [STAGE B] - Cargo Chef Cook (cache external deps)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS builder-deps
+ENV CARGO_INCREMENTAL=0
+
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/Cargo.toml /app/Cargo.lock ./
+COPY --from=planner /app/apps apps
+COPY --from=planner /app/packages packages
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo chef cook --release --recipe-path recipe.json -p kbve-gate
+
+# [STAGE C] - Foundation (compile kbve + jedi + holy from source)
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS foundation
+ENV CARGO_INCREMENTAL=0
+
+COPY --from=builder-deps /app/target target
+COPY --from=builder-deps /usr/local/cargo /usr/local/cargo
+
+COPY --from=planner /app/Cargo.toml ./
+COPY Cargo.lock ./
+
+COPY apps/kbve/kbve-gate/Cargo.toml apps/kbve/kbve-gate/Cargo.toml
+RUN mkdir -p apps/kbve/kbve-gate/src && \
+    echo "fn main() {}" > apps/kbve/kbve-gate/src/main.rs
+
+COPY packages/data/proto packages/data/proto
+
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/holy packages/rust/holy
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo build --release -p kbve -p jedi -p holy
+
+# [STAGE D] - Build Application
+FROM foundation AS builder
+
+COPY packages/data/proto packages/data/proto
+COPY packages/rust/jedi packages/rust/jedi
+COPY packages/rust/kbve packages/rust/kbve
+COPY packages/rust/holy packages/rust/holy
+
+COPY apps/kbve/kbve-gate apps/kbve/kbve-gate
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo build --release -p kbve-gate && \
+    strip target/release/kbve-gate
+
+# [STAGE Z] - Runtime
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
+
+COPY --from=builder --chown=10001:10001 /app/target/release/kbve-gate /app/kbve-gate
+
+ENV GATE_LISTEN=0.0.0.0:5678
+ENV RUST_LOG=info
+
+EXPOSE 5678
+
+ENTRYPOINT ["/app/kbve-gate"]

--- a/apps/kbve/kbve-gate/project.json
+++ b/apps/kbve/kbve-gate/project.json
@@ -1,0 +1,41 @@
+{
+	"name": "kbve-gate",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/kbve/kbve-gate/src",
+	"targets": {
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/kbve-gate"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/kbve-gate"
+			}
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/kbve-gate"
+			}
+		},
+		"run": {
+			"executor": "@monodon/rust:run",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/kbve-gate"
+			}
+		}
+	}
+}

--- a/apps/kbve/kbve-gate/src/main.rs
+++ b/apps/kbve/kbve-gate/src/main.rs
@@ -1,0 +1,30 @@
+//! kbve-gate — thin auth reverse-proxy binary built on `kbve::gate`.
+//!
+//! Runs as a sidecar in front of an internal service (PoC: n8n). Validates a
+//! Supabase JWT and applies an authz policy (`is_staff` by default), then
+//! proxies HTTP + WebSocket traffic to the upstream.
+
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() {
+    let _ = dotenvy::dotenv();
+
+    tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let cfg = match kbve::gate::config_from_env() {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!("gate config error: {e}");
+            std::process::exit(2);
+        }
+    };
+
+    if let Err(e) = kbve::gate::serve(cfg).await {
+        tracing::error!("gate exited: {e}");
+        std::process::exit(1);
+    }
+}

--- a/apps/kbve/kbve-gate/version.toml
+++ b/apps/kbve/kbve-gate/version.toml
@@ -1,0 +1,2 @@
+version = "0.1.0"
+publish = true

--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -49,7 +49,7 @@ spec:
                   imagePullPolicy: IfNotPresent
                   ports:
                       - name: http
-                        containerPort: 5678
+                        containerPort: 5681
                         protocol: TCP
                       - name: broker
                         containerPort: 5679
@@ -118,7 +118,7 @@ spec:
                       - name: N8N_TRUST_PROXY
                         value: 'true'
                       - name: N8N_PORT
-                        value: '5678'
+                        value: '5681'
                       - name: WEBHOOK_URL
                         value: 'https://n8n.kbve.com/'
                       - name: GENERIC_TIMEZONE
@@ -182,6 +182,61 @@ spec:
                           path: /healthz
                           port: http
                       initialDelaySeconds: 10
+                      periodSeconds: 5
+                      timeoutSeconds: 3
+                      failureThreshold: 3
+                - name: kbve-gate
+                  image: ghcr.io/kbve/kbve-gate:latest
+                  imagePullPolicy: IfNotPresent
+                  ports:
+                      - name: gateway
+                        containerPort: 5678
+                        protocol: TCP
+                  env:
+                      - name: GATE_LISTEN
+                        value: '0.0.0.0:5678'
+                      - name: GATE_UPSTREAM
+                        value: 'http://127.0.0.1:5681'
+                      - name: GATE_AUTHZ
+                        value: 'is_staff'
+                      - name: GATE_STAFF_SCHEMA
+                        value: 'forum'
+                      - name: GATE_LOGIN_REDIRECT
+                        value: 'https://kbve.com/login'
+                      - name: SUPABASE_URL
+                        value: 'http://supabase-postgrest.kilobase.svc.cluster.local:3000'
+                      - name: SUPABASE_JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: n8n-gate-supabase-jwt
+                                key: SUPABASE_JWT_SECRET
+                      - name: RUST_LOG
+                        value: 'info'
+                  resources:
+                      requests:
+                          memory: '64Mi'
+                          cpu: '50m'
+                      limits:
+                          memory: '128Mi'
+                          cpu: '500m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                          drop:
+                              - ALL
+                  livenessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: gateway
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                      timeoutSeconds: 5
+                      failureThreshold: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /healthz
+                          port: gateway
+                      initialDelaySeconds: 3
                       periodSeconds: 5
                       timeoutSeconds: 3
                       failureThreshold: 3

--- a/apps/kube/n8n/manifest/n8n-externalsecret.yaml
+++ b/apps/kube/n8n/manifest/n8n-externalsecret.yaml
@@ -51,6 +51,29 @@ spec:
               key: supabase-postgres
               property: password
 ---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: n8n-gate-supabase-jwt
+    namespace: n8n
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: n8n-supabase-secret-store
+        kind: SecretStore
+    target:
+        name: n8n-gate-supabase-jwt
+        creationPolicy: Owner
+        template:
+            engineVersion: v2
+            data:
+                SUPABASE_JWT_SECRET: '{{ .jwt_secret }}'
+    data:
+        - secretKey: jwt_secret
+          remoteRef:
+              key: supabase-jwt
+              property: secret
+---
 # n8n-encryption-secret: Run ../seal-encryption-key.sh before first deployment.
 # The script generates a random key, seals it via kubeseal, and writes
 # n8n-encryption-sealedsecret.yaml into this directory. Plaintext never touches disk.

--- a/apps/kube/n8n/manifest/n8n-httproute.yaml
+++ b/apps/kube/n8n/manifest/n8n-httproute.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: n8n-route
+    namespace: n8n
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - n8n.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          timeouts:
+              backendRequest: 3600s
+          backendRefs:
+              - name: n8n
+                port: 5678

--- a/packages/rust/kbve/Cargo.toml
+++ b/packages/rust/kbve/Cargo.toml
@@ -16,6 +16,7 @@ supabase = ["dep:lru", "dep:uuid"]
 image-gen = ["dep:resvg"]
 wallet = ["dep:uuid"]
 legacy-sync-db = ["diesel/postgres", "diesel/r2d2", "dep:r2d2"]
+gate = ["axum/ws", "reqwest/stream", "dep:tokio-tungstenite"]
 
 [dependencies]
 anyhow = "1.0"
@@ -40,7 +41,7 @@ axum-extra = { version = "0.12.6", features = ["cookie"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dashmap = { version = "6.1.0", features = ["serde"] }
-jsonwebtoken = "10.3.0"
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 rand_core = { version = "0.6.4", features = ["std"] }
 tokio = { version = "1.0", features = ["full"] }
 thiserror = "2"
@@ -61,6 +62,7 @@ num-bigint = "0.4"
 lru = { version = "0.16", optional = true }
 resvg = { version = "0.47.0", optional = true }
 uuid = { version = "1", features = ["v4", "serde"], optional = true }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"], optional = true }
 jedi = { path = "../jedi" }
 holy = { version = "0.2.1", path = "../holy" }
 

--- a/packages/rust/kbve/src/gate/auth.rs
+++ b/packages/rust/kbve/src/gate/auth.rs
@@ -1,0 +1,271 @@
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use dashmap::DashMap;
+use jsonwebtoken::{
+    Algorithm, DecodingKey, EncodingKey, Header, TokenData, Validation, decode, encode,
+};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+
+pub const SB_ACCESS_TOKEN_COOKIE: &str = "sb-access-token";
+pub const GATE_SESSION_COOKIE: &str = "kbve_gate";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub exp: i64,
+    #[serde(default)]
+    pub iss: String,
+    #[serde(default)]
+    pub role: String,
+    pub email: Option<String>,
+    #[serde(default)]
+    pub kbve_username: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum AuthError {
+    MissingToken,
+    InvalidToken(String),
+    TokenExpired,
+    NotStaff,
+    Upstream(String),
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::MissingToken => write!(f, "missing authentication token"),
+            AuthError::InvalidToken(m) => write!(f, "invalid token: {m}"),
+            AuthError::TokenExpired => write!(f, "token expired"),
+            AuthError::NotStaff => write!(f, "not staff"),
+            AuthError::Upstream(m) => write!(f, "authz backend: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// Validate a Supabase HS256 JWT. Issuer pinned when `SUPABASE_JWT_ISSUER` set.
+pub fn validate_token(token: &str, secret: &str) -> Result<TokenData<Claims>, AuthError> {
+    let key = DecodingKey::from_secret(secret.as_bytes());
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.validate_exp = true;
+
+    match std::env::var("SUPABASE_JWT_ISSUER") {
+        Ok(issuer) if !issuer.trim().is_empty() => validation.set_issuer(&[issuer]),
+        _ => validation.set_issuer::<String>(&[]),
+    }
+
+    decode::<Claims>(token, &key, &validation).map_err(|e| match e.kind() {
+        jsonwebtoken::errors::ErrorKind::ExpiredSignature => AuthError::TokenExpired,
+        _ => AuthError::InvalidToken(e.to_string()),
+    })
+}
+
+/// Pull a token from `Authorization: Bearer`, then the `sb-access-token` /
+/// `kbve_gate` cookies, then a `?access_token=` query param.
+pub fn extract_token(
+    auth_header: Option<&str>,
+    cookie_header: Option<&str>,
+    query: Option<&str>,
+) -> Option<String> {
+    if let Some(h) = auth_header {
+        if let Some(t) = h
+            .strip_prefix("Bearer ")
+            .or_else(|| h.strip_prefix("bearer "))
+        {
+            let t = t.trim();
+            if !t.is_empty() {
+                return Some(t.to_string());
+            }
+        }
+    }
+
+    if let Some(c) = cookie_header {
+        for name in [SB_ACCESS_TOKEN_COOKIE, GATE_SESSION_COOKIE] {
+            if let Some(v) = cookie_value(c, name) {
+                let v = v.trim();
+                if !v.is_empty() {
+                    return Some(v.to_string());
+                }
+            }
+        }
+    }
+
+    if let Some(q) = query {
+        if let Some(v) = query_param(q, "access_token") {
+            if !v.is_empty() {
+                return Some(v);
+            }
+        }
+    }
+
+    None
+}
+
+fn cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
+    for pair in cookie_header.split(';') {
+        let pair = pair.trim();
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == name {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+fn query_param(query: &str, key: &str) -> Option<String> {
+    for pair in query.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == key {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Authorization policy applied after the JWT validates.
+#[derive(Debug, Clone)]
+pub enum Authz {
+    /// Any valid Supabase JWT passes.
+    JwtOnly,
+    /// `staff.is_staff(sub)` must return true (via Supabase RPC).
+    IsStaff,
+}
+
+impl Authz {
+    pub fn from_env(raw: &str) -> Self {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "jwt" | "jwt-only" | "jwt_only" => Authz::JwtOnly,
+            _ => Authz::IsStaff,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ServiceClaims {
+    role: &'static str,
+    iss: &'static str,
+    iat: u64,
+    exp: u64,
+}
+
+/// Calls `is_staff(p_user_id)` on Supabase and caches the boolean per `sub`.
+///
+/// The PostgREST `Authorization` bearer is a `service_role` JWT minted at
+/// runtime from the cluster JWT secret — the stored `supabase-jwt.service-key`
+/// is stale-signed and rejected, so we sign our own short-lived token instead.
+pub struct StaffGate {
+    client: Client,
+    rpc_url: String,
+    jwt_secret: String,
+    apikey: Option<String>,
+    schema: String,
+    ttl_secs: u64,
+    cache: DashMap<String, (bool, u64)>,
+    service_token: Mutex<Option<(String, u64)>>,
+}
+
+impl StaffGate {
+    pub fn new(
+        supabase_url: &str,
+        jwt_secret: String,
+        apikey: Option<String>,
+        schema: String,
+        ttl_secs: u64,
+    ) -> Self {
+        let base = supabase_url.trim_end_matches('/');
+        Self {
+            client: Client::new(),
+            rpc_url: format!("{base}/rest/v1/rpc/is_staff"),
+            jwt_secret,
+            apikey,
+            schema,
+            ttl_secs,
+            cache: DashMap::new(),
+            service_token: Mutex::new(None),
+        }
+    }
+
+    fn now() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+
+    /// Mint (and cache, re-minting before expiry) a `service_role` bearer.
+    fn service_bearer(&self) -> Result<String, AuthError> {
+        let now = Self::now();
+        if let Ok(guard) = self.service_token.lock() {
+            if let Some((tok, exp)) = guard.as_ref() {
+                if now + 30 < *exp {
+                    return Ok(tok.clone());
+                }
+            }
+        }
+
+        let exp = now + 600;
+        let claims = ServiceClaims {
+            role: "service_role",
+            iss: "supabase",
+            iat: now,
+            exp,
+        };
+        let token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims,
+            &EncodingKey::from_secret(self.jwt_secret.as_bytes()),
+        )
+        .map_err(|e| AuthError::Upstream(format!("mint service token: {e}")))?;
+
+        if let Ok(mut guard) = self.service_token.lock() {
+            *guard = Some((token.clone(), exp));
+        }
+        Ok(token)
+    }
+
+    pub async fn is_staff(&self, user_id: &str) -> Result<bool, AuthError> {
+        if let Some(entry) = self.cache.get(user_id) {
+            let (val, exp) = *entry;
+            if Self::now() < exp {
+                return Ok(val);
+            }
+        }
+
+        let bearer = self.service_bearer()?;
+        let apikey = self.apikey.as_deref().unwrap_or(bearer.as_str());
+
+        let resp = self
+            .client
+            .post(&self.rpc_url)
+            .header("apikey", apikey)
+            .header("Authorization", format!("Bearer {bearer}"))
+            .header("Accept-Profile", &self.schema)
+            .header("Content-Profile", &self.schema)
+            .json(&serde_json::json!({ "p_user_id": user_id }))
+            .send()
+            .await
+            .map_err(|e| AuthError::Upstream(format!("is_staff network: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(AuthError::Upstream(format!("is_staff {status} → {body}")));
+        }
+
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| AuthError::Upstream(format!("is_staff read: {e}")))?;
+        let val = text.trim().eq_ignore_ascii_case("true");
+
+        self.cache
+            .insert(user_id.to_string(), (val, Self::now() + self.ttl_secs));
+        Ok(val)
+    }
+}

--- a/packages/rust/kbve/src/gate/mod.rs
+++ b/packages/rust/kbve/src/gate/mod.rs
@@ -1,0 +1,91 @@
+//! Reusable auth reverse-proxy ("gate"). Sits in front of any upstream and
+//! gates traffic on a Supabase JWT plus an authz policy (`jwt-only` or
+//! `is_staff`). Designed to run as a sidecar so the upstream binds localhost
+//! and only the gate is exposed.
+//!
+//! Feature-gated behind `gate`. The `kbve-gate` binary is the thin consumer;
+//! axum-kbve can adopt the same module later.
+
+mod auth;
+mod proxy;
+
+pub use auth::{AuthError, Authz, Claims, StaffGate, validate_token};
+pub use proxy::{GateConfig, GateState};
+
+use std::net::SocketAddr;
+
+/// Build a [`GateConfig`] from environment variables.
+///
+/// - `GATE_UPSTREAM`        upstream base URL (default `http://127.0.0.1:5679`)
+/// - `GATE_AUTHZ`           `is_staff` (default) | `jwt-only`
+/// - `GATE_UPSTREAM_BASIC`  optional `Basic <b64>` injected upstream
+/// - `GATE_LOGIN_REDIRECT`  optional 302 target for unauthed navigations
+/// - `GATE_STAFF_TTL_SECS`  is_staff cache TTL (default 30)
+/// - `GATE_STAFF_SCHEMA`    PostgREST schema for the RPC (default `forum`)
+/// - `SUPABASE_JWT_SECRET`        required
+/// - `SUPABASE_URL`               required when authz=is_staff
+/// - `SUPABASE_SERVICE_ROLE_KEY`  required when authz=is_staff
+pub fn config_from_env() -> Result<GateConfig, String> {
+    let upstream =
+        std::env::var("GATE_UPSTREAM").unwrap_or_else(|_| "http://127.0.0.1:5679".to_string());
+    let jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
+        .map_err(|_| "SUPABASE_JWT_SECRET is required".to_string())?;
+    let authz = Authz::from_env(&std::env::var("GATE_AUTHZ").unwrap_or_else(|_| "is_staff".into()));
+
+    let upstream_basic = std::env::var("GATE_UPSTREAM_BASIC")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let login_redirect = std::env::var("GATE_LOGIN_REDIRECT")
+        .ok()
+        .filter(|s| !s.is_empty());
+
+    let staff = match authz {
+        Authz::IsStaff => {
+            let url = std::env::var("SUPABASE_URL")
+                .map_err(|_| "SUPABASE_URL is required for authz=is_staff".to_string())?;
+            let apikey = std::env::var("SUPABASE_ANON_KEY")
+                .ok()
+                .filter(|s| !s.is_empty());
+            let schema = std::env::var("GATE_STAFF_SCHEMA").unwrap_or_else(|_| "forum".into());
+            let ttl = std::env::var("GATE_STAFF_TTL_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(30);
+            Some(StaffGate::new(
+                &url,
+                jwt_secret.clone(),
+                apikey,
+                schema,
+                ttl,
+            ))
+        }
+        Authz::JwtOnly => None,
+    };
+
+    Ok(GateConfig {
+        upstream,
+        jwt_secret,
+        authz,
+        upstream_basic,
+        login_redirect,
+        staff,
+    })
+}
+
+/// Bind `GATE_LISTEN` (default `0.0.0.0:5678`) and serve the gate forever.
+pub async fn serve(cfg: GateConfig) -> Result<(), String> {
+    let listen: SocketAddr = std::env::var("GATE_LISTEN")
+        .unwrap_or_else(|_| "0.0.0.0:5678".to_string())
+        .parse()
+        .map_err(|e| format!("invalid GATE_LISTEN: {e}"))?;
+
+    let router = GateState::new(cfg).into_router();
+    let listener = tokio::net::TcpListener::bind(listen)
+        .await
+        .map_err(|e| format!("bind {listen}: {e}"))?;
+
+    tracing::info!(%listen, "kbve gate listening");
+    axum::serve(listener, router)
+        .await
+        .map_err(|e| format!("serve: {e}"))
+}

--- a/packages/rust/kbve/src/gate/proxy.rs
+++ b/packages/rust/kbve/src/gate/proxy.rs
@@ -1,0 +1,386 @@
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::{FromRequestParts, Request, State, ws::WebSocketUpgrade},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode, Uri, header},
+    response::{IntoResponse, Response},
+};
+use reqwest::Client;
+use tracing::{debug, warn};
+
+use super::auth::{Authz, StaffGate, extract_token, validate_token};
+
+/// Runtime configuration for the gate, normally built from env in the binary.
+pub struct GateConfig {
+    /// Upstream base URL, e.g. `http://127.0.0.1:5679`.
+    pub upstream: String,
+    /// Supabase HS256 JWT secret.
+    pub jwt_secret: String,
+    /// Authorization policy applied after JWT validation.
+    pub authz: Authz,
+    /// Optional `Authorization: Basic <b64>` value injected on every upstream
+    /// request. Lets the upstream keep its own basic-auth lock while the
+    /// browser never sees the credential.
+    pub upstream_basic: Option<String>,
+    /// Where to send unauthenticated browser navigations (302). When unset a
+    /// bare 401/403 is returned instead.
+    pub login_redirect: Option<String>,
+    /// Staff RPC gate. Required when `authz` is `IsStaff`.
+    pub staff: Option<StaffGate>,
+}
+
+pub struct GateState {
+    cfg: GateConfig,
+    client: Client,
+}
+
+impl GateState {
+    pub fn new(cfg: GateConfig) -> Self {
+        Self {
+            cfg,
+            client: Client::new(),
+        }
+    }
+
+    pub fn into_router(self) -> axum::Router {
+        axum::Router::new()
+            .route("/healthz", axum::routing::get(|| async { "ok" }))
+            .fallback(gate_handler)
+            .with_state(Arc::new(self))
+    }
+}
+
+/// RFC 6455 upgrade detection.
+fn is_websocket_upgrade(headers: &HeaderMap) -> bool {
+    fn contains(headers: &HeaderMap, name: &str, needle: &str) -> bool {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .map(|v| v.split(',').any(|t| t.trim().eq_ignore_ascii_case(needle)))
+            .unwrap_or(false)
+    }
+    contains(headers, "connection", "upgrade") && contains(headers, "upgrade", "websocket")
+}
+
+/// True for top-level browser navigations — used to decide redirect vs 401.
+fn is_navigation(headers: &HeaderMap) -> bool {
+    headers
+        .get("sec-fetch-mode")
+        .and_then(|v| v.to_str().ok())
+        .map(|m| m.eq_ignore_ascii_case("navigate"))
+        .unwrap_or(false)
+        || headers
+            .get(header::ACCEPT)
+            .and_then(|v| v.to_str().ok())
+            .map(|a| a.contains("text/html"))
+            .unwrap_or(false)
+}
+
+fn deny(state: &GateState, headers: &HeaderMap, status: StatusCode, msg: &str) -> Response {
+    if status == StatusCode::UNAUTHORIZED {
+        if let Some(target) = &state.cfg.login_redirect {
+            if is_navigation(headers) {
+                return Response::builder()
+                    .status(StatusCode::FOUND)
+                    .header(header::LOCATION, target)
+                    .body(Body::empty())
+                    .unwrap()
+                    .into_response();
+            }
+        }
+    }
+    (status, axum::Json(serde_json::json!({ "error": msg }))).into_response()
+}
+
+/// Validate the JWT and apply the authz policy. Returns the user id on pass.
+async fn authorize(
+    state: &GateState,
+    headers: &HeaderMap,
+    query: Option<&str>,
+) -> Result<String, Response> {
+    let token = extract_token(
+        headers
+            .get(header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok()),
+        headers.get(header::COOKIE).and_then(|v| v.to_str().ok()),
+        query,
+    );
+
+    let token = match token {
+        Some(t) => t,
+        None => {
+            return Err(deny(
+                state,
+                headers,
+                StatusCode::UNAUTHORIZED,
+                "missing token",
+            ));
+        }
+    };
+
+    let data = match validate_token(&token, &state.cfg.jwt_secret) {
+        Ok(d) => d,
+        Err(e) => {
+            return Err(deny(
+                state,
+                headers,
+                StatusCode::UNAUTHORIZED,
+                &e.to_string(),
+            ));
+        }
+    };
+    let sub = data.claims.sub;
+
+    match &state.cfg.authz {
+        Authz::JwtOnly => Ok(sub),
+        Authz::IsStaff => {
+            let staff = match &state.cfg.staff {
+                Some(s) => s,
+                None => {
+                    return Err((
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        axum::Json(serde_json::json!({ "error": "staff gate unconfigured" })),
+                    )
+                        .into_response());
+                }
+            };
+            match staff.is_staff(&sub).await {
+                Ok(true) => Ok(sub),
+                Ok(false) => Err(deny(state, headers, StatusCode::FORBIDDEN, "staff only")),
+                Err(e) => Err((
+                    StatusCode::BAD_GATEWAY,
+                    axum::Json(serde_json::json!({ "error": e.to_string() })),
+                )
+                    .into_response()),
+            }
+        }
+    }
+}
+
+async fn gate_handler(State(state): State<Arc<GateState>>, req: Request<Body>) -> Response {
+    let headers = req.headers().clone();
+    let query = req.uri().query().map(|q| q.to_string());
+
+    if let Err(resp) = authorize(&state, &headers, query.as_deref()).await {
+        return resp;
+    }
+
+    if is_websocket_upgrade(&headers) {
+        return ws_bridge(&state, req).await;
+    }
+
+    forward_http(&state, req).await
+}
+
+const HOP_BY_HOP: &[&str] = &[
+    "connection",
+    "keep-alive",
+    "proxy-connection",
+    "te",
+    "trailers",
+    "transfer-encoding",
+    "upgrade",
+];
+
+fn upstream_uri(upstream: &str, uri: &Uri) -> String {
+    let path = uri.path();
+    let query = uri.query().map(|q| format!("?{q}")).unwrap_or_default();
+    format!("{}{}{}", upstream.trim_end_matches('/'), path, query)
+}
+
+async fn forward_http(state: &GateState, req: Request<Body>) -> Response {
+    let method = req.method().clone();
+    let url = upstream_uri(&state.cfg.upstream, req.uri());
+    let mut headers = req.headers().clone();
+
+    headers.remove(header::HOST);
+    headers.remove(header::AUTHORIZATION);
+    headers.remove(header::ACCEPT_ENCODING);
+    headers.remove(header::COOKIE);
+    for h in HOP_BY_HOP {
+        headers.remove(*h);
+    }
+
+    if let Some(basic) = &state.cfg.upstream_basic {
+        if let Ok(v) = HeaderValue::from_str(basic) {
+            headers.insert(header::AUTHORIZATION, v);
+        }
+    }
+
+    let body_bytes = match axum::body::to_bytes(req.into_body(), 25 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::PAYLOAD_TOO_LARGE,
+                axum::Json(serde_json::json!({ "error": "request body too large" })),
+            )
+                .into_response();
+        }
+    };
+
+    debug!(%url, %method, "gate forward");
+
+    let resp = match state
+        .client
+        .request(method, &url)
+        .headers(reqwest_headers(&headers))
+        .body(body_bytes)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(%url, "gate upstream error: {e}");
+            return (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(
+                    serde_json::json!({ "error": "upstream unreachable", "detail": e.to_string() }),
+                ),
+            )
+                .into_response();
+        }
+    };
+
+    let status =
+        StatusCode::from_u16(resp.status().as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+    let mut out_headers = HeaderMap::new();
+    for (k, v) in resp.headers() {
+        if let (Ok(name), Ok(val)) = (
+            HeaderName::from_bytes(k.as_str().as_bytes()),
+            HeaderValue::from_bytes(v.as_bytes()),
+        ) {
+            out_headers.append(name, val);
+        }
+    }
+    out_headers.remove("content-encoding");
+    for h in HOP_BY_HOP {
+        out_headers.remove(*h);
+    }
+
+    let body = Body::from_stream(resp.bytes_stream());
+    let mut builder = Response::builder().status(status);
+    if let Some(h) = builder.headers_mut() {
+        *h = out_headers;
+    }
+    builder
+        .body(body)
+        .unwrap_or_else(|_| {
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .unwrap()
+        })
+        .into_response()
+}
+
+fn reqwest_headers(headers: &HeaderMap) -> reqwest::header::HeaderMap {
+    let mut out = reqwest::header::HeaderMap::with_capacity(headers.len());
+    for (k, v) in headers {
+        if let (Ok(name), Ok(val)) = (
+            reqwest::header::HeaderName::from_bytes(k.as_str().as_bytes()),
+            reqwest::header::HeaderValue::from_bytes(v.as_bytes()),
+        ) {
+            out.append(name, val);
+        }
+    }
+    out
+}
+
+/// Bridge a browser WebSocket to the upstream. reqwest is HTTP-only, so the
+/// upgrade leg uses tokio-tungstenite directly.
+async fn ws_bridge(state: &GateState, req: Request<Body>) -> Response {
+    let mut ws_url = upstream_uri(&state.cfg.upstream, req.uri());
+    if let Some(rest) = ws_url.strip_prefix("http://") {
+        ws_url = format!("ws://{rest}");
+    } else if let Some(rest) = ws_url.strip_prefix("https://") {
+        ws_url = format!("wss://{rest}");
+    }
+    let basic = state.cfg.upstream_basic.clone();
+
+    let (mut parts, _body) = req.into_parts();
+    let ws = match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
+        Ok(ws) => ws,
+        Err(rej) => return rej.into_response(),
+    };
+
+    ws.on_upgrade(move |browser_ws| async move {
+        if let Err(e) = pump_ws(browser_ws, ws_url.clone(), basic).await {
+            warn!(%ws_url, "gate ws bridge error: {e}");
+        }
+    })
+}
+
+async fn pump_ws(
+    browser: axum::extract::ws::WebSocket,
+    upstream_url: String,
+    basic: Option<String>,
+) -> Result<(), String> {
+    use futures_util::{SinkExt, StreamExt};
+    use tokio_tungstenite::tungstenite::Message as TMsg;
+    use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+
+    let mut request = upstream_url
+        .as_str()
+        .into_client_request()
+        .map_err(|e| format!("ws request build: {e}"))?;
+    if let Some(b) = &basic {
+        request.headers_mut().insert(
+            "authorization",
+            b.parse().map_err(|e| format!("ws basic header: {e}"))?,
+        );
+    }
+
+    let (upstream, _resp) = tokio_tungstenite::connect_async(request)
+        .await
+        .map_err(|e| format!("ws connect: {e}"))?;
+
+    let (mut up_tx, mut up_rx) = upstream.split();
+    let (mut br_tx, mut br_rx) = browser.split();
+
+    let browser_to_upstream = async {
+        while let Some(Ok(msg)) = br_rx.next().await {
+            use axum::extract::ws::Message as AMsg;
+            let out = match msg {
+                AMsg::Text(t) => TMsg::Text(t.as_str().into()),
+                AMsg::Binary(b) => TMsg::Binary(b.to_vec().into()),
+                AMsg::Ping(b) => TMsg::Ping(b.to_vec().into()),
+                AMsg::Pong(b) => TMsg::Pong(b.to_vec().into()),
+                AMsg::Close(_) => {
+                    let _ = up_tx.send(TMsg::Close(None)).await;
+                    break;
+                }
+            };
+            if up_tx.send(out).await.is_err() {
+                break;
+            }
+        }
+    };
+
+    let upstream_to_browser = async {
+        while let Some(Ok(msg)) = up_rx.next().await {
+            use axum::extract::ws::Message as AMsg;
+            let out = match msg {
+                TMsg::Text(t) => AMsg::Text(t.as_str().into()),
+                TMsg::Binary(b) => AMsg::Binary(b.to_vec().into()),
+                TMsg::Ping(b) => AMsg::Ping(b.to_vec().into()),
+                TMsg::Pong(b) => AMsg::Pong(b.to_vec().into()),
+                TMsg::Close(_) => {
+                    let _ = br_tx.send(AMsg::Close(None)).await;
+                    break;
+                }
+                TMsg::Frame(_) => continue,
+            };
+            if br_tx.send(out).await.is_err() {
+                break;
+            }
+        }
+    };
+
+    tokio::select! {
+        _ = browser_to_upstream => {}
+        _ = upstream_to_browser => {}
+    }
+    Ok(())
+}

--- a/packages/rust/kbve/src/lib.rs
+++ b/packages/rust/kbve/src/lib.rs
@@ -18,6 +18,10 @@ pub mod spellbook;
 pub mod utility;
 
 pub mod entity;
+
+#[cfg(feature = "gate")]
+pub mod gate;
+
 #[cfg(feature = "legacy-sync-db")]
 pub mod sys;
 pub mod utils;


### PR DESCRIPTION
## What

Reusable JWT auth reverse-proxy ("gate") + first deployment fronting n8n so `n8n.kbve.com` stays staff-only.

### Gate core — `kbve` crate, feature `gate`
- `packages/rust/kbve/src/gate/{auth,proxy,mod}.rs`
- Multi-auth: `Authorization: Bearer`, `sb-access-token`/`kbve_gate` cookie, `?access_token=`
- Authz policy: `jwt-only` or `is_staff` (`forum.is_staff`)
- HTTP forward (hop-by-hop strip, streaming body, downstream basic-auth inject) + WebSocket bridge (n8n `/rest/push`)
- `is_staff` mints a short-lived `service_role` JWT from `SUPABASE_JWT_SECRET` → calls direct PostgREST, so the stale stored service-key is never used
- Unauth `/healthz` for probes

### Binary
- `apps/kbve/kbve-gate` — thin consumer + Dockerfile (cargo-chef) + pruned `Cargo.workspace.toml` + version.toml + Nx project; added to workspace members

### n8n injection
- `n8n-deployment.yaml`: n8n HTTP → `127.0.0.1:5681`, `kbve-gate` sidecar owns Service port `5678`, `is_staff` authz, login redirect, JWT secret env
- `n8n-externalsecret.yaml`: pulls `kilobase/supabase-jwt` → `n8n-gate-supabase-jwt` (existing n8n SA RBAC already covers it)
- `n8n-httproute.yaml`: `n8n.kbve.com` → gate, 3600s WS timeout
- CI registry MDX → `ci-dispatch-manifest.json` entry (`image: kbve/kbve-gate`)

## Verification
- Rust compiles; gate smoke-tested locally: **401** no-token / **200** bearer / **200** cookie / **401** bad-token (proxied to a dummy upstream)
- **Not yet exercised:** WS bridge + `is_staff` (need live n8n + Supabase); the chef Docker build (runs in CI)

## Note
Manifest regen also picked up pre-existing catch-up version bumps for other services (axum-kbve, cryptothrone, jobboard, etc.) — MDX drift on dev not previously re-synced. Kept per full-regen convention.