### PR TITLE
chore(lfs): drop stale unreal-chuck .gitattributes rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -34,40 +34,10 @@ apps/godot/**/addons/**/bin/**/*.wasm  filter=lfs diff=lfs merge=lfs -text
 # time with no LFS pull. Plugin libs are pinned third-party versions that change
 # rarely, so the history cost is acceptable for the zero-friction download.
 
-# Unreal Engine — apps/chuckrpg/unreal-chuck binary assets
-# Pointer files live in this repo; blobs live on git.kbve.com/KBVE/chuck.git
-# (see apps/chuckrpg/unreal-chuck/.lfsconfig). Covers UE cooked asset blobs,
-# raw DCC source art, audio, and packaged plugin/binary outputs.
-# UE cooked / serialized assets
-apps/chuckrpg/unreal-chuck/**/*.uasset filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.umap   filter=lfs diff=lfs merge=lfs -text
-# Raw 3D / DCC source art
-apps/chuckrpg/unreal-chuck/**/*.fbx    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.obj    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.blend  filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.psd    filter=lfs diff=lfs merge=lfs -text
-# Textures (raster + HDR)
-apps/chuckrpg/unreal-chuck/**/*.png    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.jpg    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.jpeg   filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.tga    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.exr    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.hdr    filter=lfs diff=lfs merge=lfs -text
-# Audio
-apps/chuckrpg/unreal-chuck/**/*.wav    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.mp3    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.ogg    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/*.flac   filter=lfs diff=lfs merge=lfs -text
-# Plugin / native binaries (same pattern as rareicon)
-apps/chuckrpg/unreal-chuck/**/Plugins/**/*.dylib filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/Plugins/**/*.dll   filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/Plugins/**/*.so    filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/Plugins/**/*.a     filter=lfs diff=lfs merge=lfs -text
-apps/chuckrpg/unreal-chuck/**/Plugins/**/*.bundle filter=lfs diff=lfs merge=lfs -text
-
 # Unreal Engine — apps/rentearth/unreal-rentearth binary assets
 # Pointer files live in this repo; blobs live on git.kbve.com/KBVE/rentearth.git
-# (see apps/rentearth/unreal-rentearth/.lfsconfig). Same routing as chuck.
+# (see apps/rentearth/unreal-rentearth/.lfsconfig). Routes through git.kbve.com
+# ingress-nginx the same way as the rareicon LFS repo.
 # UE cooked / serialized assets
 apps/rentearth/unreal-rentearth/**/*.uasset filter=lfs diff=lfs merge=lfs -text
 apps/rentearth/unreal-rentearth/**/*.umap   filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## What

Removes the 23 dead LFS filter rules under `apps/chuckrpg/unreal-chuck/**` from `.gitattributes` (L37–66).

## Why

`apps/chuckrpg/unreal-chuck` source tree is already removed from `dev` and `main` (only `build.toml` + `version.toml` plain-text files remain, by design). The game builds from **KBVE/chuck** now, which owns its own LFS objects on git.kbve.com. The chuck LFS rules match nothing and duplicate the `unreal-rentearth` ruleset that already covers the identical patterns.

Also fixes the rentearth comment that dangled a "Same routing as chuck" reference.

## Scope

`.gitattributes` only. Partial cleanup of the #12760 audit — remaining touchpoints (CI registry, dispatch manifest, MDX version-source docs, kbve.sh `-lfs` mirror case, proto/workflow example comments) tracked in a follow-up issue.

Refs #12760