### PR TITLE
feat(jobboard): autosave apply form draft to IndexedDB

### DIFF
--- a/apps/jobboard/web/package-lock.json
+++ b/apps/jobboard/web/package-lock.json
@@ -31,7 +31,7 @@
 				"react-native-web": "^0.21.2",
 				"react-native-worklets": "0.8.3",
 				"typegpu": "0.11.8",
-				"zod": "4.3.6"
+				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@tailwindcss/vite": "^4.1.3",
@@ -9035,9 +9035,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"

--- a/apps/jobboard/web/package.json
+++ b/apps/jobboard/web/package.json
@@ -33,7 +33,7 @@
 		"react-native-web": "^0.21.2",
 		"react-native-worklets": "0.8.3",
 		"typegpu": "0.11.8",
-		"zod": "4.3.6"
+		"zod": "^4.4.3"
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "^4.1.3",

--- a/apps/jobboard/web/src/lib/profileDraft.ts
+++ b/apps/jobboard/web/src/lib/profileDraft.ts
@@ -1,15 +1,17 @@
 import { z } from 'zod';
-import { ProfileDraftSchema, ProfileLinkSchema } from '../api/types';
+import { ProfileLinkSchema } from '../api/types';
 
-// The generated ProfileDraftSchema (proto -> zod) is the *shape* contract: field
-// names, the kind enum, types. The SQL CHECK (is_valid_profile_draft,
-// packages/data/sql/dbmate/migrations/20260617200000_jobboard_profile_details.sql
-// + the host lock in 20260618000000_jobboard_link_host_lock.sql) adds the
-// business rules proto can't express -- https-only urls, per-kind host locks, max
-// lengths, ranges, no unknown keys. This extends the generated schema with those
-// rules so the client pre-flight matches what the DB will accept; the SQL CHECK
-// stays the source of truth. (web and the codegen bundle are pinned to the same
-// zod so the generated schema can be extended directly -- v4 brands its version.)
+// Client mirror of jobboard.is_valid_profile_draft / is_valid_profile_links
+// (packages/data/sql/dbmate/migrations/20260617200000_jobboard_profile_details.sql
+// + the host lock in 20260618000000_jobboard_link_host_lock.sql). The SQL CHECK
+// is the source of truth; this is the pre-flight so a bad shape surfaces on the
+// client instead of as a server rejection.
+//
+// Authored with the workspace zod (NOT by extending the generated
+// ProfileDraftSchema): the codegen bundle resolves a separate zod module
+// instance, and zod v4 rejects schemas from a foreign instance at runtime
+// ("expected a Zod schema"). Only LINK_KINDS is read off the generated schema
+// (plain data, no cross-instance schema composition).
 
 export const LINK_KINDS = ProfileLinkSchema.shape.kind.options;
 
