### PR TITLE
fix(ci): drop constant if:false on Mac build stubs (actionlint)

### DIFF
--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1161,16 +1161,26 @@ jobs:
                   echo "2. Implement UAT build commands for Mac platform"
                   echo "3. Configure artifact packaging and upload"
 
-            - name: Upload artifact (stub)
-              if: hashFiles(format('/tmp/{0}-macos.zip', inputs.app_name)) != ''
-              uses: actions/upload-artifact@v4
+            - name: Package artifact
+              if: hashFiles('ue5-game-output/**') != ''
+              run: |
+                  if ! command -v zip >/dev/null 2>&1; then
+                    echo "::error::zip not found on macOS runner"
+                    exit 1
+                  fi
+                  cd "${GITHUB_WORKSPACE}/ue5-game-output"
+                  zip -r "/tmp/${{ inputs.app_name }}-macos.zip" .
+
+            - name: Upload artifact
+              if: hashFiles('ue5-game-output/**') != ''
+              uses: actions/upload-artifact@v7
               with:
                   name: ${{ inputs.app_name }}-macos-v${{ needs.game_gate.outputs.version }}
                   path: /tmp/${{ inputs.app_name }}-macos.zip
                   retention-days: 30
 
-            - name: Deploy to itch.io (stub)
-              if: inputs.deploy_to_itch == true && inputs.itch_game_id != '' && hashFiles(format('/tmp/{0}-macos.zip', inputs.app_name)) != ''
+            - name: Deploy to itch.io
+              if: inputs.deploy_to_itch == true && inputs.itch_game_id != '' && hashFiles('ue5-game-output/**') != ''
               uses: KikimoraGames/itch-publish@v0.0.3
               with:
                   butlerApiKey: ${{ secrets.butler_api }}

--- a/.github/workflows/ci-unreal-build.yml
+++ b/.github/workflows/ci-unreal-build.yml
@@ -1162,7 +1162,7 @@ jobs:
                   echo "3. Configure artifact packaging and upload"
 
             - name: Upload artifact (stub)
-              if: false
+              if: hashFiles(format('/tmp/{0}-macos.zip', inputs.app_name)) != ''
               uses: actions/upload-artifact@v4
               with:
                   name: ${{ inputs.app_name }}-macos-v${{ needs.game_gate.outputs.version }}
@@ -1170,7 +1170,7 @@ jobs:
                   retention-days: 30
 
             - name: Deploy to itch.io (stub)
-              if: false && inputs.deploy_to_itch == true && inputs.itch_game_id != ''
+              if: inputs.deploy_to_itch == true && inputs.itch_game_id != '' && hashFiles(format('/tmp/{0}-macos.zip', inputs.app_name)) != ''
               uses: KikimoraGames/itch-publish@v0.0.3
               with:
                   butlerApiKey: ${{ secrets.butler_api }}


### PR DESCRIPTION
## Problem

`CI - Actionlint` failing (#12855) — actionlint rejects literal `if: false`:

```
.github/workflows/ci-unreal-build.yml:1165:19: constant expression "false" in condition. remove the if: section [if-cond]
```

The Mac client job (`game_build_mac`) is still a placeholder — no UE build, no packaging. Its `Upload artifact` / `Deploy to itch.io` steps were held off with `if: false` / `if: false && ...`.

## Fix

Replace the constant guards with real wiring, mirroring the Linux client job:

- **Package artifact** step zips `ue5-game-output` → `/tmp/{app}-macos.zip`.
- **Upload** + **itch deploy** gate on `hashFiles('ue5-game-output/**') != ''`.

`hashFiles` is **workspace-relative**, so a `/tmp/*.zip` guard never matches — gating on `ue5-game-output/**` is what actually lets these fire once the build emits output. Until then (placeholder phase) the dir is empty → steps skip cleanly, and the condition is non-constant → actionlint passes.

The UE build/cook step that produces `ue5-game-output` on macOS remains the open TODO; this just ensures upload + deploy fire automatically when it lands.

`actionlint -shellcheck 'shellcheck -S error'` (exact CI invocation) exits 0.

Closes #12855