### PR TITLE
ci(unreal): fast-fail Forgejo LFS token preflight + classify auth failures

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -453,6 +453,17 @@ jobs:
                       esac
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
+                      # Preflight: fail fast with a clear, classifiable error if the token is bad,
+                      # instead of burning the whole pull on a cryptic git-lfs auth error.
+                      LFS_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+                        -X POST -H 'Accept: application/vnd.git-lfs+json' -H 'Content-Type: application/vnd.git-lfs+json' \
+                        -d '{"operation":"download","transfers":["basic"],"objects":[]}' \
+                        --max-time 20 "${AUTH_LFS}/objects/batch" || echo 000)
+                      if [ "${LFS_CODE}" = "401" ] || [ "${LFS_CODE}" = "403" ]; then
+                        echo "::error::Forgejo LFS auth failed (HTTP ${LFS_CODE}) at git.kbve.com/${REPO_PATH} — FORGEJO_TOKEN invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret."
+                        exit 1
+                      fi
+                      echo "::notice::Forgejo LFS auth OK (HTTP ${LFS_CODE})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local
                       git -c lfs.url="${AUTH_LFS}" lfs pull --include="${INCLUDE}"
                       ;;
@@ -708,6 +719,16 @@ jobs:
                   LFS_URL=$(git config -f "${PROJ}/.lfsconfig" lfs.url)
                   AUTH_URL="${LFS_URL/https:\/\//https://${FORGEJO_USER}:${FORGEJO_TOKEN}@}"
                   echo "::notice::Pulling LFS for ${PROJ} from ${LFS_URL}"
+                  # Preflight: fail fast with a clear, classifiable error if the token is bad.
+                  LFS_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+                    -X POST -H 'Accept: application/vnd.git-lfs+json' -H 'Content-Type: application/vnd.git-lfs+json' \
+                    -d '{"operation":"download","transfers":["basic"],"objects":[]}' \
+                    --max-time 20 "${AUTH_URL}/objects/batch" || echo 000)
+                  if [ "${LFS_CODE}" = "401" ] || [ "${LFS_CODE}" = "403" ]; then
+                    echo "::error::Forgejo LFS auth failed (HTTP ${LFS_CODE}) at ${LFS_URL} — FORGEJO_TOKEN invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret."
+                    exit 1
+                  fi
+                  echo "::notice::Forgejo LFS auth OK (HTTP ${LFS_CODE})"
                   git -c lfs.url="${AUTH_URL}" lfs install --local
                   git -c lfs.url="${AUTH_URL}" lfs pull --include="${PROJ}/**"
                   rm -rf /tmp/game-project
@@ -766,6 +787,17 @@ jobs:
                       esac
                       AUTH_LFS="https://${FORGEJO_USER}:${FORGEJO_TOKEN}@git.kbve.com/${REPO_PATH}"
                       echo "::notice::Pulling LFS (${INCLUDE}) from git.kbve.com/${REPO_PATH} (normalized from ${RAW_LFS})"
+                      # Preflight: fail fast with a clear, classifiable error if the token is bad,
+                      # instead of burning the whole pull on a cryptic git-lfs auth error.
+                      LFS_CODE=$(curl -s -o /dev/null -w '%{http_code}' \
+                        -X POST -H 'Accept: application/vnd.git-lfs+json' -H 'Content-Type: application/vnd.git-lfs+json' \
+                        -d '{"operation":"download","transfers":["basic"],"objects":[]}' \
+                        --max-time 20 "${AUTH_LFS}/objects/batch" || echo 000)
+                      if [ "${LFS_CODE}" = "401" ] || [ "${LFS_CODE}" = "403" ]; then
+                        echo "::error::Forgejo LFS auth failed (HTTP ${LFS_CODE}) at git.kbve.com/${REPO_PATH} — FORGEJO_TOKEN invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret."
+                        exit 1
+                      fi
+                      echo "::notice::Forgejo LFS auth OK (HTTP ${LFS_CODE})"
                       git -c lfs.url="${AUTH_LFS}" lfs install --local
                       git -c lfs.url="${AUTH_LFS}" lfs pull --include="${INCLUDE}"
                       ;;
@@ -956,6 +988,12 @@ jobs:
                   $lfsUrl = (git config -f $lfsConfig lfs.url)
                   $authUrl = $lfsUrl -replace '^https://', "https://$($env:FORGEJO_USER):$($env:FORGEJO_TOKEN)@"
                   Write-Host "::notice::Pulling LFS for $proj from $lfsUrl"
