### PR TITLE
feat(factorio): telemetry vertical — lua → relay → ClickHouse → dashboard

### DIFF
--- a/apps/agones/factorio/mods-local/kbve/control.lua
+++ b/apps/agones/factorio/mods-local/kbve/control.lua
@@ -5,6 +5,7 @@ local ExchangeGui = require('modules.exchange_gui')
 local FleetGui = require('modules.fleet_gui')
 local FleetState = require('modules.fleet_state')
 local FleetMissions = require('modules.fleet_missions')
+local Stats = require('modules.stats')
 
 local function on_player_joined(event)
 	local player = game.get_player(event.player_index)
@@ -14,6 +15,7 @@ local function on_player_joined(event)
 	end
 	Coins.handle_player_joined(event)
 	Vault.get_or_create(event.player_index)
+	Stats.player_event('join', player and player.name)
 end
 
 local function on_chunk_generated(event)
@@ -29,6 +31,7 @@ local function on_player_left(event)
 	end
 	ExchangeGui.on_player_left(event)
 	FleetGui.on_player_left(event)
+	Stats.player_event('leave', player and player.name)
 end
 
 local function on_gui_click(event)
@@ -75,6 +78,7 @@ script.on_event(defines.events.on_gui_selected_tab_changed, on_gui_selected_tab_
 script.on_event('kbve-open-exchange', ExchangeGui.on_custom_input)
 script.on_event('kbve-open-fleet', FleetGui.on_custom_input)
 script.on_event(defines.events.on_chunk_generated, on_chunk_generated)
+script.on_nth_tick(Stats.SNAPSHOT_INTERVAL_TICKS, Stats.snapshot)
 
 local function on_tick(event)
 	FleetMissions.on_tick(event)

--- a/apps/agones/factorio/mods-local/kbve/modules/stats.lua
+++ b/apps/agones/factorio/mods-local/kbve/modules/stats.lua
@@ -1,0 +1,28 @@
+local Stats = {}
+
+Stats.SNAPSHOT_INTERVAL_TICKS = 300
+
+function Stats.snapshot()
+	local surface = game.surfaces['nauvis'] or game.surfaces[1]
+	local seed = 0
+	if surface and surface.map_gen_settings then
+		seed = surface.map_gen_settings.seed or 0
+	end
+	log(string.format(
+		'[STATS] kind=snapshot players=%d game_tick=%d seed=%d',
+		#game.connected_players,
+		game.tick,
+		seed
+	))
+end
+
+function Stats.player_event(kind, player_name)
+	log(string.format(
+		'[STATS] kind=player_event event=%s player=%s game_tick=%d',
+		kind,
+		player_name or 'unknown',
+		game.tick
+	))
+end
+
+return Stats

--- a/apps/agones/factorio/relay/Cargo.toml
+++ b/apps/agones/factorio/relay/Cargo.toml
@@ -29,7 +29,7 @@ reqwest = { version = "0.12", default-features = false, features = [
     "json",
 ] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
-jedi = { path = "../../../../packages/rust/jedi" }
+jedi = { path = "../../../../packages/rust/jedi", features = ["clickhouse"] }
 tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
 webpki-roots = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }

--- a/apps/agones/factorio/relay/src/ch_writer.rs
+++ b/apps/agones/factorio/relay/src/ch_writer.rs
@@ -1,38 +1,175 @@
+use std::time::Instant;
+
 use anyhow::Result;
+use jedi::state::sidecar::ClickHouseConfig;
+use serde_json::json;
 use tokio::sync::broadcast::Receiver;
-use tracing::{debug, warn};
+use tokio::sync::broadcast::error::RecvError;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
 
 use crate::config::Config;
-use crate::event::GameEvent;
+use crate::event::{GameEvent, GameEventKind};
+
+const SNAPSHOTS_TABLE: &str = "gameops.factorio_snapshots_raw";
+const PLAYER_EVENTS_TABLE: &str = "gameops.factorio_player_events_raw";
+const CHAT_LOG_TABLE: &str = "gameops.factorio_chat_log_raw";
+
+struct Producer {
+    ch: ClickHouseConfig,
+    cfg: Config,
+    rotation_id: String,
+    started: Instant,
+    last_snapshot: Option<(u64, Instant)>,
+}
+
+impl Producer {
+    fn now_ts() -> String {
+        chrono::Utc::now()
+            .format("%Y-%m-%d %H:%M:%S%.3f")
+            .to_string()
+    }
+
+    fn ups(&mut self, game_tick: u64) -> f32 {
+        let now = Instant::now();
+        let ups = match self.last_snapshot {
+            Some((prev_tick, prev_at)) => {
+                let secs = now.duration_since(prev_at).as_secs_f32();
+                if secs > 0.0 && game_tick >= prev_tick {
+                    (game_tick - prev_tick) as f32 / secs
+                } else {
+                    0.0
+                }
+            }
+            None => 0.0,
+        };
+        self.last_snapshot = Some((game_tick, now));
+        ups
+    }
+
+    async fn snapshot(&mut self, ev: &GameEvent) {
+        let game_tick: u64 = ev
+            .field("game_tick")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let players: u64 = ev
+            .field("players")
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        let seed: u64 = ev.field("seed").and_then(|v| v.parse().ok()).unwrap_or(0);
+        let ups = self.ups(game_tick);
+
+        let row = json!({
+            "ts": Self::now_ts(),
+            "server_id": self.cfg.server_id,
+            "scenario": self.cfg.scenario_default,
+            "rotation_id": self.rotation_id,
+            "seed": seed,
+            "players": players,
+            "auto_pause_enabled": self.cfg.auto_pause_enabled as u8,
+            "map_age_wall_s": self.started.elapsed().as_secs(),
+            "map_age_game_s": game_tick / 60,
+            "game_tick": game_tick,
+            "ups": ups,
+        });
+        self.insert(SNAPSHOTS_TABLE, row).await;
+    }
+
+    async fn player_event(&self, ev: &GameEvent, event: &str) {
+        let row = json!({
+            "ts": Self::now_ts(),
+            "server_id": self.cfg.server_id,
+            "scenario": self.cfg.scenario_default,
+            "rotation_id": self.rotation_id,
+            "player": ev.player.as_deref().unwrap_or("unknown"),
+            "event": event,
+            "game_tick": ev.field("game_tick").and_then(|v| v.parse::<u64>().ok()).unwrap_or(0),
+        });
+        self.insert(PLAYER_EVENTS_TABLE, row).await;
+    }
+
+    async fn chat(&self, ev: &GameEvent) {
+        let row = json!({
+            "ts": Self::now_ts(),
+            "server_id": self.cfg.server_id,
+            "scenario": self.cfg.scenario_default,
+            "rotation_id": self.rotation_id,
+            "player": ev.player.as_deref().unwrap_or("unknown"),
+            "mode": "chat",
+            "message": ev.text,
+            "game_tick": 0u64,
+        });
+        self.insert(CHAT_LOG_TABLE, row).await;
+    }
+
+    async fn insert(&self, table: &str, row: serde_json::Value) {
+        match self
+            .ch
+            .execute_insert(table, std::slice::from_ref(&row))
+            .await
+        {
+            Ok(()) => debug!(table, "inserted row"),
+            Err(e) => warn!(table, error = %e, "clickhouse insert failed"),
+        }
+    }
+
+    async fn handle(&mut self, ev: GameEvent) {
+        match ev.kind {
+            GameEventKind::Stats => match ev.field("kind") {
+                Some("snapshot") => self.snapshot(&ev).await,
+                Some("player_event") => {
+                    let event = ev.field("event").unwrap_or("join").to_string();
+                    self.player_event(&ev, &event).await;
+                }
+                _ => {}
+            },
+            GameEventKind::Join => self.player_event(&ev, "join").await,
+            GameEventKind::Leave => self.player_event(&ev, "leave").await,
+            GameEventKind::Chat => self.chat(&ev).await,
+            GameEventKind::Command => {}
+        }
+    }
+}
 
 pub async fn run(cfg: Config, mut rx: Receiver<GameEvent>) -> Result<()> {
-    if cfg.clickhouse_url.is_none() {
+    let Some(url) = cfg.clickhouse_url.clone() else {
         warn!("ch_writer disabled: CLICKHOUSE_URL not set");
         loop {
             match rx.recv().await {
                 Ok(_) => {}
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                Err(RecvError::Closed) => break,
                 Err(_) => continue,
             }
         }
         return Ok(());
-    }
+    };
 
-    warn!(
-        url = %cfg.clickhouse_url.as_deref().unwrap_or(""),
-        database = %cfg.clickhouse_database,
-        "ch_writer stubbed (Phase 4d) — events logged but not inserted"
+    let ch = ClickHouseConfig {
+        url,
+        user: cfg.clickhouse_user.clone().unwrap_or_default(),
+        password: cfg.clickhouse_password.clone().unwrap_or_default(),
+        database: cfg.clickhouse_database.clone(),
+    };
+
+    let mut producer = Producer {
+        ch,
+        rotation_id: Uuid::new_v4().to_string(),
+        started: Instant::now(),
+        last_snapshot: None,
+        cfg,
+    };
+
+    info!(
+        rotation_id = %producer.rotation_id,
+        database = %producer.cfg.clickhouse_database,
+        "ch_writer active — inserting into gameops.factorio_*"
     );
 
     loop {
         match rx.recv().await {
-            Ok(ev) => {
-                debug!(?ev, "would insert into gameops.factorio_*");
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                warn!(skipped = n, "ch_writer lagged on broadcast");
-            }
-            Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+            Ok(ev) => producer.handle(ev).await,
+            Err(RecvError::Lagged(n)) => warn!(skipped = n, "ch_writer lagged on broadcast"),
+            Err(RecvError::Closed) => break,
         }
     }
     Ok(())

--- a/apps/agones/factorio/relay/src/config.rs
+++ b/apps/agones/factorio/relay/src/config.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub agones_health_interval_secs: u64,
     pub agones_rcon_probe_timeout_secs: u64,
     pub agones_initial_ready_delay_secs: u64,
+    pub auto_pause_enabled: bool,
 }
 
 impl Config {
@@ -56,6 +57,7 @@ impl Config {
             agones_health_interval_secs: parse_env_u64("AGONES_HEALTH_INTERVAL_SECS", 5)?,
             agones_rcon_probe_timeout_secs: parse_env_u64("AGONES_RCON_PROBE_TIMEOUT_SECS", 2)?,
             agones_initial_ready_delay_secs: parse_env_u64("AGONES_INITIAL_READY_DELAY_SECS", 0)?,
+            auto_pause_enabled: parse_env_bool("FACTORIO_AUTO_PAUSE", true),
         })
     }
 }

