### PR TITLE
feat(cryptothrone): Phaser-rendered blackjack table (#12701)

### DIFF
--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/laser-events.d.ts
@@ -9,6 +9,17 @@ declare module '@kbve/laser' {
 		'blackjack:bet': { amount: number };
 		'blackjack:action': { kind: BjActionKind };
 		'blackjack:insure': { amount: number };
+		'blackjack:sfx': {
+			kind:
+				| 'card'
+				| 'flip'
+				| 'deal'
+				| 'chip'
+				| 'win'
+				| 'blackjack'
+				| 'lose'
+				| 'push';
+		};
 		'blackjack:leave': void;
 		'npc:interact': {
 			npcId: string;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/BlackjackStageScene.ts
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/scenes/BlackjackStageScene.ts
@@ -1,0 +1,210 @@
+import Phaser from 'phaser';
+import { decodeCard } from '@kbve/laser';
+import type { BlackjackHandView } from '@kbve/laser';
+
+const SUIT_GLYPH: Record<string, string> = {
+	spades: '♠',
+	hearts: '♥',
+	diamonds: '♦',
+	clubs: '♣',
+};
+
+const CARD_W = 36;
+const CARD_H = 50;
+const FAN = 20;
+
+export interface StageState {
+	dealer: number[];
+	dealerHidden: boolean;
+	dealerValue: number | null;
+	hands: BlackjackHandView[];
+	activeHand: number | null;
+	mine: boolean;
+	phase: string;
+}
+
+/**
+ * Phaser centerpiece for the blackjack table: the dealer hand on top and the local
+ * player's hand(s) below, rebuilt only when the visual state changes (the React
+ * wrapper diffs a signature), with freshly-dealt cards tweened in from the shoe.
+ */
+export class BlackjackStageScene extends Phaser.Scene {
+	private layer!: Phaser.GameObjects.Container;
+	private prevKeys = new Set<string>();
+	private w = 0;
+	private h = 0;
+
+	constructor() {
+		super('BlackjackStage');
+	}
+
+	create() {
+		this.w = this.scale.width;
+		this.h = this.scale.height;
+		const g = this.add.graphics();
+		g.fillStyle(0x0b3d2e, 1);
+		g.fillRoundedRect(4, 4, this.w - 8, this.h - 8, 14);
+		g.lineStyle(2, 0x0f5740, 1);
+		g.strokeRoundedRect(4, 4, this.w - 8, this.h - 8, 14);
+		g.fillStyle(0x0d4636, 1);
+		g.fillCircle(this.w / 2, 6, this.w * 0.42);
+		this.layer = this.add.container(0, 0);
+		this.game.events.emit('stage-ready');
+	}
+
+	private label(x: number, y: number, text: string, color = '#a7f3d0') {
+		const t = this.add
+			.text(x, y, text, {
+				fontFamily: 'monospace',
+				fontSize: '11px',
+				color,
+			})
+			.setOrigin(0.5, 0.5);
+		this.layer.add(t);
+		return t;
+	}
+
+	private card(byte: number, faceDown: boolean) {
+		const c = this.add.container(0, 0);
+		const bg = this.add
+			.rectangle(0, 0, CARD_W, CARD_H, faceDown ? 0x3730a3 : 0xfdfdf7)
+			.setStrokeStyle(1, faceDown ? 0x818cf8 : 0x9ca3af);
+		c.add(bg);
+		if (faceDown) {
+			const back = this.add
+				.text(0, 0, '🂠', { fontSize: '20px', color: '#c7d2fe' })
+				.setOrigin(0.5);
+			c.add(back);
+		} else {
+			const d = decodeCard(byte);
+			const col = d.red ? '#dc2626' : '#111827';
+			const rank = this.add
+				.text(-CARD_W / 2 + 4, -CARD_H / 2 + 3, d.rank, {
+					fontFamily: 'monospace',
+					fontSize: '12px',
+					fontStyle: 'bold',
+					color: col,
+				})
+				.setOrigin(0, 0);
+			const suit = this.add
+				.text(0, 2, SUIT_GLYPH[d.suit], {
+					fontSize: '18px',
+					color: col,
+				})
+				.setOrigin(0.5);
+			c.add(rank);
+			c.add(suit);
+		}
+		this.layer.add(c);
+		return c;
+	}
+
+	private placeHand(
+		cards: number[],
+		cx: number,
+		y: number,
+		hideSecond: boolean,
+		keyPrefix: string,
+		newKeys: Set<string>,
+	) {
+		const count = cards.length + (hideSecond ? 1 : 0);
+		const startX = cx - ((count - 1) * FAN) / 2;
+		for (let i = 0; i < cards.length; i++) {
+			const key = `${keyPrefix}:${i}:${cards[i]}`;
+			newKeys.add(key);
+			const x = startX + i * FAN;
+			const card = this.card(cards[i], false);
+			this.settle(card, x, y, key);
+		}
+		if (hideSecond) {
+			const key = `${keyPrefix}:back`;
+			newKeys.add(key);
+			const card = this.card(0, true);
+			this.settle(card, startX + cards.length * FAN, y, key);
+		}
+	}
+
+	private settle(
+		card: Phaser.GameObjects.Container,
+		x: number,
+		y: number,
+		key: string,
+	) {
+		if (this.prevKeys.has(key)) {
+			card.setPosition(x, y);
+			return;
+		}
+		// Freshly dealt: fly in from the shoe (top-right) with a little spin.
+		card.setPosition(this.w - 18, 14)
+			.setScale(0.6)
+			.setAlpha(0)
+			.setAngle(-12);
+		this.tweens.add({
+			targets: card,
+			x,
+			y,
+			scale: 1,
+			alpha: 1,
+			angle: 0,
+			duration: 240,
+			ease: 'Cubic.out',
+		});
+	}
+
+	renderState(s: StageState) {
+		if (!this.layer) return;
+		this.layer.removeAll(true);
+		const newKeys = new Set<string>();
+
+		this.label(this.w / 2, 14, 'DEALER', '#86efac');
+		this.placeHand(s.dealer, this.w / 2, 52, s.dealerHidden, 'd', newKeys);
+		if (!s.dealerHidden && s.dealerValue != null) {
+			this.label(this.w / 2, 84, `${s.dealerValue}`, '#d1fae5');
+		}
+
+		if (s.hands.length === 0) {
+			this.label(
+				this.w / 2,
+				this.h / 2 + 20,
+				s.mine ? 'Place your bet…' : 'Spectating',
+				'#6b7280',
+			);
+		}
+
+		// The player's hands fan out across the lower half; splits sit side by side.
+		const groups = s.hands.length || 1;
+		const slot = this.w / groups;
+		s.hands.forEach((hand, hi) => {
+			const cx = slot * (hi + 0.5);
+			const y = this.h - 64;
+			const active = s.activeHand === hi && s.phase === 'player_turn';
+			if (active) {
+				const glow = this.add
+					.rectangle(cx, y, slot - 8, CARD_H + 22, 0xfacc15, 0.16)
+					.setStrokeStyle(2, 0xfacc15);
+				this.layer.add(glow);
+			}
+			this.placeHand(hand.cards, cx, y, false, `h${hi}`, newKeys);
+			const meta = `${hand.value}${hand.soft ? ' soft' : ''} · ${hand.bet}${hand.doubled ? '·2x' : ''}`;
+			this.label(cx, y + 34, meta, '#fcd34d');
+			if (hand.outcome) {
+				const colors: Record<string, string> = {
+					win: '#34d399',
+					blackjack: '#34d399',
+					push: '#d1d5db',
+					loss: '#fb7185',
+				};
+				this.label(
+					cx,
+					y - 40,
+					hand.outcome === 'blackjack'
+						? 'BLACKJACK'
+						: hand.outcome.toUpperCase(),
+					colors[hand.outcome] ?? '#fff',
+				);
+			}
+		});
+
+		this.prevKeys = newKeys;
+	}
+}

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackStage.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackStage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef } from 'react';
+import Phaser from 'phaser';
+import { decodeCard } from '@kbve/laser';
+import type { BlackjackStateView } from '@kbve/laser';
+import {
+	BlackjackStageScene,
+	type StageState,
+} from '../scenes/BlackjackStageScene';
+
+const W = 520;
+const H = 250;
+
+function dealerValue(cards: number[]): number {
+	let total = 0;
+	let aces = 0;
+	for (const b of cards) {
+		const d = decodeCard(b);
+		total += d.points;
+		if (d.rank === 'A') aces++;
+	}
+	while (total > 21 && aces > 0) {
+		total -= 10;
+		aces--;
+	}
+	return total;
+}
+
+function toStageState(state: BlackjackStateView, myName: string): StageState {
+	const mySeat = state.seats.find((s) => s.username === myName) ?? null;
+	return {
+		dealer: state.dealer_hand,
+		dealerHidden: state.dealer_hidden,
+		dealerValue: state.dealer_hidden
+			? null
+			: dealerValue(state.dealer_hand),
+		hands: mySeat?.hands ?? [],
+		activeHand:
+			mySeat && state.active_slot === mySeat.slot
+				? state.active_hand
+				: null,
+		mine: !!mySeat,
+		phase: state.phase,
+	};
+}
+
+function signature(state: BlackjackStateView, myName: string): string {
+	const mySeat = state.seats.find((s) => s.username === myName);
+	return JSON.stringify({
+		d: state.dealer_hand,
+		dh: state.dealer_hidden,
+		p: state.phase,
+		ah: state.active_slot === mySeat?.slot ? state.active_hand : null,
+		h:
+			mySeat?.hands.map((h) => [
+				h.cards,
+				h.outcome,
+				h.doubled,
+				h.bet,
+				h.value,
+			]) ?? [],
+	});
+}
+
+export function BlackjackStage({
+	state,
+	myName,
+}: {
+	state: BlackjackStateView;
+	myName: string;
+}) {
+	const hostRef = useRef<HTMLDivElement>(null);
+	const sceneRef = useRef<BlackjackStageScene | null>(null);
+	const readyRef = useRef(false);
+	const pendingRef = useRef<StageState | null>(null);
+	const sigRef = useRef('');
+
+	useEffect(() => {
+		if (!hostRef.current) return;
+		const scene = new BlackjackStageScene();
+		sceneRef.current = scene;
+		const game = new Phaser.Game({
+			type: Phaser.AUTO,
+			width: W,
+			height: H,
+			parent: hostRef.current,
+			transparent: true,
+			banner: false,
+			audio: { noAudio: true },
+			scale: {
+				mode: Phaser.Scale.FIT,
+				autoCenter: Phaser.Scale.CENTER_BOTH,
+			},
+			scene,
+		});
+		game.events.once('stage-ready', () => {
+			readyRef.current = true;
+			if (pendingRef.current) scene.renderState(pendingRef.current);
+		});
+		return () => {
+			readyRef.current = false;
+			sceneRef.current = null;
+			game.destroy(true);
+		};
+	}, []);
+
+	useEffect(() => {
+		const sig = signature(state, myName);
+		if (sig === sigRef.current) return;
+		sigRef.current = sig;
+		const ss = toStageState(state, myName);
+		pendingRef.current = ss;
+		if (readyRef.current && sceneRef.current) {
+			sceneRef.current.renderState(ss);
+		}
+	}, [state, myName]);
+
+	return (
+		<div
+			ref={hostRef}
+			className="mx-auto w-full"
+			style={{ maxWidth: W, aspectRatio: `${W} / ${H}` }}
+		/>
+	);
+}
+
+export default BlackjackStage;

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackTable.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackTable.tsx
@@ -12,6 +12,7 @@ import type {
 	BjActionKind,
 } from '@kbve/laser';
 import { useGameSelector } from '../store/GameStoreContext';
+import { BlackjackStage } from './BlackjackStage';
 import './BlackjackTable.css';
 
 // Per-phase countdown lengths, mirroring the server's BJ_*_TICKS windows (seconds).
@@ -317,6 +318,7 @@ export function BlackjackTable() {
 	};
 
 	const mySeat = state?.seats.find((s) => s.username === myName) ?? null;
+	const otherSeats = state?.seats.filter((s) => s.username !== myName) ?? [];
 	const myActiveHandIdx =
 		mySeat && state?.active_slot === mySeat.slot ? state.active_hand : null;
 	const isMyTurn = myActiveHandIdx != null;
@@ -399,32 +401,24 @@ export function BlackjackTable() {
 							/>
 						</div>
 
-						<div className="rounded bg-emerald-950/60 p-2">
-							<span className="text-xs text-zinc-400">
-								Dealer
-							</span>
-							<Hand
-								cards={state.dealer_hand}
-								hideSecond={state.dealer_hidden}
-							/>
-						</div>
+						<BlackjackStage state={state} myName={myName} />
 
-						<div className="flex flex-1 flex-col gap-1 overflow-y-auto">
-							{state.seats.length === 0 && (
-								<p className="text-sm text-zinc-500">
-									No players seated yet.
-								</p>
-							)}
-							{state.seats.map((seat) => (
-								<SeatRow
-									key={seat.slot}
-									seat={seat}
-									activeSlot={state.active_slot}
-									activeHand={state.active_hand}
-									mine={seat.username === myName}
-								/>
-							))}
-						</div>
+						{otherSeats.length > 0 && (
+							<div className="flex max-h-28 flex-col gap-1 overflow-y-auto">
+								<span className="text-[10px] uppercase tracking-wide text-zinc-500">
+									Others at the table
+								</span>
+								{otherSeats.map((seat) => (
+									<SeatRow
+										key={seat.slot}
+										seat={seat}
+										activeSlot={state.active_slot}
+										activeHand={state.active_hand}
+										mine={false}
+									/>
+								))}
+							</div>
+						)}
 
 						{!mySeat && (
 							<p className="text-xs text-zinc-400">

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackTable.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/BlackjackTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FloatingWindow } from '@kbve/astro/ui';
 import {
 	laserEvents,
@@ -8,6 +8,7 @@ import {
 import type {
 	BlackjackSeatView,
 	BlackjackHandView,
+	BlackjackStateView,
 	BjActionKind,
 } from '@kbve/laser';
 import { useGameSelector } from '../store/GameStoreContext';
@@ -241,6 +242,67 @@ function SeatRow({
 	);
 }
 
+// Watches server state transitions and fires sound cues; SoundManager plays them.
+function BlackjackSfx({
+	state,
+	myName,
+}: {
+	state: BlackjackStateView | null;
+	myName: string;
+}) {
+	const prev = useRef<{ phase: string; cards: number; bet: number } | null>(
+		null,
+	);
+	useEffect(() => {
+		if (!state) {
+			prev.current = null;
+			return;
+		}
+		const mySeat = state.seats.find((s) => s.username === myName) ?? null;
+		const cards =
+			state.dealer_hand.length +
+			state.seats.reduce(
+				(a, s) => a + s.hands.reduce((b, h) => b + h.cards.length, 0),
+				0,
+			);
+		const myBet =
+			mySeat?.hands.reduce((a, h) => a + h.bet, 0) || (mySeat?.bet ?? 0);
+		const p = prev.current;
+		if (p) {
+			if (cards > p.cards)
+				laserEvents.emit('blackjack:sfx', { kind: 'card' });
+			if (myBet > p.bet)
+				laserEvents.emit('blackjack:sfx', { kind: 'chip' });
+			if (p.phase !== state.phase) {
+				if (state.phase === 'dealer_turn')
+					laserEvents.emit('blackjack:sfx', { kind: 'flip' });
+				else if (
+					state.phase === 'player_turn' ||
+					state.phase === 'insurance'
+				)
+					laserEvents.emit('blackjack:sfx', { kind: 'deal' });
+				else if (state.phase === 'settle' && mySeat) {
+					const outs = mySeat.hands
+						.map((h) => h.outcome)
+						.filter(Boolean) as string[];
+					if (outs.includes('blackjack'))
+						laserEvents.emit('blackjack:sfx', {
+							kind: 'blackjack',
+						});
+					else if (outs.some((o) => o === 'win'))
+						laserEvents.emit('blackjack:sfx', { kind: 'win' });
+					else if (outs.length && outs.every((o) => o === 'push'))
+						laserEvents.emit('blackjack:sfx', { kind: 'push' });
+					else if (outs.length)
+						laserEvents.emit('blackjack:sfx', { kind: 'lose' });
+				}
+			}
+		}
+		prev.current = { phase: state.phase, cards, bet: myBet };
+	}, [state, myName]);
+	return null;
+}
+
 export function BlackjackTable() {
 	const bj = useGameSelector((s) => s.blackjack);
 	const myName = useGameSelector((s) => s.player.stats.username);
@@ -313,6 +375,7 @@ export function BlackjackTable() {
 			title="Blackjack"
 			onClose={close}>
 			<div className="flex h-full flex-col gap-3 bg-zinc-950 p-4 text-white">
+				<BlackjackSfx state={state} myName={myName} />
 				{!state ? (
 					<p className="text-sm text-zinc-400">Joining the table…</p>
 				) : (

--- a/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SoundManager.tsx
+++ b/apps/cryptothrone/astro-cryptothrone/src/components/game/ui/SoundManager.tsx
@@ -82,6 +82,56 @@ export function SoundManager() {
 					),
 				);
 			}),
+			laserEvents.on('blackjack:sfx', (d) => {
+				const cx = ensure();
+				if (!cx) return;
+				const { kind } = d as { kind: string };
+				const arp = (freqs: number[], step = 90, gain = 0.05) =>
+					freqs.forEach((f, i) =>
+						setTimeout(
+							() => beep(cx, f, 0.15, 'triangle', gain),
+							i * step,
+						),
+					);
+				switch (kind) {
+					case 'card':
+						beep(cx, 1100, 0.03, 'square', 0.025);
+						break;
+					case 'flip':
+						beep(cx, 760, 0.05, 'square', 0.03);
+						break;
+					case 'deal':
+						beep(cx, 520, 0.06, 'sawtooth', 0.03);
+						setTimeout(
+							() => beep(cx, 700, 0.05, 'square', 0.02),
+							60,
+						);
+						break;
+					case 'chip':
+						beep(cx, 1500, 0.04, 'sine', 0.045);
+						setTimeout(
+							() => beep(cx, 1900, 0.03, 'sine', 0.03),
+							35,
+						);
+						break;
+					case 'win':
+						arp([523, 659, 784]);
+						break;
+					case 'blackjack':
+						arp([523, 659, 784, 1047], 80, 0.055);
+						break;
+					case 'push':
+						beep(cx, 440, 0.16, 'triangle', 0.04);
+						break;
+					case 'lose':
+						beep(cx, 300, 0.14, 'sawtooth', 0.05);
+						setTimeout(
+							() => beep(cx, 150, 0.2, 'sawtooth', 0.05),
+							100,
+						);
+						break;
+				}
+			}),
 		];
 		return () => offs.forEach((o) => o());
 	}, []);


### PR DESCRIPTION
Polish follow-up for #12701. **Stacked on #12877** (sound) → #12874 → #12866 → #12863; base is the sound branch so the diff is incremental.

The headline visual: replaces the DOM card layout with an embedded **Phaser canvas** centerpiece — dealer hand on top, the local player's hand(s) below, on a felt table, with cards dealt in from the shoe.

## What
- **`BlackjackStageScene`** (Phaser): felt table, dealer + player hands, fresh cards fly in from the shoe with a spin, hole card face-down until reveal, active-hand glow, per-hand value/bet and win/blackjack/push/loss labels. Rebuilt only when the visual signature changes — not every 20 Hz frame.
- **`BlackjackStage`** (React): owns a self-contained `Phaser.Game` (transparent, no-audio, FIT scale) parented to a div, diffs a state signature and pushes only real changes to the scene, tears the game down on unmount.
- **`BlackjackTable`** swaps the DOM dealer box for the stage and keeps a compact "others at the table" list for the remaining seats. Controls / bet / insurance / countdown / fairness stay DOM (accessible, unchanged).

## Scope choice
Renders the **dealer + your hands** as the Phaser centerpiece (classic casino POV) rather than cramming all five seats into the canvas — strongest visual, far less layout risk. Other players stay in the compact DOM list.

## Verification
`astro-cryptothrone` production build green (Phaser bundles, no SSR window error — game UI is a client island), 111 unit tests green, astro check clean for changed files. ⚠️ **Visual rendering itself needs an in-browser look** — can't be asserted headlessly.

cryptothrone-only; rides the pending 0.1.51.