### PR TITLE
feat(metrics): in-house client telemetry → ClickHouse + jobboard 503 fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "matchit 0.8.4",
- "metrics",
+ "metrics 0.24.3",
  "metrics-exporter-prometheus",
  "pin-project-lite",
  "tokio",
@@ -8762,7 +8762,7 @@ dependencies = [
  "hyper 1.9.0",
  "hyper-util",
  "lru 0.18.0",
- "metrics",
+ "metrics 0.24.3",
  "once_cell",
  "papaya",
  "prost 0.14.3",
@@ -9101,7 +9101,7 @@ dependencies = [
  "jedi",
  "jsonwebtoken 10.3.0",
  "lru 0.16.3",
- "metrics",
+ "metrics 0.24.3",
  "num-bigint",
  "once_cell",
  "pulldown-cmark 0.13.3",
@@ -9850,7 +9850,7 @@ dependencies = [
  "bevy_time",
  "bevy_ui",
  "bevy_utils",
- "metrics",
+ "metrics 0.24.3",
  "metrics-util",
  "tracing",
 ]
@@ -10087,7 +10087,7 @@ dependencies = [
  "bevy_ui",
  "bevy_utils",
  "lightyear_metrics",
- "metrics",
+ "metrics 0.24.3",
  "metrics-util",
  "tracing",
 ]
@@ -10466,6 +10466,29 @@ dependencies = [
 
 [[package]]
 name = "metrics"
+version = "0.1.0"
+dependencies = [
+ "ahash",
+ "anyhow",
+ "axum 0.8.9",
+ "dotenvy",
+ "hex",
+ "jedi",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "metrics"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
@@ -10482,7 +10505,7 @@ checksum = "3589659543c04c7dc5526ec858591015b87cd8746583b51b48ef4353f99dbcda"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.1",
- "metrics",
+ "metrics 0.24.3",
  "metrics-util",
  "quanta",
  "thiserror 2.0.18",
@@ -10499,7 +10522,7 @@ dependencies = [
  "crossbeam-utils",
  "hashbrown 0.16.1",
  "indexmap 2.13.1",
- "metrics",
+ "metrics 0.24.3",
  "ordered-float 5.3.0",
  "quanta",
  "radix_trie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
 	'apps/cryptothrone/axum-cryptothrone',
 	'apps/rows',
 	'apps/jobboard',
+	'apps/metrics',
 	'apps/kbve/isometric/src-tauri',
 	'apps/kbve/desktop-kbve/src-tauri',
 	'packages/rust/bevy/bevy_inventory',

--- a/apps/jobboard/Cargo.toml
+++ b/apps/jobboard/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 tokio-postgres = { version = "0.7.2", features = ["with-uuid-1", "with-chrono-0_4", "with-serde_json-1"] }
 
 uuid = { version = "1", features = ["v4", "serde"] }
-jsonwebtoken = "10.3"
+jsonwebtoken = { version = "10.3", default-features = false, features = ["rust_crypto"] }
 lru = "0.12"
 
 tracing = "0.1"

--- a/apps/kube/kustomization.yaml
+++ b/apps/kube/kustomization.yaml
@@ -54,6 +54,7 @@ resources:
     - herbmail/application.yaml
     - memes/application.yaml
     - jobboard/application.yaml
+    - metrics/application.yaml
     - n8n/application.yaml
     - rabbitmq/application.yaml
     - rows/tenants/overlays/chuckrpg-dev/application.yaml

--- a/apps/kube/metrics/application.yaml
+++ b/apps/kube/metrics/application.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+    name: metrics
+    namespace: argocd
+spec:
+    project: default
+    source:
+        repoURL: https://github.com/KBVE/kbve
+        targetRevision: HEAD
+        path: apps/kube/metrics/manifest
+    destination:
+        server: https://kubernetes.default.svc
+        namespace: kbve
+    syncPolicy:
+        automated:
+            prune: true
+            selfHeal: true
+        syncOptions:
+            - CreateNamespace=true
+            - PrunePropagationPolicy=foreground
+            - PruneLast=true
+            - RespectIgnoreDifferences=true
+            - Replace=false

--- a/apps/kube/metrics/manifest/httproute.yaml
+++ b/apps/kube/metrics/manifest/httproute.yaml
@@ -1,0 +1,19 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+    name: metrics-route
+    namespace: kbve
+spec:
+    parentRefs:
+        - name: kbve-gateway
+          namespace: kbve
+    hostnames:
+        - metrics.kbve.com
+    rules:
+        - matches:
+              - path:
+                    type: PathPrefix
+                    value: /
+          backendRefs:
+              - name: metrics-service
+                port: 5500

--- a/apps/kube/metrics/manifest/kustomization.yaml
+++ b/apps/kube/metrics/manifest/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kbve
+
+resources:
+    - metrics-serviceaccount.yaml
+    - metrics-deployment.yaml
+    - httproute.yaml

--- a/apps/kube/metrics/manifest/metrics-deployment.yaml
+++ b/apps/kube/metrics/manifest/metrics-deployment.yaml
@@ -1,0 +1,122 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+    name: metrics-deployment
+    namespace: kbve
+    labels:
+        app: metrics
+    annotations:
+        reloader.stakater.com/auto: 'true'
+        secret.reloader.stakater.com/reload: 'clickhouse-credentials'
+spec:
+    replicas: 1
+    selector:
+        matchLabels:
+            app: metrics
+    template:
+        metadata:
+            annotations:
+                rollout-restart: '2026-06-20T00:00:00Z'
+            labels:
+                app: metrics
+                version: '0.1.0'
+        spec:
+            serviceAccountName: metrics-sa
+            automountServiceAccountToken: false
+            terminationGracePeriodSeconds: 30
+            securityContext:
+                runAsNonRoot: true
+                runAsUser: 10001
+                runAsGroup: 10001
+                fsGroup: 10001
+                seccompProfile:
+                    type: RuntimeDefault
+            containers:
+                - name: metrics
+                  image: ghcr.io/kbve/metrics:0.1.0
+                  imagePullPolicy: Always
+                  ports:
+                      - containerPort: 5500
+                        protocol: TCP
+                  env:
+                      - name: APP_VERSION
+                        value: '0.1.0'
+                      - name: HTTP_HOST
+                        value: '0.0.0.0'
+                      - name: HTTP_PORT
+                        value: '5500'
+                      - name: RUST_LOG
+                        value: 'metrics=info,tower_http=warn'
+                      - name: CLICKHOUSE_DATABASE
+                        value: 'telemetry'
+                      - name: METRICS_ERRORS_TABLE
+                        value: 'errors_distributed'
+                      - name: METRICS_ALLOWED_ORIGINS
+                        value: 'https://kbve.com,https://www.kbve.com,https://jobs.kbve.com'
+                      - name: METRICS_RATE_LIMIT_PER_MIN
+                        value: '120'
+                      - name: CLICKHOUSE_ENDPOINT
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: endpoint
+                      - name: CLICKHOUSE_USERNAME
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: username
+                      - name: CLICKHOUSE_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-credentials
+                                key: password
+                  livenessProbe:
+                      httpGet:
+                          path: /health
+                          port: 5500
+                      initialDelaySeconds: 5
+                      periodSeconds: 15
+                      timeoutSeconds: 3
+                  readinessProbe:
+                      httpGet:
+                          path: /readiness
+                          port: 5500
+                      initialDelaySeconds: 5
+                      periodSeconds: 10
+                      timeoutSeconds: 3
+                  resources:
+                      requests:
+                          memory: '64Mi'
+                          cpu: '50m'
+                      limits:
+                          memory: '256Mi'
+                          cpu: '500m'
+                  securityContext:
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+                  volumeMounts:
+                      - name: tmp
+                        mountPath: /tmp
+            volumes:
+                - name: tmp
+                  emptyDir:
+                      sizeLimit: 32Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+    name: metrics-service
+    namespace: kbve
+    labels:
+        app: metrics
+spec:
+    type: ClusterIP
+    selector:
+        app: metrics
+    ports:
+        - port: 5500
+          targetPort: 5500
+          protocol: TCP

--- a/apps/kube/metrics/manifest/metrics-serviceaccount.yaml
+++ b/apps/kube/metrics/manifest/metrics-serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    name: metrics-sa
+    namespace: kbve
+automountServiceAccountToken: false

--- a/apps/kube/vector/manifests/telemetry-ch-setup-job.yaml
+++ b/apps/kube/vector/manifests/telemetry-ch-setup-job.yaml
@@ -1,0 +1,172 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: telemetry-ch-setup-script
+    namespace: vector
+data:
+    setup.sh: |
+        #!/bin/sh
+        set -eu
+
+        echo "Verifying ClickHouse connectivity..."
+        curl -sf --max-time 10 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "SELECT 1" >/dev/null || {
+          echo "ERROR: Cannot connect to ClickHouse at ${CLICKHOUSE_ENDPOINT}"
+          exit 1
+        }
+        echo "ClickHouse connection OK."
+
+        echo "Creating telemetry database..."
+        curl -sf --max-time 10 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "CREATE DATABASE IF NOT EXISTS telemetry ON CLUSTER 'cluster'" || {
+          echo "ERROR: Failed to create telemetry database"
+          exit 1
+        }
+        echo "Database 'telemetry' ready."
+
+        echo "Creating errors_raw table (ReplicatedMergeTree, 30d TTL)..."
+        curl -sf --max-time 30 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "
+        CREATE TABLE IF NOT EXISTS telemetry.errors_raw ON CLUSTER 'cluster'
+        (
+            timestamp       DateTime64(3, 'UTC') DEFAULT now64(3),
+            project         LowCardinality(String),
+            platform        LowCardinality(String) DEFAULT 'web',
+            release         LowCardinality(String) DEFAULT '',
+            environment     LowCardinality(String) DEFAULT 'production',
+            fingerprint     String,
+            error_type      LowCardinality(String) DEFAULT '',
+            message         String,
+            stack           String DEFAULT '',
+            url             String DEFAULT '',
+            user_id         String DEFAULT '',
+            session_id      String DEFAULT '',
+            user_agent      String DEFAULT '',
+            handled         UInt8 DEFAULT 0,
+            extra           String DEFAULT '{}'
+        )
+        ENGINE = ReplicatedMergeTree('/clickhouse/tables/{shard}/telemetry/errors_raw', '{replica}')
+        ORDER BY (project, fingerprint, timestamp)
+        PARTITION BY toYYYYMMDD(timestamp)
+        TTL toDateTime(timestamp) + INTERVAL 30 DAY
+        " || {
+          echo "ERROR: Failed to create errors_raw table"
+          exit 1
+        }
+        echo "Table 'telemetry.errors_raw' ready."
+
+        echo "Enforcing 30-day TTL on errors_raw..."
+        curl -sf --max-time 30 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "ALTER TABLE telemetry.errors_raw ON CLUSTER 'cluster' MODIFY TTL toDateTime(timestamp) + INTERVAL 30 DAY" || {
+          echo "ERROR: Failed to apply TTL to errors_raw"
+          exit 1
+        }
+        echo "TTL on 'telemetry.errors_raw' enforced at 30 days."
+
+        echo "Creating errors_distributed table (Distributed)..."
+        curl -sf --max-time 30 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "
+        CREATE TABLE IF NOT EXISTS telemetry.errors_distributed ON CLUSTER 'cluster'
+        AS telemetry.errors_raw
+        ENGINE = Distributed('cluster', 'telemetry', 'errors_raw', cityHash64(fingerprint))
+        " || {
+          echo "ERROR: Failed to create errors_distributed table"
+          exit 1
+        }
+        echo "Table 'telemetry.errors_distributed' ready."
+
+        echo "Creating error_groups view (fingerprint rollup)..."
+        curl -sf --max-time 30 \
+          "${CLICKHOUSE_ENDPOINT}/?user=${CLICKHOUSE_USER}&password=${CLICKHOUSE_PASSWORD}" \
+          -d "
+        CREATE VIEW IF NOT EXISTS telemetry.error_groups ON CLUSTER 'cluster'
+        AS SELECT
+            project,
+            fingerprint,
+            any(error_type)  AS error_type,
+            any(message)     AS sample_message,
+            count()          AS events,
+            uniq(session_id) AS sessions,
+            min(timestamp)   AS first_seen,
+            max(timestamp)   AS last_seen
+        FROM telemetry.errors_distributed
+        GROUP BY project, fingerprint
+        " || {
+          echo "ERROR: Failed to create error_groups view"
+          exit 1
+        }
+        echo "View 'telemetry.error_groups' ready."
+
+        echo ""
+        echo "Telemetry schema setup complete."
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+    name: telemetry-ch-setup
+    namespace: vector
+    labels:
+        app: telemetry-ch-setup
+        component: vector
+    annotations:
+        argocd.argoproj.io/hook: PostSync
+spec:
+    ttlSecondsAfterFinished: 86400
+    backoffLimit: 3
+    template:
+        metadata:
+            labels:
+                app: telemetry-ch-setup
+        spec:
+            restartPolicy: OnFailure
+            containers:
+                - name: setup
+                  image: curlimages/curl:8.12.1
+                  command: ['/bin/sh', '/scripts/setup.sh']
+                  env:
+                      - name: CLICKHOUSE_ENDPOINT
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-vector-credentials
+                                key: endpoint
+                      - name: CLICKHOUSE_USER
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-vector-credentials
+                                key: username
+                      - name: CLICKHOUSE_PASSWORD
+                        valueFrom:
+                            secretKeyRef:
+                                name: clickhouse-vector-credentials
+                                key: password
+                  volumeMounts:
+                      - name: setup-script
+                        mountPath: /scripts
+                        readOnly: true
+                  resources:
+                      requests:
+                          memory: '32Mi'
+                          cpu: '50m'
+                      limits:
+                          memory: '64Mi'
+                          cpu: '100m'
+                  securityContext:
+                      runAsNonRoot: true
+                      runAsUser: 1000
+                      allowPrivilegeEscalation: false
+                      readOnlyRootFilesystem: true
+                      capabilities:
+                          drop:
+                              - ALL
+            volumes:
+                - name: setup-script
+                  configMap:
+                      name: telemetry-ch-setup-script
+                      defaultMode: 0555

--- a/apps/metrics/Cargo.toml
+++ b/apps/metrics/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "metrics"
+authors = ["kbve", "h0lybyte"]
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Metrics — in-house client telemetry ingest (errors/perf/events) to ClickHouse"
+
+[dependencies]
+tokio = { version = "1.0", features = ["full", "rt-multi-thread"] }
+axum = { version = "0.8.5", features = ["macros"] }
+tower = { version = "0.5.3", features = ["util"] }
+tower-http = { version = "0.6.8", features = ["compression-full", "limit", "trace", "cors", "timeout"] }
+
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+
+uuid = { version = "1", features = ["v4", "serde"] }
+sha2 = "0.10"
+hex = "0.4"
+ahash = "0.8"
+parking_lot = "0.12"
+
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+
+anyhow = "1.0"
+thiserror = "2"
+dotenvy = "0.15"
+
+jedi = { path = "../../packages/rust/jedi", features = ["clickhouse"] }

--- a/apps/metrics/Dockerfile
+++ b/apps/metrics/Dockerfile
@@ -1,0 +1,58 @@
+# syntax=docker/dockerfile:1
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS planner
+ENV CARGO_INCREMENTAL=0
+
+RUN printf '[workspace]\nmembers = ["apps/metrics", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+
+COPY apps/metrics/Cargo.toml apps/metrics/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+COPY packages/data/proto/ packages/data/proto/
+COPY apps/metrics/src/ apps/metrics/src/
+COPY packages/rust/jedi/src/ packages/rust/jedi/src/
+COPY packages/rust/holy/src/ packages/rust/holy/src/
+COPY packages/rust/kbve/src/ packages/rust/kbve/src/
+
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04-builder AS cook
+ENV CARGO_INCREMENTAL=0
+
+RUN printf '[workspace]\nmembers = ["apps/metrics", "packages/rust/jedi", "packages/rust/holy", "packages/rust/kbve"]\nresolver = "2"\n' > Cargo.toml
+
+COPY apps/metrics/Cargo.toml apps/metrics/Cargo.toml
+COPY packages/rust/jedi/Cargo.toml packages/rust/jedi/Cargo.toml
+COPY packages/rust/holy/Cargo.toml packages/rust/holy/Cargo.toml
+COPY packages/rust/kbve/Cargo.toml packages/rust/kbve/Cargo.toml
+COPY packages/data/proto/ packages/data/proto/
+
+COPY --from=planner /app/recipe.json recipe.json
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    cargo chef cook --release --recipe-path recipe.json -p metrics
+
+FROM cook AS builder
+
+COPY apps/metrics/Cargo.toml apps/metrics/Cargo.toml
+COPY packages/rust/jedi/ packages/rust/jedi/
+COPY packages/rust/holy/ packages/rust/holy/
+COPY packages/rust/kbve/ packages/rust/kbve/
+COPY apps/metrics/src/ apps/metrics/src/
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/sccache,id=sccache \
+    touch apps/metrics/src/main.rs && \
+    cargo build --release -p metrics && \
+    strip target/release/metrics
+
+FROM --platform=linux/amd64 ghcr.io/kbve/chisel-ubuntu-axum:24.04.3 AS runtime
+
+COPY --from=builder --chown=10001:10001 /app/target/release/metrics /app/metrics
+
+ENV HTTP_HOST=0.0.0.0
+ENV HTTP_PORT=5500
+ENV RUST_LOG=metrics=info,tower_http=info
+
+EXPOSE 5500
+
+ENTRYPOINT ["/app/metrics"]

--- a/apps/metrics/project.json
+++ b/apps/metrics/project.json
@@ -1,0 +1,94 @@
+{
+	"name": "metrics",
+	"$schema": "../../node_modules/nx/schemas/project-schema.json",
+	"projectType": "application",
+	"sourceRoot": "apps/metrics/src",
+	"targets": {
+		"build": {
+			"executor": "@monodon/rust:build",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/metrics"
+			},
+			"configurations": {
+				"production": {
+					"release": true
+				}
+			}
+		},
+		"test": {
+			"executor": "@monodon/rust:test",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/metrics"
+			}
+		},
+		"lint": {
+			"executor": "@monodon/rust:lint",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/metrics"
+			}
+		},
+		"run": {
+			"executor": "@monodon/rust:run",
+			"outputs": ["{options.target-dir}"],
+			"options": {
+				"target-dir": "dist/target/metrics"
+			}
+		},
+		"container": {
+			"executor": "nx:run-commands",
+			"defaultConfiguration": "local",
+			"options": {
+				"parallel": false
+			},
+			"configurations": {
+				"local": {
+					"commands": [
+						"./kbve.sh -nx metrics:containerx",
+						"VERSION=$(grep '^version' apps/metrics/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/metrics:latest kbve/metrics:$VERSION && echo \"Tagged kbve/metrics:$VERSION\""
+					]
+				},
+				"production": {
+					"commands": [
+						"./kbve.sh -nx metrics:containerx --configuration=production",
+						"VERSION=$(grep '^version' apps/metrics/Cargo.toml | head -1 | sed 's/.*\"\\(.*\\)\"/\\1/') && docker tag kbve/metrics:latest ghcr.io/kbve/metrics:latest && docker tag kbve/metrics:latest ghcr.io/kbve/metrics:$VERSION && echo \"Tagged ghcr.io/kbve/metrics:$VERSION\""
+					]
+				}
+			}
+		},
+		"containerx": {
+			"executor": "@nx-tools/nx-container:build",
+			"defaultConfiguration": "local",
+			"options": {
+				"engine": "docker",
+				"context": ".",
+				"file": "apps/metrics/Dockerfile",
+				"load": true
+			},
+			"configurations": {
+				"local": {
+					"load": true,
+					"push": false,
+					"tags": ["kbve/metrics:latest"]
+				},
+				"production": {
+					"load": true,
+					"push": false,
+					"metadata": {
+						"images": ["ghcr.io/kbve/metrics", "kbve/metrics"],
+						"tags": ["latest"]
+					},
+					"cache-from": [
+						"type=registry,ref=ghcr.io/kbve/metrics:buildcache"
+					],
+					"cache-to": [
+						"type=registry,ref=ghcr.io/kbve/metrics:buildcache,mode=max"
+					]
+				}
+			}
+		}
+	},
+	"tags": ["docker", "rust", "metrics"]
+}

