### PR TITLE
refactor(jobboard): single staff fetch via context (kill member-view flash)

### DIFF
--- a/apps/jobboard/web/src/layout/DashboardShell.tsx
+++ b/apps/jobboard/web/src/layout/DashboardShell.tsx
@@ -21,13 +21,9 @@ import {
 	ShieldCheck,
 	type LucideIcon,
 } from 'lucide-react';
-import {
-	useAuth,
-	useAuthActions,
-	useStaff,
-	StaffPermission,
-} from '@kbve/rn/auth';
+import { useAuth, useAuthActions, StaffPermission } from '@kbve/rn/auth';
 import { useBreakpoint } from './useBreakpoint';
+import { useStaffContext } from '../lib/staff';
 import { Overview } from './Overview';
 import { StaffOverview } from './StaffOverview';
 import { BrowseView } from './BrowseView';
@@ -62,7 +58,7 @@ const staffSections = (canVet: boolean): Section[] => [
 export function DashboardShell() {
 	const auth = useAuth();
 	const { signOut } = useAuthActions();
-	const staff = useStaff();
+	const staff = useStaffContext();
 	const { isDesktop, isPhone } = useBreakpoint();
 	const [active, setActive] = useState<string>('overview');
 	const [selection, setSelection] = useState<Selection>(null);

--- a/apps/jobboard/web/src/lib/staff.tsx
+++ b/apps/jobboard/web/src/lib/staff.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext, type ReactNode } from 'react';
+import { useStaff } from '@kbve/rn/auth';
+
+// One staff_permissions fetch per session, shared by the dashboard gate and the
+// shell. Calling useStaff() in each spot re-ran the RPC and flashed the member
+// view for staff while it re-resolved; the provider resolves it once.
+type StaffState = ReturnType<typeof useStaff>;
+
+const StaffContext = createContext<StaffState | null>(null);
+
+export function StaffProvider({ children }: { children: ReactNode }) {
+	const staff = useStaff();
+	return (
+		<StaffContext.Provider value={staff}>{children}</StaffContext.Provider>
+	);
+}
+
+export function useStaffContext(): StaffState {
+	const ctx = useContext(StaffContext);
+	if (!ctx) {
+		throw new Error('useStaffContext must be used within StaffProvider');
+	}
+	return ctx;
+}

--- a/apps/jobboard/web/src/main.tsx
+++ b/apps/jobboard/web/src/main.tsx
@@ -9,6 +9,7 @@ import { OverlayHost, ThemeProvider, ToastViewport } from '@kbve/rn/ui';
 import { createKvPersister } from '@kbve/rn/store';
 import { router } from './router';
 import { DevBanner } from './components/DevBanner';
+import { StaffProvider } from './lib/staff';
 import { setAuthTokenGetter } from './api/client';
 import { queryClient } from './lib/queryClient';
 import { jobboardTheme } from './lib/theme';
@@ -41,18 +42,20 @@ createRoot(document.getElementById('root')!).render(
 			apiBaseUrl={`${window.location.origin}/kbveapi`}
 			oauthUrl="https://supabase.kbve.com">
 			<AuthBridge />
-			<ThemeProvider theme={jobboardTheme}>
-				<PersistQueryClientProvider
-					client={queryClient}
-					persistOptions={{ persister }}>
-					<DevBanner />
-					{/* Public marketplace — browsing needs no auth. Login
-					    lives at /login; KbveProvider supplies the session. */}
-					<RouterProvider router={router} />
-				</PersistQueryClientProvider>
-				<OverlayHost />
-				<ToastViewport />
-			</ThemeProvider>
+			<StaffProvider>
+				<ThemeProvider theme={jobboardTheme}>
+					<PersistQueryClientProvider
+						client={queryClient}
+						persistOptions={{ persister }}>
+						<DevBanner />
+						{/* Public marketplace — browsing needs no auth. Login
+						    lives at /login; KbveProvider supplies the session. */}
+						<RouterProvider router={router} />
+					</PersistQueryClientProvider>
+					<OverlayHost />
+					<ToastViewport />
+				</ThemeProvider>
+			</StaffProvider>
 		</KbveProvider>
 	</StrictMode>,
 );

--- a/apps/jobboard/web/src/routes/dashboard.tsx
+++ b/apps/jobboard/web/src/routes/dashboard.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { useStaff } from '@kbve/rn/auth';
 import { DashboardShell } from '../layout/DashboardShell';
 import { Spinner } from '../components/ui';
 import { useAuth } from '../lib/auth';
+import { useStaffContext } from '../lib/staff';
 
 // The dashboard is for vetted members AND staff.
 //  - signed out                              → /login
@@ -14,7 +14,7 @@ import { useAuth } from '../lib/auth';
 // reactively on sign-out lands "Sign out" back on /login.
 export function DashboardPage() {
 	const { signedIn, hasCapability, loading } = useAuth();
-	const staff = useStaff();
+	const staff = useStaffContext();
 	const navigate = useNavigate();
 
 	// Wait for staff to resolve before judging capability, or a staff-only user


### PR DESCRIPTION
Follow-up to #12743. The dashboard gate (`routes/dashboard.tsx`) and `DashboardShell` each called `useStaff()`, so the `staff_permissions` RPC ran twice and a staff user briefly saw the **member** dashboard while the shell's copy re-resolved.

Lift staff to an app-local `StaffProvider` (one `useStaff()` at the root, in `main.tsx` inside `KbveProvider`) consumed via `useStaffContext()` in both spots — single fetch, no flash. No `@kbve/rn` change.

Verified: `tsc --noEmit` clean, `vite build` green.