### PR TITLE
fix(agents): direct HMAC reset + reorder GitHub setup wizard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro
@@ -11,18 +11,19 @@ import Step4SmokeBackfill from './agents/wizard/Step4SmokeBackfill';
 <section
 	id="agent-github-wizard-wrapper"
 	class="agent-github-wizard-wrapper kbve-dashboard-page"
-	aria-label="GitHub provider — webhook secret, PAT, repo allowlist (future), smoke-backfill">
+	aria-label="GitHub provider — HMAC webhook secret, PAT, repo allowlist, webhook install, smoke-backfill">
 	<div class="dashboard-content">
 		<header class="agent-header not-content">
 			<h1 class="agent-title">GitHub</h1>
 			<p class="agent-lede">
-				Per-guild GitHub integration. The four-step wizard provisions
-				the Vault rows that any KBVE agent consumes when it needs to
-				read or write against GitHub: an HMAC webhook secret (<code>
+				Per-guild GitHub integration. The wizard provisions the Vault
+				rows that any KBVE agent consumes when it needs to read or write
+				against GitHub: an HMAC webhook secret (<code>
 					github_webhook:&lt;guild&gt;
-				</code>) and a PAT (<code>github:&lt;guild&gt;</code>). Step 4
-				smoke-tests the full webhook + backfill path so you know
-				downstream agents can use the credentials.
+				</code>) and a PAT (<code>github:&lt;guild&gt;</code>). Steps
+				run top-to-bottom: secret, PAT, and allowlist first, then the
+				webhook install and a smoke-test of the full webhook + backfill
+				path so you know downstream agents can use the credentials.
 			</p>
 
 			<div
@@ -46,15 +47,15 @@ import Step4SmokeBackfill from './agents/wizard/Step4SmokeBackfill';
 		<div class="agent-stack" data-wizard-root>
 			<WizardGate client:only="react" />
 			<div class="agent-stack" data-wizard-steps hidden>
-				<ReactAgentRepoAllowlist client:only="react" />
 				<StepCard n={1} title="HMAC webhook secret">
 					<Step1Webhook client:only="react" />
 				</StepCard>
-				<StepCard n={2} title="Configure the GitHub webhook">
-					<Step2WebhookConfig client:only="react" />
-				</StepCard>
-				<StepCard n={3} title="GitHub PAT (for issue + comment reads)">
+				<StepCard n={2} title="GitHub PAT (for issue + comment reads)">
 					<Step3Pat client:only="react" />
+				</StepCard>
+				<ReactAgentRepoAllowlist client:only="react" />
+				<StepCard n={3} title="Configure the GitHub webhook">
+					<Step2WebhookConfig client:only="react" />
 				</StepCard>
 				<StepCard n={4} title="Smoke-test the backfill">
 					<Step4SmokeBackfill client:only="react" />

--- a/packages/npm/astro/src/agents/wizard/Step1Webhook.tsx
+++ b/packages/npm/astro/src/agents/wizard/Step1Webhook.tsx
@@ -1,13 +1,16 @@
 import { useState, useEffect } from 'react';
-import { useStore } from '@nanostores/react';
 import {
+	AlertTriangle,
 	CheckCircle2,
 	Copy,
 	Eye,
 	EyeOff,
 	Loader2,
+	RefreshCw,
 	Shuffle,
+	X,
 } from 'lucide-react';
