### PR TITLE
fix(kbve-gate): add container/containerx nx targets

### DIFF
--- a/apps/kbve/kbve-gate/project.json
+++ b/apps/kbve/kbve-gate/project.json
@@ -36,6 +36,58 @@
 			"options": {
 				"target-dir": "dist/target/kbve-gate"
 			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx kbve-gate:containerx",
+						"VERSION=$(grep '^version' apps/kbve/kbve-gate/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve-gate:latest kbve/kbve-gate:$VERSION && echo \"Tagged kbve/kbve-gate:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx kbve-gate:containerx --configuration=production",
+						"VERSION=$(grep '^version' apps/kbve/kbve-gate/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/kbve-gate:latest kbve/kbve-gate:$VERSION && docker tag ghcr.io/kbve/kbve-gate:latest ghcr.io/kbve/kbve-gate:$VERSION && echo \"Tagged kbve/kbve-gate:$VERSION\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/kbve/kbve-gate/Dockerfile",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/kbve-gate:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"metadata": {
+						"images": ["ghcr.io/kbve/kbve-gate", "kbve/kbve-gate"],
+						"tags": ["latest"]
+					},
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/kbve-gate:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/kbve-gate:buildcache,mode=max"
+					]
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Problem

`CI - Docker / kbve-gate` (run #27783717724, issue #12751) failed with:

```
NX  Cannot find configuration for task kbve-gate:container
```

The Docker publish workflow dispatches `kbve-gate:container --configuration=production`, but `apps/kbve/kbve-gate/project.json` only defined build/test/lint/run — no `container` target.

## Fix

Add `container` + `containerx` targets mirroring the proven `irc-gateway` pattern, retargeted at kbve-gate (Dockerfile already shipped in #12654). `nx show project kbve-gate` now resolves both targets.

Closes #12751