### PR TITLE
feat(forgejo): wire pull-request merge + edit actions into dashboard

### DIFF
--- a/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
+++ b/apps/kbve/astro-kbve/src/components/dashboard/ReactForgejoIssues.tsx
@@ -1,10 +1,16 @@
 import { useEffect, useState } from 'react';
 import { useStore } from '@nanostores/react';
-import { forgejoService, timeAgo, type ForgejoIssue } from './forgejoService';
+import {
+	forgejoService,
+	timeAgo,
+	type ForgejoIssue,
+	type PullMergeMethod,
+} from './forgejoService';
 import {
 	ActionButton,
 	SelectField,
 	TextField,
+	Toggle,
 	useForm,
 	useTabActive,
 	uiTokens,
@@ -13,6 +19,7 @@ import {
 import {
 	CircleDot,
 	GitPullRequest,
+	GitMerge,
 	Lock,
 	Unlock,
 	CheckCircle2,
@@ -25,6 +32,7 @@ import {
 	Tag,
 	Milestone,
 	Plus,
+	Pencil,
 	Trash2,
 	Send,
 } from 'lucide-react';
@@ -463,10 +471,229 @@ function IssueComments({ index }: { index: number }) {
 	);
 }
 
+const MERGE_METHODS: { value: PullMergeMethod; label: string }[] = [
+	{ value: 'squash', label: 'Squash' },
+	{ value: 'merge', label: 'Merge commit' },
+	{ value: 'rebase', label: 'Rebase' },
+	{ value: 'rebase-merge', label: 'Rebase + merge' },
+];
+
+function branchRef(label: string): string {
+	const slash = label.indexOf(':');
+	return slash >= 0 ? label.slice(slash + 1) : label;
+}
+
+function PullActions({ index }: { index: number }) {
+	const detailsMap = useStore(forgejoService.$pullDetails);
+	const busy = useStore(forgejoService.$busy);
+	const pull = detailsMap[index];
+	const [method, setMethod] = useState<PullMergeMethod>('squash');
+	const [deleteBranch, setDeleteBranch] = useState(false);
+	const [editing, setEditing] = useState(false);
+	const { state, set } = useForm({ title: '', body: '' });
+
+	useEffect(() => {
+		void forgejoService.loadPull(index);
+	}, [index]);
+
+	if (!pull) {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					padding: '0.6rem 0.85rem 0.6rem 2.6rem',
+					borderTop: border,
+					color: subText,
+					fontSize: '0.78rem',
+				}}>
+				<Loader2
+					size={14}
+					style={{ animation: 'spin 1s linear infinite' }}
+				/>
+				Loading pull request…
+			</div>
+		);
+	}
+
+	const merging = busy === `pull-merge-${index}`;
+	const startEdit = () => {
+		set('title', pull.title);
+		set('body', pull.body ?? '');
+		setEditing(true);
+	};
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+				gap: 10,
+				padding: '0.7rem 0.85rem 0.85rem 2.6rem',
+				borderTop: border,
+			}}>
+			<div
+				style={{
+					display: 'flex',
+					alignItems: 'center',
+					gap: 8,
+					flexWrap: 'wrap',
+					fontSize: '0.76rem',
+					color: subText,
+				}}>
+				<span
+					style={{
+						fontFamily: 'monospace',
+						color: textColor,
+						background: 'var(--sl-color-bg, #0d1117)',
+						border,
+						borderRadius: 6,
+						padding: '1px 6px',
+					}}>
+					{pull.base ? branchRef(pull.base.label) : 'base'}
+				</span>
+				<span>←</span>
+				<span
+					style={{
+						fontFamily: 'monospace',
+						color: textColor,
+						background: 'var(--sl-color-bg, #0d1117)',
+						border,
+						borderRadius: 6,
+						padding: '1px 6px',
+					}}>
+					{pull.head ? branchRef(pull.head.label) : 'head'}
+				</span>
+				{pull.merged ? (
+					<span style={{ color: '#8b5cf6', fontWeight: 600 }}>
+						merged
+					</span>
+				) : pull.state === 'open' ? (
+					<span
+						style={{
+							color: pull.mergeable ? '#22c55e' : '#f59e0b',
+							fontWeight: 600,
+						}}>
+						{pull.mergeable ? 'mergeable' : 'conflicts'}
+					</span>
+				) : (
+					<span>closed</span>
+				)}
+			</div>
+
+			{!pull.merged && pull.state === 'open' && (
+				<div
+					style={{
+						display: 'flex',
+						alignItems: 'flex-end',
+						gap: 10,
+						flexWrap: 'wrap',
+					}}>
+					<div style={{ width: 170 }}>
+						<SelectField
+							label="Method"
+							value={method}
+							onChange={(v) => setMethod(v as PullMergeMethod)}
+							options={MERGE_METHODS}
+						/>
+					</div>
+					<div style={{ marginBottom: '0.75rem' }}>
+						<Toggle
+							label="Delete branch after merge"
+							checked={deleteBranch}
+							onChange={setDeleteBranch}
+						/>
+					</div>
+					<div style={{ marginBottom: '0.75rem' }}>
+						<ActionButton
+							variant="primary"
+							disabled={!pull.mergeable}
+							loading={merging}
+							title={
+								pull.mergeable
+									? undefined
+									: 'Pull request has conflicts'
+							}
+							onClick={() =>
+								forgejoService.mergePull(
+									index,
+									method,
+									deleteBranch,
+								)
+							}>
+							<GitMerge size={13} /> Merge
+						</ActionButton>
+					</div>
+				</div>
+			)}
+
+			{editing ? (
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						gap: 6,
+						padding: '0.7rem',
+						borderRadius: 8,
+						border,
+					}}>
+					<TextField
+						label="Title"
+						value={state.title}
+						onChange={(v) => set('title', v)}
+					/>
+					<TextField
+						label="Body"
+						value={state.body}
+						onChange={(v) => set('body', v)}
+						textarea
+					/>
+					<div
+						style={{
+							display: 'flex',
+							justifyContent: 'flex-end',
+							gap: 8,
+						}}>
+						<ActionButton
+							variant="ghost"
+							onClick={() => setEditing(false)}>
+							Cancel
+						</ActionButton>
+						<ActionButton
+							variant="primary"
+							disabled={!state.title.trim()}
+							loading={busy === `pull-edit-${index}`}
+							onClick={async () => {
+								const ok = await forgejoService.editPull(
+									index,
+									{
+										title: state.title,
+										body: state.body,
+									},
+								);
+								if (ok) setEditing(false);
+							}}>
+							Save
+						</ActionButton>
+					</div>
+				</div>
+			) : (
+				<div>
+					<ActionButton size="sm" onClick={startEdit}>
+						<Pencil size={12} /> Edit title &amp; body
+					</ActionButton>
+				</div>
+			)}
+		</div>
+	);
+}
+
 function IssueRow({ it }: { it: ForgejoIssue }) {
 	const busy = useStore(forgejoService.$busy);
 	const [expanded, setExpanded] = useState(false);
 	const isPull = !!it.pull_request;
+	const merged = !!it.pull_request?.merged;
 
 	return (
 		<div
@@ -530,6 +757,23 @@ function IssueRow({ it }: { it: ForgejoIssue }) {
 						}}>
 						<span style={{ color: subText }}>#{it.number}</span>{' '}
 						{it.title}
+						{merged && (
+							<span
+								style={{
+									marginLeft: 6,
+									padding: '1px 6px',
+									borderRadius: 4,
+									fontSize: '0.62rem',
+									fontWeight: 600,
+									background: 'rgba(139,92,246,0.18)',
+									color: '#a78bfa',
+									textTransform: 'uppercase',
+									letterSpacing: '0.04em',
+									verticalAlign: 'middle',
+								}}>
+								merged
+							</span>
+						)}
 						{it.is_locked && (
 							<Lock
 								size={11}
@@ -608,6 +852,7 @@ function IssueRow({ it }: { it: ForgejoIssue }) {
 					</ActionButton>
 				)}
 			</div>
+			{expanded && isPull && <PullActions index={it.number} />}
 			{expanded && <IssueComments index={it.number} />}
 		</div>
 	);

--- a/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
+++ b/apps/kbve/astro-kbve/src/components/dashboard/forgejoService.ts
@@ -44,6 +44,7 @@ import type {
 	ForgejoPackage,
 	ForgejoPublicKey,
 	ForgejoGpgKey,
+	ForgejoPull,
 } from '@/data/schema/forgejo';
 
 export type {
@@ -74,6 +75,7 @@ export type {
 	ForgejoPackage,
 	ForgejoPublicKey,
 	ForgejoGpgKey,
+	ForgejoPull,
 };
 
 export interface RepoDetail {
@@ -128,6 +130,13 @@ export interface CreateMilestoneInput {
 	title: string;
 	description: string;
 	due_on?: string;
+}
+
+export type PullMergeMethod = 'merge' | 'rebase' | 'rebase-merge' | 'squash';
+
+export interface EditPullInput {
+	title?: string;
+	body?: string;
 }
 
 export interface ForgejoRunner {
@@ -706,6 +715,7 @@ class ForgejoService {
 	public readonly $issues = atom<ForgejoIssue[]>([]);
 	public readonly $issuesLoading = atom<boolean>(false);
 	public readonly $issueComments = atom<Record<number, ForgejoComment[]>>({});
+	public readonly $pullDetails = atom<Record<number, ForgejoPull>>({});
 	public readonly $repoLabels = atom<Record<string, ForgejoLabel[]>>({});
 	public readonly $repoMilestones = atom<Record<string, ForgejoMilestone[]>>(
 		{},
@@ -2200,6 +2210,68 @@ class ForgejoService {
 				await this.loadIssues();
 			},
 			lock ? `#${index} locked` : `#${index} unlocked`,
+		);
+	}
+
+	public async loadPull(index: number): Promise<void> {
+		const token = this.$accessToken.get();
+		const repo = this.$issueRepo.get();
+		if (!token || !repo) return;
+		try {
+			const pull = await apiFetch<ForgejoPull>(
+				token,
+				`/api/v1/repos/${repo}/pulls/${index}`,
+			);
+			if (pull && typeof pull.number === 'number') {
+				this.$pullDetails.set({
+					...this.$pullDetails.get(),
+					[index]: pull,
+				});
+			}
+		} catch {
+			return;
+		}
+	}
+
+	public mergePull(
+		index: number,
+		method: PullMergeMethod,
+		deleteBranch: boolean,
+	): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`pull-merge-${index}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'POST',
+					`/api/v1/repos/${repo}/pulls/${index}/merge`,
+					{ Do: method, delete_branch_after_merge: deleteBranch },
+				);
+				await this.loadPull(index);
+				await this.loadIssues();
+			},
+			`#${index} merged (${method})`,
+		);
+	}
+
+	public editPull(index: number, input: EditPullInput): Promise<boolean> {
+		const repo = this.$issueRepo.get();
+		return this._run(
+			`pull-edit-${index}`,
+			async (t) => {
+				if (!repo) return;
+				await apiMutate(
+					t,
+					'PATCH',
+					`/api/v1/repos/${repo}/pulls/${index}`,
+					input,
+				);
+				await this.loadPull(index);
+				await this.loadIssues();
+			},
+			`#${index} updated`,
 		);
 	}
 


### PR DESCRIPTION
Expanding a pull request in the **Issues & PRs** panel now loads its detail and surfaces PR-specific moderation. Pure frontend wiring against already-proxied typed routes — **no backend changes**.

## What's new
- **Merge**: method select (squash / merge commit / rebase / rebase + merge) + optional *delete branch after merge* toggle. Button disabled when the PR is not mergeable.
- **Status**: `base ← head` branch refs and a `mergeable` / `conflicts` / `merged` indicator from `GET pulls/{index}`.
- **Edit**: inline title + body edit (`PATCH pulls/{index}`).
- **Merged badge** in the row, read from the `pull_request` meta on the list.

## Notes
- Create-PR intentionally omitted — scope is moderation (merge/edit) per the chosen item; PR creation needs head/base branch pickers and isn't an admin-moderation action.
- Verified with a targeted `tsc` over the touched files (inherited tsconfig paths): zero errors in `forgejoService.ts` / `ReactForgejoIssues.tsx`. Standalone nx `astro-kbve:check` remains blocked by the unrelated `@monodon/rust` graph flake.