### PR TITLE
test(cryptothrone): adjust e2e for HudDock refactor

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/game.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from './fixtures';
 import { supportsWebGL } from './helpers/env';
 import { seedFakeSession } from './helpers/auth';
+import { waitForHud, openHudTab } from './helpers/hud';
 
 test.describe('game page layout', () => {
 	test.beforeEach(async ({ page }) => {
@@ -45,6 +46,8 @@ test.describe('game UI hydration', () => {
 		page,
 	}) => {
 		await page.goto('/game/play/', { waitUntil: 'domcontentloaded' });
+		await waitForHud(page);
+		await openHudTab(page, 'Character');
 		await expect(
 			page.getByText('Debug Mode', { exact: false }),
 		).toBeVisible({ timeout: 20_000 });
@@ -52,6 +55,8 @@ test.describe('game UI hydration', () => {
 
 	test('debug-mode toggle is interactive', async ({ page }) => {
 		await page.goto('/game/play/', { waitUntil: 'domcontentloaded' });
+		await waitForHud(page);
+		await openHudTab(page, 'Character');
 		const label = page.locator('label', { hasText: 'Debug Mode' });
 		const toggle = label.locator('input[type="checkbox"]');
 		await expect(toggle).toBeAttached({ timeout: 20_000 });

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/helpers/hud.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/helpers/hud.ts
@@ -1,0 +1,18 @@
+import { expect, type Page } from '@playwright/test';
+
+export type HudTab = 'Character' | 'Bag' | 'Chat' | 'Map' | 'Social';
+
+export async function waitForHud(page: Page): Promise<void> {
+	await expect(page.getByRole('navigation', { name: 'HUD' })).toBeVisible({
+		timeout: 20_000,
+	});
+}
+
+export async function openHudTab(page: Page, label: HudTab): Promise<void> {
+	const tab = page.getByRole('button', { name: label, exact: true });
+	await expect(tab).toBeVisible({ timeout: 20_000 });
+	if ((await tab.getAttribute('aria-pressed')) !== 'true') {
+		await tab.click();
+	}
+	await expect(tab).toHaveAttribute('aria-pressed', 'true');
+}

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/interactions.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/interactions.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from './fixtures';
 import { seedFakeSession } from './helpers/auth';
 import type { Page } from '@playwright/test';
 import { isMobileViewport } from './helpers/env';
+import { waitForHud } from './helpers/hud';
 
 /**
  * Drives the in-game React HUD through the dev-only `window.__ctEvents` seam
@@ -40,9 +41,7 @@ test.describe('in-game HUD interactions', () => {
 			.then(() => true)
 			.catch(() => false);
 		test.skip(!hasSeam, 'event seam only present in dev build');
-		await expect(
-			page.getByText('Debug Mode', { exact: false }),
-		).toBeVisible({ timeout: 20_000 });
+		await waitForHud(page);
 	});
 
 	test('character event opens and closes the dialog', async ({ page }) => {

--- a/apps/cryptothrone/astro-cryptothrone-e2e/e2e/store.spec.ts
+++ b/apps/cryptothrone/astro-cryptothrone-e2e/e2e/store.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from './fixtures';
 import { seedFakeSession } from './helpers/auth';
 import type { Page } from '@playwright/test';
 import { isMobileViewport } from './helpers/env';
+import { waitForHud, openHudTab } from './helpers/hud';
 
 /**
  * Drives the game store directly through the dev-only window.__ctDispatch seam
@@ -46,9 +47,7 @@ test.describe('store-driven HUD coverage', () => {
 			.then(() => true)
 			.catch(() => false);
 		test.skip(!ok, 'dispatch seam only present in dev build');
-		await expect(
-			page.getByText('Debug Mode', { exact: false }),
-		).toBeVisible({ timeout: 20_000 });
+		await waitForHud(page);
 	});
 
 	test('inventory renders items, tooltips, and handles unknown ids', async ({
@@ -67,15 +66,29 @@ test.describe('store-driven HUD coverage', () => {
 			payload: { itemId: 'definitely-not-an-item' },
 		});
 
-		const shark = page.locator('img[alt="Blue Shark"]');
-		await expect(shark).toBeVisible();
+		await openHudTab(page, 'Bag');
+
+		// Scope to the Bag panel's InventoryGrid — items also appear in the
+		// always-on Hotbar, which has no hover tooltip.
+		const bag = page
+			.locator('div')
+			.filter({
+				has: page.getByRole('heading', {
+					name: 'Inventory',
+					exact: true,
+				}),
+			})
+			.last();
+
+		const shark = bag.getByRole('img', { name: 'Blue Shark' });
+		await expect(shark).toBeVisible({ timeout: 15_000 });
 
 		await shark.hover();
 		await expect(
 			page.getByText('Bonuses:', { exact: false }),
 		).toBeVisible();
 
-		await page.locator('img[alt="Iron Sword"]').hover();
+		await bag.getByRole('img', { name: 'Iron Sword' }).hover();
 		await expect(page.getByText('Type:', { exact: false })).toBeVisible();
 
 		await dispatch(page, {
@@ -90,6 +103,7 @@ test.describe('store-driven HUD coverage', () => {
 			type: 'SET_PLAYER_STATS',
 			payload: { hp: 200, maxHp: 100, username: 'Hero' },
 		});
+		await openHudTab(page, 'Character');
 		await expect(page.getByText('Hero')).toBeVisible();
 		await dispatch(page, {
 			type: 'PLAYER_DAMAGE',
@@ -103,9 +117,7 @@ test.describe('store-driven HUD coverage', () => {
 			type: 'EQUIP_ITEM',
 			payload: { slot: 'mainHand', itemId: 'iron-sword' },
 		});
-		await expect(
-			page.getByText('Debug Mode', { exact: false }),
-		).toBeVisible();
+		await waitForHud(page);
 	});
 
 	test('notifications render every variant and dismiss', async ({ page }) => {
@@ -129,18 +141,27 @@ test.describe('store-driven HUD coverage', () => {
 		await expect(toasts.getByText('T-danger')).toHaveCount(0);
 	});
 
-	test('sidebar collapse toggles work', async ({ page }) => {
-		const toggles = page.locator('button', { hasText: /Stats|Settings/ });
-		const count = await toggles.count();
-		for (let i = 0; i < count; i++) {
-			await toggles.nth(i).click();
-		}
-		await dispatch(page, {
-			type: 'TOGGLE_SETTING',
-			payload: { key: 'isStatsCollapsed' },
+	test('HUD dock tabs open and close their panels', async ({ page }) => {
+		const character = page.getByRole('button', {
+			name: 'Character',
+			exact: true,
 		});
+		await openHudTab(page, 'Character');
 		await expect(
 			page.getByText('Debug Mode', { exact: false }),
+		).toBeVisible();
+
+		// Toggle the tab off rather than clicking the sheet's × — on desktop the
+		// sheet header sits under the fixed site header, which intercepts clicks.
+		await character.click();
+		await expect(character).toHaveAttribute('aria-pressed', 'false');
+		await expect(
+			page.getByText('Debug Mode', { exact: false }),
+		).toHaveCount(0);
+
+		await openHudTab(page, 'Bag');
+		await expect(
+			page.getByRole('heading', { name: 'Inventory' }),
 		).toBeVisible();
 	});
 
@@ -307,6 +328,7 @@ test.describe('store-driven HUD coverage', () => {
 				username: 'Bridged',
 			},
 		});
+		await openHudTab(page, 'Character');
 		await expect(page.getByText('Bridged')).toBeVisible();
 	});
 
@@ -314,8 +336,6 @@ test.describe('store-driven HUD coverage', () => {
 		page,
 	}) => {
 		await dispatch(page, { type: '__unknown__', payload: {} });
-		await expect(
-			page.getByText('Debug Mode', { exact: false }),
-		).toBeVisible();
+		await waitForHud(page);
 	});
 });


### PR DESCRIPTION
## What

Aligns the cryptothrone e2e suite with the HUD refactor (`10bcdbff3`), which replaced the always-visible `StickySidebar` (StatsSection + Debug Mode + inventory) with on-demand `HudDock` tabs (Character / Bag / Chat / Map / Social).

## Why

The docker e2e job failed on `game.spec.ts` — tests used the "Debug Mode" text as the React-HUD mount signal, but that toggle now lives inside the Character tab and only mounts when opened.

## Changes

- **`helpers/hud.ts`** (new) — `waitForHud` (waits on the always-mounted HUD nav) + `openHudTab`.
- **game.spec** — open the Character tab before asserting Debug Mode / the toggle.
- **store + interactions** — `waitForHud` as the mount proof; open Bag / Character for gated inventory + stats assertions.
- Replaced the obsolete `StickySidebar` collapse test with a HudDock open/close test.
- **inventory** — `ItemIcon` renders `span[role=img]` from the sprite atlas now, so match `getByRole('img')` scoped to the Bag panel instead of `img[alt]`.

## Verification

Ran the affected tests on the `dev` Playwright project (dev seam present): game-hydration, inventory, stats bars, and the new HudDock open/close test all pass. The docker/axum CI job runs only `game.spec` (store + interactions self-skip without the dev seam).

## Out of scope

The full dev matrix still shows pre-existing, non-HUD failures (`talk`/`dice`/`notifications`/`dialogue-X` — brittle `.fixed.z-[60]` / `×` selectors against modals untouched by the HUD commit). These are dev-seam-only and skip in CI.