### PR TITLE
fix(forgejo-dashboard): refresh button pulls live aggregates + 10s cooldown

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoHeader.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoHeader.tsx
@@ -1,10 +1,29 @@
 import { useStore } from '@nanostores/react';
+import { useEffect, useRef, useState } from 'react';
 import { forgejoService } from './forgejoService';
 import { RefreshCw } from 'lucide-react';
 
 export default function ReactForgejoHeader() {
 	const lastUpdated = useStore(forgejoService.$lastUpdated);
 	const loading = useStore(forgejoService.$loading);
+	const [cooldown, setCooldown] = useState(0);
+	const timer = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
+
+	useEffect(() => () => clearInterval(timer.current), []);
+
+	const onRefresh = () => {
+		forgejoService.refresh();
+		const remaining = forgejoService.manualRefreshCooldownMs();
+		setCooldown(Math.ceil(remaining / 1000));
+		clearInterval(timer.current);
+		timer.current = setInterval(() => {
+			const left = forgejoService.manualRefreshCooldownMs();
+			setCooldown(Math.ceil(left / 1000));
+			if (left <= 0) clearInterval(timer.current);
+		}, 250);
+	};
+
+	const disabled = loading || cooldown > 0;
 
 	return (
 		<div
@@ -24,8 +43,8 @@ export default function ReactForgejoHeader() {
 				</span>
 			)}
 			<button
-				onClick={() => forgejoService.refresh()}
-				disabled={loading}
+				onClick={onRefresh}
+				disabled={disabled}
 				style={{
 					display: 'flex',
 					alignItems: 'center',
@@ -35,8 +54,8 @@ export default function ReactForgejoHeader() {
 					border: '1px solid var(--sl-color-gray-5, #30363d)',
 					background: 'var(--sl-color-gray-6, #161b22)',
 					color: 'var(--sl-color-text, #e6edf3)',
-					cursor: loading ? 'not-allowed' : 'pointer',
-					opacity: loading ? 0.6 : 1,
+					cursor: disabled ? 'not-allowed' : 'pointer',
+					opacity: disabled ? 0.6 : 1,
 					fontSize: '0.8rem',
 				}}>
 				<RefreshCw
@@ -47,7 +66,7 @@ export default function ReactForgejoHeader() {
 							: undefined
 					}
 				/>
-				Refresh
+				{cooldown > 0 ? `Refresh (${cooldown}s)` : 'Refresh'}
 			</button>
 		</div>
 	);

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -226,6 +226,7 @@ const TAB_KEY = 'forgejo:activeTab';
 const CACHE_TTL_MS = 60 * 1000;
 const API_BASE = '/dashboard/forgejo/api';
 const REFRESH_INTERVAL_MS = 30 * 1000;
+const MANUAL_REFRESH_COOLDOWN_MS = 10 * 1000;
 
 // Maps a Forgejo `/api/v1/...` path (the shape every call site still uses) onto
 // the typed axum surface at /dashboard/forgejo/api/*: strip the v1 prefix and
@@ -744,6 +745,7 @@ class ForgejoService {
 	});
 
 	private _refreshInterval: ReturnType<typeof setInterval> | undefined;
+	private _lastManualRefresh = 0;
 
 	// --- Auth ---
 
@@ -821,7 +823,7 @@ class ForgejoService {
 		return { items, hasMore: last === PAGE_SIZE };
 	}
 
