### PR TITLE
fix(auth): drop space in GOTRUE_JWT_ADMIN_ROLES so service_role is admin

### DIFF
--- a/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
+++ b/apps/kube/auth/manifests/supabase-gotrue-auth.yaml
@@ -51,7 +51,7 @@ spec:
 
                       # JWT configuration - hardcoded basic values
                       - name: GOTRUE_JWT_ADMIN_ROLES
-                        value: 'supabase_admin, service_role'
+                        value: 'supabase_admin,service_role'
                       - name: GOTRUE_JWT_AUD
                         value: 'authenticated'
                       - name: GOTRUE_JWT_DEFAULT_GROUP_NAME


### PR DESCRIPTION
## Problem
The cryptothrone Discord Activity session bridge returns **502** for any Discord account not already registered in Supabase (`Session exchange failed (502)`). Backend log:
```
gotrue admin create failed status=403 Forbidden body={"code":403,"error_code":"not_admin","msg":"User not allowed"}
```

## Root cause
`axum-cryptothrone` mints a short-lived `role: service_role` JWT to call GoTrue's admin create-user API. The JWT secret matches GoTrue's (verified — signatures are identical), so the token validates; GoTrue still rejects it as **not_admin**.

GoTrue v2.177 loads `JWT.AdminRoles` via envconfig, which splits the env on `,` **without trimming whitespace**. Our value:
```
GOTRUE_JWT_ADMIN_ROLES: 'supabase_admin, service_role'
```
parses to `["supabase_admin", " service_role"]` — the second element has a leading space, so a `service_role` token matches neither admin role. Upstream supabase uses bare `service_role` (no comma/space), so this never surfaces there.

## Fix
Remove the space: `'supabase_admin,service_role'`. Both roles remain admin; `service_role` admin calls (the Discord bridge, and any other service_role admin caller) now authorize.

## Rollout
ArgoCD-managed (tracks main) → reaches the cluster after the dev→main release + a supabase-auth pod restart picks up the new env. Verify after rollout by exchanging a session for an unregistered Discord account (should register + return a session instead of 502).