### PR TITLE
feat(forgejo): per-repo git/LFS split via self-validating DB layer + drift detection

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -5,7 +5,6 @@ import {
 	formatSize,
 	langColor,
 	timeAgo,
-	type ForgejoRepo,
 } from './forgejoService';
 import { useTabActive } from './forgejoUi';
 import {
@@ -83,22 +82,28 @@ function StatCard({
 	);
 }
 
-function repoFootprint(repo: ForgejoRepo): number {
-	return repo.size + repo.lfs_size;
-}
-
 function StorageBreakdown() {
 	const repos = useStore(forgejoService.$repos);
+	const storage = useStore(forgejoService.$storage);
 
 	const { totalSize, top } = useMemo(() => {
-		const sorted = [...repos].sort(
-			(a, b) => repoFootprint(b) - repoFootprint(a),
-		);
+		const sorted = [...repos].sort((a, b) => b.size - a.size);
 		return {
-			totalSize: sorted.reduce((s, r) => s + repoFootprint(r), 0),
+			totalSize: sorted.reduce((s, r) => s + r.size, 0),
 			top: sorted.slice(0, 8),
 		};
 	}, [repos]);
+
+	const drift = useMemo(() => {
+		if (!storage?.quota_enabled) return null;
+		const quotaKb = (storage.repos_bytes + storage.lfs_bytes) / 1024;
+		const repoSumKb = repos.reduce((s, r) => s + r.size, 0);
+		const missingKb = quotaKb - repoSumKb;
+		if (quotaKb <= 0 || missingKb <= 0) return null;
+		const pct = (missingKb / quotaKb) * 100;
+		if (pct < 5 || missingKb < 100 * 1024) return null;
+		return { missingKb, pct };
+	}, [repos, storage]);
 
 	if (repos.length === 0) return null;
 
@@ -119,6 +124,27 @@ function StorageBreakdown() {
 				<HardDrive size={12} />
 				Storage by Repository
 			</div>
+			{drift && (
+				<div
+					title="Per-repo sizes are summed from Forgejo's repository.size, which only updates on push or gc. The owner quota totals include LFS that some repos haven't recomputed yet — run a Forgejo size recalculation (admin → garbage collect repositories)."
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 6,
+						padding: '0.5rem 0.7rem',
+						borderRadius: 8,
+						marginBottom: 8,
+						background: 'rgba(234, 179, 8, 0.1)',
+						border: '1px solid rgba(234, 179, 8, 0.3)',
+						fontSize: '0.72rem',
+						color: '#eab308',
+					}}>
+					<AlertTriangle size={14} />
+					Stale repo sizes: ~{formatSize(drift.missingKb)} of LFS (
+					{drift.pct.toFixed(0)}%) not yet reflected per-repo.
+					Recompute Forgejo sizes.
+				</div>
+			)}
 			{/* Stacked bar */}
 			<div
 				style={{
@@ -130,14 +156,13 @@ function StorageBreakdown() {
 					marginBottom: 8,
 				}}>
 				{top.map((repo, i) => {
-					const footprint = repoFootprint(repo);
 					const pct =
-						totalSize > 0 ? (footprint / totalSize) * 100 : 0;
+						totalSize > 0 ? (repo.size / totalSize) * 100 : 0;
 					const hue = [200, 160, 280, 30, 340, 120, 50, 240][i % 8];
 					return (
 						<div
 							key={repo.id}
-							title={`${repo.full_name}: ${formatSize(footprint)}`}
+							title={`${repo.full_name}: ${formatSize(repo.size)}`}
 							style={{
 								width: `${pct}%`,
 								background: `hsl(${hue}, 60%, 55%)`,
@@ -177,7 +202,7 @@ function StorageBreakdown() {
 							/>
 							{repo.name}
 							<span style={{ opacity: 0.6, fontSize: '0.65rem' }}>
-								{formatSize(repoFootprint(repo))}
+								{formatSize(repo.size)}
 							</span>
 						</div>
 					);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -5,6 +5,7 @@ import {
 	formatSize,
 	langColor,
 	timeAgo,
+	type ForgejoRepo,
 } from './forgejoService';
 import { useTabActive } from './forgejoUi';
 import {
@@ -82,13 +83,19 @@ function StatCard({
 	);
 }
 
+function repoFootprint(repo: ForgejoRepo): number {
+	return repo.size + repo.lfs_size;
+}
+
 function StorageBreakdown() {
 	const repos = useStore(forgejoService.$repos);
 
 	const { totalSize, top } = useMemo(() => {
-		const sorted = [...repos].sort((a, b) => b.size - a.size);
+		const sorted = [...repos].sort(
+			(a, b) => repoFootprint(b) - repoFootprint(a),
+		);
 		return {
-			totalSize: sorted.reduce((s, r) => s + r.size, 0),
+			totalSize: sorted.reduce((s, r) => s + repoFootprint(r), 0),
 			top: sorted.slice(0, 8),
 		};
 	}, [repos]);
@@ -123,13 +130,14 @@ function StorageBreakdown() {
 					marginBottom: 8,
 				}}>
 				{top.map((repo, i) => {
+					const footprint = repoFootprint(repo);
 					const pct =
-						totalSize > 0 ? (repo.size / totalSize) * 100 : 0;
+						totalSize > 0 ? (footprint / totalSize) * 100 : 0;
 					const hue = [200, 160, 280, 30, 340, 120, 50, 240][i % 8];
 					return (
 						<div
 							key={repo.id}
-							title={`${repo.full_name}: ${formatSize(repo.size)}`}
+							title={`${repo.full_name}: ${formatSize(footprint)}`}
 							style={{
 								width: `${pct}%`,
 								background: `hsl(${hue}, 60%, 55%)`,
@@ -169,7 +177,7 @@ function StorageBreakdown() {
 							/>
 							{repo.name}
 							<span style={{ opacity: 0.6, fontSize: '0.65rem' }}>
-								{formatSize(repo.size)}
+								{formatSize(repoFootprint(repo))}
 							</span>
 						</div>
 					);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -204,6 +204,15 @@ function StorageBreakdown() {
 							<span style={{ opacity: 0.6, fontSize: '0.65rem' }}>
 								{formatSize(repo.size)}
 							</span>
+							{repo.lfs_size > 0 && (
+								<span
+									style={{
+										color: '#8b5cf6',
+										fontSize: '0.6rem',
+									}}>
+									LFS {formatSize(repo.lfs_size)}
+								</span>
+							)}
 						</div>
 					);
 				})}

--- a/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
+++ b/apps/kbve/axum-kbve/src/transport/forgejo_api.rs
@@ -19,9 +19,13 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 use jedi::entity::error::JediError;
-use jedi::entity::forgejo::{ForgejoClient, ForgejoPolicy, ForgejoStats, ForgejoStorage};
+use jedi::entity::forgejo::{
+    ForgejoClient, ForgejoPolicy, ForgejoRepo, ForgejoStats, ForgejoStorage, ForgejoStorageError,
+    repo_storage, verify_schema,
+};
 
 use super::proxy::{require_dashboard_manage_with_query, require_dashboard_view};
+use crate::db::get_pg_cluster;
 
 /// Aggregates (`/stats`, `/storage`) page through every repo / owner upstream,
 /// so they are cached server-side: the 30s dashboard refresh re-hits Forgejo at
@@ -30,6 +34,79 @@ const AGG_TTL: Duration = Duration::from_secs(300);
 
 static STATS_CACHE: OnceLock<Mutex<Option<(Instant, ForgejoStats)>>> = OnceLock::new();
 static STORAGE_CACHE: OnceLock<Mutex<Option<(Instant, ForgejoStorage)>>> = OnceLock::new();
+
+/// Last observed health of the Forgejo-DB storage enrichment. The dashboard's
+/// per-repo git/LFS split is read from Forgejo's internal schema (the REST API
+/// only exposes the combined `size`); this records whether that read is healthy
+/// so a Forgejo upgrade that renames a column surfaces loud instead of silently
+/// degrading the numbers back to git-only.
+static STORAGE_DB_HEALTH: Mutex<(StorageHealth, Option<String>)> =
+    Mutex::new((StorageHealth::Unknown, None));
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum StorageHealth {
+    Unknown,
+    Ok,
+    SchemaDrift,
+    AccessDenied,
+    Db,
+    Unconfigured,
+}
+
+impl StorageHealth {
+    fn as_str(self) -> &'static str {
+        match self {
+            StorageHealth::Unknown => "unknown",
+            StorageHealth::Ok => "ok",
+            StorageHealth::SchemaDrift => "schema_drift",
+            StorageHealth::AccessDenied => "access_denied",
+            StorageHealth::Db => "db_error",
+            StorageHealth::Unconfigured => "unconfigured",
+        }
+    }
+}
+
+fn record_storage_health(status: StorageHealth, detail: Option<String>) {
+    if let Ok(mut g) = STORAGE_DB_HEALTH.lock() {
+        *g = (status, detail);
+    }
+}
+
+/// Fills each repo's `git_size`/`lfs_size` from Forgejo's DB. Degrades to the
+/// REST-only `size` on any failure and records why, never failing the request.
+async fn enrich_repo_storage(repos: &mut [ForgejoRepo]) {
+    if repos.is_empty() {
+        return;
+    }
+    let Some(cluster) = get_pg_cluster() else {
+        record_storage_health(
+            StorageHealth::Unconfigured,
+            Some("PgCluster unavailable".into()),
+        );
+        return;
+    };
+    let ids: Vec<i64> = repos.iter().map(|r| r.id as i64).collect();
+    match repo_storage(&cluster, &ids).await {
+        Ok(map) => {
+            for r in repos.iter_mut() {
+                if let Some((git, lfs)) = map.get(&(r.id as i64)) {
+                    r.git_size = *git;
+                    r.lfs_size = *lfs;
+                }
+            }
+            record_storage_health(StorageHealth::Ok, None);
+        }
+        Err(e) => {
+            let status = match e {
+                ForgejoStorageError::SchemaDrift { .. } => StorageHealth::SchemaDrift,
+                ForgejoStorageError::AccessDenied => StorageHealth::AccessDenied,
+                ForgejoStorageError::Db(_) => StorageHealth::Db,
+            };
+            tracing::warn!("Forgejo-API per-repo storage enrichment degraded: {e}");
+            record_storage_health(status, Some(e.to_string()));
+        }
+    }
+}
 
 async fn cached_stats(c: &ForgejoClient, force: bool) -> Result<ForgejoStats, JediError> {
     let cell = STATS_CACHE.get_or_init(|| Mutex::new(None));
@@ -184,7 +261,62 @@ async fn repos_search(headers: HeaderMap, q: axum::extract::Query<ListQuery>) ->
         Ok(c) => c,
         Err(r) => return r,
     };
-    reply!(c.search_repos(q.page(), q.limit(), q.q.as_deref()).await)
+    match c.search_repos(q.page(), q.limit(), q.q.as_deref()).await {
+        Ok(mut repos) => {
+            enrich_repo_storage(&mut repos).await;
+            Json(repos).into_response()
+        }
+        Err(e) => e.into_response(),
+    }
+}
+
+/// Reports whether the per-repo storage enrichment is healthy, running a live
+/// schema probe so a Forgejo upgrade that renames a column is caught here.
+async fn storage_health(headers: HeaderMap) -> Response {
+    if let Err(r) = gate(&headers).await {
+        return r;
+    }
+    let probe = match get_pg_cluster() {
+        Some(cluster) => match verify_schema(&cluster).await {
+            Ok(()) => {
+                record_storage_health(StorageHealth::Ok, None);
+                None
+            }
+            Err(e) => {
+                let status = match e {
+                    ForgejoStorageError::SchemaDrift { .. } => StorageHealth::SchemaDrift,
+                    ForgejoStorageError::AccessDenied => StorageHealth::AccessDenied,
+                    ForgejoStorageError::Db(_) => StorageHealth::Db,
+                };
+                record_storage_health(status, Some(e.to_string()));
+                Some(e.to_string())
+            }
+        },
+        None => {
+            record_storage_health(
+                StorageHealth::Unconfigured,
+                Some("PgCluster unavailable".into()),
+            );
+            Some("PgCluster unavailable".into())
+        }
+    };
+    let (status, detail) = STORAGE_DB_HEALTH
+        .lock()
+        .map(|g| (g.0, g.1.clone()))
+        .unwrap_or((StorageHealth::Unknown, None));
+    let code = if status == StorageHealth::Ok {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    (
+        code,
+        Json(json!({
+            "status": status.as_str(),
+            "detail": detail.or(probe),
+        })),
+    )
+        .into_response()
 }
 
 async fn version(headers: HeaderMap) -> Response {
@@ -1098,6 +1230,7 @@ pub fn routes() -> Router {
         // top-level
         .route(&p("/stats"), get(stats))
         .route(&p("/storage"), get(storage))
+        .route(&p("/storage/health"), get(storage_health))
         .route(&p("/version"), get(version))
         .route(&p("/cron"), get(cron))
         .route(&p("/cron/{task}"), post(run_cron))

--- a/packages/rust/jedi/src/entity/forgejo/mod.rs
+++ b/packages/rust/jedi/src/entity/forgejo/mod.rs
@@ -1,7 +1,9 @@
 mod client;
 mod policy;
+mod storage_db;
 mod types;
 
 pub use client::*;
 pub use policy::*;
+pub use storage_db::*;
 pub use types::*;

--- a/packages/rust/jedi/src/entity/forgejo/storage_db.rs
+++ b/packages/rust/jedi/src/entity/forgejo/storage_db.rs
@@ -1,0 +1,117 @@
+use std::collections::HashMap;
+
+use tokio_postgres::error::SqlState;
+
+use crate::state::pg::PgCluster;
+
+const SCHEMA: &str = "forgejo";
+const TABLE: &str = "repository";
+const REQUIRED_COLUMNS: &[&str] = &["id", "size", "git_size", "lfs_size"];
+
+#[derive(Debug, Clone)]
+pub enum ForgejoStorageError {
+    SchemaDrift { missing: Vec<String> },
+    AccessDenied,
+    Db(String),
+}
+
+impl std::fmt::Display for ForgejoStorageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ForgejoStorageError::SchemaDrift { missing } => write!(
+                f,
+                "forgejo.{TABLE} schema drift — missing/renamed columns: {}",
+                missing.join(", ")
+            ),
+            ForgejoStorageError::AccessDenied => write!(
+                f,
+                "no privilege to read forgejo.{TABLE} — grant SELECT to the app role"
+            ),
+            ForgejoStorageError::Db(e) => write!(f, "forgejo storage query failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ForgejoStorageError {}
+
+fn classify(err: &tokio_postgres::Error) -> ForgejoStorageError {
+    match err.code() {
+        Some(c) if *c == SqlState::UNDEFINED_COLUMN || *c == SqlState::UNDEFINED_TABLE => {
+            ForgejoStorageError::SchemaDrift {
+                missing: vec![format!(
+                    "{}",
+                    err.as_db_error().map(|e| e.message()).unwrap_or("?")
+                )],
+            }
+        }
+        Some(c) if *c == SqlState::INSUFFICIENT_PRIVILEGE => ForgejoStorageError::AccessDenied,
+        _ => ForgejoStorageError::Db(err.to_string()),
+    }
+}
+
+/// Probes `information_schema` for the columns this layer depends on. Returns
+/// `SchemaDrift` listing exactly what is missing so a Forgejo upgrade that
+/// renames a column fails loud and catchable instead of silently feeding zeros.
+pub async fn verify_schema(cluster: &PgCluster) -> Result<(), ForgejoStorageError> {
+    let conn = cluster
+        .read()
+        .await
+        .map_err(|e| ForgejoStorageError::Db(e.to_string()))?;
+    let rows = conn
+        .query(
+            "SELECT column_name FROM information_schema.columns \
+             WHERE table_schema = $1 AND table_name = $2",
+            &[&SCHEMA, &TABLE],
+        )
+        .await
+        .map_err(|e| classify(&e))?;
+
+    let present: std::collections::HashSet<String> =
+        rows.iter().map(|r| r.get::<_, String>(0)).collect();
+    let missing: Vec<String> = REQUIRED_COLUMNS
+        .iter()
+        .filter(|c| !present.contains(**c))
+        .map(|c| c.to_string())
+        .collect();
+
+    if present.is_empty() {
+        return Err(ForgejoStorageError::AccessDenied);
+    }
+    if !missing.is_empty() {
+        return Err(ForgejoStorageError::SchemaDrift { missing });
+    }
+    Ok(())
+}
+
+/// Per-repo git and LFS size in KB, keyed by Forgejo repo id. Forgejo's REST
+/// API only exposes the combined `size`; the git/LFS split lives only in this
+/// table. Sizes are stored in bytes, normalised to KB to match the REST units.
+pub async fn repo_storage(
+    cluster: &PgCluster,
+    repo_ids: &[i64],
+) -> Result<HashMap<i64, (u64, u64)>, ForgejoStorageError> {
+    if repo_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let conn = cluster
+        .read()
+        .await
+        .map_err(|e| ForgejoStorageError::Db(e.to_string()))?;
+    let rows = conn
+        .query(
+            "SELECT id, git_size / 1024, lfs_size / 1024 \
+             FROM forgejo.repository WHERE id = ANY($1)",
+            &[&repo_ids],
+        )
+        .await
+        .map_err(|e| classify(&e))?;
+
+    let mut out = HashMap::with_capacity(rows.len());
+    for row in &rows {
+        let id: i64 = row.get(0);
+        let git_kb: i64 = row.get(1);
+        let lfs_kb: i64 = row.get(2);
+        out.insert(id, (git_kb.max(0) as u64, lfs_kb.max(0) as u64));
+    }
+    Ok(out)
+}


### PR DESCRIPTION
## Background
Forgejo's REST repo API exposes only the combined `size` — no git/LFS split. And `repository.size` is recomputed lazily (push/gc), so a repo whose LFS landed before a recompute reports just its git tree (rentearth: 1.1 GB of LFS shown as 23 KB). The proto already had `git_size`/`lfs_size` fields, but nothing fed them (the REST API never sends those keys → always 0).

## What this does
**Feed the proto from the one source that has the split — Forgejo's DB — without silent coupling.**

### jedi — `forgejo/storage_db.rs` (self-validating layer)
- `verify_schema()` probes `information_schema` against a column contract; a Forgejo upgrade that renames/drops a column returns `ForgejoStorageError::SchemaDrift{missing}` — **loud and catchable**, not silent zeros.
- `repo_storage(ids)` returns per-repo git/LFS (KB, normalised from the DB's bytes).
- Postgres SQLSTATEs map to typed errors: `42703`/`42P01` → `SchemaDrift`, `42501` → `AccessDenied`.

### axum — `forgejo_api`
- `repos/search` enriches each repo's `git_size`/`lfs_size` from the DB. **Any failure degrades to the REST-only `size` and records why — never fails the request.**
- New `GET /storage/health` runs a live schema probe so drift is observable (200 ok / 503 + `{status, detail}`).

### web — `ReactForgejoSummary`
- Per-repo legend shows the LFS split; RecentActivity's LFS badge now populates (both read `git_size`/`lfs_size`).
- Quota-based banner stays as the independent **data-drift** signal (real LFS via quota API vs summed `repository.size`) — distinct from the schema-drift guard.

## Two drifts, both caught
- **Schema drift** (upgrade renames a column) → typed error → `/storage/health` 503 + log.
- **Data drift** (stale `repository.size`) → quota-vs-sum banner.

## Notes
- App connects as the `postgres` superuser → reads `forgejo.*` with no grant; works on deploy.
- The stale data for rentearth/rareicon was already corrected out-of-band by running Forgejo's `git_gc_repos` (`UpdateRepoSize`), so their `size` is now right regardless of this PR.
- Verified: `cargo check -p jedi`, `cargo check -p axum-kbve`, and `astro check` all clean.