### PR TITLE
fix(monitoring): AlertmanagerConfig matchType + regen ci-dispatch-manifest

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -1153,7 +1153,8 @@
 				"project_path": "chuck",
 				"build_targets": [
 					"Win64",
-					"Linux"
+					"Linux",
+					"Mac"
 				],
 				"external_repo_url": "https://github.com/kbve/chuck",
 				"server_target": "chuckServer",
@@ -1168,7 +1169,7 @@
 			},
 			"source_path": "apps/chuckrpg/unreal-chuck",
 			"shell_path": "apps/chuckrpg/unreal-chuck",
-			"version": "0.3.23",
+			"version": "0.3.25",
 			"version_toml": "apps/chuckrpg/unreal-chuck/version.toml",
 			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/unreal-chuck-beta.mdx",
 			"runner": "arc-runner-ue",
@@ -1185,7 +1186,8 @@
 				"project_path": "chuck",
 				"build_targets": [
 					"Win64",
-					"Linux"
+					"Linux",
+					"Mac"
 				],
 				"external_repo_url": "https://github.com/kbve/chuck",
 				"external_repo_ref": "dev",

--- a/apps/kube/monitoring/manifests/alertmanagerconfig-vector.yaml
+++ b/apps/kube/monitoring/manifests/alertmanagerconfig-vector.yaml
@@ -18,7 +18,7 @@ spec:
         continue: true
         matchers:
             - name: severity
-              matcher: '=~'
+              matchType: '=~'
               value: 'critical|warning|info'
     receivers:
         - name: vector-webhook


### PR DESCRIPTION
## Changes

- `fix(monitoring)`: AlertmanagerConfig matcher -> matchType (alertmanagerconfig-vector.yaml)
- `chore(ci)`: regenerate `.github/ci-dispatch-manifest.json` to clear structural drift

### Manifest drift
Commit `6e0b416a8` added `Mac` to chuck game/server runners in MDX without regenerating the manifest, failing the CI drift check. Regenerated via `astro-kbve:build` + `astro-kbve:sync:ci-manifest`. Picks up chuck `0.3.23 -> 0.3.25` already bumped in MDX.