### PR TITLE
feat(cryptothrone): KBVE community CTA on Discord Activity session end

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
+++ b/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
@@ -87,6 +87,41 @@
 			.ct-retry:hover {
 				background: #fbbf24;
 			}
+			.ct-cta {
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				gap: 0.5rem;
+				margin-top: 0.5rem;
+				border-top: 1px solid rgba(251, 191, 36, 0.1);
+				padding-top: 1rem;
+			}
+			.ct-cta-discord {
+				border: none;
+				border-radius: 0.5rem;
+				background: rgba(99, 102, 241, 0.9);
+				color: #fff;
+				font-size: 0.8125rem;
+				font-weight: 600;
+				padding: 0.5rem 1.25rem;
+				cursor: pointer;
+				transition: background 0.15s ease;
+			}
+			.ct-cta-discord:hover {
+				background: #818cf8;
+			}
+			.ct-cta-feedback {
+				border: none;
+				background: none;
+				color: rgba(252, 211, 77, 0.8);
+				font-size: 0.75rem;
+				cursor: pointer;
+				text-decoration: underline;
+				text-underline-offset: 2px;
+			}
+			.ct-cta-feedback:hover {
+				color: #fde68a;
+			}
 		</style>
 	</head>
 	<body>

--- a/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
+++ b/apps/cryptothrone/astro-cryptothrone/public/discord/index.html
@@ -125,11 +125,6 @@
 		</style>
 	</head>
 	<body>
-		<!-- Discord Activity root. discord.js runs the OAuth handshake, bridges
-		     to a game-server session, then mounts the game into #app. The boot
-		     card below is the pre-React loading state; discord.js updates its
-		     status text per stage and swaps it for an error card with a retry
-		     button on failure. -->
 		<div id="app">
 			<div class="ct-boot">
 				<span class="ct-spinner" aria-hidden="true"></span>
@@ -137,8 +132,6 @@
 				<p class="ct-boot-sub">Starting CryptoThrone.</p>
 			</div>
 		</div>
-		<!-- Relative src: under the Discord root mapping (/ -> .../discord/) an
-		     absolute /discord/discord.js would double to /discord/discord/…. -->
 		<script src="discord.js" defer></script>
 	</body>
 </html>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
@@ -1,4 +1,5 @@
 import { useGameSelector } from '../store/GameStoreContext';
