### PR TITLE
fix(forgejo): stop quota 404 storm, scope 403s, enable quota tracking

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoRepoTable.tsx
@@ -7,7 +7,7 @@ import {
 	type ForgejoRepo,
 	type RepoDetail,
 } from './forgejoService';
-import { useTabActive } from './forgejoUi';
+import { useTabActive, ForgejoNotice } from './forgejoUi';
 import {
 	Lock,
 	GitFork,
@@ -592,28 +592,30 @@ export default function ReactForgejoRepoTable() {
 	if (!active) return null;
 	if (repos.length === 0) {
 		return (
-			<div
-				className="not-content"
-				style={{
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-					gap: 8,
-					padding: '2rem',
-					color: 'var(--sl-color-gray-3, #8b949e)',
-					fontSize: '0.85rem',
-				}}>
-				{loading ? (
-					<>
-						<Loader2
-							size={16}
-							style={{ animation: 'spin 1s linear infinite' }}
-						/>
-						Loading repositories…
-					</>
-				) : (
-					'No repositories found'
-				)}
+			<div className="not-content">
+				<ForgejoNotice ctx="repos" />
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'center',
+						alignItems: 'center',
+						gap: 8,
+						padding: '2rem',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.85rem',
+					}}>
+					{loading ? (
+						<>
+							<Loader2
+								size={16}
+								style={{ animation: 'spin 1s linear infinite' }}
+							/>
+							Loading repositories…
+						</>
+					) : (
+						'No repositories found'
+					)}
+				</div>
 			</div>
 		);
 	}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserPanel.tsx
@@ -12,6 +12,7 @@ import {
 	useTabActive,
 	uiTokens,
 	LoadMoreButton,
+	ForgejoNotice,
 } from './forgejoUi';
 import { Plus, Pencil, Trash2, ShieldCheck, Search } from 'lucide-react';
 
