### PR TITLE
feat(argo-dashboard): IDB-first cache, workload metrics, sync actions, triage navigation

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
@@ -191,6 +191,25 @@ function ResourceRow({
 		version: node.version,
 		uid: node.uid,
 	};
+	const stall = detectResourceStall(node);
+	const health = node.health?.status;
+	const severity =
+		health === 'Degraded' || health === 'Missing'
+			? 'crit'
+			: stall || health === 'Progressing'
+				? 'warn'
+				: null;
+	const accent =
+		severity === 'crit'
+			? '#ef4444'
+			: severity === 'warn'
+				? '#fbbf24'
+				: null;
+	const idleBg = accent
+		? severity === 'crit'
+			? 'rgba(239, 68, 68, 0.07)'
+			: 'rgba(251, 191, 36, 0.07)'
+		: 'transparent';
 	return (
 		<>
 			<button
@@ -206,11 +225,14 @@ function ResourceRow({
 					color: 'var(--sl-color-text, #e6edf3)',
 					cursor: 'pointer',
 					borderRadius: 4,
-					background: selected
-						? 'rgba(139, 92, 246, 0.12)'
-						: 'transparent',
+					background: selected ? 'rgba(139, 92, 246, 0.12)' : idleBg,
+					borderLeft: accent
+						? `3px solid ${accent}`
+						: '3px solid transparent',
 					transition: 'background 0.12s',
-					border: 'none',
+					borderTop: 'none',
+					borderRight: 'none',
+					borderBottom: 'none',
 					textAlign: 'left',
 					width: '100%',
 					font: 'inherit',
@@ -225,7 +247,7 @@ function ResourceRow({
 				}}
 				onMouseLeave={(e) => {
 					if (!selected) {
-						e.currentTarget.style.background = 'transparent';
+						e.currentTarget.style.background = idleBg;
 					}
 				}}>
 				{node.health && (
@@ -254,18 +276,15 @@ function ResourceRow({
 					{node.namespace}/
 				</span>
 				{node.name}
-				{(() => {
-					const stall = detectResourceStall(node);
-					return stall ? (
-						<span style={{ marginLeft: 'auto' }}>
-							<StallBadge
-								reason={stall.reason}
-								ageMs={stall.ageMs}
-								compact
-							/>
-						</span>
-					) : null;
-				})()}
+				{stall ? (
+					<span style={{ marginLeft: 'auto' }}>
+						<StallBadge
+							reason={stall.reason}
+							ageMs={stall.ageMs}
+							compact
+						/>
+					</span>
+				) : null}
 			</button>
 			{selected && (
 				<ReactArgoResourceDetail

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoAppTable.tsx
@@ -21,6 +21,7 @@ import {
 	XCircle,
 	AlertCircle,
 	RefreshCw,
+	RotateCw,
 	Loader2,
 	ChevronDown,
 	ChevronRight,
@@ -898,6 +899,7 @@ export function ApplicationRow({
 					{lastSync}
 				</span>
 			</button>
+			{expanded && <AppActionBar app={app} />}
 			{expanded && (
 				<AppExpandedPanel
 					app={app}
@@ -907,6 +909,85 @@ export function ApplicationRow({
 					selectedResource={selectedResource}
 					onSelectResource={onSelectResource}
 				/>
+			)}
+		</div>
+	);
+}
+
+function AppActionBar({ app }: { app: ArgoApplication }) {
+	const busy = useStore(argoService.$actionBusy);
+	const actionError = useStore(argoService.$actionError);
+	const actionMsg = useStore(argoService.$actionMsg);
+	const name = app.metadata.name;
+	const syncing = busy === `${name}:sync`;
+	const refreshing = busy === `${name}:refresh`;
+	const anyBusy = busy !== null;
+
+	const btn: React.CSSProperties = {
+		display: 'flex',
+		alignItems: 'center',
+		gap: 6,
+		padding: '0.35rem 0.7rem',
+		borderRadius: 6,
+		border: '1px solid var(--sl-color-gray-5, #262626)',
+		background: 'var(--sl-color-bg, #0d0d0d)',
+		color: 'var(--sl-color-text, #e6edf3)',
+		fontSize: '0.78rem',
+		fontWeight: 500,
+		cursor: anyBusy ? 'wait' : 'pointer',
+	};
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				alignItems: 'center',
+				gap: 8,
+				padding: '0.5rem 1rem',
+				borderTop: '1px solid var(--sl-color-gray-6, #1c1c1c)',
+				flexWrap: 'wrap',
+			}}>
+			<button
+				type="button"
+				disabled={anyBusy}
+				onClick={() => argoService.syncApp(name)}
+				style={btn}
+				title="Trigger an ArgoCD sync (requires manage permission)">
+				{syncing ? (
+					<Loader2
+						size={13}
+						style={{ animation: 'spin 1s linear infinite' }}
+					/>
+				) : (
+					<RefreshCw size={13} />
+				)}
+				Sync
+			</button>
+			<button
+				type="button"
+				disabled={anyBusy}
+				onClick={() => argoService.hardRefreshApp(name)}
+				style={btn}
+				title="Force ArgoCD to re-read the live cluster state">
+				{refreshing ? (
+					<Loader2
+						size={13}
+						style={{ animation: 'spin 1s linear infinite' }}
+					/>
+				) : (
+					<RotateCw size={13} />
+				)}
+				Hard Refresh
+			</button>
+			{actionMsg && (
+				<span style={{ color: '#22c55e', fontSize: '0.75rem' }}>
+					{actionMsg}
+				</span>
+			)}
+			{actionError && (
+				<span style={{ color: '#fca5a5', fontSize: '0.75rem' }}>
+					{actionError}
+				</span>
 			)}
 		</div>
 	);

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoGrafanaPanel.tsx
@@ -22,6 +22,7 @@ import {
 import {
 	fetchAlerts,
 	fetchPodMetrics,
+	fetchWorkloadMetrics,
 	formatBytes,
 	grafanaService,
 	TIME_RANGE_KEYS,
@@ -35,6 +36,17 @@ import {
 	AlertRow,
 } from './grafanaAlertHelpers';
 import type { ResourceSelector } from './argoService';
+
+// Kinds whose pods can be aggregated by name regex in Prometheus. Pods use an
+// exact match; everything here sums the workload's owned pods.
+const WORKLOAD_KINDS = [
+	'Deployment',
+	'StatefulSet',
+	'DaemonSet',
+	'ReplicaSet',
+	'Rollout',
+	'Job',
+];
 
 const tickFormatter = (t: number) =>
 	new Date(t * 1000).toLocaleTimeString([], {
@@ -187,6 +199,8 @@ export default function ReactArgoGrafanaPanel({
 	const [alertsError, setAlertsError] = useState<string | null>(null);
 
 	const isPod = sel.kind === 'Pod';
+	const isWorkload = WORKLOAD_KINDS.includes(sel.kind);
+	const metricsScoped = isPod || isWorkload;
 	const ns = sel.namespace;
 	const name = sel.name;
 
@@ -203,14 +217,24 @@ export default function ReactArgoGrafanaPanel({
 		metrics.netSeries.length === 0;
 
 	useEffect(() => {
-		if (!isPod || !userId || !ns || !name) return;
+		if (!metricsScoped || !userId || !ns || !name) return;
+		const uid = userId;
 
 		let cancelled = false;
 		(async () => {
 			setLoading(true);
 			setError(null);
 			try {
-				const data = await fetchPodMetrics(token, userId, ns, name, tr);
+				const data = isPod
+					? await fetchPodMetrics(token, uid, ns, name, tr)
+					: await fetchWorkloadMetrics(
+							token,
+							uid,
+							ns,
+							sel.kind,
+							name,
+							tr,
+						);
 				if (cancelled) return;
 				if (!data) {
 					setError('Could not find Prometheus datasource in Grafana');
@@ -232,7 +256,7 @@ export default function ReactArgoGrafanaPanel({
 		return () => {
 			cancelled = true;
 		};
-	}, [token, userId, ns, name, tr, isPod]);
+	}, [token, userId, ns, name, tr, isPod, metricsScoped, sel.kind]);
 
 	// Scoped alerts — reuses the global alerts cache populated on the main
 	// /dashboard/grafana page. Filters to alerts whose labels mention this
@@ -267,18 +291,22 @@ export default function ReactArgoGrafanaPanel({
 	}, [token, userId, ns, name, isPod]);
 
 	const handleRefresh = async () => {
-		if (!userId || !isPod || loading) return;
+		if (!userId || !metricsScoped || loading) return;
+		const uid = userId;
 		setLoading(true);
 		setError(null);
 		try {
-			const data = await fetchPodMetrics(
-				token,
-				userId,
-				ns,
-				name,
-				tr,
-				true,
-			);
+			const data = isPod
+				? await fetchPodMetrics(token, uid, ns, name, tr, true)
+				: await fetchWorkloadMetrics(
+						token,
+						uid,
+						ns,
+						sel.kind,
+						name,
+						tr,
+						true,
+					);
 			if (!data) {
 				setError('Could not find Prometheus datasource in Grafana');
 				return;
@@ -357,7 +385,7 @@ export default function ReactArgoGrafanaPanel({
 		</>
 	);
 
-	if (!isPod) {
+	if (!metricsScoped) {
 		return (
 			<div
 				style={{
@@ -376,8 +404,9 @@ export default function ReactArgoGrafanaPanel({
 						gap: '0.5rem',
 					}}>
 					<span>
-						Per-resource Prometheus metrics are scoped to Pods. Open
-						one of the pods owned by this {sel.kind} to view CPU,
+						Prometheus metrics are scoped to Pods and workloads.
+						This {sel.kind} has no pod-level series — open a Pod,
+						Deployment, StatefulSet, or DaemonSet to view CPU,
 						memory, network, and restart history.
 					</span>
 					<a
@@ -423,6 +452,19 @@ export default function ReactArgoGrafanaPanel({
 					<span>
 						{ns}/{name}
 					</span>
+					{isWorkload && (
+						<span
+							style={{
+								padding: '1px 6px',
+								borderRadius: 3,
+								background: 'var(--sl-color-gray-6, #1c1c1c)',
+								fontSize: '0.65rem',
+								textTransform: 'uppercase',
+								letterSpacing: '0.05em',
+							}}>
+							{sel.kind} · all pods
+						</span>
+					)}
 					{metrics?.fromCache && (
 						<span
 							style={{

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoSummary.tsx
@@ -65,9 +65,7 @@ function StatCard({
 }
 
 function openApp(name: string): void {
-	if (argoService.$expandedApp.get() !== name) {
-		argoService.toggleExpandedApp(name);
-	}
+	void argoService.focusFailingResource(name);
 	requestAnimationFrame(() => {
 		document
 			.getElementById(`argo-app-${name}`)

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactArgoSummary.tsx
@@ -4,7 +4,6 @@ import {
 	argoService,
 	formatAge,
 	healthColor,
-	syncColor,
 	type ArgoApplication,
 	type StallReason,
 } from './argoService';

--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
@@ -1,5 +1,6 @@
 import { atom, computed } from 'nanostores';
 import { initSupa, getSupa } from '@/lib/supa';
+import { cacheGet, cacheSet, cacheDel } from '@/lib/idb-cache';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -125,19 +126,15 @@ export interface ResourceSelector {
 	uid?: string;
 }
 
-interface CachedData {
-	ts: number;
-	applications: ArgoApplication[];
-}
-
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const CACHE_KEY = 'cache:argo:applications';
+const CACHE_KEY = 'argo:applications';
 const CACHE_TTL_MS = 60 * 1000;
 const PROXY_BASE = '/dashboard/argo/proxy';
 const REFRESH_INTERVAL_MS = 30 * 1000;
+const REFRESH_DEBOUNCE_MS = 500;
 
 // ---------------------------------------------------------------------------
 // Errors
@@ -341,28 +338,16 @@ export async function fetchPodLogs(
 }
 
 // ---------------------------------------------------------------------------
-// Cache helpers
+// Cache helpers — IndexedDB-backed (SharedWorker → Dexie → localStorage →
+// memory) via the shared idb-cache layer. Render from here first, then pull.
 // ---------------------------------------------------------------------------
 
-function loadCache(): CachedData | null {
-	try {
-		const raw = localStorage.getItem(CACHE_KEY);
-		if (!raw) return null;
-		const parsed: CachedData = JSON.parse(raw);
-		if (Date.now() - parsed.ts > CACHE_TTL_MS) return null;
-		return parsed;
-	} catch {
-		return null;
-	}
+function loadCache(): Promise<ArgoApplication[] | null> {
+	return cacheGet<ArgoApplication[]>(CACHE_KEY, CACHE_TTL_MS);
 }
 
 function saveCache(applications: ArgoApplication[]): void {
-	try {
-		const data: CachedData = { ts: Date.now(), applications };
-		localStorage.setItem(CACHE_KEY, JSON.stringify(data));
-	} catch {
-		// ignore quota errors
-	}
+	void cacheSet(CACHE_KEY, applications);
 }
 
 // ---------------------------------------------------------------------------
@@ -527,6 +512,7 @@ class ArgoService {
 	);
 
 	private _refreshInterval: ReturnType<typeof setInterval> | undefined;
+	private _refreshTimer: ReturnType<typeof setTimeout> | undefined;
 
 	// --- Auth ---
 
@@ -578,18 +564,18 @@ class ArgoService {
 		}
 	}
 
-	public loadCacheAndFetch(): void {
+	public async loadCacheAndFetch(): Promise<void> {
 		const token = this.$accessToken.get();
 		if (!token) return;
 
-		const cached = loadCache();
-		if (cached) {
-			this.$applications.set(cached.applications);
-			this.$lastUpdated.set(new Date(cached.ts));
+		const cached = await loadCache();
+		if (cached && this.$applications.get().length === 0) {
+			this.$applications.set(cached);
+			this.$lastUpdated.set(new Date());
 			this.$loading.set(false);
 		}
 
-		this.fetchData();
+		this._scheduleRefresh(true);
 		this._startAutoRefresh();
 	}
 
@@ -597,8 +583,23 @@ class ArgoService {
 		const token = this.$accessToken.get();
 		if (token) {
 			this.$loading.set(true);
-			this.fetchData();
+			this._scheduleRefresh();
 		}
+	}
+
+	public async invalidateCache(): Promise<void> {
+		await cacheDel(CACHE_KEY);
+	}
+
+	private _scheduleRefresh(immediate = false): void {
+		if (this._refreshTimer) clearTimeout(this._refreshTimer);
+		this._refreshTimer = setTimeout(
+			() => {
+				this._refreshTimer = undefined;
+				void this.fetchData();
+			},
+			immediate ? 0 : REFRESH_DEBOUNCE_MS,
+		);
 	}
 
 	public toggleExpandedApp(name: string): void {
@@ -635,7 +636,7 @@ class ArgoService {
 	private _startAutoRefresh(): void {
 		if (this._refreshInterval) clearInterval(this._refreshInterval);
 		this._refreshInterval = setInterval(
-			() => this.fetchData(),
+			() => this._scheduleRefresh(),
 			REFRESH_INTERVAL_MS,
 		);
 	}

--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
@@ -338,6 +338,52 @@ export async function fetchPodLogs(
 }
 
 // ---------------------------------------------------------------------------
+// Mutations (gated by DASHBOARD_MANAGE in the axum proxy)
+// ---------------------------------------------------------------------------
+
+export class ManageForbiddenError extends Error {
+	constructor() {
+		super('Requires DASHBOARD_MANAGE permission');
+		this.name = 'ManageForbiddenError';
+	}
+}
+
+export async function syncApplication(
+	token: string,
+	appName: string,
+): Promise<void> {
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/applications/${encodeURIComponent(appName)}/sync`,
+		{
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ prune: false }),
+			signal: AbortSignal.timeout(20000),
+		},
+	);
+	if (resp.status === 403) throw new ManageForbiddenError();
+	if (!resp.ok) throw new Error(`Sync failed: ${resp.status}`);
+}
+
+export async function hardRefreshApplication(
+	token: string,
+	appName: string,
+): Promise<void> {
+	const resp = await fetch(
+		`${PROXY_BASE}/api/v1/applications/${encodeURIComponent(appName)}?refresh=hard`,
+		{
+			headers: { Authorization: `Bearer ${token}` },
+			signal: AbortSignal.timeout(20000),
+		},
+	);
+	if (resp.status === 403) throw new AccessRestrictedError();
+	if (!resp.ok) throw new Error(`Refresh failed: ${resp.status}`);
+}
+
+// ---------------------------------------------------------------------------
 // Cache helpers — IndexedDB-backed (SharedWorker → Dexie → localStorage →
 // memory) via the shared idb-cache layer. Render from here first, then pull.
 // ---------------------------------------------------------------------------
@@ -455,6 +501,12 @@ class ArgoService {
 	public readonly $appTab = atom<'resources' | 'events' | 'history'>(
 		'resources',
 	);
+
+	// Per-app action state: $actionBusy holds `${name}:sync` | `${name}:refresh`
+	// while the request is in flight; messages are transient banners.
+	public readonly $actionBusy = atom<string | null>(null);
+	public readonly $actionError = atom<string | null>(null);
+	public readonly $actionMsg = atom<string | null>(null);
 
 	// Computed
 	public readonly $totalApps = computed(
@@ -591,6 +643,50 @@ class ArgoService {
 		await cacheDel(CACHE_KEY);
 	}
 
+	public async syncApp(name: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token || this.$actionBusy.get()) return;
+		this.$actionBusy.set(`${name}:sync`);
+		this.$actionError.set(null);
+		this.$actionMsg.set(null);
+		try {
+			await syncApplication(token, name);
+			this.$actionMsg.set(`Sync triggered for ${name}`);
+			await this.invalidateCache();
+			this._scheduleRefresh(true);
+		} catch (e: unknown) {
+			this.$actionError.set(
+				e instanceof ManageForbiddenError
+					? 'Sync needs DASHBOARD_MANAGE permission'
+					: e instanceof Error
+						? e.message
+						: 'Sync failed',
+			);
+		} finally {
+			this.$actionBusy.set(null);
+		}
+	}
+
+	public async hardRefreshApp(name: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token || this.$actionBusy.get()) return;
+		this.$actionBusy.set(`${name}:refresh`);
+		this.$actionError.set(null);
+		this.$actionMsg.set(null);
+		try {
+			await hardRefreshApplication(token, name);
+			this.$actionMsg.set(`Hard refresh requested for ${name}`);
+			await this.invalidateCache();
+			this._scheduleRefresh(true);
+		} catch (e: unknown) {
+			this.$actionError.set(
+				e instanceof Error ? e.message : 'Refresh failed',
+			);
+		} finally {
+			this.$actionBusy.set(null);
+		}
+	}
+
 	private _scheduleRefresh(immediate = false): void {
 		if (this._refreshTimer) clearTimeout(this._refreshTimer);
 		this._refreshTimer = setTimeout(
@@ -603,6 +699,8 @@ class ArgoService {
 	}
 
 	public toggleExpandedApp(name: string): void {
+		this.$actionError.set(null);
+		this.$actionMsg.set(null);
 		if (this.$expandedApp.get() === name) {
 			this.$expandedApp.set(null);
 			this.$selectedResource.set(null);

--- a/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/argoService.ts
@@ -474,6 +474,34 @@ export function detectResourceStall(node: ResourceNode): StallReason | null {
 	return null;
 }
 
+/**
+ * Pick the most-actionable unhealthy node in a resource tree: Degraded first,
+ * then Missing, then Progressing; within a tier prefer a Pod (the leaf you can
+ * read logs / metrics on).
+ */
+export function pickFailingNode(nodes: ResourceNode[]): ResourceNode | null {
+	const rank = (n: ResourceNode): number => {
+		switch (n.health?.status) {
+			case 'Degraded':
+				return 0;
+			case 'Missing':
+				return 1;
+			case 'Progressing':
+				return 2;
+			default:
+				return 9;
+		}
+	};
+	const candidates = nodes
+		.filter((n) => rank(n) < 9)
+		.sort((a, b) => {
+			const r = rank(a) - rank(b);
+			if (r !== 0) return r;
+			return (a.kind === 'Pod' ? 0 : 1) - (b.kind === 'Pod' ? 0 : 1);
+		});
+	return candidates[0] ?? null;
+}
+
 export function formatAge(ageMs: number): string {
 	if (ageMs < 60 * 1000) return `${Math.floor(ageMs / 1000)}s`;
 	if (ageMs < 60 * 60 * 1000) return `${Math.floor(ageMs / 60000)}m`;
@@ -708,6 +736,35 @@ class ArgoService {
 			this.$expandedApp.set(name);
 			this.$appTab.set('resources');
 			this.$selectedResource.set(null);
+		}
+	}
+
+	public async focusFailingResource(appName: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (this.$expandedApp.get() !== appName) {
+			this.$actionError.set(null);
+			this.$actionMsg.set(null);
+			this.$expandedApp.set(appName);
+		}
+		this.$appTab.set('resources');
+		this.$selectedResource.set(null);
+		if (!token) return;
+		try {
+			const tree = await fetchResourceTree(token, appName);
+			const bad = pickFailingNode(tree.nodes);
+			if (bad) {
+				this.$selectedResource.set({
+					appName,
+					kind: bad.kind,
+					namespace: bad.namespace,
+					name: bad.name,
+					group: bad.group,
+					version: bad.version,
+					uid: bad.uid,
+				});
+			}
+		} catch {
+			/* leave the app expanded; tree fetch is best-effort */
 		}
 	}
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
@@ -1,5 +1,6 @@
 import { atom } from 'nanostores';
 import { initSupa, getSupa } from '@/lib/supa';
+import { cacheGet, cacheSet } from '@/lib/idb-cache';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -987,13 +988,7 @@ export interface PodMetrics {
 	fromCache: boolean;
 }
 
-interface CachedPodMetrics {
-	metrics: PodMetrics;
-	cached_at: number;
-	user_id: string;
-}
-
-const POD_CACHE_KEY_PREFIX = 'cache:grafana:pod';
+const POD_CACHE_KEY_PREFIX = 'grafana:pod';
 const POD_CACHE_TTL_MS = 5 * 60 * 1000;
 
 function podCacheKey(
@@ -1005,25 +1000,17 @@ function podCacheKey(
 	return `${POD_CACHE_KEY_PREFIX}:${uid}:${ns}:${pod}:${tr}`;
 }
 
-function getCachedPodMetrics(
+async function getCachedPodMetrics(
 	uid: string,
 	ns: string,
 	pod: string,
 	tr: TimeRangeKey,
-): PodMetrics | null {
-	try {
-		const raw = localStorage.getItem(podCacheKey(uid, ns, pod, tr));
-		if (!raw) return null;
-		const cached: CachedPodMetrics = JSON.parse(raw);
-		if (cached.user_id !== uid) {
-			localStorage.removeItem(podCacheKey(uid, ns, pod, tr));
-			return null;
-		}
-		if (Date.now() - cached.cached_at > POD_CACHE_TTL_MS) return null;
-		return { ...cached.metrics, fromCache: true };
-	} catch {
-		return null;
-	}
+): Promise<PodMetrics | null> {
+	const m = await cacheGet<PodMetrics>(
+		podCacheKey(uid, ns, pod, tr),
+		POD_CACHE_TTL_MS,
+	);
+	return m ? { ...m, fromCache: true } : null;
 }
 
 function setCachedPodMetrics(
@@ -1033,19 +1020,10 @@ function setCachedPodMetrics(
 	tr: TimeRangeKey,
 	metrics: PodMetrics,
 ): void {
-	try {
-		const payload: CachedPodMetrics = {
-			metrics: { ...metrics, fromCache: false },
-			cached_at: Date.now(),
-			user_id: uid,
-		};
-		localStorage.setItem(
-			podCacheKey(uid, ns, pod, tr),
-			JSON.stringify(payload),
-		);
-	} catch {
-		/* quota exceeded */
-	}
+	void cacheSet(podCacheKey(uid, ns, pod, tr), {
+		...metrics,
+		fromCache: false,
+	});
 }
 
 function escapeLabel(v: string): string {
@@ -1088,7 +1066,7 @@ export async function fetchPodMetrics(
 	skipCache = false,
 ): Promise<PodMetrics | null> {
 	if (!skipCache) {
-		const cached = getCachedPodMetrics(uid, ns, pod, tr);
+		const cached = await getCachedPodMetrics(uid, ns, pod, tr);
 		if (cached) return cached;
 	}
 

--- a/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/grafanaService.ts
@@ -988,52 +988,60 @@ export interface PodMetrics {
 	fromCache: boolean;
 }
 
-const POD_CACHE_KEY_PREFIX = 'grafana:pod';
 const POD_CACHE_TTL_MS = 5 * 60 * 1000;
 
-function podCacheKey(
-	uid: string,
-	ns: string,
-	pod: string,
-	tr: TimeRangeKey,
-): string {
-	return `${POD_CACHE_KEY_PREFIX}:${uid}:${ns}:${pod}:${tr}`;
-}
-
-async function getCachedPodMetrics(
-	uid: string,
-	ns: string,
-	pod: string,
-	tr: TimeRangeKey,
-): Promise<PodMetrics | null> {
-	const m = await cacheGet<PodMetrics>(
-		podCacheKey(uid, ns, pod, tr),
-		POD_CACHE_TTL_MS,
-	);
+async function getCachedMetrics(key: string): Promise<PodMetrics | null> {
+	const m = await cacheGet<PodMetrics>(key, POD_CACHE_TTL_MS);
 	return m ? { ...m, fromCache: true } : null;
 }
 
-function setCachedPodMetrics(
-	uid: string,
-	ns: string,
-	pod: string,
-	tr: TimeRangeKey,
-	metrics: PodMetrics,
-): void {
-	void cacheSet(podCacheKey(uid, ns, pod, tr), {
-		...metrics,
-		fromCache: false,
-	});
+function setCachedMetrics(key: string, metrics: PodMetrics): void {
+	void cacheSet(key, { ...metrics, fromCache: false });
 }
 
 function escapeLabel(v: string): string {
 	return v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
-function podQueries(
-	ns: string,
-	pod: string,
-): {
+function escapeRegex(v: string): string {
+	return v.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Prometheus `pod=~` regex matching the pods a workload owns. `=~` is fully
+ * anchored, so each pattern matches the whole pod name and won't bleed into a
+ * sibling that merely shares a name prefix.
+ *  - Deployment → ReplicaSet → `<name>-<rs-hash>-<suffix>`
+ *  - ReplicaSet → `<name>-<suffix>`
+ *  - StatefulSet → `<name>-<ordinal>`
+ *  - DaemonSet / Job / Rollout / fallback → `<name>-<suffix>`
+ */
+function workloadPodRegex(kind: string, name: string): string {
+	const n = escapeRegex(name);
+	switch (kind) {
+		case 'Deployment':
+			return `${n}-[a-z0-9]+-[a-z0-9]+`;
+		case 'StatefulSet':
+			return `${n}-[0-9]+`;
+		default:
+			return `${n}-[a-z0-9.-]+`;
+	}
+}
+
+function podSelector(ns: string, pod: string): string {
+	return `namespace="${escapeLabel(ns)}",pod="${escapeLabel(pod)}"`;
+}
+
+function workloadSelector(ns: string, kind: string, name: string): string {
+	return `namespace="${escapeLabel(ns)}",pod=~"${workloadPodRegex(kind, name)}"`;
+}
+
+/**
+ * Build the metric query set for any pod-scoped label selector. Every series
+ * is summed, so the same shapes serve a single pod (`pod="x"`) and an
+ * aggregated workload (`pod=~"x-.+"`).
+ */
+function metricQueries(selector: string): {
 	cpu: string;
 	memory: string;
 	memoryLimit: string;
@@ -1043,40 +1051,29 @@ function podQueries(
 	restarts: string;
 	running: string;
 } {
-	const sel = `namespace="${escapeLabel(ns)}",pod="${escapeLabel(pod)}"`;
-	const containerSel = `${sel},container!="POD",container!=""`;
+	const containerSel = `${selector},container!="POD",container!=""`;
 	return {
 		cpu: `sum(rate(container_cpu_usage_seconds_total{${containerSel}}[5m]))`,
 		memory: `sum(container_memory_working_set_bytes{${containerSel}})`,
-		memoryLimit: `sum(kube_pod_container_resource_limits{${sel},resource="memory"})`,
-		netRx: `sum(rate(container_network_receive_bytes_total{${sel}}[5m]))`,
-		netTx: `sum(rate(container_network_transmit_bytes_total{${sel}}[5m]))`,
+		memoryLimit: `sum(kube_pod_container_resource_limits{${selector},resource="memory"})`,
+		netRx: `sum(rate(container_network_receive_bytes_total{${selector}}[5m]))`,
+		netTx: `sum(rate(container_network_transmit_bytes_total{${selector}}[5m]))`,
 		fs: `sum(container_fs_usage_bytes{${containerSel}})`,
-		restarts: `sum(kube_pod_container_status_restarts_total{${sel}})`,
-		running: `kube_pod_status_phase{${sel},phase="Running"}`,
+		restarts: `sum(kube_pod_container_status_restarts_total{${selector}})`,
+		running: `sum(kube_pod_status_phase{${selector},phase="Running"})`,
 	};
 }
 
-export async function fetchPodMetrics(
+async function fetchScopedMetrics(
 	token: string,
-	uid: string,
-	ns: string,
-	pod: string,
+	dsId: number,
+	selector: string,
 	tr: TimeRangeKey,
-	skipCache = false,
-): Promise<PodMetrics | null> {
-	if (!skipCache) {
-		const cached = await getCachedPodMetrics(uid, ns, pod, tr);
-		if (cached) return cached;
-	}
-
-	const dsId = await findPrometheusDatasourceId(token);
-	if (dsId == null) return null;
-
+): Promise<PodMetrics> {
 	const config = TIME_RANGES[tr];
 	const now = Math.floor(Date.now() / 1000);
 	const rangeStart = now - config.seconds;
-	const q = podQueries(ns, pod);
+	const q = metricQueries(selector);
 
 	const [
 		cpuCores,
@@ -1149,7 +1146,7 @@ export async function fetchPodMetrics(
 		(a, b) => a.timestamp - b.timestamp,
 	);
 
-	const metrics: PodMetrics = {
+	return {
 		snapshot: {
 			cpuCores,
 			memoryBytes,
@@ -1164,8 +1161,56 @@ export async function fetchPodMetrics(
 		netSeries,
 		fromCache: false,
 	};
+}
 
-	setCachedPodMetrics(uid, ns, pod, tr, metrics);
+export async function fetchPodMetrics(
+	token: string,
+	uid: string,
+	ns: string,
+	pod: string,
+	tr: TimeRangeKey,
+	skipCache = false,
+): Promise<PodMetrics | null> {
+	const key = `grafana:pod:${uid}:${ns}:${pod}:${tr}`;
+	if (!skipCache) {
+		const cached = await getCachedMetrics(key);
+		if (cached) return cached;
+	}
+	const dsId = await findPrometheusDatasourceId(token);
+	if (dsId == null) return null;
+	const metrics = await fetchScopedMetrics(
+		token,
+		dsId,
+		podSelector(ns, pod),
+		tr,
+	);
+	setCachedMetrics(key, metrics);
+	return metrics;
+}
+
+export async function fetchWorkloadMetrics(
+	token: string,
+	uid: string,
+	ns: string,
+	kind: string,
+	name: string,
+	tr: TimeRangeKey,
+	skipCache = false,
+): Promise<PodMetrics | null> {
+	const key = `grafana:workload:${uid}:${ns}:${kind}:${name}:${tr}`;
+	if (!skipCache) {
+		const cached = await getCachedMetrics(key);
+		if (cached) return cached;
+	}
+	const dsId = await findPrometheusDatasourceId(token);
+	if (dsId == null) return null;
+	const metrics = await fetchScopedMetrics(
+		token,
+		dsId,
+		workloadSelector(ns, kind, name),
+		tr,
+	);
+	setCachedMetrics(key, metrics);
 	return metrics;
 }
 

--- a/apps/kbve/axum-kbve/src/transport/proxy.rs
+++ b/apps/kbve/axum-kbve/src/transport/proxy.rs
@@ -603,7 +603,9 @@ pub fn init_argo_proxy() -> bool {
 
 pub async fn argo_proxy_handler(path: Option<Path<String>>, req: Request<Body>) -> Response {
     match ARGO.get() {
-        Some(proxy) => proxy.handle(path, req).await,
+        // Method-aware: GET reads require DASHBOARD_VIEW; mutating verbs
+        // (sync, refresh-via-POST, delete) require DASHBOARD_MANAGE.
+        Some(proxy) => proxy.handle_method_aware(path, req).await,
         None => (
             StatusCode::SERVICE_UNAVAILABLE,
             axum::Json(json!({"error": "ArgoCD proxy not configured"})),


### PR DESCRIPTION
ArgoCD dashboard improvements (worktree loop on top of the scoped-metrics fix).

## Changes
- **IndexedDB-first data layer** — Argo applications + Grafana pod-metrics caches moved off raw localStorage onto the shared `idb-cache` (SharedWorker → Dexie → localStorage → memory). Renders last cached state instantly, then pulls. Hard pulls coalesce through a 500ms debounce shared by the refresh button, the 30s auto-refresh, and load-time.
- **Workload-scoped Grafana metrics** — the Grafana tab now aggregates pods for Deployment/StatefulSet/DaemonSet/ReplicaSet/Job/Rollout via an anchored `pod=~` regex keyed by kind (was a "scoped to Pods" placeholder). Pods keep their exact-match path; both share one `fetchScopedMetrics` core.
- **Per-app Sync + Hard Refresh** — Argo proxy switched to the method-aware gate (GET = DASHBOARD_VIEW, mutations = DASHBOARD_MANAGE). New Sync (POST `/sync`) and Hard Refresh (GET `?refresh=hard`) buttons in the expanded app row; both invalidate the IDB cache and trigger a debounced pull. 403 → "needs DASHBOARD_MANAGE" notice.
- **Triage navigation** — "Needs attention" rows now drill into the worst-health child node (Degraded > Missing > Progressing, preferring a Pod) and open its detail drawer, not just expand the app.
- **Tree highlighting** — Degraded/Missing nodes get a red left-accent + tint; stalled/Progressing get amber, so the failing resource stands out.

## Notes
- Builds on the prior fix (#dev `ccd0447cc`) that made scoped pod metrics load on the Argo page (`grafanaService.ensureIdentity`).
- `astro-kbve:check` clean for all touched files (one unrelated pre-existing error in `RnWebDemo.tsx`).