### PR TITLE
feat(web): render @kbve/rn on web via react-native-web in astro-kbve (#12495)

### DIFF
--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -396,6 +396,20 @@ export default defineConfig({
 	},
 	vite: {
 		plugins: [tailwindcss()],
+		resolve: {
+			alias: [{ find: /^react-native$/, replacement: 'react-native-web' }],
+			extensions: [
+				'.web.tsx',
+				'.web.ts',
+				'.web.jsx',
+				'.web.js',
+				'.tsx',
+				'.ts',
+				'.jsx',
+				'.js',
+				'.json',
+			],
+		},
 		build: {
 			rollupOptions: {
 				// noVNC CJS has broken top-level await; guacamole-common-js is
@@ -405,6 +419,7 @@ export default defineConfig({
 			},
 		},
 		optimizeDeps: {
+			include: ['react-native-web'],
 			exclude: ['fsevents', '@novnc/novnc', 'guacamole-common-js'],
 			esbuildOptions: {
 				supported: { 'top-level-await': true },

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -420,7 +420,15 @@ export default defineConfig({
 		},
 		optimizeDeps: {
 			include: ['react-native-web'],
-			exclude: ['fsevents', '@novnc/novnc', 'guacamole-common-js'],
+			exclude: [
+				'fsevents',
+				'@novnc/novnc',
+				'guacamole-common-js',
+				'react-native',
+				'react-native-reanimated',
+				'react-native-svg',
+				'react-native-gesture-handler',
+			],
 			esbuildOptions: {
 				supported: { 'top-level-await': true },
 			},

--- a/apps/kbve/astro-kbve/astro.config.mjs
+++ b/apps/kbve/astro-kbve/astro.config.mjs
@@ -396,6 +396,11 @@ export default defineConfig({
 	},
 	vite: {
 		plugins: [tailwindcss()],
+		define: {
+			'process.env.JEST_WORKER_ID': 'undefined',
+			__DEV__: 'false',
+			global: 'globalThis',
+		},
 		resolve: {
 			alias: [{ find: /^react-native$/, replacement: 'react-native-web' }],
 			extensions: [
@@ -419,18 +424,32 @@ export default defineConfig({
 			},
 		},
 		optimizeDeps: {
-			include: ['react-native-web'],
-			exclude: [
-				'fsevents',
-				'@novnc/novnc',
-				'guacamole-common-js',
-				'react-native',
+			include: [
+				'react-native-web',
 				'react-native-reanimated',
 				'react-native-svg',
 				'react-native-gesture-handler',
 			],
+			exclude: ['fsevents', '@novnc/novnc', 'guacamole-common-js'],
 			esbuildOptions: {
 				supported: { 'top-level-await': true },
+				define: {
+					'process.env.JEST_WORKER_ID': 'undefined',
+					__DEV__: 'false',
+					global: 'globalThis',
+				},
+				loader: { '.js': 'jsx' },
+				resolveExtensions: [
+					'.web.tsx',
+					'.web.ts',
+					'.web.jsx',
+					'.web.js',
+					'.tsx',
+					'.ts',
+					'.jsx',
+					'.js',
+					'.json',
+				],
 			},
 		},
 		ssr: {

--- a/apps/kbve/astro-kbve/src/components/rnweb/RnWebDemo.tsx
+++ b/apps/kbve/astro-kbve/src/components/rnweb/RnWebDemo.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import {
+	Gradient,
+	Surface,
+	Stack,
+	Text,
+	Button,
+	Badge,
+	tokens,
+} from '@kbve/rn-astro';
+
+const BUTTON_VARIANTS = [
+	'primary',
+	'secondary',
+	'outline',
+	'ghost',
+	'danger',
+] as const;
+
+export default function RnWebDemo() {
+	const [count, setCount] = useState(0);
+
+	return (
+		<Gradient
+			name="hero"
+			style={{
+				padding: tokens.space.xl,
+				borderRadius: tokens.radius.xl,
+			}}>
+			<Surface style={{ borderRadius: tokens.radius.lg }}>
+				<Stack gap="md">
+					<Stack
+						direction="row"
+						align="center"
+						justify="space-between">
+						<Text variant="title">@kbve/rn on the web</Text>
+						<Badge tone="success">react-native-web</Badge>
+					</Stack>
+
+					<Text tone="muted">
+						These are the exact same RN primitives (View / Text /
+						Pressable / StyleSheet) the native app renders — aliased
+						to react-native-web and hydrated as an Astro island.
+					</Text>
+
+					<Stack direction="row" gap="sm" wrap>
+						{BUTTON_VARIANTS.map((variant) => (
+							<Button
+								key={variant}
+								variant={variant}
+								title={variant}
+							/>
+						))}
+					</Stack>
+
+					<Stack direction="row" align="center" gap="md">
+						<Button
+							variant="primary"
+							title={`Pressed ${count}×`}
+							onPress={() => setCount((c) => c + 1)}
+						/>
+						<Text tone="faint">
+							interactive state proves hydration
+						</Text>
+					</Stack>
+				</Stack>
+			</Surface>
+		</Gradient>
+	);
+}

--- a/apps/kbve/astro-kbve/src/pages/rn-web-poc.astro
+++ b/apps/kbve/astro-kbve/src/pages/rn-web-poc.astro
@@ -1,0 +1,34 @@
+---
+import RnWebDemo from '../components/rnweb/RnWebDemo';
+---
+
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta name="robots" content="noindex" />
+		<title>@kbve/rn → web POC</title>
+		<style>
+			body {
+				margin: 0;
+				min-height: 100vh;
+				background: #121312;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				padding: 24px;
+				font-family: system-ui, sans-serif;
+			}
+			main {
+				width: 100%;
+				max-width: 640px;
+			}
+		</style>
+	</head>
+	<body>
+		<main>
+			<RnWebDemo client:only="react" />
+		</main>
+	</body>
+</html>

--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -18,7 +18,14 @@
 			"@kbve/astro/data/*": ["../../../packages/npm/astro/src/data/*"],
 			"@kbve/devops": ["../../../packages/npm/devops/src/index.ts"],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
-			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"]
+			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/core": ["../../../packages/npm/core/src/index.ts"],
+			"@kbve/rn": ["../../../packages/npm/rn/src/index.web.ts"],
+			"@kbve/rn/ui": ["../../../packages/npm/rn/src/ui/index.web.ts"],
+			"@kbve/rn-astro": ["../../../packages/npm/rn-astro/src/index.ts"],
+			"@kbve/rn-astro/integration": [
+				"../../../packages/npm/rn-astro/src/integration.ts"
+			]
 		}
 	}
 }

--- a/packages/npm/rn-astro/README.md
+++ b/packages/npm/rn-astro/README.md
@@ -17,9 +17,15 @@ DOM, so the same components render on web. This package supplies:
    `react-native` → `react-native-web` vite alias + `.web.*` resolve extensions
    (so the web variants win) + prebundles `react-native-web`.
 2. **Re-exported web-safe components** — the presentational `@kbve/rn` UI kit
-   (Text, Surface, Button, AppCard, CardList, MenuList, NavShell, Gradient, …).
+   (Text, Surface, Stack, Divider, Badge, Button, PressableSurface, Screen,
+   Gradient, AppCard, CardList, MenuItem, MenuList, EntityRenderer, Footer,
+   feedback states, `tokens`, `useTheme`).
 
 ## Usage
+
+Two wiring modes, depending on how the consuming app resolves `@kbve/*`.
+
+### A. Workspace apps (own `package.json`, npm/pnpm-linked)
 
 ```js
 // astro.config.mjs
@@ -29,6 +35,50 @@ export default defineConfig({
 	integrations: [react(), kbveRnAstro()],
 });
 ```
+
+### B. Nx tsconfig-path apps (e.g. `astro-kbve`, no `node_modules/@kbve`)
+
+`astro.config.mjs` is loaded by node before Vite, so bare `@kbve/*`
+specifiers don't resolve there — inline the same alias instead of importing
+the integration:
+
+```js
+// astro.config.mjs
+export default defineConfig({
+	vite: {
+		resolve: {
+			alias: [
+				{ find: /^react-native$/, replacement: 'react-native-web' },
+			],
+			extensions: [
+				'.web.tsx',
+				'.web.ts',
+				'.web.jsx',
+				'.web.js',
+				'.tsx',
+				'.ts',
+				'.jsx',
+				'.js',
+				'.json',
+			],
+		},
+		optimizeDeps: { include: ['react-native-web'] },
+	},
+});
+```
+
+Then point the `@kbve/rn` tsconfig paths at the **web barrels** so the
+native-only `./rails` + `./nav` graphs (which pull untranspiled
+`@expo/vector-icons`) never enter the web bundle:
+
+```jsonc
+// tsconfig.json
+"@kbve/rn": ["../../../packages/npm/rn/src/index.web.ts"],
+"@kbve/rn/ui": ["../../../packages/npm/rn/src/ui/index.web.ts"],
+"@kbve/rn-astro": ["../../../packages/npm/rn-astro/src/index.ts"]
+```
+
+### Rendering
 
 ```astro
 ---
@@ -47,6 +97,25 @@ const model = {
 
 The component runs as a hydrated React island, rendered through
 `react-native-web`. Use `client:only="react"` (RN-web components don't SSR).
+
+A live POC ships in `astro-kbve` at `/rn-web-poc/`
+(`src/components/rnweb/RnWebDemo.tsx`) — Gradient + Surface + Stack + Text +
+Button variants + a hydrated counter, all from `@kbve/rn` primitives.
+
+## Universal vs native-only boundary
+
+| Layer                                                                    | Web status      | Mechanism                                                                                                                                                                                                          |
+| ------------------------------------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `@kbve/core` (Store, signals, events, net, auth, chat)                   | universal       | no RN imports — runs as-is                                                                                                                                                                                         |
+| RN primitives (View/Text/Pressable/StyleSheet/Image/FlatList/TextInput)  | universal       | `react-native` → `react-native-web` alias                                                                                                                                                                          |
+| `@kbve/rn` UI kit (primitives, cards, menus, feedback, Gradient, Footer) | universal       | re-exported from `@kbve/rn-astro`                                                                                                                                                                                  |
+| HCaptcha, Sandbox, openExternal, viewTransition, offload, kv store       | universal       | `.web.tsx`/`.web.ts` split — web variant wins via resolve extensions                                                                                                                                               |
+| Nav (`AppBar`, `TabBar`, `NavShell`) + `navStore`/`useTab`               | **native-only** | pull `@expo/vector-icons` (untranspiled JSX, breaks web bundlers); excluded from the web barrel (`ui/index.web.ts`) and from this package's re-exports. Web nav needs `.web.tsx` icon-free variants (future work). |
+
+The split is enforced by file resolution, not runtime branching: the integration
+prepends `.web.*` to vite's resolve extensions, so for any `Foo.tsx` a sibling
+`Foo.web.tsx` is picked on web. The web UI barrel (`@kbve/rn/ui` →
+`ui/index.web.ts`) omits the nav barrel entirely.
 
 ## Requirements
 

--- a/packages/npm/rn-astro/src/components.ts
+++ b/packages/npm/rn-astro/src/components.ts
@@ -16,15 +16,10 @@ export {
 	EmptyState,
 	LoadingState,
 	ErrorState,
-	AppBar,
-	TabBar,
-	NavShell,
 	Footer,
-	navStore,
-	useTab,
 	useTheme,
 	tokens,
-} from '@kbve/rn';
+} from '@kbve/rn/ui';
 
 export type {
 	CardModel,
@@ -37,6 +32,4 @@ export type {
 	TextVariant,
 	TextTone,
 	ButtonVariant,
-	NavRoute,
-	TabItem,
-} from '@kbve/rn';
+} from '@kbve/rn/ui';


### PR DESCRIPTION
Closes #12495.

Wires the `@kbve/rn-astro` bridge into `astro-kbve` so `@kbve/rn` (React Native) components render on the **web** via `react-native-web` as `client:only` React islands. One component written once runs native + web.

## POC

Route **`/rn-web-poc/`** ([`src/components/rnweb/RnWebDemo.tsx`](apps/kbve/astro-kbve/src/components/rnweb/RnWebDemo.tsx)) renders `Gradient` + `Surface` + `Stack` + `Text` + `Button` (all 5 variants) + `Badge` from `@kbve/rn` primitives through `react-native-web`, with a hydrated counter proving island hydration. Build verified green; the island chunk bundles `react-native-web` (RN primitives → DOM).

## Changes

- **`astro.config.mjs`** — inline the `react-native` → `react-native-web` vite alias + `.web.*` resolve extensions + `optimizeDeps`. The `kbveRnAstro()` integration can't be imported here: `astro.config` is loaded by node *before* vite, and this Nx repo resolves `@kbve/*` only via tsconfig paths (no `node_modules/@kbve` symlinks).
- **`tsconfig.json`** — point `@kbve/rn` / `@kbve/rn/ui` at the **web barrels** (`index.web.ts` / `ui/index.web.ts`) so the native-only `./rails` + `./nav` graphs — which pull untranspiled `@expo/vector-icons` JSX (rollup parse crash) — never enter the web bundle.
- **`rn-astro/components.ts`** — route re-exports through `@kbve/rn/ui` (web barrel); drop nav-coupled exports (`AppBar`/`TabBar`/`NavShell`/`navStore`/`useTab`) absent from the web barrel.
- **`rn-astro/README.md`** — document both wiring modes + the universal vs native-only boundary.

## Acceptance

- [x] At least one `@kbve/rn` component renders in `astro-kbve` via react-native-web as an Astro island
- [x] Shared theme tokens + primitives (`Text`/`Surface`/`Button`) render from one source
- [x] Build pipeline documented; clear native-only vs universal boundary

## Follow-up

Native-only nav (`AppBar`/`TabBar`) still needs icon-free `.web.tsx` variants to drop `@expo/vector-icons` on web.