### PR TITLE
feat(irc-gateway): durable Valkey chat history + JWT history/identity/moderation

### DIFF
--- a/apps/irc/irc-gateway/src/auth/jwt.rs
+++ b/apps/irc/irc-gateway/src/auth/jwt.rs
@@ -54,6 +54,14 @@ impl Claims {
             .map(sanitize_nick)
             .find(|n| !n.is_empty())
     }
+
+    /// Staff/elevated identities allowed to run moderation actions.
+    pub fn is_staff(&self) -> bool {
+        matches!(
+            self.role.as_deref(),
+            Some("service_role") | Some("supabase_admin")
+        )
+    }
 }
 
 fn sanitize_nick(raw: &str) -> String {
@@ -133,6 +141,27 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     const TEST_SECRET: &str = "kbve-jwt-secret-for-tests";
+
+    fn claims_with_role(role: Option<&str>) -> Claims {
+        Claims {
+            sub: "user-1".into(),
+            email: None,
+            role: role.map(str::to_string),
+            aud: None,
+            kbve_username: None,
+            user_metadata: UserMetadata::default(),
+            exp: 0,
+            iat: 0,
+        }
+    }
+
+    #[test]
+    fn is_staff_only_for_elevated_roles() {
+        assert!(claims_with_role(Some("service_role")).is_staff());
+        assert!(claims_with_role(Some("supabase_admin")).is_staff());
+        assert!(!claims_with_role(Some("authenticated")).is_staff());
+        assert!(!claims_with_role(None).is_staff());
+    }
 
     fn now_secs() -> u64 {
         SystemTime::now()

--- a/apps/irc/irc-gateway/src/gateway/ergo.rs
+++ b/apps/irc/irc-gateway/src/gateway/ergo.rs
@@ -5,7 +5,11 @@
 //! same env vars and parse the same `PRIVMSG` shape, so the host/port lookup
 //! and the parser live here instead of being copy-pasted per task.
 
+use std::time::Duration;
+
+use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
+use tokio::time::sleep;
 
 const DEFAULT_HOST: &str = "ergo-irc-service.irc.svc.cluster.local";
 const DEFAULT_IRC_PORT: u16 = 6667;
@@ -32,6 +36,36 @@ pub fn ws_url() -> String {
 /// Open a TCP connection to ergo's IRC port using the configured host/port.
 pub async fn connect_irc() -> std::io::Result<TcpStream> {
     TcpStream::connect(format!("{}:{}", irc_host(), irc_port())).await
+}
+
+/// Open a throwaway ergo connection, register as `conn_nick`, join `channel`,
+/// and send a single pre-built `PRIVMSG` line (e.g. a gateway announcement).
+/// Used by the staff moderation endpoint; the message rides the normal
+/// envelope wire form so the history listener and live clients pick it up.
+pub async fn announce(channel: &str, conn_nick: &str, privmsg_line: &str) -> std::io::Result<()> {
+    let safe: String = conn_nick
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_')
+        .take(16)
+        .collect();
+    let safe = if safe.is_empty() { "mod".into() } else { safe };
+
+    let stream = connect_irc().await?;
+    let (_r, mut w) = stream.into_split();
+    write_line(&mut w, &format!("NICK {safe}")).await?;
+    write_line(&mut w, &format!("USER {safe} 0 * :gateway announce")).await?;
+    write_line(&mut w, &format!("JOIN {channel}")).await?;
+    write_line(&mut w, privmsg_line).await?;
+    w.flush().await?;
+    // Let ergo relay to channel members before the socket drops.
+    sleep(Duration::from_millis(200)).await;
+    Ok(())
+}
+
+async fn write_line(w: &mut tokio::net::tcp::OwnedWriteHalf, line: &str) -> std::io::Result<()> {
+    w.write_all(line.as_bytes()).await?;
+    w.write_all(b"\r\n").await?;
+    w.flush().await
 }
 
 /// Parse `:nick!user@host PRIVMSG #channel :payload` → `(sender, channel,

--- a/apps/irc/irc-gateway/src/gateway/history.rs
+++ b/apps/irc/irc-gateway/src/gateway/history.rs
@@ -37,6 +37,12 @@ pub const HISTORY_LEN: usize = 50;
 /// channel whitelists).
 const HISTORY_CHANNELS: &[&str] = &["#general", "#world-events", "#mc-global"];
 
+/// Whether a channel is one the gateway tracks history for (and thus one a
+/// client is allowed to read backscroll from / a staff announce can target).
+pub fn is_tracked(channel: &str) -> bool {
+    HISTORY_CHANNELS.contains(&channel)
+}
+
 type Store = Arc<Mutex<HashMap<String, VecDeque<ChatMessage>>>>;
 
 fn store() -> &'static Store {
@@ -194,5 +200,12 @@ mod tests {
     #[tokio::test]
     async fn recent_empty_for_unknown_channel() {
         assert!(recent("#never-seen").await.is_empty());
+    }
+
+    #[test]
+    fn is_tracked_matches_whitelist() {
+        assert!(is_tracked("#general"));
+        assert!(is_tracked("#world-events"));
+        assert!(!is_tracked("#random"));
     }
 }

--- a/apps/irc/irc-gateway/src/gateway/history.rs
+++ b/apps/irc/irc-gateway/src/gateway/history.rs
@@ -11,6 +11,12 @@
 //! the buffer. Client sessions are pure readers ([`recent`]) — this avoids the
 //! N-fold duplication you'd get if every client connection appended what it
 //! received.
+//!
+//! When Valkey is configured the ring lives there (durable across gateway
+//! restarts, shared with future replicas); otherwise it falls back to an
+//! in-process buffer. The Valkey path assumes a single gateway replica writes —
+//! scaling the deployment past one needs a single-writer lease so the listeners
+//! don't double-append.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -22,6 +28,7 @@ use tokio::time::sleep;
 use tracing::{debug, info, warn};
 
 use crate::gateway::ergo;
+use crate::gateway::kv;
 
 /// Messages retained per channel.
 pub const HISTORY_LEN: usize = 50;
@@ -37,9 +44,40 @@ fn store() -> &'static Store {
     STORE.get_or_init(|| Arc::new(Mutex::new(HashMap::new())))
 }
 
-/// Append a message to a channel's ring buffer, evicting the oldest past
-/// [`HISTORY_LEN`].
-fn push(channel: &str, msg: ChatMessage) {
+fn hist_key(channel: &str) -> String {
+    format!("chat:hist:{channel}")
+}
+
+/// Append a message to a channel's history. When Valkey is configured the ring
+/// lives there (durable across restarts, shared across gateway replicas);
+/// otherwise it falls back to the in-process buffer.
+async fn push(channel: &str, msg: ChatMessage) {
+    if let Some(cache) = kv::get() {
+        if let Ok(json) = serde_json::to_string(&msg) {
+            let _ = cache
+                .list_push_capped(&hist_key(channel), &json, HISTORY_LEN)
+                .await;
+        }
+        return;
+    }
+    push_memory(channel, msg);
+}
+
+/// Snapshot a channel's buffered messages, oldest first.
+pub async fn recent(channel: &str) -> Vec<ChatMessage> {
+    if let Some(cache) = kv::get() {
+        return cache
+            .list_range(&hist_key(channel))
+            .await
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|s| serde_json::from_str(s).ok())
+            .collect();
+    }
+    recent_memory(channel)
+}
+
+fn push_memory(channel: &str, msg: ChatMessage) {
     let mut guard = store().lock().expect("history mutex poisoned");
     let buf = guard.entry(channel.to_string()).or_default();
     if buf.len() == HISTORY_LEN {
@@ -48,8 +86,7 @@ fn push(channel: &str, msg: ChatMessage) {
     buf.push_back(msg);
 }
 
-/// Snapshot a channel's buffered messages, oldest first.
-pub fn recent(channel: &str) -> Vec<ChatMessage> {
+fn recent_memory(channel: &str) -> Vec<ChatMessage> {
     store()
         .lock()
         .expect("history mutex poisoned")
@@ -107,7 +144,7 @@ async fn listen_once(channel: &str) -> std::io::Result<()> {
                 msg.platform = "irc".into();
             }
             debug!(channel = %channel, "history buffered a message");
-            push(channel, msg);
+            push(channel, msg).await;
         }
     }
 }
@@ -135,13 +172,13 @@ mod tests {
         ChatMessage::from_irc_privmsg("#t", &format!("[CHAT] a@irc: {text}")).unwrap()
     }
 
-    #[test]
-    fn ring_buffer_evicts_oldest_and_keeps_order() {
+    #[tokio::test]
+    async fn ring_buffer_evicts_oldest_and_keeps_order() {
         let ch = "#ring-test";
         for i in 0..HISTORY_LEN + 3 {
-            push(ch, msg(&format!("m{i}")));
+            push(ch, msg(&format!("m{i}"))).await;
         }
-        let got = recent(ch);
+        let got = recent(ch).await;
         assert_eq!(got.len(), HISTORY_LEN);
         // oldest three (m0,m1,m2) evicted; newest retained in order
         assert_eq!(got.first().unwrap().content, "m3");
@@ -154,8 +191,8 @@ mod tests {
         assert_eq!(sanitize_channel("#world-events"), "worldevents");
     }
 
-    #[test]
-    fn recent_empty_for_unknown_channel() {
-        assert!(recent("#never-seen").is_empty());
+    #[tokio::test]
+    async fn recent_empty_for_unknown_channel() {
+        assert!(recent("#never-seen").await.is_empty());
     }
 }

--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -209,7 +209,7 @@ async fn session(client_ws: WebSocket, nick: String, channels: Vec<String>, plat
     // Replay recent channel history so a fresh client lands in a room with
     // context instead of an empty log.
     for ch in &channels {
-        for msg in crate::gateway::history::recent(ch) {
+        for msg in crate::gateway::history::recent(ch).await {
             if send_json(&mut client_tx, &msg).await.is_err() {
                 return;
             }

--- a/apps/irc/irc-gateway/src/gateway/minechat.rs
+++ b/apps/irc/irc-gateway/src/gateway/minechat.rs
@@ -89,10 +89,11 @@ pub async fn ws_handler(ws: WebSocketUpgrade, req: Request) -> impl IntoResponse
         Err(status) => return status.into_response(),
     };
 
-    // Derive the game nick from the JWT subject. We keep it short and
-    // prefixed so it's obvious in channel activity which identities are
-    // game clients vs. browser-IRC clients.
-    let nick = format!("mc-{}", sanitize_sub(&claims.sub, 8));
+    // Prefer the real KBVE username (same as /gamechat); fall back to a
+    // stable sub-derived handle so the player is never anonymous-but-spoofable.
+    let nick = claims
+        .irc_nick()
+        .unwrap_or_else(|| format!("mc-{}", sanitize_sub(&claims.sub, 8)));
 
     info!(user = %nick, "minechat upgrade accepted");
     ws.max_frame_size(16 * 1024)

--- a/apps/irc/irc-gateway/src/gateway/rest.rs
+++ b/apps/irc/irc-gateway/src/gateway/rest.rs
@@ -1,8 +1,17 @@
-use axum::{Extension, Json, Router, middleware, response::IntoResponse, routing::get};
+use axum::{
+    Extension, Json, Router,
+    extract::Query,
+    http::StatusCode,
+    middleware,
+    response::IntoResponse,
+    routing::{get, post},
+};
+use bevy_chat::{ChatMessage, MessageKind};
+use serde::Deserialize;
 use serde_json::json;
 
 use crate::auth::jwt::{Claims, require_auth};
-use crate::gateway::ergo;
+use crate::gateway::{ergo, history};
 
 const DEFAULT_USERNAME_SETUP_URL: &str = "https://kbve.com/askama/profile";
 
@@ -12,7 +21,82 @@ pub fn api_router() -> Router {
         .route("/channels", get(channels))
         .route("/users", get(users))
         .route("/me", get(me))
+        .route("/history", get(history_get))
+        .route("/mod/announce", post(announce))
         .layer(middleware::from_fn(require_auth))
+}
+
+#[derive(Deserialize)]
+struct HistoryQuery {
+    channel: String,
+}
+
+async fn history_get(Query(q): Query<HistoryQuery>) -> impl IntoResponse {
+    if !history::is_tracked(&q.channel) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "channel not tracked" })),
+        )
+            .into_response();
+    }
+    Json(history::recent(&q.channel).await).into_response()
+}
+
+#[derive(Deserialize)]
+struct AnnounceBody {
+    channel: String,
+    message: String,
+}
+
+async fn announce(
+    Extension(claims): Extension<Claims>,
+    Json(body): Json<AnnounceBody>,
+) -> impl IntoResponse {
+    if !claims.is_staff() {
+        return StatusCode::FORBIDDEN.into_response();
+    }
+    if !history::is_tracked(&body.channel) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(json!({ "error": "channel not tracked" })),
+        )
+            .into_response();
+    }
+    if body.message.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "empty message" })),
+        )
+            .into_response();
+    }
+
+    let sender = claims.irc_nick().unwrap_or_else(|| "staff".to_string());
+    let msg = ChatMessage {
+        kind: MessageKind::System,
+        sender: sender.clone(),
+        platform: "system".to_string(),
+        channel: body.channel.clone(),
+        content: body.message.clone(),
+        payload: None,
+    };
+
+    match ergo::announce(
+        &body.channel,
+        &format!("mod-{sender}"),
+        &msg.to_irc_privmsg(),
+    )
+    .await
+    {
+        Ok(()) => (StatusCode::ACCEPTED, Json(json!({ "status": "sent" }))).into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "staff announce relay failed");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(json!({ "error": "relay failed" })),
+            )
+                .into_response()
+        }
+    }
 }
 
 async fn me(Extension(claims): Extension<Claims>) -> impl IntoResponse {

--- a/packages/rust/jedi/Cargo.toml
+++ b/packages/rust/jedi/Cargo.toml
@@ -61,7 +61,7 @@ url = { version = "2", optional = true }
 uuid = { version = "1", optional = true, features = ["serde", "v4"] }
 rustls-pemfile = { version = "2", optional = true }
 fred = { version = "10", features = [
-  "i-keys", "i-pubsub", "i-std", "subscriber-client",
+  "i-keys", "i-lists", "i-pubsub", "i-std", "subscriber-client",
   "serde-json", "i-server", "i-scripts", "i-streams",
   "metrics", "enable-rustls", "i-tracking"
 ] }

--- a/packages/rust/jedi/src/state/kv.rs
+++ b/packages/rust/jedi/src/state/kv.rs
@@ -463,6 +463,25 @@ impl KvCache {
         }
         Some(count.max(0) as u64)
     }
