### PR TITLE
fix(rn): harden EMAIL_RE against polynomial ReDoS

### DIFF
--- a/packages/npm/rn/src/auth/useAuthForm.ts
+++ b/packages/npm/rn/src/auth/useAuthForm.ts
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useAuth, useAuthActions } from './useAuth';
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
 
 export type AuthFormMode = 'sign_in' | 'sign_up';
 


### PR DESCRIPTION
## Why

`js/polynomial-redos` (CodeQL #497). `EMAIL_RE` validates the user-typed email in `useAuthForm`, so its input is attacker-controlled. The old pattern had overlapping quantifiers around the dot — the `.` is matchable by the surrounding `[^\s@]` classes — giving quadratic backtracking on inputs like `a@aaaaaaaa…`.

## What

```diff
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@.]+(?:\.[^\s@.]+)+$/;
```

Labels exclude `.`, and the domain is one-or-more literal-dot-prefixed labels — unambiguous, linear-time. Slightly stricter (rejects `..` and trailing dots); accepts the same real-world addresses.

## Related (handled out-of-band)

The other five `polynomial-redos` alerts (#492-496) were dismissed as **won't fix**: they run on trusted build-time input (repo-authored MDX content-collection bodies in the astro sitegraph extractors) or internal route-template literals (`@kbve/core` `fillPath`), not attacker-controlled data — theoretical backtracking with no runtime DoS surface.