### PR TITLE
feat(forgejo): pin gc cron + surface storage-layer health in dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoSummary.tsx
@@ -82,9 +82,31 @@ function StatCard({
 	);
 }
 
+const STORAGE_HEALTH_LABEL: Record<string, string> = {
+	schema_drift:
+		'Schema drift — Forgejo repository columns changed. Per-repo git/LFS split disabled until the storage layer contract is updated.',
+	access_denied:
+		'DB access denied — app role lost SELECT on forgejo.repository. Per-repo git/LFS split unavailable.',
+	db_error:
+		'Storage DB error — per-repo git/LFS split unavailable, falling back to combined size.',
+	unconfigured: 'Per-repo storage DB layer not configured.',
+};
+
 function StorageBreakdown() {
 	const repos = useStore(forgejoService.$repos);
 	const storage = useStore(forgejoService.$storage);
+	const health = useStore(forgejoService.$storageHealth);
+
+	const healthIssue =
+		health && health.status !== 'ok' && health.status !== 'unknown'
+			? {
+					label:
+						STORAGE_HEALTH_LABEL[health.status] ??
+						`Storage layer: ${health.status}`,
+					detail: health.detail,
+					critical: health.status !== 'unconfigured',
+				}
+			: null;
 
 	const { totalSize, top } = useMemo(() => {
 		const sorted = [...repos].sort((a, b) => b.size - a.size);
@@ -124,6 +146,29 @@ function StorageBreakdown() {
 				<HardDrive size={12} />
 				Storage by Repository
 			</div>
+			{healthIssue && (
+				<div
+					title={healthIssue.detail ?? undefined}
+					style={{
+						display: 'flex',
+						alignItems: 'center',
+						gap: 6,
+						padding: '0.5rem 0.7rem',
+						borderRadius: 8,
+						marginBottom: 8,
+						background: healthIssue.critical
+							? 'rgba(239, 68, 68, 0.1)'
+							: 'rgba(139, 148, 158, 0.1)',
+						border: healthIssue.critical
+							? '1px solid rgba(239, 68, 68, 0.3)'
+							: '1px solid rgba(139, 148, 158, 0.3)',
+						fontSize: '0.72rem',
+						color: healthIssue.critical ? '#ef4444' : '#8b949e',
+					}}>
+					<AlertTriangle size={14} />
+					{healthIssue.label}
+				</div>
+			)}
 			{drift && (
 				<div
 					title="Per-repo sizes are summed from Forgejo's repository.size, which only updates on push or gc. The owner quota totals include LFS that some repos haven't recomputed yet — run a Forgejo size recalculation (admin → garbage collect repositories)."

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -203,6 +203,19 @@ export interface ToastMsg {
 
 export type NoticeKind = 'info' | 'warn' | 'error';
 
+export type StorageHealthStatus =
+	| 'ok'
+	| 'schema_drift'
+	| 'access_denied'
+	| 'db_error'
+	| 'unconfigured'
+	| 'unknown';
+
+export interface ForgejoStorageHealth {
+	status: StorageHealthStatus;
+	detail: string | null;
+}
+
 export interface Notice {
 	kind: NoticeKind;
 	msg: string;
@@ -651,6 +664,7 @@ class ForgejoService {
 	public readonly $unadopted = atom<string[]>([]);
 	public readonly $stats = atom<ForgejoStats | null>(null);
 	public readonly $storage = atom<ForgejoStorage | null>(null);
+	public readonly $storageHealth = atom<ForgejoStorageHealth | null>(null);
 	public readonly $runners = atom<ForgejoRunner[]>([]);
 	public readonly $runnerToken = atom<string | null>(null);
 	public readonly $runnerScope = atom<string>('instance');
@@ -934,6 +948,7 @@ class ForgejoService {
 		this.$lastUpdated.set(new Date());
 		void this.fetchStats(force);
 		void this.fetchStorage(force);
+		void this.fetchStorageHealth();
 		this.$loading.set(false);
 	}
 
@@ -986,6 +1001,25 @@ class ForgejoService {
 			const data = (await resp.json()) as ForgejoStorage;
 			if (data && typeof data.total_bytes === 'number') {
 				this.$storage.set(data);
+			}
+		} catch {
+			return;
+		}
+	}
+
+	public async fetchStorageHealth(): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		try {
+			const resp = await fetch(`${API_BASE}/storage/health`, {
+				headers: { Authorization: `Bearer ${token}` },
+				signal: AbortSignal.timeout(15000),
+			});
+			const data = (await resp
+				.json()
+				.catch(() => null)) as ForgejoStorageHealth | null;
+			if (data && typeof data.status === 'string') {
+				this.$storageHealth.set(data);
 			}
 		} catch {
 			return;

--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -103,6 +103,12 @@ spec:
                               DEFAULT_INTERVAL: 10m
                           quota:
                               ENABLED: true
+                          cron:
+                              git_gc_repos:
+                                  ENABLED: true
+                                  RUN_AT_START: false
+                                  SCHEDULE: '@every 24h'
+                                  TIMEOUT: 120s
                       additionalConfigFromEnvs:
                           - name: FORGEJO__SERVER__LFS_JWT_SECRET
                             valueFrom:

--- a/apps/kube/forgejo/application.yaml
+++ b/apps/kube/forgejo/application.yaml
@@ -44,7 +44,7 @@ spec:
                       annotations:
                           # Bump this value to force a pod rollout when config/secrets change.
                           # ArgoCD detects the annotation change → new ReplicaSet → pod restart.
-                          kbve.com/config-revision: '2026-04-25-git-canonical-url'
+                          kbve.com/config-revision: '2026-06-20-gc-cron'
 
                   gitea:
                       admin:


### PR DESCRIPTION
Follow-up to #12873. Two preventive items so the per-repo git/LFS split stays correct and stays *visible*.

## Pin gc cron (re-drift fix)
`apps/kube/forgejo/application.yaml` — adds `[cron.git_gc_repos]` (`ENABLED`, `@every 24h`, `TIMEOUT 120s`). `repository.size` only recomputes on push or gc; the one-off recompute that fixed rentearth/rareicon would have slowly gone stale again. A fixed daily gc keeps the source numbers fresh so the drift banner and `/storage/health` stay quiet. `config-revision` bumped to roll the pod onto the new config.

## Surface `/storage/health` in the UI
The self-validating DB layer from #12873 already exposes `GET /dashboard/forgejo/api/storage/health` (200 ok / 503 + `{status, detail}`). Until now it lived only in logs.

- `forgejoService.ts` — new `$storageHealth` atom + `ForgejoStorageHealth` type, polled alongside `fetchStorage` in `fetchData`.
- `ReactForgejoSummary.tsx` — banner in `StorageBreakdown`: red for `schema_drift` / `access_denied` / `db_error`, gray for `unconfigured`, hidden on `ok`/`unknown`. `detail` rides the tooltip.

Net: a future Forgejo upgrade that renames a `repository` column flips the dashboard banner (not just a log line), and the data-drift it would cause never accumulates because gc runs daily.

## Verify
- `application.yaml` parses; `cron` block nests under `gitea.config`.
- `astro check` clean on touched files (only pre-existing `@/` path-alias noise from raw check).
- No Rust changes — consumes the merged #12873 endpoint.