### PR TITLE
fix(unreal): drop deprecated StructUtils plugin dependency

### DIFF
--- a/apps/rentearth/unreal-rentearth/Source/chuck/chuck.Build.cs
+++ b/apps/rentearth/unreal-rentearth/Source/chuck/chuck.Build.cs
@@ -22,7 +22,6 @@ public class chuck : ModuleRules
 			"SlateCore",
 			"MassEntity",
 			"MassCommon",
-			"StructUtils",
 			"NetCore",
 			"ProceduralMeshComponent",
 			"NavigationSystem",

--- a/apps/rentearth/unreal-rentearth/rentearth.uproject
+++ b/apps/rentearth/unreal-rentearth/rentearth.uproject
@@ -13,8 +13,7 @@
 				"AIModule",
 				"UMG",
 				"MassEntity",
-				"MassCommon",
-				"StructUtils"
+				"MassCommon"
 			]
 		}
 	],
@@ -22,10 +21,6 @@
 		"../../../packages/unreal"
 	],
 	"Plugins": [
-		{
-			"Name": "StructUtils",
-			"Enabled": true
-		},
 		{
 			"Name": "ChaosSolverPlugin",
 			"Enabled": true

--- a/packages/unreal/KBVEWorld/KBVEWorld.uplugin
+++ b/packages/unreal/KBVEWorld/KBVEWorld.uplugin
@@ -27,10 +27,6 @@
 			"Enabled": true
 		},
 		{
-			"Name": "StructUtils",
-			"Enabled": true
-		},
-		{
 			"Name": "KBVESQLite",
 			"Enabled": true
 		},

--- a/packages/unreal/KBVEWorld/Source/KBVEWorld/KBVEWorld.Build.cs
+++ b/packages/unreal/KBVEWorld/Source/KBVEWorld/KBVEWorld.Build.cs
@@ -18,8 +18,7 @@ public class KBVEWorld : ModuleRules
 			"StaticMeshDescription",
 			"PhysicsCore",
 			"MassEntity",
-			"MassCommon",
-			"StructUtils"
+			"MassCommon"
 		});
 
 		PrivateDependencyModuleNames.AddRange(new string[]


### PR DESCRIPTION
## Problem
UE 5.7 warns on build:
```
Project 'chuckEditor' depends on plugin 'StructUtils' which was deprecated in 5.5 and will soon be removed.
Plugin 'KBVEWorld' depends on plugin 'StructUtils' which was deprecated in 5.5 and will soon be removed.
```
StructUtils was promoted into `CoreUObject` in UE 5.5; 5.7 ships the plugin only as a deprecated Experimental shim.

## Fix
Remove the `StructUtils` plugin + module dependency from:
- `apps/rentearth/unreal-rentearth/rentearth.uproject` (Plugins entry + Modules AdditionalDependencies)
- `apps/rentearth/unreal-rentearth/Source/chuck/chuck.Build.cs`
- `packages/unreal/KBVEWorld/KBVEWorld.uplugin`
- `packages/unreal/KBVEWorld/Source/KBVEWorld/KBVEWorld.Build.cs`

The types (`FInstancedStruct`, `FSharedStruct`, `FPropertyBag`...) now resolve via `CoreUObject`, already a dependency everywhere. No source includes referenced StructUtils directly.