+import { KbveCommunityCta } from './KbveCommunityCta';
 
 interface RejectInfo {
 	title: string;
@@ -76,6 +77,11 @@ export function ConnectionOverlay() {
 				)
 			: null;
 
+	// Clean session end (player left, or reconnects exhausted without a server
+	// reject). Send them off with a friendly farewell + the KBVE community CTA
+	// instead of an alarming red error.
+	const isFarewell = connection.status === 'disconnected';
+
 	return (
 		<div className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-[2px]">
 			<div className="pointer-events-auto w-full max-w-xs rounded-2xl border border-amber-200/10 bg-black/70 p-6 text-center shadow-2xl shadow-black/60 backdrop-blur-xl">
@@ -98,6 +104,35 @@ export function ConnectionOverlay() {
 									? 'This is taking longer than usual. The realm may be waking up — hang tight.'
 									: 'Establishing a secure connection to the game server.'}
 						</p>
+					</>
+				) : isFarewell ? (
+					<>
+						<svg
+							className="mx-auto mb-4 h-8 w-8 text-amber-300"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="1.75"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							aria-hidden="true">
+							<path d="M9 11l3 3L22 4" />
+							<path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11" />
+						</svg>
+						<p className="text-sm font-semibold text-amber-200">
+							Thanks for playing CryptoThrone!
+						</p>
+						<p className="mt-2 text-xs text-stone-400">
+							Your session has ended. We hope to see you back in
+							Cloud City soon.
+						</p>
+						<KbveCommunityCta />
+						<button
+							type="button"
+							onClick={() => window.location.reload()}
+							className="mt-4 w-full rounded-lg bg-amber-500/90 px-4 py-2 text-sm font-semibold text-black transition hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/70">
+							Rejoin the world
+						</button>
 					</>
 				) : (
 					<>
@@ -135,6 +170,7 @@ export function ConnectionOverlay() {
 							className="mt-4 w-full rounded-lg bg-amber-500/90 px-4 py-2 text-sm font-semibold text-black transition hover:bg-amber-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/70">
 							{reject ? reject.button : 'Retry connection'}
 						</button>
+						<KbveCommunityCta />
 					</>
 				)}
 			</div>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/ConnectionOverlay.tsx
@@ -77,9 +77,6 @@ export function ConnectionOverlay() {
 				)
 			: null;
 
-	// Clean session end (player left, or reconnects exhausted without a server
-	// reject). Send them off with a friendly farewell + the KBVE community CTA
-	// instead of an alarming red error.
 	const isFarewell = connection.status === 'disconnected';
 
 	return (

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KbveCommunityCta.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KbveCommunityCta.tsx
@@ -1,0 +1,60 @@
+import {
+	KBVE_DISCORD_URL,
+	KBVE_FEEDBACK_URL,
+	getOpenExternal,
+} from '../../../lib/kbve-links';
+
+/**
+ * KBVE community call-to-action shown when a session ends — a small nudge to
+ * join the Discord plus a feedback link. Rendered by ConnectionOverlay on
+ * terminal connection states (clean disconnect or server reject) so a player
+ * leaving the world always sees where to find us.
+ *
+ * In the Discord Activity the iframe sandbox blocks anchor navigation, so each
+ * link routes through `window.__ctOpenExternal` (the SDK's openExternalLink)
+ * when present; on the standalone web embed the anchors navigate normally.
+ */
+function handleOpen(url: string) {
+	return (e: React.MouseEvent<HTMLAnchorElement>) => {
+		const open = getOpenExternal();
+		if (open) {
+			e.preventDefault();
+			open(url);
+		}
+	};
+}
+
+export function KbveCommunityCta() {
+	return (
+		<div className="mt-5 border-t border-amber-200/10 pt-4">
+			<p className="text-xs text-stone-400">
+				Enjoying CryptoThrone? Join the KBVE community.
+			</p>
+			<div className="mt-3 flex flex-col gap-2">
+				<a
+					href={KBVE_DISCORD_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={handleOpen(KBVE_DISCORD_URL)}
+					className="flex w-full items-center justify-center gap-2 rounded-lg bg-indigo-500/90 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70">
+					<svg
+						className="h-4 w-4"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+						aria-hidden="true">
+						<path d="M20.317 4.369A19.79 19.79 0 0 0 16.558 3.2a.074.074 0 0 0-.079.037c-.34.6-.717 1.385-.98 2.003a18.27 18.27 0 0 0-5.49 0 12.6 12.6 0 0 0-.997-2.003.077.077 0 0 0-.079-.037A19.74 19.74 0 0 0 5.677 4.37a.07.07 0 0 0-.032.027C3.04 8.26 2.31 12.057 2.65 15.807a.082.082 0 0 0 .031.056 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028c.462-.63.873-1.295 1.226-1.994a.076.076 0 0 0-.041-.106 13.1 13.1 0 0 1-1.872-.892.077.077 0 0 1-.008-.128c.126-.094.252-.192.371-.291a.074.074 0 0 1 .078-.01c3.927 1.793 8.18 1.793 12.061 0a.074.074 0 0 1 .079.009c.12.099.245.198.372.292a.077.077 0 0 1-.006.127 12.3 12.3 0 0 1-1.873.891.077.077 0 0 0-.04.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.84 19.84 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-4.337-.838-8.104-3.549-11.41a.06.06 0 0 0-.031-.028zM8.02 13.524c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418z" />
+					</svg>
+					Join our Discord
+				</a>
+				<a
+					href={KBVE_FEEDBACK_URL}
+					target="_blank"
+					rel="noopener noreferrer"
+					onClick={handleOpen(KBVE_FEEDBACK_URL)}
+					className="text-xs text-amber-300/80 underline-offset-2 transition hover:text-amber-200 hover:underline">
+					Share feedback
+				</a>
+			</div>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KbveCommunityCta.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KbveCommunityCta.tsx
@@ -4,16 +4,6 @@ import {
 	getOpenExternal,
 } from '../../../lib/kbve-links';
 
-/**
- * KBVE community call-to-action shown when a session ends — a small nudge to
- * join the Discord plus a feedback link. Rendered by ConnectionOverlay on
- * terminal connection states (clean disconnect or server reject) so a player
- * leaving the world always sees where to find us.
- *
- * In the Discord Activity the iframe sandbox blocks anchor navigation, so each
- * link routes through `window.__ctOpenExternal` (the SDK's openExternalLink)
- * when present; on the standalone web embed the anchors navigate normally.
- */
 function handleOpen(url: string) {
 	return (e: React.MouseEvent<HTMLAnchorElement>) => {
 		const open = getOpenExternal();

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -5,6 +5,7 @@ import {
 } from '@discord/embedded-app-sdk';
 import { mount } from './index';
 import { startPresence } from './discord-presence';
+import { KBVE_DISCORD_URL, KBVE_FEEDBACK_URL } from '../lib/kbve-links';
 
 /**
  * Discord Activity entry — the isolated Discord path. Runs entirely on the main
@@ -82,6 +83,43 @@ function root(): HTMLElement | null {
 	return document.getElementById('app');
 }
 
+// Holds the live SDK once `ready()`. The Activity iframe sandbox blocks plain
+// anchor navigation, so community links route through `openExternalLink`;
+// before the SDK exists (e.g. a missing-client-id boot fail) fall back to
+// window.open.
+let activeSdk: DiscordSDK | null = null;
+
+function openExternal(url: string): void {
+	if (activeSdk) {
+		void activeSdk.commands.openExternalLink({ url }).catch(() => {});
+		return;
+	}
+	window.open(url, '_blank', 'noopener,noreferrer');
+}
+
+/** Build the KBVE community CTA (Discord + feedback) for the vanilla-DOM boot
+ * cards. Mirrors the React `KbveCommunityCta` shown once the game has mounted —
+ * a small nudge to join us even when the Activity never makes it in-world. */
+function communityCta(): HTMLElement {
+	const wrap = document.createElement('div');
+	wrap.className = 'ct-cta';
+
+	const discord = document.createElement('button');
+	discord.type = 'button';
+	discord.className = 'ct-cta-discord';
+	discord.textContent = 'Join our Discord';
+	discord.addEventListener('click', () => openExternal(KBVE_DISCORD_URL));
+
+	const feedback = document.createElement('button');
+	feedback.type = 'button';
+	feedback.className = 'ct-cta-feedback';
+	feedback.textContent = 'Share feedback';
+	feedback.addEventListener('click', () => openExternal(KBVE_FEEDBACK_URL));
+
+	wrap.append(discord, feedback);
+	return wrap;
+}
+
 /** Update the boot card's status line (and optional sub-line) in place so each
  * stage names itself instead of a frozen "Loading…". */
 function setStatus(status: string, sub?: string): void {
@@ -129,6 +167,7 @@ function fail(msg: string, ...extra: unknown[]): void {
 	if (msgEl) msgEl.textContent = msg;
 	const retry = el.querySelector<HTMLButtonElement>('.ct-retry');
 	retry?.addEventListener('click', () => window.location.reload());
+	el.querySelector('.ct-boot')?.appendChild(communityCta());
 }
 
 /** Run a boot step, re-throwing with a labelled message so the error card
@@ -188,6 +227,12 @@ async function boot(): Promise<void> {
 	setStatus('Linking to Cloud City…', 'Connecting to Discord.');
 	const sdk = new DiscordSDK(CLIENT_ID);
 	await step('Discord SDK ready', () => sdk.ready());
+	activeSdk = sdk;
+	// Expose the SDK's external-link opener so the in-game (shadow-root) CTA
+	// can escape the Activity sandbox — see lib/kbve-links getOpenExternal.
+	(
+		window as unknown as { __ctOpenExternal?: (url: string) => void }
+	).__ctOpenExternal = openExternal;
 
 	setStatus('Linking to Cloud City…', 'Authorizing your Discord account.');
 	const code = await authorize(CLIENT_ID, sdk);

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -7,44 +7,17 @@ import { mount } from './index';
 import { startPresence } from './discord-presence';
 import { KBVE_DISCORD_URL, KBVE_FEEDBACK_URL } from '../lib/kbve-links';
 
-/**
- * Discord Activity entry — the isolated Discord path. Runs entirely on the main
- * thread (the Activity iframe has no SharedWorkers): does the Discord OAuth
- * handshake, exchanges it for a game-server session via a backend endpoint, then
- * boots the same shadow-root game mount as the standalone embed.
- *
- * Build target: `build-discord` -> public/discord/discord.js, loaded by
- * public/discord/index.html (the Activity root URL configured in the Discord
- * developer portal).
- */
 const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
 	| string
 	| undefined;
 
-// Backend bridge (P3b): exchanges the Discord OAuth code for a Discord
-// access_token AND a game-server session {jwt, username}, linking the Discord
-// user to a KBVE profile. The Activity iframe runs on *.discordsays.com, so
-// every request — including same-origin backend calls — must carry the
-// `/.proxy/` prefix: Discord strips it and applies the portal ROOT mapping
-// (`/` -> the axum-cryptothrone host serving /api/*). Without it the fetch
-// hits discordsays.com directly and never reaches the backend.
 const SESSION_ENDPOINT = '/.proxy/api/discord/session';
 
-// External hosts the game's plain `new WebSocket('wss://game.cryptothrone…')`
-// calls reach. patchUrlMappings rewrites those real URLs through Discord's
-// proxy transparently — net-config and the rest of the game stay unchanged.
-// Each prefix must match a URL Mapping in the Discord developer portal:
-//   /cryptothrone-game -> game.cryptothrone.com
-//   /cryptothrone-chat -> chat.kbve.com
-// (plus the ROOT mapping `/` -> the axum-cryptothrone host that serves the
-// Activity + the session endpoint.)
 const URL_MAPPINGS: { prefix: string; target: string }[] = [
 	{ prefix: '/cryptothrone-game', target: 'game.cryptothrone.com' },
 	{ prefix: '/cryptothrone-chat', target: 'chat.kbve.com' },
 ];
 
-// `rpc.activities.write` is required for setActivity (rich presence). Only
-// widen the scope because the Activity adopts presence — see discord-presence.
 const AUTHORIZE_SCOPE: Types.OAuthScopes[] = [
 	'identify',
 	'email',
@@ -61,8 +34,6 @@ function errMsg(err: unknown): string {
 	if (err instanceof Error) {
 		return err.message;
 	}
-	// Discord RPC rejects with a plain {code, message} object — surface it
-	// instead of the useless "[object Object]" String() default.
 	if (err && typeof err === 'object') {
 		const o = err as Record<string, unknown>;
 		if (typeof o.message === 'string') {
@@ -83,10 +54,6 @@ function root(): HTMLElement | null {
 	return document.getElementById('app');
 }
 
-// Holds the live SDK once `ready()`. The Activity iframe sandbox blocks plain
-// anchor navigation, so community links route through `openExternalLink`;
-// before the SDK exists (e.g. a missing-client-id boot fail) fall back to
-// window.open.
 let activeSdk: DiscordSDK | null = null;
 
 function openExternal(url: string): void {
@@ -97,9 +64,6 @@ function openExternal(url: string): void {
 	window.open(url, '_blank', 'noopener,noreferrer');
 }
 
-/** Build the KBVE community CTA (Discord + feedback) for the vanilla-DOM boot
- * cards. Mirrors the React `KbveCommunityCta` shown once the game has mounted —
- * a small nudge to join us even when the Activity never makes it in-world. */
 function communityCta(): HTMLElement {
 	const wrap = document.createElement('div');
 	wrap.className = 'ct-cta';
@@ -120,8 +84,6 @@ function communityCta(): HTMLElement {
 	return wrap;
 }
 
-/** Update the boot card's status line (and optional sub-line) in place so each
- * stage names itself instead of a frozen "Loading…". */
 function setStatus(status: string, sub?: string): void {
 	const el = root();
 	if (!el) return;
@@ -130,7 +92,6 @@ function setStatus(status: string, sub?: string): void {
 	if (statusEl) {
 		statusEl.textContent = status;
 	} else {
-		// Boot card was replaced (e.g. by an error) — rebuild it.
 		el.innerHTML = `
 			<div class="ct-boot">
 				<span class="ct-spinner" aria-hidden="true"></span>
@@ -142,9 +103,6 @@ function setStatus(status: string, sub?: string): void {
 	if (subEl && sub !== undefined) subEl.textContent = sub;
 }
 
-/** Swap the boot card for a legible error with a retry button. Retry reloads
- * the Activity iframe — the cleanest reset for the SDK/OAuth handshake, same
- * pattern the in-game ConnectionOverlay uses. */
 function fail(msg: string, ...extra: unknown[]): void {
 	console.error(`[Cryptothrone/Discord] ${msg}`, ...extra);
 	const el = root();
@@ -162,7 +120,6 @@ function fail(msg: string, ...extra: unknown[]): void {
 			<p class="ct-error-msg"></p>
 			<button type="button" class="ct-retry">Try again</button>
 		</div>`;
-	// Set message via textContent so error strings can't inject markup.
 	const msgEl = el.querySelector<HTMLElement>('.ct-error-msg');
 	if (msgEl) msgEl.textContent = msg;
 	const retry = el.querySelector<HTMLButtonElement>('.ct-retry');
@@ -170,8 +127,6 @@ function fail(msg: string, ...extra: unknown[]): void {
 	el.querySelector('.ct-boot')?.appendChild(communityCta());
 }
 
-/** Run a boot step, re-throwing with a labelled message so the error card
- * names which stage failed instead of a generic "boot failed". */
 async function step<T>(label: string, run: () => Promise<T>): Promise<T> {
 	try {
 		return await run();
@@ -180,11 +135,6 @@ async function step<T>(label: string, run: () => Promise<T>): Promise<T> {
 	}
 }
 
-/** Discord authorize with a silent-first strategy. `prompt:'none'` skips the
- * consent screen for users who already authorized the app, but Discord rejects
- * it for never-authorized users — fall back to authorize *without* `prompt`,
- * which opens the OAuth consent modal, so a first-time player isn't left at a
- * dead end. */
 async function authorize(clientId: string, sdk: DiscordSDK): Promise<string> {
 	try {
 		const { code } = await sdk.commands.authorize({
@@ -228,8 +178,6 @@ async function boot(): Promise<void> {
 	const sdk = new DiscordSDK(CLIENT_ID);
 	await step('Discord SDK ready', () => sdk.ready());
 	activeSdk = sdk;
-	// Expose the SDK's external-link opener so the in-game (shadow-root) CTA
-	// can escape the Activity sandbox — see lib/kbve-links getOpenExternal.
 	(
 		window as unknown as { __ctOpenExternal?: (url: string) => void }
 	).__ctOpenExternal = openExternal;
@@ -266,8 +214,6 @@ async function boot(): Promise<void> {
 		height: '100vh',
 	});
 
-	// Surface live game state on the player's Discord profile. Subscribes to
-	// the laser bus; lives for the lifetime of the Activity iframe.
 	startPresence(sdk);
 }
 

--- a/apps/cryptothrone/astro-cryptothrone/src/lib/kbve-links.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/lib/kbve-links.ts
@@ -1,13 +1,6 @@
 export const KBVE_DISCORD_URL = 'https://discord.gg/gDahHCXHnp';
 export const KBVE_FEEDBACK_URL = 'https://kbve.com/support/';
 
-/**
- * Open a URL from inside the game. A Discord Activity runs in a sandboxed
- * iframe where normal anchor navigation is blocked — discord.tsx exposes
- * `window.__ctOpenExternal` (backed by `sdk.commands.openExternalLink`) once
- * the SDK is ready. Outside the Activity (standalone embed) the global is
- * absent and the caller falls back to a plain anchor / `window.open`.
- */
 export type OpenExternal = (url: string) => void;
 
 export function getOpenExternal(): OpenExternal | undefined {

--- a/apps/cryptothrone/astro-cryptothrone/src/lib/kbve-links.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/lib/kbve-links.ts
@@ -1,0 +1,17 @@
+export const KBVE_DISCORD_URL = 'https://discord.gg/gDahHCXHnp';
+export const KBVE_FEEDBACK_URL = 'https://kbve.com/support/';
+
+/**
+ * Open a URL from inside the game. A Discord Activity runs in a sandboxed
+ * iframe where normal anchor navigation is blocked — discord.tsx exposes
+ * `window.__ctOpenExternal` (backed by `sdk.commands.openExternalLink`) once
+ * the SDK is ready. Outside the Activity (standalone embed) the global is
+ * absent and the caller falls back to a plain anchor / `window.open`.
+ */
+export type OpenExternal = (url: string) => void;
+
+export function getOpenExternal(): OpenExternal | undefined {
+	if (typeof window === 'undefined') return undefined;
+	return (window as unknown as { __ctOpenExternal?: OpenExternal })
+		.__ctOpenExternal;
+}


### PR DESCRIPTION
## What

Adds a **Join our Discord + feedback** call-to-action when a CryptoThrone session ends — a small ad for the KBVE community shown on the disconnect screen.

## Changes
- **`lib/kbve-links.ts`** (new) — shared `discord.gg/gDahHCXHnp` invite + `kbve.com/support/` feedback URL, plus `getOpenExternal()` bridge.
- **`KbveCommunityCta.tsx`** (new) — reusable Discord + feedback block.
- **`ConnectionOverlay.tsx`** — friendly farewell card on clean `disconnected` ("Thanks for playing!" + CTA + Rejoin); CTA also appended under the terminal error/reject card.
- **`embed/discord.tsx`** — boot-fail card gets the CTA; exposes `window.__ctOpenExternal` (SDK `openExternalLink`) once the SDK is ready.
- **`public/discord/index.html`** — CSS for the DOM CTA.

## Why the external-link bridge
The Discord Activity iframe sandbox blocks plain anchor navigation. Links route through the SDK's `openExternalLink` when present; on the standalone web embed the anchors navigate normally (`window.open` fallback).

## Notes
- Issue #12520 polish items (boot spinner, retry button, `prompt:'none'` consent fallback, WS reconnect/backoff) were already implemented; this PR adds the session-end CTA on top.
- Trigger is the WS session ending (renderable). True "close the Activity tab" has no SDK render hook.

Refs #12520