### PR TITLE
fix(security): close CodeQL sanitization + stack-trace findings

### DIFF
--- a/apps/kbve/astro-kbve/src/lib/rehype-link-attrs.mjs
+++ b/apps/kbve/astro-kbve/src/lib/rehype-link-attrs.mjs
@@ -23,7 +23,9 @@ function isSkippable(href) {
 		href.startsWith('#') ||
 		href.startsWith('mailto:') ||
 		href.startsWith('tel:') ||
-		href.startsWith('javascript:')
+		href.startsWith('javascript:') ||
+		href.startsWith('data:') ||
+		href.startsWith('vbscript:')
 	);
 }
 

--- a/apps/kbve/edge/functions/discordsh/index.ts
+++ b/apps/kbve/edge/functions/discordsh/index.ts
@@ -111,7 +111,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/kbve/edge/functions/guild-vault/index.ts
+++ b/apps/kbve/edge/functions/guild-vault/index.ts
@@ -124,7 +124,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/kbve/edge/functions/irc/index.ts
+++ b/apps/kbve/edge/functions/irc/index.ts
@@ -116,7 +116,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/kbve/edge/functions/logs/index.ts
+++ b/apps/kbve/edge/functions/logs/index.ts
@@ -183,7 +183,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/kbve/edge/functions/mc/index.ts
+++ b/apps/kbve/edge/functions/mc/index.ts
@@ -118,7 +118,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/kbve/edge/functions/meme/index.ts
+++ b/apps/kbve/edge/functions/meme/index.ts
@@ -143,7 +143,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/kbve/edge/functions/ows/index.ts
+++ b/apps/kbve/edge/functions/ows/index.ts
@@ -101,7 +101,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/kbve/edge/functions/user-vault/index.ts
+++ b/apps/kbve/edge/functions/user-vault/index.ts
@@ -158,7 +158,7 @@ serve(async (req) => {
     const isAuthError =
       rawMessage.includes("authorization") || rawMessage.includes("JWT");
     if (isAuthError) {
-      return jsonResponse({ error: rawMessage }, 401);
+      return jsonResponse({ error: "Unauthorized" }, 401);
     }
     return jsonResponse({ error: "Internal server error" }, 500);
   }

--- a/apps/rareicon/icons-codegen/scripts/gen-category-landings.mjs
+++ b/apps/rareicon/icons-codegen/scripts/gen-category-landings.mjs
@@ -117,7 +117,7 @@ function emitMdx(cat) {
 		headline: titleCase(cat),
 		lede: `Catalog terms tagged primary_category=${cat}.`,
 	};
-	const headline = meta.headline.replace(/"/g, '\\"');
+	const headline = meta.headline.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 	const ledeJs = JSON.stringify(meta.lede);
 	return `---
 title: ${headline}


### PR DESCRIPTION
Three live CodeQL findings from the refreshed scan.

## #501 `js/stack-trace-exposure` — edge functions (×8)

The shared handler pattern caught an error and, on the auth branch, returned `jsonResponse({ error: rawMessage }, 401)` where `rawMessage = err.message`. The thrown auth messages are static app strings, but CodeQL can't prove the Error message is free of internal/stack detail. Return a generic `"Unauthorized"` instead — the 401 status already conveys the failure. The `rawMessage`/`isAuthError` gate is kept to choose 401 vs 500.

Applied to all 8 `index.ts` handlers sharing the pattern: meme, irc, logs, mc, user-vault, ows, guild-vault, discordsh.

## #500 `js/incomplete-url-scheme-check` — rehype-link-attrs.mjs

`isSkippable` listed `javascript:` but not the other script-bearing schemes. Added `data:` and `vbscript:`.

## #499 `js/incomplete-sanitization` — gen-category-landings.mjs

MDX title escaping handled `"` but not `\`, so a backslash in copy could break the emitted frontmatter. Escape backslashes before quotes.