### PR TITLE
fix(astro-kbve): add @kbve/chat path aliases for vite resolution

### DIFF
--- a/apps/kbve/astro-kbve/tsconfig.json
+++ b/apps/kbve/astro-kbve/tsconfig.json
@@ -19,6 +19,10 @@
 			"@kbve/devops": ["../../../packages/npm/devops/src/index.ts"],
 			"@kbve/droid": ["../../../packages/npm/droid/src/index.ts"],
 			"@kbve/laser": ["../../../packages/npm/laser/src/index.ts"],
+			"@kbve/chat": ["../../../packages/npm/chat/src/index.ts"],
+			"@kbve/chat/gamechat": [
+				"../../../packages/npm/chat/src/gamechat.ts"
+			],
 			"@kbve/proto": [
 				"../../../packages/data/codegen/generated/index.ts"
 			],


### PR DESCRIPTION
## Problem

astro-kbve build fails at vite/rollup ([run 27786450460](https://github.com/KBVE/kbve/actions/runs/27786450460)):

```
[vite]: Rollup failed to resolve import "@kbve/chat/gamechat" from
"packages/npm/laser/src/lib/net/realm-chat-client.ts"
```

## Cause

`@kbve/laser`'s `realm-chat-client.ts` imports `@kbve/chat/gamechat` (added in #12748). Astro resolves `@kbve/*` via its **own** tsconfig paths — `apps/kbve/astro-kbve/tsconfig.json` extends `astro/tsconfigs/strict` (not `tsconfig.base.json`) and re-declares a paths block that had `@kbve/laser` but no `@kbve/chat`. So laser resolved, its transitive `@kbve/chat/gamechat` did not. The alias in `tsconfig.base.json` is never read by the astro build.

## Fix

Add `@kbve/chat` + `@kbve/chat/gamechat` to astro-kbve tsconfig paths. Verified locally: `astro-kbve:build` succeeds (7765 pages).