### PR TITLE
fix(cryptothrone): player:stats partial typing + vitest config typecheck

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
@@ -27,7 +27,7 @@ declare module '@kbve/laser' {
 			balance: number;
 		};
 		'player:damage': { damage: number };
-		'player:stats': { stats: PlayerStats };
+		'player:stats': { stats: Partial<PlayerStats> };
 		'monster:nearby': { count: number };
 		'discord:participants': {
 			participants: {

--- a/apps/cryptothrone/astro-cryptothrone/vitest.config.ts
+++ b/apps/cryptothrone/astro-cryptothrone/vitest.config.ts
@@ -1,5 +1,4 @@
-/// <reference types='vitest' />
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 


### PR DESCRIPTION
## What

Next typecheck-error batch. `tsc --noEmit` on `astro-cryptothrone` reported 3 real errors.

### `player:stats` event over-typed (2 errors)

`CloudCityScene` emits `player:stats` incrementally — once with server stats (level/xp/maxHp/attack/kills) and once HP-only on change — but the event was typed `{ stats: PlayerStats }` with all fields required (PlayerStats gained `mp/maxMp/ep/maxEp/username`). The `SET_PLAYER_STATS` reducer action is already `Partial<PlayerStats>` and all three UI consumers (`Achievements`, `EquipmentSummary`, `DeathScreen`) re-cast to their own optional shapes and guard, so the event is a partial update. Typed it `{ stats: Partial<PlayerStats> }`.

### `vitest.config.ts` (1 error)

Imported `defineConfig` from `'vite'`, whose config type has no `test` key → `TS2769` on the `test` block. Switched to `'vitest/config'` (re-exports vite's `defineConfig` + the `test` typing; runtime identical).

## Verification

- `astro-cryptothrone`: `tsc` clean (only an unrelated `@astrojs/starlight` → `astro:content` `RenderResult` node_modules false-positive remains, which also affects rareicon and doesn't break builds)
- unit tests pass (exercise the new `vitest/config`)
- `nx run astro-cryptothrone:build` succeeds

Sibling apps swept: `jobboard/web` 0 errors, `rareicon` only the same node_modules false-positive.