### PR TITLE
fix(docker): wire @kbve/chat into axum builders (unbreak main CI)

### DIFF
--- a/apps/chuckrpg/axum-chuckrpg/Dockerfile
+++ b/apps/chuckrpg/axum-chuckrpg/Dockerfile
@@ -18,6 +18,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/chat/ packages/npm/chat/
 COPY packages/npm/core/ packages/npm/core/
 COPY packages/npm/rn/ packages/npm/rn/
 COPY packages/npm/rn-astro/ packages/npm/rn-astro/

--- a/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.discord.config.mts
@@ -22,6 +22,7 @@ export default defineConfig({
 			{ find: '@kbve/droid', replacement: pkg('npm/droid/src/index.ts') },
 			{ find: '@kbve/laser/ecs', replacement: pkg('npm/laser/src/ecs.ts') },
 			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
+			{ find: '@kbve/chat/gamechat', replacement: pkg('npm/chat/src/gamechat.ts') },
 			{
 				find: '@kbve/itemdb-data',
 				replacement: pkg('data/codegen/generated/itemdb.json'),

--- a/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
+++ b/apps/cryptothrone/astro-cryptothrone/vite.embed.config.mts
@@ -28,6 +28,7 @@ export default defineConfig({
 			{ find: '@kbve/droid', replacement: pkg('npm/droid/src/index.ts') },
 			{ find: '@kbve/laser/ecs', replacement: pkg('npm/laser/src/ecs.ts') },
 			{ find: '@kbve/laser', replacement: pkg('npm/laser/src/index.ts') },
+			{ find: '@kbve/chat/gamechat', replacement: pkg('npm/chat/src/gamechat.ts') },
 			{
 				find: '@kbve/itemdb-data',
 				replacement: pkg('data/codegen/generated/itemdb.json'),

--- a/apps/cryptothrone/axum-cryptothrone/Dockerfile
+++ b/apps/cryptothrone/axum-cryptothrone/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/chat/ packages/npm/chat/
 COPY packages/npm/core/ packages/npm/core/
 COPY packages/npm/rn/ packages/npm/rn/
 COPY packages/npm/rn-astro/ packages/npm/rn-astro/

--- a/apps/kbve/axum-kbve/Dockerfile
+++ b/apps/kbve/axum-kbve/Dockerfile
@@ -26,6 +26,7 @@ COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/devops/ packages/npm/devops/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/chat/ packages/npm/chat/
 COPY packages/npm/core/ packages/npm/core/
 COPY packages/npm/rn/ packages/npm/rn/
 COPY packages/npm/rn-astro/ packages/npm/rn-astro/

--- a/apps/rareicon/axum-rareicon/Dockerfile
+++ b/apps/rareicon/axum-rareicon/Dockerfile
@@ -18,6 +18,7 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store/v3,id=pnpm-store \
 COPY packages/npm/astro/ packages/npm/astro/
 COPY packages/npm/droid/ packages/npm/droid/
 COPY packages/npm/laser/ packages/npm/laser/
+COPY packages/npm/chat/ packages/npm/chat/
 COPY packages/npm/core/ packages/npm/core/
 COPY packages/npm/rn/ packages/npm/rn/
 COPY packages/npm/rn-astro/ packages/npm/rn-astro/


### PR DESCRIPTION
## Problem

#12748 added a transitive `@kbve/chat/gamechat` import via `@kbve/laser` (`realm-chat-client.ts`) but never wired the consumers. Main CI Docker builds now fail:

- **axum-kbve** (run 27796411382) — astro-kbve build
- **cryptothrone** (run 27796413362) — astro-cryptothrone embed/discord vite builds

Both die with:
```
[vite]: Rollup failed to resolve import "@kbve/chat/gamechat" from "/app/packages/npm/laser/src/lib/net/realm-chat-client.ts".
```

## Root cause

1. The astro-builder stage of every axum Dockerfile that bundles laser never COPYd `packages/npm/chat` → source absent in the image, workspace symlink dangles.
2. cryptothrone's standalone vite embed/discord configs resolve `@kbve/*` via explicit alias arrays (not workspace symlinks) and lacked a `@kbve/chat/gamechat` entry.
3. astro-kbve/tsconfig.json extends `astro/tsconfigs/strict` with its own `paths` and lacked the chat aliases.

## Fix

- COPY `packages/npm/chat` alongside laser in the chuckrpg, cryptothrone, kbve, and rareicon Dockerfiles.
- Add `@kbve/chat/gamechat` alias to cryptothrone `vite.embed`/`vite.discord` configs.
- Add `@kbve/chat` + `@kbve/chat/gamechat` paths to astro-kbve tsconfig.

Verified locally: cryptothrone embed vite build resolves the import and completes.