### PR TITLE
fix(kbve-gate): unblock first ghcr publish via version.toml sentinel

### DIFF
--- a/apps/kbve/kbve-gate/version.toml
+++ b/apps/kbve/kbve-gate/version.toml
@@ -1,2 +1,2 @@
-version = "0.1.0"
+version = "0.0.1"
 publish = true


### PR DESCRIPTION
## Problem

`n8n.kbve.com` is not requesting a JWT — the kbve-gate sidecar never deployed because its image was never published.

- `ghcr.io/kbve/kbve-gate` = 404, zero ci-docker runs ever
- MDX `version: 0.1.0` == `version.toml version = 0.1.0`
- ci-main version gate is file-based: `is_newer(MDX, toml)` → equal → "version published, skip"
- Deadlock: no file changes + toml==MDX → skipped on every main push, so the image never builds

The deployment pins `ghcr.io/kbve/kbve-gate:latest` (IfNotPresent) → new ReplicaSet ImagePullBackOff → old gateless n8n pod keeps serving → no auth gating.

## Fix

Reset `apps/kbve/kbve-gate/version.toml` to the `0.0.1` sentinel so MDX `0.1.0` outranks it. Next main push dispatches ci-docker → publishes `ghcr.io/kbve/kbve-gate:0.1.0` + `:latest`. Post-publish atom resyncs the toml to 0.1.0 and pins the n8n sidecar tag.

`0.0.1` not `0.0.0` — the gate guards `0.0.0` → false.

## Follow-up

Gate only dispatches off **main** pushes; reaches the cluster after the dev→main release PR.