+
+    /// Append `value` to a capped Valkey list and trim it to the newest
+    /// `max_len` entries. Returns `None` when L2 (Valkey) is unavailable so the
+    /// caller can fall back to in-process storage. Oldest-first ordering: read
+    /// the list back with [`list_range`](Self::list_range).
+    pub async fn list_push_capped(&self, key: &str, value: &str, max_len: usize) -> Option<()> {
+        let pool = self.l2.as_ref()?;
+        let lkey = self.qualified(key);
+        let _: i64 = pool.rpush::<i64, _, _>(&lkey, value).await.ok()?;
+        let _: () = pool.ltrim(&lkey, -(max_len as i64), -1).await.ok()?;
+        Some(())
+    }
+
+    /// Read a Valkey list oldest-first. Returns `None` when L2 is unavailable.
+    pub async fn list_range(&self, key: &str) -> Option<Vec<String>> {
+        let pool = self.l2.as_ref()?;
+        let lkey = self.qualified(key);
+        pool.lrange::<Vec<String>, _>(&lkey, 0, -1).await.ok()
+    }
 }
 
 async fn build_valkey_pool() -> Result<ValkeyPool, String> {


### PR DESCRIPTION
## What

Two chat phases on the irc-gateway: a durable history ring, then JWT-driven features on top.

### 1. Durable Valkey-backed history ring

The per-channel history was in-process only — it reset on every gateway restart and couldn't be shared. Now Valkey-backed when configured (the gateway already points at `KBVE_KV_URL`), with the in-process buffer as fallback.

- **jedi `KvCache`**: `list_push_capped` (RPUSH + LTRIM to newest N) + `list_range` (LRANGE oldest-first); enable fred's `i-lists` feature.
- **history**: `push`/`recent` are async; with Valkey the ring lives at `chat:hist:<channel>`, `ChatMessage` stored as JSON. In-process buffer kept as fallback.

> Single-writer note: the Valkey write path assumes one gateway replica (deployment is `replicas: 1`). Scaling past one needs a single-writer lease so the per-channel listeners don't double-append — called out in the module doc.

### 2. JWT-based features

- **Identity** — `/minechat` now uses `claims.irc_nick()` (kbve_username / preferred_username / …) with the `mc-<sub8>` fallback, matching `/gamechat`. Real usernames instead of opaque sub hashes.
- **Read access** — authenticated `GET /api/v1/history?channel=` serves the durable ring to any valid JWT; `403` for untracked channels. Web/clients get backscroll without a minechat session.
- **Moderation** — `Claims::is_staff()` (service_role / supabase_admin) gates `POST /api/v1/mod/announce { channel, message }`. It builds a `System` `ChatMessage` and relays it through ergo as a normal envelope `PRIVMSG`, so the history listener buffers it and live clients render it. `403` non-staff/untracked, `400` empty.

`history::is_tracked` centralizes the read/announce channel check.

## Verification

- `irc-gateway`: 50 tests (adds `is_staff` + `is_tracked` guards; ring eviction exercises the in-process fallback)
- jedi compiles with the new list ops