@@ -206,6 +207,7 @@ export default function ReactForgejoUserPanel() {
 
 	return (
 		<div className="not-content">
+			<ForgejoNotice ctx="users" />
 			<div
 				style={{
 					display: 'flex',

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -862,43 +862,91 @@ class ForgejoService {
 			return;
 		}
 
-		try {
-			this.$error.set(null);
-			this.$errorReason.set(null);
-			const [repos, users, orgs] = await Promise.all([
-				this._fetchReposRange(token),
-				this._fetchUsersRange(token),
-				this._fetchOrgsRange(token),
-			]);
-			this.$repos.set(repos.items);
-			this.$reposHasMore.set(repos.hasMore);
-			this.$users.set(users.items);
-			this.$usersHasMore.set(users.hasMore);
-			this.$orgs.set(orgs.items);
-			this.$orgsHasMore.set(orgs.hasMore);
-			this.$lastUpdated.set(new Date());
-			void saveCache(repos.items, users.items, orgs.items);
-			void this.fetchStats(force);
-			void this.fetchStorage(force);
-		} catch (e: unknown) {
-			if (e instanceof AccessRestrictedError) {
-				this.$authState.set('forbidden');
-				return;
-			}
-			if (e instanceof UpstreamUnavailableError) {
-				this.$error.set(e.message);
-				this.$errorReason.set(e.reason);
-				return;
-			}
-			if (e instanceof Error && /API error: 401/.test(e.message)) {
-				this.$accessToken.set(null);
-				this.$authState.set('unauthenticated');
-				this.$error.set('Session expired — please sign in again.');
-				return;
-			}
-			this.$error.set(e instanceof Error ? e.message : 'Unknown error');
-		} finally {
+		this.$error.set(null);
+		this.$errorReason.set(null);
+
+		const [reposR, usersR, orgsR] = await Promise.allSettled([
+			this._fetchReposRange(token),
+			this._fetchUsersRange(token),
+			this._fetchOrgsRange(token),
+		]);
+
+		const reasons = [reposR, usersR, orgsR]
+			.filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+			.map((r) => r.reason);
+
+		// Session-expiry and upstream-down are dashboard-wide; surface globally.
+		if (
+			reasons.some(
+				(e) => e instanceof Error && /API error: 401/.test(e.message),
+			)
+		) {
+			this.$accessToken.set(null);
+			this.$authState.set('unauthenticated');
+			this.$error.set('Session expired — please sign in again.');
 			this.$loading.set(false);
+			return;
+		}
+		const upstream = reasons.find(
+			(e) => e instanceof UpstreamUnavailableError,
+		) as UpstreamUnavailableError | undefined;
+		if (upstream) {
+			this.$error.set(upstream.message);
+			this.$errorReason.set(upstream.reason);
+			this.$loading.set(false);
+			return;
+		}
+		// Only a total lockout (every resource restricted) flips the whole
+		// dashboard to forbidden; a single restricted resource keeps the rest.
+		const restricted = reasons.filter(
+			(e) => e instanceof AccessRestrictedError,
+		).length;
+		if (restricted === 3) {
+			this.$authState.set('forbidden');
+			this.$loading.set(false);
+			return;
+		}
+
+		this._applyResource(reposR, 'repos', (v) => {
+			this.$repos.set(v.items);
+			this.$reposHasMore.set(v.hasMore);
+		});
+		this._applyResource(usersR, 'users', (v) => {
+			this.$users.set(v.items);
+			this.$usersHasMore.set(v.hasMore);
+		});
+		this._applyResource(orgsR, 'orgs', (v) => {
+			this.$orgs.set(v.items);
+			this.$orgsHasMore.set(v.hasMore);
+		});
+
+		if (
+			reposR.status === 'fulfilled' &&
+			usersR.status === 'fulfilled' &&
+			orgsR.status === 'fulfilled'
+		) {
+			void saveCache(
+				reposR.value.items,
+				usersR.value.items,
+				orgsR.value.items,
+			);
+		}
+		this.$lastUpdated.set(new Date());
+		void this.fetchStats(force);
+		void this.fetchStorage(force);
+		this.$loading.set(false);
+	}
+
+	private _applyResource<T>(
+		result: PromiseSettledResult<T>,
+		ctx: string,
+		apply: (value: T) => void,
+	): void {
+		if (result.status === 'fulfilled') {
+			this.clearNotice(ctx);
+			apply(result.value);
+		} else {
+			this.setNotice(ctx, this._noticeFor(result.reason));
 		}
 	}
 

--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -101,6 +101,8 @@ spec:
                           mirror:
                               ENABLED: true
                               DEFAULT_INTERVAL: 10m
+                          quota:
+                              ENABLED: true
                       additionalConfigFromEnvs:
                           - name: FORGEJO__SERVER__LFS_JWT_SECRET
                             valueFrom:

--- a/packages/rust/jedi/src/entity/forgejo/client.rs
+++ b/packages/rust/jedi/src/entity/forgejo/client.rs
@@ -11,6 +11,7 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::time::Duration;
+use tracing::{debug, warn};
 
 use super::policy::ForgejoPolicy;
 use super::types::*;
@@ -1521,16 +1522,29 @@ impl ForgejoClient {
             storage.truncated = true;
         }
 
+        let mut quota_ok = false;
         for owner in &owners {
-            if let Ok(q) = self.owner_quota(owner).await {
-                let s = &q.used.size;
-                storage.repos_bytes += s.repos.public + s.repos.private;
-                storage.lfs_bytes += s.git.lfs;
-                storage.attachments_bytes +=
-                    s.assets.attachments.issues + s.assets.attachments.releases;
-                storage.artifacts_bytes += s.assets.artifacts;
-                storage.packages_bytes += s.assets.packages.all;
-                storage.owners_counted += 1;
+            match self.owner_quota(owner).await {
+                Ok(q) => {
+                    let s = &q.used.size;
+                    storage.repos_bytes += s.repos.public + s.repos.private;
+                    storage.lfs_bytes += s.git.lfs;
+                    storage.attachments_bytes +=
+                        s.assets.attachments.issues + s.assets.attachments.releases;
+                    storage.artifacts_bytes += s.assets.artifacts;
+                    storage.packages_bytes += s.assets.packages.all;
+                    storage.owners_counted += 1;
+                    quota_ok = true;
+                }
+                Err(JediError::NotFound) => {
+                    warn!(
+                        "Forgejo quota API returned 404 — quota tracking is disabled on the instance; skipping storage aggregation. Enable [quota] ENABLED in app.ini."
+                    );
+                    break;
+                }
+                Err(e) => {
+                    debug!("Forgejo quota fetch failed for owner {owner}: {e}");
+                }
             }
         }
         storage.total_bytes = storage.repos_bytes
@@ -1538,7 +1552,7 @@ impl ForgejoClient {
             + storage.attachments_bytes
             + storage.artifacts_bytes
             + storage.packages_bytes;
-        storage.quota_enabled = storage.total_bytes > 0;
+        storage.quota_enabled = quota_ok;
         Ok(storage)
     }
 


### PR DESCRIPTION
Three related fixes for the Forgejo dashboard API, surfaced from production Forgejo logs (404 storm on `/admin/users/<u>/quota`, 403s on `/api/v1/user` and a single repo).

## 1. Quota 404 storm
`instance_storage()` calls Forgejo's per-owner quota API, but quota tracking was never enabled on the instance (no `[quota]` in app.ini) → every owner returned **404**, and the loop swallowed the error silently (`if let Ok`), re-hammering all owners on every 30s dashboard refresh.

- jedi: break on the first `NotFound` (quota disabled instance-wide), `warn!` once, and derive `quota_enabled` from an actual successful fetch instead of inferring from non-zero totals.
- helm: enable `[quota] ENABLED` in the Forgejo config so the richer numbers (artifacts/packages/attachments) become available. Until it rolls out, the dashboard already falls back to the `repo_stats` git/LFS split, so no UI regression.

## 2. A single 403 no longer blanks the whole dashboard
`fetchData` ran repos/users/orgs through `Promise.all`, so one restricted resource threw and flipped the **entire** dashboard to `forbidden`.

- Switch to `allSettled`: session-expiry (401) and upstream-down stay global; a **total** lockout (all three restricted) still shows `forbidden`; but one restricted resource now sets a scoped notice and keeps the rest.
- Surface those notices in the repo table and user panel (`ForgejoNotice ctx="repos"|"users"`).

## 3. Observability
- jedi: log skipped owners in `instance_storage()` instead of swallowing the error.

## Verification
- `cargo check -p jedi` clean.
- `astro check` clean on the edited TS/TSX (no new type errors).

Note: the helm change reaches the cluster only after the periodic dev→main release (ArgoCD tracks main).