### PR TITLE
feat(cryptothrone): steal action yields loot from the itemdb pool

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/data.test.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/data.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { getItemById as getItem, getAllItems } from './items';
+import {
+	getItemById as getItem,
+	getAllItems,
+	getStealLootPool,
+	pickStealLoot,
+} from './items';
 import { getAllItems as getCanonical } from './itemdb';
 import { getNPCById, getDialogueById } from './npcs';
 
@@ -60,6 +65,25 @@ describe('items facade', () => {
 		expect(getItem('health-potion')?.name).toBe('Health Potion');
 		expect(getItem('iron-sword')).toBeDefined();
 		expect(getItem('___nope___')).toBeUndefined();
+	});
+});
+
+describe('steal loot', () => {
+	it('pool excludes quest items and is non-empty', () => {
+		const pool = getStealLootPool();
+		expect(pool.length).toBeGreaterThan(0);
+		expect(pool.every((i) => i.type !== 'quest')).toBe(true);
+		expect(
+			pool.every((i) => i.rarity === 'common' || i.rarity === 'uncommon'),
+		).toBe(true);
+	});
+
+	it('pickStealLoot returns a real registry item across the roll range', () => {
+		for (const roll of [0, 0.25, 0.5, 0.75, 0.999]) {
+			const loot = pickStealLoot(roll);
+			expect(loot).toBeDefined();
+			expect(getItem(loot!.id)).toBeDefined();
+		}
 	});
 });
 

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/data/items.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/data/items.ts
@@ -35,3 +35,24 @@ export function getItemById(id: string): ItemData | undefined {
 export function getAllItems(): ItemData[] {
 	return items;
 }
+
+const stealLootPool: ItemData[] = items.filter(
+	(i) =>
+		i.type !== 'quest' &&
+		(i.rarity === 'common' || i.rarity === 'uncommon'),
+);
+
+export function getStealLootPool(): ItemData[] {
+	return stealLootPool;
+}
+
+export function pickStealLoot(
+	roll: number = Math.random(),
+): ItemData | undefined {
+	if (stealLootPool.length === 0) return undefined;
+	const idx = Math.min(
+		stealLootPool.length - 1,
+		Math.max(0, Math.floor(roll * stealLootPool.length)),
+	);
+	return stealLootPool[idx];
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/DiceRollModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { FloatingWindow } from '@kbve/astro/ui';
 import { useGameSelector, useGameDispatch } from '../store/GameStoreContext';
+import { pickStealLoot } from '../data/items';
 
 function rollDie(): number {
 	return Math.floor(Math.random() * 6) + 1;
@@ -60,11 +61,17 @@ export function DiceRollModal() {
 		if (!diceRoll) return;
 
 		if (total >= 17) {
+			const loot = pickStealLoot();
+			if (loot) {
+				dispatch({ type: 'ADD_ITEM', payload: { itemId: loot.id } });
+			}
 			dispatch({
 				type: 'ADD_NOTIFICATION',
 				payload: {
 					title: 'Success!',
-					message: `You rolled ${total} and stole from ${diceRoll.npcName}!`,
+					message: loot
+						? `You rolled ${total} and stole ${loot.name} from ${diceRoll.npcName}!`
+						: `You rolled ${total} and stole from ${diceRoll.npcName}!`,
 					type: 'success',
 				},
 			});


### PR DESCRIPTION
A successful steal now grants a real item instead of just flavor text.

## Changes
- **items.ts**: `getStealLootPool()` — non-quest common/uncommon items from the canonical itemdb — and `pickStealLoot(roll)`, a deterministic picker across the roll range.
- **DiceRollModal**: on a successful steal, pick loot → `ADD_ITEM` → name it in the success toast.
- **data.test.ts**: pool excludes quest items and is non-empty; `pickStealLoot` resolves to a real registry item across the roll range.

## Verification
`astro-cryptothrone` 111 vitest green (incl. 2 new steal-loot tests), on top of the merged merchant-shop work (#12741).

## Note
`ADD_ITEM` is client-side, matching the existing client-only steal dice roll — the grant is cosmetic and a server `inventory:sync` is authoritative. Server-authoritative steal can be a follow-up.