### PR TITLE
feat(ci): register metrics ingest service in CI dispatch

### DIFF
--- a/.github/ci-dispatch-manifest.json
+++ b/.github/ci-dispatch-manifest.json
@@ -433,6 +433,21 @@
 			"has_test": true
 		},
 		{
+			"key": "metrics",
+			"app_name": "metrics",
+			"version": "0.1.0",
+			"version_toml": "apps/metrics/version.toml",
+			"version_source": "apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx",
+			"version_target": "apps/metrics/Cargo.toml",
+			"source_path": "apps/metrics",
+			"runner": "ubuntu-latest",
+			"image": "kbve/metrics",
+			"e2e_name": "metrics",
+			"deployment_yaml": "apps/kube/metrics/manifest/metrics-deployment.yaml",
+			"has_test": false,
+			"nx_project": "met"
+		},
+		{
 			"key": "nd_server",
 			"app_name": "nd-server",
 			"version": "0.0.2",
@@ -1249,7 +1264,7 @@
 	],
 	"bevy_game": [],
 	"summary": {
-		"docker": 34,
+		"docker": 35,
 		"npm": 4,
 		"crates": 24,
 		"python": 2,
@@ -1259,6 +1274,6 @@
 		"godot": 1,
 		"unreal_game": 3,
 		"bevy_game": 0,
-		"total": 99
+		"total": 100
 	}
 }

--- a/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
+++ b/apps/kbve/astro-kbve/src/content/docs/project/metrics.mdx
@@ -1,0 +1,77 @@
+---
+title: Metrics
+description: |
+    Metrics — in-house observability platform (self-hosted Sentry / Datadog / PostHog).
+    A scoped Rust/Axum ingest service that captures client telemetry into a dedicated
+    ClickHouse `telemetry` database. One pipeline, three lenses (errors / perf / product)
+    over a wide table correlated by session_id; the `platform` field keeps it
+    client-agnostic so web, Unreal, Unity and other games all feed one pipe.
+sidebar:
+    label: Metrics
+    order: 51
+    badge:
+        text: New
+        variant: tip
+unsplash: 1551288049-bebda4e38f71
+img: https://images.unsplash.com/photo-1551288049-bebda4e38f71?fit=crop&w=1400&h=700&q=75
+tags:
+    - rust
+    - axum
+    - observability
+    - clickhouse
+    - telemetry
+    - docker
+key: metrics
+pipeline: docker
+app_name: metrics
+version: "0.1.0"
+source_path: apps/metrics
+version_toml: apps/metrics/version.toml
+version_target: apps/metrics/Cargo.toml
+runner: ubuntu-latest
+image: kbve/metrics
+nx_project: met
+e2e_name: metrics
+deployment_yaml: apps/kube/metrics/manifest/metrics-deployment.yaml
+has_test: false
+author: h0lybyte
+license: KBVE
+status: active
+---
+
+## Metrics — in-house observability
+
+`apps/metrics` is a scoped Rust/Axum service that ingests client telemetry into a
+self-hosted ClickHouse `telemetry` database. It replaces SaaS error/metrics tooling
+(Sentry / Datadog / PostHog) with one pipeline that exposes three lenses — errors,
+performance, and product — over a single wide table correlated by `session_id`.
+
+### Pipeline
+
+```
+@kbve/observ (browser SDK)
+   → POST metrics.kbve.com/api/v1/ingest/errors
+      → apps/metrics (axum, port 5500)
+         → jedi ClickHouseConfig::execute_insert (JSONEachRow, batched)
+            → telemetry.errors_distributed
+```
+
+The ingest path reuses the shared `jedi` ClickHouse client — no new database
+plumbing. A background tokio mpsc flusher batches rows by size and interval.
+Requests are CORS-allowlisted, per-IP rate-limited, body-capped, and run through a
+noise/PII sanitizer. Error grouping uses a `sha256(project + error_type + top-5
+stack frames)` fingerprint. `/readiness` checks ClickHouse so a degraded backend
+sheds load instead of silently 503ing.
+
+### Client-agnostic
+
+The `platform` field (`web` / `unreal` / `unity` / …) lets every client feed the
+same pipe, so the errors lens shipped for the frontend extends to game clients
+without schema changes.
+
+### Deployment
+
+Runs in the `kbve` namespace behind the Cilium Gateway at `metrics.kbve.com`,
+reusing the existing `clickhouse-credentials` ExternalSecret. Schema setup is a
+job in the `vector` namespace that creates the `telemetry` database, the
+`errors_raw` / `errors_distributed` tables, and the `error_groups` view.


### PR DESCRIPTION
## What

Registers `apps/metrics` (in-house observability ingest) as a tracked CI item so `ghcr.io/kbve/metrics` actually builds and publishes. The ArgoCD app at `apps/kube/metrics` already references `ghcr.io/kbve/metrics:0.1.0`, but no pipeline produced that image — this closes the gap.

## Changes

- **New CI registry entry** — `docs/project/metrics.mdx` (docker pipeline, 100th tracked item).
- **`nx_project: met` override** — the Cargo package and nx project are named `met` (not `metrics`) to avoid colliding with the crates.io `metrics` 0.24 facade that `jedi`/`kbve` depend on; @monodon/rust resolves the wrong Cargo.toml otherwise. CI dispatch reads `app_name=metrics` for the image/e2e but invokes `nx run met:container`.
- **Regenerated manifest** — full `astro-kbve:build` → `sync:ci-manifest` (docker 34→35, total 99→100); no surgical edit.

## Verification

- Build + sync clean; manifest diff is only the metrics entry + count bumps.
- `has_test: false` (no e2e suite yet), mirrors jobboard.

## Follow-ups

- First publish flips the image to a real tag; ArgoCD app then pulls successfully → telemetry ingest goes live.
- Then: wire `initObserv` into astro-kbve, staff-gated query endpoint for the `telemetry` DB, dashboard panel.