--- a/apps/metrics/src/config.rs
+++ b/apps/metrics/src/config.rs
@@ -1,0 +1,50 @@
+use std::env;
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub host: String,
+    pub port: u16,
+    pub errors_table: String,
+    pub allowed_origins: Vec<String>,
+    pub max_body_bytes: usize,
+    pub max_batch: usize,
+    pub channel_capacity: usize,
+    pub flush_rows: usize,
+    pub flush_interval_ms: u64,
+    pub rate_limit_per_min: u32,
+}
+
+fn get(key: &str, default: &str) -> String {
+    env::var(key).unwrap_or_else(|_| default.to_string())
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        let allowed_origins = get("METRICS_ALLOWED_ORIGINS", "")
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        Self {
+            host: get("HTTP_HOST", "0.0.0.0"),
+            port: get("HTTP_PORT", "5500").parse().unwrap_or(5500),
+            errors_table: get("METRICS_ERRORS_TABLE", "errors_distributed"),
+            allowed_origins,
+            max_body_bytes: get("METRICS_MAX_BODY_BYTES", "262144")
+                .parse()
+                .unwrap_or(262144),
+            max_batch: get("METRICS_MAX_BATCH", "50").parse().unwrap_or(50),
+            channel_capacity: get("METRICS_CHANNEL_CAPACITY", "8192")
+                .parse()
+                .unwrap_or(8192),
+            flush_rows: get("METRICS_FLUSH_ROWS", "200").parse().unwrap_or(200),
+            flush_interval_ms: get("METRICS_FLUSH_INTERVAL_MS", "2000")
+                .parse()
+                .unwrap_or(2000),
+            rate_limit_per_min: get("METRICS_RATE_LIMIT_PER_MIN", "120")
+                .parse()
+                .unwrap_or(120),
+        }
+    }
+}

