### PR TITLE
chore(rows): sync tenant base deployment on publish (v0.1.27)

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -106,7 +106,7 @@
 		{
 			"key": "cryptothrone",
 			"app_name": "cryptothrone",
-			"version": "0.1.44",
+			"version": "0.1.45",
 			"version_toml": "apps/cryptothrone/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone.mdx",
 			"version_target": "apps/cryptothrone/axum-cryptothrone/Cargo.toml",
@@ -120,7 +120,7 @@
 		{
 			"key": "cryptothrone_server",
 			"app_name": "cryptothrone-server",
-			"version": "0.0.19",
+			"version": "0.0.20",
 			"version_toml": "apps/agones/cryptothrone/server/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/cryptothrone-server.mdx",
 			"version_target": "apps/agones/cryptothrone/server/Cargo.toml",
@@ -432,7 +432,7 @@
 		{
 			"key": "rows",
 			"app_name": "rows",
-			"version": "0.1.25",
+			"version": "0.1.27",
 			"version_toml": "apps/rows/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/rows.mdx",
 			"version_target": "apps/rows/Cargo.toml",
@@ -440,6 +440,9 @@
 			"runner": "ubuntu-latest",
 			"image": "kbve/rows",
 			"deployment_yaml": "apps/kube/rows/manifest/rows-deployment.yaml",
+			"deployment_yamls": [
+				"apps/kube/rows/tenants/base/deployment.yaml"
+			],
 			"has_test": false
 		},
 		{

--- a/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/rows.mdx
@@ -12,13 +12,15 @@ tags:
 key: rows
 pipeline: docker
 app_name: rows
-version: "0.1.26"
+version: "0.1.27"
 source_path: apps/rows
 version_toml: apps/rows/version.toml
 version_target: apps/rows/Cargo.toml
 runner: ubuntu-latest
 image: kbve/rows
 deployment_yaml: apps/kube/rows/manifest/rows-deployment.yaml
+deployment_yamls:
+    - apps/kube/rows/tenants/base/deployment.yaml
 has_test: false
 author: h0lybyte
 license: KBVE


### PR DESCRIPTION
## Summary
- Add `deployment_yamls` to [rows.mdx](apps/kbve/astro-kbve/src/content/docs/project/rows.mdx) so the post-publish atom PR bumps the image tag in [apps/kube/rows/tenants/base/deployment.yaml](apps/kube/rows/tenants/base/deployment.yaml) alongside the existing `deployment_yaml` manifest pin.
- Bump rows `version` to 0.1.27.
- Regenerate `.github/ci-dispatch-manifest.json` (full regen).

## Why
Only `apps/kube/rows/manifest/rows-deployment.yaml` was auto-synced on publish; the tenant base deployment stayed pinned to a stale tag. Both are the only files carrying a `ghcr.io/kbve/rows:` pin (overlays inherit base via kustomize, no image override).

## Verify
- `rows:build` passes at 0.1.27.
- post-publish updates both files (each has an `image: ghcr.io/kbve/rows:` line; sed matches `image: <image_name>:`).