### PR TITLE
fix(codegen): populate proto map<> fields in itemdb/npcdb UE C++ parsers

### DIFF
--- a/packages/data/codegen/gen-itemdb-uecpp.mjs
+++ b/packages/data/codegen/gen-itemdb-uecpp.mjs
@@ -86,6 +86,16 @@ function loadMessages() {
 	return messages;
 }
 
+// map<string, V> value → UE element type (value kind lives on field.mapKind)
+function mapValueUE(field, messages) {
+	if (field.mapKind === 'scalar') return scalarToUE(field.scalar);
+	if (field.mapKind === 'enum') return 'FString';
+	if (field.mapKind === 'message') {
+		return messages.has(field.message.typeName) ? structName(field.message.name) : 'FString';
+	}
+	return 'FString';
+}
+
 // default initializer for a UPROPERTY of the given field
 function fieldDefault(field, messages) {
 	if (field.fieldKind === 'scalar') {
@@ -112,7 +122,7 @@ function fieldUEType(field, messages) {
 				: 'TArray<FString>';
 		}
 	}
-	if (field.fieldKind === 'map') return 'TMap<FString, FString>';
+	if (field.fieldKind === 'map') return `TMap<FString, ${mapValueUE(field, messages)}>`;
 	return 'int32';
 }
 
@@ -128,7 +138,8 @@ function topoSort(messages) {
 		const msg = messages.get(typeName);
 		for (const f of msg.fields) {
 			const dep = f.fieldKind === 'message' ? f.message
-				: (f.fieldKind === 'list' && f.listKind === 'message' ? f.message : null);
+				: (f.fieldKind === 'list' && f.listKind === 'message' ? f.message
+				: (f.fieldKind === 'map' && f.mapKind === 'message' ? f.message : null));
 			if (dep && messages.has(dep.typeName) && dep.typeName !== typeName) {
 				visit(dep.typeName);
 			}
@@ -209,8 +220,31 @@ function emitParsers(ordered, messages) {
 				}
 				lines.push('\t\t\t}');
 				lines.push('\t\t}');
+				} else if (f.fieldKind === 'map') {
+					let reader = null;
+					if (f.mapKind === 'scalar') reader = scalarReader(f.scalar, 'MV');
+					else if (f.mapKind === 'enum') reader = '(yyjson_is_str(MV) ? FString(UTF8_TO_TCHAR(yyjson_get_str(MV))) : FString())';
+					if (reader) {
+						lines.push(`\t\tif ((V = yyjson_obj_get(Obj, "${key}")) && yyjson_is_obj(V))`);
+						lines.push('\t\t{');
+						lines.push('\t\t\tsize_t MIdx, MMax; yyjson_val *MK, *MV;');
+						lines.push('\t\t\tyyjson_obj_foreach(V, MIdx, MMax, MK, MV)');
+						lines.push('\t\t\t{');
+						lines.push(`\t\t\t\tOut.${prop}.Add(FString(UTF8_TO_TCHAR(yyjson_get_str(MK))), ${reader});`);
+						lines.push('\t\t\t}');
+						lines.push('\t\t}');
+					} else if (f.mapKind === 'message' && messages.has(f.message.typeName)) {
+						lines.push(`\t\tif ((V = yyjson_obj_get(Obj, "${key}")) && yyjson_is_obj(V))`);
+						lines.push('\t\t{');
+						lines.push('\t\t\tsize_t MIdx, MMax; yyjson_val *MK, *MV;');
+						lines.push('\t\t\tyyjson_obj_foreach(V, MIdx, MMax, MK, MV)');
+						lines.push('\t\t\t{');
+						lines.push(`\t\t\t\t${structName(f.message.name)} ElemOut; Populate(ElemOut, MV); Out.${prop}.Add(FString(UTF8_TO_TCHAR(yyjson_get_str(MK))), MoveTemp(ElemOut));`);
+						lines.push('\t\t\t}');
+						lines.push('\t\t}');
+					}
+				}
 			}
-		}
 		lines.push('\t}', '');
 	}
 	lines.push('}');

--- a/packages/data/codegen/gen-npcdb-uecpp.mjs
+++ b/packages/data/codegen/gen-npcdb-uecpp.mjs
@@ -86,6 +86,16 @@ function loadMessages() {
 	return messages;
 }
 