+                  # Preflight: fail fast with a clear, classifiable error if the token is bad.
+                  $batchBody = Join-Path $env:RUNNER_TEMP 'lfs-batch.json'
+                  '{"operation":"download","transfers":["basic"],"objects":[]}' | Out-File -FilePath $batchBody -Encoding ascii -NoNewline
+                  $lfsCode = (curl.exe -s -o NUL -w "%{http_code}" -X POST -H "Accept: application/vnd.git-lfs+json" -H "Content-Type: application/vnd.git-lfs+json" --data "@$batchBody" --max-time 20 "$authUrl/objects/batch")
+                  if ($lfsCode -eq '401' -or $lfsCode -eq '403') { Write-Host "::error::Forgejo LFS auth failed (HTTP $lfsCode) at $lfsUrl — FORGEJO_TOKEN invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret."; exit 1 }
+                  Write-Host "::notice::Forgejo LFS auth OK (HTTP $lfsCode)"
                   git -c lfs.url="$authUrl" lfs install --local
                   git -c lfs.url="$authUrl" lfs pull --include="$proj/**"
                   "proj_root=$(Join-Path $env:GITHUB_WORKSPACE $proj)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding ascii
@@ -1007,6 +1045,12 @@ jobs:
                       }
                       $authLfs = "https://$($env:FORGEJO_USER):$($env:FORGEJO_TOKEN)@git.kbve.com/$repoPath"
                       Write-Host "::notice::Pulling LFS ($include) from git.kbve.com/$repoPath (normalized from $rawLfs)"
