### PR TITLE
feat(kbve-gate): SSO bounce so n8n.kbve.com accepts the browser session

### DIFF
--- a/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
+++ b/apps/kbve/astro-kbve/src/components/auth/AuthBridge.ts
@@ -65,13 +65,21 @@ class AuthBridge {
 	/**
 	 * Initiate OAuth sign-in with a provider
 	 */
-	async signInWithOAuth(provider: 'github' | 'twitch' | 'discord') {
+	async signInWithOAuth(
+		provider: 'github' | 'twitch' | 'discord',
+		gateRedirect?: string | null,
+	) {
 		const client = this.ensureClient();
+
+		let callback = `${window.location.origin}/auth/callback`;
+		if (gateRedirect) {
+			callback += `?redirect_to=${encodeURIComponent(gateRedirect)}`;
+		}
 
 		const { data, error } = await client.auth.signInWithOAuth({
 			provider,
 			options: {
-				redirectTo: `${window.location.origin}/auth/callback`,
+				redirectTo: callback,
 				skipBrowserRedirect: false,
 				scopes:
 					provider === 'discord' ? DISCORD_OAUTH_SCOPES : undefined,

--- a/apps/kbve/astro-kbve/src/components/auth/ReactAuthCallback.tsx
+++ b/apps/kbve/astro-kbve/src/components/auth/ReactAuthCallback.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { authBridge } from '@/components/auth';
+import { bounceToGate, readGateRedirect } from './gateBounce';
 import { initSupa, getSupa } from '@/lib/supa';
 import { cn } from '@/lib/utils';
 
@@ -9,6 +10,8 @@ export default function ReactAuthCallback() {
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
+		// Capture before supabase's detectSessionInUrl rewrites the URL.
+		const gateRedirect = readGateRedirect();
 		const handleCallback = async () => {
 			try {
 				// Handle the OAuth callback — stores session in IndexedDB
@@ -44,6 +47,16 @@ export default function ReactAuthCallback() {
 						await supa.connectWebSocket();
 					} catch {
 						// WebSocket failure should never block auth
+					}
+
+					// Came from a gated subdomain? Hand the token back to its
+					// gate instead of landing on the homepage.
+					if (
+						gateRedirect &&
+						session.access_token &&
+						bounceToGate(gateRedirect, session.access_token)
+					) {
+						return;
 					}
 
 					window.location.href = '/';

--- a/apps/kbve/astro-kbve/src/components/auth/ReactAuthLogin.tsx
+++ b/apps/kbve/astro-kbve/src/components/auth/ReactAuthLogin.tsx
@@ -1,14 +1,36 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { authBridge } from '@/components/auth';
+import { bounceToGate, readGateRedirect } from './gateBounce';
 import { cn } from '@/lib/utils';
 
 export default function ReactAuthLogin() {
 	const [isLoading, setIsLoading] = useState<string | null>(null);
 
+	// Arrived here from a gated subdomain (e.g. n8n.kbve.com)? If a session
+	// already exists, skip the OAuth dance and bounce straight back with a token.
+	useEffect(() => {
+		const redirectTo = readGateRedirect();
+		if (!redirectTo) return;
+		let cancelled = false;
+		(async () => {
+			try {
+				const session = await authBridge.getSession();
+				if (!cancelled && session?.access_token) {
+					bounceToGate(redirectTo, session.access_token);
+				}
+			} catch (error) {
+				console.error('Gate session check error:', error);
+			}
+		})();
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
 	const handleGitHubLogin = async () => {
 		try {
 			setIsLoading('github');
-			await authBridge.signInWithOAuth('github');
+			await authBridge.signInWithOAuth('github', readGateRedirect());
 		} catch (error) {
 			console.error('GitHub sign-in error:', error);
 			setIsLoading(null);
@@ -18,7 +40,7 @@ export default function ReactAuthLogin() {
 	const handleDiscordLogin = async () => {
 		try {
 			setIsLoading('discord');
-			await authBridge.signInWithOAuth('discord');
+			await authBridge.signInWithOAuth('discord', readGateRedirect());
 		} catch (error) {
 			console.error('Discord sign-in error:', error);
 			setIsLoading(null);

--- a/apps/kbve/astro-kbve/src/components/auth/gateBounce.ts
+++ b/apps/kbve/astro-kbve/src/components/auth/gateBounce.ts
@@ -1,0 +1,47 @@
+const GATE_REDIRECT_PARAM = 'redirect_to';
+
+function isTrustedGateHost(host: string): boolean {
+	return host === 'kbve.com' || host.endsWith('.kbve.com');
+}
+
+/**
+ * Read a validated `redirect_to` from a URL query. Only https targets on
+ * `*.kbve.com` are accepted — the value receives an access token, so an
+ * unrestricted target would be an open-redirect token-exfiltration hole.
+ */
+export function readGateRedirect(
+	search: string = typeof window !== 'undefined'
+		? window.location.search
+		: '',
+): string | null {
+	try {
+		const raw = new URLSearchParams(search).get(GATE_REDIRECT_PARAM);
+		if (!raw) return null;
+		const url = new URL(raw);
+		if (url.protocol !== 'https:') return null;
+		if (!isTrustedGateHost(url.hostname)) return null;
+		return url.toString();
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Hand the access token off to the gate by appending it to the target URL and
+ * navigating. The gate mints a `kbve_gate` cookie from it and immediately
+ * redirects to a clean URL, so the token never persists in history. Returns
+ * true when it navigated.
+ */
+export function bounceToGate(redirectTo: string, accessToken: string): boolean {
+	if (typeof window === 'undefined' || !redirectTo || !accessToken)
+		return false;
+	try {
+		const url = new URL(redirectTo);
+		if (!isTrustedGateHost(url.hostname)) return false;
+		url.searchParams.set('access_token', accessToken);
+		window.location.replace(url.toString());
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -14,7 +14,7 @@ tags:
 key: kbve_gate
 pipeline: docker
 app_name: kbve-gate
-version: "0.1.0"
+version: "0.1.1"
 source_path: apps/kbve/kbve-gate
 version_toml: apps/kbve/kbve-gate/version.toml
 version_target: apps/kbve/kbve-gate/Cargo.toml
@@ -55,8 +55,29 @@ After the JWT validates it applies an authz policy:
 | `GATE_AUTHZ` | `is_staff` | `is_staff` or `jwt-only` |
 | `GATE_UPSTREAM_BASIC` | — | `Basic <b64>` injected downstream |
 | `GATE_LOGIN_REDIRECT` | — | 302 target for unauthed browser navigations |
+| `GATE_COOKIE_DOMAIN` | — | domain scope for the minted session cookie (e.g. `.kbve.com`) |
 | `SUPABASE_JWT_SECRET` | — | required |
 | `SUPABASE_URL` | — | required for `is_staff` (direct PostgREST) |
+
+### Login bounce
+
+The KBVE session lives in the browser (IndexedDB), so a cross-subdomain
+navigation carries no token. The gate completes auth with a bounce:
+
+<Steps>
+
+1. Unauthed navigation to a gated host → `302` to
+   `GATE_LOGIN_REDIRECT?redirect_to=<original URL>`.
+2. The login page, once a session exists, returns the browser to
+   `redirect_to?access_token=<jwt>`.
+3. The gate validates the token, sets a `kbve_gate` cookie scoped to
+   `GATE_COOKIE_DOMAIN`, and `302`s to a clean URL. Subsequent requests carry
+   the cookie.
+
+</Steps>
+
+The login page only honours `redirect_to` targets on `*.kbve.com` over https,
+so the token can never be handed to a foreign origin.
 
 ### n8n deployment
 

--- a/apps/kube/n8n/manifest/n8n-deployment.yaml
+++ b/apps/kube/n8n/manifest/n8n-deployment.yaml
@@ -203,6 +203,8 @@ spec:
                         value: 'forum'
                       - name: GATE_LOGIN_REDIRECT
                         value: 'https://kbve.com/login'
+                      - name: GATE_COOKIE_DOMAIN
+                        value: '.kbve.com'
                       - name: SUPABASE_URL
                         value: 'http://supabase-postgrest.kilobase.svc.cluster.local:3000'
                       - name: SUPABASE_JWT_SECRET

--- a/packages/rust/kbve/src/gate/auth.rs
+++ b/packages/rust/kbve/src/gate/auth.rs
@@ -105,6 +105,12 @@ pub fn extract_token(
     None
 }
 
+/// Read the `access_token` query param — the token delivered by the post-login
+/// bounce, which the gate converts into a session cookie.
+pub fn access_token_in_query(query: &str) -> Option<String> {
+    query_param(query, "access_token").filter(|v| !v.is_empty())
+}
+
 fn cookie_value<'a>(cookie_header: &'a str, name: &str) -> Option<&'a str> {
     for pair in cookie_header.split(';') {
         let pair = pair.trim();

--- a/packages/rust/kbve/src/gate/mod.rs
+++ b/packages/rust/kbve/src/gate/mod.rs
@@ -20,6 +20,7 @@ use std::net::SocketAddr;
 /// - `GATE_AUTHZ`           `is_staff` (default) | `jwt-only`
 /// - `GATE_UPSTREAM_BASIC`  optional `Basic <b64>` injected upstream
 /// - `GATE_LOGIN_REDIRECT`  optional 302 target for unauthed navigations
+/// - `GATE_COOKIE_DOMAIN`   optional domain scope for the session cookie
 /// - `GATE_STAFF_TTL_SECS`  is_staff cache TTL (default 30)
 /// - `GATE_STAFF_SCHEMA`    PostgREST schema for the RPC (default `forum`)
 /// - `SUPABASE_JWT_SECRET`        required
@@ -36,6 +37,9 @@ pub fn config_from_env() -> Result<GateConfig, String> {
         .ok()
         .filter(|s| !s.is_empty());
     let login_redirect = std::env::var("GATE_LOGIN_REDIRECT")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let cookie_domain = std::env::var("GATE_COOKIE_DOMAIN")
         .ok()
         .filter(|s| !s.is_empty());
 
@@ -68,6 +72,7 @@ pub fn config_from_env() -> Result<GateConfig, String> {
         authz,
         upstream_basic,
         login_redirect,
+        cookie_domain,
         staff,
     })
 }

--- a/packages/rust/kbve/src/gate/proxy.rs
+++ b/packages/rust/kbve/src/gate/proxy.rs
@@ -9,7 +9,9 @@ use axum::{
 use reqwest::Client;
 use tracing::{debug, warn};
 
-use super::auth::{Authz, StaffGate, extract_token, validate_token};
+use super::auth::{
+    Authz, GATE_SESSION_COOKIE, StaffGate, access_token_in_query, extract_token, validate_token,
+};
 
 /// Runtime configuration for the gate, normally built from env in the binary.
 pub struct GateConfig {
@@ -24,8 +26,13 @@ pub struct GateConfig {
     /// browser never sees the credential.
     pub upstream_basic: Option<String>,
     /// Where to send unauthenticated browser navigations (302). When unset a
-    /// bare 401/403 is returned instead.
+    /// bare 401/403 is returned instead. The gate appends `?redirect_to=<this
+    /// URL>` so the login page can bounce the browser back with a token.
     pub login_redirect: Option<String>,
+    /// Domain scope for the minted `kbve_gate` session cookie, e.g. `.kbve.com`,
+    /// so every subdomain behind the gate shares it. When unset the cookie is
+    /// host-only.
+    pub cookie_domain: Option<String>,
     /// Staff RPC gate. Required when `authz` is `IsStaff`.
     pub staff: Option<StaffGate>,
 }
@@ -77,16 +84,82 @@ fn is_navigation(headers: &HeaderMap) -> bool {
             .unwrap_or(false)
 }
 
-fn deny(state: &GateState, headers: &HeaderMap, status: StatusCode, msg: &str) -> Response {
+/// 302 to `location`, optionally planting a `Set-Cookie`.
+fn redirect(location: &str, set_cookie: Option<&str>) -> Response {
+    let mut builder = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, location);
+    if let Some(c) = set_cookie {
+        builder = builder.header(header::SET_COOKIE, c);
+    }
+    builder
+        .body(Body::empty())
+        .unwrap_or_else(|_| {
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::empty())
+                .unwrap()
+        })
+        .into_response()
+}
+
+/// Reconstruct the externally-visible URL (sans query) from proxy headers, used
+/// as the `redirect_to` target so the login page can return the browser here.
+fn external_url(headers: &HeaderMap, uri: &Uri) -> String {
+    let host = headers
+        .get(header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("https");
+    format!("{scheme}://{host}{}", uri.path())
+}
+
+/// Drop the `access_token` pair from a query string, preserving the rest.
+fn strip_access_token(query: &str) -> String {
+    query
+        .split('&')
+        .filter(|p| *p != "access_token" && !p.starts_with("access_token="))
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Mint the `kbve_gate` session cookie from a URL-delivered token, then 302 to a
+/// clean URL so the JWT never lingers in history, referrers, or logs.
+fn cookie_land(state: &GateState, uri: &Uri, token: &str) -> Response {
+    let cleaned = uri.query().map(strip_access_token).unwrap_or_default();
+    let location = if cleaned.is_empty() {
+        uri.path().to_string()
+    } else {
+        format!("{}?{}", uri.path(), cleaned)
+    };
+    let mut cookie = format!(
+        "{GATE_SESSION_COOKIE}={token}; Path=/; Max-Age=3600; HttpOnly; Secure; SameSite=Lax"
+    );
+    if let Some(domain) = &state.cfg.cookie_domain {
+        cookie.push_str("; Domain=");
+        cookie.push_str(domain);
+    }
+    redirect(&location, Some(&cookie))
+}
+
+fn deny(
+    state: &GateState,
+    headers: &HeaderMap,
+    status: StatusCode,
+    msg: &str,
+    ext_url: &str,
+) -> Response {
     if status == StatusCode::UNAUTHORIZED {
         if let Some(target) = &state.cfg.login_redirect {
             if is_navigation(headers) {
-                return Response::builder()
-                    .status(StatusCode::FOUND)
-                    .header(header::LOCATION, target)
-                    .body(Body::empty())
-                    .unwrap()
-                    .into_response();
+                let enc: String =
+                    url::form_urlencoded::byte_serialize(ext_url.as_bytes()).collect();
+                let sep = if target.contains('?') { '&' } else { '?' };
+                let location = format!("{target}{sep}redirect_to={enc}");
+                return redirect(&location, None);
             }
         }
     }
@@ -98,6 +171,7 @@ async fn authorize(
     state: &GateState,
     headers: &HeaderMap,
     query: Option<&str>,
+    ext_url: &str,
 ) -> Result<String, Response> {
     let token = extract_token(
         headers
@@ -115,6 +189,7 @@ async fn authorize(
                 headers,
                 StatusCode::UNAUTHORIZED,
                 "missing token",
+                ext_url,
             ));
         }
     };
@@ -127,6 +202,7 @@ async fn authorize(
                 headers,
                 StatusCode::UNAUTHORIZED,
                 &e.to_string(),
+                ext_url,
             ));
         }
     };
@@ -147,7 +223,13 @@ async fn authorize(
             };
             match staff.is_staff(&sub).await {
                 Ok(true) => Ok(sub),
-                Ok(false) => Err(deny(state, headers, StatusCode::FORBIDDEN, "staff only")),
+                Ok(false) => Err(deny(
+                    state,
+                    headers,
+                    StatusCode::FORBIDDEN,
+                    "staff only",
+                    ext_url,
+                )),
                 Err(e) => Err((
                     StatusCode::BAD_GATEWAY,
                     axum::Json(serde_json::json!({ "error": e.to_string() })),
@@ -161,9 +243,19 @@ async fn authorize(
 async fn gate_handler(State(state): State<Arc<GateState>>, req: Request<Body>) -> Response {
     let headers = req.headers().clone();
     let query = req.uri().query().map(|q| q.to_string());
+    let ext_url = external_url(&headers, req.uri());
 
-    if let Err(resp) = authorize(&state, &headers, query.as_deref()).await {
+    if let Err(resp) = authorize(&state, &headers, query.as_deref(), &ext_url).await {
         return resp;
+    }
+
+    // Token arrived in the URL (post-login bounce): convert it to a session
+    // cookie and redirect to a clean URL. Skipped for WebSocket upgrades, which
+    // carry the token in the cookie the browser already holds.
+    if !is_websocket_upgrade(&headers) {
+        if let Some(token) = query.as_deref().and_then(access_token_in_query) {
+            return cookie_land(&state, req.uri(), &token);
+        }
     }
 
     if is_websocket_upgrade(&headers) {


### PR DESCRIPTION
## Why

`n8n.kbve.com` redirected to login forever. The kbve-gate sidecar **is** live and gating — but the KBVE session lives in the browser (IndexedDB via SharedWorker), so a cross-subdomain navigation carries no `Authorization` header, no cookie, no query token. The gate never receives a credential and loops: redirect → login → return → still nothing → redirect.

The gate auth model (cookie / bearer / `?access_token=`) and the frontend session model (IndexedDB) never met. No config fixes it — the token handoff was missing.

## What

**Gate (`kbve` crate `gate` module):**
- Unauthed navigation now redirects to `GATE_LOGIN_REDIRECT?redirect_to=<original URL>` so login knows where to return.
- On a URL-delivered `?access_token=`, the gate validates it, mints a `kbve_gate` cookie scoped to the new `GATE_COOKIE_DOMAIN`, and 302s to a clean URL (token never lingers in history/referrer/logs).
- `GateConfig.cookie_domain` + `GATE_COOKIE_DOMAIN` env.

**Frontend (astro-kbve auth):**
- `gateBounce.ts` — read/validate `redirect_to` (**https + `*.kbve.com` only**; the value receives a token, so foreign targets are rejected) and bounce with the token.
- Login bounces immediately when a session already exists, else threads `redirect_to` through the OAuth callback.
- Callback returns the browser to the gate instead of the homepage.

**Deployment:** n8n sidecar gets `GATE_COOKIE_DOMAIN=.kbve.com`; gate MDX → 0.1.1 (republish).

## Flow

```
n8n.kbve.com (no token)
  → 302 kbve.com/login?redirect_to=https://n8n.kbve.com/
  → (session exists or OAuth) → 302 n8n.kbve.com/?access_token=<jwt>
  → gate: validate + Set-Cookie kbve_gate (Domain=.kbve.com) → 302 n8n.kbve.com/
  → cookie carried on every request → is_staff gate
```

## Verification
- `kbve-gate:build` compiles clean.
- Live check after release: hit n8n.kbve.com logged-out → bounce to login → back to n8n, no loop; logged-in non-staff → 403.

## Notes
- Gate republishes off the MDX 0.1.1 bump (version.toml stays 0.1.0 until the post-publish atom syncs).
- Reaches the cluster after the dev→main release PR.