+// map<string, V> value → UE element type (value kind lives on field.mapKind)
+function mapValueUE(field, messages) {
+	if (field.mapKind === 'scalar') return scalarToUE(field.scalar);
+	if (field.mapKind === 'enum') return 'FString';
+	if (field.mapKind === 'message') {
+		return messages.has(field.message.typeName) ? structName(field.message.name) : 'FString';
+	}
+	return 'FString';
+}
+
 // default initializer for a UPROPERTY of the given field
 function fieldDefault(field, messages) {
 	if (field.fieldKind === 'scalar') {
@@ -112,7 +122,7 @@ function fieldUEType(field, messages) {
 				: 'TArray<FString>';
 		}
 	}
-	if (field.fieldKind === 'map') return 'TMap<FString, FString>';
+	if (field.fieldKind === 'map') return `TMap<FString, ${mapValueUE(field, messages)}>`;
 	return 'int32';
 }
 
@@ -128,7 +138,8 @@ function topoSort(messages) {
 		const msg = messages.get(typeName);
 		for (const f of msg.fields) {
 			const dep = f.fieldKind === 'message' ? f.message
-				: (f.fieldKind === 'list' && f.listKind === 'message' ? f.message : null);
+				: (f.fieldKind === 'list' && f.listKind === 'message' ? f.message
+				: (f.fieldKind === 'map' && f.mapKind === 'message' ? f.message : null));
 			if (dep && messages.has(dep.typeName) && dep.typeName !== typeName) {
 				visit(dep.typeName);
 			}
@@ -209,6 +220,29 @@ function emitParsers(ordered, messages) {
 				}
 				lines.push('\t\t\t}');
 				lines.push('\t\t}');
+			} else if (f.fieldKind === 'map') {
+				let reader = null;
+				if (f.mapKind === 'scalar') reader = scalarReader(f.scalar, 'MV');
+				else if (f.mapKind === 'enum') reader = '(yyjson_is_str(MV) ? FString(UTF8_TO_TCHAR(yyjson_get_str(MV))) : FString())';
+				if (reader) {
+					lines.push(`\t\tif ((V = yyjson_obj_get(Obj, "${key}")) && yyjson_is_obj(V))`);
+					lines.push('\t\t{');
+					lines.push('\t\t\tsize_t MIdx, MMax; yyjson_val *MK, *MV;');
+					lines.push('\t\t\tyyjson_obj_foreach(V, MIdx, MMax, MK, MV)');
+					lines.push('\t\t\t{');
+					lines.push(`\t\t\t\tOut.${prop}.Add(FString(UTF8_TO_TCHAR(yyjson_get_str(MK))), ${reader});`);
+					lines.push('\t\t\t}');
+					lines.push('\t\t}');
+				} else if (f.mapKind === 'message' && messages.has(f.message.typeName)) {
+					lines.push(`\t\tif ((V = yyjson_obj_get(Obj, "${key}")) && yyjson_is_obj(V))`);
+					lines.push('\t\t{');
+					lines.push('\t\t\tsize_t MIdx, MMax; yyjson_val *MK, *MV;');
+					lines.push('\t\t\tyyjson_obj_foreach(V, MIdx, MMax, MK, MV)');
+					lines.push('\t\t\t{');
+					lines.push(`\t\t\t\t${structName(f.message.name)} ElemOut; Populate(ElemOut, MV); Out.${prop}.Add(FString(UTF8_TO_TCHAR(yyjson_get_str(MK))), MoveTemp(ElemOut));`);
+					lines.push('\t\t\t}');
+					lines.push('\t\t}');
+				}
 			}
 		}
 		lines.push('\t}', '');

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/Generated/KBVEItemDBProtoParse.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/Generated/KBVEItemDBProtoParse.h
@@ -36,6 +36,14 @@ namespace KBVEItemDBProto
 		if ((V = yyjson_obj_get(Obj, "charisma"))) Out.Charisma = (int32)(yyjson_is_int(V) ? yyjson_get_int(V) : (yyjson_is_uint(V) ? (int32)yyjson_get_uint(V) : 0));
 		if ((V = yyjson_obj_get(Obj, "dexterity"))) Out.Dexterity = (int32)(yyjson_is_int(V) ? yyjson_get_int(V) : (yyjson_is_uint(V) ? (int32)yyjson_get_uint(V) : 0));
 		if ((V = yyjson_obj_get(Obj, "perception"))) Out.Perception = (int32)(yyjson_is_int(V) ? yyjson_get_int(V) : (yyjson_is_uint(V) ? (int32)yyjson_get_uint(V) : 0));
