### PR TITLE
fix(jobboard): map postgres errors to specific reasons, not blind 500

### DIFF
--- a/apps/jobboard/src/error.rs
+++ b/apps/jobboard/src/error.rs
@@ -2,6 +2,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
 use std::borrow::Cow;
+use tokio_postgres::error::SqlState;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ApiError {
@@ -15,6 +16,8 @@ pub enum ApiError {
     BadRequest(String),
     #[error("conflict: {0}")]
     Conflict(String),
+    #[error("unprocessable: {0}")]
+    Unprocessable(String),
     #[error("database: {0}")]
     Database(#[from] jedi::entity::error::JediError),
     #[error("internal: {0}")]
@@ -29,6 +32,7 @@ impl ApiError {
             Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::Unprocessable(_) => StatusCode::UNPROCESSABLE_ENTITY,
             Self::Database(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -40,6 +44,7 @@ impl ApiError {
             Self::Forbidden(_) => "FORBIDDEN",
             Self::BadRequest(_) => "BAD_REQUEST",
             Self::Conflict(_) => "CONFLICT",
+            Self::Unprocessable(_) => "UNPROCESSABLE",
             Self::Database(_) => "DATABASE_ERROR",
             Self::Internal(_) => "INTERNAL_ERROR",
         }
@@ -79,7 +84,68 @@ impl IntoResponse for ApiError {
 
 pub type ApiResult<T> = Result<axum::Json<T>, ApiError>;
 
+/// Map a postgres error to an ApiError. The full DB error (SQLSTATE, constraint,
+/// detail) is logged server-side; the client gets a stable reason derived from
+/// the SQLSTATE class and, for known constraints, a friendly message — never the
+/// raw DB text or the offending values (which carry user data). Add a constraint
+/// arm here when a new constraint should read as something other than its class
+/// default.
 pub fn pg_err(e: tokio_postgres::Error) -> ApiError {
-    tracing::error!(error = %e, "postgres query error");
-    ApiError::Internal("database error".into())
+    let Some(db) = e.as_db_error() else {
+        // Connection/protocol failure — no SQLSTATE to classify.
+        tracing::error!(error = %e, "postgres error (no db detail)");
+        return ApiError::Internal("database error".into());
+    };
+
+    let sqlstate = db.code();
+    let constraint = db.constraint().unwrap_or("");
+    tracing::error!(
+        sqlstate = sqlstate.code(),
+        constraint = constraint,
+        table = db.table().unwrap_or(""),
+        detail = db.detail().unwrap_or(""),
+        message = db.message(),
+        "postgres query error",
+    );
+
+    // Constraint-specific friendly messages (preferred over the class default).
+    match constraint {
+        "jobboard_member_applications_one_pending_uq" => {
+            return ApiError::Conflict("you already have a pending application".into());
+        }
+        "member_applications_user_id_fkey" => {
+            return ApiError::Unprocessable(
+                "your account is not provisioned on this service yet".into(),
+            );
+        }
+        "member_application_verticals_vertical_id_fkey" => {
+            return ApiError::Unprocessable("a selected vertical does not exist".into());
+        }
+        "member_applications_profile_draft_valid_ck"
+        | "talent_profiles_links_valid_ck"
+        | "talent_profiles_bio_len_ck"
+        | "talent_profiles_location_len_ck" => {
+            return ApiError::BadRequest("profile details failed validation".into());
+        }
+        _ => {}
+    }
+
+    // SQLSTATE-class defaults for anything not named above.
+    match sqlstate {
+        &SqlState::UNIQUE_VIOLATION => ApiError::Conflict("that record already exists".into()),
+        &SqlState::FOREIGN_KEY_VIOLATION => {
+            ApiError::Unprocessable("a referenced record was not found".into())
+        }
+        &SqlState::CHECK_VIOLATION => {
+            ApiError::BadRequest("a field failed a validation rule".into())
+        }
+        &SqlState::NOT_NULL_VIOLATION => {
+            ApiError::BadRequest("a required field was missing".into())
+        }
+        &SqlState::STRING_DATA_RIGHT_TRUNCATION => {
+            ApiError::BadRequest("a field was too long".into())
+        }
+        &SqlState::INSUFFICIENT_PRIVILEGE => ApiError::Forbidden("not permitted".into()),
+        _ => ApiError::Internal("database error".into()),
+    }
 }

--- a/apps/jobboard/src/rest/applications.rs
+++ b/apps/jobboard/src/rest/applications.rs
@@ -18,7 +18,6 @@ use axum::extract::{Path, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use std::sync::Arc;
-use tokio_postgres::error::SqlState;
 use uuid::Uuid;
 
 use crate::proto::jobboard::{
@@ -106,15 +105,7 @@ async fn submit(
             ],
         )
         .await
-        .map_err(|e| match e.code() {
-            Some(c) if c == &SqlState::UNIQUE_VIOLATION => {
-                ApiError::Conflict("you already have a pending application".into())
-            }
-            Some(c) if c == &SqlState::CHECK_VIOLATION => {
-                ApiError::BadRequest("profile draft failed validation".into())
-            }
-            _ => pg_err(e),
-        })?;
+        .map_err(pg_err)?;
     let id: Uuid = row.get(0);
 
     for vid in &body.vertical_ids {


### PR DESCRIPTION
Submitting an application returned a bare `HTTP 500` — `pg_err` logged tokio-postgres' terse "db error" and returned a generic Internal. No signal for the client, no SQLSTATE in the logs.

Now `pg_err` is the single mapping point:
- **Server logs** the full DB error: `sqlstate`, `constraint`, `table`, `detail`, `message`.
- **Client** gets a stable `code` + a safe human reason — never the raw DB text or the offending values (those carry user data / PII).

Mapping:
| case | status | client message |
|------|--------|----------------|
| `jobboard_member_applications_one_pending_uq` | 409 | you already have a pending application |
| `member_applications_user_id_fkey` | 422 | your account is not provisioned on this service yet |
| `member_application_verticals_vertical_id_fkey` | 422 | a selected vertical does not exist |
| profile/links/bio/location CHECK | 400 | profile details failed validation |
| unique (other) | 409 | that record already exists |
| foreign key (other) | 422 | a referenced record was not found |
| check / not-null / truncation | 400 | field-level reason |
| insufficient_privilege | 403 | not permitted |
| else | 500 | database error |

Adds an `Unprocessable` (422) variant; the submit handler drops its bespoke match and uses `pg_err` uniformly, so every DB callsite is covered.

Note: the 500 you hit was a **local-only** FK — you log into prod Supabase (remote auth) but the local DB's `auth.users` is empty, so the prod `user_id` has no row. Prod jobboard shares Supabase's DB, so it doesn't hit this. It now reads as a clear 422 instead of a blind 500.

Verified: `docker compose up --build` green, `/health` healthy, FK reproduced in-DB.