### PR TITLE
feat(cryptothrone): blackjack sound cues (#12701)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
@@ -9,6 +9,17 @@ declare module '@kbve/laser' {
 		'blackjack:bet': { amount: number };
 		'blackjack:action': { kind: BjActionKind };
 		'blackjack:insure': { amount: number };
+		'blackjack:sfx': {
+			kind:
+				| 'card'
+				| 'flip'
+				| 'deal'
+				| 'chip'
+				| 'win'
+				| 'blackjack'
+				| 'lose'
+				| 'push';
+		};
 		'blackjack:leave': void;
 		'npc:interact': {
 			npcId: string;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackTable.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FloatingWindow } from '@kbve/astro/ui';
 import {
 	laserEvents,
@@ -8,6 +8,7 @@ import {
 import type {
 	BlackjackSeatView,
 	BlackjackHandView,
+	BlackjackStateView,
 	BjActionKind,
 } from '@kbve/laser';
 import { useGameSelector } from '../store/GameStoreContext';
@@ -241,6 +242,67 @@ function SeatRow({
 	);
 }
 
+// Watches server state transitions and fires sound cues; SoundManager plays them.
+function BlackjackSfx({
+	state,
+	myName,
+}: {
+	state: BlackjackStateView | null;
+	myName: string;
+}) {
+	const prev = useRef<{ phase: string; cards: number; bet: number } | null>(
+		null,
+	);
+	useEffect(() => {
+		if (!state) {
+			prev.current = null;
+			return;
+		}
+		const mySeat = state.seats.find((s) => s.username === myName) ?? null;
+		const cards =
+			state.dealer_hand.length +
+			state.seats.reduce(
+				(a, s) => a + s.hands.reduce((b, h) => b + h.cards.length, 0),
+				0,
+			);
+		const myBet =
+			mySeat?.hands.reduce((a, h) => a + h.bet, 0) || (mySeat?.bet ?? 0);
+		const p = prev.current;
+		if (p) {
+			if (cards > p.cards)
+				laserEvents.emit('blackjack:sfx', { kind: 'card' });
+			if (myBet > p.bet)
+				laserEvents.emit('blackjack:sfx', { kind: 'chip' });
+			if (p.phase !== state.phase) {
+				if (state.phase === 'dealer_turn')
+					laserEvents.emit('blackjack:sfx', { kind: 'flip' });
+				else if (
+					state.phase === 'player_turn' ||
+					state.phase === 'insurance'
+				)
+					laserEvents.emit('blackjack:sfx', { kind: 'deal' });
+				else if (state.phase === 'settle' && mySeat) {
+					const outs = mySeat.hands
+						.map((h) => h.outcome)
+						.filter(Boolean) as string[];
+					if (outs.includes('blackjack'))
+						laserEvents.emit('blackjack:sfx', {
+							kind: 'blackjack',
+						});
+					else if (outs.some((o) => o === 'win'))
+						laserEvents.emit('blackjack:sfx', { kind: 'win' });
+					else if (outs.length && outs.every((o) => o === 'push'))
+						laserEvents.emit('blackjack:sfx', { kind: 'push' });
+					else if (outs.length)
+						laserEvents.emit('blackjack:sfx', { kind: 'lose' });
+				}
+			}
+		}
+		prev.current = { phase: state.phase, cards, bet: myBet };
+	}, [state, myName]);
+	return null;
+}
+
 export function BlackjackTable() {
 	const bj = useGameSelector((s) => s.blackjack);
 	const myName = useGameSelector((s) => s.player.stats.username);
@@ -313,6 +375,7 @@ export function BlackjackTable() {
 			title="Blackjack"
 			onClose={close}>
 			<div className="flex h-full flex-col gap-3 bg-zinc-950 p-4 text-white">
+				<BlackjackSfx state={state} myName={myName} />
 				{!state ? (
 					<p className="text-sm text-zinc-400">Joining the table…</p>
 				) : (

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SoundManager.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SoundManager.tsx
@@ -82,6 +82,56 @@ export function SoundManager() {
 					),
 				);
 			}),
+			laserEvents.on('blackjack:sfx', (d) => {
+				const cx = ensure();
+				if (!cx) return;
+				const { kind } = d as { kind: string };
+				const arp = (freqs: number[], step = 90, gain = 0.05) =>
+					freqs.forEach((f, i) =>
+						setTimeout(
+							() => beep(cx, f, 0.15, 'triangle', gain),
+							i * step,
+						),
+					);
+				switch (kind) {
+					case 'card':
+						beep(cx, 1100, 0.03, 'square', 0.025);
+						break;
+					case 'flip':
+						beep(cx, 760, 0.05, 'square', 0.03);
+						break;
+					case 'deal':
+						beep(cx, 520, 0.06, 'sawtooth', 0.03);
+						setTimeout(
+							() => beep(cx, 700, 0.05, 'square', 0.02),
+							60,
+						);
+						break;
+					case 'chip':
+						beep(cx, 1500, 0.04, 'sine', 0.045);
+						setTimeout(
+							() => beep(cx, 1900, 0.03, 'sine', 0.03),
+							35,
+						);
+						break;
+					case 'win':
+						arp([523, 659, 784]);
+						break;
+					case 'blackjack':
+						arp([523, 659, 784, 1047], 80, 0.055);
+						break;
+					case 'push':
+						beep(cx, 440, 0.16, 'triangle', 0.04);
+						break;
+					case 'lose':
+						beep(cx, 300, 0.14, 'sawtooth', 0.05);
+						setTimeout(
+							() => beep(cx, 150, 0.2, 'sawtooth', 0.05),
+							100,
+						);
+						break;
+				}
+			}),
 		];
 		return () => offs.forEach((o) => o());
 	}, []);


### PR DESCRIPTION
Polish follow-up for #12701. **Stacked on #12874** (provable fairness); base is the fairness branch so the diff is incremental.

Event-driven SFX for the casino table, synthesized through the **existing** `SoundManager` Web Audio beeps — zero audio assets, honours the global mute toggle.

## What
- `BlackjackTable` diffs server-state transitions and emits a `blackjack:sfx` cue:
  - **card** on each new card, **flip** on the dealer-turn hole-card reveal, **deal** whoosh entering play/insurance, **chip** on bet / double / split, and a **win / blackjack / push / lose** sting from the player's own settled outcome.
- `SoundManager` plays each cue with short oscillator patterns (arpeggio for win/blackjack, descending saw for lose, etc).

cryptothrone-only; rides the pending 0.1.51. Build + 111 unit tests green; astro check clean for changed files.

Last of the series — **real Phaser renderer** PR to follow.