+		if ((V = yyjson_obj_get(Obj, "extra")) && yyjson_is_obj(V))
+		{
+			size_t MIdx, MMax; yyjson_val *MK, *MV;
+			yyjson_obj_foreach(V, MIdx, MMax, MK, MV)
+			{
+				Out.Extra.Add(FString(UTF8_TO_TCHAR(yyjson_get_str(MK))), (yyjson_is_num(MV) ? yyjson_get_real(MV) : 0.0));
+			}
+		}
 	}
 
 	inline void Populate(FKBVEGenEquipmentInfo& Out, yyjson_val* Obj)
@@ -171,6 +179,14 @@ namespace KBVEItemDBProto
 		yyjson_val* V = nullptr; (void)V;
 		if ((V = yyjson_obj_get(Obj, "guid"))) Out.Guid = (yyjson_is_str(V) ? FString(UTF8_TO_TCHAR(yyjson_get_str(V))) : FString());
 		if ((V = yyjson_obj_get(Obj, "name"))) Out.Name = (yyjson_is_str(V) ? FString(UTF8_TO_TCHAR(yyjson_get_str(V))) : FString());
+		if ((V = yyjson_obj_get(Obj, "vars")) && yyjson_is_obj(V))
+		{
+			size_t MIdx, MMax; yyjson_val *MK, *MV;
+			yyjson_obj_foreach(V, MIdx, MMax, MK, MV)
+			{
+				Out.Vars.Add(FString(UTF8_TO_TCHAR(yyjson_get_str(MK))), (yyjson_is_str(MV) ? FString(UTF8_TO_TCHAR(yyjson_get_str(MV))) : FString()));
+			}
+		}
 	}
 
 	inline void Populate(FKBVEGenDeployableInfo& Out, yyjson_val* Obj)

--- a/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/Generated/KBVEItemDBProtoTypes.h
+++ b/packages/unreal/KBVEItemDB/Source/KBVEItemDB/Public/Generated/KBVEItemDBProtoTypes.h
@@ -59,7 +59,7 @@ struct KBVEITEMDB_API FKBVEGenItemBonuses
 	int32 Perception = 0;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "KBVE|ItemDB")
-	TMap<FString, FString> Extra;
+	TMap<FString, double> Extra;
 
 };
 


### PR DESCRIPTION
Sibling fix to #12815. The questdb UE C++ generator gained `map<>` support but **itemdb and npcdb never did** — generated USTRUCTs declared the map properties while `Populate()` had no map branch, so they were silently left empty at parse time.

## Bugs (KBVEItemDB plugin — shared by chuck + the plugin)
- `FKBVEGenItemBonuses.Extra` — declared `TMap<FString,FString>` but the proto is `map<string,double>` → **wrong value type** AND **never populated**
- `Vars` map — declared, **never populated**

JSON `extra` / `vars` were dropped on the floor → empty maps at runtime.

## Fix
Backport questdb generators map support into `gen-itemdb-uecpp.mjs` + `gen-npcdb-uecpp.mjs`:
- `mapValueUE()` → typed `TMap<FString, V>` instead of hardcoded `<FString,FString>`
- topo-sort now follows `map<…, message>` dependencies
- `Populate()` gains a `map` branch (`yyjson_obj_foreach`)

Regenerated headers:
- `Extra` → `TMap<FString,double>`, filled from `"extra"`
- `Vars` → filled from `"vars"`

npcdb headers are unchanged (no map fields yet) — the backport is a no-op there, kept only so the three `uecpp` generators stay consistent and this gap cannot resurface. questdb untouched.

Not UE-compiled locally (no engine on this box); changes are mechanical generator parity with questdb.