### PR TITLE
fix(chuck): restore build.toml for bundled dedicated server

### DIFF
--- a/apps/chuckrpg/unreal-chuck/build.toml
+++ b/apps/chuckrpg/unreal-chuck/build.toml
@@ -1,0 +1,6 @@
+[project]
+repo = "KBVE/chuck"
+path = "chuck.uproject"
+server_target = "chuckServer"
+ue_image_tag = "dev-5.7.4"
+server_config = "Development"


### PR DESCRIPTION
## Problem

`unreal-chuck-beta` + `unreal-chuck-dev` MDX carry `shell_path: apps/chuckrpg/unreal-chuck`, so [ci-main.yml:586](.github/workflows/ci-main.yml#L586) dispatches a bundled Linux dedicated **server** (`task: server`) on the same version gate as the itch client. The `server_config` job reads `${shell_path}/build.toml` for repo/path/server_target/ue_image_tag/server_config and hard-errors when missing ([ci-unreal-build.yml:300-303](.github/workflows/ci-unreal-build.yml#L300-L303)):

```
::error::apps/chuckrpg/unreal-chuck/build.toml not found - cannot determine build config
```

`build.toml` was deleted in `0b8bc58aa` (chuck → rentearth migration) but the chuck shell dir + `version.toml` survived and still ship (post-publish syncs through v0.3.25), so the bundled server build is broken.

## Fix

Restore `apps/chuckrpg/unreal-chuck/build.toml` (source repo `KBVE/chuck`, `chuckServer`, matching the rentearth shell). MDX `engine.*` still overrides `server_target`/`server_config` per channel (beta = Shipping, dev = Development); `repo`/`path`/`ue_image_tag` come from this file.