### PR TITLE
refactor(simgrid): ULID connection registry + central router (#12619)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15214,6 +15214,7 @@ version = "0.0.1"
 dependencies = [
  "axum 0.7.9",
  "bevy",
+ "dashmap 6.1.0",
  "futures-util",
  "jsonwebtoken 9.3.1",
  "postcard",
@@ -15222,6 +15223,7 @@ dependencies = [
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tracing",
+ "ulid",
 ]
 
 [[package]]

--- a/apps/agones/cryptothrone/server/src/main.rs
+++ b/apps/agones/cryptothrone/server/src/main.rs
@@ -6,9 +6,10 @@ use std::net::SocketAddr;
 
 use bevy::prelude::IntoScheduleConfigs;
 use simgrid::net::ServerState;
-use simgrid::{SNAPSHOT_BROADCAST_CAPACITY, build_app, run_sim_loop};
+use simgrid::proto::ServerEvent;
+use simgrid::{build_app, run_sim_loop};
 use tokio::net::TcpListener;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -40,7 +41,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(0xC0FFEE);
 
-    let (snap_tx, _) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+    let (out_tx, out_rx) = mpsc::unbounded_channel::<ServerEvent>();
     let (input_tx, input_rx) = mpsc::unbounded_channel::<simgrid::SlotInput>();
 
     let jwt_secret = std::env::var("SUPABASE_JWT_SECRET")
@@ -54,16 +55,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let registry = game::registry();
 
-    let state = ServerState::new(
-        snap_tx.clone(),
-        input_tx,
-        seed,
-        jwt_secret,
-        true,
-        game::MAX_PLAYERS,
-    )
-    .with_registry(registry.entries());
+    let state = ServerState::new(input_tx, seed, jwt_secret, true, game::MAX_PLAYERS)
+        .with_registry(registry.entries());
     let roster = state.roster.clone();
+    state.spawn_event_router(out_rx);
 
     let config = game::config();
     let map = game::walkable_map();
@@ -73,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .enable_time()
             .build()
             .expect("sim runtime");
-        let mut app = build_app(snap_tx, input_rx, roster, seed, config, map, registry);
+        let mut app = build_app(out_tx, input_rx, roster, seed, config, map, registry);
         app.insert_resource(game::consumables());
         app.insert_resource(game::buffs());
         app.insert_resource(game::equipment());

--- a/packages/rust/simgrid/Cargo.toml
+++ b/packages/rust/simgrid/Cargo.toml
@@ -26,6 +26,8 @@ bevy = { version = "0.18", default-features = false, features = ["bevy_state"] }
 axum = { version = "0.7", default-features = false, features = ["ws"] }
 tokio = { version = "1.49", features = ["rt-multi-thread", "macros", "sync", "time"] }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
+dashmap = "6.1.0"
+ulid = "1.2.1"
 jsonwebtoken = { version = "9.3", default-features = false, optional = true }
 tracing = "0.1"
 

--- a/packages/rust/simgrid/src/lib.rs
+++ b/packages/rust/simgrid/src/lib.rs
@@ -14,7 +14,7 @@ pub use net::{Roster, ServerState, SlotInput, router};
 pub use sim::{
     Aggro, AggroSpec, BuffEffects, BuffSpec, CombatStats, ConsumableEffects, Defense, EntityKind,
     EquipBonus, EquipmentEffects, Equipped, Health, Inventory, Loot, NpcLevel, NpcSpec, Path,
-    PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, SNAPSHOT_BROADCAST_CAPACITY,
-    SimConfig, SimSet, StatusEffect, StatusEffects, StepBuffer, Wander, XpState, build_app,
-    ground_item_bundle, level_attack, level_max_hp, run_sim_loop, spawn_npc_from_spec, xp_to_next,
+    PlayerSlotTag, PlayerStore, RespawnOnDeath, SIM_TICK_HZ, SimConfig, SimSet, StatusEffect,
+    StatusEffects, StepBuffer, Wander, XpState, build_app, ground_item_bundle, level_attack,
+    level_max_hp, run_sim_loop, spawn_npc_from_spec, xp_to_next,
 };

--- a/packages/rust/simgrid/src/net.rs
+++ b/packages/rust/simgrid/src/net.rs
@@ -6,15 +6,22 @@ use axum::extract::State;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::response::IntoResponse;
 use axum::routing::get;
-use tokio::sync::{broadcast, mpsc, watch};
+use dashmap::DashMap;
+use futures_util::stream::SplitSink;
+use futures_util::{SinkExt, StreamExt};
+use tokio::sync::{mpsc, watch};
+use ulid::Ulid;
 
 use crate::proto::{self, ClientMessage, Input, ServerEvent};
 
 pub type SlotInput = (proto::PlayerSlot, Input);
 
+const CONN_CHANNEL_CAPACITY: usize = 256;
+
 #[derive(Clone)]
 struct RosterEntry {
     kbve_username: String,
+    ulid: Ulid,
 }
 
 #[derive(Default)]
@@ -33,10 +40,13 @@ impl Roster {
         self.slots.len()
     }
 
-    pub(crate) fn claim(&mut self, kbve_username: String) -> Option<proto::PlayerSlot> {
+    pub(crate) fn claim(&mut self, kbve_username: String, ulid: Ulid) -> Option<proto::PlayerSlot> {
         for (i, s) in self.slots.iter_mut().enumerate() {
             if s.is_none() {
-                *s = Some(RosterEntry { kbve_username });
+                *s = Some(RosterEntry {
+                    kbve_username,
+                    ulid,
+                });
                 return Some(proto::PlayerSlot(i as u16));
             }
         }
@@ -54,6 +64,13 @@ impl Roster {
             .get(slot.0 as usize)
             .and_then(|s| s.as_ref())
             .map(|e| e.kbve_username.clone())
+    }
+
+    pub fn ulid(&self, slot: proto::PlayerSlot) -> Option<Ulid> {
+        self.slots
+            .get(slot.0 as usize)
+            .and_then(|s| s.as_ref())
+            .map(|e| e.ulid)
     }
 
     /// Slots already held by this username — used to evict prior sessions so a
@@ -93,23 +110,26 @@ impl Roster {
     }
 }
 
+struct ConnHandle {
+    tx: mpsc::Sender<ServerEvent>,
+    slot: proto::PlayerSlot,
+}
+
 #[derive(Clone)]
 pub struct ServerState {
-    pub broadcast: Option<broadcast::Sender<ServerEvent>>,
     pub input_tx: Option<mpsc::UnboundedSender<SlotInput>>,
     pub seed: u64,
     pub jwt_secret: Vec<u8>,
     pub require_username: bool,
     pub roster: Arc<RwLock<Roster>>,
     pub registry: Vec<proto::KindEntry>,
-    /// Per-slot eviction signal: a reconnecting username kicks its prior
-    /// session(s) so the same player never lingers as two ghosts.
+    conns: Arc<DashMap<Ulid, ConnHandle>>,
+    slot2id: Arc<DashMap<proto::PlayerSlot, Ulid>>,
     kicks: Arc<Mutex<HashMap<u16, watch::Sender<bool>>>>,
 }
 
 impl ServerState {
     pub fn new(
-        broadcast: broadcast::Sender<ServerEvent>,
         input_tx: mpsc::UnboundedSender<SlotInput>,
         seed: u64,
         jwt_secret: Vec<u8>,
@@ -117,13 +137,14 @@ impl ServerState {
         capacity: usize,
     ) -> Self {
         Self {
-            broadcast: Some(broadcast),
             input_tx: Some(input_tx),
             seed,
             jwt_secret,
             require_username,
             roster: Arc::new(RwLock::new(Roster::new(capacity))),
             registry: Vec::new(),
+            conns: Arc::new(DashMap::new()),
+            slot2id: Arc::new(DashMap::new()),
             kicks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -132,6 +153,71 @@ impl ServerState {
         self.registry = registry;
         self
     }
+
+    /// Drain the sim's outbound event stream and dispatch each event to the
+    /// connection(s) it names. Delivery requires naming a recipient, so a
+    /// targeted event can no longer leak to every socket. Call inside the net
+    /// runtime that owns the connections.
+    pub fn spawn_event_router(&self, mut out_rx: mpsc::UnboundedReceiver<ServerEvent>) {
+        let conns = self.conns.clone();
+        let slot2id = self.slot2id.clone();
+        tokio::spawn(async move {
+            while let Some(evt) = out_rx.recv().await {
+                route_event(&conns, &slot2id, evt);
+            }
+        });
+    }
+}
+
+fn route_event(
+    conns: &DashMap<Ulid, ConnHandle>,
+    slot2id: &DashMap<proto::PlayerSlot, Ulid>,
+    evt: ServerEvent,
+) {
+    if let ServerEvent::Ephemeral { to, .. } = &evt
+        && *to != proto::PLAYER_SLOT_NONE
+    {
+        if let Some(id) = slot2id.get(to).map(|e| *e.value())
+            && let Some(h) = conns.get(&id)
+        {
+            deliver(h.value(), evt);
+        }
+        return;
+    }
+    for h in conns.iter() {
+        deliver(h.value(), evt.clone());
+    }
+}
+
+fn deliver(handle: &ConnHandle, evt: ServerEvent) {
+    match handle.tx.try_send(evt) {
+        Ok(()) => {}
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            tracing::warn!(
+                slot = handle.slot.0,
+                "conn channel saturated; dropping event"
+            );
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => {}
+    }
+}
+
+fn ulid_from_identity(identity: &str) -> Ulid {
+    let hi = fnv1a64(identity.as_bytes());
+    let mut salted = Vec::with_capacity(identity.len() + 1);
+    salted.push(0x01);
+    salted.extend_from_slice(identity.as_bytes());
+    let lo = fnv1a64(&salted);
+    Ulid::from(((hi as u128) << 64) | lo as u128)
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0100_0000_01b3);
+    }
+    h
 }
 
 #[derive(Clone, Copy)]
@@ -142,6 +228,7 @@ enum WireFormat {
 
 struct AdmittedPlayer {
     slot: proto::PlayerSlot,
+    ulid: Ulid,
     format: WireFormat,
     kick_rx: watch::Receiver<bool>,
 }
@@ -188,9 +275,9 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
         None => return,
     };
     let slot = admitted.slot;
+    let ulid = admitted.ulid;
     let format = admitted.format;
     let mut kick_rx = admitted.kick_rx;
-    let roster_handle = state.roster.clone();
 
     let welcome = ServerEvent::Welcome {
         protocol: proto::PROTOCOL_VERSION,
@@ -201,11 +288,15 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
     if let Some(msg) = encode_event(&welcome, format)
         && socket.send(msg).await.is_err()
     {
-        release_slot(&roster_handle, slot);
+        cleanup_join(&state, slot);
         return;
     }
 
-    let mut rx = state.broadcast.as_ref().map(|tx| tx.subscribe());
+    let (sink, mut stream) = socket.split();
+    let (conn_tx, conn_rx) = mpsc::channel(CONN_CHANNEL_CAPACITY);
+    state.conns.insert(ulid, ConnHandle { tx: conn_tx, slot });
+    state.slot2id.insert(slot, ulid);
+    let writer = tokio::spawn(run_writer(sink, conn_rx, format, state.roster.clone()));
 
     loop {
         tokio::select! {
@@ -214,26 +305,7 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
                 tracing::info!(slot = slot.0, "session evicted by a newer login");
                 break;
             }
-            evt = async {
-                match &mut rx {
-                    Some(r) => r.recv().await.ok(),
-                    None => futures_util::future::pending::<Option<ServerEvent>>().await,
-                }
-            } => {
-                let Some(evt) = evt else { break };
-                if let ServerEvent::Ephemeral { to, .. } = &evt
-                    && *to != proto::PLAYER_SLOT_NONE
-                    && *to != slot
-                {
-                    continue;
-                }
-                let evt = inject_roster(evt, &state.roster);
-                let Some(msg) = encode_event(&evt, format) else { continue };
-                if socket.send(msg).await.is_err() {
-                    break;
-                }
-            }
-            incoming = socket.recv() => {
+            incoming = stream.next() => {
                 let Some(Ok(msg)) = incoming else { break };
                 if matches!(msg, Message::Close(_)) {
                     break;
@@ -249,13 +321,37 @@ async fn handle_socket(mut socket: WebSocket, state: Arc<ServerState>) {
         }
     }
 
-    // Drop our kick channel before freeing the slot: while the slot is still
+    writer.abort();
+    state.conns.remove_if(&ulid, |_, h| h.slot == slot);
+    state.slot2id.remove_if(&slot, |_, id| *id == ulid);
+    cleanup_join(&state, slot);
+}
+
+async fn run_writer(
+    mut sink: SplitSink<WebSocket, Message>,
+    mut rx: mpsc::Receiver<ServerEvent>,
+    format: WireFormat,
+    roster: Arc<RwLock<Roster>>,
+) {
+    while let Some(evt) = rx.recv().await {
+        let evt = inject_roster(evt, &roster);
+        let Some(msg) = encode_event(&evt, format) else {
+            continue;
+        };
+        if sink.send(msg).await.is_err() {
+            break;
+        }
+    }
+}
+
+fn cleanup_join(state: &ServerState, slot: proto::PlayerSlot) {
+    // Drop the kick channel before freeing the slot: while the slot is still
     // claimed no other join can take it, so we can't clobber a reused slot's
     // fresh kick sender.
     if let Ok(mut kicks) = state.kicks.lock() {
         kicks.remove(&slot.0);
     }
-    release_slot(&roster_handle, slot);
+    release_slot(&state.roster, slot);
 }
 
 fn release_slot(roster: &Arc<RwLock<Roster>>, slot: proto::PlayerSlot) {
@@ -310,11 +406,11 @@ async fn admit(
     jm: proto::JoinMatch,
     format: WireFormat,
 ) -> Option<AdmittedPlayer> {
-    let raw = if state.jwt_secret.is_empty() {
-        jm.kbve_username
+    let (raw, sub) = if state.jwt_secret.is_empty() {
+        (jm.kbve_username, String::new())
     } else {
         match crate::auth::verify_supabase_jwt(&jm.jwt, &state.jwt_secret) {
-            Ok(claims) => claims.kbve_username,
+            Ok(claims) => (claims.kbve_username, claims.sub),
             Err(e) => {
                 send_reject(socket, format, &format!("auth rejected: {e}")).await;
                 return None;
@@ -330,7 +426,12 @@ async fn admit(
         .await;
         return None;
     };
-    claim_slot(state, socket, username, format).await
+    let identity = if sub.is_empty() {
+        username.clone()
+    } else {
+        sub
+    };
+    claim_slot(state, socket, username, identity, format).await
 }
 
 #[cfg(not(feature = "supabase-auth"))]
@@ -349,7 +450,8 @@ async fn admit(
         .await;
         return None;
     };
-    claim_slot(state, socket, username, format).await
+    let identity = username.clone();
+    claim_slot(state, socket, username, identity, format).await
 }
 
 fn resolve_username(require_username: bool, name: String) -> Option<String> {
@@ -366,15 +468,17 @@ async fn claim_slot(
     state: &Arc<ServerState>,
     socket: &mut WebSocket,
     kbve_username: String,
+    identity: String,
     format: WireFormat,
 ) -> Option<AdmittedPlayer> {
+    let ulid = ulid_from_identity(&identity);
     let name = kbve_username.clone();
     // Find any prior session(s) for this username, then claim a fresh slot —
     // both under one write lock so two simultaneous joins can't race.
     let (slot, prior) = match state.roster.write() {
         Ok(mut r) => {
             let prior = r.slots_for_username(&name);
-            (r.claim(kbve_username), prior)
+            (r.claim(kbve_username, ulid), prior)
         }
         Err(_) => (None, Vec::new()),
     };
@@ -406,9 +510,10 @@ async fn claim_slot(
     if let Ok(mut kicks) = state.kicks.lock() {
         kicks.insert(slot.0, kick_tx);
     }
-    tracing::info!(slot = slot.0, username = %name, "player joined");
+    tracing::info!(slot = slot.0, username = %name, ulid = %ulid, "player joined");
     Some(AdmittedPlayer {
         slot,
+        ulid,
         format,
         kick_rx,
     })
@@ -446,25 +551,117 @@ fn inject_roster(evt: ServerEvent, roster: &Arc<RwLock<Roster>>) -> ServerEvent 
 
 #[cfg(test)]
 mod tests {
-    use super::{Roster, resolve_username};
+    use super::*;
 
     #[test]
     fn roster_dedups_username_for_eviction() {
         let mut r = Roster::new(4);
-        let s0 = r.claim("ann".into()).unwrap();
-        let _s1 = r.claim("bob".into()).unwrap();
+        let s0 = r.claim("ann".into(), ulid_from_identity("ann")).unwrap();
+        let _s1 = r.claim("bob".into(), ulid_from_identity("bob")).unwrap();
 
-        // ann reconnects: her prior slot is found, a fresh slot is claimed.
         let prior: Vec<u16> = r.slots_for_username("ann").iter().map(|s| s.0).collect();
         assert_eq!(prior, vec![s0.0]);
-        let s2 = r.claim("ann".into()).unwrap();
+        let s2 = r.claim("ann".into(), ulid_from_identity("ann")).unwrap();
         assert_ne!(s2.0, s0.0);
         assert_eq!(r.slots_for_username("ann").len(), 2);
 
-        // After the old session releases, only the new one remains.
         r.release(s0);
         let after: Vec<u16> = r.slots_for_username("ann").iter().map(|s| s.0).collect();
         assert_eq!(after, vec![s2.0]);
+    }
+
+    #[test]
+    fn ulid_is_stable_per_identity() {
+        assert_eq!(ulid_from_identity("ann"), ulid_from_identity("ann"));
+        assert_ne!(ulid_from_identity("ann"), ulid_from_identity("bob"));
+    }
+
+    #[test]
+    fn reconnect_reclaims_same_ulid() {
+        let mut r = Roster::new(4);
+        let s0 = r.claim("ann".into(), ulid_from_identity("ann")).unwrap();
+        let first = r.ulid(s0).unwrap();
+        r.release(s0);
+        let s1 = r.claim("ann".into(), ulid_from_identity("ann")).unwrap();
+        assert_eq!(first, r.ulid(s1).unwrap());
+    }
+
+    #[test]
+    fn targeted_event_reaches_only_owner() {
+        let conns: DashMap<Ulid, ConnHandle> = DashMap::new();
+        let slot2id: DashMap<proto::PlayerSlot, Ulid> = DashMap::new();
+        let (atx, mut arx) = mpsc::channel(8);
+        let (btx, mut brx) = mpsc::channel(8);
+        let aid = ulid_from_identity("a");
+        let bid = ulid_from_identity("b");
+        conns.insert(
+            aid,
+            ConnHandle {
+                tx: atx,
+                slot: proto::PlayerSlot(0),
+            },
+        );
+        conns.insert(
+            bid,
+            ConnHandle {
+                tx: btx,
+                slot: proto::PlayerSlot(1),
+            },
+        );
+        slot2id.insert(proto::PlayerSlot(0), aid);
+        slot2id.insert(proto::PlayerSlot(1), bid);
+
+        route_event(
+            &conns,
+            &slot2id,
+            ServerEvent::Ephemeral {
+                kind: 1,
+                to: proto::PlayerSlot(0),
+                payload: Vec::new(),
+            },
+        );
+
+        assert!(arx.try_recv().is_ok());
+        assert!(brx.try_recv().is_err());
+    }
+
+    #[test]
+    fn global_event_reaches_all() {
+        let conns: DashMap<Ulid, ConnHandle> = DashMap::new();
+        let slot2id: DashMap<proto::PlayerSlot, Ulid> = DashMap::new();
+        let (atx, mut arx) = mpsc::channel(8);
+        let (btx, mut brx) = mpsc::channel(8);
+        let aid = ulid_from_identity("a");
+        let bid = ulid_from_identity("b");
+        conns.insert(
+            aid,
+            ConnHandle {
+                tx: atx,
+                slot: proto::PlayerSlot(0),
+            },
+        );
+        conns.insert(
+            bid,
+            ConnHandle {
+                tx: btx,
+                slot: proto::PlayerSlot(1),
+            },
+        );
+        slot2id.insert(proto::PlayerSlot(0), aid);
+        slot2id.insert(proto::PlayerSlot(1), bid);
+
+        route_event(
+            &conns,
+            &slot2id,
+            ServerEvent::Ephemeral {
+                kind: 1,
+                to: proto::PLAYER_SLOT_NONE,
+                payload: Vec::new(),
+            },
+        );
+
+        assert!(arx.try_recv().is_ok());
+        assert!(brx.try_recv().is_ok());
     }
 
     #[test]

--- a/packages/rust/simgrid/src/sim.rs
+++ b/packages/rust/simgrid/src/sim.rs
@@ -9,7 +9,7 @@ use bevy::prelude::{
     Commands, Component, IntoScheduleConfigs, Query, Res, ResMut, Resource, Update, With, Without,
 };
 use serde_json::json;
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 use tokio::time;
 
 use crate::data::KindRegistry;
@@ -19,7 +19,6 @@ use crate::proto::{self, Dir, Input, ServerEvent, Tile};
 
 pub const SIM_TICK_HZ: u32 = 20;
 pub const SNAPSHOT_EVERY_N_TICKS: u32 = 2;
-pub const SNAPSHOT_BROADCAST_CAPACITY: usize = 256;
 pub const KEYFRAME_EVERY_N_TICKS: u32 = SIM_TICK_HZ * 5;
 
 pub const PLAYER_KIND: u16 = 0;
@@ -71,8 +70,8 @@ pub struct SimClock {
 pub struct SimSeed(pub u64);
 
 #[derive(Resource, Clone)]
-pub struct SnapshotBroadcast {
-    pub tx: broadcast::Sender<ServerEvent>,
+pub struct Outbound {
+    pub tx: mpsc::UnboundedSender<ServerEvent>,
 }
 
 #[derive(Resource)]
@@ -402,7 +401,7 @@ pub fn spawn_npc_from_spec(commands: &mut Commands, spec: &NpcSpec) {
 }
 
 pub fn build_app(
-    tx: broadcast::Sender<ServerEvent>,
+    tx: mpsc::UnboundedSender<ServerEvent>,
     input_rx: mpsc::UnboundedReceiver<(proto::PlayerSlot, Input)>,
     roster: Arc<RwLock<Roster>>,
     seed: u64,
@@ -413,7 +412,7 @@ pub fn build_app(
     let mut app = App::new();
     app.insert_resource(SimClock::default())
         .insert_resource(SimSeed(seed))
-        .insert_resource(SnapshotBroadcast { tx })
+        .insert_resource(Outbound { tx })
         .insert_resource(InputQueue {
             rx: Mutex::new(input_rx),
         })
@@ -484,7 +483,7 @@ fn tick_sim(mut clock: ResMut<SimClock>) {
 fn sync_roster(
     roster: Res<RosterHandle>,
     config: Res<SimConfig>,
-    bcast: Res<SnapshotBroadcast>,
+    bcast: Res<Outbound>,
     mut spawned: ResMut<SpawnedSlots>,
     mut store: ResMut<PlayerStore>,
     mut kill_counts: ResMut<KillCounts>,
@@ -619,7 +618,7 @@ fn drain_inputs(
     equipment: Res<EquipmentEffects>,
     config: Res<SimConfig>,
     clock: Res<SimClock>,
-    bcast: Res<SnapshotBroadcast>,
+    bcast: Res<Outbound>,
     mut actions: ResMut<PendingActions>,
     mut q: Query<(
         Entity,
@@ -764,7 +763,7 @@ fn drain_inputs(
 fn use_item(
     effects: &ConsumableEffects,
     buffs: &BuffEffects,
-    bcast: &SnapshotBroadcast,
+    bcast: &Outbound,
     slot: proto::PlayerSlot,
     item_ref: &str,
     now: u32,
@@ -808,7 +807,7 @@ fn apply_actions(
     mut actions: ResMut<PendingActions>,
     index: Res<EidIndex>,
     registry: Res<KindRegistry>,
-    bcast: Res<SnapshotBroadcast>,
+    bcast: Res<Outbound>,
     clock: Res<SimClock>,
     seed: Res<SimSeed>,
     config: Res<SimConfig>,
@@ -958,7 +957,7 @@ fn apply_actions(
 
 #[allow(clippy::too_many_arguments)]
 fn award_xp(
-    bcast: &SnapshotBroadcast,
+    bcast: &Outbound,
     slot: proto::PlayerSlot,
     config: &SimConfig,
     equipment: &EquipmentEffects,
@@ -990,7 +989,7 @@ fn award_xp(
 }
 
 fn send_equipped(
-    bcast: &SnapshotBroadcast,
+    bcast: &Outbound,
     slot: proto::PlayerSlot,
     equip_slot: &str,
     item_ref: Option<&str>,
@@ -1013,7 +1012,7 @@ fn send_equipped(
 }
 
 fn send_stats(
-    bcast: &SnapshotBroadcast,
+    bcast: &Outbound,
     slot: proto::PlayerSlot,
     level: i32,
     xp: i32,
@@ -1038,7 +1037,7 @@ fn send_stats(
     });
 }
 
-fn send_inventory(bcast: &SnapshotBroadcast, slot: proto::PlayerSlot, inv: &Inventory) {
+fn send_inventory(bcast: &Outbound, slot: proto::PlayerSlot, inv: &Inventory) {
     let items: Vec<_> = inv
         .slots
         .iter()
@@ -1093,7 +1092,7 @@ fn hostile_ai(
     clock: Res<SimClock>,
     config: Res<SimConfig>,
     map: Res<WalkableMap>,
-    bcast: Res<SnapshotBroadcast>,
+    bcast: Res<Outbound>,
     mut q_mobs: Query<(Entity, &mut GridPos, &mut MoveTarget, &mut Aggro), Without<PlayerSlotTag>>,
     mut q_players: Query<
         (
@@ -1183,7 +1182,7 @@ fn hostile_ai(
 }
 
 fn send_status(
-    bcast: &SnapshotBroadcast,
+    bcast: &Outbound,
     slot: proto::PlayerSlot,
     kind: proto::StatusKind,
     magnitude: i32,
@@ -1414,7 +1413,7 @@ fn chain_steps(
 #[allow(clippy::type_complexity)]
 fn emit_snapshot(
     clock: Res<SimClock>,
-    bcast: Res<SnapshotBroadcast>,
+    bcast: Res<Outbound>,
     q: Query<(
         Entity,
         &EntityKind,
@@ -1494,13 +1493,22 @@ mod tests {
 
     type Harness = (
         App,
-        broadcast::Receiver<ServerEvent>,
+        mpsc::UnboundedReceiver<ServerEvent>,
         mpsc::UnboundedSender<(proto::PlayerSlot, Input)>,
         Arc<RwLock<Roster>>,
     );
 
+    fn test_ulid(name: &str) -> ulid::Ulid {
+        let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+        for &b in name.as_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0100_0000_01b3);
+        }
+        ulid::Ulid::from(h as u128)
+    }
+
     fn harness(seed: u64) -> Harness {
-        let (tx, rx) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+        let (tx, rx) = mpsc::unbounded_channel();
         let (input_tx, input_rx) = mpsc::unbounded_channel();
         let roster = Arc::new(RwLock::new(Roster::new(4)));
         let map = WalkableMap::open(32, 32);
@@ -1526,7 +1534,7 @@ mod tests {
         roster
             .write()
             .unwrap()
-            .claim(name.to_string())
+            .claim(name.to_string(), test_ulid(name))
             .expect("slot available")
     }
 
@@ -1750,7 +1758,7 @@ mod tests {
 
     #[test]
     fn safe_zone_blocks_hostile_aggro() {
-        let (tx, mut rx) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+        let (tx, mut rx) = mpsc::unbounded_channel();
         let (input_tx, input_rx) = mpsc::unbounded_channel();
         let roster = Arc::new(RwLock::new(Roster::new(4)));
         let map = WalkableMap::open(32, 32);

--- a/packages/rust/simgrid/tests/ws_flow.rs
+++ b/packages/rust/simgrid/tests/ws_flow.rs
@@ -14,10 +14,9 @@ use simgrid::proto::{
     self, ClientFrame, ClientMessage, Dir, Input, JoinMatch, PROTOCOL_VERSION, ServerEvent,
 };
 use simgrid::{
-    KindRegistry, SNAPSHOT_BROADCAST_CAPACITY, ServerState, SimConfig, WalkableMap, build_app,
-    proto::Tile, router, run_sim_loop,
+    KindRegistry, ServerState, SimConfig, WalkableMap, build_app, proto::Tile, router, run_sim_loop,
 };
-use tokio::sync::{broadcast, mpsc};
+use tokio::sync::mpsc;
 
 type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
@@ -25,10 +24,11 @@ const SPAWN: Tile = Tile::new(5, 5);
 
 /// Boot a sim + router on an ephemeral port; returns the ws:// URL.
 async fn spawn_server(capacity: usize) -> String {
-    let (snap_tx, _keep) = broadcast::channel(SNAPSHOT_BROADCAST_CAPACITY);
+    let (out_tx, out_rx) = mpsc::unbounded_channel();
     let (input_tx, input_rx) = mpsc::unbounded_channel();
-    let state = ServerState::new(snap_tx.clone(), input_tx, 7, Vec::new(), true, capacity);
+    let state = ServerState::new(input_tx, 7, Vec::new(), true, capacity);
     let roster = state.roster.clone();
+    state.spawn_event_router(out_rx);
     let config = SimConfig {
         spawn: SPAWN,
         ticks_per_tile: 1,
@@ -43,7 +43,7 @@ async fn spawn_server(capacity: usize) -> String {
             .enable_all()
             .build()
             .expect("sim runtime");
-        let app = build_app(snap_tx, input_rx, roster, 7, config, map, registry);
+        let app = build_app(out_tx, input_rx, roster, 7, config, map, registry);
         rt.block_on(run_sim_loop(app));
     });
 


### PR DESCRIPTION
Closes #12619.

Replaces simgrid `net.rs` single-`broadcast` model with a ULID-keyed connection registry + central router and a sim/net thread split. Targeted delivery is now **structural** — an event reaches a client only by naming a recipient, so the leak class fixed per-callsite in #12617 can't recur.

## Changes
- **Sim → router channel:** sim emits `ServerEvent` on `mpsc::UnboundedSender` (`Outbound`, renamed from `SnapshotBroadcast`), drained by `ServerState::spawn_event_router`. `broadcast` removed from `ServerState`.
- **Registry:** `conns: DashMap<Ulid, ConnHandle{tx,slot}>` + `slot2id: DashMap<PlayerSlot, Ulid>`. Router: `to==NONE` → iterate (global); else `slot2id[to] → conns[ulid]` → single send.
- **Per-conn:** `socket.split()` — reader loop owns `SplitStream` (inputs + kick), `run_writer` task owns `SplitSink` fed by a bounded `mpsc::channel(256)`; writer does `inject_roster` + encode.
- **Backpressure:** `try_send`; drop + warn on `Full` (no kick), no-op on `Closed`. A slow client can no longer OOM or trip the old `Lagged` → disconnect.
- **ULID identity:** deterministic FNV-1a-128 over identity (Supabase `sub` if present, else username). Reconnect re-registers the **same** ULID; portable across nodes; no `uuid` dep, no wire/proto change (ULID stays server-side, `PROTOCOL_VERSION` unchanged).
- **Reconnect safety:** cleanup uses `remove_if(slot==mine / id==mine)` so an evicted same-ULID prior session can't clobber the new conn's entry.
- simgrid deps added: `dashmap`, `ulid`. `SNAPSHOT_BROADCAST_CAPACITY` const removed.

## Tasks (#12619)
- [x] ULID per slot in `Roster`
- [x] Per-conn writer task owning `SplitSink`
- [x] `DashMap<Ulid, ConnHandle>` + `slot2id` in `ServerState`
- [x] Central router task (all vs targeted)
- [x] Replace broadcast subscribe/filter with per-conn receive
- [x] Remove `broadcast` from `ServerState`
- [x] Backpressure/drop policy on bounded per-conn mpsc
- [x] Tests: targeted reaches only owner; global reaches all; reconnect re-registers same ULID

## Verification
- `cargo check -p simgrid` (default + `--no-default-features`) and `-p cryptothrone-server`
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test -p simgrid` → 44 unit + 4 integration pass