### PR TITLE
feat(jobboard): dev-mode user auto-provision + dev banner

### DIFF
--- a/apps/jobboard/src/auth.rs
+++ b/apps/jobboard/src/auth.rs
@@ -83,6 +83,24 @@ async fn remote_verify(app: &AppState, token: &str) -> Result<(), ApiError> {
     }
 }
 
+/// Dev-only: insert the remotely-verified user into the local auth.users so FKs
+/// resolve (the local DB has no Supabase users). Best-effort — a failure just
+/// leaves the downstream insert to surface its own FK error.
+async fn provision_dev_user(app: &AppState, user_id: Uuid) {
+    let Ok(conn) = app.db.write().await else {
+        return;
+    };
+    if let Err(e) = conn
+        .execute(
+            "INSERT INTO auth.users (id) VALUES ($1) ON CONFLICT (id) DO NOTHING",
+            &[&user_id],
+        )
+        .await
+    {
+        tracing::warn!(error = %e, "dev user provision failed");
+    }
+}
+
 pub struct AuthUser {
     pub user_id: Uuid,
     pub username: String,
@@ -123,7 +141,13 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
 
         match app.auth_mode {
             AuthMode::Local => verify_local(&token, &app.jwt_secret)?,
-            AuthMode::Remote => remote_verify(app, &token).await?,
+            AuthMode::Remote => {
+                remote_verify(app, &token).await?;
+                // Dev: prod-issued users have no row in the local auth.users, so
+                // every FK to it would fail. Mirror the verified user in once
+                // (cache-miss path only). Never runs in prod (Local mode).
+                provision_dev_user(app, user_id).await;
+            }
         }
 
         let cached = CachedAuth {

--- a/apps/jobboard/src/error.rs
+++ b/apps/jobboard/src/error.rs
@@ -2,6 +2,7 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
 use std::borrow::Cow;
+use tokio_postgres::error::SqlState;
 
 #[derive(Debug, thiserror::Error)]
 pub enum ApiError {
@@ -15,6 +16,8 @@ pub enum ApiError {
     BadRequest(String),
     #[error("conflict: {0}")]
     Conflict(String),
+    #[error("unprocessable: {0}")]
+    Unprocessable(String),
     #[error("database: {0}")]
     Database(#[from] jedi::entity::error::JediError),
     #[error("internal: {0}")]
@@ -29,6 +32,7 @@ impl ApiError {
             Self::Forbidden(_) => StatusCode::FORBIDDEN,
             Self::BadRequest(_) => StatusCode::BAD_REQUEST,
             Self::Conflict(_) => StatusCode::CONFLICT,
+            Self::Unprocessable(_) => StatusCode::UNPROCESSABLE_ENTITY,
             Self::Database(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
@@ -40,6 +44,7 @@ impl ApiError {
             Self::Forbidden(_) => "FORBIDDEN",
             Self::BadRequest(_) => "BAD_REQUEST",
             Self::Conflict(_) => "CONFLICT",
+            Self::Unprocessable(_) => "UNPROCESSABLE",
             Self::Database(_) => "DATABASE_ERROR",
             Self::Internal(_) => "INTERNAL_ERROR",
         }
@@ -79,7 +84,68 @@ impl IntoResponse for ApiError {
 
 pub type ApiResult<T> = Result<axum::Json<T>, ApiError>;
 
+/// Map a postgres error to an ApiError. The full DB error (SQLSTATE, constraint,
+/// detail) is logged server-side; the client gets a stable reason derived from
+/// the SQLSTATE class and, for known constraints, a friendly message — never the
+/// raw DB text or the offending values (which carry user data). Add a constraint
+/// arm here when a new constraint should read as something other than its class
+/// default.
 pub fn pg_err(e: tokio_postgres::Error) -> ApiError {
-    tracing::error!(error = %e, "postgres query error");
-    ApiError::Internal("database error".into())
+    let Some(db) = e.as_db_error() else {
+        // Connection/protocol failure — no SQLSTATE to classify.
+        tracing::error!(error = %e, "postgres error (no db detail)");
+        return ApiError::Internal("database error".into());
+    };
+
+    let sqlstate = db.code();
+    let constraint = db.constraint().unwrap_or("");
+    tracing::error!(
+        sqlstate = sqlstate.code(),
+        constraint = constraint,
+        table = db.table().unwrap_or(""),
+        detail = db.detail().unwrap_or(""),
+        message = db.message(),
+        "postgres query error",
+    );
+
+    // Constraint-specific friendly messages (preferred over the class default).
+    match constraint {
+        "jobboard_member_applications_one_pending_uq" => {
+            return ApiError::Conflict("you already have a pending application".into());
+        }
+        "member_applications_user_id_fkey" => {
+            return ApiError::Unprocessable(
+                "your account is not provisioned on this service yet".into(),
+            );
+        }
+        "member_application_verticals_vertical_id_fkey" => {
+            return ApiError::Unprocessable("a selected vertical does not exist".into());
+        }
+        "member_applications_profile_draft_valid_ck"
+        | "talent_profiles_links_valid_ck"
+        | "talent_profiles_bio_len_ck"
+        | "talent_profiles_location_len_ck" => {
+            return ApiError::BadRequest("profile details failed validation".into());
+        }
+        _ => {}
+    }
+
+    // SQLSTATE-class defaults for anything not named above.
+    match sqlstate {
+        &SqlState::UNIQUE_VIOLATION => ApiError::Conflict("that record already exists".into()),
+        &SqlState::FOREIGN_KEY_VIOLATION => {
+            ApiError::Unprocessable("a referenced record was not found".into())
+        }
+        &SqlState::CHECK_VIOLATION => {
+            ApiError::BadRequest("a field failed a validation rule".into())
+        }
+        &SqlState::NOT_NULL_VIOLATION => {
+            ApiError::BadRequest("a required field was missing".into())
+        }
+        &SqlState::STRING_DATA_RIGHT_TRUNCATION => {
+            ApiError::BadRequest("a field was too long".into())
+        }
+        &SqlState::INSUFFICIENT_PRIVILEGE => ApiError::Forbidden("not permitted".into()),
+        _ => ApiError::Internal("database error".into()),
+    }
 }

--- a/apps/jobboard/src/rest/applications.rs
+++ b/apps/jobboard/src/rest/applications.rs
@@ -18,7 +18,6 @@ use axum::extract::{Path, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use std::sync::Arc;
-use tokio_postgres::error::SqlState;
 use uuid::Uuid;
 
 use crate::proto::jobboard::{
@@ -106,15 +105,7 @@ async fn submit(
             ],
         )
         .await
-        .map_err(|e| match e.code() {
-            Some(c) if c == &SqlState::UNIQUE_VIOLATION => {
-                ApiError::Conflict("you already have a pending application".into())
-            }
-            Some(c) if c == &SqlState::CHECK_VIOLATION => {
-                ApiError::BadRequest("profile draft failed validation".into())
-            }
-            _ => pg_err(e),
-        })?;
+        .map_err(pg_err)?;
     let id: Uuid = row.get(0);
 
     for vid in &body.vertical_ids {

--- a/apps/jobboard/src/rest/mod.rs
+++ b/apps/jobboard/src/rest/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 
 pub fn router(app: Arc<AppState>) -> Router {
     let api = Router::new()
+        .merge(system::api_routes())
         .merge(auth::routes())
         .merge(verticals::routes())
         .merge(applications::routes());

--- a/apps/jobboard/src/rest/system.rs
+++ b/apps/jobboard/src/rest/system.rs
@@ -29,6 +29,18 @@ pub fn routes() -> Router<Arc<AppState>> {
         .route("/ready", get(readiness))
 }
 
+/// Routes merged under /api (SPA-facing). `dev` drives the dev-mode banner.
+pub fn api_routes() -> Router<Arc<AppState>> {
+    Router::new().route("/meta", get(meta))
+}
+
+async fn meta(State(app): State<Arc<AppState>>) -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "version": version(),
+        "dev": app.dev(),
+    }))
+}
+
 async fn health() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "status": "healthy",

--- a/apps/jobboard/src/state.rs
+++ b/apps/jobboard/src/state.rs
@@ -60,6 +60,13 @@ impl AppState {
             auth_cache: Mutex::new(LruCache::new(NonZeroUsize::new(2048).unwrap())),
         })
     }
+
+    /// Dev mode = remote auth: jobboard validates against live Supabase but
+    /// writes to a local DB whose auth.users is empty. Gates the dev-only
+    /// user auto-provision and the SPA dev banner. Prod uses local HS256.
+    pub fn dev(&self) -> bool {
+        matches!(self.auth_mode, AuthMode::Remote)
+    }
 }
 
 fn env_url(key: &str, default: &str) -> String {

--- a/apps/jobboard/web/src/api/client.ts
+++ b/apps/jobboard/web/src/api/client.ts
@@ -86,6 +86,16 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
 	return res.data as T;
 }
 
+export interface Meta {
+	version: string;
+	dev: boolean;
+}
+
+/** Server runtime metadata (public). `dev` drives the dev-mode banner. */
+export function fetchMeta(): Promise<Meta> {
+	return api<Meta>('/meta');
+}
+
 const qs = <T extends object>(params: T): string => {
 	const sp = new URLSearchParams();
 	for (const [k, v] of Object.entries(params)) {

--- a/apps/jobboard/web/src/components/DevBanner.tsx
+++ b/apps/jobboard/web/src/components/DevBanner.tsx
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchMeta } from '../api/client';
+
+// Thin banner shown only when the server reports dev mode (AUTH_MODE=remote):
+// auth resolves against live Supabase while data lands in the local DB, and
+// users are auto-provisioned. Renders nothing in prod.
+export function DevBanner() {
+	const { data } = useQuery({
+		queryKey: ['meta'],
+		queryFn: fetchMeta,
+		staleTime: Infinity,
+		retry: false,
+	});
+
+	if (!data?.dev) return null;
+
+	return (
+		<div className="bg-amber-500/15 px-4 py-1.5 text-center text-xs font-medium text-amber-300 ring-1 ring-inset ring-amber-500/30">
+			Dev mode — auth verified against live Supabase, data written to the
+			local DB (users auto-provisioned).
+		</div>
+	);
+}

--- a/apps/jobboard/web/src/main.tsx
+++ b/apps/jobboard/web/src/main.tsx
@@ -8,6 +8,7 @@ import { KbveProvider, KBVE_SUPABASE_ANON_KEY, useKbve } from '@kbve/rn/auth';
 import { OverlayHost, ThemeProvider, ToastViewport } from '@kbve/rn/ui';
 import { createKvPersister } from '@kbve/rn/store';
 import { router } from './router';
+import { DevBanner } from './components/DevBanner';
 import { setAuthTokenGetter } from './api/client';
 import { queryClient } from './lib/queryClient';
 import { jobboardTheme } from './lib/theme';
@@ -44,6 +45,7 @@ createRoot(document.getElementById('root')!).render(
 				<PersistQueryClientProvider
 					client={queryClient}
 					persistOptions={{ persister }}>
+					<DevBanner />
 					{/* Public marketplace — browsing needs no auth. Login
 					    lives at /login; KbveProvider supplies the session. */}
 					<RouterProvider router={router} />


### PR DESCRIPTION
Local dev verifies JWTs against **live Supabase** (remote auth) but writes to a **local DB** whose `auth.users` is empty — so every FK to it failed (the blind 500 on submit, now a clear 422 via #12727).

- **Auto-provision**: after a successful remote verify (dev / `AUTH_MODE=remote` only, cache-miss path), mirror the user into `auth.users` via `INSERT ... ON CONFLICT DO NOTHING`. Best-effort, never runs in prod (local HS256). A static docker init can't do this — the user is whoever logs in through prod auth, unknown ahead of time, so it has to happen once the JWT resolves.
- **Dev banner**: new public `GET /api/meta {version, dev}`; the SPA shows a dev-mode banner when `dev=true` so it's obvious data is landing in the local DB.

Stacks on #12727 (error mapping) — carries that commit until it merges.

Verified: `tsc` clean, `docker compose up --build` green, `/api/meta` → `{"dev":true,...}`. Minimal `auth.users` insert confirmed in-DB (fires the account trigger cleanly).