### PR TITLE
feat(forgejo): wire packages, user keys, issue triage, team repos into dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
+++ b/apps/kbve/astro-kbve/src/components/dashboard/AstroForgejoDashboard.astro
@@ -9,6 +9,7 @@ import ReactForgejoUserPanel from './ReactForgejoUserPanel';
 import ReactForgejoOrgPanel from './ReactForgejoOrgPanel';
 import ReactForgejoRepoAdmin from './ReactForgejoRepoAdmin';
 import ReactForgejoIssues from './ReactForgejoIssues';
+import ReactForgejoPackages from './ReactForgejoPackages';
 import ReactForgejoRunners from './ReactForgejoRunners';
 import ReactForgejoSystemPanel from './ReactForgejoSystemPanel';
 import ReactForgejoToast from './ReactForgejoToast';
@@ -46,6 +47,9 @@ import ReactForgejoToast from './ReactForgejoToast';
 				</div>
 				<div id="forgejo-issues">
 					<ReactForgejoIssues client:only="react" />
+				</div>
+				<div id="forgejo-packages">
+					<ReactForgejoPackages client:only="react" />
 				</div>
 				<div id="forgejo-runners">
 					<ReactForgejoRunners client:only="react" />

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
-import { forgejoService, timeAgo } from './forgejoService';
+import { forgejoService, timeAgo, type ForgejoIssue } from './forgejoService';
 import {
 	ActionButton,
 	SelectField,
+	TextField,
+	useForm,
 	useTabActive,
 	uiTokens,
 	ForgejoNotice,
@@ -17,6 +20,13 @@ import {
 	MessageSquare,
 	ExternalLink,
 	Loader2,
+	ChevronDown,
+	ChevronRight,
+	Tag,
+	Milestone,
+	Plus,
+	Trash2,
+	Send,
 } from 'lucide-react';
 
 const { textColor, subText, border, panelBg } = uiTokens;
@@ -66,6 +76,543 @@ function Segmented({
 	);
 }
 
+function sectionLabel(text: string) {
+	return (
+		<div
+			style={{
+				fontSize: '0.7rem',
+				fontWeight: 600,
+				color: subText,
+				textTransform: 'uppercase',
+				letterSpacing: '0.04em',
+				marginBottom: 8,
+			}}>
+			{text}
+		</div>
+	);
+}
+
+function TriageManager({ repo }: { repo: string }) {
+	const labelsMap = useStore(forgejoService.$repoLabels);
+	const milestonesMap = useStore(forgejoService.$repoMilestones);
+	const busy = useStore(forgejoService.$busy);
+	const [open, setOpen] = useState(false);
+	const labelForm = useForm({ name: '', color: '#06b6d4', description: '' });
+	const milestoneForm = useForm({ title: '', description: '' });
+	const labels = labelsMap[repo] ?? [];
+	const milestones = milestonesMap[repo] ?? [];
+
+	return (
+		<div
+			style={{
+				border,
+				borderRadius: 10,
+				background: panelBg,
+				marginBottom: '1.25rem',
+			}}>
+			<button
+				type="button"
+				onClick={() => setOpen(!open)}
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					width: '100%',
+					padding: '0.7rem 0.9rem',
+					background: 'transparent',
+					border: 'none',
+					color: textColor,
+					cursor: 'pointer',
+					fontSize: '0.85rem',
+					fontWeight: 600,
+				}}>
+				{open ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+				<Tag size={14} style={{ color: subText }} />
+				Labels &amp; milestones
+				<span style={{ color: subText, fontWeight: 400 }}>
+					{labels.length} labels · {milestones.length} milestones
+				</span>
+			</button>
+			{open && (
+				<div
+					style={{
+						display: 'grid',
+						gap: 16,
+						gridTemplateColumns:
+							'repeat(auto-fit, minmax(260px, 1fr))',
+						padding: '0 0.9rem 0.9rem',
+					}}>
+					<div>
+						{sectionLabel('Labels')}
+						<div
+							style={{
+								display: 'flex',
+								flexWrap: 'wrap',
+								gap: 6,
+								marginBottom: 10,
+							}}>
+							{labels.map((l) => (
+								<span
+									key={l.id}
+									style={{
+										display: 'inline-flex',
+										alignItems: 'center',
+										gap: 5,
+										padding: '2px 6px 2px 8px',
+										borderRadius: 12,
+										fontSize: '0.72rem',
+										fontWeight: 600,
+										background: `#${l.color}22`,
+										color: `#${l.color}`,
+										border: `1px solid #${l.color}55`,
+									}}>
+									{l.name}
+									<button
+										type="button"
+										title="Delete label"
+										disabled={
+											busy === `label-delete-${l.id}`
+										}
+										onClick={() =>
+											forgejoService.deleteLabel(l.id)
+										}
+										style={{
+											display: 'flex',
+											background: 'transparent',
+											border: 'none',
+											color: 'inherit',
+											cursor: 'pointer',
+											opacity: 0.7,
+										}}>
+										<Trash2 size={11} />
+									</button>
+								</span>
+							))}
+							{labels.length === 0 && (
+								<span
+									style={{
+										color: subText,
+										fontSize: '0.78rem',
+									}}>
+									No labels.
+								</span>
+							)}
+						</div>
+						<div style={{ display: 'flex', gap: 8 }}>
+							<input
+								type="color"
+								value={labelForm.state.color}
+								onChange={(e) =>
+									labelForm.set('color', e.target.value)
+								}
+								style={{
+									width: 34,
+									height: 34,
+									padding: 0,
+									border,
+									borderRadius: 7,
+									background: 'transparent',
+									cursor: 'pointer',
+								}}
+							/>
+							<input
+								value={labelForm.state.name}
+								onChange={(e) =>
+									labelForm.set('name', e.target.value)
+								}
+								placeholder="label name"
+								style={{
+									flex: 1,
+									padding: '0.4rem 0.6rem',
+									borderRadius: 7,
+									border,
+									background: 'var(--sl-color-bg, #0d1117)',
+									color: textColor,
+									fontSize: '0.8rem',
+								}}
+							/>
+							<ActionButton
+								size="sm"
+								variant="primary"
+								disabled={!labelForm.state.name}
+								loading={busy === `label-create-${repo}`}
+								onClick={async () => {
+									const ok = await forgejoService.createLabel(
+										{
+											name: labelForm.state.name,
+											color: labelForm.state.color.replace(
+												'#',
+												'',
+											),
+											description:
+												labelForm.state.description,
+										},
+									);
+									if (ok) labelForm.reset();
+								}}>
+								<Plus size={12} />
+							</ActionButton>
+						</div>
+					</div>
+
+					<div>
+						{sectionLabel('Milestones')}
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 6,
+								marginBottom: 10,
+							}}>
+							{milestones.map((m) => (
+								<div
+									key={m.id}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 8,
+										fontSize: '0.8rem',
+										color: textColor,
+									}}>
+									<Milestone
+										size={12}
+										style={{
+											color:
+												m.state === 'closed'
+													? '#8b5cf6'
+													: '#22c55e',
+										}}
+									/>
+									<span style={{ flex: 1 }}>{m.title}</span>
+									<span
+										style={{
+											color: subText,
+											fontSize: '0.7rem',
+										}}>
+										{m.open_issues}/
+										{m.open_issues + m.closed_issues}
+									</span>
+									<button
+										type="button"
+										title="Delete milestone"
+										disabled={
+											busy === `milestone-delete-${m.id}`
+										}
+										onClick={() =>
+											forgejoService.deleteMilestone(m.id)
+										}
+										style={{
+											display: 'flex',
+											background: 'transparent',
+											border: 'none',
+											color: '#ef4444',
+											cursor: 'pointer',
+											opacity: 0.8,
+										}}>
+										<Trash2 size={11} />
+									</button>
+								</div>
+							))}
+							{milestones.length === 0 && (
+								<span
+									style={{
+										color: subText,
+										fontSize: '0.78rem',
+									}}>
+									No milestones.
+								</span>
+							)}
+						</div>
+						<div style={{ display: 'flex', gap: 8 }}>
+							<input
+								value={milestoneForm.state.title}
+								onChange={(e) =>
+									milestoneForm.set('title', e.target.value)
+								}
+								placeholder="milestone title"
+								style={{
+									flex: 1,
+									padding: '0.4rem 0.6rem',
+									borderRadius: 7,
+									border,
+									background: 'var(--sl-color-bg, #0d1117)',
+									color: textColor,
+									fontSize: '0.8rem',
+								}}
+							/>
+							<ActionButton
+								size="sm"
+								variant="primary"
+								disabled={!milestoneForm.state.title}
+								loading={busy === `milestone-create-${repo}`}
+								onClick={async () => {
+									const ok =
+										await forgejoService.createMilestone({
+											title: milestoneForm.state.title,
+											description:
+												milestoneForm.state.description,
+										});
+									if (ok) milestoneForm.reset();
+								}}>
+								<Plus size={12} />
+							</ActionButton>
+						</div>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}
+
+function IssueComments({ index }: { index: number }) {
+	const commentsMap = useStore(forgejoService.$issueComments);
+	const busy = useStore(forgejoService.$busy);
+	const { state, set, reset } = useForm({ body: '' });
+	const comments = commentsMap[index];
+
+	useEffect(() => {
+		void forgejoService.loadIssueComments(index);
+	}, [index]);
+
+	return (
+		<div
+			style={{
+				padding: '0.75rem 0.85rem 0.85rem 2.6rem',
+				borderTop: border,
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 8,
+			}}>
+			{comments === undefined ? (
+				<Loader2
+					size={15}
+					style={{
+						animation: 'spin 1s linear infinite',
+						color: subText,
+					}}
+				/>
+			) : (
+				comments.map((c) => (
+					<div
+						key={c.id}
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 2,
+							padding: '0.5rem 0.65rem',
+							borderRadius: 7,
+							border,
+							background: 'var(--sl-color-bg, #0d1117)',
+						}}>
+						<div
+							style={{
+								display: 'flex',
+								gap: 8,
+								fontSize: '0.7rem',
+								color: subText,
+							}}>
+							<span style={{ fontWeight: 600 }}>
+								@{c.user?.login ?? 'unknown'}
+							</span>
+							<span>{timeAgo(c.created_at)}</span>
+						</div>
+						<div
+							style={{
+								color: textColor,
+								fontSize: '0.8rem',
+								whiteSpace: 'pre-wrap',
+								wordBreak: 'break-word',
+							}}>
+							{c.body}
+						</div>
+					</div>
+				))
+			)}
+			{comments && comments.length === 0 && (
+				<span style={{ color: subText, fontSize: '0.78rem' }}>
+					No comments.
+				</span>
+			)}
+			<div style={{ display: 'flex', gap: 8, alignItems: 'flex-end' }}>
+				<div style={{ flex: 1 }}>
+					<TextField
+						label=""
+						value={state.body}
+						onChange={(v) => set('body', v)}
+						placeholder="Add a moderation comment…"
+						textarea
+					/>
+				</div>
+				<div style={{ marginBottom: '0.75rem' }}>
+					<ActionButton
+						variant="primary"
+						disabled={!state.body.trim()}
+						loading={busy === `issue-comment-${index}`}
+						onClick={async () => {
+							const ok = await forgejoService.addIssueComment(
+								index,
+								state.body,
+							);
+							if (ok) reset();
+						}}>
+						<Send size={13} /> Comment
+					</ActionButton>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+function IssueRow({ it }: { it: ForgejoIssue }) {
+	const busy = useStore(forgejoService.$busy);
+	const [expanded, setExpanded] = useState(false);
+	const isPull = !!it.pull_request;
+
+	return (
+		<div
+			style={{
+				borderRadius: 8,
+				border,
+				background: panelBg,
+				overflow: 'hidden',
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 10,
+					padding: '0.6rem 0.8rem',
+				}}>
+				<button
+					type="button"
+					onClick={() => setExpanded(!expanded)}
+					title="Comments"
+					style={{
+						background: 'transparent',
+						border: 'none',
+						color: subText,
+						cursor: 'pointer',
+						display: 'flex',
+						flexShrink: 0,
+					}}>
+					{expanded ? (
+						<ChevronDown size={14} />
+					) : (
+						<ChevronRight size={14} />
+					)}
+				</button>
+				{isPull ? (
+					<GitPullRequest
+						size={15}
+						style={{
+							color: it.state === 'open' ? '#22c55e' : '#8b5cf6',
+							flexShrink: 0,
+						}}
+					/>
+				) : (
+					<CircleDot
+						size={15}
+						style={{
+							color: it.state === 'open' ? '#22c55e' : '#6b7280',
+							flexShrink: 0,
+						}}
+					/>
+				)}
+				<div style={{ flex: 1, minWidth: 0 }}>
+					<div
+						style={{
+							color: textColor,
+							fontSize: '0.85rem',
+							fontWeight: 500,
+							overflow: 'hidden',
+							textOverflow: 'ellipsis',
+							whiteSpace: 'nowrap',
+						}}>
+						<span style={{ color: subText }}>#{it.number}</span>{' '}
+						{it.title}
+						{it.is_locked && (
+							<Lock
+								size={11}
+								style={{
+									color: '#f59e0b',
+									marginLeft: 6,
+									verticalAlign: 'middle',
+								}}
+							/>
+						)}
+					</div>
+					<div
+						style={{
+							color: subText,
+							fontSize: '0.7rem',
+							display: 'flex',
+							gap: 10,
+							marginTop: 2,
+						}}>
+						<span>@{it.user?.login}</span>
+						<span>{timeAgo(it.created_at)}</span>
+						{it.comments > 0 && (
+							<span
+								style={{
+									display: 'inline-flex',
+									alignItems: 'center',
+									gap: 3,
+								}}>
+								<MessageSquare size={10} />
+								{it.comments}
+							</span>
+						)}
+					</div>
+				</div>
+
+				<a
+					href={it.html_url}
+					target="_blank"
+					rel="noreferrer"
+					style={{ color: subText, display: 'flex' }}
+					title="Open in Forgejo">
+					<ExternalLink size={13} />
+				</a>
+				<ActionButton
+					size="sm"
+					title={it.is_locked ? 'Unlock' : 'Lock'}
+					loading={busy === `issue-lock-${it.number}`}
+					onClick={() =>
+						forgejoService.setIssueLock(it.number, !it.is_locked)
+					}>
+					{it.is_locked ? <Unlock size={12} /> : <Lock size={12} />}
+				</ActionButton>
+				{it.state === 'open' ? (
+					<ActionButton
+						size="sm"
+						variant="danger"
+						title="Close"
+						loading={busy === `issue-state-${it.number}`}
+						onClick={() =>
+							forgejoService.setIssueOpenState(
+								it.number,
+								'closed',
+							)
+						}>
+						<CheckCircle2 size={12} />
+					</ActionButton>
+				) : (
+					<ActionButton
+						size="sm"
+						title="Reopen"
+						loading={busy === `issue-state-${it.number}`}
+						onClick={() =>
+							forgejoService.setIssueOpenState(it.number, 'open')
+						}>
+						<RotateCcw size={12} />
+					</ActionButton>
+				)}
+			</div>
+			{expanded && <IssueComments index={it.number} />}
+		</div>
+	);
+}
+
 export default function ReactForgejoIssues() {
 	const active = useTabActive('issues');
 	const repos = useStore(forgejoService.$repos);
@@ -74,7 +621,6 @@ export default function ReactForgejoIssues() {
 	const state = useStore(forgejoService.$issueState);
 	const type = useStore(forgejoService.$issueType);
 	const loading = useStore(forgejoService.$issuesLoading);
-	const busy = useStore(forgejoService.$busy);
 
 	if (!active) return null;
 
@@ -139,6 +685,8 @@ export default function ReactForgejoIssues() {
 				</span>
 			)}
 
+			{selected && <TriageManager repo={selected} />}
+
 			{selected && loading && issues.length === 0 && (
 				<div
 					style={{
@@ -163,151 +711,9 @@ export default function ReactForgejoIssues() {
 						flexDirection: 'column',
 						gap: 8,
 					}}>
-					{issues.map((it) => {
-						const isPull = !!it.pull_request;
-						return (
-							<div
-								key={it.id}
-								style={{
-									display: 'flex',
-									alignItems: 'center',
-									gap: 10,
-									padding: '0.6rem 0.8rem',
-									borderRadius: 8,
-									border,
-									background: panelBg,
-								}}>
-								{isPull ? (
-									<GitPullRequest
-										size={15}
-										style={{
-											color:
-												it.state === 'open'
-													? '#22c55e'
-													: '#8b5cf6',
-											flexShrink: 0,
-										}}
-									/>
-								) : (
-									<CircleDot
-										size={15}
-										style={{
-											color:
-												it.state === 'open'
-													? '#22c55e'
-													: '#6b7280',
-											flexShrink: 0,
-										}}
-									/>
-								)}
-								<div style={{ flex: 1, minWidth: 0 }}>
-									<div
-										style={{
-											color: textColor,
-											fontSize: '0.85rem',
-											fontWeight: 500,
-											overflow: 'hidden',
-											textOverflow: 'ellipsis',
-											whiteSpace: 'nowrap',
-										}}>
-										<span style={{ color: subText }}>
-											#{it.number}
-										</span>{' '}
-										{it.title}
-										{it.is_locked && (
-											<Lock
-												size={11}
-												style={{
-													color: '#f59e0b',
-													marginLeft: 6,
-													verticalAlign: 'middle',
-												}}
-											/>
-										)}
-									</div>
-									<div
-										style={{
-											color: subText,
-											fontSize: '0.7rem',
-											display: 'flex',
-											gap: 10,
-											marginTop: 2,
-										}}>
-										<span>@{it.user?.login}</span>
-										<span>{timeAgo(it.created_at)}</span>
-										{it.comments > 0 && (
-											<span
-												style={{
-													display: 'inline-flex',
-													alignItems: 'center',
-													gap: 3,
-												}}>
-												<MessageSquare size={10} />
-												{it.comments}
-											</span>
-										)}
-									</div>
-								</div>
-
-								<a
-									href={it.html_url}
-									target="_blank"
-									rel="noreferrer"
-									style={{ color: subText, display: 'flex' }}
-									title="Open in Forgejo">
-									<ExternalLink size={13} />
-								</a>
-								<ActionButton
-									size="sm"
-									title={it.is_locked ? 'Unlock' : 'Lock'}
-									loading={busy === `issue-lock-${it.number}`}
-									onClick={() =>
-										forgejoService.setIssueLock(
-											it.number,
-											!it.is_locked,
-										)
-									}>
-									{it.is_locked ? (
-										<Unlock size={12} />
-									) : (
-										<Lock size={12} />
-									)}
-								</ActionButton>
-								{it.state === 'open' ? (
-									<ActionButton
-										size="sm"
-										variant="danger"
-										title="Close"
-										loading={
-											busy === `issue-state-${it.number}`
-										}
-										onClick={() =>
-											forgejoService.setIssueOpenState(
-												it.number,
-												'closed',
-											)
-										}>
-										<CheckCircle2 size={12} />
-									</ActionButton>
-								) : (
-									<ActionButton
-										size="sm"
-										title="Reopen"
-										loading={
-											busy === `issue-state-${it.number}`
-										}
-										onClick={() =>
-											forgejoService.setIssueOpenState(
-												it.number,
-												'open',
-											)
-										}>
-										<RotateCcw size={12} />
-									</ActionButton>
-								)}
-							</div>
-						);
-					})}
+					{issues.map((it) => (
+						<IssueRow key={it.id} it={it} />
+					))}
 					{!loading && issues.length === 0 && (
 						<span style={{ color: subText, fontSize: '0.85rem' }}>
 							No {state}{' '}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoOrgPanel.tsx
@@ -27,6 +27,8 @@ import {
 	Users,
 	X,
 	UserPlus,
+	BookMarked,
+	BookPlus,
 } from 'lucide-react';
 
 const { textColor, subText, border, panelBg } = uiTokens;
@@ -240,15 +242,19 @@ function CreateTeamModal({
 function TeamRow({ org, team }: { org: string; team: ForgejoTeam }) {
 	const busy = useStore(forgejoService.$busy);
 	const membersMap = useStore(forgejoService.$teamMembers);
+	const reposMap = useStore(forgejoService.$teamRepos);
 	const [open, setOpen] = useState(false);
 	const [newMember, setNewMember] = useState('');
+	const [newRepo, setNewRepo] = useState('');
 	const members = membersMap[team.id];
+	const repos = reposMap[team.id];
 
 	const toggle = () => {
 		const next = !open;
 		setOpen(next);
 		if (next && members === undefined)
 			forgejoService.loadTeamMembers(team.id);
+		if (next && repos === undefined) forgejoService.loadTeamRepos(team.id);
 	};
 
 	return (
@@ -378,6 +384,121 @@ function TeamRow({ org, team }: { org: string; team: ForgejoTeam }) {
 							}}>
 							<UserPlus size={12} /> Add
 						</ActionButton>
+					</div>
+
+					<div
+						style={{
+							marginTop: 12,
+							paddingTop: 10,
+							borderTop: border,
+						}}>
+						<div
+							style={{
+								fontSize: '0.68rem',
+								fontWeight: 600,
+								color: subText,
+								textTransform: 'uppercase',
+								letterSpacing: '0.04em',
+								marginBottom: 8,
+							}}>
+							Repositories
+						</div>
+						<div
+							style={{
+								display: 'flex',
+								flexDirection: 'column',
+								gap: 6,
+								marginBottom: 8,
+							}}>
+							{(repos ?? []).map((r) => (
+								<div
+									key={r.id}
+									style={{
+										display: 'flex',
+										alignItems: 'center',
+										gap: 8,
+										fontSize: '0.8rem',
+										color: textColor,
+									}}>
+									<BookMarked
+										size={12}
+										style={{ color: subText }}
+									/>
+									<span style={{ flex: 1 }}>
+										{r.name}
+										{r.private && (
+											<span
+												style={{
+													color: subText,
+													fontSize: '0.68rem',
+													marginLeft: 6,
+												}}>
+												private
+											</span>
+										)}
+									</span>
+									<ActionButton
+										size="sm"
+										variant="danger"
+										loading={
+											busy ===
+											`team-repo-remove-${team.id}-${r.name}`
+										}
+										onClick={() =>
+											forgejoService.removeTeamRepo(
+												team.id,
+												org,
+												r.name,
+											)
+										}>
+										<X size={11} />
+									</ActionButton>
+								</div>
+							))}
+							{repos && repos.length === 0 && (
+								<span
+									style={{
+										color: subText,
+										fontSize: '0.78rem',
+									}}>
+									No repositories assigned.
+								</span>
+							)}
+						</div>
+						<div style={{ display: 'flex', gap: 6 }}>
+							<input
+								value={newRepo}
+								onChange={(e) => setNewRepo(e.target.value)}
+								placeholder="repository name"
+								style={{
+									flex: 1,
+									padding: '0.3rem 0.5rem',
+									borderRadius: 6,
+									border,
+									background: 'var(--sl-color-bg, #0d1117)',
+									color: textColor,
+									fontSize: '0.78rem',
+								}}
+							/>
+							<ActionButton
+								size="sm"
+								variant="primary"
+								disabled={!newRepo}
+								loading={
+									busy ===
+									`team-repo-add-${team.id}-${newRepo}`
+								}
+								onClick={async () => {
+									await forgejoService.addTeamRepo(
+										team.id,
+										org,
+										newRepo,
+									);
+									setNewRepo('');
+								}}>
+								<BookPlus size={12} /> Add
+							</ActionButton>
+						</div>
 					</div>
 				</div>
 			)}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoPackages.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoPackages.tsx
@@ -1,0 +1,255 @@
+import { useState } from 'react';
+import { useStore } from '@nanostores/react';
+import { forgejoService, timeAgo, type ForgejoPackage } from './forgejoService';
+import {
+	ActionButton,
+	ConfirmDialog,
+	SelectField,
+	useTabActive,
+	uiTokens,
+	ForgejoNotice,
+} from './forgejoUi';
+import {
+	Package,
+	Trash2,
+	ExternalLink,
+	Loader2,
+	RefreshCw,
+} from 'lucide-react';
+
+const { textColor, subText, border, panelBg } = uiTokens;
+
+const th: React.CSSProperties = {
+	padding: '0.55rem 0.75rem',
+	textAlign: 'left',
+	color: subText,
+	fontWeight: 600,
+	fontSize: '0.7rem',
+	textTransform: 'uppercase',
+	letterSpacing: '0.05em',
+};
+const td: React.CSSProperties = {
+	padding: '0.55rem 0.75rem',
+	fontSize: '0.82rem',
+	color: textColor,
+	borderBottom: border,
+};
+
+function typePill(type: string) {
+	return (
+		<span
+			style={{
+				display: 'inline-block',
+				padding: '1px 6px',
+				borderRadius: 4,
+				fontSize: '0.62rem',
+				fontWeight: 600,
+				background: 'rgba(139,92,246,0.18)',
+				color: '#a78bfa',
+				textTransform: 'uppercase',
+				letterSpacing: '0.04em',
+			}}>
+			{type}
+		</span>
+	);
+}
+
+export default function ReactForgejoPackages() {
+	const active = useTabActive('packages');
+	const orgs = useStore(forgejoService.$orgs);
+	const users = useStore(forgejoService.$users);
+	const owner = useStore(forgejoService.$packagesOwner);
+	const packagesMap = useStore(forgejoService.$packages);
+	const loading = useStore(forgejoService.$packagesLoading);
+	const busy = useStore(forgejoService.$busy);
+	const [target, setTarget] = useState<ForgejoPackage | null>(null);
+
+	if (!active) return null;
+
+	const packages = owner ? (packagesMap[owner] ?? []) : [];
+	const owners = Array.from(
+		new Set([...orgs.map((o) => o.username), ...users.map((u) => u.login)]),
+	)
+		.filter(Boolean)
+		.sort();
+
+	return (
+		<div className="not-content">
+			<ForgejoNotice
+				ctx="packages"
+				onRetry={() => owner && forgejoService.loadPackages(owner)}
+			/>
+			<div
+				style={{
+					display: 'flex',
+					gap: 12,
+					alignItems: 'flex-end',
+					flexWrap: 'wrap',
+					marginBottom: '1.25rem',
+				}}>
+				<div style={{ flex: '1 1 280px', maxWidth: 420 }}>
+					<SelectField
+						label="Owner"
+						value={owner ?? ''}
+						onChange={(v) => v && forgejoService.loadPackages(v)}
+						options={[
+							{ value: '', label: 'Select an owner…' },
+							...owners.map((o) => ({ value: o, label: o })),
+						]}
+					/>
+				</div>
+				{owner && (
+					<div style={{ marginBottom: '0.75rem' }}>
+						<ActionButton
+							size="sm"
+							onClick={() => forgejoService.loadPackages(owner)}>
+							<RefreshCw size={12} /> Refresh
+						</ActionButton>
+					</div>
+				)}
+			</div>
+
+			{!owner && (
+				<span style={{ color: subText, fontSize: '0.85rem' }}>
+					Choose an owner to inspect their published packages.
+				</span>
+			)}
+
+			{owner && loading && packages.length === 0 && (
+				<div
+					style={{
+						display: 'flex',
+						justifyContent: 'center',
+						padding: '2rem',
+					}}>
+					<Loader2
+						size={22}
+						style={{
+							animation: 'spin 1s linear infinite',
+							color: 'var(--sl-color-accent, #06b6d4)',
+						}}
+					/>
+				</div>
+			)}
+
+			{owner && (!loading || packages.length > 0) && (
+				<div style={{ borderRadius: 10, border, overflow: 'hidden' }}>
+					<table
+						style={{ width: '100%', borderCollapse: 'collapse' }}>
+						<thead>
+							<tr style={{ background: panelBg }}>
+								<th style={th}>Type</th>
+								<th style={th}>Name</th>
+								<th style={th}>Version</th>
+								<th style={th}>Created</th>
+								<th style={{ ...th, textAlign: 'right' }}>
+									Actions
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							{packages.map((p) => (
+								<tr key={p.id}>
+									<td style={td}>{typePill(p.type)}</td>
+									<td style={td}>
+										<div
+											style={{
+												display: 'flex',
+												alignItems: 'center',
+												gap: 8,
+											}}>
+											<Package
+												size={13}
+												style={{ color: subText }}
+											/>
+											<span style={{ fontWeight: 500 }}>
+												{p.name}
+											</span>
+										</div>
+									</td>
+									<td style={{ ...td, color: subText }}>
+										{p.version}
+									</td>
+									<td
+										style={{
+											...td,
+											color: subText,
+											fontSize: '0.72rem',
+										}}>
+										{p.created_at &&
+										!p.created_at.startsWith('0001')
+											? timeAgo(p.created_at)
+											: '—'}
+									</td>
+									<td style={{ ...td, textAlign: 'right' }}>
+										<div
+											style={{
+												display: 'inline-flex',
+												gap: 4,
+											}}>
+											{p.html_url && (
+												<a
+													href={p.html_url}
+													target="_blank"
+													rel="noreferrer"
+													style={{
+														color: subText,
+														display: 'flex',
+														alignItems: 'center',
+													}}
+													title="Open in Forgejo">
+													<ExternalLink size={13} />
+												</a>
+											)}
+											<ActionButton
+												size="sm"
+												variant="danger"
+												title="Delete version"
+												onClick={() => setTarget(p)}>
+												<Trash2 size={12} />
+											</ActionButton>
+										</div>
+									</td>
+								</tr>
+							))}
+							{!loading && packages.length === 0 && (
+								<tr>
+									<td
+										style={{
+											...td,
+											color: subText,
+											textAlign: 'center',
+										}}
+										colSpan={5}>
+										No packages published by {owner}.
+									</td>
+								</tr>
+							)}
+						</tbody>
+					</table>
+				</div>
+			)}
+
+			{target && owner && (
+				<ConfirmDialog
+					title="Delete package version"
+					message={`Delete ${target.type} package ${target.name}@${target.version}? This cannot be undone.`}
+					confirmLabel="Delete"
+					danger
+					loading={
+						busy ===
+						`pkg-delete-${owner}-${target.type}-${target.name}-${target.version}`
+					}
+					onCancel={() => setTarget(null)}
+					onConfirm={async () => {
+						const ok = await forgejoService.deletePackage(
+							owner,
+							target,
+						);
+						if (ok) setTarget(null);
+					}}
+				/>
+			)}
+		</div>
+	);
+}

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoTabs.tsx
@@ -7,6 +7,7 @@ import {
 	Building2,
 	Webhook,
 	CircleDot,
+	Package,
 	Cpu,
 	ServerCog,
 } from 'lucide-react';
@@ -22,6 +23,7 @@ const TABS: { id: ForgejoTab; label: string; icon: React.ReactNode }[] = [
 		icon: <Webhook size={14} />,
 	},
 	{ id: 'issues', label: 'Issues & PRs', icon: <CircleDot size={14} /> },
+	{ id: 'packages', label: 'Packages', icon: <Package size={14} /> },
 	{ id: 'runners', label: 'Runners', icon: <Cpu size={14} /> },
 	{ id: 'system', label: 'System', icon: <ServerCog size={14} /> },
 ];

--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserPanel.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoUserPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
 import { forgejoService, timeAgo, type ForgejoUser } from './forgejoService';
 import {
@@ -14,7 +14,16 @@ import {
 	LoadMoreButton,
 	ForgejoNotice,
 } from './forgejoUi';
-import { Plus, Pencil, Trash2, ShieldCheck, Search } from 'lucide-react';
+import {
+	Plus,
+	Pencil,
+	Trash2,
+	ShieldCheck,
+	Search,
+	KeyRound,
+	X,
+	Loader2,
+} from 'lucide-react';
 
 const { textColor, subText, border, panelBg } = uiTokens;
 
@@ -57,7 +66,228 @@ type ModalKind =
 	| { type: 'create' }
 	| { type: 'edit'; user: ForgejoUser }
 	| { type: 'delete'; user: ForgejoUser }
+	| { type: 'keys'; user: ForgejoUser }
 	| null;
+
+function KeysModal({
+	user,
+	onClose,
+}: {
+	user: ForgejoUser;
+	onClose: () => void;
+}) {
+	const busy = useStore(forgejoService.$busy);
+	const loading = useStore(forgejoService.$userKeysLoading);
+	const keysMap = useStore(forgejoService.$userKeys);
+	const gpgMap = useStore(forgejoService.$userGpgKeys);
+	const { state, set, reset } = useForm({ title: '', key: '' });
+	const keys = keysMap[user.login];
+	const gpgKeys = gpgMap[user.login] ?? [];
+
+	useEffect(() => {
+		void forgejoService.loadUserKeys(user.login);
+	}, [user.login]);
+
+	const submit = async () => {
+		const ok = await forgejoService.addUserKey(user.login, {
+			title: state.title,
+			key: state.key,
+			read_only: true,
+		});
+		if (ok) reset();
+	};
+
+	return (
+		<Modal
+			title={`Keys · ${user.login}`}
+			onClose={onClose}
+			width={560}
+			footer={
+				<ActionButton variant="ghost" onClick={onClose}>
+					Close
+				</ActionButton>
+			}>
+			<div style={{ marginBottom: '1rem' }}>
+				<div
+					style={{
+						fontSize: '0.72rem',
+						fontWeight: 600,
+						color: subText,
+						textTransform: 'uppercase',
+						letterSpacing: '0.04em',
+						marginBottom: 8,
+					}}>
+					SSH keys
+				</div>
+				{loading && (keys === undefined || keys.length === 0) ? (
+					<div
+						style={{
+							display: 'flex',
+							justifyContent: 'center',
+							padding: '1rem',
+						}}>
+						<Loader2
+							size={18}
+							style={{
+								animation: 'spin 1s linear infinite',
+								color: '#06b6d4',
+							}}
+						/>
+					</div>
+				) : (
+					<div
+						style={{
+							display: 'flex',
+							flexDirection: 'column',
+							gap: 6,
+						}}>
+						{(keys ?? []).map((k) => (
+							<div
+								key={k.id}
+								style={{
+									display: 'flex',
+									alignItems: 'center',
+									gap: 8,
+									padding: '0.45rem 0.6rem',
+									borderRadius: 7,
+									border,
+									background: panelBg,
+								}}>
+								<KeyRound
+									size={13}
+									style={{ color: subText }}
+								/>
+								<div style={{ flex: 1, minWidth: 0 }}>
+									<div
+										style={{
+											color: textColor,
+											fontSize: '0.8rem',
+											fontWeight: 500,
+										}}>
+										{k.title}
+									</div>
+									<div
+										style={{
+											color: subText,
+											fontSize: '0.68rem',
+											fontFamily: 'monospace',
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+											whiteSpace: 'nowrap',
+										}}>
+										{k.fingerprint}
+									</div>
+								</div>
+								<ActionButton
+									size="sm"
+									variant="danger"
+									title="Delete key"
+									loading={
+										busy ===
+										`userkey-delete-${user.login}-${k.id}`
+									}
+									onClick={() =>
+										forgejoService.deleteUserKey(
+											user.login,
+											k.id,
+										)
+									}>
+									<X size={11} />
+								</ActionButton>
+							</div>
+						))}
+						{keys && keys.length === 0 && (
+							<span
+								style={{
+									color: subText,
+									fontSize: '0.78rem',
+								}}>
+								No SSH keys.
+							</span>
+						)}
+					</div>
+				)}
+			</div>
+
+			<div
+				style={{
+					display: 'flex',
+					flexDirection: 'column',
+					gap: 8,
+					padding: '0.75rem',
+					borderRadius: 8,
+					border,
+					marginBottom: '1.25rem',
+				}}>
+				<TextField
+					label="Key title"
+					value={state.title}
+					onChange={(v) => set('title', v)}
+					placeholder="laptop"
+				/>
+				<TextField
+					label="Public key"
+					value={state.key}
+					onChange={(v) => set('key', v)}
+					placeholder="ssh-ed25519 AAAA…"
+					textarea
+				/>
+				<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+					<ActionButton
+						variant="primary"
+						disabled={!state.title || !state.key}
+						loading={busy === `userkey-add-${user.login}`}
+						onClick={submit}>
+						<Plus size={13} /> Add SSH key
+					</ActionButton>
+				</div>
+			</div>
+
+			<div
+				style={{
+					fontSize: '0.72rem',
+					fontWeight: 600,
+					color: subText,
+					textTransform: 'uppercase',
+					letterSpacing: '0.04em',
+					marginBottom: 8,
+				}}>
+				GPG keys
+			</div>
+			<div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+				{gpgKeys.map((g) => (
+					<div
+						key={g.id}
+						style={{
+							display: 'flex',
+							alignItems: 'center',
+							gap: 8,
+							padding: '0.45rem 0.6rem',
+							borderRadius: 7,
+							border,
+							background: panelBg,
+							fontSize: '0.78rem',
+							color: textColor,
+						}}>
+						<span style={{ fontFamily: 'monospace' }}>
+							{g.key_id}
+						</span>
+						<span style={{ color: subText, fontSize: '0.68rem' }}>
+							{g.can_sign ? 'sign' : ''}
+							{g.can_sign && g.can_certify ? ' · ' : ''}
+							{g.can_certify ? 'certify' : ''}
+						</span>
+					</div>
+				))}
+				{gpgKeys.length === 0 && (
+					<span style={{ color: subText, fontSize: '0.78rem' }}>
+						No GPG keys.
+					</span>
+				)}
+			</div>
+		</Modal>
+	);
+}
 
 function CreateUserModal({ onClose }: { onClose: () => void }) {
 	const busy = useStore(forgejoService.$busy);
@@ -324,6 +554,17 @@ export default function ReactForgejoUserPanel() {
 										}}>
 										<ActionButton
 											size="sm"
+											title="Keys"
+											onClick={() =>
+												setModal({
+													type: 'keys',
+													user: u,
+												})
+											}>
+											<KeyRound size={12} />
+										</ActionButton>
+										<ActionButton
+											size="sm"
 											title="Edit"
 											onClick={() =>
 												setModal({
@@ -367,6 +608,9 @@ export default function ReactForgejoUserPanel() {
 					user={modal.user}
 					onClose={() => setModal(null)}
 				/>
+			)}
+			{modal?.type === 'keys' && (
+				<KeysModal user={modal.user} onClose={() => setModal(null)} />
 			)}
 			{modal?.type === 'delete' && (
 				<ConfirmDialog

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -38,6 +38,12 @@ import type {
 	ForgejoStats,
 	ForgejoStorage,
 	ForgejoIssue,
+	ForgejoLabel,
+	ForgejoMilestone,
+	ForgejoComment,
+	ForgejoPackage,
+	ForgejoPublicKey,
+	ForgejoGpgKey,
 } from '@/data/schema/forgejo';
 
 export type {
@@ -62,6 +68,12 @@ export type {
 	ForgejoStats,
 	ForgejoStorage,
 	ForgejoIssue,
+	ForgejoLabel,
+	ForgejoMilestone,
+	ForgejoComment,
+	ForgejoPackage,
+	ForgejoPublicKey,
+	ForgejoGpgKey,
 };
 
 export interface RepoDetail {
@@ -96,8 +108,27 @@ export type ForgejoTab =
 	| 'orgs'
 	| 'webhooks'
 	| 'issues'
+	| 'packages'
 	| 'runners'
 	| 'system';
+
+export interface CreateUserKeyInput {
+	title: string;
+	key: string;
+	read_only: boolean;
+}
+
+export interface CreateLabelInput {
+	name: string;
+	color: string;
+	description: string;
+}
+
+export interface CreateMilestoneInput {
+	title: string;
+	description: string;
+	due_on?: string;
+}
 
 export interface ForgejoRunner {
 	id?: number;
@@ -674,6 +705,24 @@ class ForgejoService {
 	public readonly $issueType = atom<'issues' | 'pulls'>('issues');
 	public readonly $issues = atom<ForgejoIssue[]>([]);
 	public readonly $issuesLoading = atom<boolean>(false);
+	public readonly $issueComments = atom<Record<number, ForgejoComment[]>>({});
+	public readonly $repoLabels = atom<Record<string, ForgejoLabel[]>>({});
+	public readonly $repoMilestones = atom<Record<string, ForgejoMilestone[]>>(
+		{},
+	);
+
+	// User keys
+	public readonly $userKeys = atom<Record<string, ForgejoPublicKey[]>>({});
+	public readonly $userGpgKeys = atom<Record<string, ForgejoGpgKey[]>>({});
+	public readonly $userKeysLoading = atom<boolean>(false);
+
+	// Packages
+	public readonly $packagesOwner = atom<string | null>(null);
+	public readonly $packages = atom<Record<string, ForgejoPackage[]>>({});
+	public readonly $packagesLoading = atom<boolean>(false);
+
+	// Team repositories
+	public readonly $teamRepos = atom<Record<number, ForgejoRepo[]>>({});
 
 	// Pagination + search
 	public readonly $repoQuery = atom<string>('');
@@ -1608,6 +1657,54 @@ class ForgejoService {
 		);
 	}
 
+	public async loadTeamRepos(teamId: number): Promise<void> {
+		await this._loadResource<ForgejoRepo[]>(
+			'orgs',
+			`forgejo:teamrepos:${teamId}`,
+			`/api/v1/teams/${teamId}/repos?limit=${PAGE_SIZE}`,
+			(d) =>
+				this.$teamRepos.set({ ...this.$teamRepos.get(), [teamId]: d }),
+		);
+	}
+
+	public addTeamRepo(
+		teamId: number,
+		org: string,
+		repo: string,
+	): Promise<boolean> {
+		return this._run(
+			`team-repo-add-${teamId}-${repo}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'PUT',
+					`/api/v1/teams/${teamId}/repos/${org}/${repo}`,
+				);
+				await this.loadTeamRepos(teamId);
+			},
+			`${org}/${repo} added to team`,
+		);
+	}
+
+	public removeTeamRepo(
+		teamId: number,
+		org: string,
+		repo: string,
+	): Promise<boolean> {
+		return this._run(
+			`team-repo-remove-${teamId}-${repo}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/teams/${teamId}/repos/${org}/${repo}`,
+				);
+				await this.loadTeamRepos(teamId);
+			},
+			`${org}/${repo} removed from team`,
+		);
+	}
+
 	// --- Webhook actions ---
 
 	public async loadRepoHooks(fullName: string): Promise<void> {
@@ -1888,6 +1985,145 @@ class ForgejoService {
 	public selectIssueRepo(fullName: string): void {
 		this.$issueRepo.set(fullName);
 		this.loadIssues();
+		this.loadRepoLabels();
+		this.loadRepoMilestones();
+	}
+
+	public async loadIssueComments(index: number): Promise<void> {
+		const token = this.$accessToken.get();
+		const repo = this.$issueRepo.get();
+		if (!token || !repo) return;
+		const data = await apiFetch<ForgejoComment[]>(
+			token,
+			`/api/v1/repos/${repo}/issues/${index}/comments?limit=${PAGE_SIZE}`,
+			[] as ForgejoComment[],
+		);
+		this.$issueComments.set({
+			...this.$issueComments.get(),
+			[index]: Array.isArray(data) ? data : [],
+		});
+	}
+
+	public addIssueComment(index: number, body: string): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`issue-comment-${index}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'POST',
+					`/api/v1/repos/${repo}/issues/${index}/comments`,
+					{ body },
+				);
+				await this.loadIssueComments(index);
+			},
+			`Comment added to #${index}`,
+		);
+	}
+
+	public async loadRepoLabels(): Promise<void> {
+		const token = this.$accessToken.get();
+		const repo = this.$issueRepo.get();
+		if (!token || !repo) return;
+		const data = await apiFetch<ForgejoLabel[]>(
+			token,
+			`/api/v1/repos/${repo}/labels?limit=${PAGE_SIZE}`,
+			[] as ForgejoLabel[],
+		);
+		this.$repoLabels.set({
+			...this.$repoLabels.get(),
+			[repo]: Array.isArray(data) ? data : [],
+		});
+	}
+
+	public createLabel(input: CreateLabelInput): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`label-create-${repo}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(t, 'POST', `/api/v1/repos/${repo}/labels`, {
+					name: input.name,
+					color: input.color,
+					description: input.description,
+				});
+				await this.loadRepoLabels();
+			},
+			`Label ${input.name} created`,
+		);
+	}
+
+	public deleteLabel(id: number): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`label-delete-${id}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${repo}/labels/${id}`,
+				);
+				await this.loadRepoLabels();
+			},
+			`Label deleted`,
+		);
+	}
+
+	public async loadRepoMilestones(): Promise<void> {
+		const token = this.$accessToken.get();
+		const repo = this.$issueRepo.get();
+		if (!token || !repo) return;
+		const data = await apiFetch<ForgejoMilestone[]>(
+			token,
+			`/api/v1/repos/${repo}/milestones?state=all&limit=${PAGE_SIZE}`,
+			[] as ForgejoMilestone[],
+		);
+		this.$repoMilestones.set({
+			...this.$repoMilestones.get(),
+			[repo]: Array.isArray(data) ? data : [],
+		});
+	}
+
+	public createMilestone(input: CreateMilestoneInput): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`milestone-create-${repo}`,
+			async (t) => {
+				if (!repo) return;
+				const body: Record<string, unknown> = {
+					title: input.title,
+					description: input.description,
+				};
+				if (input.due_on) body.due_on = input.due_on;
+				await apiMutate(
+					t,
+					'POST',
+					`/api/v1/repos/${repo}/milestones`,
+					body,
+				);
+				await this.loadRepoMilestones();
+			},
+			`Milestone ${input.title} created`,
+		);
+	}
+
+	public deleteMilestone(id: number): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`milestone-delete-${id}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/repos/${repo}/milestones/${id}`,
+				);
+				await this.loadRepoMilestones();
+			},
+			`Milestone deleted`,
+		);
 	}
 
 	public setIssueState(state: 'open' | 'closed'): void {
@@ -2120,6 +2356,112 @@ class ForgejoService {
 				await this.loadSystem();
 			},
 			`Deleted unadopted ${fullName}`,
+		);
+	}
+
+	// --- User key actions ---
+
+	public async loadUserKeys(login: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		this.$userKeysLoading.set(true);
+		try {
+			const [keys, gpg] = await Promise.all([
+				apiFetch<ForgejoPublicKey[]>(
+					token,
+					`/api/v1/users/${login}/keys?limit=${PAGE_SIZE}`,
+					[] as ForgejoPublicKey[],
+				),
+				apiFetch<ForgejoGpgKey[]>(
+					token,
+					`/api/v1/users/${login}/gpg_keys?limit=${PAGE_SIZE}`,
+					[] as ForgejoGpgKey[],
+				),
+			]);
+			this.$userKeys.set({
+				...this.$userKeys.get(),
+				[login]: Array.isArray(keys) ? keys : [],
+			});
+			this.$userGpgKeys.set({
+				...this.$userGpgKeys.get(),
+				[login]: Array.isArray(gpg) ? gpg : [],
+			});
+		} finally {
+			this.$userKeysLoading.set(false);
+		}
+	}
+
+	public addUserKey(
+		login: string,
+		input: CreateUserKeyInput,
+	): Promise<boolean> {
+		return this._run(
+			`userkey-add-${login}`,
+			async (t) => {
+				await apiMutate(t, 'POST', `/api/v1/users/${login}/keys`, {
+					title: input.title,
+					key: input.key,
+					read_only: input.read_only,
+				});
+				await this.loadUserKeys(login);
+			},
+			`SSH key added for ${login}`,
+		);
+	}
+
+	public deleteUserKey(login: string, id: number): Promise<boolean> {
+		return this._run(
+			`userkey-delete-${login}-${id}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/users/${login}/keys/${id}`,
+				);
+				await this.loadUserKeys(login);
+			},
+			`SSH key removed`,
+		);
+	}
+
+	// --- Package actions ---
+
+	public async loadPackages(owner: string): Promise<void> {
+		const token = this.$accessToken.get();
+		if (!token) return;
+		this.$packagesOwner.set(owner);
+		this.$packagesLoading.set(true);
+		try {
+			const data = await apiFetch<ForgejoPackage[]>(
+				token,
+				`/api/v1/packages/${owner}?limit=${PAGE_SIZE}&page=1`,
+			);
+			this.$packages.set({
+				...this.$packages.get(),
+				[owner]: Array.isArray(data) ? data : [],
+			});
+			this.clearNotice('packages');
+		} catch (e) {
+			this.setNotice('packages', this._noticeFor(e));
+		} finally {
+			this.$packagesLoading.set(false);
+		}
+	}
+
+	public deletePackage(owner: string, pkg: ForgejoPackage): Promise<boolean> {
+		return this._run(
+			`pkg-delete-${owner}-${pkg.type}-${pkg.name}-${pkg.version}`,
+			async (t) => {
+				await apiMutate(
+					t,
+					'DELETE',
+					`/api/v1/packages/${owner}/${pkg.type}/${encodeURIComponent(
+						pkg.name,
+					)}/${encodeURIComponent(pkg.version)}`,
+				);
+				await this.loadPackages(owner);
+			},
+			`Package ${pkg.name}@${pkg.version} deleted`,
 		);
 	}
 }


### PR DESCRIPTION
Surfaces four Forgejo backend proxy areas that already had typed routes at `/dashboard/forgejo/api/*` but no dashboard UI. Pure frontend wiring — **no backend changes**. Wire types come from the proto-generated `@/data/schema/forgejo` barrel.

## What's new

**Packages registry** (new tab + panel)
- Pick an owner (orgs + users) → list published packages (type / name / version / created)
- Per-version delete with confirm dialog
- Ties to the storage work: package registry consumes disk

**User SSH/GPG keys** (Users panel → per-user Keys modal)
- List / add / delete SSH keys (title + fingerprint)
- List GPG keys (key id, sign/certify caps) — read-only, matching the backend

**Issue triage depth** (Issues panel)
- Repo-level **Labels & Milestones** manager: list / create (color picker for labels) / delete
- Per-issue **comment thread**: expand a row to read comments and post moderation comments

**Team → repo assignment** (Orgs & Teams panel)
- Repositories subsection in each team row: list / add / remove — completes org admin (members were already wired)

## Notes
- Per-issue label assignment intentionally omitted: only the destructive PUT (full replace) is proxied with no safe read path for current labels, so only the repo-level catalog is surfaced.
- Verified with a targeted `tsc` over the touched files (inherited tsconfig paths): zero errors in any changed file. The standalone nx `astro-kbve:check` is blocked by the unrelated `@monodon/rust` graph flake (metrics-0.24.3 cargo registry scan).