--- a/apps/agones/factorio/relay/src/event.rs
+++ b/apps/agones/factorio/relay/src/event.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -15,6 +17,13 @@ pub struct GameEvent {
     pub player: Option<String>,
     pub text: String,
     pub raw: String,
+    pub fields: HashMap<String, String>,
+}
+
+impl GameEvent {
+    pub fn field(&self, key: &str) -> Option<&str> {
+        self.fields.get(key).map(String::as_str)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/apps/agones/factorio/relay/src/log_tail.rs
+++ b/apps/agones/factorio/relay/src/log_tail.rs
@@ -72,6 +72,8 @@ fn parse_line(line: &str) -> Option<GameEvent> {
 
     let after_tag = trimmed[tag_idx + tag.len()..].trim_start();
 
+    let mut fields = std::collections::HashMap::new();
+
     let (player, text) = match kind {
         GameEventKind::Chat => match after_tag.split_once(": ") {
             Some((p, m)) => (Some(p.to_string()), m.to_string()),
@@ -81,6 +83,14 @@ fn parse_line(line: &str) -> Option<GameEvent> {
             let player = after_tag.split_whitespace().next().map(str::to_string);
             (player, after_tag.to_string())
         }
+        GameEventKind::Stats => {
+            for tok in after_tag.split_whitespace() {
+                if let Some((k, v)) = tok.split_once('=') {
+                    fields.insert(k.to_string(), v.to_string());
+                }
+            }
+            (fields.get("player").cloned(), after_tag.to_string())
+        }
         _ => (None, after_tag.to_string()),
     };
 
@@ -89,5 +99,38 @@ fn parse_line(line: &str) -> Option<GameEvent> {
         player,
         text,
         raw: trimmed.to_string(),
+        fields,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_snapshot_stats() {
+        let line = "  12.345 Script @__kbve__/control.lua:1: [STATS] kind=snapshot players=3 game_tick=18000 seed=42\n";
+        let ev = parse_line(line).expect("stats event");
+        assert!(matches!(ev.kind, GameEventKind::Stats));
+        assert_eq!(ev.field("kind"), Some("snapshot"));
+        assert_eq!(ev.field("players"), Some("3"));
+        assert_eq!(ev.field("game_tick"), Some("18000"));
+        assert_eq!(ev.field("seed"), Some("42"));
+    }
+
+    #[test]
+    fn parses_player_event_stats() {
+        let line = "[STATS] kind=player_event event=join player=Engineer game_tick=600";
+        let ev = parse_line(line).expect("stats event");
+        assert_eq!(ev.field("event"), Some("join"));
+        assert_eq!(ev.player.as_deref(), Some("Engineer"));
+    }
+
+    #[test]
+    fn parses_chat() {
+        let ev = parse_line("[CHAT] Engineer: hello world").expect("chat event");
+        assert!(matches!(ev.kind, GameEventKind::Chat));
+        assert_eq!(ev.player.as_deref(), Some("Engineer"));
+        assert_eq!(ev.text, "hello world");
+    }
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactFactorioDashboard.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactFactorioDashboard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, type ReactNode } from 'react';
 import { useStore } from '@nanostores/react';
 import {
 	Factory,
@@ -7,12 +8,27 @@ import {
 	Container,
 	Server,
 	Clock,
+	Users,
+	Gauge,
+	Hash,
+	Activity,
 } from 'lucide-react';
 import { homeService } from './homeService';
+import {
+	$current,
+	$currentStatus,
+	$playerEvents,
+	$rotations,
+	fetchAll,
+	fetchCurrent,
+	num,
+	formatGameAge,
+	isLive,
+} from './factorioTelemetryService';
 
 const IMAGE_NAME = 'ghcr.io/kbve/agones-factorio';
 const FACTORIO_VERSION = '2.0.76';
-const ISSUE_URL = 'https://github.com/KBVE/kbve/issues/11138';
+const ISSUE_URL = 'https://github.com/KBVE/kbve/issues/12735';
 const PROJECT_MDX = '/docs/project/agones-factorio/';
 
 const styles = {
@@ -41,7 +57,7 @@ const styles = {
 		gap: '0.75rem',
 		marginBottom: '1rem',
 	},
-	statusRow: {
+	statusRow: (live: boolean, error: boolean) => ({
 		display: 'inline-flex',
 		alignItems: 'center',
 		gap: '0.5rem',
@@ -49,20 +65,32 @@ const styles = {
 		borderRadius: '999px',
 		fontSize: '0.85rem',
 		fontWeight: 500,
-		background: 'rgba(210, 153, 34, 0.15)',
-		color: 'var(--sl-color-orange, #d29922)',
-		border: '1px solid rgba(210, 153, 34, 0.4)',
-	},
-	statusDot: {
+		background: error
+			? 'rgba(248, 81, 73, 0.15)'
+			: live
+				? 'rgba(63, 185, 80, 0.15)'
+				: 'rgba(210, 153, 34, 0.15)',
+		color: error
+			? 'var(--sl-color-red, #f85149)'
+			: live
+				? 'var(--sl-color-green, #3fb950)'
+				: 'var(--sl-color-orange, #d29922)',
+		border: `1px solid ${error ? 'rgba(248, 81, 73, 0.4)' : live ? 'rgba(63, 185, 80, 0.4)' : 'rgba(210, 153, 34, 0.4)'}`,
+	}),
+	statusDot: (live: boolean, error: boolean) => ({
 		width: '0.5rem',
 		height: '0.5rem',
 		borderRadius: '50%',
-		background: 'var(--sl-color-orange, #d29922)',
-	},
+		background: error
+			? 'var(--sl-color-red, #f85149)'
+			: live
+				? 'var(--sl-color-green, #3fb950)'
+				: 'var(--sl-color-orange, #d29922)',
+	}),
 	grid: {
 		display: 'grid',
 		gap: '1rem',
-		gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+		gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
 		marginTop: '1.5rem',
 	},
 	card: {
@@ -88,21 +116,23 @@ const styles = {
 		color: 'var(--sl-color-text, #e6edf3)',
 		wordBreak: 'break-all' as const,
 	},
-	roadmap: {
+	panel: {
 		marginTop: '2rem',
 		padding: '1.25rem',
 		borderRadius: '0.75rem',
 		border: '1px solid var(--sl-color-gray-5, #30363d)',
 		background: 'var(--sl-color-bg-nav, rgba(13, 17, 23, 0.6))',
 	},
-	roadmapList: {
+	list: {
 		margin: '0.75rem 0 0',
-		paddingLeft: '1.25rem',
+		padding: 0,
+		listStyle: 'none',
 		display: 'flex',
 		flexDirection: 'column' as const,
 		gap: '0.4rem',
 		color: 'var(--sl-color-gray-2, #c9d1d9)',
-		fontSize: '0.9rem',
+		fontSize: '0.85rem',
+		fontFamily: 'var(--sl-font-mono, ui-monospace, monospace)',
 	},
 	links: {
 		display: 'flex',
@@ -124,8 +154,39 @@ const styles = {
 	},
 };
 
+function Card({
+	icon,
+	label,
+	value,
+}: {
+	icon: ReactNode;
+	label: string;
+	value: string;
+}) {
+	return (
+		<div style={styles.card}>
+			<div style={styles.cardLabel}>
+				{icon}
+				{label}
+			</div>
+			<p style={styles.cardValue}>{value}</p>
+		</div>
+	);
+}
+
 export default function ReactFactorioDashboard() {
 	const isStaff = useStore(homeService.$isStaff);
+	const current = useStore($current);
+	const currentStatus = useStore($currentStatus);
+	const playerEvents = useStore($playerEvents);
+	const rotations = useStore($rotations);
+
+	useEffect(() => {
+		if (!isStaff) return;
+		fetchAll();
+		const id = setInterval(() => fetchCurrent(), 10_000);
+		return () => clearInterval(id);
+	}, [isStaff]);
 
 	if (!isStaff) {
 		return (
@@ -139,72 +200,117 @@ export default function ReactFactorioDashboard() {
 		);
 	}
 
+	const row = current?.[0];
+	const live = isLive(row);
+	const error = currentStatus === 'error';
+	const statusText = error
+		? 'Telemetry error'
+		: live
+			? `Live · ${num(row?.players)} online`
+			: currentStatus === 'loading'
+				? 'Loading…'
+				: 'No live data (server idle or not deployed)';
+
 	return (
 		<div>
 			<div style={styles.header}>
 				<Factory size={28} color="var(--sl-color-accent, #2f81f7)" />
 				<h1 style={styles.heading}>Factorio</h1>
 			</div>
-			<span style={styles.statusRow}>
-				<span style={styles.statusDot} />
-				Phase 0 · Image published · No live data yet
+			<span style={styles.statusRow(live, error)}>
+				<span style={styles.statusDot(live, error)} />
+				{statusText}
 			</span>
 
 			<div style={styles.grid}>
-				<div style={styles.card}>
-					<div style={styles.cardLabel}>
-						<Container size={16} />
-						Image
-					</div>
-					<p style={styles.cardValue}>{IMAGE_NAME}</p>
-				</div>
-				<div style={styles.card}>
-					<div style={styles.cardLabel}>
-						<Server size={16} />
-						Factorio version
-					</div>
-					<p style={styles.cardValue}>{FACTORIO_VERSION}</p>
-				</div>
-				<div style={styles.card}>
-					<div style={styles.cardLabel}>
-						<Clock size={16} />
-						GameServer / Fleet
-					</div>
-					<p style={styles.cardValue}>not deployed (Phase 1)</p>
-				</div>
+				<Card
+					icon={<Users size={16} />}
+					label="Players online"
+					value={row ? String(num(row.players)) : '—'}
+				/>
+				<Card
+					icon={<Gauge size={16} />}
+					label="UPS"
+					value={row ? num(row.ups).toFixed(1) : '—'}
+				/>
+				<Card
+					icon={<Clock size={16} />}
+					label="Map age (game)"
+					value={row ? formatGameAge(num(row.map_age_game_s)) : '—'}
+				/>
+				<Card
+					icon={<Hash size={16} />}
+					label="Seed"
+					value={row ? String(num(row.seed)) : '—'}
+				/>
+				<Card
+					icon={<Activity size={16} />}
+					label="Scenario"
+					value={row?.scenario ?? '—'}
+				/>
+				<Card
+					icon={<Server size={16} />}
+					label="Server"
+					value={row?.server_id ?? 'not deployed'}
+				/>
+				<Card
+					icon={<Container size={16} />}
+					label="Image"
+					value={IMAGE_NAME}
+				/>
+				<Card
+					icon={<Server size={16} />}
+					label="Factorio version"
+					value={FACTORIO_VERSION}
+				/>
 			</div>
 
-			<div style={styles.roadmap}>
-				<strong>Phasing</strong>
-				<ul style={styles.roadmapList}>
-					<li>
-						Phase 0 — Custom image, KBVE scenario, lifecycle shim
-						(done).
-					</li>
-					<li>
-						Phase 1 — <code>apps/kube/agones/factorio/</code>{' '}
-						GameServer / Fleet + UDP service.
-					</li>
-					<li>
-						Phase 2 — ConfigMap-driven{' '}
-						<code>server-settings.json</code> +{' '}
-						<code>ExternalSecret</code> for matchmaking token and
-						RCON password.
-					</li>
-					<li>
-						Phase 3 — <code>apps/agones/factorio/relay/</code> chat
-						relay sidecar (Rust) → IRC → existing Discord bridge.
-					</li>
-					<li>
-						Phase 2.5+ — <code>factorio-ctl</code> Axum REST API;
-						wires player count, save rotation, RCON passthrough into
-						this dashboard.
-					</li>
-					<li>
-						Phase 4 — PVC + rotation CronJob, public save download
-						URL.
-					</li>
-					<li>Phase 5 — Log / RCON metrics + UPS / player alerts.</li>
+			<div style={styles.panel}>
+				<strong>Recent player events</strong>
+				<ul style={styles.list}>
+					{playerEvents && playerEvents.length > 0 ? (
+						playerEvents.slice(0, 12).map((e, i) => (
+							<li key={`${e.ts}-${i}`}>
+								{e.ts} ·{' '}
+								{e.event === 'join'
+									? '→'
+									: e.event === 'leave'
+										? '←'
+										: '×'}{' '}
+								{e.player}
+							</li>
+						))
+					) : (
+						<li
+							style={{
+								color: 'var(--sl-color-gray-3, #8b949e)',
+							}}>
+							No events in the last 24h.
+						</li>
+					)}
+				</ul>
+			</div>
+
+			<div style={styles.panel}>
+				<strong>Map rotations</strong>
+				<ul style={styles.list}>
+					{rotations && rotations.length > 0 ? (
+						rotations.slice(0, 10).map((r) => (
+							<li key={r.rotation_id}>
+								{r.started_at} · seed {num(r.seed)} ·{' '}
+								{r.scenario} · peak {num(r.peak_players)} ·{' '}
+								{r.end_reason}
+							</li>
+						))
+					) : (
+						<li
+							style={{
+								color: 'var(--sl-color-gray-3, #8b949e)',
+							}}>
+							No rotation history yet (relay writes lifecycle rows
+							in a later phase).
+						</li>
+					)}
 				</ul>
 			</div>
 
@@ -214,7 +320,7 @@ export default function ReactFactorioDashboard() {
 					target="_blank"
 					rel="noopener"
 					style={styles.linkButton}>
-					<Github size={16} /> Tracking issue #11138
+					<Github size={16} /> Tracking issue #12735
 					<ExternalLink size={14} />
 				</a>
 				<a href={PROJECT_MDX} style={styles.linkButton}>

--- a/apps/kbve/astro-kbve/src/components/dashboard/factorioTelemetryService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/factorioTelemetryService.ts
@@ -1,0 +1,225 @@
+import { atom } from 'nanostores';
+import { initSupa, getSupa } from '@/lib/supa';
+
+// ---------------------------------------------------------------------------
+// Types — match the axum-kbve /dashboard/clickhouse/proxy factorio_* commands
+// (gameops.factorio_* tables). ClickHouse JSONEachRow can serialize UInt64 as
+// strings, so numeric fields are coerced at the display layer, not here.
+// ---------------------------------------------------------------------------
+
+export type FetchStatus = 'idle' | 'loading' | 'ok' | 'error';
+
+export interface FactorioCurrent {
+	server_id: string;
+	scenario: string;
+	rotation_id: string;
+	seed: number | string;
+	players: number | string;
+	ups: number;
+	map_age_game_s: number | string;
+	map_age_wall_s: number | string;
+	auto_pause_enabled: number | string;
+	game_tick: number | string;
+	ts: string;
+}
+
+export interface FactorioSnapshot {
+	ts: string;
+	server_id: string;
+	players: number | string;
+	ups: number;
+	map_age_game_s: number | string;
+	map_age_wall_s: number | string;
+}
+
+export interface FactorioPlayerEvent {
+	ts: string;
+	server_id: string;
+	player: string;
+	event: string;
+	game_tick: number | string;
+}
+
+export interface FactorioRotation {
+	rotation_id: string;
+	server_id: string;
+	scenario: string;
+	seed: number | string;
+	started_at: string;
+	ended_at: string | null;
+	end_reason: string;
+	peak_players: number | string;
+	joins_first_15m: number | string;
+	joins_first_60m: number | string;
+	total_player_seconds: number | string;
+	wall_age_s: number | string;
+	game_age_s: number | string;
+}
+
+// ---------------------------------------------------------------------------
+// Stores
+// ---------------------------------------------------------------------------
+
+export const $current = atom<FactorioCurrent[] | null>(null);
+export const $currentStatus = atom<FetchStatus>('idle');
+
+export const $snapshots = atom<FactorioSnapshot[] | null>(null);
+export const $snapshotsStatus = atom<FetchStatus>('idle');
+
+export const $playerEvents = atom<FactorioPlayerEvent[] | null>(null);
+export const $playerEventsStatus = atom<FetchStatus>('idle');
+
+export const $rotations = atom<FactorioRotation[] | null>(null);
+export const $rotationsStatus = atom<FetchStatus>('idle');
+
+// ---------------------------------------------------------------------------
+// Proxy + auth
+// ---------------------------------------------------------------------------
+
+const PROXY_URL = '/dashboard/clickhouse/proxy';
+
+async function getAuthHeaders(): Promise<Record<string, string>> {
+	const supa = getSupa() ?? initSupa();
+	if (!supa) return {};
+	const { session } = await supa.getSession();
+	if (!session?.access_token) return {};
+	return {
+		Authorization: `Bearer ${session.access_token}`,
+		'Content-Type': 'application/json',
+	};
+}
+
+interface ProxyResponse<T> {
+	rows: T[];
+	count: number;
+}
+
+async function proxyCommand<T>(
+	body: Record<string, unknown>,
+): Promise<T[] | null> {
+	const headers = await getAuthHeaders();
+	if (!headers.Authorization) return null;
+	try {
+		const resp = await fetch(PROXY_URL, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(body),
+			signal: AbortSignal.timeout(15000),
+		});
+		if (!resp.ok) {
+			console.warn(
+				`[factorio-telemetry] ${body.command} → HTTP ${resp.status}`,
+			);
+			return null;
+		}
+		const data = (await resp.json()) as ProxyResponse<T>;
+		return data.rows ?? [];
+	} catch (e) {
+		console.error(`[factorio-telemetry] ${body.command} failed:`, e);
+		return null;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fetchers
+// ---------------------------------------------------------------------------
+
+export async function fetchCurrent(serverId?: string): Promise<void> {
+	$currentStatus.set('loading');
+	const rows = await proxyCommand<FactorioCurrent>({
+		command: 'factorio_current',
+		minutes: 15,
+		server_id: serverId,
+	});
+	if (rows === null) {
+		$currentStatus.set('error');
+		return;
+	}
+	$current.set(rows);
+	$currentStatus.set('ok');
+}
+
+export async function fetchSnapshots(
+	serverId?: string,
+	minutes = 60,
+): Promise<void> {
+	$snapshotsStatus.set('loading');
+	const rows = await proxyCommand<FactorioSnapshot>({
+		command: 'factorio_snapshots',
+		minutes,
+		limit: 500,
+		server_id: serverId,
+	});
+	if (rows === null) {
+		$snapshotsStatus.set('error');
+		return;
+	}
+	$snapshots.set(rows);
+	$snapshotsStatus.set('ok');
+}
+
+export async function fetchPlayerEvents(serverId?: string): Promise<void> {
+	$playerEventsStatus.set('loading');
+	const rows = await proxyCommand<FactorioPlayerEvent>({
+		command: 'factorio_players',
+		minutes: 1440,
+		limit: 50,
+		server_id: serverId,
+	});
+	if (rows === null) {
+		$playerEventsStatus.set('error');
+		return;
+	}
+	$playerEvents.set(rows);
+	$playerEventsStatus.set('ok');
+}
+
+export async function fetchRotations(serverId?: string): Promise<void> {
+	$rotationsStatus.set('loading');
+	const rows = await proxyCommand<FactorioRotation>({
+		command: 'factorio_rotations',
+		limit: 25,
+		server_id: serverId,
+	});
+	if (rows === null) {
+		$rotationsStatus.set('error');
+		return;
+	}
+	$rotations.set(rows);
+	$rotationsStatus.set('ok');
+}
+
+export async function fetchAll(serverId?: string): Promise<void> {
+	await Promise.all([
+		fetchCurrent(serverId),
+		fetchSnapshots(serverId),
+		fetchPlayerEvents(serverId),
+		fetchRotations(serverId),
+	]);
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+export function num(v: number | string | null | undefined): number {
+	if (v === null || v === undefined) return 0;
+	const n = typeof v === 'number' ? v : Number(v);
+	return Number.isFinite(n) ? n : 0;
+}
+
+export function formatGameAge(seconds: number): string {
+	const h = Math.floor(seconds / 3600);
+	const m = Math.floor((seconds % 3600) / 60);
+	if (h > 0) return `${h}h ${m}m`;
+	return `${m}m`;
+}
+
+export function isLive(
+	row: FactorioCurrent | undefined,
+	maxAgeMs = 60_000,
+): boolean {
+	if (!row) return false;
+	const ts = new Date(row.ts.replace(' ', 'T') + 'Z').getTime();
+	return Number.isFinite(ts) && Date.now() - ts < maxAgeMs;
+}

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -606,6 +606,7 @@ pub async fn argo_proxy_handler(path: Option<Path<String>>, req: Request<Body>) 
 }
 
 use jedi::entity::pipe_clickhouse::alerts as ch_alerts;
+use jedi::entity::pipe_clickhouse::factorio as ch_factorio;
 use jedi::entity::pipe_clickhouse::logs as ch_logs;
 use jedi::state::sidecar::ClickHouseConfig;
 
@@ -670,6 +671,10 @@ pub struct ClickHouseLogsRequest {
     /// clamped 5..=3600. Ignored by other commands.
     #[serde(default)]
     pub bucket_seconds: Option<u32>,
+    /// Filter by Factorio `server_id` for the `factorio_*` commands. Ignored
+    /// by log/alert commands.
+    #[serde(default)]
+    pub server_id: Option<String>,
 }
 
 /// Response shape for the ClickHouse logs route. `rows` is the raw
@@ -800,6 +805,21 @@ pub async fn clickhouse_logs_proxy_handler(headers: HeaderMap, body: Bytes) -> R
             };
             ch_alerts::run_alerts_top(config, &params).await
         }
+        "factorio_current" | "factorio_snapshots" | "factorio_players" | "factorio_chat"
+        | "factorio_rotations" => {
+            let params = ch_factorio::FactorioParams {
+                server_id: req.server_id,
+                minutes: req.minutes,
+                limit: req.limit,
+            };
+            match req.command.as_str() {
+                "factorio_current" => ch_factorio::run_current(config, &params).await,
+                "factorio_snapshots" => ch_factorio::run_snapshots(config, &params).await,
+                "factorio_players" => ch_factorio::run_players(config, &params).await,
+                "factorio_chat" => ch_factorio::run_chat(config, &params).await,
+                _ => ch_factorio::run_rotations(config, &params).await,
+            }
+        }
         other => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -808,7 +828,9 @@ pub async fn clickhouse_logs_proxy_handler(headers: HeaderMap, body: Bytes) -> R
                         "unknown command '{other}', expected one of: \
                          query, stats, rows_request_rate, rows_status_histogram, \
                          rows_top_endpoints, rows_errors, \
-                         alerts_recent, alerts_firing, alerts_by_severity, alerts_top"
+                         alerts_recent, alerts_firing, alerts_by_severity, alerts_top, \
+                         factorio_current, factorio_snapshots, factorio_players, \
+                         factorio_chat, factorio_rotations"
                     )
                 })),
             )

--- a/apps/kube/agones/factorio/manifests/clickhouse-externalsecret.yaml
+++ b/apps/kube/agones/factorio/manifests/clickhouse-externalsecret.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: factorio-external-secrets
+    namespace: factorio
+    labels:
+        app.kubernetes.io/part-of: factorio
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+    name: vector-remote-secret-store
+    namespace: factorio
+spec:
+    provider:
+        kubernetes:
+            remoteNamespace: vector
+            auth:
+                serviceAccount:
+                    name: factorio-external-secrets
+                    namespace: factorio
+            server:
+                url: https://kubernetes.default.svc
+                caProvider:
+                    type: ConfigMap
+                    name: kube-root-ca.crt
+                    key: ca.crt
+                    namespace: kube-system
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+    name: clickhouse-credentials
+    namespace: factorio
+spec:
+    refreshInterval: 1h
+    secretStoreRef:
+        name: vector-remote-secret-store
+        kind: SecretStore
+    target:
+        name: clickhouse-credentials
+        creationPolicy: Owner
+    data:
+        - secretKey: endpoint
+          remoteRef:
+              key: clickhouse-vector-credentials
+              property: endpoint
+        - secretKey: username
+          remoteRef:
+              key: clickhouse-vector-credentials
+              property: username
+        - secretKey: password
+          remoteRef:
+              key: clickhouse-vector-credentials
+              property: password

--- a/apps/kube/agones/factorio/manifests/gameserver.yaml
+++ b/apps/kube/agones/factorio/manifests/gameserver.yaml
@@ -161,6 +161,28 @@ spec:
                         value: '60'
                       - name: RUST_LOG
                         value: 'info,agones_factorio_relay=debug'
+                      - name: FACTORIO_SCENARIO_DEFAULT
+                        value: 'kbve'
+                      - name: CLICKHOUSE_URL
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: endpoint
+                                optional: true
+                      - name: CLICKHOUSE_USER
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: username
+                                optional: true
+                      - name: CLICKHOUSE_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: password
+                                optional: true
+                      - name: CLICKHOUSE_DATABASE
+                        value: 'gameops'
                   volumeMounts:
                       - name: log-spool
                         mountPath: /shared/log

--- a/apps/kube/vector/manifests/factorio-ch-credentials-rbac.yaml
+++ b/apps/kube/vector/manifests/factorio-ch-credentials-rbac.yaml
@@ -1,0 +1,28 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+    name: clickhouse-credentials-reader-for-factorio
+    namespace: vector
+    labels:
+        app.kubernetes.io/part-of: observability
+rules:
+    - apiGroups: ['']
+      resources: ['secrets']
+      verbs: ['get', 'list', 'watch']
+      resourceNames: ['clickhouse-vector-credentials']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+    name: factorio-read-clickhouse-credentials
+    namespace: vector
+    labels:
+        app.kubernetes.io/part-of: observability
+roleRef:
+    apiGroup: rbac.authorization.k8s.io
+    kind: Role
+    name: clickhouse-credentials-reader-for-factorio
+subjects:
+    - kind: ServiceAccount
+      name: factorio-external-secrets
+      namespace: factorio

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/factorio.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/factorio.rs
@@ -1,0 +1,218 @@
+// Typed query builders for the gameops.factorio_* Distributed tables.
+//
+// Mirrors logs.rs: build SQL inside Rust so axum-kbve can hit ClickHouse
+// directly via ClickHouseConfig::execute_select. Tables are the Distributed
+// twins defined in packages/data/ch/schemas/factorio.sql and fed by the relay
+// sidecar (apps/agones/factorio/relay). Fully-qualified `gameops.*` names so
+// the query is independent of the connection's default database.
+//
+// Bounds match logs.rs (minutes 1..=10080, limit 1..=500). The optional
+// server_id filter is escaped + inlined the same way.
+
+use serde::{Deserialize, Serialize};
+
+use super::super::super::error::JediError;
+use super::super::super::state::sidecar::ClickHouseConfig;
+use super::logs::{LogsResult, MAX_LIMIT, MAX_MINUTES};
+
+const DEFAULT_MINUTES: u32 = 60;
+const DEFAULT_LIMIT: u32 = 200;
+
+fn escape(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '\'' => out.push_str("\\'"),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+fn clamped_minutes(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_MINUTES).clamp(1, MAX_MINUTES)
+}
+
+fn clamped_limit(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT)
+}
+
+fn server_filter(server_id: &Option<String>) -> String {
+    match server_id.as_deref().filter(|s| !s.is_empty()) {
+        Some(id) => format!(" AND server_id = '{}'", escape(id)),
+        None => String::new(),
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FactorioParams {
+    #[serde(default)]
+    pub server_id: Option<String>,
+    #[serde(default)]
+    pub minutes: Option<u32>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+/// Latest snapshot per server — the "current status" view.
+pub fn build_current_sql(params: &FactorioParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    format!(
+        "SELECT server_id, scenario, toString(rotation_id) AS rotation_id, \
+		 seed, players, ups, map_age_game_s, map_age_wall_s, \
+		 auto_pause_enabled, game_tick, ts \
+		 FROM gameops.factorio_snapshots \
+		 WHERE ts > now() - INTERVAL {minutes} MINUTE{server} \
+		 ORDER BY ts DESC \
+		 LIMIT 1 BY server_id",
+        minutes = minutes,
+        server = server_filter(&params.server_id),
+    )
+}
+
+/// Raw snapshot time-series (player count / UPS / map age over time).
+pub fn build_snapshots_sql(params: &FactorioParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let limit = clamped_limit(params.limit);
+    format!(
+        "SELECT ts, server_id, players, ups, map_age_game_s, map_age_wall_s \
+		 FROM gameops.factorio_snapshots \
+		 WHERE ts > now() - INTERVAL {minutes} MINUTE{server} \
+		 ORDER BY ts DESC \
+		 LIMIT {limit}",
+        minutes = minutes,
+        server = server_filter(&params.server_id),
+        limit = limit,
+    )
+}
+
+/// Recent player join / leave / kick events.
+pub fn build_players_sql(params: &FactorioParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let limit = clamped_limit(params.limit);
+    format!(
+        "SELECT ts, server_id, player, event, game_tick \
+		 FROM gameops.factorio_player_events \
+		 WHERE ts > now() - INTERVAL {minutes} MINUTE{server} \
+		 ORDER BY ts DESC \
+		 LIMIT {limit}",
+        minutes = minutes,
+        server = server_filter(&params.server_id),
+        limit = limit,
+    )
+}
+
+/// Recent chat / command / system lines (moderation buffer).
+pub fn build_chat_sql(params: &FactorioParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let limit = clamped_limit(params.limit);
+    format!(
+        "SELECT ts, server_id, player, mode, message, game_tick \
+		 FROM gameops.factorio_chat_log \
+		 WHERE ts > now() - INTERVAL {minutes} MINUTE{server} \
+		 ORDER BY ts DESC \
+		 LIMIT {limit}",
+        minutes = minutes,
+        server = server_filter(&params.server_id),
+        limit = limit,
+    )
+}
+
+/// Map rotation history. `FINAL` collapses the ReplacingMergeTree so the
+/// latest upsert of each rotation_id wins. No time window — bounded by limit.
+pub fn build_rotations_sql(params: &FactorioParams) -> String {
+    let limit = clamped_limit(params.limit);
+    let server = match params.server_id.as_deref().filter(|s| !s.is_empty()) {
+        Some(id) => format!("WHERE server_id = '{}' ", escape(id)),
+        None => String::new(),
+    };
+    format!(
+        "SELECT toString(rotation_id) AS rotation_id, server_id, scenario, seed, \
+		 started_at, ended_at, end_reason, auto_pause_enabled, peak_players, \
+		 time_to_peak_s, joins_first_15m, joins_first_60m, total_player_seconds, \
+		 wall_age_s, game_age_s \
+		 FROM gameops.factorio_rotations FINAL \
+		 {server}\
+		 ORDER BY started_at DESC \
+		 LIMIT {limit}",
+        server = server,
+        limit = limit,
+    )
+}
+
+async fn run(config: &ClickHouseConfig, sql: String) -> Result<LogsResult, JediError> {
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
+pub async fn run_current(
+    config: &ClickHouseConfig,
+    params: &FactorioParams,
+) -> Result<LogsResult, JediError> {
+    run(config, build_current_sql(params)).await
+}
+
+pub async fn run_snapshots(
+    config: &ClickHouseConfig,
+    params: &FactorioParams,
+) -> Result<LogsResult, JediError> {
+    run(config, build_snapshots_sql(params)).await
+}
+
+pub async fn run_players(
+    config: &ClickHouseConfig,
+    params: &FactorioParams,
+) -> Result<LogsResult, JediError> {
+    run(config, build_players_sql(params)).await
+}
+
+pub async fn run_chat(
+    config: &ClickHouseConfig,
+    params: &FactorioParams,
+) -> Result<LogsResult, JediError> {
+    run(config, build_chat_sql(params)).await
+}
+
+pub async fn run_rotations(
+    config: &ClickHouseConfig,
+    params: &FactorioParams,
+) -> Result<LogsResult, JediError> {
+    run(config, build_rotations_sql(params)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn server_filter_escapes_and_omits() {
+        let none = FactorioParams::default();
+        assert!(!build_snapshots_sql(&none).contains("server_id ="));
+        let some = FactorioParams {
+            server_id: Some("factorio-1".into()),
+            ..Default::default()
+        };
+        assert!(build_snapshots_sql(&some).contains("server_id = 'factorio-1'"));
+        let inject = FactorioParams {
+            server_id: Some("x' OR '1'='1".into()),
+            ..Default::default()
+        };
+        assert!(build_snapshots_sql(&inject).contains("\\' OR"));
+    }
+
+    #[test]
+    fn clamps_bounds() {
+        let p = FactorioParams {
+            minutes: Some(999_999),
+            limit: Some(999_999),
+            ..Default::default()
+        };
+        let sql = build_snapshots_sql(&p);
+        assert!(sql.contains(&format!("INTERVAL {MAX_MINUTES} MINUTE")));
+        assert!(sql.contains(&format!("LIMIT {MAX_LIMIT}")));
+    }
+}

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/mod.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/mod.rs
@@ -1,6 +1,7 @@
 pub mod alerts;
 pub mod clickhouse_types;
 pub mod core;
+pub mod factorio;
 pub mod logs;
 
 pub use clickhouse_types::*;


### PR DESCRIPTION
Builds the end-to-end Factorio telemetry pipeline for the Agones server (tracking #12735, supersedes the planning issue #11138).

## What lands

**Phase 4d — producer**
- `stats.lua` soft-mod module: emits `[STATS] kind=snapshot players/game_tick/seed` every 300 ticks + `kind=player_event` on join/leave; wired into `control.lua`.
- Relay `ch_writer.rs` (was a stub): parses `[STATS]` `key=value` fields and inserts into `gameops.factorio_snapshots_raw` / `player_events_raw` / `chat_log_raw` via `jedi` `ClickHouseConfig::execute_insert` (JSONEachRow). Relay derives UPS from game-tick deltas, map age (game/wall), and a per-process `rotation_id`.
- `event.rs`/`log_tail.rs`: `GameEvent.fields` + STATS parsing (+ unit tests). `config.rs`: `FACTORIO_AUTO_PAUSE`. Relay enables `jedi`'s `clickhouse` feature.

**Phase 4b — reader**
- New `jedi` `pipe_clickhouse/factorio.rs`: query builders (`current`/`snapshots`/`players`/`chat`/`rotations`) over the Distributed twins; inputs escaped + clamped (SQL-injection test included).
- `axum-kbve` `/dashboard/clickhouse/proxy`: five `factorio_*` commands + `server_id` param behind the existing `DASHBOARD_VIEW` gate.

**Phase 4e — dashboard**
- `factorioTelemetryService.ts` (mirrors `rowsTelemetryService.ts`) + `ReactFactorioDashboard.tsx`: live players/UPS/map-age/seed cards, status pill (live/idle/error), player-event + rotation panels, 10s poll.

**Infra**
- `gameserver.yaml`: optional `CLICKHOUSE_*` env on the relay (graceful disable when unset).
- ExternalSecret (`factorio` ns) + RBAC (`vector` ns) sync `clickhouse-credentials` from the vector namespace, mirroring the kbve pattern.

## Verification
- relay build + lint + test, lua syntax, `jedi` factorio tests, `axum-kbve cargo check` (0 errors), `astro-kbve check` (0 errors).

## Deferred (in #12735)
- Rotation-lifecycle writes (`factorio_rotations_raw`) — partial rows would mislead; needs a SIGTERM finalizer + safe aggregation. Dashboard shows "No rotation history yet" until then.
- `naming` note: the proposed operator API uses `/factorio/*` routes, never `/fc/*` (firecracker).

## Caveat
Factorio pauses the sim at 0 players, so `on_nth_tick` stops and no snapshots are written during empty periods — dashboards infer idle from the gap.