--- a/apps/metrics/src/error.rs
+++ b/apps/metrics/src/error.rs
@@ -1,0 +1,39 @@
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+
+#[derive(Debug, thiserror::Error)]
+pub enum ApiError {
+    #[error("{0}")]
+    BadRequest(String),
+    #[error("{0}")]
+    TooLarge(String),
+    #[error("rate limited")]
+    RateLimited,
+}
+
+impl ApiError {
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::BadRequest(_) => StatusCode::BAD_REQUEST,
+            Self::TooLarge(_) => StatusCode::PAYLOAD_TOO_LARGE,
+            Self::RateLimited => StatusCode::TOO_MANY_REQUESTS,
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self {
+            Self::BadRequest(_) => "BAD_REQUEST",
+            Self::TooLarge(_) => "PAYLOAD_TOO_LARGE",
+            Self::RateLimited => "RATE_LIMITED",
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = Json(json!({ "error": self.code(), "message": self.to_string() }));
+        (self.status(), body).into_response()
+    }
+}

--- a/apps/metrics/src/main.rs
+++ b/apps/metrics/src/main.rs
@@ -1,0 +1,67 @@
+mod config;
+mod error;
+mod rest;
+mod state;
+mod telemetry;
+
+use std::sync::Arc;
+
+use axum::http::{HeaderValue, Method, header};
+use tokio::sync::mpsc;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::trace::TraceLayer;
+use tracing_subscriber::EnvFilter;
+
+use crate::config::Config;
+use crate::state::{AppState, spawn_flusher};
+
+fn cors_layer(cfg: &Config) -> CorsLayer {
+    let origins: Vec<HeaderValue> = cfg
+        .allowed_origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+    let allow = if origins.is_empty() {
+        AllowOrigin::any()
+    } else {
+        AllowOrigin::list(origins)
+    };
+    CorsLayer::new()
+        .allow_origin(allow)
+        .allow_methods([Method::GET, Method::POST])
+        .allow_headers([header::CONTENT_TYPE])
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let _ = dotenvy::dotenv();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| "metrics=info".into()),
+        )
+        .json()
+        .init();
+
+    let cfg = Config::from_env();
+    let ch = jedi::state::sidecar::ClickHouseConfig::from_env();
+    tracing::info!(database = %ch.database, url = %ch.url, "clickhouse configured");
+
+    let (tx, rx) = mpsc::channel(cfg.channel_capacity);
+    let max_body = cfg.max_body_bytes;
+    let cors = cors_layer(&cfg);
+    let addr = format!("{}:{}", cfg.host, cfg.port);
+
+    let state = Arc::new(AppState::new(cfg, ch, tx));
+    spawn_flusher(state.clone(), rx);
+
+    let app = rest::router(state)
+        .layer(cors)
+        .layer(RequestBodyLimitLayer::new(max_body))
+        .layer(TraceLayer::new_for_http());
+
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    tracing::info!(%addr, "metrics ingest listening");
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/apps/metrics/src/rest/ingest.rs
+++ b/apps/metrics/src/rest/ingest.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use serde_json::json;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+use crate::telemetry::ErrorBatch;
+
+fn header_str<'a>(headers: &'a HeaderMap, name: &str) -> &'a str {
+    headers
+        .get(name)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+}
+
+fn client_ip(headers: &HeaderMap) -> String {
+    let xff = header_str(headers, "x-forwarded-for");
+    if !xff.is_empty() {
+        return xff.split(',').next().unwrap_or(xff).trim().to_string();
+    }
+    let real = header_str(headers, "x-real-ip");
+    if !real.is_empty() {
+        return real.to_string();
+    }
+    "unknown".to_string()
+}
+
+pub async fn ingest_errors(
+    State(app): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(batch): Json<ErrorBatch>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ip = client_ip(&headers);
+    if !app.allow(&ip) {
+        return Err(ApiError::RateLimited);
+    }
+    if batch.events.is_empty() {
+        return Err(ApiError::BadRequest("empty batch".into()));
+    }
+    if batch.events.len() > app.cfg.max_batch {
+        return Err(ApiError::TooLarge(format!(
+            "batch exceeds {} events",
+            app.cfg.max_batch
+        )));
+    }
+
+    let user_agent = header_str(&headers, "user-agent").to_string();
+    let mut accepted = 0usize;
+    let mut dropped = 0usize;
+    for event in batch.events {
+        match event.into_row(&user_agent) {
+            Some(row) => match app.tx.try_send(row) {
+                Ok(_) => accepted += 1,
+                Err(_) => dropped += 1,
+            },
+            None => dropped += 1,
+        }
+    }
+
+    Ok((
+        StatusCode::ACCEPTED,
+        Json(json!({ "accepted": accepted, "dropped": dropped })),
+    ))
+}

