### PR TITLE
fix(astro): copy rn/rn-astro/core sources in axum Dockerfiles (#12739)

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -18,6 +18,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -21,6 +21,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 COPY packages/data/codegen/*.ts packages/data/codegen/

--- a/apps/discordsh/axum-discordsh/Dockerfile
+++ b/apps/discordsh/axum-discordsh/Dockerfile
@@ -23,6 +23,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 # Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 # Copy generated schemas (content collections may import these)
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/

--- a/apps/herbmail/axum-herbmail/Dockerfile
+++ b/apps/herbmail/axum-herbmail/Dockerfile
@@ -20,6 +20,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 

--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -20,6 +20,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -26,6 +26,9 @@ COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/devops/ packages/npm/devops/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 # Copy generated schemas used by astro-kbve content collections
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/

--- a/apps/memes/axum-memes/Dockerfile
+++ b/apps/memes/axum-memes/Dockerfile
@@ -23,6 +23,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 # Copy workspace package sources (TypeScript path aliases resolve to these)
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 # Copy generated schemas (content collections may import these)
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -18,6 +18,9 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/rn/ packages/npm/rn/
+COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 
 COPY packages/data/codegen/generated/ packages/data/codegen/generated/
 


### PR DESCRIPTION
## Problem

axum-kbve Docker build fails (#12739):

```
[vite]: Rollup failed to resolve import "@kbve/rn-astro" from
"/app/apps/kbve/astro-kbve/src/components/rnweb/RnWebDemo.tsx".
```

The axum/astro Dockerfiles copy workspace package **sources** by hand so the astro-app `tsconfig.json` path aliases (e.g. `@kbve/rn-astro` → `../../../packages/npm/rn-astro/src/index.ts`) resolve at build time. #12715 added the `RnWebDemo.tsx` → `@kbve/rn-astro` import but never added the matching `COPY` lines, so the source dir was absent in the Docker build context → Rollup resolution failure. (Local nx build passes because pnpm symlinks the workspace into `node_modules`; the Docker context only has what's explicitly copied.)

## Fix

Add `COPY packages/npm/{core,rn,rn-astro}` to **every** axum/astro Docker build. Dependency chain: `rn-astro` → `@kbve/rn/ui` → `@kbve/core` → `@kbve/astro` (already copied).

The other seven astro apps don't import `rn-astro` yet, but wiring the copies in now lets each adopt the RN-on-web bridge without a follow-up Docker fix. Source-only copies are unreferenced where unused, so they have **no effect** on those builds (Astro/Rollup only bundles imported modules).

## Files

8 Dockerfiles, +3 lines each:
axum-kbve, axum-herbmail, axum-discordsh, axum-cryptothrone, axum-chuckrpg, axum-rareicon, axum-memes, irc-gateway.

Verified the other seven had no existing gap (their `@kbve/*` imports already resolve to copied `packages/data/codegen/...` / npm dirs).