### PR TITLE
fix(rows): repoint GameOps dashboard at per-tenant ROWS namespaces

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactRowsDashboard.tsx
@@ -7,7 +7,11 @@ import {
 	$activePlayers,
 	$instanceLog,
 	$deploymentInfo,
+	$tenants,
+	$selectedTenant,
 	fetchAll,
+	fetchTenants,
+	setTenant,
 	statusColor,
 	formatUptime,
 	type HealthCheck,
@@ -486,11 +490,38 @@ function TimelineCard() {
 // Main Dashboard Component
 // ---------------------------------------------------------------------------
 
+function TenantSelector() {
+	const tenants = useStore($tenants);
+	const selected = useStore($selectedTenant);
+	if (tenants.length < 2) return null;
+	return (
+		<select
+			value={selected ?? ''}
+			onChange={(e) => void setTenant(e.target.value)}
+			style={{
+				background: 'var(--sl-color-bg-nav, #161b22)',
+				color: 'var(--sl-color-text, #e6edf3)',
+				border: '1px solid var(--sl-color-hairline, #30363d)',
+				borderRadius: 8,
+				padding: '0.4rem 0.6rem',
+				fontSize: '0.85rem',
+			}}>
+			{tenants.map((t) => (
+				<option key={t.id} value={t.id}>
+					{t.label}
+				</option>
+			))}
+		</select>
+	);
+}
+
 export default function ReactRowsDashboard() {
 	const [loading, setLoading] = useState(true);
 
 	useEffect(() => {
-		fetchAll().finally(() => setLoading(false));
+		fetchTenants()
+			.then(() => fetchAll())
+			.finally(() => setLoading(false));
 		const interval = setInterval(fetchAll, 30_000);
 		return () => clearInterval(interval);
 	}, []);
@@ -514,6 +545,15 @@ export default function ReactRowsDashboard() {
 
 	return (
 		<div style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'flex-end',
+				}}>
+				<TenantSelector />
+			</div>
+
 			{/* Row 1: Deployment + Health */}
 			<div
 				style={{

--- a/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/rowsService.ts
@@ -89,18 +89,33 @@ export interface DeploymentInfo {
 // Stores
 // ---------------------------------------------------------------------------
 
+export interface RowsTenant {
+	id: string;
+	label: string;
+	default?: boolean;
+}
+
 export const $rowsHealth = atom<RowsHealth | null>(null);
 export const $rowsHealthStatus = atom<ServiceStatus>('loading');
 export const $fleetStatus = atom<FleetStatus | null>(null);
 export const $activePlayers = atom<ActivePlayers | null>(null);
 export const $instanceLog = atom<InstanceLog | null>(null);
 export const $deploymentInfo = atom<DeploymentInfo | null>(null);
+export const $tenants = atom<RowsTenant[]>([]);
+export const $selectedTenant = atom<string | null>(null);
 
 // ---------------------------------------------------------------------------
 // Proxy base — goes through axum-kbve JWT-gated proxy
 // ---------------------------------------------------------------------------
 
-const PROXY_BASE = '/dashboard/chuckrpg/proxy';
+const PROXY_ROOT = '/dashboard/chuckrpg';
+
+function proxyBase(): string {
+	const tenant = $selectedTenant.get();
+	return tenant
+		? `${PROXY_ROOT}/proxy/${encodeURIComponent(tenant)}`
+		: `${PROXY_ROOT}/proxy`;
+}
 
 // ---------------------------------------------------------------------------
 // Fetch helpers
@@ -122,7 +137,7 @@ async function fetchRows<T>(path: string): Promise<T | null> {
 		const headers = await getAuthHeaders();
 		if (!headers.Authorization) return null;
 
-		const resp = await fetch(`${PROXY_BASE}${path}`, {
+		const resp = await fetch(`${proxyBase()}${path}`, {
 			headers,
 			signal: AbortSignal.timeout(8000),
 		});
@@ -190,6 +205,54 @@ export async function fetchInstanceLog(): Promise<void> {
 export async function fetchDeploymentInfo(): Promise<void> {
 	const data = await fetchRows<DeploymentInfo>('/api/System/DeploymentInfo');
 	if (data) $deploymentInfo.set(data);
+}
+
+/**
+ * Load the tenant list from the backend and pick a selection if none set.
+ * Returns true when at least one tenant is available.
+ */
+export async function fetchTenants(): Promise<boolean> {
+	try {
+		const headers = await getAuthHeaders();
+		if (!headers.Authorization) return false;
+		const resp = await fetch(`${PROXY_ROOT}/tenants`, {
+			headers,
+			signal: AbortSignal.timeout(8000),
+		});
+		if (!resp.ok) return false;
+		const data = (await resp.json()) as {
+			tenants: RowsTenant[];
+			default?: string;
+		};
+		const tenants = data.tenants ?? [];
+		$tenants.set(tenants);
+		if (tenants.length === 0) return false;
+		const current = $selectedTenant.get();
+		if (!current || !tenants.some((t) => t.id === current)) {
+			const fallback =
+				data.default ??
+				tenants.find((t) => t.default)?.id ??
+				tenants[0].id;
+			$selectedTenant.set(fallback);
+		}
+		return true;
+	} catch (e) {
+		console.error('[rows] fetchTenants failed:', e);
+		return false;
+	}
+}
+
+/** Switch the active tenant and refetch all data for it. */
+export async function setTenant(id: string): Promise<void> {
+	if ($selectedTenant.get() === id) return;
+	$selectedTenant.set(id);
+	$rowsHealth.set(null);
+	$fleetStatus.set(null);
+	$activePlayers.set(null);
+	$instanceLog.set(null);
+	$deploymentInfo.set(null);
+	$rowsHealthStatus.set('loading');
+	await fetchAll();
 }
 
 /** Fetch all ROWS data in parallel. */

--- a/apps/kbve/axum-kbve/src/main.rs
+++ b/apps/kbve/axum-kbve/src/main.rs
@@ -230,15 +230,11 @@ async fn main() -> anyhow::Result<()> {
     }
 
     if transport::proxy::init_chuckrpg_proxy() {
-        info!("ChuckRPG proxy initialized - /dashboard/chuckrpg/proxy enabled");
+        info!(
+            "ChuckRPG proxy initialized - /dashboard/chuckrpg/proxy/{{tenant}} + /api/rows/openapi.json enabled"
+        );
     } else {
-        info!("ChuckRPG proxy not configured (CHUCKRPG_UPSTREAM_URL not set)");
-    }
-
-    if transport::proxy::init_chuckrpg_docs_proxy() {
-        info!("ChuckRPG docs proxy initialized - /api/rows/openapi.json enabled");
-    } else {
-        info!("ChuckRPG docs proxy not configured (CHUCKRPG_DOCS_URL not set)");
+        info!("ChuckRPG proxy not configured (CHUCKRPG_TENANTS not set)");
     }
 
     // Initialize game server (headless Bevy + lightyear + avian3d)

--- a/apps/kbve/axum-kbve/src/transport/https.rs
+++ b/apps/kbve/axum-kbve/src/transport/https.rs
@@ -694,11 +694,11 @@ fn router(state: AppState) -> Router {
             any(super::proxy::edge_proxy_handler),
         )
         .route(
-            "/dashboard/chuckrpg/proxy/{*path}",
-            any(super::proxy::chuckrpg_proxy_handler),
+            "/dashboard/chuckrpg/tenants",
+            axum::routing::get(super::proxy::chuckrpg_tenants_handler),
         )
         .route(
-            "/dashboard/chuckrpg/proxy",
+            "/dashboard/chuckrpg/proxy/{tenant}/{*path}",
             any(super::proxy::chuckrpg_proxy_handler),
         );
 

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use axum::{
@@ -2454,103 +2455,272 @@ pub async fn edge_proxy_handler(path: Option<Path<String>>, req: Request<Body>) 
     }
 }
 
-static CHUCKRPG: OnceLock<ServiceProxy> = OnceLock::new();
+/// One ROWS tenant: a main `/api/*` proxy plus its docs/openapi proxy.
+struct ChuckRpgTenant {
+    id: String,
+    label: String,
+    main: ServiceProxy,
+    docs: ServiceProxy,
+}
 
+/// Registry of all configured ROWS tenants, keyed by id, with insertion order
+/// preserved for stable listing and a default for tenant-less requests.
+struct ChuckRpgRegistry {
+    tenants: HashMap<String, ChuckRpgTenant>,
+    order: Vec<String>,
+    default_id: String,
+}
+
+static CHUCKRPG: OnceLock<ChuckRpgRegistry> = OnceLock::new();
+
+fn build_chuckrpg_client() -> Client {
+    Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("failed to build reqwest client for chuckrpg proxy")
+}
+
+fn chuckrpg_guid_headers(id: &str, guid: Option<&str>) -> Vec<(HeaderName, HeaderValue)> {
+    let mut headers = Vec::new();
+    match guid.map(str::trim).filter(|g| !g.is_empty()) {
+        Some(g) => match HeaderValue::from_str(g) {
+            Ok(val) => headers.push((HeaderName::from_static("x-customerguid"), val)),
+            Err(e) => {
+                warn!(tenant = %id, error = %e, "invalid ROWS customer guid, header not injected")
+            }
+        },
+        None => warn!(tenant = %id, "no customer guid — ROWS /api/System/* will return 401"),
+    }
+    headers
+}
+
+fn make_chuckrpg_tenant(
+    id: String,
+    label: String,
+    upstream: String,
+    docs: String,
+    guid: Option<&str>,
+) -> ChuckRpgTenant {
+    let main = ServiceProxy {
+        name: "ChuckRPG",
+        client: build_chuckrpg_client(),
+        upstream,
+        upstream_token: None,
+        upstream_headers: chuckrpg_guid_headers(&id, guid),
+        iframe_safe: false,
+        streaming: false,
+    };
+    let docs = ServiceProxy {
+        name: "ChuckRPG-Docs",
+        client: build_chuckrpg_client(),
+        upstream: docs,
+        upstream_token: None,
+        upstream_headers: Vec::new(),
+        iframe_safe: false,
+        streaming: false,
+    };
+    ChuckRpgTenant {
+        id,
+        label,
+        main,
+        docs,
+    }
+}
+
+/// Parse `CHUCKRPG_TENANTS` (JSON array of {id,label,upstream,docs,guid_env}),
+/// resolving each tenant's customer guid from the env var it names. Falls back
+/// to the legacy single-tenant `CHUCKRPG_UPSTREAM_URL` envs when unset.
 pub fn init_chuckrpg_proxy() -> bool {
-    let upstream = match std::env::var("CHUCKRPG_UPSTREAM_URL") {
-        Ok(u) => u.trim_end_matches('/').to_string(),
-        Err(_) => return false,
+    let raw = match std::env::var("CHUCKRPG_TENANTS") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => return init_chuckrpg_proxy_legacy(),
     };
 
-    let mut upstream_headers: Vec<(HeaderName, HeaderValue)> = Vec::new();
-    match std::env::var("CHUCKRPG_CUSTOMER_GUID") {
-        Ok(guid) => {
-            let trimmed = guid.trim();
-            if trimmed.is_empty() {
-                warn!("CHUCKRPG_CUSTOMER_GUID set but empty — ROWS /api/System/* will return 401");
-            } else {
-                match HeaderValue::from_str(trimmed) {
-                    Ok(val) => {
-                        upstream_headers.push((HeaderName::from_static("x-customerguid"), val))
-                    }
-                    Err(e) => {
-                        warn!(error = %e, "invalid CHUCKRPG_CUSTOMER_GUID, header not injected")
-                    }
-                }
-            }
+    let parsed: serde_json::Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(error = %e, "CHUCKRPG_TENANTS is not valid JSON — ROWS proxy disabled");
+            return false;
         }
-        Err(_) => warn!("CHUCKRPG_CUSTOMER_GUID unset — ROWS /api/System/* will return 401"),
+    };
+    let arr = match parsed.as_array() {
+        Some(a) => a,
+        None => {
+            warn!("CHUCKRPG_TENANTS must be a JSON array — ROWS proxy disabled");
+            return false;
+        }
+    };
+
+    let mut tenants = HashMap::new();
+    let mut order = Vec::new();
+    for item in arr {
+        let id = item
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if id.is_empty() {
+            warn!("CHUCKRPG_TENANTS entry missing 'id' — skipped");
+            continue;
+        }
+        let label = item
+            .get("label")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| id.clone());
+        let upstream = item
+            .get("upstream")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim_end_matches('/')
+            .to_string();
+        if upstream.is_empty() {
+            warn!(tenant = %id, "CHUCKRPG_TENANTS entry missing 'upstream' — skipped");
+            continue;
+        }
+        let docs = item
+            .get("docs")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim_end_matches('/').to_string())
+            .unwrap_or_else(|| upstream.clone());
+        let guid = item
+            .get("guid_env")
+            .and_then(|v| v.as_str())
+            .and_then(|name| std::env::var(name).ok());
+
+        tenants.insert(
+            id.clone(),
+            make_chuckrpg_tenant(id.clone(), label, upstream, docs, guid.as_deref()),
+        );
+        order.push(id);
     }
 
-    let client = Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(Duration::from_secs(5))
-        .timeout(Duration::from_secs(15))
-        .build()
-        .expect("failed to build reqwest client for chuckrpg proxy");
-
+    if tenants.is_empty() {
+        warn!("CHUCKRPG_TENANTS produced no valid tenants — ROWS proxy disabled");
+        return false;
+    }
+    let default_id = order[0].clone();
     CHUCKRPG
-        .set(ServiceProxy {
-            name: "ChuckRPG",
-            client,
-            upstream,
-            upstream_token: None,
-            upstream_headers,
-            iframe_safe: false,
-            streaming: false,
+        .set(ChuckRpgRegistry {
+            tenants,
+            order,
+            default_id,
         })
         .is_ok()
 }
 
-pub async fn chuckrpg_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
+fn init_chuckrpg_proxy_legacy() -> bool {
+    let upstream = match std::env::var("CHUCKRPG_UPSTREAM_URL") {
+        Ok(u) if !u.trim().is_empty() => u.trim_end_matches('/').to_string(),
+        _ => return false,
+    };
+    let docs = std::env::var("CHUCKRPG_DOCS_URL")
+        .ok()
+        .map(|s| s.trim_end_matches('/').to_string())
+        .unwrap_or_else(|| upstream.clone());
+    let guid = std::env::var("CHUCKRPG_CUSTOMER_GUID").ok();
+    let id = "default".to_string();
+    let mut tenants = HashMap::new();
+    tenants.insert(
+        id.clone(),
+        make_chuckrpg_tenant(
+            id.clone(),
+            "ROWS".to_string(),
+            upstream,
+            docs,
+            guid.as_deref(),
+        ),
+    );
+    CHUCKRPG
+        .set(ChuckRpgRegistry {
+            tenants,
+            order: vec![id.clone()],
+            default_id: id,
+        })
+        .is_ok()
+}
+
+fn chuckrpg_not_configured() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        axum::Json(json!({"error": "ChuckRPG proxy not configured"})),
+    )
+        .into_response()
+}
+
+fn chuckrpg_unknown_tenant(tenant: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        axum::Json(json!({"error": format!("unknown ROWS tenant '{tenant}'")})),
+    )
+        .into_response()
+}
+
+/// `/dashboard/chuckrpg/proxy/{tenant}/{*path}` — route to the named tenant's
+/// main proxy.
+pub async fn chuckrpg_proxy_handler(
+    Path((tenant, rest)): Path<(String, String)>,
+    req: Request<Body>,
+) -> Response {
     match CHUCKRPG.get() {
-        Some(proxy) => proxy.handle(path, req).await,
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(json!({"error": "ChuckRPG proxy not configured"})),
-        )
-            .into_response(),
+        Some(reg) => match reg.tenants.get(tenant.trim()) {
+            Some(t) => t.main.handle(Some(Path(rest)), req).await,
+            None => chuckrpg_unknown_tenant(&tenant),
+        },
+        None => chuckrpg_not_configured(),
     }
 }
 
-static CHUCKRPG_DOCS: OnceLock<ServiceProxy> = OnceLock::new();
-
-pub fn init_chuckrpg_docs_proxy() -> bool {
-    let upstream = std::env::var("CHUCKRPG_DOCS_URL")
-        .unwrap_or_else(|_| "http://rows.rows.svc.cluster.local:4323".into());
-
-    let client = Client::builder()
-        .redirect(reqwest::redirect::Policy::none())
-        .connect_timeout(Duration::from_secs(5))
-        .timeout(Duration::from_secs(15))
-        .build()
-        .expect("failed to build reqwest client for chuckrpg docs proxy");
-
-    CHUCKRPG_DOCS
-        .set(ServiceProxy {
-            name: "ChuckRPG-Docs",
-            client,
-            upstream: upstream.trim_end_matches('/').to_string(),
-            upstream_token: None,
-            upstream_headers: Vec::new(),
-            iframe_safe: false,
-            streaming: false,
-        })
-        .is_ok()
+/// `/dashboard/chuckrpg/tenants` — list configured tenants for the dashboard
+/// selector. Gated by DASHBOARD_VIEW like the proxied endpoints.
+pub async fn chuckrpg_tenants_handler(req: Request<Body>) -> Response {
+    let req_headers = req.headers().clone();
+    let raw_query = req.uri().query().map(|q| q.to_string());
+    if let Err(resp) =
+        require_dashboard_view_with_query(&req_headers, raw_query.as_deref(), "ChuckRPG").await
+    {
+        return resp;
+    }
+    match CHUCKRPG.get() {
+        Some(reg) => {
+            let list: Vec<_> = reg
+                .order
+                .iter()
+                .filter_map(|id| reg.tenants.get(id))
+                .map(|t| json!({"id": t.id, "label": t.label, "default": t.id == reg.default_id}))
+                .collect();
+            axum::Json(json!({"tenants": list, "default": reg.default_id})).into_response()
+        }
+        None => chuckrpg_not_configured(),
+    }
 }
 
 pub async fn chuckrpg_openapi_handler(req: Request<Body>) -> Response {
-    match CHUCKRPG_DOCS.get() {
-        Some(proxy) => {
-            proxy
-                .handle_preauthorized(Some(Path("api-docs/openapi.json".to_string())), req)
-                .await
+    let tenant = req.uri().query().and_then(|q| {
+        q.split('&')
+            .find_map(|kv| kv.strip_prefix("tenant="))
+            .map(|s| s.to_string())
+    });
+    match CHUCKRPG.get() {
+        Some(reg) => {
+            let key = tenant
+                .as_deref()
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or(&reg.default_id);
+            match reg.tenants.get(key) {
+                Some(t) => {
+                    t.docs
+                        .handle_preauthorized(Some(Path("api-docs/openapi.json".to_string())), req)
+                        .await
+                }
+                None => chuckrpg_unknown_tenant(key),
+            }
         }
-        None => (
-            StatusCode::SERVICE_UNAVAILABLE,
-            axum::Json(json!({"error": "ChuckRPG docs proxy not configured"})),
-        )
-            .into_response(),
+        None => chuckrpg_not_configured(),
     }
 }
 

--- a/apps/kube/kbve/manifest/kbve-deployment.yaml
+++ b/apps/kube/kbve/manifest/kbve-deployment.yaml
@@ -132,14 +132,17 @@ spec:
                         value: '/etc/ssl/webtransport-selfsigned/tls.crt'
                       - name: GAME_WT_SELFSIGNED_KEY
                         value: '/etc/ssl/webtransport-selfsigned/tls.key'
-                      - name: CHUCKRPG_UPSTREAM_URL
-                        value: 'http://rows.rows.svc.cluster.local:4322'
-                      - name: CHUCKRPG_DOCS_URL
-                        value: 'http://rows.rows.svc.cluster.local:4323'
-                      - name: CHUCKRPG_CUSTOMER_GUID
+                      - name: CHUCKRPG_TENANTS
+                        value: '[{"id":"chuckrpg-dev","label":"ChuckRPG Dev","upstream":"http://rows.rows-chuckrpg-dev.svc.cluster.local:4322","docs":"http://rows.rows-chuckrpg-dev.svc.cluster.local:4323","guid_env":"CHUCKRPG_GUID_DEV"},{"id":"chuckrpg-beta","label":"ChuckRPG Beta","upstream":"http://rows.rows-chuckrpg-beta.svc.cluster.local:4322","docs":"http://rows.rows-chuckrpg-beta.svc.cluster.local:4323","guid_env":"CHUCKRPG_GUID_BETA"}]'
+                      - name: CHUCKRPG_GUID_DEV
                         valueFrom:
                             secretKeyRef:
-                                name: chuckrpg-customer-guid
+                                name: chuckrpg-guid-dev
+                                key: customer-guid
+                      - name: CHUCKRPG_GUID_BETA
+                        valueFrom:
+                            secretKeyRef:
+                                name: chuckrpg-guid-beta
                                 key: customer-guid
                       # MC RCON (multi-server) — drives /api/v1/mc/players.
                       # axum-kbve polls both backends in parallel, tags each

--- a/apps/kube/kbve/manifest/rows-customer-guid-externalsecret.yaml
+++ b/apps/kube/kbve/manifest/rows-customer-guid-externalsecret.yaml
@@ -1,12 +1,12 @@
 apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
-    name: rows-remote-secret-store
+    name: rows-chuckrpg-dev-secret-store
     namespace: kbve
 spec:
     provider:
         kubernetes:
-            remoteNamespace: rows
+            remoteNamespace: rows-chuckrpg-dev
             auth:
                 serviceAccount:
                     name: kbve-external-secrets
@@ -22,18 +22,58 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-    name: chuckrpg-customer-guid
+    name: chuckrpg-guid-dev
     namespace: kbve
 spec:
     refreshInterval: 1h
     secretStoreRef:
-        name: rows-remote-secret-store
+        name: rows-chuckrpg-dev-secret-store
         kind: SecretStore
     target:
-        name: chuckrpg-customer-guid
+        name: chuckrpg-guid-dev
         creationPolicy: Owner
     data:
         - secretKey: customer-guid
           remoteRef:
-              key: ows-customer-guid
+              key: rows-customer-guid
+              property: customer-guid
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: rows-chuckrpg-beta-secret-store
+    namespace: kbve
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: rows-chuckrpg-beta
+            auth:
+                serviceAccount:
+                    name: kbve-external-secrets
+                    namespace: kbve
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: chuckrpg-guid-beta
+    namespace: kbve
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: rows-chuckrpg-beta-secret-store
+        kind: SecretStore
+    target:
+        name: chuckrpg-guid-beta
+        creationPolicy: Owner
+    data:
+        - secretKey: customer-guid
+          remoteRef:
+              key: rows-customer-guid
               property: customer-guid

--- a/apps/kube/rows/tenants/base/kbve-guid-rbac.yaml
+++ b/apps/kube/rows/tenants/base/kbve-guid-rbac.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: customer-guid-reader-for-kbve
+    labels:
+        app.kubernetes.io/part-of: rows
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'list', 'watch']
+      resourceNames: ['rows-customer-guid']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: kbve-read-customer-guid
+    labels:
+        app.kubernetes.io/part-of: rows
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: customer-guid-reader-for-kbve
+subjects:
+    - kind: ServiceAccount
+      name: kbve-external-secrets
+      namespace: kbve

--- a/apps/kube/rows/tenants/base/kustomization.yaml
+++ b/apps/kube/rows/tenants/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
     - seed-job.yaml
     - secrets.yaml
     - routing.yaml
+    - kbve-guid-rbac.yaml
 
 # tenants_init.sql is a copy of packages/data/sql/schema/ows/seed/tenants_init.sql.
 # kustomize cannot read files outside its root (no LoadRestrictionsNone configured),


### PR DESCRIPTION
## Problem

GameOps → ROWS dashboard shows **System Health → Unable to reach ROWS**.

`axum-kbve` still proxied `rows.rows.svc.cluster.local:4322/4323`, but ROWS went multi-tenant and moved to per-tenant namespaces (`rows-chuckrpg-dev`, `rows-chuckrpg-beta`). The old single `rows` service no longer exists, so every `/api/System/*` call 502s → frontend renders the error state.

## Fix

**Backend (`axum-kbve`)**
- Replace the single `CHUCKRPG`/`CHUCKRPG_DOCS` proxies with a tenant registry parsed from `CHUCKRPG_TENANTS` (JSON: `id`/`label`/`upstream`/`docs`/`guid_env`). Each tenant carries its own `x-customerguid`.
- New routes: `/dashboard/chuckrpg/proxy/{tenant}/{*path}` and `/dashboard/chuckrpg/tenants` (gated by `DASHBOARD_VIEW`). `openapi` accepts `?tenant=`.
- Legacy single-env (`CHUCKRPG_UPSTREAM_URL`) path kept as fallback.

**Frontend (`astro-kbve`)**
- `rowsService.ts`: `$tenants` / `$selectedTenant`, `fetchTenants()`, `setTenant()`; proxy base is tenant-scoped.
- `ReactRowsDashboard.tsx`: tenant `<select>` (hidden when < 2 tenants).

**K8s (`apps/kube`)**
- `kbve-deployment.yaml`: `CHUCKRPG_TENANTS` JSON (dev + beta) + `CHUCKRPG_GUID_DEV`/`CHUCKRPG_GUID_BETA` from new secrets.
- `rows-customer-guid-externalsecret.yaml`: two SecretStores (per tenant ns) + two ExternalSecrets producing `chuckrpg-guid-dev`/`chuckrpg-guid-beta` from each tenant's `rows-customer-guid`.
- `rows/tenants/base/kbve-guid-rbac.yaml`: Role+RoleBinding so the `kbve-external-secrets` SA can read `rows-customer-guid` in each tenant namespace.

## Verification
- `cargo check -p axum-kbve` — 0 errors.
- Frontend type-check clean (only pre-existing path-alias noise).

## Rollout notes
- ArgoCD tracks `main`; live only after the dev→main release. ExternalSecrets + RBAC must sync before the deployment rollout consumes the new GUID secrets.
- Adding a tenant later = append to `CHUCKRPG_TENANTS` + add its `*_GUID_*` env/ExternalSecret; base RBAC already covers any deployed tenant overlay.