### PR TITLE
fix(cryptothrone-server): copy itemdb-data.json into Docker builder

### DIFF
--- a/apps/agones/cryptothrone/server/Dockerfile
+++ b/apps/agones/cryptothrone/server/Dockerfile
@@ -62,6 +62,7 @@ COPY Cargo.lock ./
 COPY packages/rust/simgrid packages/rust/simgrid
 COPY packages/rust/jedi packages/rust/jedi
 COPY packages/data/codegen/generated/npcdb-data.json packages/data/codegen/generated/npcdb-data.json
+COPY packages/data/codegen/generated/itemdb-data.json packages/data/codegen/generated/itemdb-data.json
 COPY apps/agones/cryptothrone/server apps/agones/cryptothrone/server
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
Fixes #12752

`cargo build -p cryptothrone-server` failed in CI:

```
error: couldn't read `.../packages/data/codegen/generated/itemdb-data.json`: No such file or directory (os error 2)
```

Commit bb4ee014a added `include_bytes!(itemdb-data.json)` in [game.rs:19](apps/agones/cryptothrone/server/src/game.rs#L19) for the steal-loot feature, but the Dockerfile builder stage only copied `npcdb-data.json`. Added the matching COPY for `itemdb-data.json`.