### PR TITLE
fix(jobboard): set AUTH_MODE=local in prod deployment

### DIFF
--- a/apps/kube/jobboard/manifest/jobboard-deployment.yaml
+++ b/apps/kube/jobboard/manifest/jobboard-deployment.yaml
@@ -49,6 +49,13 @@ spec:
                         value: '5400'
                       - name: SECURE_COOKIES
                         value: 'true'
+                      - name: AUTH_MODE
+                        value: 'local'
+                      - name: SUPABASE_JWT_SECRET
+                        valueFrom:
+                            secretKeyRef:
+                                name: supabase-shared
+                                key: jwt-secret
                       - name: KBVE_PG_RW_URL
                         valueFrom:
                             secretKeyRef:


### PR DESCRIPTION
## Problem
jobs.kbve.com shows the **dev-mode banner** in production.

## Root cause
`AppState::new` defaults `AUTH_MODE` to `AuthMode::Remote` when unset ([state.rs:47-50](apps/jobboard/src/state.rs#L47-L50)). Remote = dev mode → `/api/meta` returns `dev:true` → SPA renders DevBanner. The prod deployment never set `AUTH_MODE`, so it fell to the Remote default.

## Fix
Wire prod env in [jobboard-deployment.yaml](apps/kube/jobboard/manifest/jobboard-deployment.yaml):
- `AUTH_MODE=local` → offline HS256 (`AppState::dev()` false, no banner)
- `SUPABASE_JWT_SECRET` from the existing `supabase-shared/jwt-secret` key (Local mode needs it for signature verification)

Reloader already watches `supabase-shared`, so rotation rolls the pod.

## Rollout
ArgoCD tracks `main`; reaches cluster on the next dev→main release PR.