### PR TITLE
fix(ci-unreal): build dependency plugins for standalone plugin verify

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1747,9 +1747,20 @@ jobs:
                       if [ -d /deps ]; then
                         MARKETPLACE_DIR="$ENGINE_ROOT/Engine/Plugins/Marketplace"
                         mkdir -p "$MARKETPLACE_DIR"
+                        DEP_SRC=/tmp/dep_src
+                        mkdir -p "$DEP_SRC"
                         for dep in /deps/*/; do
                           dep_name=$(basename "$dep")
-                          cp -r "$dep" "$MARKETPLACE_DIR/$dep_name"
+                          cp -r "$dep" "$DEP_SRC/$dep_name"
+                          dep_uplugin=$(find "$DEP_SRC/$dep_name" -maxdepth 1 -name "*.uplugin" | head -1)
+                          if [ -z "$dep_uplugin" ]; then echo "::error::No .uplugin in dependency $dep_name"; exit 1; fi
+                          echo "::group::Build dependency plugin $dep_name"
+                          "$RUNUAT" BuildPlugin \
+                            -Plugin="$dep_uplugin" \
+                            -Package="$MARKETPLACE_DIR/$dep_name" \
+                            -TargetPlatforms=${{ inputs.target_platforms }} \
+                            -Rocket
+                          echo "::endgroup::"
                         done
                       fi
 
@@ -1836,6 +1847,7 @@ jobs:
             - name: Install dependency plugins
               if: inputs.dependency_plugin_paths != ''
               run: |
+                  $runuat = '${{ steps.engine.outputs.runuat }}'
                   $engineRoot = '${{ steps.engine.outputs.engine_root }}'
                   $marketplaceDir = Join-Path $engineRoot "Engine\Plugins\Marketplace"
                   New-Item -ItemType Directory -Force -Path $marketplaceDir | Out-Null
@@ -1844,9 +1856,13 @@ jobs:
                       if ([string]::IsNullOrWhiteSpace($depPath)) { continue }
                       $depName = Split-Path $depPath -Leaf
                       $src = Join-Path $env:GITHUB_WORKSPACE $depPath
+                      $depUplugin = Get-ChildItem -Path $src -Filter *.uplugin -File | Select-Object -First 1
+                      if (-not $depUplugin) { Write-Host "::error::No .uplugin in dependency $depName"; exit 1 }
                       $dst = Join-Path $marketplaceDir $depName
-                      Write-Host "::notice::Installing dependency: $depName -> $dst"
-                      Copy-Item -Path $src -Destination $dst -Recurse -Force
+                      Write-Host "::group::Build dependency plugin $depName"
+                      & $runuat BuildPlugin -Plugin="$($depUplugin.FullName)" -Package="$dst" -TargetPlatforms=${{ inputs.target_platforms }} -Rocket
+                      if ($LASTEXITCODE -ne 0) { Write-Host "::error::Dependency BuildPlugin failed for $depName ($LASTEXITCODE)"; exit $LASTEXITCODE }
+                      Write-Host "::endgroup::"
                   }
 
             - name: Build plugin with RunUAT


### PR DESCRIPTION
## Problem

`CI - Unreal Build (plugin) / KBVEItemDB` fails at link (issue #12830, run [#27810219591](https://github.com/KBVE/kbve/actions/runs/27810219591)):

```
ld.lld: error: unable to find library -lUnrealEditor-KBVESQLite
ld.lld: error: unable to find library -lUnrealEditor-KBVEYYJson
```

KBVEItemDB's module depends on `KBVESQLite` + `KBVEYYJson`. The per-plugin verify pipeline (#12770) staged those deps as **source** into `Engine/Plugins/Marketplace`, then ran `BuildPlugin -Rocket`. Under an installed/Rocket engine UBT treats Marketplace plugins as **precompiled** and never builds them — so no `libUnrealEditor-*.so` exists for the host plugin to link. First plugin in the graph with cross-plugin module deps to actually compile, so it's structural, not from the codegen PR that tripped it.

## Fix

`BuildPlugin` each dependency plugin first (Linux docker script + Win64 VM step), packaging into Marketplace so the editor binaries exist before the host plugin builds. Dep graph is flat (sqlite/yyjson have no further deps).

Closes #12830