### PR TITLE
fix(ci-unreal-plugins): grant caller perms for reusable build jobs

### DIFF
--- a/.github/workflows/ci-unreal-plugins.yml
+++ b/.github/workflows/ci-unreal-plugins.yml
@@ -23,7 +23,11 @@ on:
                 default: 'dev-5.7.4'
 
 permissions:
-    contents: read
+    contents: write
+    packages: write
+    issues: write
+    pull-requests: write
+    actions: write
 
 concurrency:
     group: ci-unreal-plugins-${{ github.ref }}


### PR DESCRIPTION
## Problem

`CI - Unreal Plugins (verify)` fails with **startup_failure** ([run 27807814636](https://github.com/KBVE/kbve/actions/runs/27807814636)):

```
Invalid workflow file: ci-unreal-plugins.yml (Line: 68)
Error calling workflow 'ci-unreal-build.yml@...'
The nested job 'server_build' is requesting 'packages: read', but is only allowed 'packages: none'.
... 'game_build_linux' is requesting 'packages: read', but is only allowed 'packages: none'.
```

## Cause

GitHub statically validates **every** nested job in a called reusable workflow at startup — including jobs gated off by `if:` that never run for `mode: plugin`. `ci-unreal-build.yml` nested jobs (server/game/engine/publish/track) request `contents`/`packages`/`actions`/`pull-requests`/`issues: write`. The verify caller only granted `contents: read`, so the whole call-graph is rejected before any job (incl. `discover`) runs.

## Fix

Widen `ci-unreal-plugins.yml` top-level permissions to match the router `ci-unreal.yml`, satisfying static validation. Plugin verify still runs `verify_only` and pushes nothing.