### PR TITLE
fix(rows): enable jsonwebtoken rust_crypto provider to stop JWT verify panic (#12660)

### DIFF
--- a/apps/memes/axum-memes/Cargo.toml
+++ b/apps/memes/axum-memes/Cargo.toml
@@ -27,7 +27,7 @@ axum-extra = { version = "0.12.1", features = ["cookie"] }
 askama = "0.15.4"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 dashmap = "6.1"
-jsonwebtoken = "10.3.0"
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 socket2 = "0.6.1"
 num_cpus = "1.17.0"
 dotenvy = "0.15"

--- a/apps/rows/Cargo.toml
+++ b/apps/rows/Cargo.toml
@@ -37,7 +37,7 @@ sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls", "postgres",
 
 # Auth / crypto
 uuid = { version = "1", features = ["v4", "serde"] }
-jsonwebtoken = "10.3.0"
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 argon2 = { version = "0.5", features = ["password-hash"] }
 
 # Observability

--- a/apps/rows/src/supabase.rs
+++ b/apps/rows/src/supabase.rs
@@ -133,3 +133,71 @@ pub enum JwtError {
     #[error("Invalid service key")]
     InvalidServiceKey,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use jsonwebtoken::{EncodingKey, Header, encode};
+
+    fn config(secret: &str) -> SupabaseConfig {
+        SupabaseConfig {
+            jwt_secret: Some(secret.to_string()),
+            url: None,
+            service_key_hash: None,
+        }
+    }
+
+    fn sign(secret: &str, claims: &SupabaseClaims) -> String {
+        encode(
+            &Header::new(Algorithm::HS256),
+            claims,
+            &EncodingKey::from_secret(secret.as_bytes()),
+        )
+        .expect("signing an HS256 token should succeed")
+    }
+
+    fn sample_claims() -> SupabaseClaims {
+        SupabaseClaims {
+            sub: "cc274223-6acc-4a2e-9bb4-09eebffb83cb".into(),
+            aud: "authenticated".into(),
+            role: "authenticated".into(),
+            iat: 0,
+            // Year 2286 — keeps the default `exp` validation happy without wall-clock flakiness.
+            exp: 9_999_999_999,
+            email: Some("player@example.com".into()),
+            app_metadata: Some(AppMetadata {
+                customer_guid: Some("cc274223-6acc-4a2e-9bb4-09eebffb83cb".into()),
+                is_admin: Some(true),
+            }),
+        }
+    }
+
+    /// Regression for #12660: verifying a real HS256 token must NOT panic.
+    /// Before the `rust_crypto` feature was enabled, no crypto provider was compiled
+    /// in and `jsonwebtoken`'s verifier_factory panicked the tokio worker → 503.
+    #[test]
+    fn hs256_token_verifies_against_matching_secret() {
+        let secret = "super-secret-gotrue-hs256-key";
+        let token = sign(secret, &sample_claims());
+
+        let user = validate_jwt(&token, &config(secret)).expect("valid token should verify");
+
+        assert_eq!(
+            user.user_id.to_string(),
+            "cc274223-6acc-4a2e-9bb4-09eebffb83cb"
+        );
+        assert_eq!(user.role, "authenticated");
+        assert_eq!(user.email.as_deref(), Some("player@example.com"));
+        assert!(user.is_admin);
+    }
+
+    /// A token signed with a different secret must return an auth error, not panic.
+    #[test]
+    fn wrong_secret_returns_error_not_panic() {
+        let token = sign("the-real-secret", &sample_claims());
+
+        let result = validate_jwt(&token, &config("a-different-secret"));
+
+        assert!(matches!(result, Err(JwtError::Invalid(_))));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #12660 — `apps/rows` panics while verifying a real Supabase HS256 JWT in `ExternalLoginAndCreateSession`, killing the tokio worker and surfacing to clients as a gateway **503** (blocks chuckrpg-dev login).

## Root cause (not the one the issue hypothesized)

The panic at `jsonwebtoken-10.x/src/crypto/mod.rs:125:42` is the dummy `verifier_factory: |_, _| panic!(...)`. In jsonwebtoken 10.x the crypto backend is **feature-gated**, and the default features (`use_pem` only) compile in **no provider**. So:

- **dummy token** → fails base64/parse *before* the crypto step → `authenticated:false` (no panic)
- **real token** → parses, reaches `verify()` → calls the panicking dummy → worker dies → Envoy 503

The verification config was already correct (`Algorithm::HS256` + `DecodingKey::from_secret`) — the crate just had no engine to run it. A version bump does **not** fix this; the whole 10.x line uses the same design.

## Fix

Enable `features = ["rust_crypto"]`, matching the workspace crates that already work (`irc-gateway`, `axum-kbve`, `packages/rust/kbve`):

- `apps/rows/Cargo.toml`
- `apps/memes/axum-memes/Cargo.toml` (same latent panic)

## Tests

Added regression tests in `rows::supabase`:
- an HS256 token verifies against the matching secret (the exact path that used to panic)
- a wrong-secret token returns `JwtError::Invalid` instead of panicking

`cargo test -p rows --bins supabase` → 2 passed. `rows` and `axum-memes` both build clean.

## Notes

- `packages/rust/kbve` already has `rust_crypto` on `dev`, so no change there.
- The issue's robustness ask ("verify must never panic") is satisfied: once a provider is installed, `decode` returns `Err` for bad tokens (already handled via `map_err`). No `catch_unwind` needed.