### PR TITLE
ci(security): restore CodeQL scanning (advanced setup, +rust) + fix unused var

### DIFF
--- a/.github/workflows/ci-codeql.yml
+++ b/.github/workflows/ci-codeql.yml
@@ -1,0 +1,57 @@
+name: CI - CodeQL
+
+on:
+    push:
+        branches:
+            - main
+            - dev
+    pull_request:
+        branches:
+            - dev
+            - main
+    schedule:
+        - cron: '0 9 * * 1'
+    workflow_dispatch:
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+    analyze:
+        name: Analyze (${{ matrix.language }})
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
+        permissions:
+            security-events: write
+            packages: read
+            actions: read
+            contents: read
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - language: javascript-typescript
+                      build-mode: none
+                    - language: python
+                      build-mode: none
+                    - language: rust
+                      build-mode: none
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v6
+
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v3
+              with:
+                  languages: ${{ matrix.language }}
+                  build-mode: ${{ matrix.build-mode }}
+
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v3
+              with:
+                  category: '/language:${{ matrix.language }}'

--- a/packages/rust/q/src/manager/gui_manager.rs
+++ b/packages/rust/q/src/manager/gui_manager.rs
@@ -38,6 +38,9 @@ impl GUIManagerExt for Gd<CanvasLayer> {
         {
             enable_mac_transparency(transparency_value);
         }
+
+        #[cfg(not(any(target_os = "windows", target_os = "macos")))]
+        let _ = transparency_value;
     }
 
     fn with_windowflag(&mut self, flag: WindowFlags, flag_boolean: bool) {


### PR DESCRIPTION
## Why

CodeQL stopped running on **2026-03-21**. The repo's open code-scanning alerts (61 at time of writing) are a frozen 3-month-old snapshot; ~5.5k dev commits have landed since, and most flagged code is already fixed or deleted. Root cause: scanning ran via **GitHub default setup**, which got disabled (`default-setup: not-configured`) — config that lives in repo settings and can be silently turned off, with no version-controlled record.

Default setup also **cannot analyze Rust**, so rust alerts (e.g. `rust/insecure-cookie`) had no scanner to re-evaluate them.

## What

- **`ci-codeql.yml`**: committed advanced CodeQL workflow analyzing `javascript-typescript`, `python`, and `rust` (all `build-mode: none`), on push to main/dev, PRs, and a weekly schedule. Version-controlled so scanning can't be silently disabled again, and it adds the rust coverage default setup couldn't provide.
- **`q` gui_manager**: bind `transparency_value` on the non-windows/macos path so `GUIManagerExt::with_transparency` stops tripping `rust/unused-variable` when analyzed on Linux (the one genuinely-live rust finding).

## Cutover (DONE)

Default and advanced setup are **mutually exclusive**; the advanced workflow's SARIF upload is rejected while default setup is enabled. Default setup has now been **disabled** (`default-setup: not-configured`) so this workflow owns all three languages. The js/py alert refresh ran before cutover, so no scanning gap.

## Already handled out-of-band

- Re-triggered the js/py default-setup scan → refreshes & auto-closes the stale js/py alert majority.
- Dismissed 7 persistent rust alerts: `cleartext-transmission` ×5 (false positive — outbound HTTPS to first-party provider APIs with bearer auth) and `hard-coded-cryptographic-value` ×2 (used in `#[cfg(test)] #[ignore]` integration tests).
- Remaining stale rust alerts (insecure-cookie ×3, non-https-url, cleartext-logging, unused-variable ×2) are already fixed/deleted in dev and will auto-close once this rust scan runs.
