### PR TITLE
fix(cryptothrone): proxy-aware PixelPanel border-image for Discord Activity

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/PixelPanel.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/PixelPanel.tsx
@@ -13,6 +13,17 @@ export const PANELS = {
 
 export type PanelVariant = keyof typeof PANELS;
 
+function proxyAsset(path: string): string {
+	if (!path.startsWith('/') || path.startsWith('/.proxy')) return path;
+	if (
+		typeof window !== 'undefined' &&
+		window.location.hostname.endsWith('.discordsays.com')
+	) {
+		return `/.proxy${path}`;
+	}
+	return path;
+}
+
 interface PixelPanelProps {
 	children?: ReactNode;
 	className?: string;
@@ -46,7 +57,7 @@ export const PixelPanel = forwardRef<HTMLDivElement, PixelPanelProps>(
 		},
 		ref,
 	) {
-		const source = src ?? PANELS[variant];
+		const source = proxyAsset(src ?? PANELS[variant]);
 		return (
 			<div
 				ref={ref}


### PR DESCRIPTION
## Problem
In the Discord Activity, the HUD/dock panels render **white** (no background). PixelPanel draws its background via CSS `border-image-source: url(/ui/panel-*.png)` with `border-image-slice: N fill`.

## Cause
The Discord SDK's `patchUrlMappings` only rewrites `fetch` / `WebSocket` / `XMLHttpRequest` — **not CSS `url()`**. So inside the Activity iframe (`*.discordsays.com`) the browser requests `/ui/panel-*.png` from the Discord origin directly, bypassing the proxy → 404/blocked → no `fill` → white panels. (Phaser sprites work because they go through `fetch`, which *is* patched — same reason the session endpoint needs the explicit `/.proxy/` prefix.)

## Fix
`proxyAsset()` prefixes absolute panel paths with `/.proxy` when `location.hostname` ends with `.discordsays.com`; plain `/ui/...` on the web. Mirrors the proven `/.proxy/api/discord/session` pattern. Fixes every PixelPanel (dock, ActionMenu, TargetFrame, QuestTracker, DeathScreen, inventory tooltip) at once. Assets already exist in `public/ui/` and serve on web.

`astro check` clean (no new errors). Ships via the astro-cryptothrone build + deploy.