### PR TITLE
fix(irc-gateway): copy @kbve/chat into Docker astro builder

### DIFF
--- a/apps/irc/irc-gateway/Dockerfile
+++ b/apps/irc/irc-gateway/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/core/ packages/npm/core/
+COPY packages/npm/chat/ packages/npm/chat/
 COPY packages/npm/rn/ packages/npm/rn/
 COPY packages/npm/rn-astro/ packages/npm/rn-astro/
 


### PR DESCRIPTION
irc-gateway Docker build fails at `vite build --config vite.embed.config.ts`:

```
[vite:load-fallback] Could not load /app/packages/npm/chat/src/index.ts (imported by src/embed/state.ts): ENOENT
```

Commit e041e6a76 (share IRC codec) added a `@kbve/chat` import in the embed bundle, but the astro-builder stage only copied astro/droid/core/rn/rn-astro. Added `COPY packages/npm/chat/`.

Run: https://github.com/KBVE/kbve/actions/runs/27783715015