### PR TITLE
feat(cryptothrone): Discord Activity lobby, mobile layout, hw-accel + external links

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
@@ -11,5 +11,13 @@ declare module '@kbve/laser' {
 		'player:damage': { damage: number };
 		'player:stats': { stats: PlayerStats };
 		'monster:nearby': { count: number };
+		'discord:participants': {
+			participants: {
+				id: string;
+				name: string;
+				avatarUrl: string | null;
+				bot: boolean;
+			}[];
+		};
 	}
 }

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KbveCommunityCta.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/KbveCommunityCta.tsx
@@ -1,18 +1,8 @@
 import {
 	KBVE_DISCORD_URL,
 	KBVE_FEEDBACK_URL,
-	getOpenExternal,
+	onExternalClick,
 } from '../../../lib/kbve-links';
-
-function handleOpen(url: string) {
-	return (e: React.MouseEvent<HTMLAnchorElement>) => {
-		const open = getOpenExternal();
-		if (open) {
-			e.preventDefault();
-			open(url);
-		}
-	};
-}
 
 export function KbveCommunityCta() {
 	return (
@@ -25,7 +15,7 @@ export function KbveCommunityCta() {
 					href={KBVE_DISCORD_URL}
 					target="_blank"
 					rel="noopener noreferrer"
-					onClick={handleOpen(KBVE_DISCORD_URL)}
+					onClick={onExternalClick(KBVE_DISCORD_URL)}
 					className="flex w-full items-center justify-center gap-2 rounded-lg bg-indigo-500/90 px-4 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/70">
 					<svg
 						className="h-4 w-4"
@@ -40,7 +30,7 @@ export function KbveCommunityCta() {
 					href={KBVE_FEEDBACK_URL}
 					target="_blank"
 					rel="noopener noreferrer"
-					onClick={handleOpen(KBVE_FEEDBACK_URL)}
+					onClick={onExternalClick(KBVE_FEEDBACK_URL)}
 					className="text-xs text-amber-300/80 underline-offset-2 transition hover:text-amber-200 hover:underline">
 					Share feedback
 				</a>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/OnlinePlayers.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/OnlinePlayers.tsx
@@ -1,4 +1,5 @@
 import { useGameSelector } from '../store/GameStoreContext';
+import { onExternalClick } from '../../../lib/kbve-links';
 
 export function OnlinePlayers() {
 	const players = useGameSelector((s) => s.players);
@@ -28,6 +29,9 @@ export function OnlinePlayers() {
 								href={`https://kbve.com/@${p.username}`}
 								target="_blank"
 								rel="noopener"
+								onClick={onExternalClick(
+									`https://kbve.com/@${p.username}`,
+								)}
 								className="truncate text-stone-300 no-underline hover:text-amber-300">
 								{p.username}
 								{p.username === me && (

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/hud/DiscordLobby.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/hud/DiscordLobby.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { laserEvents } from '@kbve/laser';
+
+interface Participant {
+	id: string;
+	name: string;
+	avatarUrl: string | null;
+	bot: boolean;
+}
+
+export function DiscordLobby() {
+	const [participants, setParticipants] = useState<Participant[]>([]);
+
+	useEffect(
+		() =>
+			laserEvents.on('discord:participants', (data) => {
+				setParticipants(data.participants);
+			}),
+		[],
+	);
+
+	if (participants.length === 0) return null;
+
+	return (
+		<div>
+			<h2 className="mb-2 text-lg font-semibold">
+				In this Activity
+				<span className="ml-2 rounded-full bg-indigo-500/20 px-2 py-0.5 text-xs font-semibold text-indigo-300">
+					{participants.length}
+				</span>
+			</h2>
+			<ul className="flex flex-col gap-1">
+				{participants.map((p) => (
+					<li key={p.id} className="flex items-center gap-2 text-sm">
+						{p.avatarUrl ? (
+							<img
+								src={p.avatarUrl}
+								alt=""
+								width={20}
+								height={20}
+								className="h-5 w-5 rounded-full"
+								onError={(e) => {
+									e.currentTarget.style.display = 'none';
+								}}
+							/>
+						) : null}
+						<span className="truncate text-stone-300">
+							{p.name}
+						</span>
+						{p.bot && (
+							<span className="rounded bg-indigo-500/30 px-1 text-[0.6rem] font-semibold text-indigo-200">
+								BOT
+							</span>
+						)}
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/hud/HudDock.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/hud/HudDock.tsx
@@ -157,7 +157,7 @@ export function HudDock() {
 			<>
 				{sheet('inset-x-2 bottom-[4.5rem] max-h-[68vh]')}
 				<nav
-					className="pointer-events-auto fixed inset-x-0 bottom-0 z-40 flex gap-1 border-t border-white/10 bg-black/70 px-2 pb-[env(safe-area-inset-bottom)] pt-1 backdrop-blur-md"
+					className="pointer-events-auto fixed inset-x-0 bottom-0 z-40 flex gap-1 border-t border-white/10 bg-black/70 pl-[max(0.5rem,var(--discord-safe-area-inset-left,0px))] pr-[max(0.5rem,var(--discord-safe-area-inset-right,0px))] pb-[max(env(safe-area-inset-bottom),var(--discord-safe-area-inset-bottom,0px))] pt-1 backdrop-blur-md"
 					aria-label="HUD">
 					{TABS.map((t) => tabButton(t, 'row'))}
 				</nav>

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/hud/SocialPanel.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/hud/SocialPanel.tsx
@@ -1,5 +1,7 @@
 import { useState, type ComponentType, type SVGProps } from 'react';
 import { laserEvents } from '@kbve/laser';
+import { onExternalClick } from '../../../../lib/kbve-links';
+import { DiscordLobby } from './DiscordLobby';
 import { WaveIcon, SmileIcon, HeartIcon, FlameIcon, AngryIcon } from './icons';
 
 const EMOTES: {
@@ -47,6 +49,7 @@ export function SocialPanel() {
 
 	return (
 		<div className="flex flex-col gap-4 text-yellow-400">
+			<DiscordLobby />
 			<div>
 				<h2 className="mb-2 text-lg font-semibold">Connect</h2>
 				<div className="flex flex-wrap gap-2">
@@ -54,6 +57,7 @@ export function SocialPanel() {
 						href="https://kbve.com/discord/"
 						target="_blank"
 						rel="noopener"
+						onClick={onExternalClick('https://kbve.com/discord/')}
 						className="flex h-10 items-center gap-2 rounded-lg border border-white/10 bg-black/40 px-3 text-sm text-[#5865f2] transition hover:border-[#5865f2]/50">
 						<svg
 							viewBox="0 0 16 16"

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord-layout.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord-layout.ts
@@ -1,0 +1,31 @@
+import { Events, type DiscordSDK } from '@discord/embedded-app-sdk';
+
+/**
+ * Relayout bridge for the Discord Activity. The client injects
+ * `--discord-safe-area-inset-*` CSS vars on the iframe document root and updates
+ * them on layout-mode (fullscreen / PiP / focused) and orientation changes —
+ * but they are empty until the first such event fires
+ * (discord/embedded-app-sdk#304). HUD CSS reads the vars directly with a 0px
+ * fallback; here we only nudge a window resize so Phaser's FIT scale manager
+ * refits the canvas to the new viewport on each event.
+ */
+export function startLayout(sdk: DiscordSDK): () => void {
+	let raf = 0;
+
+	const relayout = () => {
+		if (raf) return;
+		raf = window.requestAnimationFrame(() => {
+			raf = 0;
+			window.dispatchEvent(new Event('resize'));
+		});
+	};
+
+	void sdk.subscribe(Events.ACTIVITY_LAYOUT_MODE_UPDATE, relayout);
+	void sdk.subscribe(Events.ORIENTATION_UPDATE, relayout);
+
+	return () => {
+		window.cancelAnimationFrame(raf);
+		void sdk.unsubscribe(Events.ACTIVITY_LAYOUT_MODE_UPDATE, relayout);
+		void sdk.unsubscribe(Events.ORIENTATION_UPDATE, relayout);
+	};
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord-participants.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord-participants.ts
@@ -1,0 +1,75 @@
+import { Events, type DiscordSDK } from '@discord/embedded-app-sdk';
+import { laserEvents } from '@kbve/laser';
+
+export interface DiscordParticipant {
+	id: string;
+	name: string;
+	avatarUrl: string | null;
+	bot: boolean;
+}
+
+interface RawParticipant {
+	id: string;
+	username: string;
+	discriminator: string;
+	bot: boolean;
+	avatar?: string | null;
+	global_name?: string | null;
+	nickname?: string;
+}
+
+function displayName(p: RawParticipant): string {
+	return p.nickname || p.global_name || p.username;
+}
+
+function avatarUrl(p: RawParticipant): string | null {
+	if (p.avatar) {
+		return `https://cdn.discordapp.com/avatars/${p.id}/${p.avatar}.png?size=64`;
+	}
+	const idx = Number(BigInt(p.id) % 6n);
+	return `https://cdn.discordapp.com/embed/avatars/${idx}.png`;
+}
+
+function normalize(list: RawParticipant[]): DiscordParticipant[] {
+	return list.map((p) => ({
+		id: p.id,
+		name: displayName(p),
+		avatarUrl: avatarUrl(p),
+		bot: p.bot,
+	}));
+}
+
+export function startParticipants(sdk: DiscordSDK): () => void {
+	let stopped = false;
+
+	const emit = (raw: RawParticipant[]) => {
+		if (stopped) return;
+		laserEvents.emit('discord:participants', {
+			participants: normalize(raw),
+		});
+	};
+
+	const onUpdate = (data: { participants: RawParticipant[] }) => {
+		emit(data.participants ?? []);
+	};
+
+	void sdk.commands
+		.getInstanceConnectedParticipants()
+		.then((res) => emit(res.participants ?? []))
+		.catch((err) => {
+			console.warn(
+				'[Cryptothrone/Discord] getInstanceConnectedParticipants failed',
+				err,
+			);
+		});
+
+	void sdk.subscribe(Events.ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE, onUpdate);
+
+	return () => {
+		stopped = true;
+		void sdk.unsubscribe(
+			Events.ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE,
+			onUpdate,
+		);
+	};
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/embed/discord.tsx
@@ -5,6 +5,8 @@ import {
 } from '@discord/embedded-app-sdk';
 import { mount } from './index';
 import { startPresence } from './discord-presence';
+import { startParticipants } from './discord-participants';
+import { startLayout } from './discord-layout';
 import { KBVE_DISCORD_URL, KBVE_FEEDBACK_URL } from '../lib/kbve-links';
 
 const CLIENT_ID = import.meta.env.PUBLIC_DISCORD_CLIENT_ID as
@@ -182,6 +184,8 @@ async function boot(): Promise<void> {
 		window as unknown as { __ctOpenExternal?: (url: string) => void }
 	).__ctOpenExternal = openExternal;
 
+	void sdk.commands.encourageHardwareAcceleration().catch(() => {});
+
 	setStatus('Linking to Cloud City…', 'Authorizing your Discord account.');
 	const code = await authorize(CLIENT_ID, sdk);
 
@@ -215,6 +219,8 @@ async function boot(): Promise<void> {
 	});
 
 	startPresence(sdk);
+	startParticipants(sdk);
+	startLayout(sdk);
 }
 
 void boot().catch((err) => fail(`Boot failed — ${errMsg(err)}`, err));

--- a/apps/cryptothrone/astro-cryptothrone/src/lib/kbve-links.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/lib/kbve-links.ts
@@ -8,3 +8,13 @@ export function getOpenExternal(): OpenExternal | undefined {
 	return (window as unknown as { __ctOpenExternal?: OpenExternal })
 		.__ctOpenExternal;
 }
+
+export function onExternalClick(url: string) {
+	return (e: { preventDefault: () => void }) => {
+		const open = getOpenExternal();
+		if (open) {
+			e.preventDefault();
+			open(url);
+		}
+	};
+}


### PR DESCRIPTION
Resolves the resolvable parts of the Discord Activity enhancement batch (#12530–#12533) for cryptothrone.

## #12533 — openExternalLink + encourageHardwareAcceleration
- `encourageHardwareAcceleration()` called once at boot (web/desktop; no-op on mobile, failures swallowed).
- Remaining in-game HUD outbound links (`OnlinePlayers` profile links, `SocialPanel` Discord link) now route through Discord's external-link modal via a shared `onExternalClick` helper in `kbve-links.ts` (deduped the local copy in `KbveCommunityCta`). Marketing site links (Footer/Header/landing) left as native `target=_blank` — not inside the iframe.

## #12531 — activity-instance participant lobby
- New `embed/discord-participants.ts`: initial roster via `getInstanceConnectedParticipants`, live deltas via `ACTIVITY_INSTANCE_PARTICIPANTS_UPDATE`, normalized + pushed onto the laser bus (`discord:participants`).
- New `DiscordLobby` HUD component renders the live Discord-instance roster in the Social panel; renders nothing outside the Activity (empty roster). Avatar via Discord CDN, degrades to hidden on error.

## #12532 — mobile layout (partial)
- New `embed/discord-layout.ts`: subscribes `ACTIVITY_LAYOUT_MODE_UPDATE` + `ORIENTATION_UPDATE`, rAF-debounced `window.resize` nudge so the Phaser `Scale.FIT` canvas refits on fullscreen/PiP/orientation changes.
- HUD bottom nav consumes `--discord-safe-area-inset-{left,right,bottom}` with `env()`/0px fallback (vars are empty at boot per discord/embedded-app-sdk#304; CSS `var()` re-reads when the client populates them).

## #12530 — rich presence
Already shipped in #12612 (`discord-presence.ts`). No change.

## Not in this PR (→ consolidated follow-up ticket)
- Real mobile-device verification (notch/PiP/landscape, join/leave timing).
- `THERMAL_STATE_UPDATE` effect throttling.
- Optional reconcile of Discord-instance roster vs game-socket roster.

## Verify
- `astro-cryptothrone:build-discord` ✅
- `astro-cryptothrone:test` ✅ 109/109
- `astro check` OOMs project-wide here (environmental; only surfaced a pre-existing `vitest.config.ts` diagnostic).