@@ -48,7 +50,8 @@ const httpsUrl = z
 	.regex(/^https:\/\//i, { message: 'Must be an https:// URL' })
 	.max(2048, { message: 'URL too long' });
 
-export const profileLinkCheck = ProfileLinkSchema.extend({ url: httpsUrl })
+export const profileLinkCheck = z
+	.object({ kind: z.enum(LINK_KINDS), url: httpsUrl })
 	.strict()
 	.superRefine((link, ctx) => {
 		if (!hostOk(link.kind, link.url)) {
@@ -60,13 +63,15 @@ export const profileLinkCheck = ProfileLinkSchema.extend({ url: httpsUrl })
 		}
 	});
 
-export const profileDraftSchema = ProfileDraftSchema.extend({
-	headline: z.string().max(200).optional(),
-	bio: z.string().max(5000).optional(),
-	years_experience: z.number().int().min(0).max(100).optional(),
-	location: z.string().max(120).optional(),
-	links: z.array(profileLinkCheck).max(20).optional(),
-	discipline_ids: z.array(z.number().int().positive()).max(20).optional(),
-}).strict();
+export const profileDraftSchema = z
+	.object({
+		headline: z.string().max(200).optional(),
+		bio: z.string().max(5000).optional(),
+		years_experience: z.number().int().min(0).max(100).optional(),
+		location: z.string().max(120).optional(),
+		links: z.array(profileLinkCheck).max(20).optional(),
+		discipline_ids: z.array(z.number().int().positive()).max(20).optional(),
+	})
+	.strict();
 
 export type ProfileDraftChecked = z.infer<typeof profileDraftSchema>;

--- a/apps/jobboard/web/src/lib/useFormDraft.ts
+++ b/apps/jobboard/web/src/lib/useFormDraft.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import type { FieldValues, UseFormReset, UseFormWatch } from 'react-hook-form';
+import { createWorkerPool } from '@kbve/rn';
+
+// Auto-persist a react-hook-form's values to IndexedDB through the @kbve/rn
+// worker (the tab's sole IndexedDB writer) so a half-filled form survives a
+// reload and refills itself. Restores once on mount, debounce-saves on change,
+// and exposes clearDraft() to drop the saved copy after a successful submit.
+//
+// Persistence is keyed by `key` (the form id) and stores the whole RHF values
+// object — no per-field DOM wiring; restore goes through reset() so controlled
+// inputs and field arrays stay consistent.
+
+const pool = createWorkerPool();
+
+interface FormDraftOptions<T extends FieldValues> {
+	key: string;
+	watch: UseFormWatch<T>;
+	reset: UseFormReset<T>;
+	defaults: T;
+	enabled?: boolean;
+	debounceMs?: number;
+}
+
+export function useFormDraft<T extends FieldValues>({
+	key,
+	watch,
+	reset,
+	defaults,
+	enabled = true,
+	debounceMs = 400,
+}: FormDraftOptions<T>): { clearDraft: () => void } {
+	const cleared = useRef(false);
+
+	useEffect(() => {
+		if (!enabled) return;
+		let active = true;
+		pool.cacheGet<Partial<T>>(key).then((saved) => {
+			if (active && saved && !cleared.current) {
+				reset({ ...defaults, ...saved });
+			}
+		});
+		return () => {
+			active = false;
+		};
+		// defaults is a stable literal from the caller; key identifies the form.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [key, enabled]);
+
+	useEffect(() => {
+		if (!enabled) return;
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const sub = watch((values) => {
+			if (cleared.current) return;
+			clearTimeout(timer);
+			timer = setTimeout(() => {
+				void pool.cacheSet(key, values);
+			}, debounceMs);
+		});
+		return () => {
+			clearTimeout(timer);
+			sub.unsubscribe();
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [key, enabled, debounceMs]);
+
+	const clearDraft = () => {
+		cleared.current = true;
+		void pool.cacheRemove(key);
+	};
+
+	return { clearDraft };
+}

--- a/apps/jobboard/web/src/routes/apply.tsx
+++ b/apps/jobboard/web/src/routes/apply.tsx
@@ -32,6 +32,7 @@ import {
 	FieldMessage,
 } from '../components/form';
 import { useAuth } from '../lib/auth';
+import { useFormDraft } from '../lib/useFormDraft';
 
 const GAME_DEV_ID = 1;
 const CAP_TAKER = Capability.CAP_TAKER;
@@ -87,6 +88,19 @@ const applicationSchema = z.object({
 });
 
 type ApplicationValues = z.infer<typeof applicationSchema>;
+
+const APPLY_DRAFT_KEY = 'jobboard-apply-draft';
+const APPLY_DEFAULTS: ApplicationValues = {
+	caps: 0,
+	verticalIds: [],
+	disciplineIds: [],
+	headline: '',
+	about: '',
+	years: '',
+	location: '',
+	links: [{ kind: 'github', url: '' }],
+	projects: [{ url: '' }],
+};
 
 export function ApplyPage() {
 	const { user } = useAuth();
@@ -201,10 +215,6 @@ function ApplicationForm({
 	onSubmitted: () => void;
 }) {
 	const [draftError, setDraftError] = useState<string | null>(null);
-	const mutation = useMutation({
-		mutationFn: submitApplication,
-		onSuccess: onSubmitted,
-	});
 
 	const {
 		register,
@@ -212,20 +222,26 @@ function ApplicationForm({
 		control,
 		watch,
 		setValue,
+		reset,
 		formState: { errors, submitCount },
 	} = useForm<ApplicationValues>({
 		resolver: zodResolver(applicationSchema),
 		mode: 'onBlur',
-		defaultValues: {
-			caps: 0,
-			verticalIds: [],
-			disciplineIds: [],
-			headline: '',
-			about: '',
-			years: '',
-			location: '',
-			links: [{ kind: 'github', url: '' }],
-			projects: [{ url: '' }],
+		defaultValues: APPLY_DEFAULTS,
+	});
+
+	const { clearDraft } = useFormDraft<ApplicationValues>({
+		key: APPLY_DRAFT_KEY,
+		watch,
+		reset,
+		defaults: APPLY_DEFAULTS,
+	});
+
+	const mutation = useMutation({
+		mutationFn: submitApplication,
+		onSuccess: () => {
+			clearDraft();
+			onSubmitted();
 		},
 	});
 


### PR DESCRIPTION
Half-filled membership applications now survive a reload and refill themselves — no retyping.

New `useFormDraft` hook subscribes to react-hook-form `watch()`, debounce-writes the whole values object to IndexedDB through the `@kbve/rn` worker (the tab's sole IndexedDB writer), restores via `reset()` on mount, and clears the saved copy on a successful submit. Keyed by form id; whole-form persistence, no per-field DOM wiring.

Stacks on #12716 (the profile_draft runtime-zod fix) — that commit rides along until #12716 merges, after which this PR's diff is just the autosave (`useFormDraft.ts` + apply.tsx wiring).

Verified: `tsc --noEmit` clean, `docker compose up --build` green, `/health` healthy.