### PR TITLE
fix(ci): resilient Playwright browser install (cache + retry + mcr fallback)

### DIFF
--- a/.github/workflows/docker-test-app.yml
+++ b/.github/workflows/docker-test-app.yml
@@ -255,36 +255,34 @@ jobs:
               if: ${{ steps.detect-playwright.outputs.uses_playwright == 'true' && steps.baked-playwright.outputs.all_present != 'true' && steps.playwright-cache.outputs.cache-hit != 'true' }}
               timeout-minutes: 40
               env:
-                  UV_THREADPOOL_SIZE: '16'
+                  UV_THREADPOOL_SIZE: '128'
+                  PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: '120000'
                   MISSING: ${{ steps.baked-playwright.outputs.missing || steps.detect-playwright.outputs.browsers }}
                   PW_VERSION: ${{ steps.playwright-version.outputs.version }}
               run: |
                   set -uo pipefail
-                  attempt_install() {
-                    local label="$1"
-                    echo "::group::playwright install via ${label}"
+                  # Only cdn.playwright.dev serves the Chrome-for-Testing
+                  # artifacts (prss/npmmirror/azureedge do not mirror them), so
+                  # retry the default host — UV_THREADPOOL_SIZE dodges the
+                  # chromium-extract libuv deadlock, CONNECTION_TIMEOUT + `timeout`
+                  # turn a silent 100% stall into a retryable error — then fall
+                  # back to the bundled mcr docker image.
+                  attempt() {
+                    echo "::group::playwright install ($1)"
                     timeout 600 pnpm exec playwright install --with-deps ${MISSING}
                     local rc=$?
                     echo "::endgroup::"
                     return $rc
                   }
-
-                  attempt_install "default cdn (try 1)" && exit 0
-                  echo "::warning::default cdn try 1 failed; retrying"
+                  attempt "try 1" && exit 0
+                  echo "::warning::try 1 failed/stalled; retrying"
                   sleep 10
-                  attempt_install "default cdn (try 2)" && exit 0
-                  echo "::warning::default cdn exhausted; trying azure edge mirror"
+                  attempt "try 2" && exit 0
+                  echo "::warning::try 2 failed/stalled; retrying"
+                  sleep 15
+                  attempt "try 3" && exit 0
+                  echo "::warning::cdn.playwright.dev exhausted; falling back to mcr playwright image"
 
-                  export PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT=120000
-                  export PLAYWRIGHT_DOWNLOAD_HOST=https://playwright.azureedge.net
-                  attempt_install "azureedge (try 1)" && exit 0
-                  echo "::warning::azureedge try 1 failed; retrying"
-                  sleep 10
-                  attempt_install "azureedge (try 2)" && exit 0
-                  echo "::warning::azureedge exhausted; falling back to mcr playwright image"
-
-                  unset PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT
-                  unset PLAYWRIGHT_DOWNLOAD_HOST
                   IMG="mcr.microsoft.com/playwright:v${PW_VERSION}-jammy"
                   DEST="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
                   mkdir -p "$DEST"

--- a/.github/workflows/npm-test-package.yml
+++ b/.github/workflows/npm-test-package.yml
@@ -51,17 +51,79 @@ jobs:
                   UV_THREADPOOL_SIZE: '16'
               run: pnpm install --frozen-lockfile --prefer-offline
 
-            # Every NPM package the dispatcher fans into this workflow
-            # (devops, droid, khashvault, laser) has a sibling `<pkg>-e2e`
-            # Playwright suite, so always install chromium up front. The
-            # `pnpm install` step's UV_THREADPOOL_SIZE bump carries over to
-            # avoid the chromium-extract libuv-threadpool deadlock seen in
-            # earlier runs.
+            - name: Resolve Playwright version
+              id: playwright-version
+              run: |
+                  VER=$(node -e "console.log(require('./node_modules/playwright/package.json').version)" 2>/dev/null || echo "unknown")
+                  echo "version=${VER}" >> "$GITHUB_OUTPUT"
+                  echo "Resolved Playwright version: ${VER}"
+
+            - name: Cache Playwright Browsers
+              id: playwright-cache
+              uses: actions/cache@v5
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-chromium
+                  restore-keys: |
+                      ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-
+                      ${{ runner.os }}-playwright-
+
+            # Every NPM package fanned into this workflow has a sibling e2e
+            # Playwright suite, so provision chromium up front. Only
+            # cdn.playwright.dev serves the Chrome-for-Testing artifacts (prss/
+            # npmmirror/azureedge do not mirror them), so retry the default host
+            # — UV_THREADPOOL_SIZE dodges the chromium-extract libuv deadlock,
+            # CONNECTION_TIMEOUT + `timeout` turn a silent 100% stall into a
+            # retryable error — then fall back to the bundled mcr docker image.
             - name: Install Playwright Browsers
-              timeout-minutes: 15
+              if: ${{ steps.playwright-cache.outputs.cache-hit != 'true' }}
+              timeout-minutes: 25
               env:
-                  UV_THREADPOOL_SIZE: '16'
-              run: pnpm exec playwright install --with-deps chromium
+                  UV_THREADPOOL_SIZE: '128'
+                  PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT: '120000'
+                  PW_VERSION: ${{ steps.playwright-version.outputs.version }}
+              run: |
+                  set -uo pipefail
+                  BROWSERS=chromium
+                  attempt() {
+                    echo "::group::playwright install ($1)"
+                    timeout 480 pnpm exec playwright install --with-deps ${BROWSERS}
+                    local rc=$?
+                    echo "::endgroup::"
+                    return $rc
+                  }
+                  attempt "try 1" && exit 0
+                  echo "::warning::try 1 failed/stalled; retrying"
+                  sleep 10
+                  attempt "try 2" && exit 0
+                  echo "::warning::try 2 failed/stalled; retrying"
+                  sleep 15
+                  attempt "try 3" && exit 0
+                  echo "::warning::cdn.playwright.dev exhausted; falling back to mcr playwright image"
+
+                  IMG="mcr.microsoft.com/playwright:v${PW_VERSION}-jammy"
+                  DEST="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+                  mkdir -p "$DEST"
+                  echo "::group::pull ${IMG}"
+                  if ! docker pull "$IMG"; then
+                    echo "::error::docker pull ${IMG} failed"
+                    echo "::endgroup::"
+                    exit 1
+                  fi
+                  echo "::endgroup::"
+                  CID=$(docker create "$IMG")
+                  docker cp "$CID:/ms-playwright/." "$DEST/"
+                  docker rm "$CID" >/dev/null
+                  pnpm exec playwright install-deps ${BROWSERS}
+                  echo "playwright browsers restored from ${IMG} into ${DEST}"
+
+            - name: Install Playwright OS deps (cache hit)
+              if: ${{ steps.playwright-cache.outputs.cache-hit == 'true' }}
+              timeout-minutes: 10
+              run: |
+                  set -uo pipefail
+                  sudo apt-get update || true
+                  pnpm exec playwright install-deps chromium || pnpm exec playwright install --with-deps chromium
 
             - name: Nx e2e ${{ inputs.project }}
               run: pnpm nx e2e ${{ inputs.project }} --no-cloud


### PR DESCRIPTION
Fixes the `Install Playwright Browsers` step stalling at 100% download then dying at the 15-min timeout ([run 27801714088](https://github.com/KBVE/kbve/actions/runs/27801714088/job/82273179523), laser e2e).

## Root cause
Playwright 1.59 ships chromium as **Chrome-for-Testing** (`/builds/cft/...`). On a cache miss the download hits 100% then **silently stalls with no error** — extract/libuv-threadpool deadlock — and hangs to the job timeout. `npm-test-package.yml` had no caching, no retry, no per-attempt timeout.

## Fix (both `npm-test-package.yml` + `docker-test-app.yml`)
- **Cache** `~/.cache/ms-playwright` keyed by playwright version → most runs skip download entirely
- **`UV_THREADPOOL_SIZE=128`** → dodges the chromium-extract libuv deadlock
- **`PLAYWRIGHT_DOWNLOAD_CONNECTION_TIMEOUT` + per-attempt `timeout`** → a 100% stall becomes a retryable error instead of hanging to the cap
- **3× retry on `cdn.playwright.dev`**, then **`mcr.microsoft.com/playwright:v<ver>-jammy`** docker-image fallback (bundles browsers)

## CDN verification
Probed every candidate host for the CfT artifact:

| Host | Result |
|------|--------|
| `cdn.playwright.dev` (default) | **206 ✓** |
| `prss.microsoft.com` | 400/404 ✗ (legacy `/builds/chromium/` only) |
| `npmmirror.com` (all path variants) | 404 ✗ (no CfT mirror) |
| `azureedge.net` | 400 ✗ (retired) |

Only the default host serves the artifacts, so the old `azureedge` hop in `docker-test-app.yml` was dead weight and is removed. The genuinely independent fallback is the mcr docker image (`v1.59.1-jammy` confirmed present).