### PR TITLE
fix(ci-unreal-build): epic_pat->UNITY_PAT fallback for plugin GHCR login

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1695,8 +1695,20 @@ jobs:
                   jq --arg v "$VERSION" '.VersionName = $v' "$UPLUGIN" > "$UPLUGIN.tmp" && mv "$UPLUGIN.tmp" "$UPLUGIN"
                   echo "Stamped $UPLUGIN VersionName=$VERSION"
 
+            - name: Resolve PAT (epic_pat -> UNITY_PAT fallback)
+              id: pat
+              run: |
+                  TOKEN="${{ secrets.epic_pat }}"
+                  [ -z "${TOKEN}" ] && TOKEN="${{ secrets.UNITY_PAT }}"
+                  if [ -z "${TOKEN}" ]; then
+                    echo "::error::No PAT available - set epic_pat or UNITY_PAT"
+                    exit 1
+                  fi
+                  echo "::add-mask::${TOKEN}"
+                  echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
+
             - name: Login to GHCR
-              run: echo "${{ secrets.epic_pat }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+              run: echo "${{ steps.pat.outputs.token }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
             - name: Pull Unreal Engine image
               run: docker pull "ghcr.io/epicgames/unreal-engine:${{ inputs.ue_image_tag }}"


### PR DESCRIPTION
## Problem

`Build Plugin (KBVEWorld)` in **CI - Unreal Plugins (verify)** fails at GHCR login:

```
echo "" | docker login ghcr.io -u h0lybyte --password-stdin
password is empty
##[error]Process completed with exit code 1.
```

`plugin_build_linux` logged in with bare `secrets.epic_pat`. That secret is unset → empty password → exit 1. Perms fix #12819 let the job reach the login step, exposing the missing fallback.

## Fix

Add the same **Resolve PAT (epic_pat → UNITY_PAT fallback)** step the `server`/`game` jobs already use, then login with `steps.pat.outputs.token`. `plugin-win` uses prebuilt UE (no GHCR pull) so it is unaffected.