### PR TITLE
fix(monitoring): AlertmanagerConfig matcher -> matchType (unwedge sync)

### DIFF
--- a/apps/kube/monitoring/manifests/alertmanagerconfig-vector.yaml
+++ b/apps/kube/monitoring/manifests/alertmanagerconfig-vector.yaml
@@ -18,7 +18,7 @@ spec:
         continue: true
         matchers:
             - name: severity
-              matcher: '=~'
+              matchType: '=~'
               value: 'critical|warning|info'
     receivers:
         - name: vector-webhook


### PR DESCRIPTION
## Problem

The `monitoring` ArgoCD app sync is **wedged**:

```
ComparisonError: .spec.route.matchers[0].matcher: field not declared in schema
(AlertmanagerConfig monitoring/vector-sink) — operationState Failed, retried 5x
```

`apps/kube/monitoring/manifests/alertmanagerconfig-vector.yaml` uses `matcher: '=~'`, but the PrometheusOperator `AlertmanagerConfig` v1alpha1 `Matcher` schema field is **`matchType`** (enum `=`, `!=`, `=~`, `!~`). Server-side apply rejects the unknown field, which fails the whole app sync and blocks **every** other monitoring manifest.

## Impact

This blocked the `grafana-gate` rollout (PR #12782 / #12805): the live pod is stuck on the old `kbve-gate:latest` spec with no `GATE_COOKIE_DOMAIN`, so `grafana.kbve.com` 302s to a bare `kbve.com/login` (no `redirect_to`) and loops instead of completing the SSO bounce.

## Fix

`matcher` → `matchType`. One-line. Unwedges the monitoring app so the pinned `grafana-gate:0.1.1` + `GATE_COOKIE_DOMAIN` finally applies.

## Verified
- Diagnosed live: `kubectl -n argocd get application monitoring` → `sync=Unknown`, `ComparisonError` on the `matcher` field; `phase=Failed`.
- grafana-gate pod healthy but running the pre-`0.1.1` spec (no `GATE_COOKIE_DOMAIN`), confirming the update is stuck behind this error.

## Note
Lands on `dev`; reaches the cluster on the next dev→main release. Separate from the kbve.com login-bounce JS republish (astro-kbve), which is handled separately.