### PR TITLE
fix(jobboard): profile_draft preflight crash — build on workspace zod

### DIFF
--- a/apps/jobboard/web/package-lock.json
+++ b/apps/jobboard/web/package-lock.json
@@ -31,7 +31,7 @@
 				"react-native-web": "^0.21.2",
 				"react-native-worklets": "0.8.3",
 				"typegpu": "0.11.8",
-				"zod": "4.3.6"
+				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@tailwindcss/vite": "^4.1.3",
@@ -9035,9 +9035,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/apps/jobboard/web/package.json
+++ b/apps/jobboard/web/package.json
@@ -33,7 +33,7 @@
 		"react-native-web": "^0.21.2",
 		"react-native-worklets": "0.8.3",
 		"typegpu": "0.11.8",
-		"zod": "4.3.6"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "^4.1.3",

--- a/apps/jobboard/web/src/lib/profileDraft.ts
+++ b/apps/jobboard/web/src/lib/profileDraft.ts
@@ -1,15 +1,17 @@
 import { z } from 'zod';
-import { ProfileDraftSchema, ProfileLinkSchema } from '../api/types';
+import { ProfileLinkSchema } from '../api/types';
 
-// The generated ProfileDraftSchema (proto -> zod) is the *shape* contract: field
-// names, the kind enum, types. The SQL CHECK (is_valid_profile_draft,
-// packages/data/sql/dbmate/migrations/20260617200000_jobboard_profile_details.sql
-// + the host lock in 20260618000000_jobboard_link_host_lock.sql) adds the
-// business rules proto can't express -- https-only urls, per-kind host locks, max
-// lengths, ranges, no unknown keys. This extends the generated schema with those
-// rules so the client pre-flight matches what the DB will accept; the SQL CHECK
-// stays the source of truth. (web and the codegen bundle are pinned to the same
-// zod so the generated schema can be extended directly -- v4 brands its version.)
+// Client mirror of jobboard.is_valid_profile_draft / is_valid_profile_links
+// (packages/data/sql/dbmate/migrations/20260617200000_jobboard_profile_details.sql
+// + the host lock in 20260618000000_jobboard_link_host_lock.sql). The SQL CHECK
+// is the source of truth; this is the pre-flight so a bad shape surfaces on the
+// client instead of as a server rejection.
+//
+// Authored with the workspace zod (NOT by extending the generated
+// ProfileDraftSchema): the codegen bundle resolves a separate zod module
+// instance, and zod v4 rejects schemas from a foreign instance at runtime
+// ("expected a Zod schema"). Only LINK_KINDS is read off the generated schema
+// (plain data, no cross-instance schema composition).
 
 export const LINK_KINDS = ProfileLinkSchema.shape.kind.options;
 
@@ -48,7 +50,8 @@ const httpsUrl = z
 	.regex(/^https:\/\//i, { message: 'Must be an https:// URL' })
 	.max(2048, { message: 'URL too long' });
 
-export const profileLinkCheck = ProfileLinkSchema.extend({ url: httpsUrl })
+export const profileLinkCheck = z
+	.object({ kind: z.enum(LINK_KINDS), url: httpsUrl })
 	.strict()
 	.superRefine((link, ctx) => {
 		if (!hostOk(link.kind, link.url)) {
@@ -60,13 +63,15 @@ export const profileLinkCheck = ProfileLinkSchema.extend({ url: httpsUrl })
 		}
 	});
 
-export const profileDraftSchema = ProfileDraftSchema.extend({
-	headline: z.string().max(200).optional(),
-	bio: z.string().max(5000).optional(),
-	years_experience: z.number().int().min(0).max(100).optional(),
-	location: z.string().max(120).optional(),
-	links: z.array(profileLinkCheck).max(20).optional(),
-	discipline_ids: z.array(z.number().int().positive()).max(20).optional(),
-}).strict();
+export const profileDraftSchema = z
+	.object({
+		headline: z.string().max(200).optional(),
+		bio: z.string().max(5000).optional(),
+		years_experience: z.number().int().min(0).max(100).optional(),
+		location: z.string().max(120).optional(),
+		links: z.array(profileLinkCheck).max(20).optional(),
+		discipline_ids: z.array(z.number().int().positive()).max(20).optional(),
+	})
+	.strict();
 
 export type ProfileDraftChecked = z.infer<typeof profileDraftSchema>;


### PR DESCRIPTION
Follow-up to #12706 (merged). That PR's client pre-flight extended the generated `ProfileDraftSchema`, which crashed at runtime:

> Unhandled Promise Rejection: Invalid element at key "headline": expected a Zod schema

The codegen bundle resolves a **separate zod module instance**; zod v4 rejects schemas from a foreign instance, so `ProfileDraftSchema.extend({ headline: z.string() })` blew up at module load.

Fix: rebuild the pre-flight with the workspace zod (single instance). Only `LINK_KINDS` is read off the generated schema (plain `.options` data — no cross-instance composition). Revert the web `zod` pin back to `^4.4.3` (it was only there to enable the abandoned `.extend()`).

Verified: `tsc --noEmit` clean, `docker compose up --build` green, `/health` healthy.