-	public async fetchData(): Promise<void> {
+	public async fetchData(force = false): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
 
@@ -841,8 +843,8 @@ class ForgejoService {
 			this.$orgsHasMore.set(orgs.hasMore);
 			this.$lastUpdated.set(new Date());
 			void saveCache(repos.items, users.items, orgs.items);
-			void this.fetchStats();
-			void this.fetchStorage();
+			void this.fetchStats(force);
+			void this.fetchStorage(force);
 		} catch (e: unknown) {
 			if (e instanceof AccessRestrictedError) {
 				this.$authState.set('forbidden');
@@ -859,14 +861,17 @@ class ForgejoService {
 		}
 	}
 
-	public async fetchStats(): Promise<void> {
+	public async fetchStats(force = false): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
 		try {
-			const resp = await fetch(`${API_BASE}/stats`, {
-				headers: { Authorization: `Bearer ${token}` },
-				signal: AbortSignal.timeout(20000),
-			});
+			const resp = await fetch(
+				`${API_BASE}/stats${force ? '?force=1' : ''}`,
+				{
+					headers: { Authorization: `Bearer ${token}` },
+					signal: AbortSignal.timeout(20000),
+				},
+			);
 			if (!resp.ok) return;
 			const data = (await resp.json()) as ForgejoStats;
 			if (data && typeof data.total_size_kb === 'number') {
@@ -877,14 +882,17 @@ class ForgejoService {
 		}
 	}
 
-	public async fetchStorage(): Promise<void> {
+	public async fetchStorage(force = false): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
 		try {
-			const resp = await fetch(`${API_BASE}/storage`, {
-				headers: { Authorization: `Bearer ${token}` },
-				signal: AbortSignal.timeout(30000),
-			});
+			const resp = await fetch(
+				`${API_BASE}/storage${force ? '?force=1' : ''}`,
+				{
+					headers: { Authorization: `Bearer ${token}` },
+					signal: AbortSignal.timeout(30000),
+				},
+			);
 			if (!resp.ok) return;
 			const data = (await resp.json()) as ForgejoStorage;
 			if (data && typeof data.total_bytes === 'number') {
@@ -926,10 +934,25 @@ class ForgejoService {
 
 	public refresh(): void {
 		const token = this.$accessToken.get();
-		if (token) {
-			this.$loading.set(true);
-			void invalidateDataCache().then(() => this.fetchData());
+		if (!token) return;
+		const now = Date.now();
+		const since = now - this._lastManualRefresh;
+		if (since < MANUAL_REFRESH_COOLDOWN_MS) {
+			const wait = Math.ceil((MANUAL_REFRESH_COOLDOWN_MS - since) / 1000);
+			this.showToast('info', `Refresh cooling down, wait ${wait}s`);
+			return;
 		}
+		this._lastManualRefresh = now;
+		this.showToast('info', 'Refreshing repository cache…');
+		this.$loading.set(true);
+		void invalidateDataCache().then(() => this.fetchData(true));
+	}
+
+	public manualRefreshCooldownMs(): number {
+		return Math.max(
+			0,
+			MANUAL_REFRESH_COOLDOWN_MS - (Date.now() - this._lastManualRefresh),
+		);
 	}
 
 	public setRepoSearch(query: string): void {

--- a/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
+++ b/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
@@ -31,14 +31,16 @@ const AGG_TTL: Duration = Duration::from_secs(300);
 static STATS_CACHE: OnceLock<Mutex<Option<(Instant, ForgejoStats)>>> = OnceLock::new();
 static STORAGE_CACHE: OnceLock<Mutex<Option<(Instant, ForgejoStorage)>>> = OnceLock::new();
 
-async fn cached_stats(c: &ForgejoClient) -> Result<ForgejoStats, JediError> {
+async fn cached_stats(c: &ForgejoClient, force: bool) -> Result<ForgejoStats, JediError> {
     let cell = STATS_CACHE.get_or_init(|| Mutex::new(None));
-    if let Some(v) = cell.lock().ok().and_then(|g| {
-        g.as_ref()
-            .filter(|(t, _)| t.elapsed() < AGG_TTL)
-            .map(|(_, v)| v.clone())
-    }) {
-        return Ok(v);
+    if !force {
+        if let Some(v) = cell.lock().ok().and_then(|g| {
+            g.as_ref()
+                .filter(|(t, _)| t.elapsed() < AGG_TTL)
+                .map(|(_, v)| v.clone())
+        }) {
+            return Ok(v);
+        }
     }
     let fresh = c.repo_stats().await?;
     if let Ok(mut g) = cell.lock() {
@@ -47,14 +49,16 @@ async fn cached_stats(c: &ForgejoClient) -> Result<ForgejoStats, JediError> {
     Ok(fresh)
 }
 
-async fn cached_storage(c: &ForgejoClient) -> Result<ForgejoStorage, JediError> {
+async fn cached_storage(c: &ForgejoClient, force: bool) -> Result<ForgejoStorage, JediError> {
     let cell = STORAGE_CACHE.get_or_init(|| Mutex::new(None));
-    if let Some(v) = cell.lock().ok().and_then(|g| {
-        g.as_ref()
-            .filter(|(t, _)| t.elapsed() < AGG_TTL)
-            .map(|(_, v)| v.clone())
-    }) {
-        return Ok(v);
+    if !force {
+        if let Some(v) = cell.lock().ok().and_then(|g| {
+            g.as_ref()
+                .filter(|(t, _)| t.elapsed() < AGG_TTL)
+                .map(|(_, v)| v.clone())
+        }) {
+            return Ok(v);
+        }
     }
     let fresh = c.instance_storage().await?;
     if let Ok(mut g) = cell.lock() {
@@ -103,6 +107,7 @@ pub struct ListQuery {
     purge: Option<bool>,
     #[serde(rename = "ref")]
     git_ref: Option<String>,
+    force: Option<bool>,
 }
 
 impl ListQuery {
@@ -111,6 +116,9 @@ impl ListQuery {
     }
     fn limit(&self) -> u32 {
         self.limit.unwrap_or(50)
+    }
+    fn force(&self) -> bool {
+        self.force.unwrap_or(false)
     }
 }
 
@@ -422,14 +430,14 @@ async fn team_members(
 
 // ── Aggregate / runners (reads) ──────────────────────────────────────
 
-async fn stats(headers: HeaderMap) -> Response {
+async fn stats(headers: HeaderMap, q: axum::extract::Query<ListQuery>) -> Response {
     let c = vc!(headers);
-    reply!(cached_stats(c).await)
+    reply!(cached_stats(c, q.force()).await)
 }
 
-async fn storage(headers: HeaderMap) -> Response {
+async fn storage(headers: HeaderMap, q: axum::extract::Query<ListQuery>) -> Response {
     let c = vc!(headers);
-    reply!(cached_storage(c).await)
+    reply!(cached_storage(c, q.force()).await)
 }
 
 async fn repo_runners(headers: HeaderMap, Path((owner, repo)): Path<(String, String)>) -> Response {


### PR DESCRIPTION
## Problem
On `/dashboard/forgejo/`, the **Refresh** button invalidated the frontend IndexedDB cache and refetched — but `/stats` and `/storage` are cached **server-side** in `axum-kbve` for `AGG_TTL` (5 min). So clicking refresh kept showing stale *Repository Storage* / counts (e.g. `24.23 GB`) for up to 5 minutes. IndexedDB caching itself was fine; the live pull was blocked by the server agg cache.

## Fix
Thread a `force` flag end-to-end:
- Frontend: `refresh()` → `fetchData(true)` → `fetchStats(true)` / `fetchStorage(true)` append `?force=1`.
- Backend: `cached_stats` / `cached_storage` bypass the agg cache when `force=1` (still repopulating it). `ListQuery` gains a `force` field; the `/stats` + `/storage` handlers read it.
- Auto-poll (30s) and initial load pass **no** force, so upstream re-aggregation only happens on explicit user refresh. IndexedDB caching untouched.

## Anti-spam
The aggregate pages through every repo/owner upstream, so a forced refresh is expensive. Added a **10s manual-refresh cooldown**:
- `refresh()` toasts `Refreshing repository cache…`, or `Refresh cooling down, wait Ns` if re-clicked inside the window.
- Header button shows a live countdown (`Refresh (7s)`) and stays disabled until it clears.

## Verify
- `cargo check -p axum-kbve` — clean.
- TS: no new errors in `forgejoService.ts` / `ReactForgejoHeader.tsx`.