+                      # Preflight: fail fast with a clear, classifiable error if the token is bad.
+                      $batchBody = Join-Path $env:RUNNER_TEMP 'lfs-batch.json'
+                      '{"operation":"download","transfers":["basic"],"objects":[]}' | Out-File -FilePath $batchBody -Encoding ascii -NoNewline
+                      $lfsCode = (curl.exe -s -o NUL -w "%{http_code}" -X POST -H "Accept: application/vnd.git-lfs+json" -H "Content-Type: application/vnd.git-lfs+json" --data "@$batchBody" --max-time 20 "$authLfs/objects/batch")
+                      if ($lfsCode -eq '401' -or $lfsCode -eq '403') { Write-Host "::error::Forgejo LFS auth failed (HTTP $lfsCode) at git.kbve.com/$repoPath — FORGEJO_TOKEN invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret."; exit 1 }
+                      Write-Host "::notice::Forgejo LFS auth OK (HTTP $lfsCode)"
                       git -c lfs.url="$authLfs" lfs install --local
                       git -c lfs.url="$authLfs" lfs pull --include="$include"
                   } else {

--- a/.github/workflows/utils-ci-failure-tracker.yml
+++ b/.github/workflows/utils-ci-failure-tracker.yml
@@ -75,6 +75,7 @@ jobs:
                   fi
 
                   # Try to get log snippet — logs may not be available yet
+                  RAW_LOG=""
                   LOG_SNIPPET="See [run logs](${{ inputs.run_url }}) for details."
                   if [ -n "$JOB_ID" ]; then
                     RAW_LOG=$(gh api "repos/${{ github.repository }}/actions/jobs/${JOB_ID}/logs" \
@@ -84,9 +85,16 @@ jobs:
                     fi
                   fi
 
+                  # Classify a likely cause from the logs so the issue states WHY, not just where.
+                  REASON=""
+                  if printf '%s' "${RAW_LOG}${LOG_SNIPPET}" | grep -qiE 'Forgejo LFS auth failed|Authentication required|Authorization error|info/lfs/objects/batch'; then
+                    REASON="🔑 Forgejo LFS authentication failed — FORGEJO_TOKEN is likely invalid or expired. Rotate the token via kube (forgejo namespace: forgejo-deploy-keys / forgejo-admin) and re-sync the FORGEJO_TOKEN GitHub secret."
+                  fi
+
                   # Write to file to avoid delimiter issues
                   echo "$LOG_SNIPPET" > /tmp/log_snippet.txt
                   echo "failed_step=${FAILED_STEP:-unknown}" >> "$GITHUB_OUTPUT"
+                  echo "reason=${REASON}" >> "$GITHUB_OUTPUT"
 
             - name: Create new failure issue
               if: inputs.status == 'failure' && steps.search.outputs.issue_number == ''
@@ -98,6 +106,7 @@ jobs:
                   RUN_ID: ${{ inputs.run_id }}
                   RUN_URL: ${{ inputs.run_url }}
                   FAILED_STEP: ${{ steps.logs.outputs.failed_step }}
+                  REASON: ${{ steps.logs.outputs.reason }}
                   VERSION: ${{ inputs.version }}
               run: |
                   set -euo pipefail
@@ -109,6 +118,10 @@ jobs:
                     VERSION_LINE="**Version:** ${VERSION}"
                     VERSION_MARKER="<!-- ci-tracker:version=${VERSION} -->"
                   fi
+                  REASON_LINE=""
+                  if [ -n "${REASON:-}" ]; then
+                    REASON_LINE="**Likely cause:** ${REASON}"
+                  fi
 
                   cat > /tmp/issue-body.md << ISSUEEOF
                   ## ${TITLE}
@@ -118,6 +131,7 @@ jobs:
                   **Job:** ${JOB_NAME}
                   ${VERSION_LINE}
                   **Failed step:** ${FAILED_STEP}
+                  ${REASON_LINE}
                   **Status:** Failing since ${TIMESTAMP}
                   **Consecutive failures:** 1
 
@@ -158,6 +172,7 @@ jobs:
                   RUN_ID: ${{ inputs.run_id }}
                   RUN_URL: ${{ inputs.run_url }}
                   FAILED_STEP: ${{ steps.logs.outputs.failed_step }}
+                  REASON: ${{ steps.logs.outputs.reason }}
                   VERSION: ${{ inputs.version }}
               run: |
                   set -euo pipefail
@@ -167,12 +182,17 @@ jobs:
                   if [ -n "${VERSION:-}" ]; then
                     VERSION_LINE="- **Version:** ${VERSION}"
                   fi
+                  REASON_LINE=""
+                  if [ -n "${REASON:-}" ]; then
+                    REASON_LINE="- **Likely cause:** ${REASON}"
+                  fi
 
                   cat > /tmp/comment-body.md << COMMENTEOF
                   ## Failure — ${TIMESTAMP}
 
                   - **Run:** [#${RUN_ID}](${RUN_URL})
                   - **Failed step:** ${FAILED_STEP}
+                  ${REASON_LINE}
                   ${VERSION_LINE}
                   - **Ref:** ${{ github.ref }}
                   - **Trigger:** ${{ github.event_name }}


### PR DESCRIPTION
## What

The UE5 game builds (`ci-unreal-build.yml`) clone an external repo and pull LFS from **git.kbve.com** (Forgejo). When `FORGEJO_TOKEN` is stale, the failure only surfaced deep in `git lfs pull` as a cryptic `batch response: Authentication required: Authorization error` — *after* the Windows-VM boot + engine-locate runway was already spent ([example run](https://github.com/KBVE/kbve/actions/runs/27793904788/job/82249680416)).

## Changes

- **Preflight token check** before every Forgejo `lfs pull` (both Linux bash + Windows PowerShell, monorepo + external-clone paths). POSTs an empty batch request to the LFS endpoint; on HTTP **401/403** it fails immediately with an explicit `FORGEJO_TOKEN invalid or expired — rotate via kube` error.
- **Failure tracker** (`utils-ci-failure-tracker.yml`) now classifies that auth signature and adds a prominent **Likely cause:** line to the auto-opened issue and its recurrence comments — so the issue says *why*, not just *where*.

## Root cause (already mitigated)

The token in kube (`forgejo` ns: `forgejo-deploy-keys` / `forgejo-admin`, user `kbve-admin`) authenticates fine (HTTP 200 against `KBVE/chuck.git/info/lfs/objects/batch`); the GitHub Actions `FORGEJO_TOKEN`/`FORGEJO_USER` secrets had drifted and returned 401. **The secrets have been re-synced to the working kube credential**, so builds should authenticate again. This PR is the guardrail so the next drift fails fast and self-documents.

Note: `KBVE/chuck` (uppercase) is the correct LFS route — lowercase `kbve` 302-bounces to /dashboard (confirmed live), consistent with #12398.

## Verification

Probe logic tested against the live endpoint: good token → 200 (pass), bad token → 401 (clear error). Both YAMLs parse.