### PR TITLE
fix(kbve-gate): republish kbve.com login bounce + pin grafana-gate

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -40,7 +40,7 @@
 		{
 			"key": "astro_kbve",
 			"app_name": "axum-kbve",
-			"version": "1.0.203",
+			"version": "1.0.204",
 			"version_toml": "apps/kbve/axum-kbve/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/api.mdx",
 			"version_target": "apps/kbve/axum-kbve/Cargo.toml",
@@ -312,14 +312,17 @@
 		{
 			"key": "kbve_gate",
 			"app_name": "kbve-gate",
-			"version": "0.1.0",
+			"version": "0.1.1",
 			"version_toml": "apps/kbve/kbve-gate/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx",
 			"version_target": "apps/kbve/kbve-gate/Cargo.toml",
 			"source_path": "apps/kbve/kbve-gate",
 			"runner": "ubuntu-latest",
 			"image": "kbve/kbve-gate",
-			"deployment_yaml": "apps/kube/n8n/manifest/n8n-deployment.yaml",
+			"deployment_yamls": [
+				"apps/kube/n8n/manifest/n8n-deployment.yaml",
+				"apps/kube/monitoring/manifests/grafana-gate-deployment.yaml"
+			],
 			"has_test": false
 		},
 		{

--- a/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/api.mdx
@@ -12,7 +12,7 @@ tags:
 key: astro_kbve
 pipeline: docker
 app_name: axum-kbve
-version: "1.0.203"
+version: "1.0.204"
 source_path: apps/kbve/astro-kbve
 version_toml: apps/kbve/axum-kbve/version.toml
 version_target: apps/kbve/axum-kbve/Cargo.toml

--- a/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/kbve-gate.mdx
@@ -20,7 +20,9 @@ version_toml: apps/kbve/kbve-gate/version.toml
 version_target: apps/kbve/kbve-gate/Cargo.toml
 runner: ubuntu-latest
 image: kbve/kbve-gate
-deployment_yaml: apps/kube/n8n/manifest/n8n-deployment.yaml
+deployment_yamls:
+    - apps/kube/n8n/manifest/n8n-deployment.yaml
+    - apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
 has_test: false
 author: h0lybyte
 license: KBVE

--- a/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
+++ b/apps/kube/monitoring/manifests/grafana-gate-deployment.yaml
@@ -27,7 +27,7 @@ spec:
                     type: RuntimeDefault
             containers:
                 - name: kbve-gate
-                  image: ghcr.io/kbve/kbve-gate:latest
+                  image: ghcr.io/kbve/kbve-gate:0.1.1
                   imagePullPolicy: IfNotPresent
                   ports:
                       - name: gateway
@@ -46,6 +46,8 @@ spec:
                         value: 'forum'
                       - name: GATE_LOGIN_REDIRECT
                         value: 'https://kbve.com/login'
+                      - name: GATE_COOKIE_DOMAIN
+                        value: '.kbve.com'
                       - name: SUPABASE_URL
                         value: 'http://supabase-postgrest.kilobase.svc.cluster.local:3000'
                       - name: SUPABASE_JWT_SECRET


### PR DESCRIPTION
## Why the n8n loop persisted

The SSO bounce (#12783) shipped the **gate** half (kbve-gate 0.1.1, n8n pinned, live), but the loop continued. Root cause: the browser-side bounce lives in **astro-kbve**, and kbve.com was never republished. Verified against prod — the live `ReactAuthLogin.*.js` bundle contains **none** of the `redirect_to` / `access_token` handoff. Old login ignores `redirect_to` → never returns a token → loop.

## Changes

1. **astro-kbve republish** — `api.mdx` 1.0.203 → 1.0.204. Rebuilds kbve.com with the login bounce. **This is the loop fix.**
2. **grafana-gate** (second gate, fronts Grafana, also `is_staff`) was missed by the publish atom and stuck on `:latest`:
   - pinned `:latest` → `:0.1.1`
   - added `GATE_COOKIE_DOMAIN=.kbve.com` (otherwise it loops the same way)
3. **kbve-gate.mdx** `deployment_yaml` → `deployment_yamls` listing **both** the n8n and grafana-gate manifests, so the post-publish atom keeps both image tags in sync on every future bump.
4. regenerated `ci-dispatch-manifest.json` (ci-docker reads `deployment_yamls` from it, not the MDX).

## After merge + dev→main release
- kbve.com serves the bounce → n8n.kbve.com: logged-out bounces to login and **back** without looping; logged-in non-staff → 403.
- grafana-gate tracks the gate version going forward.

Gate stays at 0.1.1 — it's live and correct; no gate code change here.