### PR TITLE
feat(clickhouse): error-signature triage digest scoped by namespace

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroClickHouseDashboard.astro
@@ -7,6 +7,7 @@ import ReactCHNamespaceGrid from './ReactCHNamespaceGrid';
 import ReactCHFilterBar from './ReactCHFilterBar';
 import ReactCHLogStream from './ReactCHLogStream';
 import ReactCHQueryTabs from './ReactCHQueryTabs';
+import ReactCHErrorDigest from './ReactCHErrorDigest';
 ---
 
 <section
@@ -33,6 +34,11 @@ import ReactCHQueryTabs from './ReactCHQueryTabs';
 				<!-- Island: Sort controls + namespace card grid -->
 				<div id="ch-namespace-grid" class="ch-namespace-section">
 					<ReactCHNamespaceGrid client:only="react" />
+				</div>
+
+				<!-- Island: Top errors digest (grouped error signatures) -->
+				<div id="ch-error-digest">
+					<ReactCHErrorDigest client:only="react" />
 				</div>
 
 				<!-- Static shell: Log explorer container -->

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCHErrorDigest.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCHErrorDigest.tsx
@@ -1,0 +1,329 @@
+import { useEffect, useRef, useState } from 'react';
+import { useStore } from '@nanostores/react';
+import {
+	XCircle,
+	Loader2,
+	ChevronDown,
+	ChevronUp,
+	ArrowRight,
+	Layers,
+} from 'lucide-react';
+import {
+	clickhouseService,
+	formatRelativeTime,
+	type ErrorGroupRow,
+} from './clickhouseService';
+
+function scrollToLogExplorer() {
+	document
+		.getElementById('ch-log-explorer')
+		?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
+function ErrorGroupItem({ row, rank }: { row: ErrorGroupRow; rank: number }) {
+	const [expanded, setExpanded] = useState(false);
+	const count = parseInt(row.cnt, 10) || 0;
+	const showSample = row.sample && row.sample !== row.signature;
+
+	return (
+		<div
+			style={{
+				borderBottom: '1px solid var(--sl-color-gray-6, #1a1a1a)',
+				padding: '0.6rem 0',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'flex-start',
+					gap: 10,
+				}}>
+				<span
+					style={{
+						fontSize: '0.7rem',
+						color: 'var(--sl-color-gray-4, #6b7280)',
+						fontVariantNumeric: 'tabular-nums',
+						width: 18,
+						textAlign: 'right',
+						paddingTop: 3,
+						flexShrink: 0,
+					}}>
+					{rank}
+				</span>
+				<span
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: 4,
+						padding: '2px 8px',
+						borderRadius: 4,
+						fontSize: '0.8rem',
+						fontWeight: 700,
+						color: '#ef4444',
+						background: 'rgba(239, 68, 68, 0.12)',
+						border: '1px solid rgba(239, 68, 68, 0.3)',
+						fontVariantNumeric: 'tabular-nums',
+						flexShrink: 0,
+					}}>
+					<XCircle size={12} />
+					{count.toLocaleString()}
+				</span>
+				<div
+					style={{
+						flex: 1,
+						minWidth: 0,
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 3,
+					}}>
+					<span
+						onClick={() => showSample && setExpanded(!expanded)}
+						style={{
+							fontSize: '0.75rem',
+							color: 'var(--sl-color-text, #e6edf3)',
+							fontFamily: 'monospace',
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: expanded ? 'pre-wrap' : 'nowrap',
+							wordBreak: expanded ? 'break-all' : undefined,
+							cursor: showSample ? 'pointer' : 'default',
+						}}>
+						{row.signature}
+					</span>
+					<div
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+							fontSize: '0.7rem',
+							color: 'rgba(255, 255, 255, 0.45)',
+							fontWeight: 500,
+						}}>
+						<span
+							style={{
+								color: 'var(--sl-color-accent, #06b6d4)',
+							}}>
+							{row.pod_namespace}
+						</span>
+						{row.service && <span>· {row.service}</span>}
+						<span>· {formatRelativeTime(row.last_seen)}</span>
+					</div>
+					{expanded && showSample && (
+						<pre
+							style={{
+								margin: '4px 0 0',
+								padding: 8,
+								borderRadius: 4,
+								background: 'rgba(0, 0, 0, 0.3)',
+								overflow: 'auto',
+								maxHeight: 200,
+								fontSize: '0.65rem',
+								color: 'var(--sl-color-gray-3, #8b949e)',
+								whiteSpace: 'pre-wrap',
+								wordBreak: 'break-all',
+							}}>
+							{row.sample}
+						</pre>
+					)}
+				</div>
+				<button
+					onClick={() => {
+						clickhouseService.drillIntoErrorGroup(
+							row.pod_namespace,
+						);
+						scrollToLogExplorer();
+					}}
+					title="Show matching logs"
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						gap: 4,
+						padding: '3px 8px',
+						borderRadius: 5,
+						border: '1px solid var(--sl-color-gray-5, #262626)',
+						background: 'transparent',
+						color: 'var(--sl-color-gray-3, #8b949e)',
+						fontSize: '0.7rem',
+						fontWeight: 600,
+						cursor: 'pointer',
+						flexShrink: 0,
+						whiteSpace: 'nowrap',
+					}}>
+					Logs <ArrowRight size={11} />
+				</button>
+				{showSample && (
+					<span
+						onClick={() => setExpanded(!expanded)}
+						style={{
+							flexShrink: 0,
+							color: 'var(--sl-color-gray-4)',
+							cursor: 'pointer',
+							paddingTop: 2,
+						}}>
+						{expanded ? (
+							<ChevronUp size={14} />
+						) : (
+							<ChevronDown size={14} />
+						)}
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}
+
+export default function ReactCHErrorDigest() {
+	const authState = useStore(clickhouseService.$authState);
+	const minutes = useStore(clickhouseService.$minutes);
+	const errorGroups = useStore(clickhouseService.$errorGroups);
+	const loading = useStore(clickhouseService.$errorGroupsLoading);
+	const scope = useStore(clickhouseService.$errorScope);
+	const focusTick = useStore(clickhouseService.$errorDigestFocus);
+	const containerRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (
+			authState === 'authenticated' &&
+			clickhouseService.$errorGroups.get() === null
+		) {
+			clickhouseService.loadErrorGroups();
+		}
+	}, [authState, minutes]);
+
+	useEffect(() => {
+		if (focusTick > 0) {
+			containerRef.current?.scrollIntoView({
+				behavior: 'smooth',
+				block: 'start',
+			});
+		}
+	}, [focusTick]);
+
+	const rows = errorGroups?.rows ?? [];
+	if (!loading && rows.length === 0 && !scope) return null;
+
+	return (
+		<div
+			ref={containerRef}
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 8,
+				padding: '0.85rem 1rem',
+				borderRadius: 12,
+				border: '1px solid rgba(239, 68, 68, 0.25)',
+				background: 'var(--sl-color-bg-nav, #111)',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					flexWrap: 'wrap',
+				}}>
+				<XCircle size={15} style={{ color: '#ef4444' }} />
+				<span
+					style={{
+						fontWeight: 700,
+						fontSize: '0.95rem',
+						color: 'var(--sl-color-text, #e6edf3)',
+					}}>
+					Top errors
+				</span>
+				{scope ? (
+					<button
+						onClick={() => clickhouseService.setErrorScope('')}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: 4,
+							padding: '2px 8px',
+							borderRadius: 999,
+							border: '1px solid var(--sl-color-accent, #06b6d4)',
+							background: 'rgba(6, 182, 212, 0.12)',
+							color: 'var(--sl-color-accent, #06b6d4)',
+							fontSize: '0.72rem',
+							fontWeight: 600,
+							cursor: 'pointer',
+						}}>
+						{scope}
+						<span style={{ opacity: 0.7 }}>✕</span>
+					</button>
+				) : (
+					<span
+						style={{
+							fontSize: '0.72rem',
+							color: 'rgba(255, 255, 255, 0.45)',
+							fontWeight: 500,
+						}}>
+						all namespaces
+					</span>
+				)}
+				<div
+					style={{
+						marginLeft: 'auto',
+						display: 'flex',
+						alignItems: 'center',
+						gap: 8,
+					}}>
+					<button
+						onClick={() => {
+							clickhouseService.setSortField('errors');
+							document
+								.getElementById('ch-namespace-grid')
+								?.scrollIntoView({
+									behavior: 'smooth',
+									block: 'start',
+								});
+						}}
+						style={{
+							display: 'inline-flex',
+							alignItems: 'center',
+							gap: 4,
+							padding: '3px 9px',
+							borderRadius: 6,
+							border: '1px solid var(--sl-color-gray-5, #262626)',
+							background: 'transparent',
+							color: 'var(--sl-color-gray-3, #8b949e)',
+							fontSize: '0.72rem',
+							fontWeight: 600,
+							cursor: 'pointer',
+						}}>
+						<Layers size={12} /> Top namespaces
+					</button>
+					{loading && (
+						<Loader2
+							size={14}
+							style={{
+								animation: 'spin 1s linear infinite',
+								color: 'rgba(255, 255, 255, 0.5)',
+							}}
+						/>
+					)}
+				</div>
+			</div>
+
+			{rows.length > 0 ? (
+				<div>
+					{rows.map((row, i) => (
+						<ErrorGroupItem
+							key={`${row.pod_namespace}-${i}`}
+							row={row}
+							rank={i + 1}
+						/>
+					))}
+				</div>
+			) : (
+				!loading && (
+					<div
+						style={{
+							padding: '1rem 0',
+							color: 'rgba(255, 255, 255, 0.5)',
+							fontSize: '0.8rem',
+						}}>
+						No errors in this window.
+					</div>
+				)
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactCHNamespaceGrid.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactCHNamespaceGrid.tsx
@@ -160,6 +160,30 @@ function NamespaceCard({
 					ns={summary.namespace}
 				/>
 			</div>
+			{summary.errors > 0 && (
+				<button
+					onClick={(e) => {
+						e.stopPropagation();
+						clickhouseService.focusErrorDigest(summary.namespace);
+					}}
+					style={{
+						display: 'inline-flex',
+						alignItems: 'center',
+						justifyContent: 'center',
+						gap: 5,
+						padding: '4px 8px',
+						borderRadius: 6,
+						border: '1px solid rgba(239, 68, 68, 0.35)',
+						background: 'rgba(239, 68, 68, 0.08)',
+						color: '#ef4444',
+						fontSize: '0.72rem',
+						fontWeight: 600,
+						cursor: 'pointer',
+						transition: 'all 0.15s',
+					}}>
+					<Bug size={12} /> Debug errors
+				</button>
+			)}
 		</div>
 	);
 }

--- a/apps/kbve/astro-kbve/src/components/dashboard/clickhouseService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/clickhouseService.ts
@@ -11,9 +11,19 @@ import type {
 	StatsData,
 	QueryData,
 	QueryParams,
+	ErrorGroupRow,
+	ErrorGroupsData,
 } from '@/data/schema';
 
-export type { LogRow, StatRow, StatsData, QueryData, QueryParams };
+export type {
+	LogRow,
+	StatRow,
+	StatsData,
+	QueryData,
+	QueryParams,
+	ErrorGroupRow,
+	ErrorGroupsData,
+};
 
 export type AuthState =
 	| 'loading'
@@ -136,6 +146,21 @@ export function formatTimestamp(ts: string): string {
 	}
 }
 
+export function formatRelativeTime(ts: string): string {
+	try {
+		const then = new Date(ts.replace(' ', 'T') + 'Z').getTime();
+		const diffSec = Math.max(0, Math.round((Date.now() - then) / 1000));
+		if (diffSec < 60) return `${diffSec}s ago`;
+		const diffMin = Math.round(diffSec / 60);
+		if (diffMin < 60) return `${diffMin}m ago`;
+		const diffHr = Math.round(diffMin / 60);
+		if (diffHr < 24) return `${diffHr}h ago`;
+		return `${Math.round(diffHr / 24)}d ago`;
+	} catch {
+		return ts;
+	}
+}
+
 function buildNamespaceSummaries(stats: StatsData): NamespaceSummary[] {
 	const map = new Map<string, NamespaceSummary>();
 	for (const row of stats.rows) {
@@ -217,10 +242,15 @@ class ClickHouseService {
 	// Data
 	public readonly $stats = atom<StatsData | null>(null);
 	public readonly $logs = atom<QueryData | null>(null);
+	public readonly $errorGroups = atom<ErrorGroupsData | null>(null);
 
 	// Loading
 	public readonly $statsLoading = atom<boolean>(true);
 	public readonly $logsLoading = atom<boolean>(false);
+	public readonly $errorGroupsLoading = atom<boolean>(false);
+
+	public readonly $errorScope = atom<string>('');
+	public readonly $errorDigestFocus = atom<number>(0);
 
 	public readonly $upstreamError = atom<UpstreamErrorInfo | null>(null);
 
@@ -425,9 +455,76 @@ class ClickHouseService {
 		this.$logsLoading.set(false);
 	}
 
+	public async loadErrorGroups(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		this.$errorGroupsLoading.set(true);
+		try {
+			const body: Record<string, unknown> = {
+				command: 'error_groups',
+				minutes: this.$minutes.get(),
+				limit: 25,
+			};
+			const scope = this.$errorScope.get();
+			if (scope) body.pod_namespace = scope;
+
+			const resp = await fetch(PROXY_BASE, {
+				method: 'POST',
+				headers: {
+					Authorization: `Bearer ${token}`,
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify(body),
+				signal: AbortSignal.timeout(15000),
+			});
+			if (resp.status === 403) {
+				this.$authState.set('forbidden');
+				this.$errorGroupsLoading.set(false);
+				return;
+			}
+			if (!resp.ok) {
+				this.$upstreamError.set({
+					source: 'stats',
+					status: resp.status,
+					body: await readErrorBody(resp),
+				});
+				this.$errorGroupsLoading.set(false);
+				return;
+			}
+			const data: ErrorGroupsData = await resp.json();
+			this.$errorGroups.set(data);
+		} catch (err) {
+			this.$upstreamError.set({
+				source: 'stats',
+				status: 0,
+				body: err instanceof Error ? err.message : 'network error',
+			});
+		}
+		this.$errorGroupsLoading.set(false);
+	}
+
+	public setErrorScope(ns: string): void {
+		this.$errorScope.set(ns);
+		this.loadErrorGroups();
+	}
+
+	public focusErrorDigest(ns: string): void {
+		this.$errorScope.set(ns);
+		this.loadErrorGroups();
+		this.$errorDigestFocus.set(this.$errorDigestFocus.get() + 1);
+	}
+
+	public drillIntoErrorGroup(ns: string): void {
+		this.$namespaceFilter.set(ns);
+		this.$levelFilter.set('error');
+		this.$serviceFilter.set('');
+		this.clearSearch();
+	}
+
 	public refreshAll(): void {
 		this.loadStats();
 		this.loadLogs();
+		this.loadErrorGroups();
 	}
 
 	// --- Filter actions ---

--- a/apps/kbve/astro-kbve/src/data/schema/IClickHouseSchema.ts
+++ b/apps/kbve/astro-kbve/src/data/schema/IClickHouseSchema.ts
@@ -78,6 +78,27 @@ export interface StatsData {
 	count: number;
 }
 
+/**
+ * An `error_groups` row — `level = 'error'` messages collapsed into a
+ * normalized `signature` and aggregated by frequency. Wire format from the
+ * ClickHouse SQL: `cnt` is a string, `last_seen` is a ClickHouse datetime
+ * string, `sample` is a representative raw message for the group.
+ */
+export interface ErrorGroupRow {
+	pod_namespace: string;
+	service: string;
+	signature: string;
+	cnt: string;
+	last_seen: string;
+	sample: string;
+}
+
+/** Error-groups query response */
+export interface ErrorGroupsData {
+	rows: ErrorGroupRow[];
+	count: number;
+}
+
 /** Query parameters sent to the logs edge function */
 export type QueryParams = {
 	pod_namespace?: string | null;

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -693,6 +693,7 @@ pub struct ClickHouseLogsResponse {
     /// One JSON object per row. Shape depends on `command`:
     /// - `"query"` → `{ timestamp, pod_namespace, service, level, message, pod_name, metadata }`
     /// - `"stats"` → `{ pod_namespace, service, level, cnt }`
+    /// - `"error_groups"` → `{ pod_namespace, service, signature, cnt, last_seen, sample }`
     #[schema(value_type = Vec<serde_json::Value>)]
     pub rows: Vec<serde_json::Value>,
     pub count: usize,
@@ -758,6 +759,14 @@ pub async fn clickhouse_logs_proxy_handler(headers: HeaderMap, body: Bytes) -> R
                 minutes: req.minutes,
             };
             ch_logs::run_stats(config, &params).await
+        }
+        "error_groups" => {
+            let params = ch_logs::ErrorGroupsParams {
+                pod_namespace: req.pod_namespace,
+                minutes: req.minutes,
+                limit: req.limit,
+            };
+            ch_logs::run_error_groups(config, &params).await
         }
         "rows_request_rate" => {
             let params = ch_logs::RowsRequestRateParams {
@@ -833,7 +842,7 @@ pub async fn clickhouse_logs_proxy_handler(headers: HeaderMap, body: Bytes) -> R
                 axum::Json(json!({
                     "error": format!(
                         "unknown command '{other}', expected one of: \
-                         query, stats, rows_request_rate, rows_status_histogram, \
+                         query, stats, error_groups, rows_request_rate, rows_status_histogram, \
                          rows_top_endpoints, rows_errors, \
                          alerts_recent, alerts_firing, alerts_by_severity, alerts_top, \
                          factorio_current, factorio_snapshots, factorio_players, \

--- a/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
+++ b/packages/rust/jedi/src/entity/pipe_clickhouse/logs.rs
@@ -53,6 +53,16 @@ pub struct LogsStatsParams {
     pub minutes: Option<u32>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ErrorGroupsParams {
+    #[serde(default)]
+    pub pod_namespace: Option<String>,
+    #[serde(default)]
+    pub minutes: Option<u32>,
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LogsResult {
     pub rows: Vec<serde_json::Value>,
@@ -163,6 +173,70 @@ pub async fn run_stats(
     params: &LogsStatsParams,
 ) -> Result<LogsResult, JediError> {
     let sql = build_stats_sql(params);
+    let rows = config.execute_select(&sql).await?;
+    Ok(LogsResult {
+        count: rows.len(),
+        rows,
+    })
+}
+
+pub const MAX_ERROR_GROUPS: u32 = 100;
+pub const DEFAULT_ERROR_GROUPS: u32 = 25;
+const ERROR_GROUP_SIGNATURE_LENGTH: u32 = 200;
+
+fn clamped_error_groups(raw: Option<u32>) -> u32 {
+    raw.unwrap_or(DEFAULT_ERROR_GROUPS)
+        .clamp(1, MAX_ERROR_GROUPS)
+}
+
+/// Build the `error_groups` SQL — collapse `level = 'error'` messages into
+/// normalized signatures (numbers and long id/hex tokens masked) and aggregate
+/// by frequency. Turns a flat error stream into "this error ×1840, last seen
+/// 2m ago" so callers can triage the dominant failure first. Optionally scoped
+/// to a single namespace.
+pub fn build_error_groups_sql(params: &ErrorGroupsParams) -> String {
+    let minutes = clamped_minutes(params.minutes);
+    let limit = clamped_error_groups(params.limit);
+
+    let mut conditions: Vec<String> = vec![
+        format!("timestamp > now() - INTERVAL {} MINUTE", minutes),
+        "level = 'error'".to_string(),
+    ];
+    if let Some(ns) = params.pod_namespace.as_deref().filter(|s| !s.is_empty()) {
+        conditions.push(format!(
+            "pod_namespace = '{}'",
+            escape_clickhouse_string(ns)
+        ));
+    }
+    let where_clause = conditions.join(" AND ");
+
+    // Bracket-class regexes only — no backslash escapes to thread through both
+    // the Rust string literal and the ClickHouse SQL literal. Braces in the
+    // quantifier are doubled for `format!`.
+    format!(
+        "SELECT \
+            pod_namespace, \
+            any(service) AS service, \
+            substring(replaceRegexpAll(replaceRegexpAll(message, '[0-9a-fA-F-]{{16,}}', '<id>'), '[0-9]+', 'N'), 1, {sig_len}) AS signature, \
+            count() AS cnt, \
+            max(timestamp) AS last_seen, \
+            any(message) AS sample \
+         FROM logs_distributed \
+         WHERE {where_clause} \
+         GROUP BY pod_namespace, signature \
+         ORDER BY cnt DESC \
+         LIMIT {limit}",
+        sig_len = ERROR_GROUP_SIGNATURE_LENGTH,
+        where_clause = where_clause,
+        limit = limit,
+    )
+}
+
+pub async fn run_error_groups(
+    config: &ClickHouseConfig,
+    params: &ErrorGroupsParams,
+) -> Result<LogsResult, JediError> {
+    let sql = build_error_groups_sql(params);
     let rows = config.execute_select(&sql).await?;
     Ok(LogsResult {
         count: rows.len(),
@@ -399,6 +473,34 @@ mod tests {
         let sql = build_stats_sql(&LogsStatsParams::default());
         assert!(sql.contains(&format!("INTERVAL {} MINUTE", DEFAULT_MINUTES)));
         assert!(sql.contains("GROUP BY pod_namespace, service, level"));
+    }
+
+    #[test]
+    fn build_error_groups_sql_shape() {
+        let sql = build_error_groups_sql(&ErrorGroupsParams {
+            pod_namespace: Some("kbve".into()),
+            minutes: Some(120),
+            limit: Some(10),
+        });
+        assert!(sql.contains("INTERVAL 120 MINUTE"));
+        assert!(sql.contains("level = 'error'"));
+        assert!(sql.contains("pod_namespace = 'kbve'"));
+        assert!(sql.contains("AS signature"));
+        assert!(sql.contains("count() AS cnt"));
+        assert!(sql.contains("max(timestamp) AS last_seen"));
+        assert!(sql.contains("GROUP BY pod_namespace, signature"));
+        assert!(sql.contains("'[0-9a-fA-F-]{16,}'"));
+        assert!(sql.contains("LIMIT 10"));
+    }
+
+    #[test]
+    fn build_error_groups_sql_unscoped_clamps_limit() {
+        let sql = build_error_groups_sql(&ErrorGroupsParams::default());
+        assert!(sql.contains(&format!("INTERVAL {} MINUTE", DEFAULT_MINUTES)));
+        assert!(!sql.contains("pod_namespace = '"));
+        assert!(sql.contains(&format!("LIMIT {}", DEFAULT_ERROR_GROUPS)));
+        assert_eq!(clamped_error_groups(Some(0)), 1);
+        assert_eq!(clamped_error_groups(Some(9_999)), MAX_ERROR_GROUPS);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds namespace-scoped error triage to the ClickHouse dashboard (`/dashboard/clickhouse/`).

### Backend
New `error_groups` command on the logs proxy (`jedi` logs.rs + `axum-kbve` proxy.rs). Collapses `level = 'error'` messages into normalized signatures (digit runs → `N`, long id/hex tokens → `<id>`), groups by signature, returns `cnt`, `last_seen`, and a raw `sample`. Optionally scoped to a single `pod_namespace`. Reuses the existing escape/clamp helpers and the `DASHBOARD_VIEW` auth gate. 2 unit tests added.

### Frontend
New **Top errors** digest panel (`ReactCHErrorDigest.tsx`) between the namespace grid and log explorer:
- Ranked rows: count badge, signature, namespace/service, relative last-seen, expandable raw sample.
- Per-row **Logs →** button pins ns + error filter and scrolls to the log stream.
- Scope chip (all namespaces ↔ single ns) + **Top namespaces** jump (sorts grid by errors).
- Each namespace card gains a **Debug errors** button (when errors > 0) that scopes the digest and scrolls it into view.

Turns a flat stream of N errors into 'this error ×1840, last seen 2m ago' so the dominant failure is triaged first.

## Verify
- jedi error_groups tests pass (2/2)
- `cargo check -p axum-kbve` clean
- astro-kbve `check` clean for changed files

Note: live dashboard surfaces grouped errors only after axum-kbve publishes the new command.