--- a/apps/metrics/src/rest/mod.rs
+++ b/apps/metrics/src/rest/mod.rs
@@ -1,0 +1,17 @@
+pub mod ingest;
+pub mod system;
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::routing::{get, post};
+
+use crate::state::AppState;
+
+pub fn router(state: Arc<AppState>) -> Router {
+    Router::new()
+        .route("/health", get(system::health))
+        .route("/readiness", get(system::readiness))
+        .route("/api/v1/ingest/errors", post(ingest::ingest_errors))
+        .with_state(state)
+}

--- a/apps/metrics/src/rest/system.rs
+++ b/apps/metrics/src/rest/system.rs
@@ -1,0 +1,34 @@
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+use crate::state::AppState;
+
+pub async fn health() -> Json<serde_json::Value> {
+    Json(json!({
+        "status": "healthy",
+        "service": "metrics",
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+}
+
+pub async fn readiness(State(app): State<Arc<AppState>>) -> impl IntoResponse {
+    let ready = app.ch.execute_select("SELECT 1").await.is_ok();
+    let status = if ready {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+    let body = json!({
+        "status": if ready { "ready" } else { "degraded" },
+        "service": "metrics",
+        "version": env!("CARGO_PKG_VERSION"),
+        "uptime_seconds": app.started_at.elapsed().as_secs(),
+        "clickhouse": ready,
+    });
+    (status, Json(body))
+}

--- a/apps/metrics/src/state.rs
+++ b/apps/metrics/src/state.rs
@@ -1,0 +1,100 @@
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ahash::AHashMap;
+use jedi::state::sidecar::ClickHouseConfig;
+use parking_lot::Mutex;
+use serde_json::Value;
+use tokio::sync::mpsc;
+
+use crate::config::Config;
+
+pub struct AppState {
+    pub cfg: Config,
+    pub ch: ClickHouseConfig,
+    pub tx: mpsc::Sender<Value>,
+    pub started_at: Instant,
+    limiter: Mutex<AHashMap<String, Bucket>>,
+}
+
+struct Bucket {
+    count: u32,
+    window_start: Instant,
+}
+
+impl AppState {
+    pub fn new(cfg: Config, ch: ClickHouseConfig, tx: mpsc::Sender<Value>) -> Self {
+        Self {
+            cfg,
+            ch,
+            tx,
+            started_at: Instant::now(),
+            limiter: Mutex::new(AHashMap::new()),
+        }
+    }
+
+    pub fn allow(&self, key: &str) -> bool {
+        let now = Instant::now();
+        let window = Duration::from_secs(60);
+        let mut map = self.limiter.lock();
+        if map.len() > 50_000 {
+            map.retain(|_, b| now.duration_since(b.window_start) < window);
+        }
+        let bucket = map.entry(key.to_string()).or_insert(Bucket {
+            count: 0,
+            window_start: now,
+        });
+        if now.duration_since(bucket.window_start) >= window {
+            bucket.count = 0;
+            bucket.window_start = now;
+        }
+        bucket.count += 1;
+        bucket.count <= self.cfg.rate_limit_per_min
+    }
+}
+
+pub fn spawn_flusher(state: Arc<AppState>, mut rx: mpsc::Receiver<Value>) {
+    let table = state.cfg.errors_table.clone();
+    let flush_rows = state.cfg.flush_rows;
+    let interval = Duration::from_millis(state.cfg.flush_interval_ms);
+    tokio::spawn(async move {
+        let mut buf: Vec<Value> = Vec::with_capacity(flush_rows);
+        let mut tick = tokio::time::interval(interval);
+        loop {
+            tokio::select! {
+                msg = rx.recv() => {
+                    match msg {
+                        Some(row) => {
+                            buf.push(row);
+                            if buf.len() >= flush_rows {
+                                flush(&state.ch, &table, &mut buf).await;
+                            }
+                        }
+                        None => {
+                            flush(&state.ch, &table, &mut buf).await;
+                            break;
+                        }
+                    }
+                }
+                _ = tick.tick() => {
+                    if !buf.is_empty() {
+                        flush(&state.ch, &table, &mut buf).await;
+                    }
+                }
+            }
+        }
+    });
+}
+
+async fn flush(ch: &ClickHouseConfig, table: &str, buf: &mut Vec<Value>) {
+    if buf.is_empty() {
+        return;
+    }
+    let rows = std::mem::take(buf);
+    let n = rows.len();
+    if let Err(e) = ch.execute_insert(table, &rows).await {
+        tracing::error!(error = %e, rows = n, "clickhouse insert failed");
+    } else {
+        tracing::debug!(rows = n, "flushed telemetry rows");
+    }
+}

--- a/apps/metrics/src/telemetry.rs
+++ b/apps/metrics/src/telemetry.rs
@@ -1,0 +1,132 @@
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+use sha2::{Digest, Sha256};
+
+const MAX_MESSAGE: usize = 4096;
+const MAX_STACK: usize = 16384;
+const MAX_URL: usize = 1024;
+const MAX_EXTRA_KEYS: usize = 32;
+const MAX_EXTRA_VALUE: usize = 1024;
+
+const NOISE: &[&str] = &[
+    "ResizeObserver loop limit exceeded",
+    "ResizeObserver loop completed with undelivered notifications",
+    "Script error.",
+    "Non-Error promise rejection captured",
+];
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorBatch {
+    pub events: Vec<ErrorEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErrorEvent {
+    pub project: String,
+    #[serde(default)]
+    pub platform: Option<String>,
+    #[serde(default)]
+    pub release: Option<String>,
+    #[serde(default)]
+    pub environment: Option<String>,
+    #[serde(default)]
+    pub error_type: Option<String>,
+    pub message: String,
+    #[serde(default)]
+    pub stack: Option<String>,
+    #[serde(default)]
+    pub url: Option<String>,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub handled: Option<bool>,
+    #[serde(default)]
+    pub extra: Option<Map<String, Value>>,
+}
+
+fn truncate(mut s: String, max: usize) -> String {
+    if s.len() > max {
+        s.truncate(max);
+    }
+    s
+}
+
+fn strip_query(url: &str) -> String {
+    let base = url.split(['?', '#']).next().unwrap_or(url);
+    truncate(base.to_string(), MAX_URL)
+}
+
+fn is_noise(message: &str) -> bool {
+    NOISE.iter().any(|n| message.contains(n))
+}
+
+fn fingerprint(project: &str, error_type: &str, stack: &str, message: &str) -> String {
+    let basis = if stack.is_empty() { message } else { stack };
+    let normalized: String = basis
+        .lines()
+        .take(5)
+        .map(|l| l.split(['(', '@']).next().unwrap_or(l).trim())
+        .collect::<Vec<_>>()
+        .join("|");
+    let mut hasher = Sha256::new();
+    hasher.update(project.as_bytes());
+    hasher.update(b":");
+    hasher.update(error_type.as_bytes());
+    hasher.update(b":");
+    hasher.update(normalized.as_bytes());
+    hex::encode(&hasher.finalize()[..16])
+}
+
+fn sanitize_extra(extra: Option<Map<String, Value>>) -> String {
+    let Some(map) = extra else {
+        return "{}".to_string();
+    };
+    let mut out = Map::new();
+    for (k, v) in map.into_iter().take(MAX_EXTRA_KEYS) {
+        let s = match v {
+            Value::String(s) => Value::String(truncate(s, MAX_EXTRA_VALUE)),
+            Value::Object(_) | Value::Array(_) => {
+                Value::String(truncate(v.to_string(), MAX_EXTRA_VALUE))
+            }
+            other => other,
+        };
+        out.insert(k, s);
+    }
+    serde_json::to_string(&out).unwrap_or_else(|_| "{}".to_string())
+}
+
+impl ErrorEvent {
+    pub fn into_row(self, user_agent: &str) -> Option<Value> {
+        let message = truncate(self.message, MAX_MESSAGE);
+        if message.is_empty() || is_noise(&message) {
+            return None;
+        }
+        let project = truncate(self.project, 128);
+        if project.is_empty() {
+            return None;
+        }
+        let error_type = truncate(self.error_type.unwrap_or_default(), 128);
+        let stack = truncate(self.stack.unwrap_or_default(), MAX_STACK);
+        let url = self.url.map(|u| strip_query(&u)).unwrap_or_default();
+        let fp = fingerprint(&project, &error_type, &stack, &message);
+
+        Some(json!({
+            "project": project,
+            "platform": truncate(self.platform.unwrap_or_else(|| "web".into()), 32),
+            "release": truncate(self.release.unwrap_or_default(), 64),
+            "environment": truncate(self.environment.unwrap_or_else(|| "production".into()), 32),
+            "fingerprint": fp,
+            "error_type": error_type,
+            "message": message,
+            "stack": stack,
+            "url": url,
+            "user_id": truncate(self.user_id.unwrap_or_default(), 128),
+            "session_id": truncate(self.session_id.unwrap_or_default(), 128),
+            "user_agent": truncate(user_agent.to_string(), 512),
+            "handled": if self.handled.unwrap_or(false) { 1u8 } else { 0u8 },
+            "extra": sanitize_extra(self.extra),
+        }))
+    }
+}

--- a/apps/metrics/version.toml
+++ b/apps/metrics/version.toml
@@ -1,0 +1,2 @@
+version = "0.1.0"
+publish = true

--- a/packages/npm/observ/.eslintrc.json
+++ b/packages/npm/observ/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+	"extends": ["../../../.eslintrc.base.json"],
+	"ignorePatterns": ["!**/*"],
+	"overrides": [
+		{
+			"files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+			"rules": {}
+		},
+		{
+			"files": ["*.json"],
+			"parser": "jsonc-eslint-parser",
+			"rules": {
+				"@nx/dependency-checks": [
+					"error",
+					{
+						"ignoredFiles": [
+							"{projectRoot}/eslint.config.{js,cjs,mjs}"
+						]
+					}
+				]
+			}
+		}
+	]
+}

--- a/packages/npm/observ/package.json
+++ b/packages/npm/observ/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "@kbve/observ",
+	"version": "0.0.1",
+	"description": "Framework-agnostic client telemetry SDK for KBVE — captures JS errors/rejections and ships batched events to the in-house metrics ingest (ClickHouse).",
+	"keywords": [
+		"kbve",
+		"observability",
+		"telemetry",
+		"errors",
+		"rum"
+	],
+	"homepage": "https://kbve.com/application/javascript/",
+	"bugs": {
+		"url": "https://github.com/KBVE/kbve/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/KBVE/kbve.git"
+	},
+	"author": "KBVE <hello@kbve.com>",
+	"license": "MIT",
+	"type": "module",
+	"main": "./src/index.ts",
+	"module": "./src/index.ts",
+	"types": "./src/index.ts",
+	"exports": {
+		".": {
+			"types": "./src/index.ts",
+			"import": "./src/index.ts"
+		}
+	},
+	"files": [
+		"src/",
+		"*.md",
+		"LICENSE"
+	],
+	"dependencies": {},
+	"peerDependencies": {},
+	"publishConfig": {
+		"access": "public"
+	}
+}

--- a/packages/npm/observ/project.json
+++ b/packages/npm/observ/project.json
@@ -1,0 +1,18 @@
+{
+	"name": "observ",
+	"$schema": "../../../node_modules/nx/schemas/project-schema.json",
+	"sourceRoot": "packages/npm/observ/src",
+	"projectType": "library",
+	"tags": ["scope:shared", "type:lib"],
+	"targets": {
+		"lint": {
+			"executor": "@nx/eslint:lint"
+		},
+		"typecheck": {
+			"executor": "nx:run-commands",
+			"options": {
+				"command": "tsc --noEmit -p packages/npm/observ/tsconfig.lib.json"
+			}
+		}
+	}
+}

--- a/packages/npm/observ/src/client.ts
+++ b/packages/npm/observ/src/client.ts
@@ -9,7 +9,13 @@ const NOISE = [
 function randomId(): string {
 	const c = globalThis.crypto as Crypto | undefined;
 	if (c?.randomUUID) return c.randomUUID();
-	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+	if (c?.getRandomValues) {
+		const bytes = c.getRandomValues(new Uint8Array(16));
+		return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join(
+			'',
+		);
+	}
+	return `anon-${Date.now().toString(36)}`;
 }
 
 function isNoise(message: string): boolean {

--- a/packages/npm/observ/src/client.ts
+++ b/packages/npm/observ/src/client.ts
@@ -1,0 +1,156 @@
+import type { ErrorEvent, ObservConfig } from './types';
+
+const NOISE = [
+	'ResizeObserver loop limit exceeded',
+	'ResizeObserver loop completed with undelivered notifications',
+	'Script error.',
+];
+
+function randomId(): string {
+	const c = globalThis.crypto as Crypto | undefined;
+	if (c?.randomUUID) return c.randomUUID();
+	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function isNoise(message: string): boolean {
+	return NOISE.some((n) => message.includes(n));
+}
+
+function errorType(err: unknown): string {
+	if (err instanceof Error) return err.name || 'Error';
+	return typeof err;
+}
+
+export class Observer {
+	private cfg: Required<
+		Pick<ObservConfig, 'maxBatch' | 'flushIntervalMs' | 'sampleRate'>
+	> &
+		ObservConfig;
+	private queue: ErrorEvent[] = [];
+	private timer: ReturnType<typeof setInterval> | null = null;
+	private session: string;
+	private installed = false;
+
+	constructor(config: ObservConfig) {
+		this.cfg = {
+			maxBatch: 20,
+			flushIntervalMs: 5000,
+			sampleRate: 1,
+			...config,
+		};
+		this.session = config.sessionId ?? randomId();
+	}
+
+	install(): this {
+		if (this.installed || typeof window === 'undefined') return this;
+		this.installed = true;
+
+		window.addEventListener('error', (e: ErrorEvent_) => {
+			const err = e.error;
+			this.capture({
+				message: e.message || String(err) || 'unknown error',
+				stack: err instanceof Error ? err.stack : undefined,
+				error_type: errorType(err),
+				url:
+					typeof location !== 'undefined' ? location.href : undefined,
+				handled: false,
+			});
+		});
+
+		window.addEventListener(
+			'unhandledrejection',
+			(e: PromiseRejectionEvent) => {
+				const reason = e.reason;
+				this.capture({
+					message:
+						reason instanceof Error
+							? reason.message
+							: String(reason),
+					stack: reason instanceof Error ? reason.stack : undefined,
+					error_type:
+						reason instanceof Error
+							? reason.name
+							: 'UnhandledRejection',
+					url:
+						typeof location !== 'undefined'
+							? location.href
+							: undefined,
+					handled: false,
+				});
+			},
+		);
+
+		const flushNow = () => this.flush(true);
+		window.addEventListener('visibilitychange', () => {
+			if (document.visibilityState === 'hidden') flushNow();
+		});
+		window.addEventListener('pagehide', flushNow);
+
+		this.timer = setInterval(
+			() => this.flush(false),
+			this.cfg.flushIntervalMs,
+		);
+		return this;
+	}
+
+	captureException(err: unknown, extra?: Record<string, unknown>): void {
+		this.capture({
+			message: err instanceof Error ? err.message : String(err),
+			stack: err instanceof Error ? err.stack : undefined,
+			error_type: errorType(err),
+			url: typeof location !== 'undefined' ? location.href : undefined,
+			handled: true,
+			extra,
+		});
+	}
+
+	private capture(partial: Partial<ErrorEvent> & { message: string }): void {
+		if (this.cfg.sampleRate < 1 && Math.random() > this.cfg.sampleRate)
+			return;
+		if (!partial.message || isNoise(partial.message)) return;
+
+		let event: ErrorEvent = {
+			project: this.cfg.project,
+			platform: this.cfg.platform ?? 'web',
+			release: this.cfg.release,
+			environment: this.cfg.environment,
+			session_id: this.session,
+			user_id: this.cfg.getUserId?.(),
+			...partial,
+		};
+
+		if (this.cfg.beforeSend) {
+			const out = this.cfg.beforeSend(event);
+			if (!out) return;
+			event = out;
+		}
+
+		this.queue.push(event);
+		if (this.queue.length >= this.cfg.maxBatch) this.flush(false);
+	}
+
+	flush(useBeacon: boolean): void {
+		if (this.queue.length === 0) return;
+		const events = this.queue.splice(0, this.queue.length);
+		const body = JSON.stringify({ events });
+
+		if (
+			useBeacon &&
+			typeof navigator !== 'undefined' &&
+			navigator.sendBeacon
+		) {
+			const blob = new Blob([body], { type: 'application/json' });
+			if (navigator.sendBeacon(this.cfg.endpoint, blob)) return;
+		}
+
+		void fetch(this.cfg.endpoint, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json' },
+			body,
+			keepalive: true,
+			credentials: 'omit',
+		}).catch(() => undefined);
+	}
+}
+
+type ErrorEvent_ = Event & { message: string; error?: unknown };

--- a/packages/npm/observ/src/index.ts
+++ b/packages/npm/observ/src/index.ts
@@ -1,0 +1,20 @@
+import { Observer } from './client';
+import type { ObservConfig } from './types';
+
+export { Observer } from './client';
+export type { ErrorEvent, ObservConfig } from './types';
+
+let singleton: Observer | null = null;
+
+export function initObserv(config: ObservConfig): Observer {
+	if (singleton) return singleton;
+	singleton = new Observer(config).install();
+	return singleton;
+}
+
+export function captureException(
+	err: unknown,
+	extra?: Record<string, unknown>,
+): void {
+	singleton?.captureException(err, extra);
+}

--- a/packages/npm/observ/src/types.ts
+++ b/packages/npm/observ/src/types.ts
@@ -1,0 +1,28 @@
+export interface ErrorEvent {
+	project: string;
+	platform?: string;
+	release?: string;
+	environment?: string;
+	error_type?: string;
+	message: string;
+	stack?: string;
+	url?: string;
+	user_id?: string;
+	session_id?: string;
+	handled?: boolean;
+	extra?: Record<string, unknown>;
+}
+
+export interface ObservConfig {
+	endpoint: string;
+	project: string;
+	release?: string;
+	environment?: string;
+	platform?: string;
+	sessionId?: string;
+	getUserId?: () => string | undefined;
+	maxBatch?: number;
+	flushIntervalMs?: number;
+	sampleRate?: number;
+	beforeSend?: (event: ErrorEvent) => ErrorEvent | null;
+}

--- a/packages/npm/observ/tsconfig.json
+++ b/packages/npm/observ/tsconfig.json
@@ -1,0 +1,19 @@
+{
+	"extends": "../../../tsconfig.base.json",
+	"compilerOptions": {
+		"declaration": true,
+		"declarationMap": true,
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"target": "esnext",
+		"lib": ["esnext", "dom"],
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"importHelpers": true,
+		"noImplicitOverride": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noPropertyAccessFromIndexSignature": true
+	},
+	"include": ["src"]
+}

--- a/packages/npm/observ/tsconfig.lib.json
+++ b/packages/npm/observ/tsconfig.lib.json
@@ -1,0 +1,10 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"outDir": "../../../dist/out-tsc",
+		"declaration": true,
+		"skipLibCheck": true
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/npm/observ/version.toml
+++ b/packages/npm/observ/version.toml
@@ -1,0 +1,2 @@
+version = "0.0.1"
+publish = false

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -27,6 +27,7 @@
 			"@kbve/laser": ["packages/npm/laser/src/index.ts"],
 			"@kbve/laser/ecs": ["packages/npm/laser/src/ecs.ts"],
 			"@kbve/npcdb": ["packages/data/codegen/npcdb.ts"],
+			"@kbve/observ": ["packages/npm/observ/src/index.ts"],
 			"@kbve/proto": ["packages/data/codegen/generated/index.ts"],
 			"@kbve/proto/*": ["packages/data/codegen/generated/*"],
 			"@kbve/chat": ["packages/npm/chat/src/index.ts"],


### PR DESCRIPTION
## Summary

Two changes:

1. **jobboard 503 hotfix** — `jsonwebtoken` 10.3 default features did not uniquely select a crypto backend, so HS256 verification panicked at runtime (`Could not automatically determine the process-level CryptoProvider`). Every authenticated request killed its tokio worker → gateway returned **503 on `/api/auth/me` and `/api/admin/applications`** while the pod stayed `Ready`. Pinned `default-features=false` + `rust_crypto`.

2. **apps/metrics** — new Rust/axum ingest service for in-house client telemetry (our own Sentry/Datadog/PostHog lane) writing to a new ClickHouse `telemetry` database. First lens is **error capture**.

## Architecture

```
browser (@kbve/observ)  window error + unhandledrejection
   → batch (sendBeacon/keepalive)
   → POST metrics.kbve.com/api/v1/ingest/errors   (CORS allowlist + rate-limit + sanitize)
   → jedi ClickHouse client  → telemetry.errors_distributed
```

- **One wide table, three intended lenses** (errors / perf / product) correlated by `session_id`.
- **Client-agnostic** via a `platform` field — web / Unreal / Unity / games all feed one pipe.
- Fingerprint = `sha256(project + error_type + top-5 stack frames)` → grouping for free (`telemetry.error_groups` view).
- CH schema setup job lives in the `vector` namespace alongside the other CH setup jobs; reuses the existing `clickhouse-vector-credentials`. 30-day TTL.
- Runtime reuses the `clickhouse-credentials` secret already synced into the `kbve` namespace. ArgoCD app registered in the root app-of-apps.
- Noise (`ResizeObserver loop …`) filtered on both client and server.

## Not in this PR (follow-ups)

- CI-registry proto entry + MDX docs page for `metrics`.
- Wire `initObserv()` into the astro-kbve root layout.
- Perf/product lenses + source-map symbolication.

## Test

- `cargo check -p metrics` — clean.
- `tsc --noEmit -p packages/npm/observ/tsconfig.lib.json` — clean.
- jobboard root-caused from live pod logs (panic backtrace at `jsonwebtoken-10.4.0/src/crypto/mod.rs:125`).