+import { useStore } from '@nanostores/react';
 import { useAgents } from '../context';
 import { useStepCardStatus } from '../../dashboard/useStepCardStatus';
 import {
@@ -43,12 +46,14 @@ export default function Step1Webhook() {
 
 	const [reveal, setReveal] = useState(false);
 	const [copied, setCopied] = useState(false);
+	const [resetting, setResetting] = useState(false);
 
 	const stored = !!existing;
 
 	useEffect(() => {
 		setReveal(false);
 		setCopied(false);
+		setResetting(false);
 	}, [guildId]);
 
 	useEffect(() => {
@@ -57,10 +62,23 @@ export default function Step1Webhook() {
 		return () => clearTimeout(t);
 	}, [copied]);
 
-	async function generate() {
+	function generate() {
 		agents.setWebhookDraft(guildId, genHex(32));
 		setReveal(true);
 		setCopied(false);
+		agents.clearWebhookError(guildId);
+	}
+
+	function startReset() {
+		setResetting(true);
+		generate();
+	}
+
+	function cancelReset() {
+		setResetting(false);
+		setReveal(false);
+		setCopied(false);
+		agents.setWebhookDraft(guildId, null);
 		agents.clearWebhookError(guildId);
 	}
 
@@ -71,7 +89,10 @@ export default function Step1Webhook() {
 			WEBHOOK_TOKEN_NAME,
 			`GitHub webhook HMAC for guild ${guildId}`,
 		);
-		if (r.ok) setReveal(false);
+		if (r.ok) {
+			setReveal(false);
+			setResetting(false);
+		}
 	}
 
 	async function copy() {
@@ -85,10 +106,100 @@ export default function Step1Webhook() {
 
 	if (!guild) return <span ref={anchor} hidden aria-hidden="true" />;
 
-	return (
+	const editor = (
 		<>
-			<span ref={anchor} hidden aria-hidden="true" />
-			{stored ? (
+			{!secret && (
+				<button type="button" onClick={generate} style={primaryBtn}>
+					<Shuffle size={14} />
+					Generate 32-byte hex secret
+				</button>
+			)}
+			{secret && (
+				<>
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'stretch',
+							gap: '0.4rem',
+						}}>
+						<input
+							readOnly
+							type={reveal ? 'text' : 'password'}
+							value={secret}
+							style={{
+								...inputStyle,
+								fontFamily:
+									'var(--sl-font-mono, ui-monospace, monospace)',
+								flex: 1,
+							}}
+						/>
+						<button
+							type="button"
+							onClick={() => setReveal((r) => !r)}
+							style={iconBtn}
+							aria-label={reveal ? 'Hide' : 'Reveal'}>
+							{reveal ? <EyeOff size={14} /> : <Eye size={14} />}
+						</button>
+						<button
+							type="button"
+							onClick={copy}
+							style={iconBtn}
+							aria-label="Copy">
+							<Copy size={14} />
+							{copied ? ' Copied' : ''}
+						</button>
+					</div>
+					<div
+						style={{
+							display: 'flex',
+							gap: '0.4rem',
+							flexWrap: 'wrap',
+						}}>
+						<button
+							type="button"
+							onClick={generate}
+							style={secondaryBtn}>
+							<Shuffle size={14} />
+							Regenerate
+						</button>
+						<button
+							type="button"
+							onClick={save}
+							disabled={busy}
+							title={
+								busy
+									? 'HMAC save in flight — wait for it to finish.'
+									: 'Store the generated HMAC secret as github_webhook in the vault.'
+							}
+							style={primaryBtn}>
+							{busy ? (
+								<Loader2 size={14} style={spinStyle} />
+							) : (
+								<CheckCircle2 size={14} />
+							)}
+							{busy ? 'Saving…' : 'Save to Vault'}
+						</button>
+						{resetting && (
+							<button
+								type="button"
+								onClick={cancelReset}
+								disabled={busy}
+								style={secondaryBtn}>
+								<X size={14} />
+								Cancel
+							</button>
+						)}
+					</div>
+				</>
+			)}
+			{error && <p style={errText}>{error}</p>}
+		</>
+	);
+
+	if (stored && !resetting) {
+		return (
+			<>
+				<span ref={anchor} hidden aria-hidden="true" />
 				<p style={mutedText}>
 					<CheckCircle2
 						size={14}
@@ -99,101 +210,57 @@ export default function Step1Webhook() {
 					<code>
 						{WEBHOOK_SERVICE}:{guildId}
 					</code>{' '}
-					(token <code>{existing!.token_name}</code>). To rotate, use
-					the <strong>Rotate HMAC secret</strong> control in Step 2 —
-					it regenerates the secret and updates GitHub + the vault in
-					one step.
+					(token <code>{existing!.token_name}</code>).
 				</p>
-			) : (
-				<>
-					<p style={mutedText}>
-						Generate a random ≥32-char HMAC secret. The same value
-						goes into the GitHub webhook config in Step 2.
-					</p>
-					{!secret && (
-						<button
-							type="button"
-							onClick={generate}
-							style={primaryBtn}>
-							<Shuffle size={14} />
-							Generate 32-byte hex secret
-						</button>
-					)}
-					{secret && (
-						<>
-							<div
-								style={{
-									display: 'flex',
-									alignItems: 'stretch',
-									gap: '0.4rem',
-								}}>
-								<input
-									readOnly
-									type={reveal ? 'text' : 'password'}
-									value={secret}
-									style={{
-										...inputStyle,
-										fontFamily:
-											'var(--sl-font-mono, ui-monospace, monospace)',
-										flex: 1,
-									}}
-								/>
-								<button
-									type="button"
-									onClick={() => setReveal((r) => !r)}
-									style={iconBtn}
-									aria-label={reveal ? 'Hide' : 'Reveal'}>
-									{reveal ? (
-										<EyeOff size={14} />
-									) : (
-										<Eye size={14} />
-									)}
-								</button>
-								<button
-									type="button"
-									onClick={copy}
-									style={iconBtn}
-									aria-label="Copy">
-									<Copy size={14} />
-									{copied ? ' Copied' : ''}
-								</button>
-							</div>
-							<div
-								style={{
-									display: 'flex',
-									gap: '0.4rem',
-									flexWrap: 'wrap',
-								}}>
-								<button
-									type="button"
-									onClick={generate}
-									style={secondaryBtn}>
-									<Shuffle size={14} />
-									Regenerate
-								</button>
-								<button
-									type="button"
-									onClick={save}
-									disabled={busy}
-									title={
-										busy
-											? 'HMAC save in flight — wait for it to finish.'
-											: 'Store the generated HMAC secret as github_webhook in the vault.'
-									}
-									style={primaryBtn}>
-									{busy ? (
-										<Loader2 size={14} style={spinStyle} />
-									) : (
-										<CheckCircle2 size={14} />
-									)}
-									{busy ? 'Saving…' : 'Save to Vault'}
-								</button>
-							</div>
-						</>
-					)}
-					{error && <p style={errText}>{error}</p>}
-				</>
+				<button
+					type="button"
+					onClick={startReset}
+					title="Generate a fresh HMAC and overwrite the vault row in place. Does not touch GitHub — update the hook's Secret field or use Rotate in the Configure webhook step."
+					style={secondaryBtn}>
+					<RefreshCw size={14} />
+					Reset HMAC secret
+				</button>
+				{error && <p style={errText}>{error}</p>}
+			</>
+		);
+	}
+
+	return (
+		<>
+			<span ref={anchor} hidden aria-hidden="true" />
+			{resetting && (
+				<div
+					style={{
+						display: 'flex',
+						gap: '0.5rem',
+						padding: '0.6rem 0.75rem',
+						borderRadius: 8,
+						border: '1px solid rgba(245,158,11,0.4)',
+						background: 'rgba(245,158,11,0.08)',
+						fontSize: '0.82rem',
+						lineHeight: 1.5,
+						color: 'var(--sl-color-gray-1, #e6e8eb)',
+					}}>
+					<AlertTriangle
+						size={16}
+						color="#f59e0b"
+						style={{ flexShrink: 0, marginTop: '0.1rem' }}
+					/>
+					<span>
+						Vault-only reset. If a GitHub webhook is already
+						installed, its old secret will fail signature until you
+						also update the hook's <strong>Secret</strong> field —
+						or run <strong>Rotate HMAC secret</strong> in the
+						Configure webhook step, which updates GitHub + Vault
+						together.
+					</span>
+				</div>
 			)}
+			<p style={mutedText}>
+				Generate a random ≥32-char HMAC secret. The same value goes into
+				the GitHub webhook config in the Configure webhook step.
+			</p>
+			{editor}
 		</>
 	);
 }

--- a/packages/npm/astro/src/agents/wizard/Step2WebhookConfig.tsx
+++ b/packages/npm/astro/src/agents/wizard/Step2WebhookConfig.tsx
@@ -273,7 +273,7 @@ export default function Step2WebhookConfig() {
 					</strong>
 				</div>
 				<p style={{ ...mutedText, fontSize: '0.82rem' }}>
-					Uses your stored GitHub PAT (Step 3 must be done first) to
+					Uses your stored GitHub PAT (Step 2 must be done first) to
 					POST <code>/repos/&lt;owner&gt;/&lt;repo&gt;/hooks</code>{' '}
 					with the URL and HMAC secret you just stored. Only repos in
 					your allowlist are eligible.

--- a/packages/npm/astro/src/agents/wizard/Step4SmokeBackfill.tsx
+++ b/packages/npm/astro/src/agents/wizard/Step4SmokeBackfill.tsx
@@ -83,7 +83,7 @@ export default function Step4SmokeBackfill() {
 		setRunBlockMsg(null);
 		if (!ready) {
 			setRunBlockMsg(
-				'Finish Steps 1 + 3 first — HMAC secret and PAT must be stored before the smoke can run.',
+				'Finish Steps 1 + 2 first — HMAC secret and PAT must be stored before the smoke can run.',
 			);
 			return;
 		}


### PR DESCRIPTION
## What

Two UX fixes to the GitHub agents setup wizard (`/dashboard/agents/github/`).

### 1. Direct HMAC reset in Step 1
Previously, once an HMAC secret was stored, Step 1 only printed *"use the Rotate HMAC secret control in Step 2"*. That Step 2 rotate requires an **already-installed GitHub hook + a stored PAT** — otherwise it 404s (`No kbve webhook found on this repo — install one before rotating`). So there was no way to simply reset/regenerate the secret. Re-saving also surfaced raw `22023` SQL errors (see linked issue).

Step 1 now has an inline **Reset HMAC secret** button that regenerates the `github_webhook` vault row in place via the existing `set_token` upsert (`service_set_guild_token`, which re-encrypts through `vault.update_secret`). No GitHub/PAT dependency, no bounce to another step. An amber warning notes a vault-only reset desyncs an already-installed hook — update GitHub's Secret field, or use the Configure-webhook **Rotate** (which updates GitHub + vault together). Step 2 rotate/delete kept as-is.

### 2. Reorder the wizard so it flows top-to-bottom
Old order forced backtracking: webhook install (Step 2) needed the PAT (Step 3) and allowlist repos, both rendered *below* it. New order puts dependencies first:

`1 HMAC → 2 PAT → Repo allowlist → 3 Configure webhook (auto-install) → 4 Smoke`

Fixed the step-number cross-references broken by the move (Step 2 "PAT is Step 2", Step 4 "Steps 1 + 2").

## Files
- `apps/kbve/astro-kbve/src/components/dashboard/AstroAgentGithubWizard.astro` — reorder
- `packages/npm/astro/src/agents/wizard/Step1Webhook.tsx` — reset control
- `packages/npm/astro/src/agents/wizard/Step2WebhookConfig.tsx` — PAT step ref
- `packages/npm/astro/src/agents/wizard/Step4SmokeBackfill.tsx` — step ref

## Verify
`nx run astro:build` passes (astro lib + droid dep).

## Note
The reset's correctness depends on migration `20260614120000` being applied to the prod DB — tracked separately (linked issue).